### PR TITLE
Initialize Normalizer using .new, not constructor

### DIFF
--- a/bindings/python/tokenizers/normalizers/__init__.py
+++ b/bindings/python/tokenizers/normalizers/__init__.py
@@ -25,4 +25,4 @@ def unicode_normalizer_from_str(normalizer: str) -> Normalizer:
                 .format(normalizer, NORMALIZERS.keys())
         )
 
-    return NORMALIZERS[normalizer]()
+    return NORMALIZERS[normalizer].new()


### PR DESCRIPTION
Normalizers are initialised using .new and not __init__