### PR TITLE
Big improvement over BPE speed (Training & Tokenization)

### DIFF
--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -520,6 +520,8 @@ impl BpeTrainer {
                 .par_iter()
                 .flat_map(|i| {
                     let w = &words[*i] as *const _ as *mut _;
+                    // We can merge each of these words in parallel here because each position
+                    // can be there only once (HashSet). So this is safe.
                     unsafe {
                         let word: &mut Word = &mut (*w);
                         word.merge(top.pair.0, top.pair.1, new_token_id)


### PR DESCRIPTION
This PR includes various changes:
- Update the way we apply merges to each word during both Training and Tokenization (Improves the complexity from `O(n2)` to `O(n)`).
-  Add multithreading in some places. 

All these modifications are especially important for some languages where pre-tokenizing on spaces doesn't make sense, thus ending-up with very long words.

Here is a comparison, training and tokenizing a 100MB file in a few different languages:

### `master`:
| | English | Chinese | Japanese |
|-|-|-|-|
|Train|90.1s|437.7s|348.3s|
|Tokenization|6.3s|11.3s|12.7s|

### `faster-bpe`:
| | English | Chinese | Japanese |
|-|-|-|-|
|Train|20.5s (**4.4x faster**)|53.5s (**8.2x faster**)|59.6s (**5.8x faster**)|
|Tokenization|5.8s (**1.1x faster**)|5.0s (**2.3x faster**)|5.3s (**2.4x faster**)|