### PR TITLE
node: expose tokenizer configuration / truncation / padding

### DIFF
--- a/bindings/node/build.js
+++ b/bindings/node/build.js
@@ -117,9 +117,9 @@ function buildTs() {
 async function npmPublish() {
   shell.echo("PUBLISHING ON NPM...");
 
-  shell.cp("-r", ["lib/bindings"], distPath);
+  shell.cp("-ur", ["lib/bindings/**/*.{js,d.ts}"], `${distPath}/bindings/`);
   shell.mv([`${distPath}/bindings/native.prod.js`], [`${distPath}/bindings/native.js`]);
-  shell.rm("-r", [`${distPath}/**/*.test.ts`]);
+  // shell.rm("-r", [`${distPath}/**/*.test.ts`]); // No more remaining *.test.ts files for now at this step
 
   shell.cp("-r", ["package.json", "README.md", "../../LICENSE"], distPath);
 

--- a/bindings/node/jest.config.js
+++ b/bindings/node/jest.config.js
@@ -148,9 +148,10 @@ module.exports = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    "/dist/"
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/bindings/node/lib/bindings/encoding.d.ts
+++ b/bindings/node/lib/bindings/encoding.d.ts
@@ -1,3 +1,5 @@
+import { PaddingDirection } from "./enums";
+
 /**
  * An Encoding as returned by the Tokenizer
  */
@@ -70,7 +72,7 @@ interface PaddingOptions {
   /**
    * @default "right"
    */
-  direction?: "left" | "right";
+  direction?: PaddingDirection;
   /**
    * The index to be used when padding
    * @default 0

--- a/bindings/node/lib/bindings/enums.ts
+++ b/bindings/node/lib/bindings/enums.ts
@@ -1,0 +1,10 @@
+export enum TruncationStrategy {
+  LongestFirst = "longest_first",
+  OnlyFirst = "only_first",
+  OnlySecond = "only_second"
+}
+
+export enum PaddingDirection {
+  Left = "left",
+  Right = "right"
+}

--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -24,6 +24,16 @@ export interface TruncationOptions {
   strategy?: TruncationStrategy;
 }
 
+export interface TruncationConfiguration extends Required<TruncationOptions> {
+  /**
+   * The maximum length at which to truncate
+   */
+  maxLength: number;
+}
+
+export type PaddingConfiguration = Required<Omit<PaddingOptions, "maxLength">> &
+  Pick<PaddingOptions, "maxLength">;
+
 export interface PaddingOptions {
   /**
    * @default "right"
@@ -153,7 +163,7 @@ export class Tokenizer {
    * Enable/change padding with specified options
    * @param [options] Padding options
    */
-  setPadding(options?: PaddingOptions): void;
+  setPadding(options?: PaddingOptions): PaddingConfiguration;
 
   /**
    * Disable padding
@@ -166,7 +176,7 @@ export class Tokenizer {
    * @param maxLength The maximum length at which to truncate
    * @param [options] Additional truncation options
    */
-  setTruncation(maxLength: number, options?: TruncationOptions): void;
+  setTruncation(maxLength: number, options?: TruncationOptions): TruncationConfiguration;
 
   /**
    * Disable truncation

--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -1,5 +1,6 @@
 import { Decoder } from "./decoders";
 import { Encoding } from "./encoding";
+import { PaddingDirection, TruncationStrategy } from "./enums";
 import { Model } from "./models";
 import { Normalizer } from "./normalizers";
 import { PostProcessor } from "./post-processors";
@@ -20,14 +21,14 @@ export interface TruncationOptions {
    * - `only_second` Only truncate the second sequence.
    * @default "longest_first"
    */
-  strategy?: "longest_first" | "only_first" | "only_second";
+  strategy?: TruncationStrategy;
 }
 
 export interface PaddingOptions {
   /**
    * @default "right"
    */
-  direction?: "left" | "right";
+  direction?: PaddingDirection;
   /**
    * Padding length. If not provided:
    * - Will default to the longest sequence when encoding in batch.

--- a/bindings/node/lib/bindings/tokenizer.test.ts
+++ b/bindings/node/lib/bindings/tokenizer.test.ts
@@ -1,6 +1,7 @@
 import { promisify } from "util";
 
 import { Encoding } from "./encoding";
+import { TruncationStrategy } from "./enums";
 import { BPE } from "./models";
 import { Tokenizer } from "./tokenizer";
 
@@ -119,7 +120,7 @@ describe("Tokenizer", () => {
       });
 
       it("throws an error with strategy `only_second` and no pair is encoded", async () => {
-        tokenizer.setTruncation(2, { strategy: "only_second" });
+        tokenizer.setTruncation(2, { strategy: TruncationStrategy.OnlySecond });
         await expect(encode("my name is john", null)).rejects.toThrow();
       });
     });

--- a/bindings/node/lib/bindings/tokenizer.test.ts
+++ b/bindings/node/lib/bindings/tokenizer.test.ts
@@ -1,9 +1,9 @@
 import { promisify } from "util";
 
 import { Encoding } from "./encoding";
-import { TruncationStrategy } from "./enums";
+import { PaddingDirection, TruncationStrategy } from "./enums";
 import { BPE } from "./models";
-import { Tokenizer } from "./tokenizer";
+import { PaddingConfiguration, Tokenizer, TruncationConfiguration } from "./tokenizer";
 
 // jest.mock('../bindings/tokenizer');
 // jest.mock('../bindings/models', () => ({
@@ -156,6 +156,31 @@ describe("Tokenizer", () => {
           "[PAD]",
           "[PAD]"
         ]);
+      });
+    });
+
+    describe("setTruncation", () => {
+      it("returns the full truncation configuration", () => {
+        const truncation = tokenizer.setTruncation(2);
+        const expectedConfig: TruncationConfiguration = {
+          maxLength: 2,
+          strategy: TruncationStrategy.LongestFirst,
+          stride: 0
+        };
+        expect(truncation).toEqual(expectedConfig);
+      });
+    });
+
+    describe("setPadding", () => {
+      it("returns the full padding params", () => {
+        const padding = tokenizer.setPadding();
+        const expectedConfig: PaddingConfiguration = {
+          direction: PaddingDirection.Right,
+          padId: 0,
+          padToken: "[PAD]",
+          padTypeId: 0
+        };
+        expect(padding).toEqual(expectedConfig);
       });
     });
   });

--- a/bindings/node/lib/index.ts
+++ b/bindings/node/lib/index.ts
@@ -1,2 +1,5 @@
 // export * from "./bindings";
 export * from "./tokenizers";
+export * from "./bindings/enums";
+export { PaddingOptions, TruncationOptions } from "./bindings/tokenizer";
+export { Encoding } from "./bindings/encoding";

--- a/bindings/node/lib/tokenizers/base.tokenizer.test.ts
+++ b/bindings/node/lib/tokenizers/base.tokenizer.test.ts
@@ -1,0 +1,66 @@
+import { PaddingDirection, TruncationStrategy } from "../bindings/enums";
+import { BPE } from "../bindings/models";
+import {
+  PaddingConfiguration,
+  Tokenizer,
+  TruncationConfiguration
+} from "../bindings/tokenizer";
+import { BaseTokenizer } from "./base.tokenizer";
+
+describe("BaseTokenizer", () => {
+  let tokenizer: BaseTokenizer<{}>;
+
+  beforeEach(() => {
+    // Clear all instances and calls to constructor and all methods:
+    // TokenizerMock.mockClear();
+
+    const model = BPE.empty();
+    const t = new Tokenizer(model);
+    tokenizer = new BaseTokenizer(t, {});
+  });
+
+  describe("truncation", () => {
+    it("returns `null` if no truncation setted", () => {
+      expect(tokenizer.truncation).toBeNull();
+    });
+
+    it("returns configuration when `setTruncation` has been called", () => {
+      tokenizer.setTruncation(2);
+      const expectedConfig: TruncationConfiguration = {
+        maxLength: 2,
+        strategy: TruncationStrategy.LongestFirst,
+        stride: 0
+      };
+      expect(tokenizer.truncation).toEqual(expectedConfig);
+    });
+
+    it("returns null when `disableTruncation` has been called", () => {
+      tokenizer.setTruncation(2);
+      tokenizer.disableTruncation();
+      expect(tokenizer.truncation).toBeNull();
+    });
+  });
+
+  describe("padding", () => {
+    it("returns `null` if no padding setted", () => {
+      expect(tokenizer.padding).toBeNull();
+    });
+
+    it("returns configuration when `setPadding` has been called", () => {
+      tokenizer.setPadding();
+      const expectedConfig: PaddingConfiguration = {
+        direction: PaddingDirection.Right,
+        padId: 0,
+        padToken: "[PAD]",
+        padTypeId: 0
+      };
+      expect(tokenizer.padding).toEqual(expectedConfig);
+    });
+
+    it("returns null when `disablePadding` has been called", () => {
+      tokenizer.setPadding();
+      tokenizer.disablePadding();
+      expect(tokenizer.padding).toBeNull();
+    });
+  });
+});

--- a/bindings/node/lib/tokenizers/base.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/base.tokenizer.ts
@@ -3,9 +3,16 @@ import { promisify } from "util";
 import { Encoding } from "../bindings/encoding";
 import { PaddingOptions, Tokenizer, TruncationOptions } from "../bindings/tokenizer";
 
+export class BaseTokenizer<TConfig extends object> {
 
-export class BaseTokenizer {
-  constructor(protected tokenizer: Tokenizer) {}
+  constructor(
+    protected tokenizer: Tokenizer,
+    /**
+     * @since 0.4.0
+     */
+    readonly configuration: Readonly<TConfig>
+  ) {}
+
 
   /**
    * Add the given tokens to the vocabulary

--- a/bindings/node/lib/tokenizers/base.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/base.tokenizer.ts
@@ -3,7 +3,6 @@ import { promisify } from "util";
 import { Encoding } from "../bindings/encoding";
 import { PaddingOptions, Tokenizer, TruncationOptions } from "../bindings/tokenizer";
 
-export { Encoding, TruncationOptions };
 
 export class BaseTokenizer {
   constructor(protected tokenizer: Tokenizer) {}

--- a/bindings/node/lib/tokenizers/base.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/base.tokenizer.ts
@@ -1,9 +1,17 @@
 import { promisify } from "util";
 
 import { Encoding } from "../bindings/encoding";
-import { PaddingOptions, Tokenizer, TruncationOptions } from "../bindings/tokenizer";
+import {
+  PaddingConfiguration,
+  PaddingOptions,
+  Tokenizer,
+  TruncationConfiguration,
+  TruncationOptions
+} from "../bindings/tokenizer";
 
 export class BaseTokenizer<TConfig extends object> {
+  private _truncation?: TruncationConfiguration;
+  private _padding?: PaddingConfiguration;
 
   constructor(
     protected tokenizer: Tokenizer,
@@ -13,6 +21,27 @@ export class BaseTokenizer<TConfig extends object> {
     readonly configuration: Readonly<TConfig>
   ) {}
 
+  /**
+   * Truncation configuration if enabled, `null` otherwise.
+   *
+   * @see {@link BaseTokenizer#setTruncation} to change truncation configuration
+   * @see {@link BaseTokenizer#disableTruncation} to disable truncation
+   * @since 0.4.0
+   */
+  get truncation(): Readonly<TruncationConfiguration> | null {
+    return this._truncation ?? null;
+  }
+
+  /**
+   * Padding configuration if enabled, `null` otherwise
+   *
+   * @see {@link BaseTokenizer#setPadding} to change padding configuration
+   * @see {@link BaseTokenizer#disablePadding} to disable padding
+   * @since 0.4.0
+   */
+  get padding(): Readonly<PaddingConfiguration> | null {
+    return this._padding ?? null;
+  }
 
   /**
    * Add the given tokens to the vocabulary
@@ -65,31 +94,40 @@ export class BaseTokenizer<TConfig extends object> {
    *
    * @param maxLength The maximum length at which to truncate
    * @param options Additional truncation options
+   * @returns Full truncation configuration
    */
-  setTruncation(maxLength: number, options?: TruncationOptions): void {
-    return this.tokenizer.setTruncation(maxLength, options);
+  setTruncation(
+    maxLength: number,
+    options?: TruncationOptions
+  ): Readonly<TruncationConfiguration> {
+    const result = this.tokenizer.setTruncation(maxLength, options);
+    return (this._truncation = result);
   }
 
   /**
    * Disable truncation
    */
   disableTruncation(): void {
-    return this.tokenizer.disableTruncation();
+    this.tokenizer.disableTruncation();
+    delete this._truncation;
   }
 
   /**
    * Enable/change padding with specified options
    * @param [options] Padding options
+   * @returns Full padding configuration
    */
-  setPadding(options?: PaddingOptions): void {
-    return this.tokenizer.setPadding(options);
+  setPadding(options?: PaddingOptions): Readonly<PaddingConfiguration> {
+    const result = this.tokenizer.setPadding(options);
+    return (this._padding = result);
   }
 
   /**
    * Disable padding
    */
   disablePadding(): void {
-    return this.tokenizer.disablePadding();
+    this.tokenizer.disablePadding();
+    delete this._padding;
   }
 
   /**

--- a/bindings/node/lib/tokenizers/bert-wordpiece.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/bert-wordpiece.tokenizer.ts
@@ -80,13 +80,15 @@ export interface BertWordPieceTrainOptions {
   wordpiecesPrefix?: string;
 }
 
+type BertTokenizerConfig = Required<Omit<BertWordPieceOptions, "vocabFile">> & {
+  vocabFile?: string;
+};
+
 /**
  * Bert WordPiece Tokenizer
  */
-export class BertWordPieceTokenizer extends BaseTokenizer {
-  private static readonly defaultBertOptions: Required<
-    Omit<BertWordPieceOptions, "vocabFile">
-  > & { vocabFile?: string } = {
+export class BertWordPieceTokenizer extends BaseTokenizer<BertTokenizerConfig> {
+  private static readonly defaultBertOptions: BertTokenizerConfig = {
     addSpecialTokens: true,
     cleanText: true,
     clsToken: "[CLS]",
@@ -108,8 +110,8 @@ export class BertWordPieceTokenizer extends BaseTokenizer {
     wordpiecesPrefix: "##"
   };
 
-  private constructor(tokenizer: Tokenizer) {
-    super(tokenizer);
+  private constructor(tokenizer: Tokenizer, configuration: BertTokenizerConfig) {
+    super(tokenizer, configuration);
   }
 
   /**
@@ -158,7 +160,7 @@ export class BertWordPieceTokenizer extends BaseTokenizer {
     const decoder = wordPieceDecoder(opts.wordpiecesPrefix);
     tokenizer.setDecoder(decoder);
 
-    return new BertWordPieceTokenizer(tokenizer);
+    return new BertWordPieceTokenizer(tokenizer, opts);
   }
 
   /**

--- a/bindings/node/lib/tokenizers/bpe.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/bpe.tokenizer.ts
@@ -57,13 +57,15 @@ export interface BPETokenizerTrainOptions {
   vocabSize?: number;
 }
 
+type BPETokenizerConfig = BPETokenizerOptions &
+  Required<Pick<BPETokenizerOptions, "unkToken" | "suffix">>;
+
 /**
  * Original BPE Tokenizer.
  * Represents the BPE algorithm, as introduced by Rico Sennrich (https://arxiv.org/abs/1508.07909)
  */
-export class BPETokenizer extends BaseTokenizer {
-  private static readonly defaultBPEOptions: BPETokenizerOptions &
-    Required<Pick<BPETokenizerOptions, "unkToken" | "suffix">> = {
+export class BPETokenizer extends BaseTokenizer<BPETokenizerConfig> {
+  private static readonly defaultBPEOptions: BPETokenizerConfig = {
     suffix: "</w>",
     unkToken: "<unk>"
   };
@@ -78,8 +80,8 @@ export class BPETokenizer extends BaseTokenizer {
     vocabSize: 30000
   };
 
-  private constructor(tokenizer: Tokenizer) {
-    super(tokenizer);
+  private constructor(tokenizer: Tokenizer, configuration: BPETokenizerConfig) {
+    super(tokenizer, configuration);
   }
 
   /**
@@ -114,7 +116,7 @@ export class BPETokenizer extends BaseTokenizer {
     const decoder = bpeDecoder(opts.suffix);
     tokenizer.setDecoder(decoder);
 
-    return new BPETokenizer(tokenizer);
+    return new BPETokenizer(tokenizer, opts);
   }
 
   /**

--- a/bindings/node/lib/tokenizers/byte-level-bpe.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/byte-level-bpe.tokenizer.ts
@@ -34,12 +34,14 @@ export interface ByteLevelBPETrainOptions {
   vocabSize?: number;
 }
 
+type ByteLevelBPETokenizerConfig = ByteLevelBPETokenizerOptions &
+  Required<Pick<ByteLevelBPETokenizerOptions, "addPrefixSpace">>;
+
 /**
  * Represents a Byte-level BPE as introduced by OpenAI with their GPT-2 model
  */
-export class ByteLevelBPETokenizer extends BaseTokenizer {
-  private static readonly defaultOptions: ByteLevelBPETokenizerOptions &
-    Required<Pick<ByteLevelBPETokenizerOptions, "addPrefixSpace">> = {
+export class ByteLevelBPETokenizer extends BaseTokenizer<ByteLevelBPETokenizerConfig> {
+  private static readonly defaultOptions: ByteLevelBPETokenizerConfig = {
     addPrefixSpace: false
   };
 
@@ -50,8 +52,8 @@ export class ByteLevelBPETokenizer extends BaseTokenizer {
     vocabSize: 30000
   };
 
-  private constructor(tokenizer: Tokenizer) {
-    super(tokenizer);
+  private constructor(tokenizer: Tokenizer, configuration: ByteLevelBPETokenizerConfig) {
+    super(tokenizer, configuration);
   }
 
   static async fromOptions(
@@ -75,7 +77,7 @@ export class ByteLevelBPETokenizer extends BaseTokenizer {
     tokenizer.setPreTokenizer(preTokenizer);
     tokenizer.setDecoder(byteLevelDecoder());
 
-    return new ByteLevelBPETokenizer(tokenizer);
+    return new ByteLevelBPETokenizer(tokenizer, opts);
   }
 
   /**

--- a/bindings/node/lib/tokenizers/index.ts
+++ b/bindings/node/lib/tokenizers/index.ts
@@ -1,4 +1,3 @@
-export { Encoding } from "./base.tokenizer";
 export * from "./bert-wordpiece.tokenizer";
 export * from "./bpe.tokenizer";
 export * from "./byte-level-bpe.tokenizer";

--- a/bindings/node/lib/tokenizers/sentence-piece-bpe.tokenizer.ts
+++ b/bindings/node/lib/tokenizers/sentence-piece-bpe.tokenizer.ts
@@ -54,12 +54,16 @@ export interface SentencePieceBPETrainOptions {
   vocabSize?: number;
 }
 
+type SentencePieceBPETokenizerConfig = SentencePieceBPETokenizerOptions &
+  Required<OptionsWithDefaults>;
+
 /**
  * Represents the BPE algorithm, with the pretokenization used by SentencePiece
  */
-export class SentencePieceBPETokenizer extends BaseTokenizer {
-  private static readonly defaultOptions: SentencePieceBPETokenizerOptions &
-    Required<OptionsWithDefaults> = {
+export class SentencePieceBPETokenizer extends BaseTokenizer<
+  SentencePieceBPETokenizerConfig
+> {
+  private static readonly defaultOptions: SentencePieceBPETokenizerConfig = {
     addPrefixSpace: true,
     replacement: "▁",
     unkToken: "<unk>"
@@ -74,8 +78,11 @@ export class SentencePieceBPETokenizer extends BaseTokenizer {
     vocabSize: 30000
   };
 
-  private constructor(tokenizer: Tokenizer) {
-    super(tokenizer);
+  private constructor(
+    tokenizer: Tokenizer,
+    configuration: SentencePieceBPETokenizerConfig
+  ) {
+    super(tokenizer, configuration);
   }
 
   static async fromOptions(
@@ -107,7 +114,7 @@ export class SentencePieceBPETokenizer extends BaseTokenizer {
     const decoder = metaspaceDecoder(opts.replacement, opts.addPrefixSpace);
     tokenizer.setDecoder(decoder);
 
-    return new SentencePieceBPETokenizer(tokenizer);
+    return new SentencePieceBPETokenizer(tokenizer, opts);
   }
 
   /**

--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -244,7 +244,7 @@ declare_types! {
             let mut this = cx.this();
             let guard = cx.lock();
             this.borrow_mut(&guard).encoding.execute_mut(|encoding| {
-                encoding.unwrap().pad(length, pad_id, pad_type_id, &pad_token, &direction);
+                encoding.unwrap().pad(length, pad_id, pad_type_id, &pad_token, direction);
             });
 
             Ok(cx.undefined().upcast())

--- a/bindings/node/native/src/tokenizer.rs
+++ b/bindings/node/native/src/tokenizer.rs
@@ -342,7 +342,16 @@ declare_types! {
                 }));
             }
 
-            Ok(cx.undefined().upcast())
+            let params_object = JsObject::new(&mut cx);
+            let obj_length = cx.number(max_length as f64);
+            let obj_stride = cx.number(stride as f64);
+            let obj_strat = cx.string(strategy);
+
+            params_object.set(&mut cx, "maxLength", obj_length).unwrap();
+            params_object.set(&mut cx, "stride", obj_stride).unwrap();
+            params_object.set(&mut cx, "strategy", obj_strat).unwrap();
+
+            Ok(params_object.upcast())
         }
 
         method disableTruncation(mut cx) {
@@ -402,6 +411,20 @@ declare_types! {
                 PaddingStrategy::BatchLongest
             };
 
+            let params_object = JsObject::new(&mut cx);
+            if let Some(max_length) = max_length {
+                let obj_length = cx.number(max_length as f64);
+                params_object.set(&mut cx, "maxLength", obj_length).unwrap();
+            }
+            let obj_pad_id = cx.number(pad_id);
+            let obj_pad_type_id = cx.number(pad_type_id);
+            let obj_pad_token = cx.string(&pad_token);
+            let obj_direction = cx.string(&direction);
+            params_object.set(&mut cx, "padId", obj_pad_id).unwrap();
+            params_object.set(&mut cx, "padTypeId", obj_pad_type_id).unwrap();
+            params_object.set(&mut cx, "padToken", obj_pad_token).unwrap();
+            params_object.set(&mut cx, "direction", obj_direction).unwrap();
+
             let mut this = cx.this();
             {
                 let guard = cx.lock();
@@ -415,7 +438,7 @@ declare_types! {
                 }));
             }
 
-            Ok(cx.undefined().upcast())
+            Ok(params_object.upcast())
         }
 
         method disablePadding(mut cx) {

--- a/bindings/node/native/src/tokenizer.rs
+++ b/bindings/node/native/src/tokenizer.rs
@@ -411,20 +411,6 @@ declare_types! {
                 PaddingStrategy::BatchLongest
             };
 
-            let params_object = JsObject::new(&mut cx);
-            if let Some(max_length) = max_length {
-                let obj_length = cx.number(max_length as f64);
-                params_object.set(&mut cx, "maxLength", obj_length).unwrap();
-            }
-            let obj_pad_id = cx.number(pad_id);
-            let obj_pad_type_id = cx.number(pad_type_id);
-            let obj_pad_token = cx.string(&pad_token);
-            let obj_direction = cx.string(&direction);
-            params_object.set(&mut cx, "padId", obj_pad_id).unwrap();
-            params_object.set(&mut cx, "padTypeId", obj_pad_type_id).unwrap();
-            params_object.set(&mut cx, "padToken", obj_pad_token).unwrap();
-            params_object.set(&mut cx, "direction", obj_direction).unwrap();
-
             let mut this = cx.this();
             {
                 let guard = cx.lock();
@@ -437,6 +423,20 @@ declare_types! {
                     pad_token: pad_token.to_owned(),
                 }));
             }
+
+            let params_object = JsObject::new(&mut cx);
+            if let Some(max_length) = max_length {
+                let obj_length = cx.number(max_length as f64);
+                params_object.set(&mut cx, "maxLength", obj_length).unwrap();
+            }
+            let obj_pad_id = cx.number(pad_id);
+            let obj_pad_type_id = cx.number(pad_type_id);
+            let obj_pad_token = cx.string(pad_token);
+            let obj_direction = cx.string(direction);
+            params_object.set(&mut cx, "padId", obj_pad_id).unwrap();
+            params_object.set(&mut cx, "padTypeId", obj_pad_type_id).unwrap();
+            params_object.set(&mut cx, "padToken", obj_pad_token).unwrap();
+            params_object.set(&mut cx, "direction", obj_direction).unwrap();
 
             Ok(params_object.upcast())
         }

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -35,7 +35,7 @@
     "node": ">=10 < 11 || >=12 <14"
   },
   "scripts": {
-    "dev-ts": "rm -rf dist && tsc -p tsconfig.lib.json && ln -s $(pwd)/lib/bindings dist/bindings",
+    "dev-ts": "rm -rf dist && tsc -p tsconfig.lib.json && rsync -a $(pwd)/lib/bindings/ dist/bindings/",
     "dev-rs": "neon build",
     "dev": "npm run dev-rs && npm run dev-ts",
     "compile": "neon build --release",

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -253,7 +253,7 @@ impl Encoding {
 
         Ok(self
             .encoding
-            .pad(length, pad_id, pad_type_id, pad_token, &direction))
+            .pad(length, pad_id, pad_type_id, pad_token, direction))
     }
 
     #[args(kwargs = "**")]

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -1,7 +1,7 @@
 use crate::tokenizer::NormalizedString;
 
 /// The various possible padding directions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum PaddingDirection {
     Left,
     Right,
@@ -219,7 +219,7 @@ impl Encoding {
         pad_id: u32,
         pad_type_id: u32,
         pad_token: &str,
-        direction: &PaddingDirection,
+        direction: PaddingDirection,
     ) {
         if self.ids.len() > target_length {
             // We just do nothing if the wanted padding length is smaller than us

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -7,6 +7,15 @@ pub enum PaddingDirection {
     Right,
 }
 
+impl std::convert::AsRef<str> for PaddingDirection {
+    fn as_ref(&self) -> &str {
+        match self {
+            PaddingDirection::Left => "left",
+            PaddingDirection::Right => "right",
+        }
+    }
+}
+
 /// Represents the output of a `Tokenizer`.
 #[derive(Default, PartialEq, Debug, Clone)]
 pub struct Encoding {

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -553,7 +553,7 @@ impl Tokenizer {
                 params.pad_id,
                 params.pad_type_id,
                 &params.pad_token,
-                &params.direction,
+                params.direction,
             );
         }
 

--- a/tokenizers/src/utils.rs
+++ b/tokenizers/src/utils.rs
@@ -139,7 +139,7 @@ pub fn pad_encodings(
             params.pad_id,
             params.pad_type_id,
             &params.pad_token,
-            &params.direction,
+            params.direction,
         );
     }
 

--- a/tokenizers/src/utils.rs
+++ b/tokenizers/src/utils.rs
@@ -50,6 +50,16 @@ pub enum TruncationStrategy {
     OnlySecond,
 }
 
+impl std::convert::AsRef<str> for TruncationStrategy {
+    fn as_ref(&self) -> &str {
+        match self {
+            TruncationStrategy::LongestFirst => "longest_first",
+            TruncationStrategy::OnlyFirst => "only_first",
+            TruncationStrategy::OnlySecond => "only_second",
+        }
+    }
+}
+
 pub fn truncate_encodings(
     mut encoding: Encoding,
     mut pair_encoding: Option<Encoding>,


### PR DESCRIPTION
Add a few new APIs to Node bindings:
- `configuration` on tokenizers implementations
- `truncation` and `padding` configurations, which are now returned by `setPadding` and `setTruncation` methods