### PR TITLE
node: add tokenizer truncation / padding bindings

### DIFF
--- a/bindings/node/lib/bindings/encoding.d.ts
+++ b/bindings/node/lib/bindings/encoding.d.ts
@@ -1,0 +1,89 @@
+/**
+ * An Encoding as returned by the Tokenizer
+ */
+export interface Encoding {
+  /**
+   * Returns the attention mask
+   */
+  getAttentionMask(): number[];
+
+  /**
+   * Returns the tokenized ids
+   */
+  getIds(): number[];
+
+  /**
+   * Returns the offsets
+   */
+  getOffsets(): [number, number][];
+
+  /**
+   * Returns the overflowing encoding, after truncation
+   */
+  getOverflowing(): Encoding | undefined;
+
+  /**
+   * Returns the special tokens mask
+   */
+  getSpecialTokensMask(): number;
+
+  /**
+   * Returns the tokenized string
+   */
+  getTokens(): string[];
+
+  /**
+   * Returns the type ids
+   */
+  getTypeIds(): number[];
+
+  /**
+   * Returns the original string
+   *
+   * @param [begin] The index from which to start (can be negative).
+   * @param [end] The index (excluded) to which to stop (can be negative).
+   * Stopping at the end of the string if not provided.
+   * @returns The full original string if no parameter is provided,
+   * otherwise the original string between `begin` and `end`
+   */
+  getOriginalString(begin?: number, end?: number): string;
+
+  /**
+   * Pad the current Encoding at the given length
+   *
+   * @param length The length at which to pad
+   * @param [options] Padding options
+   */
+  pad(length: number, options?: PaddingOptions): void;
+
+  /**
+   * Truncate the current Encoding at the given max_length
+   *
+   * @param length The maximum length to be kept
+   * @param [stride=0] The length of the previous first sequence
+   * to be included in the overflowing sequence
+   */
+  truncate(length: number, stride?: number): void;
+}
+
+interface PaddingOptions {
+  /**
+   * @default "right"
+   */
+  direction?: "left" | "right";
+  /**
+   * The index to be used when padding
+   * @default 0
+   */
+  padId?: number;
+  /**
+   * The type index to be used when padding
+   * @default 0
+   */
+  padTypeId?: number;
+  /**
+   * The pad token to be used when padding
+   * @default "[PAD]"
+   */
+  padToken?: string;
+}

--- a/bindings/node/lib/bindings/encoding.test.ts
+++ b/bindings/node/lib/bindings/encoding.test.ts
@@ -1,7 +1,8 @@
 import { promisify } from "util";
 
+import { Encoding } from "./encoding";
 import { BPE } from "./models";
-import { Encoding, Tokenizer } from "./tokenizer";
+import { Tokenizer } from "./tokenizer";
 
 describe("Encoding", () => {
   const originalString = "my name is john";

--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -1,4 +1,5 @@
 import { Decoder } from "./decoders";
+import { Encoding } from "./encoding";
 import { Model } from "./models";
 import { Normalizer } from "./normalizers";
 import { PostProcessor } from "./post-processors";
@@ -186,94 +187,4 @@ export class Tokenizer {
    * @throws Will throw an error if the decoder is already used in another Tokenizer
    */
   setDecoder(decoder: Decoder): void;
-}
-
-/**
- * An Encoding as returned by the Tokenizer
- */
-interface Encoding {
-  /**
-   * Returns the attention mask
-   */
-  getAttentionMask(): number[];
-
-  /**
-   * Returns the tokenized ids
-   */
-  getIds(): number[];
-
-  /**
-   * Returns the offsets
-   */
-  getOffsets(): [number, number][];
-
-  /**
-   * Returns the overflowing encoding, after truncation
-   */
-  getOverflowing(): Encoding | undefined;
-
-  /**
-   * Returns the special tokens mask
-   */
-  getSpecialTokensMask(): number;
-
-  /**
-   * Returns the tokenized string
-   */
-  getTokens(): string[];
-
-  /**
-   * Returns the type ids
-   */
-  getTypeIds(): number[];
-
-  /**
-   * Returns the original string
-   *
-   * @param [begin] The index from which to start (can be negative).
-   * @param [end] The index (excluded) to which to stop (can be negative).
-   * Stopping at the end of the string if not provided.
-   * @returns The full original string if no parameter is provided,
-   * otherwise the original string between `begin` and `end`
-   */
-  getOriginalString(begin?: number, end?: number): string;
-
-  /**
-   * Pad the current Encoding at the given length
-   *
-   * @param length The length at which to pad
-   * @param [options] Padding options
-   */
-  pad(length: number, options?: PaddingOptions): void;
-
-  /**
-   * Truncate the current Encoding at the given max_length
-   *
-   * @param length The maximum length to be kept
-   * @param [stride=0] The length of the previous first sequence
-   * to be included in the overflowing sequence
-   */
-  truncate(length: number, stride?: number): void;
-}
-
-interface PaddingOptions {
-  /**
-   * @default "right"
-   */
-  direction?: "left" | "right";
-  /**
-   * The index to be used when padding
-   * @default 0
-   */
-  padId?: number;
-  /**
-   * The type index to be used when padding
-   * @default 0
-   */
-  padTypeId?: number;
-  /**
-   * The pad token to be used when padding
-   * @default "[PAD]"
-   */
-  padToken?: string;
 }

--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -23,6 +23,34 @@ export interface TruncationOptions {
   strategy?: "longest_first" | "only_first" | "only_second";
 }
 
+export interface PaddingOptions {
+  /**
+   * @default "right"
+   */
+  direction?: "left" | "right";
+  /**
+   * Padding length. If not provided:
+   * - Will default to the longest sequence when encoding in batch.
+   * - No padding will be applied when single encoding
+   */
+  maxLength?: number;
+  /**
+   * The index to be used when padding
+   * @default 0
+   */
+  padId?: number;
+  /**
+   * The type index to be used when padding
+   * @default 0
+   */
+  padTypeId?: number;
+  /**
+   * The pad token to be used when padding
+   * @default "[PAD]"
+   */
+  padToken?: string;
+}
+
 /**
  * A Tokenizer works as a pipeline, it processes some raw text as input and outputs
  * an `Encoding`.
@@ -119,6 +147,12 @@ export class Tokenizer {
    * @returns The corresponding id if it exists
    */
   tokenToId(token: string): number | undefined;
+
+  /**
+   * Enable/change padding with specified options
+   * @param [options] Padding options
+   */
+  setPadding(options?: PaddingOptions): void;
 
   /**
    * Enable/change truncation with specified options

--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -6,6 +6,23 @@ import { PostProcessor } from "./post-processors";
 import { PreTokenizer } from "./pre-tokenizers";
 import { Trainer } from "./trainers";
 
+export interface TruncationOptions {
+  /**
+   * The length of the previous sequence to be included in the overflowing sequence
+   * @default 0
+   */
+  stride?: number;
+  /**
+   * Strategy to use:
+   * - `longest_first` Iteratively reduce the inputs sequence until the input is under max_length
+   * starting from the longest one at each token (when there is a pair of input sequences).
+   * - `only_first` Only truncate the first sequence.
+   * - `only_second` Only truncate the second sequence.
+   * @default "longest_first"
+   */
+  strategy?: "longest_first" | "only_first" | "only_second";
+}
+
 /**
  * A Tokenizer works as a pipeline, it processes some raw text as input and outputs
  * an `Encoding`.
@@ -102,6 +119,14 @@ export class Tokenizer {
    * @returns The corresponding id if it exists
    */
   tokenToId(token: string): number | undefined;
+
+  /**
+   * Enable/change truncation with specified options
+   *
+   * @param maxLength The maximum length at which to truncate
+   * @param [options] Additional truncation options
+   */
+  setTruncation(maxLength: number, options?: TruncationOptions): void;
 
   /**
    * Train the model using the given files

--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -155,12 +155,22 @@ export class Tokenizer {
   setPadding(options?: PaddingOptions): void;
 
   /**
+   * Disable padding
+   */
+  disablePadding(): void;
+
+  /**
    * Enable/change truncation with specified options
    *
    * @param maxLength The maximum length at which to truncate
    * @param [options] Additional truncation options
    */
   setTruncation(maxLength: number, options?: TruncationOptions): void;
+
+  /**
+   * Disable truncation
+   */
+  disableTruncation(): void;
 
   /**
    * Train the model using the given files

--- a/bindings/node/lib/bindings/tokenizer.test.ts
+++ b/bindings/node/lib/bindings/tokenizer.test.ts
@@ -106,5 +106,56 @@ describe("Tokenizer", () => {
       expect(encoding.getTokens()).toEqual(["my", "name", "is", "john", "pair"]);
       expect(encoding.getTypeIds()).toEqual([0, 0, 0, 0, 1]);
     });
+
+    describe("when truncation is enabled", () => {
+      it("should truncate with default if no truncation options provided", async () => {
+        tokenizer.setTruncation(2);
+
+        const singleEncoding = await encode("my name is john", null);
+        expect(singleEncoding.getTokens()).toEqual(["my", "name"]);
+
+        const pairEncoding = await encode("my name is john", "pair");
+        expect(pairEncoding.getTokens()).toEqual(["my", "pair"]);
+      });
+
+      it("should throw an error with strategy `only_second` and no pair is encoded", async () => {
+        tokenizer.setTruncation(2, { strategy: "only_second" });
+        await expect(encode("my name is john", null)).rejects.toThrow();
+      });
+    });
+
+    describe("when padding is enabled", () => {
+      it("should not pad anything with default options", async () => {
+        tokenizer.setPadding();
+
+        const singleEncoding = await encode("my name", null);
+        expect(singleEncoding.getTokens()).toEqual(["my", "name"]);
+
+        const pairEncoding = await encode("my name", "pair");
+        expect(pairEncoding.getTokens()).toEqual(["my", "name", "pair"]);
+      });
+
+      it("should pad to the right by default", async () => {
+        tokenizer.setPadding({ maxLength: 5 });
+
+        const singleEncoding = await encode("my name", null);
+        expect(singleEncoding.getTokens()).toEqual([
+          "my",
+          "name",
+          "[PAD]",
+          "[PAD]",
+          "[PAD]"
+        ]);
+
+        const pairEncoding = await encode("my name", "pair");
+        expect(pairEncoding.getTokens()).toEqual([
+          "my",
+          "name",
+          "pair",
+          "[PAD]",
+          "[PAD]"
+        ]);
+      });
+    });
   });
 });

--- a/bindings/node/lib/bindings/tokenizer.test.ts
+++ b/bindings/node/lib/bindings/tokenizer.test.ts
@@ -1,5 +1,6 @@
 import { promisify } from "util";
 
+import { Encoding } from "./encoding";
 import { BPE } from "./models";
 import { Tokenizer } from "./tokenizer";
 
@@ -17,6 +18,36 @@ import { Tokenizer } from "./tokenizer";
 // const TokenizerMock = mocked(Tokenizer);
 
 describe("Tokenizer", () => {
+  it("has expected methods", () => {
+    const model = BPE.empty();
+    const tokenizer = new Tokenizer(model);
+
+    expect(typeof tokenizer.addSpecialTokens).toBe("function");
+    expect(typeof tokenizer.addTokens).toBe("function");
+    expect(typeof tokenizer.decode).toBe("function");
+    expect(typeof tokenizer.decodeBatch).toBe("function");
+    expect(typeof tokenizer.disablePadding).toBe("function");
+    expect(typeof tokenizer.disableTruncation).toBe("function");
+    expect(typeof tokenizer.encode).toBe("function");
+    expect(typeof tokenizer.encodeBatch).toBe("function");
+    expect(typeof tokenizer.getDecoder).toBe("function");
+    expect(typeof tokenizer.getNormalizer).toBe("function");
+    expect(typeof tokenizer.getPostProcessor).toBe("function");
+    expect(typeof tokenizer.getPreTokenizer).toBe("function");
+    expect(typeof tokenizer.getVocabSize).toBe("function");
+    expect(typeof tokenizer.idToToken).toBe("function");
+    expect(typeof tokenizer.runningTasks).toBe("function");
+    expect(typeof tokenizer.setDecoder).toBe("function");
+    expect(typeof tokenizer.setModel).toBe("function");
+    expect(typeof tokenizer.setNormalizer).toBe("function");
+    expect(typeof tokenizer.setPadding).toBe("function");
+    expect(typeof tokenizer.setPostProcessor).toBe("function");
+    expect(typeof tokenizer.setPreTokenizer).toBe("function");
+    expect(typeof tokenizer.setTruncation).toBe("function");
+    expect(typeof tokenizer.tokenToId).toBe("function");
+    expect(typeof tokenizer.train).toBe("function");
+  });
+
   describe("addTokens", () => {
     it("accepts a list of string as new tokens when initial model is empty", () => {
       const model = BPE.empty();
@@ -29,6 +60,7 @@ describe("Tokenizer", () => {
 
   describe("encode", () => {
     let tokenizer: Tokenizer;
+    let encode: (sequence: string, pair: string | null) => Promise<Encoding>;
 
     beforeEach(() => {
       // Clear all instances and calls to constructor and all methods:
@@ -37,26 +69,20 @@ describe("Tokenizer", () => {
       const model = BPE.empty();
       tokenizer = new Tokenizer(model);
       tokenizer.addTokens(["my", "name", "is", "john", "pair"]);
-    });
-
-    it("is a function w/ parameters", async () => {
-      expect(typeof tokenizer.encode).toBe("function");
+      encode = promisify(tokenizer.encode.bind(tokenizer));
     });
 
     it("accepts a pair of strings as parameters", async () => {
-      const encode = promisify(tokenizer.encode.bind(tokenizer));
       const encoding = await encode("my name is john", "pair");
       expect(encoding).toBeDefined();
     });
 
     it("accepts a string with a null pair", async () => {
-      const encode = promisify(tokenizer.encode.bind(tokenizer));
       const encoding = await encode("my name is john", null);
       expect(encoding).toBeDefined();
     });
 
     it("returns an Encoding", async () => {
-      const encode = promisify(tokenizer.encode.bind(tokenizer));
       const encoding = await encode("my name is john", "pair");
 
       expect(encoding.getAttentionMask()).toEqual([1, 1, 1, 1, 1]);

--- a/bindings/node/lib/index.ts
+++ b/bindings/node/lib/index.ts
@@ -1,2 +1,2 @@
-// export * from './bindings';
+// export * from "./bindings";
 export * from "./tokenizers";

--- a/bindings/node/lib/tokenizers/base.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/base.tokenizer.ts
@@ -1,7 +1,7 @@
 import { promisify } from "util";
 
 import { Encoding } from "../bindings/encoding";
-import { Tokenizer, TruncationOptions } from "../bindings/tokenizer";
+import { PaddingOptions, Tokenizer, TruncationOptions } from "../bindings/tokenizer";
 
 export { Encoding, TruncationOptions };
 
@@ -38,5 +38,13 @@ export class BaseTokenizer {
    */
   setTruncation(maxLength: number, options?: TruncationOptions): void {
     return this.tokenizer.setTruncation(maxLength, options);
+  }
+
+  /**
+   * Enable/change padding with specified options
+   * @param [options] Padding options
+   */
+  setPadding(options?: PaddingOptions): void {
+    return this.tokenizer.setPadding(options);
   }
 }

--- a/bindings/node/lib/tokenizers/base.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/base.tokenizer.ts
@@ -1,6 +1,9 @@
 import { promisify } from "util";
 
-import { Encoding, Tokenizer } from "../bindings/tokenizer";
+import { Encoding } from "../bindings/encoding";
+import { Tokenizer } from "../bindings/tokenizer";
+
+export { Encoding };
 
 export class BaseTokenizer {
   constructor(protected tokenizer: Tokenizer) {}

--- a/bindings/node/lib/tokenizers/base.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/base.tokenizer.ts
@@ -1,9 +1,9 @@
 import { promisify } from "util";
 
 import { Encoding } from "../bindings/encoding";
-import { Tokenizer } from "../bindings/tokenizer";
+import { Tokenizer, TruncationOptions } from "../bindings/tokenizer";
 
-export { Encoding };
+export { Encoding, TruncationOptions };
 
 export class BaseTokenizer {
   constructor(protected tokenizer: Tokenizer) {}
@@ -28,5 +28,15 @@ export class BaseTokenizer {
   async encodeBatch(sequences: (string | [string, string])[]): Promise<Encoding[]> {
     const encodeBatch = promisify(this.tokenizer.encodeBatch.bind(this.tokenizer));
     return encodeBatch(sequences);
+  }
+
+  /**
+   * Enable/change truncation with specified options
+   *
+   * @param maxLength The maximum length at which to truncate
+   * @param options Additional truncation options
+   */
+  setTruncation(maxLength: number, options?: TruncationOptions): void {
+    return this.tokenizer.setTruncation(maxLength, options);
   }
 }

--- a/bindings/node/lib/tokenizers/base.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/base.tokenizer.ts
@@ -41,10 +41,24 @@ export class BaseTokenizer {
   }
 
   /**
+   * Disable truncation
+   */
+  disableTruncation(): void {
+    return this.tokenizer.disableTruncation();
+  }
+
+  /**
    * Enable/change padding with specified options
    * @param [options] Padding options
    */
   setPadding(options?: PaddingOptions): void {
     return this.tokenizer.setPadding(options);
+  }
+
+  /**
+   * Disable padding
+   */
+  disablePadding(): void {
+    return this.tokenizer.disablePadding();
   }
 }

--- a/bindings/node/lib/tokenizers/index.ts
+++ b/bindings/node/lib/tokenizers/index.ts
@@ -1,3 +1,4 @@
+export { Encoding } from "./base.tokenizer";
 export * from "./bert-wordpiece.tokenizer";
 export * from "./bpe.tokenizer";
 export * from "./byte-level-bpe.tokenizer";

--- a/bindings/node/native/src/lib.rs
+++ b/bindings/node/native/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 extern crate neon;
 extern crate tokenizers as tk;
 

--- a/bindings/node/native/src/tokenizer.rs
+++ b/bindings/node/native/src/tokenizer.rs
@@ -345,6 +345,13 @@ declare_types! {
             Ok(cx.undefined().upcast())
         }
 
+        method disableTruncation(mut cx) {
+            let mut this = cx.this();
+            let guard = cx.lock();
+            this.borrow_mut(&guard).tokenizer.with_truncation(None);
+            Ok(cx.undefined().upcast())
+        }
+
         method setPadding(mut cx) {
             // setPadding(options?: { direction?: "left" | "right"; padId?: number?; padTypeId?: number?; padToken: string; maxLength?: number })
             let mut direction = PaddingDirection::Right;
@@ -408,6 +415,13 @@ declare_types! {
                 }));
             }
 
+            Ok(cx.undefined().upcast())
+        }
+
+        method disablePadding(mut cx) {
+            let mut this = cx.this();
+            let guard = cx.lock();
+            this.borrow_mut(&guard).tokenizer.with_padding(None);
             Ok(cx.undefined().upcast())
         }
 


### PR DESCRIPTION
I'm adding bindings I need for question answering in Node. For now:
- `tokenizer.setTruncation`
- `tokenizer.setPadding`