### PR TITLE
Improve truncation

### DIFF
--- a/bindings/node/lib/bindings/encoding.d.ts
+++ b/bindings/node/lib/bindings/encoding.d.ts
@@ -18,9 +18,9 @@ export interface Encoding {
   getOffsets(): [number, number][];
 
   /**
-   * Returns the overflowing encoding, after truncation
+   * Returns the overflowing encodings, after truncation
    */
-  getOverflowing(): Encoding | undefined;
+  getOverflowing(): Encoding[];
 
   /**
    * Returns the special tokens mask

--- a/bindings/node/lib/bindings/tokenizer.test.ts
+++ b/bindings/node/lib/bindings/tokenizer.test.ts
@@ -101,7 +101,7 @@ describe("Tokenizer", () => {
         [8, 12],
         [12, 16]
       ]);
-      expect(encoding.getOverflowing()).toBeUndefined();
+      expect(encoding.getOverflowing()).toEqual([]);
       expect(encoding.getSpecialTokensMask()).toEqual([0, 0, 0, 0, 0]);
       expect(encoding.getTokens()).toEqual(["my", "name", "is", "john", "pair"]);
       expect(encoding.getTypeIds()).toEqual([0, 0, 0, 0, 1]);

--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -125,8 +125,8 @@ declare_types! {
             Ok(js_offsets.upcast())
         }
 
-        method getOverflowings(mut cx) {
-            // getOverflowings(): Encoding[]
+        method getOverflowing(mut cx) {
+            // getOverflowing(): Encoding[]
 
             let this = cx.this();
             let guard = cx.lock();

--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -125,27 +125,28 @@ declare_types! {
             Ok(js_offsets.upcast())
         }
 
-        method getOverflowing(mut cx) {
-            // getOverflowing(): Encoding | undefined;
+        method getOverflowings(mut cx) {
+            // getOverflowings(): Encoding[]
 
             let this = cx.this();
             let guard = cx.lock();
 
-            let overflowing = this.borrow(&guard).encoding.execute(|encoding| {
-                encoding.unwrap().get_overflowing().cloned()
+            let overflowings = this.borrow(&guard).encoding.execute(|encoding| {
+                encoding.unwrap().get_overflowing().clone()
             });
+            let js_overflowings = JsArray::new(&mut cx, overflowings.len() as u32);
 
-            if let Some(overflowing) = overflowing {
+            for (index, overflowing) in overflowings.iter().enumerate() {
                 let mut js_overflowing = JsEncoding::new::<_, JsEncoding, _>(&mut cx, vec![])?;
 
                 // Set the content
                 let guard = cx.lock();
-                js_overflowing.borrow_mut(&guard).encoding.to_owned(Box::new(overflowing));
+                js_overflowing.borrow_mut(&guard).encoding.to_owned(Box::new(overflowing.clone()));
 
-                Ok(js_overflowing.upcast())
-            } else {
-                Ok(cx.undefined().upcast())
+                js_overflowings.set(&mut cx, index as u32, js_overflowing)?;
             }
+
+            Ok(js_overflowings.upcast())
         }
 
         method getOriginalString(mut cx) {

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -193,8 +193,13 @@ impl Encoding {
     }
 
     #[getter]
-    fn get_overflowing(&self) -> Option<Encoding> {
-        self.encoding.get_overflowing().cloned().map(Encoding::new)
+    fn get_overflowing(&self) -> Vec<Encoding> {
+        self.encoding
+            .get_overflowing()
+            .clone()
+            .into_iter()
+            .map(Encoding::new)
+            .collect()
     }
 
     #[args(kwargs = "**")]

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -45,7 +45,35 @@ impl PostProcessor for BertProcessing {
             offsets,
             special_tokens,
             attention_mask,
-            encoding.take_overflowing(),
+            encoding
+                .take_overflowing()
+                .into_iter()
+                .map(|encoding| {
+                    let ids = [&[self.cls.1], &encoding.get_ids()[..], &[self.sep.1]].concat();
+                    let type_ids = [&[0], &encoding.get_type_ids()[..], &[0]].concat();
+                    let tokens = [
+                        &[self.cls.0.clone()],
+                        &encoding.get_tokens()[..],
+                        &[self.sep.0.clone()],
+                    ]
+                    .concat();
+                    let offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
+                    let special_tokens =
+                        [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
+                    let attention_mask = vec![1; ids.len()];
+
+                    Encoding::new(
+                        encoding.get_normalized().clone(),
+                        ids,
+                        type_ids,
+                        tokens,
+                        offsets,
+                        special_tokens,
+                        attention_mask,
+                        vec![],
+                    )
+                })
+                .collect(),
         );
 
         if let Some(mut encoding) = pair_encoding {
@@ -65,7 +93,31 @@ impl PostProcessor for BertProcessing {
                 pair_offsets,
                 pair_special_tokens,
                 pair_attention_mask,
-                encoding.take_overflowing(),
+                encoding
+                    .take_overflowing()
+                    .into_iter()
+                    .map(|encoding| {
+                        let pair_ids = [&encoding.get_ids()[..], &[self.sep.1]].concat();
+                        let pair_type_ids = [&encoding.get_type_ids()[..], &[1]].concat();
+                        let pair_tokens =
+                            [&encoding.get_tokens()[..], &[self.sep.0.clone()]].concat();
+                        let pair_offsets = [&encoding.get_offsets()[..], &[(0, 0)]].concat();
+                        let pair_special_tokens =
+                            [&vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
+                        let pair_attention_mask = vec![1; pair_ids.len()];
+
+                        Encoding::new(
+                            encoding.get_normalized().clone(),
+                            pair_ids,
+                            pair_type_ids,
+                            pair_tokens,
+                            pair_offsets,
+                            pair_special_tokens,
+                            pair_attention_mask,
+                            vec![],
+                        )
+                    })
+                    .collect(),
             );
 
             new_encoding.merge_with(new_pair_encoding);

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -218,6 +218,11 @@ impl Encoding {
                 self.offsets = [&self.offsets[..], &offsets_pad[..]].concat();
             }
         }
+
+        // Also pad each overflowing encoding
+        self.overflowing.iter_mut().for_each(|encoding| {
+            encoding.pad(pad_length, pad_id, pad_type_id, pad_token, direction)
+        });
     }
 }
 

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -285,7 +285,7 @@ impl Tokenizer {
                             vec![(0, sentence.len())],
                             vec![0],
                             vec![1],
-                            None,
+                            vec![],
                         ));
                     }
 
@@ -321,7 +321,7 @@ impl Tokenizer {
                         offsets,
                         vec![0; length],
                         vec![1; length],
-                        None,
+                        vec![],
                     ))
                 })
                 .collect::<Result<Vec<Encoding>>>()?;

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -542,15 +542,19 @@ impl Tokenizer {
         if let Some(params) = &self.padding {
             // We can only pad for a given size. If the Strategy is BatchLongest, it will be done
             // when we handle a batch
-            if let PaddingStrategy::Fixed(size) = params.strategy {
-                final_encoding.pad(
-                    size,
-                    params.pad_id,
-                    params.pad_type_id,
-                    &params.pad_token,
-                    &params.direction,
-                );
-            }
+            let size = if let PaddingStrategy::Fixed(size) = params.strategy {
+                size
+            } else {
+                final_encoding.get_ids().len()
+            };
+
+            final_encoding.pad(
+                size,
+                params.pad_id,
+                params.pad_type_id,
+                &params.pad_token,
+                &params.direction,
+            );
         }
 
         Ok(final_encoding)


### PR DESCRIPTION
Applying truncation on an `Encoding` will now produce an output `Encoding` and populate its `overflowing` property with as many other `Encoding` as needed to cover all the possible combinations.

@thomwolf @mfuntowicz This should cover everything as we discussed it.