### PR TITLE
Update CharLevelBPE to match GPT BPE

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -20,9 +20,10 @@ normalized one anymore.
 - The added token given to `add_special_tokens` or `add_tokens` on a `Tokenizer`, or while using
 `train(special_tokens=...)` can now be instances of `AddedToken` to provide more control over these
 tokens.
-- [#136] Updated Pyo3 version
-- [#136] Static methods `Model.from_files` and `Model.empty` are removed in favor of using
+- [#136]: Updated Pyo3 version
+- [#136]: Static methods `Model.from_files` and `Model.empty` are removed in favor of using
 constructors.
+- [#239]: `CharBPETokenizer` now corresponds to OpenAI GPT BPE implementation by default.
 
 ### Added
 - [#188]: `ByteLevel` is also a `PostProcessor` now and handles trimming the offsets if activated.
@@ -59,6 +60,8 @@ are now relative to the original string by default.
 `normalize(sequence)` on the `Tokenizer`
 - Change `Model.from_files` and `Model.empty` to use constructor. The model constructor should take
 the same arguments as the old methods. (ie `BPE(vocab, merges)` or `BPE()`)
+- If you were using the `CharBPETokenizer` and want to keep the same behavior as before, set
+`bert_normalizer=False` and `split_on_whitespace_only=True`.
 
 ## [0.6.0]
 
@@ -159,6 +162,7 @@ delimiter (Works like `.split(delimiter)`)
 - Fix a bug with the IDs associated with added tokens.
 - Fix a bug that was causing crashes in Python 3.5
 
+[#239]: https://github.com/huggingface/tokenizers/pull/239
 [#236]: https://github.com/huggingface/tokenizers/pull/236
 [#234]: https://github.com/huggingface/tokenizers/pull/234
 [#208]: https://github.com/huggingface/tokenizers/pull/208

--- a/bindings/python/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/char_level_bpe.py
@@ -9,15 +9,17 @@ from typing import Optional, List, Union
 class CharBPETokenizer(BaseTokenizer):
     """ Original BPE Tokenizer
 
-        Represents the BPE algorithm, as introduced by Rico Sennrich (https://arxiv.org/abs/1508.07909)
+        Represents the BPE algorithm, as introduced by Rico Sennrich
+        (https://arxiv.org/abs/1508.07909)
 
-        The defaults settings corresponds to OpenAI GPT BPE tokenizers and differs from
-        the original Sennrich subword-nmt implementation by the following options that you can deactivate:
-            - adding a normalizer to clean up the text (deactivate it with `bert_normalizer=False`) by:
+        The defaults settings corresponds to OpenAI GPT BPE tokenizers and differs from the original
+        Sennrich subword-nmt implementation by the following options that you can deactivate:
+            - adding a normalizer to clean up the text (deactivate with `bert_normalizer=False`) by:
                 * removing any control characters and replacing all whitespaces by the classic one.
                 * handle chinese chars by putting spaces around them.
                 * strip all accents.
-            - spitting on punctuation in addition to whitespaces (deactivate it with `split_on_whitespace_only=True`)
+            - spitting on punctuation in addition to whitespaces (deactivate it with
+              `split_on_whitespace_only=True`)
     """
 
     def __init__(

--- a/bindings/python/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/char_level_bpe.py
@@ -81,7 +81,7 @@ class CharBPETokenizer(BaseTokenizer):
             "dropout": dropout,
             "lowercase": lowercase,
             "unicode_normalizer": unicode_normalizer,
-            "bert_normalizer":bert_normalizer,
+            "bert_normalizer": bert_normalizer,
             "split_on_whitespace_only": split_on_whitespace_only,
         }
 


### PR DESCRIPTION
This updates CharLevelBPE to match OpenAI GPT BPE, in particular by having a punctuation splitter instead of a whitespace splitter. We still keep the lowercasing deactivated by default.