### PR TITLE
Improve padding truncation

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -16,6 +16,7 @@ This adds some methods to easily save/load an entire tokenizer (`from_str`, `fro
 - [#289]: Ability to pad to a multiple of a specified value. This is especially useful to ensure
 activation of the Tensor Cores, while ensuring padding to a multiple of 8. Use with
 `enable_padding(pad_to_multiple_of=8)` for example.
+- [#298]: Ability to get the currently set truncation/padding params
 
 ### Changed
 - Improved errors generated during truncation: When the provided max length is too low are

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -294,17 +294,17 @@ impl Tokenizer {
 
     #[args(kwargs = "**")]
     fn enable_truncation(&mut self, max_length: usize, kwargs: Option<&PyDict>) -> PyResult<()> {
-        let mut stride = 0;
-        let mut strategy = TruncationStrategy::LongestFirst;
+        let mut params = TruncationParams::default();
+        params.max_length = max_length;
 
         if let Some(kwargs) = kwargs {
             for (key, value) in kwargs {
                 let key: &str = key.extract()?;
                 match key {
-                    "stride" => stride = value.extract()?,
+                    "stride" => params.stride = value.extract()?,
                     "strategy" => {
                         let value: &str = value.extract()?;
-                        strategy = match value {
+                        params.strategy = match value {
                             "longest_first" => Ok(TruncationStrategy::LongestFirst),
                             "only_first" => Ok(TruncationStrategy::OnlyFirst),
                             "only_second" => Ok(TruncationStrategy::OnlySecond),
@@ -321,11 +321,7 @@ impl Tokenizer {
             }
         }
 
-        self.tokenizer.with_truncation(Some(TruncationParams {
-            max_length,
-            stride,
-            strategy,
-        }));
+        self.tokenizer.with_truncation(Some(params));
 
         Ok(())
     }
@@ -334,14 +330,22 @@ impl Tokenizer {
         self.tokenizer.with_truncation(None);
     }
 
+    #[getter]
+    fn get_truncation<'py>(&self, py: Python<'py>) -> PyResult<Option<&'py PyDict>> {
+        self.tokenizer.get_truncation().map_or(Ok(None), |params| {
+            let dict = PyDict::new(py);
+
+            dict.set_item("max_length", params.max_length)?;
+            dict.set_item("stride", params.stride)?;
+            dict.set_item("strategy", params.strategy.as_ref())?;
+
+            Ok(Some(dict))
+        })
+    }
+
     #[args(kwargs = "**")]
     fn enable_padding(&mut self, kwargs: Option<&PyDict>) -> PyResult<()> {
-        let mut direction = PaddingDirection::Right;
-        let mut pad_to_multiple_of: Option<usize> = None;
-        let mut pad_id: u32 = 0;
-        let mut pad_type_id: u32 = 0;
-        let mut pad_token = String::from("[PAD]");
-        let mut max_length: Option<usize> = None;
+        let mut params = PaddingParams::default();
 
         if let Some(kwargs) = kwargs {
             for (key, value) in kwargs {
@@ -349,7 +353,7 @@ impl Tokenizer {
                 match key {
                     "direction" => {
                         let value: &str = value.extract()?;
-                        direction = match value {
+                        params.direction = match value {
                             "left" => Ok(PaddingDirection::Left),
                             "right" => Ok(PaddingDirection::Right),
                             other => Err(PyError(format!(
@@ -360,36 +364,66 @@ impl Tokenizer {
                             .into_pyerr()),
                         }?;
                     }
-                    "pad_to_multiple_of" => pad_to_multiple_of = value.extract()?,
-                    "pad_id" => pad_id = value.extract()?,
-                    "pad_type_id" => pad_type_id = value.extract()?,
-                    "pad_token" => pad_token = value.extract()?,
-                    "max_length" => max_length = value.extract()?,
+                    "pad_to_multiple_of" => {
+                        if let Some(multiple) = value.extract()? {
+                            params.pad_to_multiple_of = multiple;
+                        }
+                    }
+                    "pad_id" => params.pad_id = value.extract()?,
+                    "pad_type_id" => params.pad_type_id = value.extract()?,
+                    "pad_token" => params.pad_token = value.extract()?,
+                    "max_length" => {
+                        println!(
+                            "enable_padding(max_length=X) is deprecated, \
+                                 use enable_padding(length=X) instead"
+                        );
+                        if let Some(l) = value.extract()? {
+                            params.strategy = PaddingStrategy::Fixed(l);
+                        } else {
+                            params.strategy = PaddingStrategy::BatchLongest;
+                        }
+                    }
+                    "length" => {
+                        if let Some(l) = value.extract()? {
+                            params.strategy = PaddingStrategy::Fixed(l);
+                        } else {
+                            params.strategy = PaddingStrategy::BatchLongest;
+                        }
+                    }
                     _ => println!("Ignored unknown kwarg option {}", key),
                 }
             }
         }
 
-        let strategy = if let Some(max_length) = max_length {
-            PaddingStrategy::Fixed(max_length)
-        } else {
-            PaddingStrategy::BatchLongest
-        };
-
-        self.tokenizer.with_padding(Some(PaddingParams {
-            strategy,
-            direction,
-            pad_to_multiple_of,
-            pad_id,
-            pad_type_id,
-            pad_token: pad_token.to_owned(),
-        }));
+        self.tokenizer.with_padding(Some(params));
 
         Ok(())
     }
 
     fn no_padding(&mut self) {
         self.tokenizer.with_padding(None);
+    }
+
+    #[getter]
+    fn get_padding<'py>(&self, py: Python<'py>) -> PyResult<Option<&'py PyDict>> {
+        self.tokenizer.get_padding().map_or(Ok(None), |params| {
+            let dict = PyDict::new(py);
+
+            dict.set_item(
+                "length",
+                match params.strategy {
+                    tk::PaddingStrategy::BatchLongest => None,
+                    tk::PaddingStrategy::Fixed(size) => Some(size),
+                },
+            )?;
+            dict.set_item("pad_to_multiple_of", params.pad_to_multiple_of)?;
+            dict.set_item("pad_id", params.pad_id)?;
+            dict.set_item("pad_token", &params.pad_token)?;
+            dict.set_item("pad_type_id", params.pad_type_id)?;
+            dict.set_item("direction", params.direction.as_ref())?;
+
+            Ok(Some(dict))
+        })
     }
 
     fn normalize(&self, sentence: &str) -> PyResult<String> {

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -181,6 +181,10 @@ class TestTokenizer:
         output = tokenizer.encode("my name is john", "pair")
         assert output.tokens == ["my", "pair"]
 
+        # Can get the params and give them to enable_truncation
+        trunc = tokenizer.truncation
+        tokenizer.enable_truncation(**trunc)
+
     def test_padding(self):
         tokenizer = Tokenizer(BPE())
         tokenizer.add_tokens(["my", "name", "is", "john", "pair"])
@@ -194,12 +198,16 @@ class TestTokenizer:
         output = tokenizer.encode_batch(["my name", "my name is john"])
         assert all([len(encoding) == 4 for encoding in output])
 
-        # Can pad to the specified max length otherwise
-        tokenizer.enable_padding(max_length=4)
+        # Can pad to the specified length otherwise
+        tokenizer.enable_padding(length=4)
         output = tokenizer.encode("my name")
         assert output.tokens == ["my", "name", "[PAD]", "[PAD]"]
         output = tokenizer.encode("my name", "pair")
         assert output.tokens == ["my", "name", "pair", "[PAD]"]
+
+        # Can get the params and give them to enable_padding
+        padding = tokenizer.padding
+        tokenizer.enable_padding(**padding)
 
     def test_decode(self):
         tokenizer = Tokenizer(BPE())
@@ -249,7 +257,7 @@ class TestTokenizer:
         tokenizer = Tokenizer(BPE())
         tokenizer.add_tokens(["my", "name", "is", "john", "pair"])
         tokenizer.enable_truncation(2)
-        tokenizer.enable_padding(max_length=4)
+        tokenizer.enable_padding(length=4)
 
         encoding = tokenizer.encode("my name is john")
         pair_encoding = tokenizer.encode("pair")

--- a/bindings/python/tokenizers/__init__.pyi
+++ b/bindings/python/tokenizers/__init__.pyi
@@ -392,6 +392,15 @@ class Tokenizer:
     def no_truncation(self):
         """ Disable truncation """
         pass
+    @property
+    def truncation(self) -> Optional[dict]:
+        """ Get the current truncation parameters
+
+        Returns:
+            None if truncation is disabled, a dict with the current truncation parameters if
+            truncation is enabled
+        """
+        pass
     def enable_padding(
         self,
         direction: Optional[str] = "right",
@@ -399,7 +408,7 @@ class Tokenizer:
         pad_id: Optional[int] = 0,
         pad_type_id: Optional[int] = 0,
         pad_token: Optional[str] = "[PAD]",
-        max_length: Optional[int] = None,
+        length: Optional[int] = None,
     ):
         """ Enable the padding
 
@@ -421,13 +430,22 @@ class Tokenizer:
             pad_token: (`optional`) str:
                 The pad token to be used when padding
 
-            max_length: (`optional`) unsigned int:
+            length: (`optional`) unsigned int:
                 If specified, the length at which to pad. If not specified
                 we pad using the size of the longest sequence in a batch
         """
         pass
     def no_padding(self):
         """ Disable padding """
+        pass
+    @property
+    def padding(self) -> Optional[dict]:
+        """ Get the current padding parameters
+
+        Returns:
+            None if padding is disabled, a dict with the currently set parameters
+            if the padding is enabled.
+        """
         pass
     def normalize(self, sequence: str) -> str:
         """ Normalize the given sequence

--- a/bindings/python/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/tokenizers/implementations/base_tokenizer.py
@@ -56,7 +56,7 @@ class BaseTokenizer:
         pad_id: Optional[int] = 0,
         pad_type_id: Optional[int] = 0,
         pad_token: Optional[str] = "[PAD]",
-        max_length: Optional[int] = None,
+        length: Optional[int] = None,
     ):
         """ Change the padding strategy
 
@@ -78,7 +78,7 @@ class BaseTokenizer:
             pad_token: (`optional`) str:
                 The pad token to be used when padding
 
-            max_length: (`optional`) unsigned int:
+            length: (`optional`) unsigned int:
                 If specified, the length at which to pad. If not specified
                 we pad using the size of the longest sequence in a batch
         """
@@ -88,12 +88,22 @@ class BaseTokenizer:
             pad_id=pad_id,
             pad_type_id=pad_type_id,
             pad_token=pad_token,
-            max_length=max_length,
+            length=length,
         )
 
     def no_padding(self):
         """ Disable padding """
         return self._tokenizer.no_padding()
+
+    @property
+    def padding(self) -> Optional[dict]:
+        """ Get the current padding parameters
+
+        Returns:
+            None if padding is disabled, a dict with the currently set parameters
+            if the padding is enabled.
+        """
+        return self._tokenizer.padding
 
     def enable_truncation(
         self, max_length: int, stride: Optional[int] = 0, strategy: Optional[str] = "longest_first"
@@ -116,6 +126,16 @@ class BaseTokenizer:
     def no_truncation(self):
         """ Disable truncation """
         return self._tokenizer.no_truncation()
+
+    @property
+    def truncation(self) -> Optional[dict]:
+        """ Get the current truncation parameters
+
+        Returns:
+            None if truncation is disabled, a dict with the current truncation parameters if
+            truncation is enabled
+        """
+        return self._tokenizer.truncation
 
     def add_tokens(self, tokens: List[Union[str, AddedToken]]) -> int:
         """ Add the given tokens to the vocabulary

--- a/tokenizers/CHANGELOG.md
+++ b/tokenizers/CHANGELOG.md
@@ -38,6 +38,7 @@ on this front.
 using serde. It is now easy to save/load an entire tokenizer.
 - [#289]: Ability to pad to a multiple of a specified value. This is especially useful to ensure
 activation of the Tensor Cores, while ensuring padding to a multiple of 8.
+- [#298]: Ability to get the currently set truncation/padding params
 
 ### How to migrate
 - Replace any `XXX_to_YYY_offsets()` method call by any of the new ones.
@@ -112,6 +113,7 @@ advised, but that's not the question)
 split up in multiple bytes
 - [#174]: The `LongestFirst` truncation strategy had a bug
 
+[#298]: https://github.com/huggingface/tokenizers/pull/298
 [#289]: https://github.com/huggingface/tokenizers/pull/289
 [#286]: https://github.com/huggingface/tokenizers/pull/286
 [#280]: https://github.com/huggingface/tokenizers/pull/280

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -431,10 +431,30 @@ impl Tokenizer {
         self
     }
 
-    /// Set the padding strategy
+    /// Get the currently set truncation parameters
+    pub fn get_truncation(&self) -> Option<&TruncationParams> {
+        self.truncation.as_ref()
+    }
+
+    /// Get a mutable reference to the currently set truncation parameters
+    pub fn get_truncation_mut(&mut self) -> Option<&mut TruncationParams> {
+        self.truncation.as_mut()
+    }
+
+    /// Set the padding parameters
     pub fn with_padding(&mut self, padding: Option<PaddingParams>) -> &Self {
         self.padding = padding;
         self
+    }
+
+    /// Get the currently set padding parameters
+    pub fn get_padding(&self) -> Option<&PaddingParams> {
+        self.padding.as_ref()
+    }
+
+    /// Get a mutable reference to the currently set padding parameters
+    pub fn get_padding_mut(&mut self) -> Option<&mut PaddingParams> {
+        self.padding.as_mut()
     }
 
     /// Get the vocabulary

--- a/tokenizers/src/utils/padding.rs
+++ b/tokenizers/src/utils/padding.rs
@@ -28,6 +28,19 @@ pub struct PaddingParams {
     pub pad_token: String,
 }
 
+impl Default for PaddingParams {
+    fn default() -> Self {
+        Self {
+            strategy: PaddingStrategy::BatchLongest,
+            direction: PaddingDirection::Right,
+            pad_to_multiple_of: None,
+            pad_id: 0,
+            pad_type_id: 0,
+            pad_token: String::from("[PAD]"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PaddingStrategy {
     BatchLongest,

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -8,6 +8,16 @@ pub struct TruncationParams {
     pub stride: usize,
 }
 
+impl Default for TruncationParams {
+    fn default() -> Self {
+        Self {
+            max_length: 512,
+            strategy: TruncationStrategy::LongestFirst,
+            stride: 0,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum TruncationError {
     /// We are supposed to truncate the pair sequence, but it has not been provided.


### PR DESCRIPTION
- Expose getters to access padding/truncation params
- Python: Move all default padding/truncation values to `Default` implementation
- Python: Deprecate `enable_padding(max_length=` and replace with `enable_padding(length=`