### PR TITLE
Add the ability to get the vocabulary

### DIFF
--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -251,6 +251,13 @@ export class Tokenizer {
   train(trainer: Trainer, files: string[]): void;
 
   /**
+   * Returns the vocabulary
+   *
+   * @param [withAddedTokens=true] Whether to include the added tokens in the vocabulary
+   */
+  getVocab(withAddedTokens?: boolean): { [token: string]: number };
+
+  /**
    * Returns the size of the vocabulary
    *
    * @param [withAddedTokens=true] Whether to include the added tokens in the vocabulary's size

--- a/bindings/node/lib/bindings/tokenizer.test.ts
+++ b/bindings/node/lib/bindings/tokenizer.test.ts
@@ -74,6 +74,7 @@ describe("Tokenizer", () => {
     expect(typeof tokenizer.getNormalizer).toBe("function");
     expect(typeof tokenizer.getPostProcessor).toBe("function");
     expect(typeof tokenizer.getPreTokenizer).toBe("function");
+    expect(typeof tokenizer.getVocab).toBe("function");
     expect(typeof tokenizer.getVocabSize).toBe("function");
     expect(typeof tokenizer.idToToken).toBe("function");
     expect(typeof tokenizer.runningTasks).toBe("function");
@@ -300,6 +301,28 @@ describe("Tokenizer", () => {
         "my name is john",
         "pair"
       ]);
+    });
+  });
+
+  describe("getVocab", () => {
+    it("accepts `undefined` as parameter", () => {
+      const model = BPE.empty();
+      const tokenizer = new Tokenizer(model);
+
+      expect(tokenizer.getVocab(undefined)).toBeDefined();
+    });
+
+    it("returns the vocabulary", () => {
+      const model = BPE.empty();
+      const tokenizer = new Tokenizer(model);
+      tokenizer.addTokens(["my", "name", "is", "john"]);
+
+      expect(tokenizer.getVocab(true)).toEqual({
+        my: 0,
+        name: 1,
+        is: 2,
+        john: 3
+      });
     });
   });
 

--- a/bindings/node/native/Cargo.lock
+++ b/bindings/node/native/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
  "neon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokenizers 0.8.0",
+ "tokenizers 0.9.0",
 ]
 
 [[package]]
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "tokenizers"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bindings/node/native/src/tokenizer.rs
+++ b/bindings/node/native/src/tokenizer.rs
@@ -114,20 +114,47 @@ declare_types! {
             Ok(cx.number(running as f64).upcast())
         }
 
-        method getVocabSize(mut cx) {
-            // getVocabSize(withAddedTokens: bool = true)
+        method getVocab(mut cx) {
+            // getVocab(withAddedTokens: bool = true)
             let mut with_added_tokens = true;
-            if let Some(args) = cx.argument_opt(0) {
-                if args.downcast::<JsUndefined>().is_err() {
-                    with_added_tokens = args.downcast::<JsBoolean>()
+            if let Some(arg) = cx.argument_opt(0) {
+                if arg.downcast::<JsUndefined>().is_err() {
+                    with_added_tokens = arg.downcast::<JsBoolean>()
                         .or_throw(&mut cx)?
                         .value() as bool;
                 }
             }
 
-            let mut this = cx.this();
+            let this = cx.this();
             let guard = cx.lock();
-            let size = this.borrow_mut(&guard)
+            let vocab = this.borrow(&guard)
+                .tokenizer
+                .get_vocab(with_added_tokens);
+
+            let js_vocab = JsObject::new(&mut cx);
+            for (token, id) in vocab {
+                let js_token = cx.string(token);
+                let js_id = cx.number(id as f64);
+                js_vocab.set(&mut cx, js_token, js_id)?;
+            }
+
+            Ok(js_vocab.upcast())
+        }
+
+        method getVocabSize(mut cx) {
+            // getVocabSize(withAddedTokens: bool = true)
+            let mut with_added_tokens = true;
+            if let Some(arg) = cx.argument_opt(0) {
+                if arg.downcast::<JsUndefined>().is_err() {
+                    with_added_tokens = arg.downcast::<JsBoolean>()
+                        .or_throw(&mut cx)?
+                        .value() as bool;
+                }
+            }
+
+            let this = cx.this();
+            let guard = cx.lock();
+            let size = this.borrow(&guard)
                 .tokenizer
                 .get_vocab_size(with_added_tokens);
 

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -4,6 +4,7 @@ use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
 use pyo3::PyObjectProtocol;
+use std::collections::HashMap;
 
 use super::decoders::Decoder;
 use super::encoding::Encoding;
@@ -87,20 +88,13 @@ impl Tokenizer {
             .map_or(0, |p| p.as_ref().added_tokens(is_pair)))
     }
 
-    #[args(kwargs = "**")]
-    fn get_vocab_size(&self, kwargs: Option<&PyDict>) -> PyResult<usize> {
-        let mut with_added_tokens = true;
+    #[args(with_added_tokens = true)]
+    fn get_vocab(&self, with_added_tokens: bool) -> PyResult<HashMap<String, u32>> {
+        Ok(self.tokenizer.get_vocab(with_added_tokens))
+    }
 
-        if let Some(kwargs) = kwargs {
-            for (key, value) in kwargs {
-                let key: &str = key.extract()?;
-                match key {
-                    "with_added_tokens" => with_added_tokens = value.extract()?,
-                    _ => println!("Ignored unknown kwarg option {}", key),
-                }
-            }
-        }
-
+    #[args(with_added_tokens = true)]
+    fn get_vocab_size(&self, with_added_tokens: bool) -> PyResult<usize> {
         Ok(self.tokenizer.get_vocab_size(with_added_tokens))
     }
 

--- a/bindings/python/tokenizers/__init__.pyi
+++ b/bindings/python/tokenizers/__init__.pyi
@@ -258,12 +258,26 @@ class Tokenizer:
         :return:
         """
         pass
-    def get_vocab_size(self, with_added_tokens: Optional[bool]) -> int:
+    def get_vocab(self, with_added_tokens: bool = True) -> Dict[str, int]:
+        """ Returns the vocabulary
+
+        Args:
+            with_added_tokens: boolean:
+                Whether to include the added tokens in the vocabulary
+
+        Returns:
+            The vocabulary
+        """
+        pass
+    def get_vocab_size(self, with_added_tokens: bool = True) -> int:
         """ Returns the size of the vocabulary
 
         Args:
-            with_added_tokens: (`optional`) boolean:
+            with_added_tokens: boolean:
                 Whether to include the added tokens in the vocabulary's size
+
+        Returns:
+            The size of the vocabulary
         """
         pass
     def enable_truncation(self, max_length: int, stride: Optional[int], strategy: Optional[str]):

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -335,6 +335,10 @@ impl BPE {
 }
 
 impl Model for BPE {
+    fn get_vocab(&self) -> &HashMap<String, u32> {
+        &self.vocab
+    }
+
     fn get_vocab_size(&self) -> usize {
         self.vocab.len()
     }

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -160,6 +160,10 @@ impl Model for WordLevel {
         self.vocab_r.get(&id).cloned()
     }
 
+    fn get_vocab(&self) -> &HashMap<String, u32> {
+        &self.vocab
+    }
+
     fn get_vocab_size(&self) -> usize {
         self.vocab.keys().len()
     }

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -186,6 +186,10 @@ impl WordPiece {
 }
 
 impl Model for WordPiece {
+    fn get_vocab(&self) -> &HashMap<String, u32> {
+        &self.vocab
+    }
+
     fn get_vocab_size(&self) -> usize {
         self.vocab.len()
     }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -49,6 +49,7 @@ pub trait Model {
     fn tokenize(&self, tokens: Vec<(String, Offsets)>) -> Result<Vec<Token>>;
     fn token_to_id(&self, token: &str) -> Option<u32>;
     fn id_to_token(&self, id: u32) -> Option<String>;
+    fn get_vocab(&self) -> &HashMap<String, u32>;
     fn get_vocab_size(&self) -> usize;
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>>;
 }
@@ -345,6 +346,20 @@ impl Tokenizer {
     pub fn with_padding(&mut self, padding: Option<PaddingParams>) -> &Self {
         self.padding = padding;
         self
+    }
+
+    /// Get the vocabulary
+    pub fn get_vocab(&self, with_added_tokens: bool) -> HashMap<String, u32> {
+        let mut final_vocab = self.model.get_vocab().clone();
+
+        if with_added_tokens && !self.added_tokens_map.is_empty() {
+            final_vocab.reserve(self.added_tokens_map.len());
+            for (token, id) in &self.added_tokens_map {
+                final_vocab.insert(token.clone(), *id);
+            }
+        }
+
+        final_vocab
     }
 
     /// Get the size of the vocabulary


### PR DESCRIPTION
Has been requested multiple times so here it is! Fix #207 

@Pierrci I tried to add the typings also since these are quite easy to add and I realized, I don't think `getVocabSize` is exposed on the base tokenizer (for implementations). I also didn't add `getVocab` there.