### PR TITLE
Fix BPE trainer pair counts

### DIFF
--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -291,6 +291,8 @@ impl BpeTrainer {
                 w2id.insert(s, (id2w.len() - 1) as u32);
             }
         });
+
+        println!("Alphabet: {:?}", w2id);
     }
 
     /// Tokenize words and add subwords to the vocabulary when relevant
@@ -341,6 +343,8 @@ impl BpeTrainer {
             }
         }
 
+        println!("Words: {:#?}", words);
+        println!("Counts: {:#?}", counts);
         (words, counts)
     }
 
@@ -468,6 +472,7 @@ impl BpeTrainer {
                 });
             }
         });
+        println!("Queue: {:#?}", queue);
         self.finalize_progress(&progress, words.len());
 
         //
@@ -491,6 +496,7 @@ impl BpeTrainer {
                 queue.push(top);
                 continue;
             }
+            println!("Top: {:?}", top);
 
             if top.count < 1 || self.min_frequency > top.count {
                 break;
@@ -507,6 +513,7 @@ impl BpeTrainer {
                 }
             }
             let new_token = format!("{}{}", part_a, part_b);
+            println!("New token: {}", new_token);
 
             // Insert new token
             let new_token_id = id_to_word.len() as u32;

--- a/tokenizers/src/models/bpe/word.rs
+++ b/tokenizers/src/models/bpe/word.rs
@@ -56,6 +56,22 @@ impl Symbol {
 pub(super) struct Word {
     symbols: Vec<Symbol>,
 }
+impl std::fmt::Debug for Word {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.debug_struct("Word")
+            .field(
+                "chars",
+                &self
+                    .symbols
+                    .iter()
+                    .map(|s| s.c.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            )
+            .field("symbols", &self.symbols)
+            .finish()
+    }
+}
 
 impl Word {
     pub(super) fn new() -> Self {


### PR DESCRIPTION
Fix a bug during the count of pairs for the BPE training. The last batch of words wasn't processed correctly.

This was happening randomly in the CI because it actually depends on the number of CPUs available, and apparently runners don't necessarily have the same number of CPUs.