### PR TITLE
python: fix inverted normalized/original string range

### DIFF
--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -77,8 +77,8 @@ impl PyMappingProtocol for IndexableString {
 
         // Get the range from the relevant string
         let s = match self.t {
-            IndexableStringType::Original => self.s.get_range(range),
-            IndexableStringType::Normalized => self.s.get_range_original(range),
+            IndexableStringType::Original => self.s.get_range_original(range),
+            IndexableStringType::Normalized => self.s.get_range(range),
         };
 
         s.map(|s| s.to_owned())


### PR DESCRIPTION
If my understanding is correct, there was an inversion between the original and normalized string range (failing test related to https://github.com/huggingface/tokenizers/pull/109#issuecomment-580417438).