### PR TITLE
Python: Implement __new__ to make constructor available

### DIFF
--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -26,25 +26,25 @@ impl Decoder {
     }
 }
 
-#[pyclass]
+#[pyclass(extends=Decoder)]
 pub struct ByteLevel {}
 #[pymethods]
 impl ByteLevel {
-    #[staticmethod]
-    fn new() -> PyResult<Decoder> {
-        Ok(Decoder {
+    #[new]
+    fn new(obj: &PyRawObject) -> PyResult<()> {
+        Ok(obj.init(Decoder {
             decoder: Container::Owned(Box::new(tk::decoders::byte_level::ByteLevel::new(false))),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=Decoder)]
 pub struct WordPiece {}
 #[pymethods]
 impl WordPiece {
-    #[staticmethod]
+    #[new]
     #[args(kwargs="**")]
-    fn new(kwargs: Option<&PyDict>) -> PyResult<Decoder> {
+    fn new(obj: &PyRawObject, kwargs: Option<&PyDict>) -> PyResult<()> {
         let mut prefix = String::from("##");
 
         if let Some(kwargs) = kwargs {
@@ -53,19 +53,19 @@ impl WordPiece {
             }
         }
 
-        Ok(Decoder {
+        Ok(obj.init(Decoder {
             decoder: Container::Owned(Box::new(tk::decoders::wordpiece::WordPiece::new(prefix))),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=Decoder)]
 pub struct Metaspace {}
 #[pymethods]
 impl Metaspace {
-    #[staticmethod]
+    #[new]
     #[args(kwargs = "**")]
-    fn new(kwargs: Option<&PyDict>) -> PyResult<Decoder> {
+    fn new(obj: &PyRawObject, kwargs: Option<&PyDict>) -> PyResult<()> {
         let mut replacement = '▁';
         let mut add_prefix_space = true;
 
@@ -85,22 +85,22 @@ impl Metaspace {
             }
         }
 
-        Ok(Decoder {
+        Ok(obj.init(Decoder {
             decoder: Container::Owned(Box::new(tk::decoders::metaspace::Metaspace::new(
                 replacement,
                 add_prefix_space,
             ))),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=Decoder)]
 pub struct BPEDecoder {}
 #[pymethods]
 impl BPEDecoder {
-    #[staticmethod]
+    #[new]
     #[args(kwargs = "**")]
-    fn new(kwargs: Option<&PyDict>) -> PyResult<Decoder> {
+    fn new(obj: &PyRawObject, kwargs: Option<&PyDict>) -> PyResult<()> {
         let mut suffix = String::from("</w");
 
         if let Some(kwargs) = kwargs {
@@ -113,9 +113,9 @@ impl BPEDecoder {
             }
         }
 
-        Ok(Decoder {
+        Ok(obj.init(Decoder {
             decoder: Container::Owned(Box::new(tk::decoders::bpe::BPEDecoder::new(suffix))),
-        })
+        }))
     }
 }
 

--- a/bindings/python/src/normalizers.rs
+++ b/bindings/python/src/normalizers.rs
@@ -10,13 +10,13 @@ pub struct Normalizer {
     pub normalizer: Container<dyn tk::tokenizer::Normalizer + Sync>,
 }
 
-#[pyclass]
+#[pyclass(extends=Normalizer)]
 pub struct BertNormalizer {}
 #[pymethods]
 impl BertNormalizer {
-    #[staticmethod]
+    #[new]
     #[args(kwargs = "**")]
-    fn new(kwargs: Option<&PyDict>) -> PyResult<Normalizer> {
+    fn new(obj: &PyRawObject, kwargs: Option<&PyDict>) -> PyResult<()> {
         let mut clean_text = true;
         let mut handle_chinese_chars = true;
         let mut strip_accents = true;
@@ -35,71 +35,71 @@ impl BertNormalizer {
             }
         }
 
-        Ok(Normalizer {
+        Ok(obj.init(Normalizer {
             normalizer: Container::Owned(Box::new(tk::normalizers::bert::BertNormalizer::new(
                 clean_text,
                 handle_chinese_chars,
                 strip_accents,
                 lowercase,
             ))),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=Normalizer)]
 pub struct NFD {}
 #[pymethods]
 impl NFD {
-    #[staticmethod]
-    fn new() -> PyResult<Normalizer> {
-        Ok(Normalizer {
+    #[new]
+    fn new(obj: &PyRawObject) -> PyResult<()> {
+        Ok(obj.init(Normalizer {
             normalizer: Container::Owned(Box::new(tk::normalizers::unicode::NFD)),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=Normalizer)]
 pub struct NFKD {}
 #[pymethods]
 impl NFKD {
-    #[staticmethod]
-    fn new() -> PyResult<Normalizer> {
-        Ok(Normalizer {
+    #[new]
+    fn new(obj: &PyRawObject) -> PyResult<()> {
+        Ok(obj.init(Normalizer {
             normalizer: Container::Owned(Box::new(tk::normalizers::unicode::NFKD)),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=Normalizer)]
 pub struct NFC {}
 #[pymethods]
 impl NFC {
-    #[staticmethod]
-    fn new() -> PyResult<Normalizer> {
-        Ok(Normalizer {
+    #[new]
+    fn new(obj: &PyRawObject) -> PyResult<()> {
+        Ok(obj.init(Normalizer {
             normalizer: Container::Owned(Box::new(tk::normalizers::unicode::NFC)),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=Normalizer)]
 pub struct NFKC {}
 #[pymethods]
 impl NFKC {
-    #[staticmethod]
-    fn new() -> PyResult<Normalizer> {
-        Ok(Normalizer {
+    #[new]
+    fn new(obj: &PyRawObject) -> PyResult<()> {
+        Ok(obj.init(Normalizer {
             normalizer: Container::Owned(Box::new(tk::normalizers::unicode::NFKC)),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=Normalizer)]
 pub struct Sequence {}
 #[pymethods]
 impl Sequence {
-    #[staticmethod]
-    fn new(normalizers: &PyList) -> PyResult<Normalizer> {
+    #[new]
+    fn new(obj: &PyRawObject, normalizers: &PyList) -> PyResult<()> {
         let normalizers = normalizers
             .iter()
             .map(|n| {
@@ -114,22 +114,22 @@ impl Sequence {
             })
             .collect::<PyResult<_>>()?;
 
-        Ok(Normalizer {
+        Ok(obj.init(Normalizer {
             normalizer: Container::Owned(Box::new(tk::normalizers::utils::Sequence::new(
                 normalizers,
             ))),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=Normalizer)]
 pub struct Lowercase {}
 #[pymethods]
 impl Lowercase {
-    #[staticmethod]
-    fn new() -> PyResult<Normalizer> {
-        Ok(Normalizer {
+    #[new]
+    fn new(obj: &PyRawObject) -> PyResult<()> {
+        Ok(obj.init(Normalizer {
             normalizer: Container::Owned(Box::new(tk::normalizers::utils::Lowercase)),
-        })
+        }))
     }
 }

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -26,13 +26,13 @@ impl PreTokenizer {
     }
 }
 
-#[pyclass]
+#[pyclass(extends=PreTokenizer)]
 pub struct ByteLevel {}
 #[pymethods]
 impl ByteLevel {
-    #[staticmethod]
+    #[new]
     #[args(kwargs = "**")]
-    fn new(kwargs: Option<&PyDict>) -> PyResult<PreTokenizer> {
+    fn new(obj: &PyRawObject, kwargs: Option<&PyDict>) -> PyResult<()> {
         let mut add_prefix_space = true;
 
         if let Some(kwargs) = kwargs {
@@ -45,11 +45,11 @@ impl ByteLevel {
             }
         }
 
-        Ok(PreTokenizer {
+        Ok(obj.init(PreTokenizer {
             pretok: Container::Owned(Box::new(tk::pre_tokenizers::byte_level::ByteLevel::new(
                 add_prefix_space,
             ))),
-        })
+        }))
     }
 
     #[staticmethod]
@@ -61,66 +61,66 @@ impl ByteLevel {
     }
 }
 
-#[pyclass]
+#[pyclass(extends=PreTokenizer)]
 pub struct Whitespace {}
 #[pymethods]
 impl Whitespace {
-    #[staticmethod]
-    fn new() -> PyResult<PreTokenizer> {
-        Ok(PreTokenizer {
+    #[new]
+    fn new(obj: &PyRawObject) -> PyResult<()> {
+        Ok(obj.init(PreTokenizer {
             pretok: Container::Owned(Box::new(tk::pre_tokenizers::whitespace::Whitespace)),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=PreTokenizer)]
 pub struct WhitespaceSplit {}
 #[pymethods]
 impl WhitespaceSplit {
-    #[staticmethod]
-    fn new() -> PyResult<PreTokenizer> {
-        Ok(PreTokenizer {
+    #[new]
+    fn new(obj: &PyRawObject) -> PyResult<()> {
+        Ok(obj.init(PreTokenizer {
             pretok: Container::Owned(Box::new(tk::pre_tokenizers::whitespace::WhitespaceSplit)),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=PreTokenizer)]
 pub struct CharDelimiterSplit {}
 #[pymethods]
 impl CharDelimiterSplit {
-    #[staticmethod]
-    pub fn new(delimiter: &str) -> PyResult<PreTokenizer> {
+    #[new]
+    pub fn new(obj: &PyRawObject, delimiter: &str) -> PyResult<()> {
         let chr_delimiter = delimiter.chars().nth(0).ok_or(exceptions::Exception::py_err(
             "delimiter must be a single character",
         ))?;
-        Ok(PreTokenizer{
+        Ok(obj.init(PreTokenizer{
             pretok:Container::Owned(Box::new(
                 tk::pre_tokenizers::delimiter::CharDelimiterSplit::new(chr_delimiter)
             ))
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=PreTokenizer)]
 pub struct BertPreTokenizer {}
 #[pymethods]
 impl BertPreTokenizer {
-    #[staticmethod]
-    fn new() -> PyResult<PreTokenizer> {
-        Ok(PreTokenizer {
+    #[new]
+    fn new(obj: &PyRawObject) -> PyResult<()> {
+        Ok(obj.init(PreTokenizer {
             pretok: Container::Owned(Box::new(tk::pre_tokenizers::bert::BertPreTokenizer)),
-        })
+        }))
     }
 }
 
-#[pyclass]
+#[pyclass(extends=PreTokenizer)]
 pub struct Metaspace {}
 #[pymethods]
 impl Metaspace {
-    #[staticmethod]
+    #[new]
     #[args(kwargs = "**")]
-    fn new(kwargs: Option<&PyDict>) -> PyResult<PreTokenizer> {
+    fn new(obj: &PyRawObject, kwargs: Option<&PyDict>) -> PyResult<()> {
         let mut replacement = '▁';
         let mut add_prefix_space = true;
 
@@ -140,12 +140,12 @@ impl Metaspace {
             }
         }
 
-        Ok(PreTokenizer {
+        Ok(obj.init(PreTokenizer {
             pretok: Container::Owned(Box::new(tk::pre_tokenizers::metaspace::Metaspace::new(
                 replacement,
                 add_prefix_space,
             ))),
-        })
+        }))
     }
 }
 

--- a/bindings/python/src/processors.rs
+++ b/bindings/python/src/processors.rs
@@ -8,31 +8,31 @@ pub struct PostProcessor {
     pub processor: Container<dyn tk::tokenizer::PostProcessor + Sync>,
 }
 
-#[pyclass]
+#[pyclass(extends=PostProcessor)]
 pub struct BertProcessing {}
 #[pymethods]
 impl BertProcessing {
-    #[staticmethod]
-    fn new(sep: (String, u32), cls: (String, u32)) -> PyResult<PostProcessor> {
-        Ok(PostProcessor {
+    #[new]
+    fn new(obj: &PyRawObject, sep: (String, u32), cls: (String, u32)) -> PyResult<()> {
+        Ok(obj.init(PostProcessor {
             processor: Container::Owned(Box::new(tk::processors::bert::BertProcessing::new(
                 sep, cls,
             ))),
-        })
+        }))
     }
 }
 
 
-#[pyclass]
+#[pyclass(extends=PostProcessor)]
 pub struct RobertaProcessing {}
 #[pymethods]
 impl RobertaProcessing {
-    #[staticmethod]
-    fn new(sep: (String, u32), cls: (String, u32)) -> PyResult<PostProcessor> {
-        Ok(PostProcessor {
+    #[new]
+    fn new(obj: &PyRawObject, sep: (String, u32), cls: (String, u32)) -> PyResult<()> {
+        Ok(obj.init(PostProcessor {
             processor: Container::Owned(Box::new(tk::processors::roberta::RobertaProcessing::new(
                 sep, cls,
             ))),
-        })
+        }))
     }
 }

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -9,7 +9,7 @@ pub struct Trainer {
     pub trainer: Container<dyn tk::tokenizer::Trainer>,
 }
 
-#[pyclass]
+#[pyclass(extends=Trainer)]
 pub struct BpeTrainer {}
 #[pymethods]
 impl BpeTrainer {
@@ -17,9 +17,9 @@ impl BpeTrainer {
     /// --
     ///
     /// Create a new BpeTrainer with the given configuration
-    #[staticmethod]
+    #[new]
     #[args(kwargs = "**")]
-    pub fn new(kwargs: Option<&PyDict>) -> PyResult<Trainer> {
+    pub fn new(obj: &PyRawObject, kwargs: Option<&PyDict>) -> PyResult<()> {
         let mut builder = tk::models::bpe::BpeTrainer::builder();
         if let Some(kwargs) = kwargs {
             for (key, val) in kwargs {
@@ -49,10 +49,9 @@ impl BpeTrainer {
                 };
             }
         }
-
-        Ok(Trainer {
+        Ok(obj.init(Trainer {
             trainer: Container::Owned(Box::new(builder.build())),
-        })
+        }))
     }
 }
 
@@ -64,9 +63,9 @@ impl WordPieceTrainer {
     /// --
     ///
     /// Create a new BpeTrainer with the given configuration
-    #[staticmethod]
+    #[new]
     #[args(kwargs = "**")]
-    pub fn new(kwargs: Option<&PyDict>) -> PyResult<Trainer> {
+    pub fn new(obj: &PyRawObject, kwargs: Option<&PyDict>) -> PyResult<()> {
         let mut builder = tk::models::wordpiece::WordPieceTrainer::builder();
         if let Some(kwargs) = kwargs {
             for (key, val) in kwargs {
@@ -97,8 +96,8 @@ impl WordPieceTrainer {
             }
         }
 
-        Ok(Trainer {
+        Ok(obj.init(Trainer {
             trainer: Container::Owned(Box::new(builder.build())),
-        })
+        }))
     }
 }

--- a/bindings/python/tokenizers/decoders/__init__.pyi
+++ b/bindings/python/tokenizers/decoders/__init__.pyi
@@ -14,8 +14,7 @@ class Decoder:
 class ByteLevel:
     """ ByteLevel Decoder """
 
-    @staticmethod
-    def new() -> Decoder:
+    def __init__(self) -> None:
         """ Instantiate a new ByteLevel Decoder """
         pass
 
@@ -23,7 +22,7 @@ class WordPiece:
     """ WordPiece Decoder """
 
     @staticmethod
-    def new(prefix: str="##") -> Decoder:
+    def __init__(self, prefix: str = "##") -> Decoder:
         """ Instantiate a new WordPiece Decoder
 
         Args:
@@ -35,9 +34,7 @@ class WordPiece:
 class Metaspace:
     """ Metaspace decoder """
 
-    @staticmethod
-    def new(replacement: str="▁",
-            add_prefix_space: bool=True) -> Decoder:
+    def __init__(self, replacement: str = "▁", add_prefix_space: bool = True) -> None:
         """ Instantiate a new Metaspace
 
         Args:
@@ -54,8 +51,7 @@ class Metaspace:
 class BPEDecoder:
     """ BPEDecoder """
 
-    @staticmethod
-    def new(suffix: str="</w>") -> Decoder:
+    def __init__(self, suffix: str = "</w>") -> None:
         """ Instantiate a new BPEDecoder
 
         Args:

--- a/bindings/python/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/tokenizers/implementations/bert_wordpiece.py
@@ -65,24 +65,27 @@ class BertWordPieceTokenizer(BaseTokenizer):
 
         super().__init__(tokenizer, parameters)
 
-    def train(self, files: Union[str, List[str]],
-              vocab_size: int=30000,
-              min_frequency: int=2,
-              limit_alphabet: int=1000,
-              initial_alphabet: List[str]=[],
-              special_tokens: List[str]=["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"],
-              show_progress: bool=True,
-              wordpieces_prefix: str="##"):
+    def train(
+        self,
+        files: Union[str, List[str]],
+        vocab_size: int = 30000,
+        min_frequency: int = 2,
+        limit_alphabet: int = 1000,
+        initial_alphabet: List[str] = [],
+        special_tokens: List[str] = ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"],
+        show_progress: bool = True,
+        wordpieces_prefix: str = "##",
+    ):
         """ Train the model using the given files """
 
-        trainer = trainers.WordPieceTrainer.new(
+        trainer = trainers.WordPieceTrainer(
             vocab_size=vocab_size,
             min_frequency=min_frequency,
             limit_alphabet=limit_alphabet,
             initial_alphabet=initial_alphabet,
             special_tokens=special_tokens,
             show_progress=show_progress,
-            continuing_subword_prefix=wordpieces_prefix
+            continuing_subword_prefix=wordpieces_prefix,
         )
         if isinstance(files, str):
             files = [files]

--- a/bindings/python/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/tokenizers/implementations/bert_wordpiece.py
@@ -7,20 +7,23 @@ from .base_tokenizer import BaseTokenizer
 
 from typing import Optional, List, Union
 
+
 class BertWordPieceTokenizer(BaseTokenizer):
     """ Bert WordPiece Tokenizer """
 
-    def __init__(self,
-                 vocab_file: Optional[str]=None,
-                 add_special_tokens: bool=True,
-                 unk_token: str="[UNK]",
-                 sep_token: str="[SEP]",
-                 cls_token: str="[CLS]",
-                 clean_text: bool=True,
-                 handle_chinese_chars: bool=True,
-                 strip_accents: bool=True,
-                 lowercase: bool=True,
-                 wordpieces_prefix: str="##"):
+    def __init__(
+        self,
+        vocab_file: Optional[str] = None,
+        add_special_tokens: bool = True,
+        unk_token: str = "[UNK]",
+        sep_token: str = "[SEP]",
+        cls_token: str = "[CLS]",
+        clean_text: bool = True,
+        handle_chinese_chars: bool = True,
+        strip_accents: bool = True,
+        lowercase: bool = True,
+        wordpieces_prefix: str = "##",
+    ):
 
         if vocab_file is not None:
             tokenizer = Tokenizer(WordPiece.from_files(vocab_file, unk_token=unk_token))
@@ -44,9 +47,8 @@ class BertWordPieceTokenizer(BaseTokenizer):
             if cls_token_id is None:
                 raise TypeError("cls_token not found in the vocabulary")
 
-            tokenizer.post_processor = BertProcessing.new(
-                (sep_token, sep_token_id),
-                (cls_token, cls_token_id)
+            tokenizer.post_processor = BertProcessing(
+                (sep_token, sep_token_id), (cls_token, cls_token_id)
             )
         tokenizer.decoders = decoders.WordPiece(prefix=wordpieces_prefix)
 

--- a/bindings/python/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/tokenizers/implementations/bert_wordpiece.py
@@ -27,11 +27,13 @@ class BertWordPieceTokenizer(BaseTokenizer):
         else:
             tokenizer = Tokenizer(WordPiece.empty())
 
-        tokenizer.add_special_tokens([ unk_token, sep_token, cls_token ])
-        tokenizer.normalizer = BertNormalizer.new(clean_text=clean_text,
-                                                  handle_chinese_chars=handle_chinese_chars,
-                                                  strip_accents=strip_accents,
-                                                  lowercase=lowercase)
+        tokenizer.add_special_tokens([unk_token, sep_token, cls_token])
+        tokenizer.normalizer = BertNormalizer(
+            clean_text=clean_text,
+            handle_chinese_chars=handle_chinese_chars,
+            strip_accents=strip_accents,
+            lowercase=lowercase,
+        )
         tokenizer.pre_tokenizer = BertPreTokenizer.new()
 
         if add_special_tokens and vocab_file is not None:

--- a/bindings/python/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/tokenizers/implementations/bert_wordpiece.py
@@ -37,7 +37,7 @@ class BertWordPieceTokenizer(BaseTokenizer):
             strip_accents=strip_accents,
             lowercase=lowercase,
         )
-        tokenizer.pre_tokenizer = BertPreTokenizer.new()
+        tokenizer.pre_tokenizer = BertPreTokenizer()
 
         if add_special_tokens and vocab_file is not None:
             sep_token_id = tokenizer.token_to_id(sep_token)

--- a/bindings/python/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/tokenizers/implementations/bert_wordpiece.py
@@ -48,7 +48,7 @@ class BertWordPieceTokenizer(BaseTokenizer):
                 (sep_token, sep_token_id),
                 (cls_token, cls_token_id)
             )
-        tokenizer.decoders = decoders.WordPiece.new(prefix=wordpieces_prefix)
+        tokenizer.decoders = decoders.WordPiece(prefix=wordpieces_prefix)
 
         parameters = {
             "model": "BertWordPiece",

--- a/bindings/python/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/byte_level_bpe.py
@@ -45,13 +45,12 @@ class ByteLevelBPETokenizer(BaseTokenizer):
             else:
                 tokenizer.normalizer = normalizers[0]
 
-        tokenizer.pre_tokenizer = pre_tokenizers.ByteLevel.new(add_prefix_space=add_prefix_space)
+        tokenizer.pre_tokenizer = pre_tokenizers.ByteLevel(
+            add_prefix_space=add_prefix_space
+        )
         tokenizer.decoder = decoders.ByteLevel()
 
-        parameters = {
-            "model": "ByteLevelBPE",
-            "add_prefix_space": add_prefix_space,
-        }
+        parameters = {"model": "ByteLevelBPE", "add_prefix_space": add_prefix_space}
 
         super().__init__(tokenizer, parameters)
 

--- a/bindings/python/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/byte_level_bpe.py
@@ -46,7 +46,7 @@ class ByteLevelBPETokenizer(BaseTokenizer):
                 tokenizer.normalizer = normalizers[0]
 
         tokenizer.pre_tokenizer = pre_tokenizers.ByteLevel.new(add_prefix_space=add_prefix_space)
-        tokenizer.decoder = decoders.ByteLevel.new()
+        tokenizer.decoder = decoders.ByteLevel()
 
         parameters = {
             "model": "ByteLevelBPE",

--- a/bindings/python/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/byte_level_bpe.py
@@ -55,19 +55,22 @@ class ByteLevelBPETokenizer(BaseTokenizer):
 
         super().__init__(tokenizer, parameters)
 
-    def train(self, files: Union[str, List[str]],
-              vocab_size: int=30000,
-              min_frequency: int=2,
-              show_progress: bool=True,
-              special_tokens: List[str]=[]):
+    def train(
+        self,
+        files: Union[str, List[str]],
+        vocab_size: int = 30000,
+        min_frequency: int = 2,
+        show_progress: bool = True,
+        special_tokens: List[str] = [],
+    ):
         """ Train the model using the given files """
 
-        trainer = trainers.BpeTrainer.new(
+        trainer = trainers.BpeTrainer(
             vocab_size=vocab_size,
             min_frequency=min_frequency,
             show_progress=show_progress,
             special_tokens=special_tokens,
-            initial_alphabet=pre_tokenizers.ByteLevel.alphabet()
+            initial_alphabet=pre_tokenizers.ByteLevel.alphabet(),
         )
         if isinstance(files, str):
             files = [files]

--- a/bindings/python/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/byte_level_bpe.py
@@ -36,12 +36,12 @@ class ByteLevelBPETokenizer(BaseTokenizer):
             normalizers += [unicode_normalizer_from_str(unicode_normalizer)]
 
         if do_lowercase:
-            normalizers += [Lowercase.new()]
+            normalizers += [Lowercase()]
 
         # Create the normalizer structure
         if len(normalizers) > 0:
             if len(normalizers) > 1:
-                tokenizer.normalizer = Sequence.new(normalizers)
+                tokenizer.normalizer = Sequence(normalizers)
             else:
                 tokenizer.normalizer = normalizers[0]
 

--- a/bindings/python/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/char_level_bpe.py
@@ -42,12 +42,12 @@ class CharBPETokenizer(BaseTokenizer):
             normalizers += [unicode_normalizer_from_str(unicode_normalizer)]
 
         if do_lowercase:
-            normalizers += [Lowercase.new()]
+            normalizers += [Lowercase()]
 
         # Create the normalizer structure
         if len(normalizers) > 0:
             if len(normalizers) > 1:
-                tokenizer.normalizer = Sequence.new(normalizers)
+                tokenizer.normalizer = Sequence(normalizers)
             else:
                 tokenizer.normalizer = normalizers[0]
 

--- a/bindings/python/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/char_level_bpe.py
@@ -52,7 +52,7 @@ class CharBPETokenizer(BaseTokenizer):
                 tokenizer.normalizer = normalizers[0]
 
         tokenizer.pre_tokenizer = pre_tokenizers.WhitespaceSplit.new()
-        tokenizer.decoder = decoders.BPEDecoder.new(suffix=suffix)
+        tokenizer.decoder = decoders.BPEDecoder(suffix=suffix)
 
         parameters = {
             "model": "BPE",

--- a/bindings/python/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/char_level_bpe.py
@@ -63,24 +63,27 @@ class CharBPETokenizer(BaseTokenizer):
 
         super().__init__(tokenizer, parameters)
 
-    def train(self, files: Union[str, List[str]],
-              vocab_size: int=30000,
-              min_frequency: int=2,
-              special_tokens: List[str]=["<unk>"],
-              limit_alphabet: int=1000,
-              initial_alphabet: List[str]=[],
-              suffix: Optional[str]="</w>",
-              show_progress: bool=True):
+    def train(
+        self,
+        files: Union[str, List[str]],
+        vocab_size: int = 30000,
+        min_frequency: int = 2,
+        special_tokens: List[str] = ["<unk>"],
+        limit_alphabet: int = 1000,
+        initial_alphabet: List[str] = [],
+        suffix: Optional[str] = "</w>",
+        show_progress: bool = True,
+    ):
         """ Train the model using the given files """
 
-        trainer = trainers.BpeTrainer.new(
+        trainer = trainers.BpeTrainer(
             vocab_size=vocab_size,
             min_frequency=min_frequency,
             special_tokens=special_tokens,
             limit_alphabet=limit_alphabet,
             initial_alphabet=initial_alphabet,
             end_of_word_suffix=suffix,
-            show_progress=show_progress
+            show_progress=show_progress,
         )
         if isinstance(files, str):
             files = [files]

--- a/bindings/python/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/char_level_bpe.py
@@ -51,7 +51,7 @@ class CharBPETokenizer(BaseTokenizer):
             else:
                 tokenizer.normalizer = normalizers[0]
 
-        tokenizer.pre_tokenizer = pre_tokenizers.WhitespaceSplit.new()
+        tokenizer.pre_tokenizer = pre_tokenizers.WhitespaceSplit()
         tokenizer.decoder = decoders.BPEDecoder(suffix=suffix)
 
         parameters = {

--- a/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
@@ -28,9 +28,11 @@ class SentencePieceBPETokenizer(BaseTokenizer):
 
         tokenizer.add_special_tokens([ unk_token ])
 
+
         tokenizer.normalizer = NFKC()
-        tokenizer.pre_tokenizer = pre_tokenizers.Metaspace.new(replacement=replacement,
-                                                               add_prefix_space=add_prefix_space)
+        tokenizer.pre_tokenizer = pre_tokenizers.Metaspace(
+            replacement=replacement, add_prefix_space=add_prefix_space
+        )
         tokenizer.decoder = decoders.Metaspace(
             replacement=replacement, add_prefix_space=add_prefix_space
         )

--- a/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
@@ -28,7 +28,7 @@ class SentencePieceBPETokenizer(BaseTokenizer):
 
         tokenizer.add_special_tokens([ unk_token ])
 
-        tokenizer.normalizer = NFKC.new()
+        tokenizer.normalizer = NFKC()
         tokenizer.pre_tokenizer = pre_tokenizers.Metaspace.new(replacement=replacement,
                                                                add_prefix_space=add_prefix_space)
         tokenizer.decoder = decoders.Metaspace.new(replacement=replacement,

--- a/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
@@ -31,8 +31,9 @@ class SentencePieceBPETokenizer(BaseTokenizer):
         tokenizer.normalizer = NFKC()
         tokenizer.pre_tokenizer = pre_tokenizers.Metaspace.new(replacement=replacement,
                                                                add_prefix_space=add_prefix_space)
-        tokenizer.decoder = decoders.Metaspace.new(replacement=replacement,
-                                                   add_prefix_space=add_prefix_space)
+        tokenizer.decoder = decoders.Metaspace(
+            replacement=replacement, add_prefix_space=add_prefix_space
+        )
 
         parameters = {
             "model": "SentencePieceBPE",

--- a/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
@@ -44,22 +44,25 @@ class SentencePieceBPETokenizer(BaseTokenizer):
 
         super().__init__(tokenizer, parameters)
 
-    def train(self, files: Union[str, List[str]],
-              vocab_size: int=30000,
-              min_frequency: int=2,
-              special_tokens: List[str]=["<unk>"],
-              limit_alphabet: int=1000,
-              initial_alphabet: List[str]=[],
-              show_progress: bool=True):
+    def train(
+        self,
+        files: Union[str, List[str]],
+        vocab_size: int = 30000,
+        min_frequency: int = 2,
+        special_tokens: List[str] = ["<unk>"],
+        limit_alphabet: int = 1000,
+        initial_alphabet: List[str] = [],
+        show_progress: bool = True,
+    ):
         """ Train the model using the given files """
 
-        trainer = trainers.BpeTrainer.new(
+        trainer = trainers.BpeTrainer(
             vocab_size=vocab_size,
             min_frequency=min_frequency,
             special_tokens=special_tokens,
             limit_alphabet=limit_alphabet,
             initial_alphabet=initial_alphabet,
-            show_progress=show_progress
+            show_progress=show_progress,
         )
         if isinstance(files, str):
             files = [files]

--- a/bindings/python/tokenizers/normalizers/__init__.pyi
+++ b/bindings/python/tokenizers/normalizers/__init__.pyi
@@ -14,11 +14,13 @@ class BertNormalizer(Normalizer):
     This includes cleaning the text, handling accents, chinese chars and lowercasing
     """
 
-    @staticmethod
-    def new(clean_text: Optional[bool]=True,
-            handle_chinese_chars: Optional[bool]=True,
-            strip_accents: Optional[bool]=True,
-            lowercase: Optional[bool]=True) -> Normalizer:
+    def __init__(
+        self,
+        clean_text: Optional[bool] = True,
+        handle_chinese_chars: Optional[bool] = True,
+        strip_accents: Optional[bool] = True,
+        lowercase: Optional[bool] = True,
+    ) -> None:
         """ Instantiate a BertNormalizer with the given options.
 
         Args:
@@ -43,32 +45,28 @@ class BertNormalizer(Normalizer):
 class NFD(Normalizer):
     """ NFD Unicode Normalizer """
 
-    @staticmethod
-    def new() -> Normalizer:
+    def __init__(self) -> None:
         """ Instantiate a new NFD Normalizer """
         pass
 
 class NFKD(Normalizer):
     """ NFKD Unicode Normalizer """
 
-    @staticmethod
-    def new() -> Normalizer:
+    def __init__(self) -> None:
         """ Instantiate a new NFKD Normalizer """
         pass
 
 class NFC(Normalizer):
     """ NFC Unicode Normalizer """
 
-    @staticmethod
-    def new() -> Normalizer:
+    def __init__(self) -> None:
         """ Instantiate a new NFC Normalizer """
         pass
 
 class NFKC(Normalizer):
     """ NFKC Unicode Normalizer """
 
-    @staticmethod
-    def new() -> Normalizer:
+    def __init__(self) -> None:
         """ Instantiate a new NFKC Normalizer """
         pass
 
@@ -78,8 +76,7 @@ class Sequence(Normalizer):
     All the normalizers run in sequence in the given order
     """
 
-    @staticmethod
-    def new(normalizers: List[Normalizer]) -> Normalizer:
+    def __init__(self, normalizers: List[Normalizer]) -> None:
         """ Instantiate a new normalization Sequence using the given normalizers
 
         Args:
@@ -91,11 +88,9 @@ class Sequence(Normalizer):
 class Lowercase(Normalizer):
     """ Lowercase Normalizer """
 
-    @staticmethod
-    def new() -> Normalizer:
+    def __init__(self) -> None:
         """ Instantiate a new Lowercase Normalizer """
         pass
-
 
 def unicode_normalizer_from_str(normalizer: str) -> Normalizer:
     """

--- a/bindings/python/tokenizers/pre_tokenizers/__init__.pyi
+++ b/bindings/python/tokenizers/pre_tokenizers/__init__.pyi
@@ -21,7 +21,7 @@ class ByteLevel(PreTokenizer):
     """
 
     @staticmethod
-    def new(add_prefix_space: Optional[bool]=True) -> PreTokenizer:
+    def __init__(self, add_prefix_space: Optional[bool] = True) -> None:
         """ Instantiate a new ByteLevel PreTokenizer
 
         Args:
@@ -50,8 +50,7 @@ class Whitespace(PreTokenizer):
     This pre-tokenizer simply splits using the following regex: `\w+|[^\w\s]+`
     """
 
-    @staticmethod
-    def new() -> PreTokenizer:
+    def __init__(self) -> None:
         """ Instantiate a new Whitespace PreTokenizer """
         pass
 
@@ -61,8 +60,7 @@ class WhitespaceSplit(PreTokenizer):
     This pre-tokenizer simply splits on the whitespace. Works like `.split()`
     """
 
-    @staticmethod
-    def new() -> PreTokenizer:
+    def __init__(self) -> None:
         """ Instantiate a new WhitespaceSplit PreTokenizer """
         pass
 
@@ -73,8 +71,7 @@ class BertPreTokenizer(PreTokenizer):
     Each occurence of a punctuation character will be treated separately.
     """
 
-    @staticmethod
-    def new() -> PreTokenizer:
+    def __init__(self) -> None:
         """ Instantiate a new BertPreTokenizer """
         pass
 
@@ -85,9 +82,7 @@ class Metaspace(PreTokenizer):
     It then tries to split on these spaces.
     """
 
-    @staticmethod
-    def new(replacement: str="▁",
-            add_prefix_space: bool=True) -> PreTokenizer:
+    def __init__(self, replacement: str = "▁", add_prefix_space: bool = True) -> None:
         """ Instantiate a new Metaspace
 
         Args:
@@ -109,7 +104,7 @@ class CharDelimiterSplit(PreTokenizer):
     """
 
     @staticmethod
-    def new(delimiter: str) -> PreTokenizer:
+    def __init__(self, delimiter: str) -> None:
         """ Instantiate a new CharDelimiterSplit PreTokenizer
 
         Args:

--- a/bindings/python/tokenizers/processors/__init__.pyi
+++ b/bindings/python/tokenizers/processors/__init__.pyi
@@ -16,8 +16,7 @@ class BertProcessing:
         - a CLS token
     """
 
-    @staticmethod
-    def new(sep: Tuple[str, int], cls: Tuple[str, int]) -> PostProcessor:
+    def __init__(self, sep: Tuple[str, int], cls: Tuple[str, int]) -> None:
         """ Instantiate a new BertProcessing with the given tokens
 
         Args:
@@ -32,7 +31,6 @@ class BertProcessing:
         """
         pass
 
-
 class RobertaProcessing:
     """ RobertaProcessing
 
@@ -42,8 +40,7 @@ class RobertaProcessing:
         - a CLS token
     """
 
-    @staticmethod
-    def new(sep: Tuple[str, int], cls: Tuple[str, int]) -> PostProcessor:
+    def __init__(self, sep: Tuple[str, int], cls: Tuple[str, int]) -> None:
         """ Instantiate a new RobertaProcessing with the given tokens
 
         Args:

--- a/bindings/python/tokenizers/trainers/__init__.pyi
+++ b/bindings/python/tokenizers/trainers/__init__.pyi
@@ -13,15 +13,17 @@ class BpeTrainer:
     Capable of training a BPE model
     """
 
-    @staticmethod
-    def new(vocab_size: int=30000,
-            min_frequency: int=0,
-            show_progress: bool=True,
-            special_tokens: List[str]=[],
-            limit_alphabet: Optional[int]=None,
-            initial_alphabet: List[str]=[],
-            continuing_subword_prefix: Optional[str]=None,
-            end_of_word_suffix: Optional[str]=None) -> Trainer:
+    def __init__(
+        self,
+        vocab_size: int = 30000,
+        min_frequency: int = 0,
+        show_progress: bool = True,
+        special_tokens: List[str] = [],
+        limit_alphabet: Optional[int] = None,
+        initial_alphabet: List[str] = [],
+        continuing_subword_prefix: Optional[str] = None,
+        end_of_word_suffix: Optional[str] = None,
+    ) -> None:
         """ Instantiate a new BpeTrainer with the given options:
 
         Args:
@@ -63,15 +65,17 @@ class WordPieceTrainer:
     Capable of training a WordPiece model
     """
 
-    @staticmethod
-    def new(vocab_size: int=30000,
-            min_frequency: int=0,
-            show_progress: bool=True,
-            special_tokens: List[str]=[],
-            limit_alphabet: Optional[int]=None,
-            initial_alphabet: List[str]=[],
-            continuing_subword_prefix: Optional[str]="##",
-            end_of_word_suffix: Optional[str]=None) -> Trainer:
+    def __init__(
+        self,
+        vocab_size: int = 30000,
+        min_frequency: int = 0,
+        show_progress: bool = True,
+        special_tokens: List[str] = [],
+        limit_alphabet: Optional[int] = None,
+        initial_alphabet: List[str] = [],
+        continuing_subword_prefix: Optional[str] = "##",
+        end_of_word_suffix: Optional[str] = None,
+    ) -> Trainer:
         """ Instantiate a new WordPieceTrainer with the given options:
 
         Args:


### PR DESCRIPTION
We implement `__new__` to make constructors for these classes available in Python
   - Normalizers
   - Trainers
   - Decoders
   - PostProcessors
   - PreTokenizers

This also makes the objects the correct class on inspection from python.

Closes #129 