### PR TITLE
Improve Management of added tokens

### DIFF
--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -85,21 +85,20 @@ export class Tokenizer {
    * Add the given tokens to the vocabulary
    *
    * @param tokens A list of tokens to add to the vocabulary.
-   * Each token can either be a string, or a tuple with a string representing the token,
-   * and a boolean option representing whether to match on single words only.
-   * If the boolean is not included, it defaults to False
+   * Each token can either be a string, or an instance of {@link AddedToken}.
    * @returns The number of tokens that were added to the vocabulary
    */
-  addTokens(tokens: (string | [string, boolean])[]): number;
+  addTokens(tokens: (string | AddedToken)[]): number;
 
   /**
    * Add the given special tokens to the vocabulary, and treat them as special tokens.
    * The special tokens will never be processed by the model, and will be removed while decoding.
    *
-   * @param tokens The list of special tokens to add
+   * @param tokens The list of special tokens to add.
+   * Each token can either be a string or an instance of {@link AddedToken}.
    * @returns The number of tokens that were added to the vocabulary
    */
-  addSpecialTokens(tokens: string[]): number;
+  addSpecialTokens(tokens: (string | AddedToken)[]): number;
 
   /**
    * Encode the given sequence
@@ -287,4 +286,46 @@ export class Tokenizer {
    * @throws Will throw an error if the decoder is already used in another Tokenizer
    */
   setDecoder(decoder: Decoder): void;
+}
+
+/**
+ * Options used to construct an AddedToken
+ * @since 0.6.0
+ */
+export interface AddedTokenOptions {
+  /**
+   * Whether this token should strip all potential whitespaces on the left side.
+   * If True, this token will greedily match any whitespace on the left and then strip
+   * them out.
+   * @default False
+   */
+  leftStrip?: boolean;
+  /**
+   * Whether this token should strip all potential whitespaces on the right side.
+   * If True, this token will greedily match any whitespace on the right and then strip
+   * them out.
+   * @default False
+   */
+  rightStrip?: boolean;
+  /**
+   * Whether this token should only match against single word.
+   * If True, this token will never match inside of a word.
+   * @default False
+   */
+  singleWord?: boolean;
+}
+
+/**
+ * AddedToken represents a token to be added to a Tokenizer.
+ * An AddedToken can have special options defining the way it should behave.
+ *
+ * @since 0.6.0
+ */
+export class AddedToken {
+  /**
+   * Instantiate a new AddedToken
+   * @param content The content of the token
+   * @param [options] Options for the token
+   */
+  constructor(content: string, options?: AddedTokenOptions);
 }

--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -328,4 +328,9 @@ export class AddedToken {
    * @param [options] Options for the token
    */
   constructor(content: string, options?: AddedTokenOptions);
+
+  /**
+   * Get the content of the AddedToken
+   */
+  getContent(): string;
 }

--- a/bindings/node/lib/bindings/tokenizer.js
+++ b/bindings/node/lib/bindings/tokenizer.js
@@ -1,5 +1,6 @@
 const native = require("./native");
 
 module.exports = {
+  AddedToken: native.tokenizer_AddedToken,
   Tokenizer: native.tokenizer_Tokenizer
 };

--- a/bindings/node/lib/bindings/tokenizer.test.ts
+++ b/bindings/node/lib/bindings/tokenizer.test.ts
@@ -46,6 +46,13 @@ describe("AddedToken", () => {
     });
     expect(addToken.constructor.name).toEqual("AddedToken");
   });
+
+  describe("getContent", () => {
+    it("returns the string content of AddedToken", () => {
+      const addedToken = new AddedToken("test");
+      expect(addedToken.getContent()).toEqual("test");
+    });
+  });
 });
 
 describe("Tokenizer", () => {

--- a/bindings/node/lib/bindings/tokenizer.test.ts
+++ b/bindings/node/lib/bindings/tokenizer.test.ts
@@ -7,7 +7,12 @@ import { PaddingDirection, TruncationStrategy } from "./enums";
 import { BPE } from "./models";
 import { lowercaseNormalizer } from "./normalizers";
 import { RawEncoding } from "./raw-encoding";
-import { PaddingConfiguration, Tokenizer, TruncationConfiguration } from "./tokenizer";
+import {
+  AddedToken,
+  PaddingConfiguration,
+  Tokenizer,
+  TruncationConfiguration
+} from "./tokenizer";
 
 // jest.mock('../bindings/tokenizer');
 // jest.mock('../bindings/models', () => ({
@@ -21,6 +26,27 @@ import { PaddingConfiguration, Tokenizer, TruncationConfiguration } from "./toke
 // });
 
 // const TokenizerMock = mocked(Tokenizer);
+
+describe("AddedToken", () => {
+  it("instantiates with only content", () => {
+    const addToken = new AddedToken("test");
+    expect(addToken.constructor.name).toEqual("AddedToken");
+  });
+
+  it("instantiates with empty options", () => {
+    const addToken = new AddedToken("test", {});
+    expect(addToken.constructor.name).toEqual("AddedToken");
+  });
+
+  it("instantiates with options", () => {
+    const addToken = new AddedToken("test", {
+      leftStrip: true,
+      rightStrip: true,
+      singleWord: true
+    });
+    expect(addToken.constructor.name).toEqual("AddedToken");
+  });
+});
 
 describe("Tokenizer", () => {
   it("has expected methods", () => {
@@ -61,6 +87,15 @@ describe("Tokenizer", () => {
       const nbAdd = tokenizer.addTokens(["my", "name", "is", "john", "pair"]);
       expect(nbAdd).toBe(5);
     });
+
+    it("accepts a list of AddedToken as new tokens when initial model is empty", () => {
+      const model = BPE.empty();
+      const tokenizer = new Tokenizer(model);
+      const addedToken = new AddedToken("test");
+
+      const nbAdd = tokenizer.addTokens([addedToken]);
+      expect(nbAdd).toBe(1);
+    });
   });
 
   describe("encode", () => {
@@ -78,6 +113,14 @@ describe("Tokenizer", () => {
       const model = BPE.empty();
       tokenizer = new Tokenizer(model);
       tokenizer.addTokens(["my", "name", "is", "john", "pair"]);
+
+      // const my = new AddedToken("my");
+      // const name = new AddedToken("name");
+      // const is = new AddedToken("is");
+      // const john = new AddedToken("john");
+      // const pair = new AddedToken("pair");
+      // tokenizer.addTokens([my, name, is, john, pair]);
+
       encode = promisify(tokenizer.encode.bind(tokenizer));
     });
 

--- a/bindings/node/lib/bindings/tokenizer.test.ts
+++ b/bindings/node/lib/bindings/tokenizer.test.ts
@@ -112,14 +112,7 @@ describe("Tokenizer", () => {
 
       const model = BPE.empty();
       tokenizer = new Tokenizer(model);
-      tokenizer.addTokens(["my", "name", "is", "john", "pair"]);
-
-      // const my = new AddedToken("my");
-      // const name = new AddedToken("name");
-      // const is = new AddedToken("is");
-      // const john = new AddedToken("john");
-      // const pair = new AddedToken("pair");
-      // tokenizer.addTokens([my, name, is, john, pair]);
+      tokenizer.addTokens(["my", "name", "is", "john", new AddedToken("pair")]);
 
       encode = promisify(tokenizer.encode.bind(tokenizer));
     });
@@ -154,9 +147,9 @@ describe("Tokenizer", () => {
 
       expect(encoding.getOffsets()).toEqual([
         [0, 2],
-        [2, 6],
-        [6, 8],
-        [8, 12],
+        [3, 7],
+        [8, 10],
+        [11, 15],
         [0, 4]
       ]);
       expect(encoding.getOverflowing()).toEqual([]);

--- a/bindings/node/lib/bindings/trainers.d.ts
+++ b/bindings/node/lib/bindings/trainers.d.ts
@@ -2,6 +2,9 @@
  * This class is not supposed to be instantiated directly. Instead, any implementation of a
  * Trainer will return an instance of this class when instantiated.
  */
+
+import { AddedToken } from "./tokenizer";
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Trainer {}
 
@@ -40,7 +43,7 @@ export interface TrainerOptions {
    * A list of special tokens the model should know of.
    * @default []
    */
-  specialTokens?: string[];
+  specialTokens?: (string | AddedToken)[];
   /**
    * The size of the final vocabulary, including all tokens and alphabet.
    * @default 30000

--- a/bindings/node/lib/implementations/tokenizers/base.tokenizer.ts
+++ b/bindings/node/lib/implementations/tokenizers/base.tokenizer.ts
@@ -1,6 +1,7 @@
 import { promisify } from "util";
 
 import {
+  AddedToken,
   PaddingConfiguration,
   PaddingOptions,
   Tokenizer,
@@ -47,12 +48,9 @@ export class BaseTokenizer<TConfig extends object> {
    * Add the given tokens to the vocabulary
    *
    * @param tokens A list of tokens to add to the vocabulary.
-   * Each token can either be a string, or a tuple with a string representing the token,
-   * and a boolean option representing whether to match on single words only.
-   * If the boolean is not included, it defaults to False
-   * @returns The number of tokens that were added to the vocabulary
+   * Each token can either be a string, or an instance of AddedToken.
    */
-  addTokens(tokens: (string | [string, boolean])[]): number {
+  addTokens(tokens: (string | AddedToken)[]): number {
     return this.tokenizer.addTokens(tokens);
   }
 
@@ -60,10 +58,11 @@ export class BaseTokenizer<TConfig extends object> {
    * Add the given special tokens to the vocabulary, and treat them as special tokens.
    * The special tokens will never be processed by the model, and will be removed while decoding.
    *
-   * @param tokens The list of special tokens to add
+   * @param tokens The list of special tokens to add.
+   * Each token can either be a string, or an instance of AddedToken
    * @returns The number of tokens that were added to the vocabulary
    */
-  addSpecialTokens(tokens: string[]): number {
+  addSpecialTokens(tokens: (string | AddedToken)[]): number {
     return this.tokenizer.addSpecialTokens(tokens);
   }
 

--- a/bindings/node/lib/implementations/tokenizers/base.tokenizer.ts
+++ b/bindings/node/lib/implementations/tokenizers/base.tokenizer.ts
@@ -192,3 +192,11 @@ export class BaseTokenizer<TConfig extends object> {
     return this.tokenizer.tokenToId(token);
   }
 }
+
+/**
+ * Get the string content from a token, which can be a string or AddedToken
+ * @param token The token from which get the content
+ */
+export function getTokenContent(token: string | AddedToken): string {
+  return typeof token === "string" ? token : token.getContent();
+}

--- a/bindings/node/lib/implementations/tokenizers/bert-wordpiece.tokenizer.ts
+++ b/bindings/node/lib/implementations/tokenizers/bert-wordpiece.tokenizer.ts
@@ -5,7 +5,7 @@ import { Model, WordPiece, WordPieceOptions } from "../../bindings/models";
 import { bertNormalizer } from "../../bindings/normalizers";
 import { bertProcessing } from "../../bindings/post-processors";
 import { bertPreTokenizer } from "../../bindings/pre-tokenizers";
-import { Tokenizer } from "../../bindings/tokenizer";
+import { AddedToken, Tokenizer } from "../../bindings/tokenizer";
 import { wordPieceTrainer } from "../../bindings/trainers";
 import { BaseTokenizer } from "./base.tokenizer";
 
@@ -21,7 +21,7 @@ export interface BertWordPieceOptions {
   /**
    * @default "[CLS]"
    */
-  clsToken?: string;
+  clsToken?: string | AddedToken;
   /**
    * @default true
    */
@@ -33,15 +33,15 @@ export interface BertWordPieceOptions {
   /**
    * @default "[MASK]"
    */
-  maskToken?: string;
+  maskToken?: string | AddedToken;
   /**
    * @default "[PAD]"
    */
-  padToken?: string;
+  padToken?: string | AddedToken;
   /**
    * @default "[SEP]"
    */
-  sepToken?: string;
+  sepToken?: string | AddedToken;
   /**
    * @default true
    */
@@ -49,7 +49,7 @@ export interface BertWordPieceOptions {
   /**
    * @default "[UNK]"
    */
-  unkToken?: string;
+  unkToken?: string | AddedToken;
   vocabFile?: string;
   /**
    * The prefix to attach to subword units that don't represent a beginning of word
@@ -78,7 +78,7 @@ export interface BertWordPieceTrainOptions {
   /**
    * @default ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"]
    */
-  specialTokens?: string[];
+  specialTokens?: (string | AddedToken)[];
   /**
    * @default 30000
    */

--- a/bindings/node/lib/implementations/tokenizers/bert-wordpiece.tokenizer.ts
+++ b/bindings/node/lib/implementations/tokenizers/bert-wordpiece.tokenizer.ts
@@ -7,7 +7,7 @@ import { bertProcessing } from "../../bindings/post-processors";
 import { bertPreTokenizer } from "../../bindings/pre-tokenizers";
 import { AddedToken, Tokenizer } from "../../bindings/tokenizer";
 import { wordPieceTrainer } from "../../bindings/trainers";
-import { BaseTokenizer } from "./base.tokenizer";
+import { BaseTokenizer, getTokenContent } from "./base.tokenizer";
 
 export interface BertWordPieceOptions {
   /**
@@ -139,7 +139,7 @@ export class BertWordPieceTokenizer extends BaseTokenizer<BertTokenizerConfig> {
     if (opts.vocabFile) {
       const fromFiles = promisify<string, WordPieceOptions, Model>(WordPiece.fromFiles);
       model = await fromFiles(opts.vocabFile, {
-        unkToken: opts.unkToken,
+        unkToken: getTokenContent(opts.unkToken),
         continuingSubwordPrefix: opts.wordpiecesPrefix
       });
     } else {
@@ -155,7 +155,7 @@ export class BertWordPieceTokenizer extends BaseTokenizer<BertTokenizerConfig> {
       opts.padToken,
       opts.maskToken
     ]) {
-      if (tokenizer.tokenToId(token) !== undefined) {
+      if (tokenizer.tokenToId(getTokenContent(token)) !== undefined) {
         tokenizer.addSpecialTokens([token]);
       }
     }
@@ -165,19 +165,19 @@ export class BertWordPieceTokenizer extends BaseTokenizer<BertTokenizerConfig> {
     tokenizer.setPreTokenizer(bertPreTokenizer());
 
     if (opts.vocabFile && opts.addSpecialTokens) {
-      const sepTokenId = tokenizer.tokenToId(opts.sepToken);
+      const sepTokenId = tokenizer.tokenToId(getTokenContent(opts.sepToken));
       if (sepTokenId === undefined) {
         throw new Error("sepToken not found in the vocabulary");
       }
 
-      const clsTokenId = tokenizer.tokenToId(opts.clsToken);
+      const clsTokenId = tokenizer.tokenToId(getTokenContent(opts.clsToken));
       if (clsTokenId === undefined) {
         throw new Error("clsToken not found in the vocabulary");
       }
 
       const processor = bertProcessing(
-        [opts.sepToken, sepTokenId],
-        [opts.clsToken, clsTokenId]
+        [getTokenContent(opts.sepToken), sepTokenId],
+        [getTokenContent(opts.clsToken), clsTokenId]
       );
       tokenizer.setPostProcessor(processor);
     }

--- a/bindings/node/lib/implementations/tokenizers/byte-level-bpe.tokenizer.ts
+++ b/bindings/node/lib/implementations/tokenizers/byte-level-bpe.tokenizer.ts
@@ -9,7 +9,7 @@ import {
 } from "../../bindings/normalizers";
 import { byteLevelProcessing } from "../../bindings/post-processors";
 import { byteLevelAlphabet, byteLevelPreTokenizer } from "../../bindings/pre-tokenizers";
-import { Tokenizer } from "../../bindings/tokenizer";
+import { AddedToken, Tokenizer } from "../../bindings/tokenizer";
 import { bpeTrainer } from "../../bindings/trainers";
 import { BaseTokenizer } from "./base.tokenizer";
 
@@ -56,7 +56,7 @@ export interface ByteLevelBPETrainOptions {
   /**
    * @default []
    */
-  specialTokens?: string[];
+  specialTokens?: (string | AddedToken)[];
   /**
    * @default 30000
    */

--- a/bindings/node/lib/implementations/tokenizers/index.ts
+++ b/bindings/node/lib/implementations/tokenizers/index.ts
@@ -2,3 +2,4 @@ export * from "./bert-wordpiece.tokenizer";
 export * from "./bpe.tokenizer";
 export * from "./byte-level-bpe.tokenizer";
 export * from "./sentence-piece-bpe.tokenizer";
+export { getTokenContent } from "./base.tokenizer";

--- a/bindings/node/lib/index.ts
+++ b/bindings/node/lib/index.ts
@@ -2,5 +2,10 @@
 export * from "./implementations/tokenizers";
 export * from "./bindings/enums";
 export { slice } from "./bindings/utils";
-export { PaddingOptions, TruncationOptions } from "./bindings/tokenizer";
+export {
+  AddedToken,
+  AddedTokenOptions,
+  PaddingOptions,
+  TruncationOptions
+} from "./bindings/tokenizer";
 export { Encoding } from "./implementations/encoding";

--- a/bindings/node/native/src/tokenizer.rs
+++ b/bindings/node/native/src/tokenizer.rs
@@ -52,6 +52,19 @@ declare_types! {
 
             Ok(AddedToken { token })
         }
+
+        method getContent(mut cx) {
+            // getContent()
+
+            let this = cx.this();
+            let content = {
+                let guard = cx.lock();
+                let token = this.borrow(&guard);
+                token.token.content.clone()
+            };
+
+            Ok(cx.string(content).upcast())
+        }
     }
 }
 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -18,6 +18,7 @@ special tokens. This is activated by default. ([#193](https://github.com/hugging
 - Fix some issues with the offsets being wrong with the `ByteLevel` BPE ([#193](https://github.com/huggingface/tokenizers/pull/193)):
 	- when `add_prefix_space=True`
 	- when a Unicode character gets split-up in multiple byte-level characters ([#156](https://github.com/huggingface/tokenizers/issues/156))
+- Fix a bug where offsets were wrong when there was any added tokens in the sequence being encoded.
 
 ## How to migrate:
 - Add the `ByteLevel` `PostProcessor` to your byte-level BPE tokenizers if relevant. If you are

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -85,6 +85,7 @@ fn normalizers(_py: Python, m: &PyModule) -> PyResult<()> {
 #[pymodule]
 fn tokenizers(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<tokenizer::Tokenizer>()?;
+    m.add_class::<tokenizer::AddedToken>()?;
     m.add_class::<encoding::Encoding>()?;
     m.add_wrapped(wrap_pymodule!(models))?;
     m.add_wrapped(wrap_pymodule!(pre_tokenizers))?;

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -3,6 +3,7 @@ extern crate tokenizers as tk;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
+use pyo3::PyObjectProtocol;
 
 use super::decoders::Decoder;
 use super::encoding::Encoding;
@@ -43,6 +44,19 @@ impl AddedToken {
 
         obj.init({ AddedToken { token } });
         Ok(())
+    }
+}
+#[pyproto]
+impl PyObjectProtocol for AddedToken {
+    fn __str__(&'p self) -> PyResult<&'p str> {
+        Ok(&self.token.content)
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "AddedToken(\"{}\", rstrip={}, lstrip={}, single_word={})",
+            self.token.content, self.token.rstrip, self.token.lstrip, self.token.single_word
+        ))
     }
 }
 

--- a/bindings/python/tokenizers/__init__.py
+++ b/bindings/python/tokenizers/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "0.6.0"
 
-from .tokenizers import Tokenizer, Encoding
+from .tokenizers import Tokenizer, Encoding, AddedToken
 from .tokenizers import decoders
 from .tokenizers import models
 from .tokenizers import normalizers

--- a/bindings/python/tokenizers/__init__.pyi
+++ b/bindings/python/tokenizers/__init__.pyi
@@ -91,6 +91,37 @@ class Encoding:
         """
         pass
 
+class AddedToken:
+    """ AddedToken represents a token to be added to a Tokenizer
+
+    An AddedToken can have special options defining the way it should behave.
+    """
+
+    def __new__(
+        cls, content: str, single_word: bool = False, lstrip: bool = False, rstrip: bool = False
+    ) -> AddedToken:
+        """ Instantiate a new AddedToken
+
+        Args:
+            content: str:
+                The content of the token
+
+            single_word: bool
+                Whether this token should only match against single word. If True,
+                this token will never match inside of a word.
+
+            lstrip: bool
+                Whether this token should strip all potential whitespaces on the left side.
+                If True, this token will greedily match any whitespace on the left and then strip
+                them out.
+
+            rstrip: bool
+                Whether this token should strip all potential whitespaces on the right side.
+                If True, this token will greedily match any whitespace on the right and then strip
+                them out.
+        """
+        pass
+
 class Tokenizer:
     """ Tokenizer
 
@@ -320,29 +351,28 @@ class Tokenizer:
             The corresponding string if it exists, None otherwise
         """
         pass
-    def add_tokens(self, tokens: List[Union[str, Tuple[str, bool]]]) -> int:
+    def add_tokens(self, tokens: List[Union[str, AddedToken]]) -> int:
         """ Add the given tokens to the vocabulary
 
         Args:
-            tokens: List[Union[str, Tuple[str, bool]]]:
+            tokens: List[Union[str, AddedToken]]:
                 A list of tokens to add to the vocabulary. Each token can either be
-                a string, or a tuple with a string representing the token, and a boolean
-                option representing whether to match on single words only.
-                If the boolean is not included, it defaults to False
+                a string, or an instance of AddedToken
 
         Returns:
             The number of tokens that were added to the vocabulary
         """
         pass
-    def add_special_tokens(self, tokens: List[str]) -> int:
+    def add_special_tokens(self, tokens: List[Union[str, AddedToken]]) -> int:
         """ Add the given special tokens to the vocabulary, and treat them as special tokens.
 
         The special tokens will never be processed by the model, and will be
         removed while decoding.
 
         Args:
-            tokens: List[str]:
-                The list of special tokens to add
+            tokens: List[Union[str, AddedToken]]:
+                The list of special tokens to add. Each token can either be a string
+                or an instance of AddedToken
 
         Returns:
             The number of tokens that were added to the vocabulary

--- a/bindings/python/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/tokenizers/implementations/base_tokenizer.py
@@ -95,30 +95,29 @@ class BaseTokenizer:
         """ Disable truncation """
         return self._tokenizer.no_truncation()
 
-    def add_tokens(self, tokens: List[Union[str, Tuple[str, bool]]]) -> int:
+    def add_tokens(self, tokens: List[Union[str, AddedToken]]) -> int:
         """ Add the given tokens to the vocabulary
 
         Args:
-            tokens: List[Union[str, Tuple[str, bool]]]:
+            tokens: List[Union[str, AddedToken]]:
                 A list of tokens to add to the vocabulary. Each token can either be
-                a string, or a tuple with a string representing the token, and a boolean
-                option representing whether to match on single words only.
-                If the boolean is not included, it defaults to False
+                a string, or an instance of AddedToken
 
         Returns:
             The number of tokens that were added to the vocabulary
         """
         return self._tokenizer.add_tokens(tokens)
 
-    def add_special_tokens(self, special_tokens: List[str]) -> int:
+    def add_special_tokens(self, special_tokens: List[Union[str, AddedToken]]) -> int:
         """ Add the given special tokens to the vocabulary, and treat them as special tokens.
 
         The special tokens will never be processed by the model, and will be
         removed while decoding.
 
         Args:
-            tokens: List[str]:
-                The list of special tokens to add
+            tokens: List[Union[str, AddedToken]]:
+                A list of special tokens to add to the vocabulary. Each token can either be
+                a string, or an instance of AddedToken
 
         Returns:
             The number of tokens that were added to the vocabulary

--- a/bindings/python/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/tokenizers/implementations/bert_wordpiece.py
@@ -1,4 +1,4 @@
-from tokenizers import Tokenizer, decoders, trainers
+from tokenizers import Tokenizer, AddedToken, decoders, trainers
 from tokenizers.models import WordPiece
 from tokenizers.normalizers import BertNormalizer
 from tokenizers.pre_tokenizers import BertPreTokenizer
@@ -15,11 +15,11 @@ class BertWordPieceTokenizer(BaseTokenizer):
         self,
         vocab_file: Optional[str] = None,
         add_special_tokens: bool = True,
-        unk_token: str = "[UNK]",
-        sep_token: str = "[SEP]",
-        cls_token: str = "[CLS]",
-        pad_token: str = "[PAD]",
-        mask_token: str = "[MASK]",
+        unk_token: Union[str, AddedToken] = "[UNK]",
+        sep_token: Union[str, AddedToken] = "[SEP]",
+        cls_token: Union[str, AddedToken] = "[CLS]",
+        pad_token: Union[str, AddedToken] = "[PAD]",
+        mask_token: Union[str, AddedToken] = "[MASK]",
         clean_text: bool = True,
         handle_chinese_chars: bool = True,
         strip_accents: bool = True,
@@ -89,7 +89,13 @@ class BertWordPieceTokenizer(BaseTokenizer):
         min_frequency: int = 2,
         limit_alphabet: int = 1000,
         initial_alphabet: List[str] = [],
-        special_tokens: List[str] = ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"],
+        special_tokens: List[Union[str, AddedToken]] = [
+            "[PAD]",
+            "[UNK]",
+            "[CLS]",
+            "[SEP]",
+            "[MASK]",
+        ],
         show_progress: bool = True,
         wordpieces_prefix: str = "##",
     ):

--- a/bindings/python/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/tokenizers/implementations/bert_wordpiece.py
@@ -28,21 +28,21 @@ class BertWordPieceTokenizer(BaseTokenizer):
     ):
 
         if vocab_file is not None:
-            tokenizer = Tokenizer(WordPiece.from_files(vocab_file, unk_token=unk_token))
+            tokenizer = Tokenizer(WordPiece.from_files(vocab_file, unk_token=str(unk_token)))
         else:
             tokenizer = Tokenizer(WordPiece.empty())
 
         # Let the tokenizer know about special tokens if they are part of the vocab
-        if tokenizer.token_to_id(unk_token) is not None:
-            tokenizer.add_special_tokens([unk_token])
-        if tokenizer.token_to_id(sep_token) is not None:
-            tokenizer.add_special_tokens([sep_token])
-        if tokenizer.token_to_id(cls_token) is not None:
-            tokenizer.add_special_tokens([cls_token])
-        if tokenizer.token_to_id(pad_token) is not None:
-            tokenizer.add_special_tokens([pad_token])
-        if tokenizer.token_to_id(mask_token) is not None:
-            tokenizer.add_special_tokens([mask_token])
+        if tokenizer.token_to_id(str(unk_token)) is not None:
+            tokenizer.add_special_tokens([str(unk_token)])
+        if tokenizer.token_to_id(str(sep_token)) is not None:
+            tokenizer.add_special_tokens([str(sep_token)])
+        if tokenizer.token_to_id(str(cls_token)) is not None:
+            tokenizer.add_special_tokens([str(cls_token)])
+        if tokenizer.token_to_id(str(pad_token)) is not None:
+            tokenizer.add_special_tokens([str(pad_token)])
+        if tokenizer.token_to_id(str(mask_token)) is not None:
+            tokenizer.add_special_tokens([str(mask_token)])
 
         tokenizer.normalizer = BertNormalizer(
             clean_text=clean_text,
@@ -53,15 +53,15 @@ class BertWordPieceTokenizer(BaseTokenizer):
         tokenizer.pre_tokenizer = BertPreTokenizer()
 
         if add_special_tokens and vocab_file is not None:
-            sep_token_id = tokenizer.token_to_id(sep_token)
+            sep_token_id = tokenizer.token_to_id(str(sep_token))
             if sep_token_id is None:
                 raise TypeError("sep_token not found in the vocabulary")
-            cls_token_id = tokenizer.token_to_id(cls_token)
+            cls_token_id = tokenizer.token_to_id(str(cls_token))
             if cls_token_id is None:
                 raise TypeError("cls_token not found in the vocabulary")
 
             tokenizer.post_processor = BertProcessing(
-                (sep_token, sep_token_id), (cls_token, cls_token_id)
+                (str(sep_token), sep_token_id), (str(cls_token), cls_token_id)
             )
         tokenizer.decoder = decoders.WordPiece(prefix=wordpieces_prefix)
 

--- a/bindings/python/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/byte_level_bpe.py
@@ -1,4 +1,4 @@
-from tokenizers import Tokenizer, pre_tokenizers, decoders, trainers, processors
+from tokenizers import Tokenizer, AddedToken, pre_tokenizers, decoders, trainers, processors
 from tokenizers.models import BPE
 from tokenizers.normalizers import unicode_normalizer_from_str, Lowercase, Sequence
 from .base_tokenizer import BaseTokenizer
@@ -76,7 +76,7 @@ class ByteLevelBPETokenizer(BaseTokenizer):
         vocab_size: int = 30000,
         min_frequency: int = 2,
         show_progress: bool = True,
-        special_tokens: List[str] = [],
+        special_tokens: List[Union[str, AddedToken]] = [],
     ):
         """ Train the model using the given files """
 

--- a/bindings/python/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/char_level_bpe.py
@@ -28,15 +28,15 @@ class CharBPETokenizer(BaseTokenizer):
                     vocab_file,
                     merges_file,
                     dropout=dropout,
-                    unk_token=unk_token,
+                    unk_token=str(unk_token),
                     end_of_word_suffix=suffix,
                 )
             )
         else:
             tokenizer = Tokenizer(BPE.empty())
 
-        if tokenizer.token_to_id(unk_token) is not None:
-            tokenizer.add_special_tokens([unk_token])
+        if tokenizer.token_to_id(str(unk_token)) is not None:
+            tokenizer.add_special_tokens([str(unk_token)])
 
         # Check for Unicode normalization first (before everything else)
         normalizers = []

--- a/bindings/python/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/char_level_bpe.py
@@ -1,4 +1,4 @@
-from .. import Tokenizer, pre_tokenizers, decoders, trainers
+from .. import Tokenizer, AddedToken, pre_tokenizers, decoders, trainers
 from ..models import BPE
 from ..normalizers import Sequence, Lowercase, unicode_normalizer_from_str
 from .base_tokenizer import BaseTokenizer
@@ -16,8 +16,8 @@ class CharBPETokenizer(BaseTokenizer):
         self,
         vocab_file: Optional[str] = None,
         merges_file: Optional[str] = None,
-        unk_token: Optional[str] = "<unk>",
-        suffix: Optional[str] = "</w>",
+        unk_token: Union[str, AddedToken] = "<unk>",
+        suffix: str = "</w>",
         dropout: Optional[float] = None,
         lowercase: bool = False,
         unicode_normalizer: Optional[str] = None,
@@ -73,7 +73,7 @@ class CharBPETokenizer(BaseTokenizer):
         files: Union[str, List[str]],
         vocab_size: int = 30000,
         min_frequency: int = 2,
-        special_tokens: List[str] = ["<unk>"],
+        special_tokens: List[Union[str, AddedToken]] = ["<unk>"],
         limit_alphabet: int = 1000,
         initial_alphabet: List[str] = [],
         suffix: Optional[str] = "</w>",

--- a/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
@@ -1,4 +1,4 @@
-from tokenizers import Tokenizer, pre_tokenizers, decoders, trainers
+from tokenizers import Tokenizer, AddedToken, pre_tokenizers, decoders, trainers
 from tokenizers.models import BPE
 from tokenizers.normalizers import NFKC
 from .base_tokenizer import BaseTokenizer
@@ -16,7 +16,7 @@ class SentencePieceBPETokenizer(BaseTokenizer):
         self,
         vocab_file: Optional[str] = None,
         merges_file: Optional[str] = None,
-        unk_token: str = "<unk>",
+        unk_token: Union[str, AddedToken] = "<unk>",
         replacement: str = "▁",
         add_prefix_space: bool = True,
         dropout: Optional[float] = None,
@@ -54,7 +54,7 @@ class SentencePieceBPETokenizer(BaseTokenizer):
         files: Union[str, List[str]],
         vocab_size: int = 30000,
         min_frequency: int = 2,
-        special_tokens: List[str] = ["<unk>"],
+        special_tokens: List[Union[str, AddedToken]] = ["<unk>"],
         limit_alphabet: int = 1000,
         initial_alphabet: List[str] = [],
         show_progress: bool = True,

--- a/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
@@ -28,8 +28,8 @@ class SentencePieceBPETokenizer(BaseTokenizer):
         else:
             tokenizer = Tokenizer(BPE.empty())
 
-        if tokenizer.token_to_id(unk_token) is not None:
-            tokenizer.add_special_tokens([unk_token])
+        if tokenizer.token_to_id(str(unk_token)) is not None:
+            tokenizer.add_special_tokens([str(unk_token)])
 
         tokenizer.normalizer = NFKC()
         tokenizer.pre_tokenizer = pre_tokenizers.Metaspace(

--- a/bindings/python/tokenizers/trainers/__init__.pyi
+++ b/bindings/python/tokenizers/trainers/__init__.pyi
@@ -1,4 +1,5 @@
-from typing import Optional, List
+from .. import AddedToken
+from typing import Optional, List, Union
 
 class Trainer:
     """ Base class for all trainers
@@ -18,7 +19,7 @@ class BpeTrainer(Trainer):
         vocab_size: int = 30000,
         min_frequency: int = 0,
         show_progress: bool = True,
-        special_tokens: List[str] = [],
+        special_tokens: List[Union[str, AddedToken]] = [],
         limit_alphabet: Optional[int] = None,
         initial_alphabet: List[str] = [],
         continuing_subword_prefix: Optional[str] = None,
@@ -36,7 +37,7 @@ class BpeTrainer(Trainer):
             show_progress: boolean:
                 Whether to show progress bars while training.
 
-            special_tokens: List[str]:
+            special_tokens: List[Union[str, AddedToken]]:
                 A list of special tokens the model should know of.
 
             limit_alphabet: unsigned int:
@@ -70,7 +71,7 @@ class WordPieceTrainer(Trainer):
         vocab_size: int = 30000,
         min_frequency: int = 0,
         show_progress: bool = True,
-        special_tokens: List[str] = [],
+        special_tokens: List[Union[str, AddedToken]] = [],
         limit_alphabet: Optional[int] = None,
         initial_alphabet: List[str] = [],
         continuing_subword_prefix: Optional[str] = "##",
@@ -88,7 +89,7 @@ class WordPieceTrainer(Trainer):
             show_progress: boolean:
                 Whether to show progress bars while training.
 
-            special_tokens: List[str]:
+            special_tokens: List[Union[str, AddedToken]]:
                 A list of special tokens the model should know of.
 
             limit_alphabet: unsigned int:

--- a/tokenizers/CHANGELOG.md
+++ b/tokenizers/CHANGELOG.md
@@ -21,6 +21,7 @@ one anymore. ([#197](https://github.com/huggingface/tokenizers/pull/197))
 - Fix some issues with the offsets being wrong with the `ByteLevel` BPE:
 	- when `add_prefix_space` is activated
 	- when a Unicode character gets split-up in multiple byte-level characters ([#156](https://github.com/huggingface/tokenizers/issues/156))
+- Fix a bug where offsets were wrong when there was any added tokens in the sequence being encoded.
 
 ## How to migrate:
 - Add the `ByteLevel` `PostProcessor` to your byte-level BPE tokenizers if relevant.

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -6,7 +6,7 @@ dir_guard=@mkdir -p $(@D)
 
 SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2-merges.txt
 BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/big.txt
-TESTS_RESOURCES = $(SHARED_RESOURCES)
+TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/bert-base-uncased-vocab.txt
 
 .PHONY : build
 build :
@@ -48,6 +48,10 @@ bench : $(BENCHMARK_RESOURCES)
 $(DATA_DIR)/gpt2-% :
 	$(dir_guard)
 	wget https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-$* -O $@
+
+$(DATA_DIR)/bert-% :
+	$(dir_guard)
+	wget https://s3.amazonaws.com/models.huggingface.co/bert/bert-$* -O $@
 
 $(DATA_DIR)/big.txt :
 	$(dir_guard)

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -17,14 +17,8 @@ fn create_gpt2_tokenizer(bpe: BPE) -> Tokenizer {
     tokenizer.with_pre_tokenizer(Box::new(ByteLevel::default()));
     tokenizer.with_decoder(Box::new(ByteLevel::default()));
     tokenizer.add_tokens(&[
-        AddedToken {
-            content: String::from("ing"),
-            single_word: false,
-        },
-        AddedToken {
-            content: String::from("[ENT]"),
-            single_word: true,
-        },
+        AddedToken::from(String::from("ing")).single_word(false),
+        AddedToken::from(String::from("[ENT]")).single_word(true),
     ]);
     tokenizer
 }

--- a/tokenizers/src/cli.rs
+++ b/tokenizers/src/cli.rs
@@ -22,14 +22,8 @@ fn shell(matches: &ArgMatches) -> Result<()> {
     tokenizer.with_decoder(Box::new(ByteLevel::default()));
 
     tokenizer.add_tokens(&[
-        AddedToken {
-            content: String::from("ing"),
-            single_word: false,
-        },
-        AddedToken {
-            content: String::from("[ENT]"),
-            single_word: true,
-        },
+        AddedToken::from(String::from("ing")).single_word(false),
+        AddedToken::from(String::from("[ENT]")).single_word(true),
     ]);
 
     let stdin = io::stdin();

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -1,6 +1,6 @@
 use super::WordPiece;
 use crate::models::bpe::{BpeTrainer, BpeTrainerBuilder};
-use crate::tokenizer::{Model, Result, Trainer};
+use crate::tokenizer::{AddedToken, Model, Result, Trainer};
 use std::collections::{HashMap, HashSet};
 
 /// A `WordPieceTrainerBuilder` can be used to create a `WordPieceTrainer` with a custom
@@ -42,7 +42,7 @@ impl WordPieceTrainerBuilder {
     }
 
     /// Set the special tokens
-    pub fn special_tokens(mut self, tokens: Vec<String>) -> Self {
+    pub fn special_tokens(mut self, tokens: Vec<AddedToken>) -> Self {
         self.bpe_trainer_builder = self.bpe_trainer_builder.special_tokens(tokens);
         self
     }
@@ -89,7 +89,7 @@ impl WordPieceTrainer {
         WordPieceTrainerBuilder::default()
     }
 
-    pub fn train(&self, word_counts: HashMap<String, u32>) -> Result<(WordPiece, Vec<String>)> {
+    pub fn train(&self, word_counts: HashMap<String, u32>) -> Result<(WordPiece, Vec<AddedToken>)> {
         let (bpe, tokens) = self.bpe_trainer.train(word_counts)?;
         Ok((WordPiece::from_bpe(&bpe), tokens))
     }
@@ -99,7 +99,7 @@ impl Trainer for WordPieceTrainer {
     fn train(
         &self,
         word_counts: HashMap<String, u32>,
-    ) -> Result<(Box<dyn Model + Sync>, Vec<String>)> {
+    ) -> Result<(Box<dyn Model + Sync>, Vec<AddedToken>)> {
         let (wp, tokens) = self.train(word_counts)?;
         Ok((Box::new(wp), tokens))
     }

--- a/tokenizers/src/normalizers/bert.rs
+++ b/tokenizers/src/normalizers/bert.rs
@@ -60,6 +60,17 @@ pub struct BertNormalizer {
     lowercase: bool,
 }
 
+impl Default for BertNormalizer {
+    fn default() -> Self {
+        Self {
+            clean_text: true,
+            handle_chinese_chars: true,
+            strip_accents: true,
+            lowercase: true,
+        }
+    }
+}
+
 impl BertNormalizer {
     pub fn new(
         clean_text: bool,

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -94,7 +94,10 @@ pub trait Trainer: Sync {
     fn should_show_progress(&self) -> bool;
     /// The actual training method. This will return a new trained Model as well as a list
     /// of `special_tokens` to be added directly to the tokenizer along with the model.
-    fn train(&self, words: HashMap<String, u32>) -> Result<(Box<dyn Model + Sync>, Vec<String>)>;
+    fn train(
+        &self,
+        words: HashMap<String, u32>,
+    ) -> Result<(Box<dyn Model + Sync>, Vec<AddedToken>)>;
     /// Process a bunch of token, counting them as relevant.
     fn process_tokens(&self, words: &mut HashMap<String, u32>, tokens: Vec<String>);
 }
@@ -645,13 +648,7 @@ impl Tokenizer {
 
         let (model, special_tokens) = trainer.train(words)?;
         self.model = model;
-        // TODO: Trainer should give added tokens directly
-        self.add_special_tokens(
-            &special_tokens
-                .iter()
-                .map(|s| AddedToken::from(s.to_owned()))
-                .collect::<Vec<_>>(),
-        );
+        self.add_special_tokens(&special_tokens);
 
         Ok(())
     }

--- a/tokenizers/tests/added_tokens.rs
+++ b/tokenizers/tests/added_tokens.rs
@@ -1,0 +1,18 @@
+mod common;
+
+use common::*;
+use tokenizers::tokenizer::{AddedToken, EncodeInput};
+
+#[test]
+fn handle_added_tokens() {
+    let mut tokenizer = get_byte_level(true, false);
+    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into()).lstrip(true)]);
+
+    let input = String::from("I saw a <mask> 😺");
+    let output = tokenizer.encode(EncodeInput::Single(input), false).unwrap();
+
+    assert_eq!(
+        output.get_tokens(),
+        &["ĠI", "Ġsaw", "Ġa", "<mask>", "ĠðŁĺ", "º"]
+    );
+}

--- a/tokenizers/tests/added_tokens.rs
+++ b/tokenizers/tests/added_tokens.rs
@@ -4,7 +4,7 @@ use common::*;
 use tokenizers::tokenizer::{AddedToken, EncodeInput};
 
 #[test]
-fn handle_added_tokens() {
+fn lstrip_tokens() {
     let mut tokenizer = get_byte_level(true, false);
     tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into()).lstrip(true)]);
 
@@ -15,4 +15,78 @@ fn handle_added_tokens() {
         output.get_tokens(),
         &["ĠI", "Ġsaw", "Ġa", "<mask>", "ĠðŁĺ", "º"]
     );
+}
+
+#[test]
+fn rstrip_tokens() {
+    let mut tokenizer = get_byte_level(false, false);
+    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into()).rstrip(true)]);
+
+    let input = String::from("I saw a <mask> 😺");
+    let output = tokenizer.encode(EncodeInput::Single(input), false).unwrap();
+
+    assert_eq!(
+        output.get_tokens(),
+        &["I", "Ġsaw", "Ġa", "Ġ", "<mask>", "ðŁĺ", "º"]
+    );
+
+    // When `add_prefix_space = true` rstrip cannot work as a prefix space is added
+    // to the next token
+    let mut tokenizer = get_byte_level(true, false);
+    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into()).rstrip(true)]);
+
+    let input = String::from("I saw a <mask> 😺");
+    let output = tokenizer.encode(EncodeInput::Single(input), false).unwrap();
+
+    assert_eq!(
+        output.get_tokens(),
+        &["ĠI", "Ġsaw", "Ġa", "Ġ", "<mask>", "ĠðŁĺ", "º"]
+    );
+}
+
+#[test]
+fn single_word_tokens() {
+    // If `single_word = true` it shouldn't split `dancing`
+    let mut tokenizer = get_byte_level(false, false);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing".into()).single_word(true)]);
+
+    let input = String::from("I like dancing");
+    let output = tokenizer.encode(EncodeInput::Single(input), false).unwrap();
+
+    assert_eq!(output.get_tokens(), &["I", "Ġlike", "Ġdancing"]);
+
+    // If `single_word = false` it should split `dancing`
+    let mut tokenizer = get_byte_level(false, false);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing".into()).single_word(false)]);
+
+    let input = String::from("I like dancing");
+    let output = tokenizer.encode(EncodeInput::Single(input), false).unwrap();
+
+    assert_eq!(output.get_tokens(), &["I", "Ġlike", "Ġd", "anc", "ing"]);
+}
+
+#[test]
+fn overlapping_tokens() {
+    let mut tokenizer = get_byte_level(false, false);
+
+    tokenizer.add_special_tokens(&[AddedToken::from("danc".into())]);
+    tokenizer.add_special_tokens(&[AddedToken::from("nci".into())]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing".into())]);
+
+    let input = String::from("I like dancing");
+    let output = tokenizer.encode(EncodeInput::Single(input), false).unwrap();
+
+    assert_eq!(output.get_tokens(), &["I", "Ġlike", "Ġ", "danc", "ing"]);
+
+    let mut tokenizer = get_byte_level(false, false);
+
+    tokenizer.add_special_tokens(&[AddedToken::from("nci".into())]);
+    tokenizer.add_special_tokens(&[AddedToken::from("danc".into())]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing".into())]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ike".into())]);
+
+    let input = String::from("I like dancing");
+    let output = tokenizer.encode(EncodeInput::Single(input), false).unwrap();
+
+    assert_eq!(output.get_tokens(), &["I", "Ġl", "ike", "Ġda", "nci", "ng"]);
 }

--- a/tokenizers/tests/common/mod.rs
+++ b/tokenizers/tests/common/mod.rs
@@ -1,0 +1,46 @@
+use tokenizers::decoders::wordpiece::WordPiece as WordPieceDecoder;
+use tokenizers::models::bpe::BPE;
+use tokenizers::models::wordpiece::WordPiece;
+use tokenizers::normalizers::bert::BertNormalizer;
+use tokenizers::pre_tokenizers::bert::BertPreTokenizer;
+use tokenizers::pre_tokenizers::byte_level::ByteLevel;
+use tokenizers::processors::bert::BertProcessing;
+use tokenizers::tokenizer::Tokenizer;
+
+pub fn get_byte_level(add_prefix_space: bool, trim_offsets: bool) -> Tokenizer {
+    let mut tokenizer = Tokenizer::new(Box::new(
+        BPE::from_files("data/gpt2-vocab.json", "data/gpt2-merges.txt")
+            .build()
+            .expect("Files not found, run `make test` to download these files"),
+    ));
+    tokenizer.with_pre_tokenizer(Box::new(
+        ByteLevel::default().add_prefix_space(add_prefix_space),
+    ));
+    tokenizer.with_decoder(Box::new(ByteLevel::default()));
+    tokenizer.with_post_processor(Box::new(ByteLevel::default().trim_offsets(trim_offsets)));
+
+    tokenizer
+}
+
+pub fn get_bert() -> Tokenizer {
+    let mut tokenizer = Tokenizer::new(Box::new(
+        WordPiece::from_files("data/bert-base-uncased-vocab.txt")
+            .build()
+            .expect("Files not found, run `make test` to download these files"),
+    ));
+    tokenizer.with_normalizer(Box::new(BertNormalizer::default()));
+    tokenizer.with_pre_tokenizer(Box::new(BertPreTokenizer));
+    tokenizer.with_decoder(Box::new(WordPieceDecoder::default()));
+    tokenizer.with_post_processor(Box::new(BertProcessing::new(
+        (
+            String::from("[SEP]"),
+            tokenizer.get_model().token_to_id("[SEP]").unwrap(),
+        ),
+        (
+            String::from("[CLS]"),
+            tokenizer.get_model().token_to_id("[CLS]").unwrap(),
+        ),
+    )));
+
+    tokenizer
+}

--- a/tokenizers/tests/common/mod.rs
+++ b/tokenizers/tests/common/mod.rs
@@ -7,6 +7,7 @@ use tokenizers::pre_tokenizers::byte_level::ByteLevel;
 use tokenizers::processors::bert::BertProcessing;
 use tokenizers::tokenizer::Tokenizer;
 
+#[allow(dead_code)]
 pub fn get_byte_level(add_prefix_space: bool, trim_offsets: bool) -> Tokenizer {
     let mut tokenizer = Tokenizer::new(Box::new(
         BPE::from_files("data/gpt2-vocab.json", "data/gpt2-merges.txt")
@@ -22,6 +23,7 @@ pub fn get_byte_level(add_prefix_space: bool, trim_offsets: bool) -> Tokenizer {
     tokenizer
 }
 
+#[allow(dead_code)]
 pub fn get_bert() -> Tokenizer {
     let mut tokenizer = Tokenizer::new(Box::new(
         WordPiece::from_files("data/bert-base-uncased-vocab.txt")

--- a/tokenizers/tests/offsets.rs
+++ b/tokenizers/tests/offsets.rs
@@ -5,7 +5,7 @@ use tokenizers::normalizers::bert::BertNormalizer;
 use tokenizers::pre_tokenizers::bert::BertPreTokenizer;
 use tokenizers::pre_tokenizers::byte_level::ByteLevel;
 use tokenizers::processors::bert::BertProcessing;
-use tokenizers::tokenizer::{get_range_of, EncodeInput, Tokenizer};
+use tokenizers::tokenizer::{get_range_of, AddedToken, EncodeInput, Tokenizer};
 
 fn get_byte_level(add_prefix_space: bool, trim_offsets: bool) -> Tokenizer {
     let mut tokenizer = Tokenizer::new(Box::new(
@@ -186,7 +186,7 @@ fn split_on_added_tokens_bert() {
     let input = String::from("Yesterday I saw a [MASK] far away");
 
     let mut tokenizer = get_bert();
-    tokenizer.add_special_tokens(&["[MASK]"]);
+    tokenizer.add_special_tokens(&[AddedToken::from("[MASK]".into())]);
     let output = tokenizer.encode(EncodeInput::Single(input), false).unwrap();
 
     assert_eq!(


### PR DESCRIPTION
- Fix a bug where offsets were wrong if an added token was part of the sequence to encode (cf https://github.com/huggingface/transformers/issues/3058#issuecomment-592781499)
- We can now have thousands of added tokens (even if not advised, but that's not the question). (Fix https://github.com/huggingface/tokenizers/issues/175)
- Added tokens can have a customized behavior. This will allow covering cases like: the `<mask>` special token for Roberta does not expect the previous whitespace to be kept in the tokenization. It should be stripped out.

Still missing:
 - [x] `Trainer`s should be able to pass `AddedToken`s instead of `String` to include options
 - [x] Python bindings
 - [x] Node bindings
 - [x] More tests