### PR TITLE
Fix overflowings offsets

### DIFF
--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -112,6 +112,10 @@ impl Encoding {
         &self.overflowing
     }
 
+    pub fn get_overflowing_mut(&mut self) -> &mut Vec<Encoding> {
+        &mut self.overflowing
+    }
+
     pub fn take_overflowing(&mut self) -> Vec<Encoding> {
         std::mem::replace(&mut self.overflowing, vec![])
     }


### PR DESCRIPTION
This fix ensures that the overflowing offsets are converted back to the original string before returning from `tokenizer.encode`, in addition to the "main" encoding offsets.

@n1t0 there might be a better way to code that in rust, so feel free to improve it :)