### PR TITLE
Expose num_added_tokens on Python side 

### DIFF
--- a/bindings/python/src/processors.rs
+++ b/bindings/python/src/processors.rs
@@ -8,6 +8,13 @@ pub struct PostProcessor {
     pub processor: Container<dyn tk::tokenizer::PostProcessor + Sync>,
 }
 
+#[pymethods]
+impl PostProcessor {
+    fn num_added_tokens(&self, is_pair: bool) -> usize {
+        self.processor.execute(|p| p.added_tokens(is_pair))
+    }
+}
+
 #[pyclass(extends=PostProcessor)]
 pub struct BertProcessing {}
 #[pymethods]

--- a/bindings/python/src/processors.rs
+++ b/bindings/python/src/processors.rs
@@ -10,7 +10,7 @@ pub struct PostProcessor {
 
 #[pymethods]
 impl PostProcessor {
-    fn num_added_tokens(&self, is_pair: bool) -> usize {
+    fn num_special_tokens_to_add(&self, is_pair: bool) -> usize {
         self.processor.execute(|p| p.added_tokens(is_pair))
     }
 }

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -38,6 +38,13 @@ impl Tokenizer {
         }
     }
 
+    fn num_added_tokens(&self, is_pair: bool) -> PyResult<usize> {
+        Ok(self.tokenizer
+               .get_post_processor()
+               .map_or(0, |p| p.as_ref().added_tokens(is_pair))
+        )
+    }
+
     #[args(kwargs = "**")]
     fn get_vocab_size(&self, kwargs: Option<&PyDict>) -> PyResult<usize> {
         let mut with_added_tokens = true;

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -38,7 +38,7 @@ impl Tokenizer {
         }
     }
 
-    fn num_added_tokens(&self, is_pair: bool) -> PyResult<usize> {
+    fn num_special_tokens_to_add(&self, is_pair: bool) -> PyResult<usize> {
         Ok(self.tokenizer
                .get_post_processor()
                .map_or(0, |p| p.as_ref().added_tokens(is_pair))

--- a/bindings/python/tokenizers/__init__.pyi
+++ b/bindings/python/tokenizers/__init__.pyi
@@ -201,7 +201,7 @@ class Tokenizer:
     def normalizer(self, normalizer: normalizers.Normalizer):
         """ Change the normalizer to use with this Tokenizer """
 
-    def num_added_tokens(self, is_pair: bool) -> int:
+    def num_special_tokens_to_add(self, is_pair: bool) -> int:
         """
         Return the number of special tokens that would be added for single/pair sentences.
         :param is_pair: Boolean indicating if the input would be a single sentence or a pair

--- a/bindings/python/tokenizers/__init__.pyi
+++ b/bindings/python/tokenizers/__init__.pyi
@@ -201,6 +201,14 @@ class Tokenizer:
     def normalizer(self, normalizer: normalizers.Normalizer):
         """ Change the normalizer to use with this Tokenizer """
 
+    def num_added_tokens(self, is_pair: bool) -> int:
+        """
+        Return the number of special tokens that would be added for single/pair sentences.
+        :param is_pair: Boolean indicating if the input would be a single sentence or a pair
+        :return:
+        """
+        pass
+
 
     def get_vocab_size(self, with_added_tokens: Optional[bool]) -> int:
         """ Returns the size of the vocabulary

--- a/bindings/python/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/tokenizers/implementations/base_tokenizer.py
@@ -13,7 +13,7 @@ class BaseTokenizer:
             self._tokenizer.get_vocab_size(),
             ', '.join(k + '=' + str(v) for k, v in self._parameters.items()))
 
-    def num_added_tokens(self, is_pair: bool) -> int:
+    def num_special_tokens_to_add(self, is_pair: bool) -> int:
         """
         Return the number of special tokens that would be added for single/pair sentences.
         :param is_pair: Boolean indicating if the input would be a single sentence or a pair

--- a/bindings/python/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/tokenizers/implementations/base_tokenizer.py
@@ -13,6 +13,14 @@ class BaseTokenizer:
             self._tokenizer.get_vocab_size(),
             ', '.join(k + '=' + str(v) for k, v in self._parameters.items()))
 
+    def num_added_tokens(self, is_pair: bool) -> int:
+        """
+        Return the number of special tokens that would be added for single/pair sentences.
+        :param is_pair: Boolean indicating if the input would be a single sentence or a pair
+        :return:
+        """
+        return self._tokenizer.num_added_tokens(is_pair)
+
     def get_vocab_size(self, with_added_tokens: bool = True):
         """ Return the size of vocabulary, with or without added tokens.
 

--- a/bindings/python/tokenizers/processors/__init__.pyi
+++ b/bindings/python/tokenizers/processors/__init__.pyi
@@ -7,6 +7,14 @@ class PostProcessor:
     a PostProcessor will return an instance of this class when instantiated.
     """
 
+    def num_added_tokens(self, is_pair: bool) -> int:
+        """
+        Return the number of special tokens that would be added for single/pair sentences.
+        :param is_pair: Boolean indicating if the input would be a single sentence or a pair
+        :return:
+        """
+        pass
+
 class BertProcessing(PostProcessor):
     """ BertProcessing
 

--- a/bindings/python/tokenizers/processors/__init__.pyi
+++ b/bindings/python/tokenizers/processors/__init__.pyi
@@ -7,7 +7,7 @@ class PostProcessor:
     a PostProcessor will return an instance of this class when instantiated.
     """
 
-    def num_added_tokens(self, is_pair: bool) -> int:
+    def num_special_tokens_to_add(self, is_pair: bool) -> int:
         """
         Return the number of special tokens that would be added for single/pair sentences.
         :param is_pair: Boolean indicating if the input would be a single sentence or a pair

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -12,15 +12,11 @@ impl BertProcessing {
 }
 
 impl PostProcessor for BertProcessing {
-    fn added_tokens(
-        &self,
-        _encoding: &Encoding,
-        pair_encoding: &Option<Encoding>,
-    ) -> Result<usize> {
-        if pair_encoding.is_some() {
-            Ok(3)
+    fn added_tokens(&self, is_pair: bool) -> usize {
+        if is_pair {
+            3
         } else {
-            Ok(2)
+            2
         }
     }
 

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -12,15 +12,11 @@ impl RobertaProcessing {
 }
 
 impl PostProcessor for RobertaProcessing {
-    fn added_tokens(
-        &self,
-        _encoding: &Encoding,
-        pair_encoding: &Option<Encoding>,
-    ) -> Result<usize> {
-        if pair_encoding.is_some() {
-            Ok(4)
+    fn added_tokens(&self, is_pair: bool) -> usize {
+        if is_pair {
+            4
         } else {
-            Ok(2)
+            2
         }
     }
 


### PR DESCRIPTION
without the need to pass an Encoding to added_tokens.

This allows to compute the max sentence length for single/pair inputs without actually the need to have an Encoding structure.
As the number of added tokens is fixed and static during compilation it allows more flexible usage of the method.

Signed-off-by: Morgan Funtowicz <morgan@huggingface.co>