### PR TITLE
Improve models builders

### DIFF
--- a/bindings/node/native/Cargo.lock
+++ b/bindings/node/native/Cargo.lock
@@ -251,7 +251,7 @@ version = "0.1.0"
 dependencies = [
  "neon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokenizers 0.7.0",
+ "tokenizers 0.8.0",
 ]
 
 [[package]]
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "tokenizers"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tokenizers/CHANGELOG.md
+++ b/tokenizers/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Changes:
 - Keep only one progress bar while reading files during training. This is better for use-cases with
 a high number of files as it avoids having too many progress bar on screen.
+- Improve BPE and WordPiece builders.
 
 # v0.8.0
 

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -69,7 +69,6 @@ fn iter_bench_encode_batch(
 
 fn bench_gpt2(c: &mut Criterion) {
     let bpe = BPE::from_files("benches/gpt2-vocab.json", "benches/gpt2-merges.txt")
-        .unwrap()
         .build()
         .unwrap();
     let tokenizer = create_gpt2_tokenizer(bpe);
@@ -95,7 +94,6 @@ fn bench_gpt2(c: &mut Criterion) {
     });
 
     let bpe = BPE::from_files("benches/gpt2-vocab.json", "benches/gpt2-merges.txt")
-        .unwrap()
         .cache_capacity(0)
         .build()
         .unwrap();

--- a/tokenizers/src/cli.rs
+++ b/tokenizers/src/cli.rs
@@ -16,7 +16,7 @@ fn shell(matches: &ArgMatches) -> Result<()> {
         .value_of("merges")
         .expect("Must give a merges.txt file");
 
-    let bpe = BPE::from_files(vocab, merges)?.build()?;
+    let bpe = BPE::from_files(vocab, merges).build()?;
     let mut tokenizer = Tokenizer::new(Box::new(bpe));
     tokenizer.with_pre_tokenizer(Box::new(ByteLevel::new(true)));
     tokenizer.with_decoder(Box::new(ByteLevel::new(false)));

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -29,7 +29,7 @@
 //! use tokenizers::models::bpe::BPE;
 //!
 //! fn main() -> Result<()> {
-//!     let bpe_builder = BPE::from_files("./path/to/vocab.json", "./path/to/merges.txt")?;
+//!     let bpe_builder = BPE::from_files("./path/to/vocab.json", "./path/to/merges.txt");
 //!     let bpe = bpe_builder
 //!         .dropout(0.1)
 //!         .unk_token("[UNK]".into())


### PR DESCRIPTION
- `from_files` now returns a builder, and cannot fail
- All possible failures are handled during the `build` phase of each builder
- This also moves any I/O to the `build` phase. This behavior seems more intuitive: we first construct our builders with all their respective configurations and then finally build at the end, doing the real work only then.
- This simplifies both python and node bindings where we don't need to have any default values.
- Add the `continuing_subword_prefix` option to both bindings for WordPiece.