### PR TITLE
Fix offsets

### DIFF
--- a/bindings/node/lib/bindings/post-processors.d.ts
+++ b/bindings/node/lib/bindings/post-processors.d.ts
@@ -32,8 +32,12 @@ export function byteLevelProcessing(trimOffsets?: boolean): PostProcessor;
  *
  * @param sep A tuple with the string representation of the SEP token, and its id
  * @param cls A tuple with the string representation of the CLS token, and its id
+ * @param trimOffsets Whether to trim the whitespaces in the produced offsets
+ * @param addPrefixSpace Whether addPrefixSpace was ON during the pre-tokenization
  */
 export function robertaProcessing(
   sep: [string, number],
-  cls: [string, number]
+  cls: [string, number],
+  trimOffsets: boolean,
+  addPrefixSpace: boolean
 ): PostProcessor;

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -29,6 +29,7 @@ constructors.
 This avoids the unintuitive inclusion of the whitespaces in the produced offsets, even if these
 whitespaces are part of the actual token.
 It has been added to `ByteLevelBPETokenizer` but it is off by default (`trim_offsets=False`).
+- [#236]: `RobertaProcessing` also handles trimming the offsets.
 - More alignment mappings on the `Encoding`.
 - `post_process` can be called on the `Tokenizer`
 - [#208]: Ability to retrieve the vocabulary from the `Tokenizer` with
@@ -157,7 +158,9 @@ delimiter (Works like `.split(delimiter)`)
 - Fix a bug with the IDs associated with added tokens.
 - Fix a bug that was causing crashes in Python 3.5
 
+[#236]: https://github.com/huggingface/tokenizers/pull/236
 [#208]: https://github.com/huggingface/tokenizers/pull/208
+[#205]: https://github.com/huggingface/tokenizers/issues/205
 [#197]: https://github.com/huggingface/tokenizers/pull/197
 [#193]: https://github.com/huggingface/tokenizers/pull/193
 [#190]: https://github.com/huggingface/tokenizers/pull/190

--- a/bindings/python/src/processors.rs
+++ b/bindings/python/src/processors.rs
@@ -38,12 +38,20 @@ pub struct RobertaProcessing {}
 #[pymethods]
 impl RobertaProcessing {
     #[new]
-    fn new(sep: (String, u32), cls: (String, u32)) -> PyResult<(Self, PostProcessor)> {
+    #[args(trim_offsets = true, add_prefix_space = true)]
+    fn new(
+        sep: (String, u32),
+        cls: (String, u32),
+        trim_offsets: bool,
+        add_prefix_space: bool,
+    ) -> PyResult<(Self, PostProcessor)> {
         Ok((
             RobertaProcessing {},
             PostProcessor {
                 processor: Container::Owned(Box::new(
-                    tk::processors::roberta::RobertaProcessing::new(sep, cls),
+                    tk::processors::roberta::RobertaProcessing::new(sep, cls)
+                        .trim_offsets(trim_offsets)
+                        .add_prefix_space(add_prefix_space),
                 )),
             },
         ))

--- a/bindings/python/tokenizers/processors/__init__.pyi
+++ b/bindings/python/tokenizers/processors/__init__.pyi
@@ -46,9 +46,20 @@ class RobertaProcessing(PostProcessor):
     a Roberta model:
         - a SEP token
         - a CLS token
+
+    It also takes care of trimming the offsets.
+    By default, the ByteLevel BPE might include whitespaces in the produced tokens. If you don't
+    want the offsets to include these whitespaces, then this PostProcessor should be initialized
+    with `trim_offsets=True`
     """
 
-    def __init__(self, sep: Tuple[str, int], cls: Tuple[str, int]) -> None:
+    def __init__(
+        self,
+        sep: Tuple[str, int],
+        cls: Tuple[str, int],
+        trim_offsets: bool = True,
+        add_prefix_space: bool = True,
+    ) -> None:
         """ Instantiate a new RobertaProcessing with the given tokens
 
         Args:
@@ -57,6 +68,13 @@ class RobertaProcessing(PostProcessor):
 
             cls: Tuple[str, int]:
                 A tuple with the string representation of the CLS token, and its id
+
+            trim_offsets: bool:
+                Whether to trim the whitespaces from the produced offsets.
+
+            add_prefix_space: bool:
+                Whether the add_prefix_space option was enabled during pre-tokenization. This
+                is relevant because it defines the way the offsets are trimmed out.
 
         Returns:
             PostProcessor

--- a/tokenizers/CHANGELOG.md
+++ b/tokenizers/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- [#236]: Fix a bug with offsets being shifted when there are sub-sequences (Usually with
+special tokens and/or added tokens in the sequence).
+
+### Changed
+- [#236]: `AddedToken` with special options like `rstrip` will keep the matched whitespaces
+in the textual representation of the token, exposed in `tokens` on the `Encoding`. The ID stays
+the same as usual. This fixes the offsets for said tokens.
+- [#236]: Offsets are now converted back to the original referential before we merge the
+sub-sequences together and then do the post-processing. This also fixes some offsets bugs.
+- [#236]: ByteLevel PostProcessor now uses the `add_prefix_space` attribute to determine how to
+trim offsets.
+
+### Added
+- [#236]: RobertaProcessing is now also taking care of trimming offsets, and works just as ByteLevel
+on this front.
+
+### How to migrate
+- Specify the `add_prefix_space` and `trim_offsets` options on `RobertaProcessing` if you don't
+want the offsets trimmed out.
+- Any custom `PostProcessor` now handles offsets relative to the original string (as opposed to the
+normalized one).
+
 ## [0.10.1]
 
 ### Fixed
@@ -71,6 +96,8 @@ split up in multiple bytes
 - [#174]: The `LongestFirst` truncation strategy had a bug
 
 [b770f36]: https://github.com/huggingface/tokenizers/commit/b770f364280af33efeffea8f0003102cda8cf1b7
+[#236]: https://github.com/huggingface/tokenizers/pull/236
+[#226]: https://github.com/huggingface/tokenizers/pull/226
 [#222]: https://github.com/huggingface/tokenizers/pull/222
 [#208]: https://github.com/huggingface/tokenizers/pull/208
 [#205]: https://github.com/huggingface/tokenizers/issues/205

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -242,10 +242,19 @@ impl PostProcessor for ByteLevel {
         };
 
         process_offsets(&mut encoding);
+        encoding
+            .get_overflowing_mut()
+            .iter_mut()
+            .for_each(|mut encoding| process_offsets(&mut encoding));
+
         let final_encoding = match pair_encoding {
             None => encoding,
             Some(mut pair) => {
                 process_offsets(&mut pair);
+                pair.get_overflowing_mut()
+                    .iter_mut()
+                    .for_each(|mut encoding| process_offsets(&mut encoding));
+
                 encoding.merge_with(pair, false);
                 encoding
             }

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -223,9 +223,16 @@ impl PostProcessor for ByteLevel {
                 .filter(|(_, v)| v.0 > 0 || v.1 > 0)
                 .collect::<Vec<_>>();
 
-            modifs.into_iter().for_each(|(i, (ld, tl))| {
+            modifs.into_iter().for_each(|(i, (mut ld, tl))| {
                 let mut offsets = &mut encoding.get_offsets_mut()[i];
                 if ld > 0 {
+                    if i == 0 && self.add_prefix_space && ld == 1 {
+                        // If we are processing the first pair of offsets, with `add_prefix_space`,
+                        // then we shouldn't remove anything we added. If there are more than one
+                        // leading spaces though, it means we didn't add them, and they should be
+                        // removed.
+                        ld = 0;
+                    }
                     offsets.0 = std::cmp::min(offsets.0 + ld, offsets.1);
                 }
                 if tl > 0 {

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -196,72 +196,65 @@ impl PostProcessor for ByteLevel {
     fn process(
         &self,
         mut encoding: Encoding,
-        pair_encoding: Option<Encoding>,
-        _add_special_tokens: bool,
+        mut pair_encoding: Option<Encoding>,
+        add_special_tokens: bool,
     ) -> Result<Encoding> {
-        let process_offsets = |encoding: &mut Encoding| {
-            if !self.trim_offsets {
-                return;
-            }
+        if self.trim_offsets {
+            process_offsets(&mut encoding, self.add_prefix_space);
+            encoding
+                .get_overflowing_mut()
+                .iter_mut()
+                .for_each(|mut encoding| process_offsets(&mut encoding, self.add_prefix_space));
 
-            let modifs = encoding
-                .get_tokens()
-                .iter()
-                .map(|token| {
-                    let leading_spaces = token
-                        .chars()
-                        .take_while(|c| *c == BYTES_CHAR[&b' '])
-                        .count();
-                    let trailing_spaces = token
-                        .chars()
-                        .rev()
-                        .take_while(|c| *c == BYTES_CHAR[&b' '])
-                        .count();
-                    (leading_spaces, trailing_spaces)
-                })
-                .enumerate()
-                .filter(|(_, v)| v.0 > 0 || v.1 > 0)
-                .collect::<Vec<_>>();
-
-            modifs.into_iter().for_each(|(i, (mut ld, tl))| {
-                let mut offsets = &mut encoding.get_offsets_mut()[i];
-                if ld > 0 {
-                    if i == 0 && self.add_prefix_space && ld == 1 {
-                        // If we are processing the first pair of offsets, with `add_prefix_space`,
-                        // then we shouldn't remove anything we added. If there are more than one
-                        // leading spaces though, it means we didn't add them, and they should be
-                        // removed.
-                        ld = 0;
-                    }
-                    offsets.0 = std::cmp::min(offsets.0 + ld, offsets.1);
-                }
-                if tl > 0 {
-                    offsets.1 = std::cmp::max(offsets.1 - tl, offsets.0);
-                }
-            });
-        };
-
-        process_offsets(&mut encoding);
-        encoding
-            .get_overflowing_mut()
-            .iter_mut()
-            .for_each(|mut encoding| process_offsets(&mut encoding));
-
-        let final_encoding = match pair_encoding {
-            None => encoding,
-            Some(mut pair) => {
-                process_offsets(&mut pair);
-                pair.get_overflowing_mut()
-                    .iter_mut()
-                    .for_each(|mut encoding| process_offsets(&mut encoding));
-
-                encoding.merge_with(pair, false);
+            if let Some(mut encoding) = pair_encoding.as_mut() {
+                process_offsets(&mut encoding, self.add_prefix_space);
                 encoding
+                    .get_overflowing_mut()
+                    .iter_mut()
+                    .for_each(|mut encoding| process_offsets(&mut encoding, self.add_prefix_space));
             }
-        };
+        }
 
-        Ok(final_encoding)
+        PostProcessor::default_process(encoding, pair_encoding, add_special_tokens)
     }
+}
+
+pub fn process_offsets(encoding: &mut Encoding, add_prefix_space: bool) {
+    let modifs = encoding
+        .get_tokens()
+        .iter()
+        .map(|token| {
+            let leading_spaces = token
+                .chars()
+                .take_while(|c| *c == BYTES_CHAR[&b' '])
+                .count();
+            let trailing_spaces = token
+                .chars()
+                .rev()
+                .take_while(|c| *c == BYTES_CHAR[&b' '])
+                .count();
+            (leading_spaces, trailing_spaces)
+        })
+        .enumerate()
+        .filter(|(_, v)| v.0 > 0 || v.1 > 0)
+        .collect::<Vec<_>>();
+
+    modifs.into_iter().for_each(|(i, (mut ld, tl))| {
+        let mut offsets = &mut encoding.get_offsets_mut()[i];
+        if ld > 0 {
+            if i == 0 && add_prefix_space && ld == 1 {
+                // If we are processing the first pair of offsets, with `add_prefix_space`,
+                // then we shouldn't remove anything we added. If there are more than one
+                // leading spaces though, it means we didn't add them, and they should be
+                // removed.
+                ld = 0;
+            }
+            offsets.0 = std::cmp::min(offsets.0 + ld, offsets.1);
+        }
+        if tl > 0 {
+            offsets.1 = std::cmp::max(offsets.1 - tl, offsets.0);
+        }
+    });
 }
 
 #[cfg(test)]

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -721,4 +721,19 @@ mod tests {
         assert_eq!(get_range_of(&s, ..), Some(&s[..]));
         assert_eq!(get_range_of(&s, 17..), Some("John 👋"));
     }
+
+    #[test]
+    fn merge() {
+        let mut s = NormalizedString::from("A sentence that will be merged");
+        s.prepend(" ");
+
+        let mut merged = NormalizedString::from("A sentence");
+        let s2 = NormalizedString::from(" that will");
+        let s3 = NormalizedString::from(" be merged");
+        merged.prepend(" ");
+        merged.merge_with(&s2);
+        merged.merge_with(&s3);
+
+        assert_eq!(s, merged);
+    }
 }

--- a/tokenizers/tests/added_tokens.rs
+++ b/tokenizers/tests/added_tokens.rs
@@ -38,7 +38,11 @@ fn lstrip_tokens() {
 
     assert_eq!(
         output.get_tokens(),
-        &["ĠI", "Ġsaw", "Ġa", "<mask>", "ĠðŁĺ", "º"]
+        &["ĠI", "Ġsaw", "Ġa", " <mask>", "ĠðŁĺ", "º"]
+    );
+    assert_eq!(
+        output.get_offsets(),
+        &[(0, 1), (1, 5), (5, 7), (7, 14), (14, 16), (15, 16)]
     );
 }
 
@@ -52,7 +56,7 @@ fn rstrip_tokens() {
 
     assert_eq!(
         output.get_tokens(),
-        &["I", "Ġsaw", "Ġa", "Ġ", "<mask>", "ðŁĺ", "º"]
+        &["I", "Ġsaw", "Ġa", "Ġ", "<mask> ", "ðŁĺ", "º"]
     );
 
     // When `add_prefix_space = true` rstrip cannot work as a prefix space is added
@@ -65,7 +69,7 @@ fn rstrip_tokens() {
 
     assert_eq!(
         output.get_tokens(),
-        &["ĠI", "Ġsaw", "Ġa", "Ġ", "<mask>", "ĠðŁĺ", "º"]
+        &["ĠI", "Ġsaw", "Ġa", "Ġ", "<mask> ", "ĠðŁĺ", "º"]
     );
 }
 


### PR DESCRIPTION
This PR fixes the bug described in https://github.com/huggingface/transformers/issues/3796

Changes:
  - `AddedToken` that trim the content are now displayed with the whole content. `" <mask>"` will now be shown as such, with the leading space in the list of `tokens`. The ID obviously stays the same.
  - Offsets are converted back to the original space before we merge all sub-sequences together.
  - `ByteLevel` offsets trimming has been updated to work on original offsets, instead of normalized ones.
  - `RobertaProcessing` now trim offsets by default.