### PR TITLE
Python - Fix bug in bert wordpiece example script

### DIFF
--- a/bindings/python/examples/train_bert_wordpiece.py
+++ b/bindings/python/examples/train_bert_wordpiece.py
@@ -36,7 +36,7 @@ tokenizer = BertWordPieceTokenizer(
 )
 
 # And then train
-trainer = tokenizer.train(
+tokenizer.train(
     files,
     vocab_size=10000,
     min_frequency=2,


### PR DESCRIPTION
`tokenizer.train()` does not have a return. Changed it to be consistent with the other example scripts.