### PR TITLE
BPE trainer fixes

### DIFF
--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -485,10 +485,15 @@ impl BpeTrainer {
             }
             let new_token = format!("{}{}", part_a, part_b);
 
-            // Insert new token
-            let new_token_id = id_to_word.len() as u32;
-            id_to_word.push(new_token.clone());
-            word_to_id.insert(new_token.clone(), new_token_id);
+            // Insert new token if it does not already exist
+            let new_token_id = word_to_id
+                .get(&new_token)
+                .copied()
+                .unwrap_or_else(|| id_to_word.len() as u32);
+            if word_to_id.get(&new_token).is_none() {
+                id_to_word.push(new_token.clone());
+                word_to_id.insert(new_token.clone(), new_token_id);
+            }
             merges.push((top.pair, new_token_id));
 
             // Merge the new pair in every words


### PR DESCRIPTION
Fix #284 #214

This PR modifies two different things:
 1. Simplifies how we count pairs, by using `par_iter` + `reduce` instead of the manual setup. It fixes a crash that had already been reported (cf #214) but that we weren't able to reproduce. The snippet provided in #284 did reproduce it.
 2. Allow having the result of a merge operation being a token that already exists in the vocab. Before this change, it was replacing the existing id by the new one, leaving a hole in the attributed ids. This is an edge case, that happens only if we are able to construct one of the provided `special_tokens`.