### PR TITLE
Hotfix models save

### DIFF
--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -1,7 +1,9 @@
-use super::{Cache, Error, Pair, WithFirstLastIterator, Word, DEFAULT_CACHE_CAPACITY};
+use super::{
+    super::OrderedVocabIter, Cache, Error, Pair, WithFirstLastIterator, Word,
+    DEFAULT_CACHE_CAPACITY,
+};
 use crate::tokenizer::{Model, Offsets, Result, Token};
 use rand::{thread_rng, Rng};
-use serde::{Serialize, Serializer};
 use serde_json::Value;
 use std::{
     collections::HashMap,
@@ -460,28 +462,6 @@ impl Model for BPE {
         )?;
 
         Ok(vec![vocab_path, merges_path])
-    }
-}
-
-/// Wraps a vocab mapping (ID -> token) to a struct that will be serialized in order
-/// of token ID, smallest to largest.
-struct OrderedVocabIter<'a> {
-    vocab_r: &'a HashMap<u32, String>,
-}
-
-impl<'a> OrderedVocabIter<'a> {
-    fn new(vocab_r: &'a HashMap<u32, String>) -> Self {
-        Self { vocab_r }
-    }
-}
-
-impl<'a> Serialize for OrderedVocabIter<'a> {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let iter = (0u32..(self.vocab_r.len() as u32)).map(|i| (&self.vocab_r[&i], i));
-        serializer.collect_map(iter)
     }
 }
 

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -3,3 +3,29 @@
 pub mod bpe;
 pub mod wordlevel;
 pub mod wordpiece;
+
+use serde::{Serialize, Serializer};
+use std::collections::HashMap;
+
+/// Wraps a vocab mapping (ID -> token) to a struct that will be serialized in order
+/// of token ID, smallest to largest.
+struct OrderedVocabIter<'a> {
+    vocab_r: &'a HashMap<u32, String>,
+}
+
+impl<'a> OrderedVocabIter<'a> {
+    fn new(vocab_r: &'a HashMap<u32, String>) -> Self {
+        Self { vocab_r }
+    }
+}
+
+impl<'a> Serialize for OrderedVocabIter<'a> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let iter = (0u32..(self.vocab_r.len() as u32)).map(|i| (&self.vocab_r[&i], i));
+        serializer.collect_map(iter)
+    }
+}
+

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -28,4 +28,3 @@ impl<'a> Serialize for OrderedVocabIter<'a> {
         serializer.collect_map(iter)
     }
 }
-

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -252,8 +252,8 @@ impl Model for WordPiece {
 
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>> {
         let vocab_file_name = match name {
-            Some(name) => format!("{}-vocab.json", name),
-            None => "vocab.json".to_string(),
+            Some(name) => format!("{}-vocab.txt", name),
+            None => "vocab.txt".to_string(),
         };
 
         // Write vocab.txt


### PR DESCRIPTION
Fix:
- `WordPiece.save` used the wrong name for one of the files
- `WordLevel.save` didn't save in the right format.