### PR TITLE
Rust - Use Onig for byte-level

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -32,6 +32,7 @@ harness = false
 [dependencies]
 lazy_static = "1.4"
 rand = "0.7"
+onig = { version = "6.0", default-features = false }
 regex = "1.3"
 regex-syntax = "0.6"
 rayon = "1.3"

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -1,11 +1,10 @@
 use crate::tokenizer::{
     Decoder, Encoding, NormalizedString, Offsets, PostProcessor, PreTokenizer, Result,
 };
+use onig::Regex;
 use rayon::prelude::*;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use unicode_categories::UnicodeCategories;
 
 fn bytes_char() -> HashMap<u8, char> {
     let mut bs: Vec<u8> = vec![];
@@ -32,7 +31,8 @@ fn bytes_char() -> HashMap<u8, char> {
 
 lazy_static! {
     static ref RE: Regex =
-        Regex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+").unwrap();
+        Regex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+")
+            .unwrap();
     static ref BYTES_CHAR: HashMap<u8, char> = bytes_char();
     static ref CHAR_BYTES: HashMap<char, u8> =
         bytes_char().into_iter().map(|(c, b)| (b, c)).collect();
@@ -92,34 +92,8 @@ impl PreTokenizer for ByteLevel {
         }
 
         let positions = RE
-            .captures_iter(normalized.get())
-            .map(|capture| {
-                let s = normalized.get();
-                let capture = capture.get(0).unwrap();
-                let start = capture.start();
-                let end = capture.end();
-
-                // if our last character is a whitespace, followed by a non whitespace,
-                // we don't want to return it
-                let last = s[start..end].chars().last();
-                let next = s[end..].chars().next();
-                if let (Some(last), Some(next)) = (last, next) {
-                    if last.is_separator_space() && !next.is_separator_space() {
-                        return start..end - last.len_utf8();
-                    }
-                }
-                // if our first char is not a whitespace but the previous one was, we return
-                // a whitespace before our match
-                let prev = s[0..start].chars().last();
-                let current = s[start..end].chars().next().map(|c| c.is_whitespace());
-                if let (Some(prev), Some(current)) = (prev, current) {
-                    if prev.is_separator_space() && !current {
-                        return start - prev.len_utf8()..end;
-                    }
-                }
-
-                start..end
-            })
+            .find_iter(normalized.get())
+            .map(|(start, end)| start..end)
             .collect::<Vec<_>>();
 
         let splits = positions


### PR DESCRIPTION
This is an attempt at using `onig` again for byte-level pre-tokenization. We removed this dependency at the very beginning because we didn't manage to make it build on all the target platforms we added in the CI. This should now be possible though and would remove all the differences with the original byte-level from GPT-2

Also fix #240 