### PR TITLE
Word indexes are None for special tokens

### DIFF
--- a/bindings/node/lib/bindings/raw-encoding.d.ts
+++ b/bindings/node/lib/bindings/raw-encoding.d.ts
@@ -69,7 +69,7 @@ export interface RawEncoding {
    * The tokenized words indexes
    * @since 0.6.0
    */
-  getWords(): number[];
+  getWords(): (number | undefined)[];
 
   /**
    * Pad the current Encoding at the given length

--- a/bindings/node/lib/implementations/encoding.ts
+++ b/bindings/node/lib/implementations/encoding.ts
@@ -10,7 +10,7 @@ export class Encoding {
   private _specialTokensMask?: number[];
   private _tokens?: string[];
   private _typeIds?: number[];
-  private _wordIndexes?: number[];
+  private _wordIndexes?: (number | undefined)[];
 
   constructor(private _rawEncoding: RawEncoding) {}
 
@@ -132,7 +132,7 @@ export class Encoding {
   /**
    * The tokenized words indexes
    */
-  get wordIndexes(): number[] {
+  get wordIndexes(): (number | undefined)[] {
     if (this._wordIndexes) {
       return this._wordIndexes;
     }

--- a/bindings/node/native/Cargo.lock
+++ b/bindings/node/native/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
  "neon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokenizers 0.9.0",
+ "tokenizers 0.10.0",
 ]
 
 [[package]]
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "tokenizers"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -124,8 +124,13 @@ declare_types! {
             });
             let js_ids = JsArray::new(&mut cx, ids.len() as u32);
             for (i, id) in ids.into_iter().enumerate() {
-                let n = JsNumber::new(&mut cx, id as f64);
-                js_ids.set(&mut cx, i as u32, n)?;
+                if let Some(id) = id {
+                    let n = JsNumber::new(&mut cx, id as f64);
+                    js_ids.set(&mut cx, i as u32, n)?;
+                } else {
+                    let v = cx.undefined();
+                    js_ids.set(&mut cx, i as u32, v)?;
+                }
             }
 
             Ok(js_ids.upcast())

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -62,7 +62,7 @@ impl Encoding {
     }
 
     #[getter]
-    fn get_words(&self) -> Vec<u32> {
+    fn get_words(&self) -> Vec<Option<u32>> {
         self.encoding.get_words().to_vec()
     }
 

--- a/bindings/python/tokenizers/__init__.pyi
+++ b/bindings/python/tokenizers/__init__.pyi
@@ -43,7 +43,7 @@ class Encoding:
         """ The tokenized strings """
         pass
     @property
-    def words(self) -> List[int]:
+    def words(self) -> List[Optional[int]]:
         """ The tokenized words index """
         pass
     @property

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -38,12 +38,7 @@ impl PostProcessor for BertProcessing {
             &[self.sep.0.clone()],
         ]
         .concat();
-        let words = [
-            &[0],
-            &encoding.get_words()[..],
-            &[encoding.get_words().last().map_or(0, |w| *w + 2)],
-        ]
-        .concat();
+        let words = [&[None], &encoding.get_words()[..], &[None]].concat();
         let offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
         let special_tokens = [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
         let attention_mask = vec![1; ids.len()];
@@ -68,12 +63,7 @@ impl PostProcessor for BertProcessing {
                         &[self.sep.0.clone()],
                     ]
                     .concat();
-                    let words = [
-                        &[0],
-                        &encoding.get_words()[..],
-                        &[encoding.get_words().last().map_or(0, |w| *w + 2)],
-                    ]
-                    .concat();
+                    let words = [&[None], &encoding.get_words()[..], &[None]].concat();
                     let offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
                     let special_tokens =
                         [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
@@ -97,11 +87,7 @@ impl PostProcessor for BertProcessing {
             let pair_ids = [&encoding.get_ids()[..], &[self.sep.1]].concat();
             let pair_type_ids = [&encoding.get_type_ids()[..], &[1]].concat();
             let pair_tokens = [&encoding.get_tokens()[..], &[self.sep.0.clone()]].concat();
-            let pair_words = [
-                &encoding.get_words()[..],
-                &[encoding.get_words().last().map_or(0, |w| *w + 1)],
-            ]
-            .concat();
+            let pair_words = [&encoding.get_words()[..], &[None]].concat();
             let pair_offsets = [&encoding.get_offsets()[..], &[(0, 0)]].concat();
             let pair_special_tokens =
                 [&vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
@@ -123,11 +109,7 @@ impl PostProcessor for BertProcessing {
                         let pair_type_ids = [&encoding.get_type_ids()[..], &[1]].concat();
                         let pair_tokens =
                             [&encoding.get_tokens()[..], &[self.sep.0.clone()]].concat();
-                        let pair_words = [
-                            &encoding.get_words()[..],
-                            &[encoding.get_words().last().map_or(0, |w| *w + 1)],
-                        ]
-                        .concat();
+                        let pair_words = [&encoding.get_words()[..], &[None]].concat();
                         let pair_offsets = [&encoding.get_offsets()[..], &[(0, 0)]].concat();
                         let pair_special_tokens =
                             [&vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -38,12 +38,7 @@ impl PostProcessor for RobertaProcessing {
             &[self.sep.0.clone()],
         ]
         .concat();
-        let words = [
-            &[0],
-            &encoding.get_words()[..],
-            &[encoding.get_words().last().map_or(0, |w| *w + 2)],
-        ]
-        .concat();
+        let words = [&[None], &encoding.get_words()[..], &[None]].concat();
         let offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
         let special_tokens = [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
         let attention_mask = vec![1; ids.len()];
@@ -68,12 +63,7 @@ impl PostProcessor for RobertaProcessing {
                         &[self.sep.0.clone()],
                     ]
                     .concat();
-                    let words = [
-                        &[0],
-                        &encoding.get_words()[..],
-                        &[encoding.get_words().last().map_or(0, |w| *w + 2)],
-                    ]
-                    .concat();
+                    let words = [&[None], &encoding.get_words()[..], &[None]].concat();
                     let offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
                     let special_tokens =
                         [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
@@ -102,12 +92,7 @@ impl PostProcessor for RobertaProcessing {
                 &[self.sep.0.clone()],
             ]
             .concat();
-            let pair_words = [
-                &[0],
-                &encoding.get_words()[..],
-                &[encoding.get_words().last().map_or(0, |w| *w + 2)],
-            ]
-            .concat();
+            let pair_words = [&[None], &encoding.get_words()[..], &[None]].concat();
             let pair_offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
             let pair_special_tokens =
                 [&[1], &vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
@@ -134,12 +119,7 @@ impl PostProcessor for RobertaProcessing {
                             &[self.sep.0.clone()],
                         ]
                         .concat();
-                        let pair_words = [
-                            &[0],
-                            &encoding.get_words()[..],
-                            &[encoding.get_words().last().map_or(0, |w| *w + 2)],
-                        ]
-                        .concat();
+                        let pair_words = [&[None], &encoding.get_words()[..], &[None]].concat();
                         let pair_offsets =
                             [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
                         let pair_special_tokens =

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -428,7 +428,7 @@ impl Tokenizer {
                                     vec![id],
                                     vec![type_id],
                                     vec![sentence.get().to_owned()],
-                                    vec![0],
+                                    vec![Some(0)],
                                     vec![(0, sentence.len())],
                                     vec![0],
                                     vec![1],


### PR DESCRIPTION
Before these changes, the indexes were wrong when there were special tokens.