### PR TITLE
python: release action on tag push

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,8 +1,9 @@
 name: Python Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - python-v*
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
As discussed @n1t0: the python release action will be triggered when a `python-v*` tag is pushed in the repo instead of when a release is created.
It means that the release in itself will have to be created from the tag.