### PR TITLE
Allow dropout option in ByteLevelBPETokenizer

### DIFF
--- a/bindings/python/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/byte_level_bpe.py
@@ -15,16 +15,18 @@ class ByteLevelBPETokenizer(BaseTokenizer):
                  vocab_file: Optional[str]=None,
                  merges_file: Optional[str]=None,
                  add_prefix_space: bool=False,
-                 do_lowercase: bool = False,
-                 unicode_normalizer: Optional[str] = None,
-                 continuing_subword_prefix: Optional[str] = None,
-                 end_of_word_suffix: Optional[str] = None
+                 do_lowercase: bool=False,
+                 dropout: Optional[float]=None,
+                 unicode_normalizer: Optional[str]=None,
+                 continuing_subword_prefix: Optional[str]=None,
+                 end_of_word_suffix: Optional[str]=None
                  ):
         if vocab_file is not None and merges_file is not None:
             tokenizer = Tokenizer(BPE.from_files(
                 vocab_file, merges_file,
+                dropout=dropout,
                 continuing_subword_prefix=continuing_subword_prefix or "",
-                end_of_word_suffix=end_of_word_suffix or ""
+                end_of_word_suffix=end_of_word_suffix or "",
             ))
         else:
             tokenizer = Tokenizer(BPE.empty())


### PR DESCRIPTION
I tested it, and it appears to work as expected. Running this script:
```python
from pathlib import Path
import tokenizers


directory = Path('./')
vocab = str(directory / 'vocab.json' )
merges = str(directory / 'merges.txt')

msg = 'Hello how are you??'
print(f'Encoding: {msg}')

tokenizer = tokenizers.ByteLevelBPETokenizer(vocab, merges)
print('No dropout')
print(tokenizer.encode(msg).tokens)

tokenizer = tokenizers.ByteLevelBPETokenizer(vocab, merges, dropout=0.4)
print(f'dropout = 0.4')
print(tokenizer.encode(msg).tokens)
print(tokenizer.encode(msg).tokens)

tokenizer = tokenizers.ByteLevelBPETokenizer(vocab, merges, dropout=0.99)
print(f'dropout = 0.99')
print(tokenizer.encode(msg).tokens)
```
yields the output:
```
Encoding: Hello how are you??
No dropout
['Hello', 'Ġhow', 'Ġare', 'Ġyou', '??']
dropout = 0.4
['H', 'e', 'l', 'lo', 'Ġ', 'how', 'Ġ', 'ar', 'e', 'Ġy', 'o', 'u', '??']
['H', 'el', 'lo', 'Ġh', 'ow', 'Ġa', 're', 'Ġy', 'o', 'u', '??']
dropout = 0.99
['H', 'e', 'l', 'l', 'o', 'Ġ', 'h', 'o', 'w', 'Ġ', 'a', 'r', 'e', 'Ġ', 'y', 'o', 'u', '?', '?'] 
```