### PR TITLE
Require Send for all parts of the tokenizer

### DIFF
--- a/bindings/node/native/src/decoders.rs
+++ b/bindings/node/native/src/decoders.rs
@@ -5,7 +5,7 @@ use neon::prelude::*;
 
 /// Decoder
 pub struct Decoder {
-    pub decoder: Container<dyn tk::tokenizer::Decoder + Sync>,
+    pub decoder: Container<dyn tk::tokenizer::Decoder>,
 }
 
 declare_types! {

--- a/bindings/node/native/src/models.rs
+++ b/bindings/node/native/src/models.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 /// Model
 pub struct Model {
-    pub model: Container<dyn tk::tokenizer::Model + Sync>,
+    pub model: Container<dyn tk::tokenizer::Model>,
 }
 
 declare_types! {

--- a/bindings/node/native/src/normalizers.rs
+++ b/bindings/node/native/src/normalizers.rs
@@ -5,7 +5,7 @@ use neon::prelude::*;
 
 /// Normalizer
 pub struct Normalizer {
-    pub normalizer: Container<dyn tk::tokenizer::Normalizer + Sync>,
+    pub normalizer: Container<dyn tk::tokenizer::Normalizer>,
 }
 
 declare_types! {

--- a/bindings/node/native/src/pre_tokenizers.rs
+++ b/bindings/node/native/src/pre_tokenizers.rs
@@ -5,7 +5,7 @@ use neon::prelude::*;
 
 /// PreTokenizers
 pub struct PreTokenizer {
-    pub pretok: Container<dyn tk::tokenizer::PreTokenizer + Sync>,
+    pub pretok: Container<dyn tk::tokenizer::PreTokenizer>,
 }
 
 declare_types! {

--- a/bindings/node/native/src/processors.rs
+++ b/bindings/node/native/src/processors.rs
@@ -5,7 +5,7 @@ use neon::prelude::*;
 
 /// Processor
 pub struct Processor {
-    pub processor: Container<dyn tk::tokenizer::PostProcessor + Sync>,
+    pub processor: Container<dyn tk::tokenizer::PostProcessor>,
 }
 
 declare_types! {

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -9,7 +9,7 @@ use tk::tokenizer::Result;
 
 #[pyclass(dict)]
 pub struct Decoder {
-    pub decoder: Container<dyn tk::tokenizer::Decoder + Sync>,
+    pub decoder: Container<dyn tk::tokenizer::Decoder>,
 }
 #[pymethods]
 impl Decoder {

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -78,7 +78,7 @@ impl<'source> FromPyObject<'source> for EncodeInput {
 /// This class cannot be constructed directly. Please use one of the concrete models.
 #[pyclass]
 pub struct Model {
-    pub model: Container<dyn tk::tokenizer::Model + Sync>,
+    pub model: Container<dyn tk::tokenizer::Model>,
 }
 
 #[pymethods]

--- a/bindings/python/src/normalizers.rs
+++ b/bindings/python/src/normalizers.rs
@@ -7,7 +7,7 @@ use pyo3::types::*;
 
 #[pyclass(dict)]
 pub struct Normalizer {
-    pub normalizer: Container<dyn tk::tokenizer::Normalizer + Sync>,
+    pub normalizer: Container<dyn tk::tokenizer::Normalizer>,
 }
 
 #[pyclass(extends=Normalizer)]

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -9,7 +9,7 @@ use tk::tokenizer::{Offsets, Result};
 
 #[pyclass(dict)]
 pub struct PreTokenizer {
-    pub pretok: Container<dyn tk::tokenizer::PreTokenizer + Sync>,
+    pub pretok: Container<dyn tk::tokenizer::PreTokenizer>,
 }
 #[pymethods]
 impl PreTokenizer {

--- a/bindings/python/src/processors.rs
+++ b/bindings/python/src/processors.rs
@@ -6,7 +6,7 @@ use pyo3::types::*;
 
 #[pyclass(dict)]
 pub struct PostProcessor {
-    pub processor: Container<dyn tk::tokenizer::PostProcessor + Sync>,
+    pub processor: Container<dyn tk::tokenizer::PostProcessor>,
 }
 
 #[pymethods]

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -601,7 +601,7 @@ impl Trainer for BpeTrainer {
     fn train(
         &self,
         word_counts: HashMap<String, u32>,
-    ) -> Result<(Box<dyn Model + Sync>, Vec<AddedToken>)> {
+    ) -> Result<(Box<dyn Model>, Vec<AddedToken>)> {
         let (bpe, tokens) = self.train(word_counts)?;
         Ok((Box::new(bpe), tokens))
     }

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -99,7 +99,7 @@ impl Trainer for WordPieceTrainer {
     fn train(
         &self,
         word_counts: HashMap<String, u32>,
-    ) -> Result<(Box<dyn Model + Sync>, Vec<AddedToken>)> {
+    ) -> Result<(Box<dyn Model>, Vec<AddedToken>)> {
         let (wp, tokens) = self.train(word_counts)?;
         Ok((Box::new(wp), tokens))
     }

--- a/tokenizers/src/normalizers/utils.rs
+++ b/tokenizers/src/normalizers/utils.rs
@@ -3,11 +3,11 @@ use crate::tokenizer::{NormalizedString, Normalizer, Result};
 /// Allows concatenating multiple other Normalizer as a Sequence.
 /// All the normalizers run in sequence in the given order against the same NormalizedString.
 pub struct Sequence {
-    normalizers: Vec<Box<dyn Normalizer + Sync>>,
+    normalizers: Vec<Box<dyn Normalizer>>,
 }
 
 impl Sequence {
-    pub fn new(normalizers: Vec<Box<dyn Normalizer + Sync>>) -> Self {
+    pub fn new(normalizers: Vec<Box<dyn Normalizer>>) -> Self {
         Self { normalizers }
     }
 }


### PR DESCRIPTION
This allows us to use a tokenizer from an async context.

The change itself was very trivial: Just add a `Send` bound to all parts of the tokenizer and then add it everywhere the compiler wants it.