### PR TITLE
Speedup train process by reading file in one pass and iterating in parallel over lines.

### DIFF
--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -6,7 +6,7 @@ dir_guard=@mkdir -p $(@D)
 
 SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2-merges.txt
 BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/big.txt
-TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/bert-base-uncased-vocab.txt
+TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/bert-base-uncased-vocab.txt $(DATA_DIR)/small.txt
 
 .PHONY : build
 build :
@@ -56,3 +56,6 @@ $(DATA_DIR)/bert-% :
 $(DATA_DIR)/big.txt :
 	$(dir_guard)
 	wget https://norvig.com/big.txt -O $@
+
+$(DATA_DIR)/small.txt : $(DATA_DIR)/big.txt
+	head -100 $(DATA_DIR)/big.txt > $@

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -5,8 +5,8 @@ TESTS_DIR = tests
 dir_guard=@mkdir -p $(@D)
 
 SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2-merges.txt
-BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/big.txt
-TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/bert-base-uncased-vocab.txt $(DATA_DIR)/small.txt
+BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/big.txt $(DATA_DIR)/small.txt
+TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/bert-base-uncased-vocab.txt
 
 .PHONY : build
 build :

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -103,6 +103,7 @@ fn bench_gpt2(c: &mut Criterion) {
     });
 }
 
+#[allow(clippy::borrowed_box)]
 fn iter_bench_train(
     iters: u64,
     tokenizer: &mut Tokenizer,
@@ -130,7 +131,7 @@ fn bench_gpt2_train(c: &mut Criterion) {
                 iters,
                 &mut tokenizer,
                 &trainer,
-                vec!["data/small.txt".to_string()].clone(),
+                vec!["data/small.txt".to_string()],
             )
         })
     });
@@ -141,7 +142,7 @@ fn bench_gpt2_train(c: &mut Criterion) {
                 iters,
                 &mut tokenizer,
                 &trainer,
-                vec!["data/big.txt".to_string()].clone(),
+                vec!["data/big.txt".to_string()],
             )
         })
     });

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -6,9 +6,10 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::Path;
 use std::time::{Duration, Instant};
-use tokenizers::models::bpe::BPE;
+use tokenizers::models::bpe::{BpeTrainerBuilder, BPE};
 use tokenizers::pre_tokenizers::byte_level::ByteLevel;
-use tokenizers::tokenizer::{AddedToken, EncodeInput, Tokenizer};
+use tokenizers::pre_tokenizers::whitespace::Whitespace;
+use tokenizers::tokenizer::{AddedToken, EncodeInput, Tokenizer, Trainer};
 
 static BATCH_SIZE: usize = 1_000;
 
@@ -102,9 +103,58 @@ fn bench_gpt2(c: &mut Criterion) {
     });
 }
 
+fn iter_bench_train(
+    iters: u64,
+    tokenizer: &mut Tokenizer,
+    trainer: &Box<dyn Trainer>,
+    files: Vec<String>,
+) -> Duration {
+    let mut duration = Duration::new(0, 0);
+    for _i in 0..iters {
+        let start = Instant::now();
+        let _ = black_box(tokenizer.train(&trainer, files.clone()));
+        duration = duration.checked_add(start.elapsed()).unwrap();
+    }
+    duration
+}
+
+fn bench_gpt2_train(c: &mut Criterion) {
+    let mut tokenizer = Tokenizer::new(Box::new(BPE::default()));
+    tokenizer.with_pre_tokenizer(Box::new(Whitespace));
+
+    let trainer: Box<dyn Trainer> =
+        Box::new(BpeTrainerBuilder::default().show_progress(false).build());
+    c.bench_function("BPE Train vocabulary (small)", |b| {
+        b.iter_custom(|iters| {
+            iter_bench_train(
+                iters,
+                &mut tokenizer,
+                &trainer,
+                vec!["data/small.txt".to_string()].clone(),
+            )
+        })
+    });
+
+    c.bench_function("BPE Train vocabulary (big)", |b| {
+        b.iter_custom(|iters| {
+            iter_bench_train(
+                iters,
+                &mut tokenizer,
+                &trainer,
+                vec!["data/big.txt".to_string()].clone(),
+            )
+        })
+    });
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(20);
     targets = bench_gpt2
 }
-criterion_main!(benches);
+criterion_group! {
+    name = benches_train;
+    config = Criterion::default().sample_size(10);
+    targets = bench_gpt2_train
+}
+criterion_main!(benches, benches_train);

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -119,7 +119,7 @@ fn iter_bench_train(
     duration
 }
 
-fn bench_gpt2_train(c: &mut Criterion) {
+fn bench_train(c: &mut Criterion) {
     let mut tokenizer = Tokenizer::new(Box::new(BPE::default()));
     tokenizer.with_pre_tokenizer(Box::new(Whitespace));
 
@@ -156,6 +156,6 @@ criterion_group! {
 criterion_group! {
     name = benches_train;
     config = Criterion::default().sample_size(10);
-    targets = bench_gpt2_train
+    targets = bench_train
 }
 criterion_main!(benches, benches_train);

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -220,6 +220,7 @@ impl BpeTrainer {
         if let Some(p) = p {
             p.set_message(message);
             p.set_length(len as u64);
+            p.set_draw_delta(len as u64 / 100);
             p.reset();
         }
     }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -904,20 +904,20 @@ impl Tokenizer {
 mod tests {
     use super::*;
     use crate::models::bpe::{BpeTrainerBuilder, BPE};
-    use crate::pre_tokenizers::byte_level::ByteLevel;
+    use crate::pre_tokenizers::whitespace::Whitespace;
 
     #[test]
     fn test_word_count() {
         let mut tokenizer = Tokenizer::new(Box::new(BPE::default()));
-        tokenizer.with_pre_tokenizer(Box::new(ByteLevel::default()));
+        tokenizer.with_pre_tokenizer(Box::new(Whitespace));
 
         let trainer: Box<dyn Trainer> =
             Box::new(BpeTrainerBuilder::default().show_progress(false).build());
         let words = tokenizer
             .word_count(&trainer, vec!["data/small.txt".to_string()])
             .unwrap();
-        assert_eq!(words.get(&"1520".to_string()), Some(&1));
-        assert_eq!(words.len(), 1503);
-        assert_eq!(words.into_iter().map(|(_, v)| v).sum::<u32>(), 3085);
+        assert_eq!(words.get(&"Holmes".to_string()), Some(&7));
+        assert_eq!(words.len(), 680);
+        assert_eq!(words.into_iter().map(|(_, v)| v).sum::<u32>(), 1541);
     }
 }

--- a/tokenizers/src/utils/iter.rs
+++ b/tokenizers/src/utils/iter.rs
@@ -2,6 +2,8 @@
 //! (cf https://github.com/rust-lang/rust/blob/25091ed9b7739e12466fb2490baa1e8a2815121c/src/libcore/iter/adapters/mod.rs#L2664)
 //! We are now using the version from https://stackoverflow.com/questions/44544323/how-to-unzip-a-sequence-of-resulta-b-e-to-a-veca-vecb-and-stop-on-f
 //! because the one from the libcore seems to cause overflowing stacks in some cases
+//! It also contains a lines_with_ending that copies std::io::BufRead but keeps line endings.
+use std::io::BufRead;
 
 pub struct ResultShunt<I, E> {
     iter: I,
@@ -53,6 +55,45 @@ where
                 None
             }
             None => None,
+        }
+    }
+}
+
+/// Copied from std::io::BufRead but keep newline characters.
+#[derive(Debug)]
+pub struct Lines<B> {
+    buf: B,
+}
+
+pub trait LinesWithEnding<B> {
+    fn lines_with_ending(self) -> Lines<B>;
+}
+
+impl<B> LinesWithEnding<B> for B
+where
+    B: BufRead,
+{
+    fn lines_with_ending(self) -> Lines<B> {
+        Lines::<B> { buf: self }
+    }
+}
+impl<B: BufRead> Iterator for Lines<B> {
+    type Item = std::io::Result<String>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut buf = String::new();
+        match self.buf.read_line(&mut buf) {
+            Ok(0) => None,
+            Ok(_n) => {
+                // if buf.ends_with('\n') {
+                //     buf.pop();
+                //     if buf.ends_with('\r') {
+                //         buf.pop();
+                //     }
+                // }
+                Some(Ok(buf))
+            }
+            Err(e) => Some(Err(e)),
         }
     }
 }


### PR DESCRIPTION
Looking at [YouTokenToMe](https://github.com/VKCOM/YouTokenToMe) it looks like 
tokenizers is still a bit behind in tokenizer training time (BPE) (3-4s vs ~20s on a 
100Mo dataset and it gets worse with size, 10 vs 120s on 500Mo). I'm starting to 
look into it to see what could be done. The first culprit seems to be file loading.
On a 100Mo file, loading everything into memory in one go takes ~30ms on my computer
whereas it takes ~13s to do the "Reading files" step.

There seem to be 3 culprits:
 - First, the read_line method uses a small buffer by
default (8kb) which make tons of syscalls.
 - Second, the parallel iteration occurs
on various files, and not within a single file (most datasets include large files
IMHO).
 - Third, within the line parsing function, lots of string copies are done.

This PR aims at reading the files in one chunk (or at least larger chunks) and 
iterating over lines in parallel instead. The result on my computer on a 100Mo
dataset is going from ~13s to ~7s on the `Reading files` step while maintining 
backward compatibility. Reducing copies is harder but could probably drop the 
time to ~1-2s (~1s is what youtokentome achieves to end up with the full
word count hashmap).

- It will fail on very large files (using read_to_string, *but* it's much faster than previous
iterations. (No bench yet.)
- It should be easy enough to support large files by chunking them at
space boundaries.
- Currently still pretty slow because lots of string copies happen at
train time (Normalizer + PreTokenizer). I also added one to include extra '\n' that
par_lines would remove. No default iterator seems to keep them so we will probably have
to do some custom logic if '\n' need to be kept. It seems Normalizer and PreTokenizer

(Lower bound is indeed 1s : https://gist.github.com/Narsil/833ef43fe4e6169cf54de57733a753b5)