### PR TITLE
Python - improve compatibility with sentencepiece in the conversion script

### DIFF
--- a/bindings/python/scripts/sentencepiece_extractor.py
+++ b/bindings/python/scripts/sentencepiece_extractor.py
@@ -33,12 +33,12 @@ class SentencePieceExtractor:
         merges = []
         for piece_l in tqdm(vocab.keys(), total=sp.GetPieceSize()):
             for piece_r in vocab.keys():
-                if piece_l != piece_r:
-                    merge = sp.PieceToId(f"{piece_l}{piece_r}")
-                    score = sp.GetScore(merge)
-
-                    if score != 0.:
-                        merges += [(piece_l, piece_r)]
+                merge = f"{piece_l}{piece_r}"
+                piece_id = vocab.get(merge, None)
+                if piece_id:
+                    merges += [(piece_l, piece_r, piece_id)]
+        merges = sorted(merges, key=lambda val: val[2])
+        merges = [(val[0], val[1]) for val in merges]
 
         return vocab, merges
 


### PR DESCRIPTION
This fix improves compatibility between the original sentencepiece model and the model converted using `sentencepiece_extractor.py` script. It introduces two simple changes:
1. Merges are sorted according to the piece IDs.
2. Removes the condition `piece_l != piece_r` as it should be valid to merge two instances of the same piece.

I tested the conversion process on a dataset of 5000 sentences by comparing the result produced by the original sentencepiece model and the converted tokenizers model.
For the initial version of the script, 4021 (80%) sentences were mismatched.
For the modified version, the results were identical for all sentences.