### PR TITLE
Allow importing from tokenizers modules.

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,18 +1,47 @@
+import platform
+import sys
 from setuptools import setup
 from setuptools_rust import Binding, RustExtension
 
-setup(
-    name="tokenizers",
-    version="0.0.11",
-    description="Fast and Customizable Tokenizers",
-    long_description=open("README.md", "r", encoding="utf-8").read(),
-    long_description_content_type="text/markdown",
-    keywords="NLP tokenizer BPE transformer deep learning",
-    author="Anthony MOI",
-    author_email="anthony@huggingface.co",
-    url="https://github.com/huggingface/tokenizers",
-    license="Apache License 2.0",
-    rust_extensions=[RustExtension("tokenizers.tokenizers", binding=Binding.PyO3)],
-    packages=["tokenizers"],
-    zip_safe=False,
-)
+
+def get_py_version_cfgs():
+    # For now each Cfg Py_3_X flag is interpreted as "at least 3.X"
+    version = sys.version_info[0:2]
+    py3_min = 5
+    out_cfg = []
+    for minor in range(py3_min, version[1] + 1):
+        out_cfg.append("--cfg=Py_3_%d" % minor)
+
+    if platform.python_implementation() == "PyPy":
+        out_cfg.append("--cfg=PyPy")
+
+    return out_cfg
+
+
+def make_rust_extension(module_name):
+    setup(
+        name="tokenizers",
+        version="0.0.11",
+        description="Fast and Customizable Tokenizers",
+        long_description=open("README.md", "r", encoding="utf-8").read(),
+        long_description_content_type="text/markdown",
+        keywords="NLP tokenizer BPE transformer deep learning",
+        author="Anthony MOI",
+        author_email="anthony@huggingface.co",
+        url="https://github.com/huggingface/tokenizers",
+        license="Apache License 2.0",
+        rust_extensions=[
+            make_rust_extension("tokenizers"),
+            make_rust_extension("tokenizers.decoders"),
+            make_rust_extension("tokenizers.encoding"),
+            make_rust_extension("tokenizers.error"),
+            make_rust_extension("tokenizers.models"),
+            make_rust_extension("tokenizers.pretokenizers"),
+            make_rust_extension("tokenizers.trainer"),
+        ],
+        packages=["tokenizers"],
+        zip_safe=False,
+    )
+    return RustExtension(
+        module_name, "Cargo.toml", rustc_flags=get_py_version_cfgs(), binding=Binding.PyO3, debug=None
+    )

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -19,29 +19,32 @@ def get_py_version_cfgs():
 
 
 def make_rust_extension(module_name):
-    setup(
-        name="tokenizers",
-        version="0.0.11",
-        description="Fast and Customizable Tokenizers",
-        long_description=open("README.md", "r", encoding="utf-8").read(),
-        long_description_content_type="text/markdown",
-        keywords="NLP tokenizer BPE transformer deep learning",
-        author="Anthony MOI",
-        author_email="anthony@huggingface.co",
-        url="https://github.com/huggingface/tokenizers",
-        license="Apache License 2.0",
-        rust_extensions=[
-            make_rust_extension("tokenizers"),
-            make_rust_extension("tokenizers.decoders"),
-            make_rust_extension("tokenizers.encoding"),
-            make_rust_extension("tokenizers.error"),
-            make_rust_extension("tokenizers.models"),
-            make_rust_extension("tokenizers.pretokenizers"),
-            make_rust_extension("tokenizers.trainer"),
-        ],
-        packages=["tokenizers"],
-        zip_safe=False,
-    )
     return RustExtension(
         module_name, "Cargo.toml", rustc_flags=get_py_version_cfgs(), binding=Binding.PyO3, debug=None
     )
+
+
+setup(
+    name="tokenizers",
+    version="0.0.11",
+    description="Fast and Customizable Tokenizers",
+    long_description=open("README.md", "r", encoding="utf-8").read(),
+    long_description_content_type="text/markdown",
+    keywords="NLP tokenizer BPE transformer deep learning",
+    author="Anthony MOI",
+    author_email="anthony@huggingface.co",
+    url="https://github.com/huggingface/tokenizers",
+    license="Apache License 2.0",
+    rust_extensions=[
+        make_rust_extension("tokenizers"),
+        make_rust_extension("tokenizers.decoders"),
+        make_rust_extension("tokenizers.encoding"),
+        make_rust_extension("tokenizers.error"),
+        make_rust_extension("tokenizers.models"),
+        make_rust_extension("tokenizers.pretokenizers"),
+        make_rust_extension("tokenizers.trainer"),
+    ],
+    packages=["tokenizers"],
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -1,15 +1,18 @@
 extern crate tokenizers as tk;
 
-use super::error::{PyError, ToPyResult};
-use super::utils::Container;
 use pyo3::prelude::*;
 use pyo3::types::*;
+
 use tk::tokenizer::Result;
+
+use super::error::{PyError, ToPyResult};
+use super::utils::Container;
 
 #[pyclass(dict)]
 pub struct Decoder {
     pub decoder: Container<dyn tk::tokenizer::Decoder + Sync>,
 }
+
 #[pymethods]
 impl Decoder {
     #[staticmethod]
@@ -78,4 +81,12 @@ impl tk::tokenizer::Decoder for PyDecoder {
             }
         }
     }
+}
+
+#[pymodule(decoders)]
+fn decoders(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<Decoder>()?;
+    m.add_class::<ByteLevel>()?;
+    m.add_class::<WordPiece>()?;
+    Ok(())
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,68 +1,23 @@
-mod decoders;
+use pyo3::{PyResult, Python};
+use pyo3::prelude::*;
+
 mod encoding;
 mod error;
-mod models;
-mod pre_tokenizers;
-mod processors;
 mod token;
-mod tokenizer;
-mod trainers;
 mod utils;
 
-use pyo3::prelude::*;
-use pyo3::wrap_pymodule;
+pub mod decoders;
+pub mod models;
+pub mod pre_tokenizers;
+pub mod processors;
+pub mod tokenizer;
+pub mod trainers;
 
-/// Trainers Module
-#[pymodule]
-fn trainers(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<trainers::Trainer>()?;
-    m.add_class::<trainers::BpeTrainer>()?;
-    Ok(())
-}
 
-/// Models Module
-#[pymodule]
-fn models(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<models::Model>()?;
-    m.add_class::<models::BPE>()?;
-    m.add_class::<models::WordPiece>()?;
-    Ok(())
-}
-
-/// PreTokenizers Module
-#[pymodule]
-fn pre_tokenizers(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<pre_tokenizers::PreTokenizer>()?;
-    m.add_class::<pre_tokenizers::ByteLevel>()?;
-    m.add_class::<pre_tokenizers::BertPreTokenizer>()?;
-    Ok(())
-}
-
-/// Decoders Module
-#[pymodule]
-fn decoders(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<decoders::Decoder>()?;
-    m.add_class::<decoders::ByteLevel>()?;
-    m.add_class::<decoders::WordPiece>()?;
-    Ok(())
-}
-
-/// Processors Module
-#[pymodule]
-fn processors(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<processors::PostProcessor>()?;
-    m.add_class::<processors::BertProcessing>()?;
-    Ok(())
-}
-
-/// Tokenizers Module
 #[pymodule]
 fn tokenizers(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<tokenizer::Tokenizer>()?;
-    m.add_wrapped(wrap_pymodule!(models))?;
-    m.add_wrapped(wrap_pymodule!(pre_tokenizers))?;
-    m.add_wrapped(wrap_pymodule!(decoders))?;
-    m.add_wrapped(wrap_pymodule!(processors))?;
-    m.add_wrapped(wrap_pymodule!(trainers))?;
+    m.add_class::<token::Token>()?;
+    m.add_class::<encoding::Encoding>()?;
     Ok(())
 }

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -1,10 +1,10 @@
 extern crate tokenizers as tk;
 
-use super::utils::Container;
-
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
+
+use super::utils::Container;
 
 /// A Model represents some tokenization algorithm like BPE or Word
 /// This class cannot be constructed directly. Please use one of the concrete models.
@@ -104,4 +104,12 @@ impl WordPiece {
             }),
         }
     }
+}
+
+#[pymodule(models)]
+fn models(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<Model>()?;
+    m.add_class::<BPE>()?;
+    m.add_class::<WordPiece>()?;
+    Ok(())
 }

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -1,16 +1,20 @@
 extern crate tokenizers as tk;
 
-use super::error::{PyError, ToPyResult};
-use super::utils::Container;
+use std::collections::HashSet;
+
 use pyo3::prelude::*;
 use pyo3::types::*;
-use std::collections::HashSet;
+
 use tk::tokenizer::Result;
+
+use super::error::{PyError, ToPyResult};
+use super::utils::Container;
 
 #[pyclass(dict)]
 pub struct PreTokenizer {
     pub pretok: Container<dyn tk::tokenizer::PreTokenizer + Sync>,
 }
+
 #[pymethods]
 impl PreTokenizer {
     #[staticmethod]
@@ -123,4 +127,12 @@ impl tk::tokenizer::PreTokenizer for PyPreTokenizer {
             }
         }
     }
+}
+
+#[pymodule(pretokenizers)]
+fn pretokenizers(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<PreTokenizer>()?;
+    m.add_class::<ByteLevel>()?;
+    m.add_class::<BertPreTokenizer>()?;
+    Ok(())
 }

--- a/bindings/python/src/processors.rs
+++ b/bindings/python/src/processors.rs
@@ -1,7 +1,8 @@
 extern crate tokenizers as tk;
 
-use super::utils::Container;
 use pyo3::prelude::*;
+
+use super::utils::Container;
 
 #[pyclass(dict)]
 pub struct PostProcessor {
@@ -10,6 +11,7 @@ pub struct PostProcessor {
 
 #[pyclass]
 pub struct BertProcessing {}
+
 #[pymethods]
 impl BertProcessing {
     #[staticmethod]
@@ -20,4 +22,11 @@ impl BertProcessing {
             ))),
         })
     }
+}
+
+#[pymodule(processors)]
+fn processors(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<PostProcessor>()?;
+    m.add_class::<BertProcessing>()?;
+    Ok(())
 }

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -1,8 +1,9 @@
 extern crate tokenizers as tk;
 
-use super::utils::Container;
 use pyo3::prelude::*;
 use pyo3::types::*;
+
+use super::utils::Container;
 
 #[pyclass]
 pub struct Trainer {
@@ -11,6 +12,7 @@ pub struct Trainer {
 
 #[pyclass]
 pub struct BpeTrainer {}
+
 #[pymethods]
 impl BpeTrainer {
     /// new(/vocab_size, min_frequency)
@@ -42,4 +44,11 @@ impl BpeTrainer {
             trainer: Container::Owned(Box::new(trainer)),
         })
     }
+}
+
+#[pymodule(trainers)]
+fn trainers(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<Trainer>()?;
+    m.add_class::<BpeTrainer>()?;
+    Ok(())
 }

--- a/bindings/python/tokenizers/__init__.py
+++ b/bindings/python/tokenizers/__init__.py
@@ -1,3 +1,3 @@
 __version__ = "0.0.11"
 
-from .tokenizers import Tokenizer, models, decoders, pre_tokenizers, trainers, processors
+from .tokenizers import Encoding, Tokenizer, Token


### PR DESCRIPTION
Aim of this PR is to allow more pythonic imports for the library:

```python
from tokenizers.models import WordPiece
```

The main changes are related to the setup.py RustExtension which now exports all the different submodules as separate .so objects Python is able to lookup for symbols.