### PR TITLE
replace print statements with logging

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/cli.rs"
 
 [dependencies]
 lazy_static = "1.3.0"
+log = "0.4.8"
 rand = "0.7.2"
 regex = "1.3.1"
 regex-syntax = "0.6.12"

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -1,5 +1,6 @@
 use super::{Cache, Error, Pair, Word};
 use crate::tokenizer::{Model, Offsets, Result, Token};
+use log::warn;
 use rand::{thread_rng, Rng};
 use serde_json::Value;
 use std::{
@@ -128,7 +129,7 @@ impl BPE {
         for c in w.chars() {
             match self.vocab.get(&c.to_string()) {
                 // TODO: Handle UNK
-                None => println!("{} is an unknown character. Skip it.", c.escape_unicode()),
+                None => warn!("{} is an unknown character. Skip it.", c.escape_unicode()),
                 Some(id) => word.add(*id),
             }
         }

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -2,6 +2,7 @@
 
 use super::{Pair, Word, BPE};
 use crate::tokenizer::{Model, Result, Trainer};
+use log::info;
 use std::{
     collections::{HashMap, HashSet},
     time::Instant,
@@ -72,7 +73,7 @@ impl Trainer for BpeTrainer {
             }
             words.push(current_word);
         }
-        println!("[{:?}] Tokenized {} words", timer.elapsed(), words.len());
+        info!("[{:?}] Tokenized {} words", timer.elapsed(), words.len());
 
         //
         // 2. Count pairs in words
@@ -103,7 +104,7 @@ impl Trainer for BpeTrainer {
                 pair_counts.get_mut(&cur_pair).unwrap().0 += count;
             }
         }
-        println!(
+        info!(
             "[{:?}] Counted {} pairs with {} unique tokens",
             timer.elapsed(),
             pair_counts.len(),
@@ -179,7 +180,7 @@ impl Trainer for BpeTrainer {
                 }
             }
         }
-        println!("[{:?}] Computed {} merges", timer.elapsed(), merges.len());
+        info!("[{:?}] Computed {} merges", timer.elapsed(), merges.len());
 
         Ok(Box::new(BPE::new(
             word_to_id.clone(),


### PR DESCRIPTION
I noticed while running benchmarks that the `println` statements interfere with the output of the benchmarking program, so I think it would be better to use logging macros instead.