### PR TITLE
Node bindings - Huge refactoring

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          components: rustfmt, clippy
 
       # Necessary for now for the cargo cache: https://github.com/actions/cache/issues/133#issuecomment-599102035
       - run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
@@ -56,6 +57,18 @@ jobs:
       - name: Build all
         working-directory: ./bindings/node
         run: node build.js --all
+
+      - name: Lint Rust formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path ./bindings/node/native/Cargo.toml -- --check
+
+      - name: Lint Rust with Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path ./bindings/node/native/Cargo.toml --all-targets --all-features -- -D warnings
 
       - name: Lint TS
         working-directory: ./bindings/node

--- a/bindings/node/lib/bindings/decoders.test.ts
+++ b/bindings/node/lib/bindings/decoders.test.ts
@@ -16,7 +16,7 @@ describe("metaspaceDecoder", () => {
   });
 
   it("accepts `undefined` as second parameter", () => {
-    expect(metaspaceDecoder("test", undefined)).toBeDefined();
+    expect(metaspaceDecoder("t", undefined)).toBeDefined();
   });
 });
 

--- a/bindings/node/lib/bindings/models.test.ts
+++ b/bindings/node/lib/bindings/models.test.ts
@@ -11,9 +11,9 @@ describe("WordPiece", () => {
       expect(() => (WordPiece as any).fromFiles("test")).toThrow("not enough arguments");
     });
 
-    it("throws if called with 2 arguments without a callback as second argument", () => {
+    it("throws if called with 2 arguments without a callback as third argument", () => {
       expect(() => (WordPiece as any).fromFiles("test", {})).toThrow(
-        "failed downcast to function"
+        "not enough arguments"
       );
     });
 
@@ -57,9 +57,9 @@ describe("BPE", () => {
       expect(() => (BPE as any).fromFiles("test", "bis")).toThrow("not enough arguments");
     });
 
-    it("throws if called with 3 arguments without a callback as third argument", () => {
+    it("throws if called with 3 arguments without a callback as last argument", () => {
       expect(() => (BPE as any).fromFiles("test", "bis", {})).toThrow(
-        "failed downcast to function"
+        "not enough arguments"
       );
     });
   });

--- a/bindings/node/lib/bindings/post-processors.test.ts
+++ b/bindings/node/lib/bindings/post-processors.test.ts
@@ -1,4 +1,28 @@
-import { byteLevelProcessing, robertaProcessing } from "./post-processors";
+import {
+  bertProcessing,
+  byteLevelProcessing,
+  robertaProcessing
+} from "./post-processors";
+
+describe("bertProcessing", () => {
+  it("instantiates correctly with only two parameters", () => {
+    const processor = bertProcessing(["sep", 1], ["cls", 2]);
+    expect(processor.constructor.name).toEqual("Processor");
+  });
+
+  it("throws if only one argument is provided", () => {
+    expect(() => (bertProcessing as any)(["sep", 1])).toThrow("Argument 1 is missing");
+  });
+
+  it("throws if arguments are malformed", () => {
+    expect(() => (bertProcessing as any)(["sep", "1"], ["cls", "2"])).toThrow(
+      'invalid type: string "1", expected u32'
+    );
+    expect(() => (bertProcessing as any)(["sep"], ["cls"])).toThrow(
+      "invalid length 1, expected a tuple of size 2"
+    );
+  });
+});
 
 describe("byteLevelProcessing", () => {
   it("instantiates correctly without any parameter", () => {

--- a/bindings/node/lib/bindings/post-processors.test.ts
+++ b/bindings/node/lib/bindings/post-processors.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import {
   bertProcessing,
   byteLevelProcessing,

--- a/bindings/node/lib/bindings/pre-tokenizers.test.ts
+++ b/bindings/node/lib/bindings/pre-tokenizers.test.ts
@@ -18,6 +18,6 @@ describe("metaspacePreTokenizer", () => {
   });
 
   it("accepts `undefined` as second parameter", () => {
-    expect(metaspacePreTokenizer("test", undefined)).toBeDefined();
+    expect(metaspacePreTokenizer("t", undefined)).toBeDefined();
   });
 });

--- a/bindings/node/lib/bindings/raw-encoding.test.ts
+++ b/bindings/node/lib/bindings/raw-encoding.test.ts
@@ -1,5 +1,6 @@
 import { promisify } from "util";
 
+import { PaddingDirection } from "./enums";
 import { Model, WordPiece, WordPieceOptions } from "./models";
 import { whitespacePreTokenizer } from "./pre-tokenizers";
 import { RawEncoding } from "./raw-encoding";
@@ -135,6 +136,33 @@ describe("RawEncoding", () => {
     it("returns undefined when out of range char", () => {
       const index = encoding.charToWord(100);
       expect(index).toBeUndefined();
+    });
+  });
+
+  describe("pad", () => {
+    it("works correctly with only one parameter", () => {
+      encoding.pad(10);
+      expect(encoding.getTokens()).toHaveLength(10);
+    });
+
+    it("accepts `undefined` as second parameter", () => {
+      encoding.pad(10, undefined);
+      expect(encoding.getTokens()).toHaveLength(10);
+    });
+
+    it("accepts options as second parameter", () => {
+      encoding.pad(10, {
+        direction: PaddingDirection.Left,
+        padToken: "[PA]",
+        padTypeId: 10,
+        padId: 400
+      });
+
+      const tokens = encoding.getTokens();
+      expect(tokens).toHaveLength(10);
+      expect(tokens[0]).toBe("[PA]");
+      expect(encoding.getTypeIds()[0]).toBe(10);
+      expect(encoding.getIds()[0]).toBe(400);
     });
   });
 });

--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -15,11 +15,11 @@ export interface TruncationOptions {
   stride?: number;
   /**
    * Strategy to use:
-   * - `longest_first` Iteratively reduce the inputs sequence until the input is under max_length
+   * - `TruncationStrategy.LongestFirst` Iteratively reduce the inputs sequence until the input is under max_length
    * starting from the longest one at each token (when there is a pair of input sequences).
-   * - `only_first` Only truncate the first sequence.
-   * - `only_second` Only truncate the second sequence.
-   * @default "longest_first"
+   * - `TruncationStrategy.OnlyFirst` Only truncate the first sequence.
+   * - `TruncationStrategy.OnlySecond` Only truncate the second sequence.
+   * @default TruncationStrategy.LongestFirst
    */
   strategy?: TruncationStrategy;
 }
@@ -38,7 +38,7 @@ export type PaddingConfiguration = Required<
 
 export interface PaddingOptions {
   /**
-   * @default "right"
+   * @default PaddingDirection.Right
    */
   direction?: PaddingDirection;
   /**

--- a/bindings/node/native/src/container.rs
+++ b/bindings/node/native/src/container.rs
@@ -18,8 +18,8 @@ impl<T> Container<T>
 where
     T: ?Sized,
 {
-    pub fn from_ref(reference: &Box<T>) -> Self {
-        let content: *const T = &**reference;
+    pub fn from_ref<R: AsRef<T>>(reference: R) -> Self {
+        let content: *const T = reference.as_ref();
         Container::Pointer(content as *mut _)
     }
 
@@ -41,7 +41,7 @@ where
     }
 
     /// Replace an empty content by the new provided owned one, otherwise do nothing
-    pub fn to_owned(&mut self, o: Box<T>) {
+    pub fn make_owned(&mut self, o: Box<T>) {
         if let Container::Empty = self {
             unsafe {
                 let new_container = Container::Owned(o);
@@ -51,7 +51,7 @@ where
     }
 
     /// Return the owned T, keeping a Pointer to it if we currently own it. None otherwise
-    pub fn to_pointer(&mut self) -> Option<Box<T>> {
+    pub fn make_pointer(&mut self) -> Option<Box<T>> {
         if let Container::Owned(_) = self {
             unsafe {
                 let old_container = std::ptr::read(self);

--- a/bindings/node/native/src/decoders.rs
+++ b/bindings/node/native/src/decoders.rs
@@ -1,6 +1,7 @@
 extern crate tokenizers as tk;
 
 use crate::container::Container;
+use crate::extraction::*;
 use neon::prelude::*;
 
 /// Decoder
@@ -32,19 +33,10 @@ fn byte_level(mut cx: FunctionContext) -> JsResult<JsDecoder> {
 
 /// wordpiece(prefix: String = "##", cleanup: bool)
 fn wordpiece(mut cx: FunctionContext) -> JsResult<JsDecoder> {
-    let mut prefix = String::from("##");
-    if let Some(args) = cx.argument_opt(0) {
-        if args.downcast::<JsUndefined>().is_err() {
-            prefix = args.downcast::<JsString>().or_throw(&mut cx)?.value() as String;
-        }
-    }
-
-    let mut cleanup = true;
-    if let Some(args) = cx.argument_opt(1) {
-        if args.downcast::<JsUndefined>().is_err() {
-            cleanup = args.downcast::<JsBoolean>().or_throw(&mut cx)?.value();
-        }
-    }
+    let prefix = cx
+        .extract_opt::<String>(0)?
+        .unwrap_or_else(|| String::from("##"));
+    let cleanup = cx.extract_opt::<bool>(1)?.unwrap_or(true);
 
     let mut decoder = JsDecoder::new::<_, JsDecoder, _>(&mut cx, vec![])?;
     let guard = cx.lock();
@@ -59,23 +51,8 @@ fn wordpiece(mut cx: FunctionContext) -> JsResult<JsDecoder> {
 
 /// metaspace(replacement: String = "_", add_prefix_space: bool = true)
 fn metaspace(mut cx: FunctionContext) -> JsResult<JsDecoder> {
-    let mut replacement = '▁';
-    if let Some(args) = cx.argument_opt(0) {
-        if args.downcast::<JsUndefined>().is_err() {
-            let rep = args.downcast::<JsString>().or_throw(&mut cx)?.value() as String;
-            replacement = rep.chars().nth(0).ok_or_else(|| {
-                cx.throw_error::<_, ()>("replacement must be a character")
-                    .unwrap_err()
-            })?;
-        }
-    };
-
-    let mut add_prefix_space = true;
-    if let Some(args) = cx.argument_opt(1) {
-        if args.downcast::<JsUndefined>().is_err() {
-            add_prefix_space = args.downcast::<JsBoolean>().or_throw(&mut cx)?.value() as bool;
-        }
-    }
+    let replacement = cx.extract_opt::<char>(0)?.unwrap_or('▁');
+    let add_prefix_space = cx.extract_opt::<bool>(1)?.unwrap_or(true);
 
     let mut decoder = JsDecoder::new::<_, JsDecoder, _>(&mut cx, vec![])?;
     let guard = cx.lock();
@@ -91,12 +68,9 @@ fn metaspace(mut cx: FunctionContext) -> JsResult<JsDecoder> {
 
 /// bpe_decoder(suffix: String = "</w>")
 fn bpe_decoder(mut cx: FunctionContext) -> JsResult<JsDecoder> {
-    let mut suffix = String::from("</w>");
-    if let Some(args) = cx.argument_opt(0) {
-        if args.downcast::<JsUndefined>().is_err() {
-            suffix = args.downcast::<JsString>().or_throw(&mut cx)?.value() as String;
-        }
-    }
+    let suffix = cx
+        .extract_opt::<String>(0)?
+        .unwrap_or_else(|| String::from("</w>"));
 
     let mut decoder = JsDecoder::new::<_, JsDecoder, _>(&mut cx, vec![])?;
     let guard = cx.lock();

--- a/bindings/node/native/src/decoders.rs
+++ b/bindings/node/native/src/decoders.rs
@@ -27,7 +27,7 @@ fn byte_level(mut cx: FunctionContext) -> JsResult<JsDecoder> {
     decoder
         .borrow_mut(&guard)
         .decoder
-        .to_owned(Box::new(tk::decoders::byte_level::ByteLevel::default()));
+        .make_owned(Box::new(tk::decoders::byte_level::ByteLevel::default()));
     Ok(decoder)
 }
 
@@ -40,12 +40,9 @@ fn wordpiece(mut cx: FunctionContext) -> JsResult<JsDecoder> {
 
     let mut decoder = JsDecoder::new::<_, JsDecoder, _>(&mut cx, vec![])?;
     let guard = cx.lock();
-    decoder
-        .borrow_mut(&guard)
-        .decoder
-        .to_owned(Box::new(tk::decoders::wordpiece::WordPiece::new(
-            prefix, cleanup,
-        )));
+    decoder.borrow_mut(&guard).decoder.make_owned(Box::new(
+        tk::decoders::wordpiece::WordPiece::new(prefix, cleanup),
+    ));
     Ok(decoder)
 }
 
@@ -56,13 +53,9 @@ fn metaspace(mut cx: FunctionContext) -> JsResult<JsDecoder> {
 
     let mut decoder = JsDecoder::new::<_, JsDecoder, _>(&mut cx, vec![])?;
     let guard = cx.lock();
-    decoder
-        .borrow_mut(&guard)
-        .decoder
-        .to_owned(Box::new(tk::decoders::metaspace::Metaspace::new(
-            replacement,
-            add_prefix_space,
-        )));
+    decoder.borrow_mut(&guard).decoder.make_owned(Box::new(
+        tk::decoders::metaspace::Metaspace::new(replacement, add_prefix_space),
+    ));
     Ok(decoder)
 }
 
@@ -77,7 +70,7 @@ fn bpe_decoder(mut cx: FunctionContext) -> JsResult<JsDecoder> {
     decoder
         .borrow_mut(&guard)
         .decoder
-        .to_owned(Box::new(tk::decoders::bpe::BPEDecoder::new(suffix)));
+        .make_owned(Box::new(tk::decoders::bpe::BPEDecoder::new(suffix)));
     Ok(decoder)
 }
 

--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -257,7 +257,7 @@ declare_types! {
             //   padToken?: string = "[PAD]"
             // }
             let length = cx.extract::<usize>(0)?;
-            let params = cx.extract_opt::<PaddingParams>(0)?
+            let params = cx.extract_opt::<PaddingParams>(1)?
                 .map_or_else(tk::PaddingParams::default, |p| p.0);
 
             let mut this = cx.this();

--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -130,7 +130,7 @@ declare_types! {
 
                 // Set the content
                 let guard = cx.lock();
-                js_overflowing.borrow_mut(&guard).encoding.to_owned(Box::new(overflowing.clone()));
+                js_overflowing.borrow_mut(&guard).encoding.make_owned(Box::new(overflowing.clone()));
 
                 js_overflowings.set(&mut cx, index as u32, js_overflowing)?;
             }

--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -1,8 +1,8 @@
 extern crate tokenizers as tk;
 
-use tk::tokenizer::PaddingDirection;
-
 use crate::container::Container;
+use crate::extraction::*;
+use crate::tokenizer::PaddingParams;
 use neon::prelude::*;
 
 /// Encoding
@@ -22,11 +22,11 @@ declare_types! {
         method getLength(mut cx) {
             let this = cx.this();
             let guard = cx.lock();
-            let ids = this.borrow(&guard).encoding.execute(|encoding| {
-                encoding.unwrap().get_ids().to_vec()
+            let length = this.borrow(&guard).encoding.execute(|encoding| {
+                encoding.unwrap().get_ids().len()
             });
 
-            Ok(cx.number(ids.len() as f64).upcast())
+            Ok(cx.number(length as f64).upcast())
         }
 
         method getIds(mut cx) {
@@ -37,13 +37,8 @@ declare_types! {
             let ids = this.borrow(&guard).encoding.execute(|encoding| {
                 encoding.unwrap().get_ids().to_vec()
             });
-            let js_ids = JsArray::new(&mut cx, ids.len() as u32);
-            for (i, id) in ids.into_iter().enumerate() {
-                let n = JsNumber::new(&mut cx, id as f64);
-                js_ids.set(&mut cx, i as u32, n)?;
-            }
 
-            Ok(js_ids.upcast())
+            Ok(neon_serde::to_value(&mut cx, &ids)?)
         }
 
         method getTypeIds(mut cx) {
@@ -54,13 +49,8 @@ declare_types! {
             let ids = this.borrow(&guard).encoding.execute(|encoding| {
                 encoding.unwrap().get_type_ids().to_vec()
             });
-            let js_ids = JsArray::new(&mut cx, ids.len() as u32);
-            for (i, id) in ids.into_iter().enumerate() {
-                let n = JsNumber::new(&mut cx, id as f64);
-                js_ids.set(&mut cx, i as u32, n)?;
-            }
 
-            Ok(js_ids.upcast())
+            Ok(neon_serde::to_value(&mut cx, &ids)?)
         }
 
         method getAttentionMask(mut cx) {
@@ -71,13 +61,8 @@ declare_types! {
             let ids = this.borrow(&guard).encoding.execute(|encoding| {
                 encoding.unwrap().get_attention_mask().to_vec()
             });
-            let js_ids = JsArray::new(&mut cx, ids.len() as u32);
-            for (i, id) in ids.into_iter().enumerate() {
-                let n = JsNumber::new(&mut cx, id as f64);
-                js_ids.set(&mut cx, i as u32, n)?;
-            }
 
-            Ok(js_ids.upcast())
+            Ok(neon_serde::to_value(&mut cx, &ids)?)
         }
 
         method getSpecialTokensMask(mut cx) {
@@ -88,13 +73,8 @@ declare_types! {
             let ids = this.borrow(&guard).encoding.execute(|encoding| {
                 encoding.unwrap().get_special_tokens_mask().to_vec()
             });
-            let js_ids = JsArray::new(&mut cx, ids.len() as u32);
-            for (i, id) in ids.into_iter().enumerate() {
-                let n = JsNumber::new(&mut cx, id as f64);
-                js_ids.set(&mut cx, i as u32, n)?;
-            }
 
-            Ok(js_ids.upcast())
+            Ok(neon_serde::to_value(&mut cx, &ids)?)
         }
 
         method getTokens(mut cx) {
@@ -105,13 +85,8 @@ declare_types! {
             let tokens = this.borrow(&guard).encoding.execute(|encoding| {
                 encoding.unwrap().get_tokens().to_vec()
             });
-            let js_tokens = JsArray::new(&mut cx, tokens.len() as u32);
-            for (i, token) in tokens.into_iter().enumerate() {
-                let n = JsString::new(&mut cx, token);
-                js_tokens.set(&mut cx, i as u32, n)?;
-            }
 
-            Ok(js_tokens.upcast())
+            Ok(neon_serde::to_value(&mut cx, &tokens)?)
         }
 
         method getWords(mut cx) {
@@ -122,18 +97,8 @@ declare_types! {
             let ids = this.borrow(&guard).encoding.execute(|encoding| {
                 encoding.unwrap().get_words().to_vec()
             });
-            let js_ids = JsArray::new(&mut cx, ids.len() as u32);
-            for (i, id) in ids.into_iter().enumerate() {
-                if let Some(id) = id {
-                    let n = JsNumber::new(&mut cx, id as f64);
-                    js_ids.set(&mut cx, i as u32, n)?;
-                } else {
-                    let v = cx.undefined();
-                    js_ids.set(&mut cx, i as u32, v)?;
-                }
-            }
 
-            Ok(js_ids.upcast())
+            Ok(neon_serde::to_value(&mut cx, &ids)?)
         }
 
         method getOffsets(mut cx) {
@@ -144,17 +109,9 @@ declare_types! {
             let offsets = this.borrow(&guard).encoding.execute(|encoding| {
                 encoding.unwrap().get_offsets().to_vec()
             });
-            let js_offsets = JsArray::new(&mut cx, offsets.len() as u32);
-            for (i, offsets) in offsets.into_iter().enumerate() {
-                let n = JsArray::new(&mut cx, 2);
-                let o_0 = JsNumber::new(&mut cx, offsets.0 as f64);
-                let o_1 = JsNumber::new(&mut cx, offsets.1 as f64);
-                n.set(&mut cx, 0, o_0)?;
-                n.set(&mut cx, 1, o_1)?;
-                js_offsets.set(&mut cx, i as u32, n)?;
-            }
+            let js_offsets = neon_serde::to_value(&mut cx, &offsets)?;
 
-            Ok(js_offsets.upcast())
+            Ok(js_offsets)
         }
 
         method getOverflowing(mut cx) {
@@ -184,7 +141,7 @@ declare_types! {
         method wordToTokens(mut cx) {
             // wordToTokens(word: number): [number, number] | undefined
 
-            let word = cx.argument::<JsNumber>(0)?.value() as u32;
+            let word = cx.extract::<u32>(0)?;
 
             let this = cx.this();
             let guard = cx.lock();
@@ -194,12 +151,7 @@ declare_types! {
             });
 
             if let Some(tokens) = res {
-                let js_tuple = JsArray::new(&mut cx, 2);
-                let n = cx.number(tokens.0 as f64);
-                js_tuple.set(&mut cx, 0, n)?;
-                let n = cx.number(tokens.1 as f64);
-                js_tuple.set(&mut cx, 1, n)?;
-                Ok(js_tuple.upcast())
+                Ok(neon_serde::to_value(&mut cx, &tokens)?)
             } else {
                 Ok(cx.undefined().upcast())
             }
@@ -218,12 +170,7 @@ declare_types! {
             });
 
             if let Some(offsets) = res {
-                let js_tuple = JsArray::new(&mut cx, 2);
-                let n = cx.number(offsets.0 as f64);
-                js_tuple.set(&mut cx, 0, n)?;
-                let n = cx.number(offsets.1 as f64);
-                js_tuple.set(&mut cx, 1, n)?;
-                Ok(js_tuple.upcast())
+                Ok(neon_serde::to_value(&mut cx, &offsets)?)
             } else {
                 Ok(cx.undefined().upcast())
             }
@@ -242,12 +189,7 @@ declare_types! {
             });
 
             if let Some(offsets) = res {
-                let js_tuple = JsArray::new(&mut cx, 2);
-                let n = cx.number(offsets.0 as f64);
-                js_tuple.set(&mut cx, 0, n)?;
-                let n = cx.number(offsets.1 as f64);
-                js_tuple.set(&mut cx, 1, n)?;
-                Ok(js_tuple.upcast())
+                Ok(neon_serde::to_value(&mut cx, &offsets)?)
             } else {
                 Ok(cx.undefined().upcast())
             }
@@ -314,48 +256,20 @@ declare_types! {
             //   padTypeId?: number = 0,
             //   padToken?: string = "[PAD]"
             // }
-
-            let length = cx.argument::<JsNumber>(0)?.value() as usize;
-            let mut direction = PaddingDirection::Right;
-            let mut pad_id = 0;
-            let mut pad_type_id = 0;
-            let mut pad_token = String::from("[PAD]");
-
-            let options = cx.argument_opt(1);
-            if let Some(options) = options {
-                if let Ok(options) = options.downcast::<JsObject>() {
-                    if let Ok(dir) = options.get(&mut cx, "direction") {
-                        if let Err(_) = dir.downcast::<JsUndefined>() {
-                            let dir = dir.downcast::<JsString>().or_throw(&mut cx)?.value();
-                            match &dir[..] {
-                                "right" => direction = PaddingDirection::Right,
-                                "left" => direction = PaddingDirection::Left,
-                                _ => return cx.throw_error("direction can be 'right' or 'left'"),
-                            }
-                        }
-                    }
-                    if let Ok(pid) = options.get(&mut cx, "padId") {
-                        if let Err(_) = pid.downcast::<JsUndefined>() {
-                            pad_id = pid.downcast::<JsNumber>().or_throw(&mut cx)?.value() as u32;
-                        }
-                    }
-                    if let Ok(pid) = options.get(&mut cx, "padTypeId") {
-                        if let Err(_) = pid.downcast::<JsUndefined>() {
-                            pad_type_id = pid.downcast::<JsNumber>().or_throw(&mut cx)?.value() as u32;
-                        }
-                    }
-                    if let Ok(token) = options.get(&mut cx, "padToken") {
-                        if let Err(_) = token.downcast::<JsUndefined>() {
-                            pad_token = token.downcast::<JsString>().or_throw(&mut cx)?.value();
-                        }
-                    }
-                }
-            }
+            let length = cx.extract::<usize>(0)?;
+            let params = cx.extract_opt::<PaddingParams>(0)?
+                .map_or_else(tk::PaddingParams::default, |p| p.0);
 
             let mut this = cx.this();
             let guard = cx.lock();
             this.borrow_mut(&guard).encoding.execute_mut(|encoding| {
-                encoding.unwrap().pad(length, pad_id, pad_type_id, &pad_token, direction);
+                encoding.unwrap().pad(
+                    length,
+                    params.pad_id,
+                    params.pad_type_id,
+                    &params.pad_token,
+                    params.direction
+                );
             });
 
             Ok(cx.undefined().upcast())
@@ -364,13 +278,8 @@ declare_types! {
         method truncate(mut cx) {
             // truncate(length: number, stride: number = 0)
 
-            let length = cx.argument::<JsNumber>(0)?.value() as usize;
-            let mut stride = 0;
-            if let Some(args) = cx.argument_opt(1) {
-                if args.downcast::<JsUndefined>().is_err() {
-                    stride = args.downcast::<JsNumber>().or_throw(&mut cx)?.value() as usize;
-                }
-            }
+            let length = cx.extract::<usize>(0)?;
+            let stride = cx.extract_opt::<usize>(1)?.unwrap_or(0);
 
             let mut this = cx.this();
             let guard = cx.lock();

--- a/bindings/node/native/src/extraction.rs
+++ b/bindings/node/native/src/extraction.rs
@@ -97,4 +97,3 @@ impl<'c, T: neon::object::This> Extract for CallContext<'c, T> {
             .map_or(Ok(None), |v| v.map(Some))
     }
 }
-

--- a/bindings/node/native/src/models.rs
+++ b/bindings/node/native/src/models.rs
@@ -91,7 +91,7 @@ pub fn bpe_empty(mut cx: FunctionContext) -> JsResult<JsModel> {
     let bpe = tk::models::bpe::BPE::default();
 
     let guard = cx.lock();
-    model.borrow_mut(&guard).model.to_owned(Box::new(bpe));
+    model.borrow_mut(&guard).model.make_owned(Box::new(bpe));
 
     Ok(model)
 }
@@ -150,7 +150,10 @@ pub fn wordpiece_empty(mut cx: FunctionContext) -> JsResult<JsModel> {
     let wordpiece = tk::models::wordpiece::WordPiece::default();
 
     let guard = cx.lock();
-    model.borrow_mut(&guard).model.to_owned(Box::new(wordpiece));
+    model
+        .borrow_mut(&guard)
+        .model
+        .make_owned(Box::new(wordpiece));
 
     Ok(model)
 }

--- a/bindings/node/native/src/models.rs
+++ b/bindings/node/native/src/models.rs
@@ -1,9 +1,11 @@
 extern crate tokenizers as tk;
 
 use crate::container::Container;
+use crate::extraction::*;
 use crate::tasks::models::{BPEFromFilesTask, WordPieceFromFilesTask};
 use neon::prelude::*;
 use std::path::Path;
+use tk::models::{bpe::BpeBuilder, wordpiece::WordPieceBuilder};
 
 /// Model
 pub struct Model {
@@ -20,37 +22,38 @@ declare_types! {
         }
 
         method save(mut cx) {
-            /// save(folder: string, name?: string)
-            let folder = cx.argument::<JsString>(0)?.value();
-
-            let name = if let Some(name_arg) = cx.argument_opt(1) {
-                if name_arg.downcast::<JsUndefined>().is_err() {
-                    Some(name_arg.downcast_or_throw::<JsString, _>(&mut cx)?.value())
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
+            // save(folder: string, name?: string)
+            let folder = cx.extract::<String>(0)?;
+            let name = cx.extract_opt::<String>(1)?;
 
             let this = cx.this();
             let guard = cx.lock();
-            let result = this.borrow(&guard).model.execute(|model| {
-                model.unwrap().save(Path::new(&folder), name.as_deref())
-            });
 
-            match result {
-                Ok(r) => {
-                    let array = JsArray::new(&mut cx, r.len() as u32);
-                    for (i, path) in r.into_iter().enumerate() {
-                        let n = JsString::new(&mut cx, path.to_string_lossy().into_owned());
-                        array.set(&mut cx, i as u32, n)?;
-                    }
-                    Ok(array.upcast())
-                },
-                Err(e) => cx.throw_error(format!("{}", e))
-            }
+            let files = this.borrow(&guard).model.execute(|model| {
+                model.unwrap().save(Path::new(&folder), name.as_deref())
+            }).map_err(|e| Error(format!("{}", e)))?;
+
+            Ok(neon_serde::to_value(&mut cx, &files)?)
         }
+    }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct BpeOptions {
+    cache_capacity: Option<usize>,
+    dropout: Option<usize>,
+    unk_token: Option<String>,
+    continuing_subword_prefix: Option<String>,
+    end_of_word_suffix: Option<String>,
+}
+impl BpeOptions {
+    fn apply_to_bpe_builder(self, mut builder: BpeBuilder) -> BpeBuilder {
+        if let Some(cache_capacity) = self.cache_capacity {
+            builder = builder.cache_capacity(cache_capacity);
+        }
+
+        builder
     }
 }
 
@@ -62,59 +65,20 @@ declare_types! {
 ///   endOfWordSuffix?: String
 /// }, callback)
 pub fn bpe_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-    let vocab = cx.argument::<JsString>(0)?.value() as String;
-    let merges = cx.argument::<JsString>(1)?.value() as String;
-    let options: Option<Handle<JsObject>>;
-    let callback: Handle<JsFunction>;
+    let vocab = cx.extract::<String>(0)?;
+    let merges = cx.extract::<String>(1)?;
 
-    if cx.len() == 3 {
-        options = None;
-        callback = cx.argument::<JsFunction>(2)?;
-    } else {
-        options = Some(cx.argument::<JsObject>(2)?);
-        callback = cx.argument::<JsFunction>(3)?;
+    let (options, callback) = match cx.extract_opt::<BpeOptions>(2) {
+        // Options were there, and extracted
+        Ok(Some(options)) => (options, cx.argument::<JsFunction>(3)?),
+        // Options were undefined or null
+        Ok(None) => (BpeOptions::default(), cx.argument::<JsFunction>(3)?),
+        // Options not specified, callback instead
+        Err(_) => (BpeOptions::default(), cx.argument::<JsFunction>(2)?),
     };
 
     let mut builder = tk::models::bpe::BPE::from_files(&vocab, &merges);
-
-    if let Some(options) = options {
-        if let Ok(options) = options.downcast::<JsObject>() {
-            if let Ok(cache_capacity) = options.get(&mut cx, "cacheCapacity") {
-                if cache_capacity.downcast::<JsUndefined>().is_err() {
-                    let cache_capacity = cache_capacity
-                        .downcast::<JsNumber>()
-                        .or_throw(&mut cx)?
-                        .value() as usize;
-                    builder = builder.cache_capacity(cache_capacity);
-                }
-            }
-            if let Ok(dropout) = options.get(&mut cx, "dropout") {
-                if dropout.downcast::<JsUndefined>().is_err() {
-                    let dropout = dropout.downcast::<JsNumber>().or_throw(&mut cx)?.value() as f32;
-                    builder = builder.dropout(dropout);
-                }
-            }
-            if let Ok(unk_token) = options.get(&mut cx, "unkToken") {
-                if unk_token.downcast::<JsUndefined>().is_err() {
-                    let unk_token =
-                        unk_token.downcast::<JsString>().or_throw(&mut cx)?.value() as String;
-                    builder = builder.unk_token(unk_token);
-                }
-            }
-            if let Ok(prefix) = options.get(&mut cx, "continuingSubwordPrefix") {
-                if prefix.downcast::<JsUndefined>().is_err() {
-                    let prefix = prefix.downcast::<JsString>().or_throw(&mut cx)?.value() as String;
-                    builder = builder.continuing_subword_prefix(prefix);
-                }
-            }
-            if let Ok(suffix) = options.get(&mut cx, "endOfWordSuffix") {
-                if suffix.downcast::<JsUndefined>().is_err() {
-                    let suffix = suffix.downcast::<JsString>().or_throw(&mut cx)?.value() as String;
-                    builder = builder.end_of_word_suffix(suffix);
-                }
-            }
-        }
-    }
+    builder = options.apply_to_bpe_builder(builder);
 
     let task = BPEFromFilesTask::new(builder);
     task.schedule(callback);
@@ -132,50 +96,48 @@ pub fn bpe_empty(mut cx: FunctionContext) -> JsResult<JsModel> {
     Ok(model)
 }
 
+#[derive(Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct WordPieceOptions {
+    unk_token: Option<String>,
+    continuing_subword_prefix: Option<String>,
+    max_input_chars_per_word: Option<usize>,
+}
+impl WordPieceOptions {
+    fn apply_to_wordpiece_builder(self, mut builder: WordPieceBuilder) -> WordPieceBuilder {
+        if let Some(token) = self.unk_token {
+            builder = builder.unk_token(token);
+        }
+        if let Some(prefix) = self.continuing_subword_prefix {
+            builder = builder.continuing_subword_prefix(prefix);
+        }
+        if let Some(max) = self.max_input_chars_per_word {
+            builder = builder.max_input_chars_per_word(max);
+        }
+
+        builder
+    }
+}
+
 /// wordpiece_from_files(vocab: String, options: {
 ///   unkToken?: String = "[UNK]",
 ///   maxInputCharsPerWord?: number = 100,
 ///   continuingSubwordPrefix?: "##",
 /// }, callback)
 pub fn wordpiece_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-    let vocab = cx.argument::<JsString>(0)?.value() as String;
-    let options: Option<Handle<JsObject>>;
-    let callback: Handle<JsFunction>;
+    let vocab = cx.extract::<String>(0)?;
 
-    if cx.len() == 2 {
-        options = None;
-        callback = cx.argument::<JsFunction>(1)?;
-    } else {
-        options = Some(cx.argument::<JsObject>(1)?);
-        callback = cx.argument::<JsFunction>(2)?;
+    let (options, callback) = match cx.extract_opt::<WordPieceOptions>(1) {
+        // Options were there, and extracted
+        Ok(Some(options)) => (options, cx.argument::<JsFunction>(2)?),
+        // Options were undefined or null
+        Ok(None) => (WordPieceOptions::default(), cx.argument::<JsFunction>(2)?),
+        // Options not specified, callback instead
+        Err(_) => (WordPieceOptions::default(), cx.argument::<JsFunction>(1)?),
     };
 
     let mut builder = tk::models::wordpiece::WordPiece::from_files(&vocab);
-
-    if let Some(options) = options {
-        if let Ok(options) = options.downcast::<JsObject>() {
-            if let Ok(unk) = options.get(&mut cx, "unkToken") {
-                if unk.downcast::<JsUndefined>().is_err() {
-                    builder = builder
-                        .unk_token(unk.downcast::<JsString>().or_throw(&mut cx)?.value() as String);
-                }
-            }
-            if let Ok(max) = options.get(&mut cx, "maxInputCharsPerWord") {
-                if max.downcast::<JsUndefined>().is_err() {
-                    builder = builder.max_input_chars_per_word(
-                        max.downcast::<JsNumber>().or_throw(&mut cx)?.value() as usize,
-                    );
-                }
-            }
-            if let Ok(prefix) = options.get(&mut cx, "continuingSubwordPrefix") {
-                if prefix.downcast::<JsUndefined>().is_err() {
-                    builder = builder.continuing_subword_prefix(
-                        prefix.downcast::<JsString>().or_throw(&mut cx)?.value() as String,
-                    );
-                }
-            }
-        }
-    }
+    builder = options.apply_to_wordpiece_builder(builder);
 
     let task = WordPieceFromFilesTask::new(builder);
     task.schedule(callback);

--- a/bindings/node/native/src/normalizers.rs
+++ b/bindings/node/native/src/normalizers.rs
@@ -1,6 +1,7 @@
 extern crate tokenizers as tk;
 
 use crate::container::Container;
+use crate::extraction::*;
 use neon::prelude::*;
 
 /// Normalizer
@@ -19,6 +20,25 @@ declare_types! {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BertNormalizerOptions {
+    clean_text: bool,
+    handle_chinese_chars: bool,
+    strip_accents: bool,
+    lowercase: bool,
+}
+impl Default for BertNormalizerOptions {
+    fn default() -> Self {
+        Self {
+            clean_text: true,
+            handle_chinese_chars: true,
+            strip_accents: true,
+            lowercase: true,
+        }
+    }
+}
+
 /// bert_normalizer(options?: {
 ///   cleanText?: bool = true,
 ///   handleChineseChars?: bool = true,
@@ -26,43 +46,18 @@ declare_types! {
 ///   lowercase?: bool = true
 /// })
 fn bert_normalizer(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
-    let mut clean_text = true;
-    let mut handle_chinese_chars = true;
-    let mut strip_accents = true;
-    let mut lowercase = true;
-
-    if let Some(options) = cx.argument_opt(0) {
-        let options = options.downcast::<JsObject>().or_throw(&mut cx)?;
-        if let Ok(ct) = options.get(&mut cx, "cleanText") {
-            if let Err(_) = ct.downcast::<JsUndefined>() {
-                clean_text = ct.downcast::<JsBoolean>().or_throw(&mut cx)?.value();
-            }
-        }
-        if let Ok(hcc) = options.get(&mut cx, "handleChineseChars") {
-            if let Err(_) = hcc.downcast::<JsUndefined>() {
-                handle_chinese_chars = hcc.downcast::<JsBoolean>().or_throw(&mut cx)?.value();
-            }
-        }
-        if let Ok(sa) = options.get(&mut cx, "stripAccents") {
-            if let Err(_) = sa.downcast::<JsUndefined>() {
-                strip_accents = sa.downcast::<JsBoolean>().or_throw(&mut cx)?.value();
-            }
-        }
-        if let Ok(l) = options.get(&mut cx, "lowercase") {
-            if let Err(_) = l.downcast::<JsUndefined>() {
-                lowercase = l.downcast::<JsBoolean>().or_throw(&mut cx)?.value();
-            }
-        }
-    }
+    let options = cx
+        .extract_opt::<BertNormalizerOptions>(0)?
+        .unwrap_or_else(BertNormalizerOptions::default);
 
     let mut normalizer = JsNormalizer::new::<_, JsNormalizer, _>(&mut cx, vec![])?;
     let guard = cx.lock();
     normalizer.borrow_mut(&guard).normalizer.to_owned(Box::new(
         tk::normalizers::bert::BertNormalizer::new(
-            clean_text,
-            handle_chinese_chars,
-            strip_accents,
-            lowercase,
+            options.clean_text,
+            options.handle_chinese_chars,
+            options.strip_accents,
+            options.lowercase,
         ),
     ));
     Ok(normalizer)
@@ -114,22 +109,8 @@ fn nfkc(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
 
 /// strip(left?: boolean, right?: boolean)
 fn strip(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
-    let mut left = true;
-    let mut right = true;
-
-    if let Some(left_arg) = cx.argument_opt(0) {
-        if left_arg.downcast::<JsUndefined>().is_err() {
-            left = left_arg.downcast_or_throw::<JsBoolean, _>(&mut cx)?.value();
-        }
-
-        if let Some(right_arg) = cx.argument_opt(1) {
-            if right_arg.downcast::<JsUndefined>().is_err() {
-                right = right_arg
-                    .downcast_or_throw::<JsBoolean, _>(&mut cx)?
-                    .value();
-            }
-        }
-    }
+    let left = cx.extract_opt::<bool>(0)?.unwrap_or(true);
+    let right = cx.extract_opt::<bool>(1)?.unwrap_or(true);
 
     let mut normalizer = JsNormalizer::new::<_, JsNormalizer, _>(&mut cx, vec![])?;
     let guard = cx.lock();
@@ -147,19 +128,22 @@ fn sequence(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
         .argument::<JsArray>(0)?
         .to_vec(&mut cx)?
         .into_iter()
-        .map(|normalizer| {
-            match normalizer.downcast::<JsNormalizer>().or_throw(&mut cx) {
+        .map(
+            |normalizer| match normalizer.downcast::<JsNormalizer>().or_throw(&mut cx) {
                 Ok(normalizer) => {
-                     let guard = cx.lock();
-                     if !normalizer.borrow(&guard).normalizer.is_owned() {
-                         cx.throw_error("At least one of the normalizers is already being used in another Tokenizer")
-                     } else {
-                         Ok(normalizer)
-                     }
-                },
-                Err(e) => Err(e)
-            }
-        })
+                    let guard = cx.lock();
+                    if !normalizer.borrow(&guard).normalizer.is_owned() {
+                        cx.throw_error(
+                            "At least one of the normalizers is \
+                                        already being used in another Tokenizer",
+                        )
+                    } else {
+                        Ok(normalizer)
+                    }
+                }
+                Err(e) => Err(e),
+            },
+        )
         .collect::<NeonResult<Vec<_>>>()?;
 
     // We've checked that all the normalizers can be used, now we can convert them and attach
@@ -168,12 +152,8 @@ fn sequence(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
         .into_iter()
         .map(|mut normalizer| {
             let guard = cx.lock();
-            let n = normalizer
-                .borrow_mut(&guard)
-                .normalizer
-                .to_pointer()
-                .unwrap();
-            n
+            let mut n = normalizer.borrow_mut(&guard);
+            n.normalizer.to_pointer().unwrap()
         })
         .collect::<Vec<_>>();
 

--- a/bindings/node/native/src/normalizers.rs
+++ b/bindings/node/native/src/normalizers.rs
@@ -52,14 +52,15 @@ fn bert_normalizer(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
 
     let mut normalizer = JsNormalizer::new::<_, JsNormalizer, _>(&mut cx, vec![])?;
     let guard = cx.lock();
-    normalizer.borrow_mut(&guard).normalizer.to_owned(Box::new(
-        tk::normalizers::bert::BertNormalizer::new(
+    normalizer
+        .borrow_mut(&guard)
+        .normalizer
+        .make_owned(Box::new(tk::normalizers::bert::BertNormalizer::new(
             options.clean_text,
             options.handle_chinese_chars,
             options.strip_accents,
             options.lowercase,
-        ),
-    ));
+        )));
     Ok(normalizer)
 }
 
@@ -70,7 +71,7 @@ fn nfd(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
     normalizer
         .borrow_mut(&guard)
         .normalizer
-        .to_owned(Box::new(tk::normalizers::unicode::NFD));
+        .make_owned(Box::new(tk::normalizers::unicode::NFD));
     Ok(normalizer)
 }
 
@@ -81,7 +82,7 @@ fn nfkd(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
     normalizer
         .borrow_mut(&guard)
         .normalizer
-        .to_owned(Box::new(tk::normalizers::unicode::NFKD));
+        .make_owned(Box::new(tk::normalizers::unicode::NFKD));
     Ok(normalizer)
 }
 
@@ -92,7 +93,7 @@ fn nfc(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
     normalizer
         .borrow_mut(&guard)
         .normalizer
-        .to_owned(Box::new(tk::normalizers::unicode::NFC));
+        .make_owned(Box::new(tk::normalizers::unicode::NFC));
     Ok(normalizer)
 }
 
@@ -103,7 +104,7 @@ fn nfkc(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
     normalizer
         .borrow_mut(&guard)
         .normalizer
-        .to_owned(Box::new(tk::normalizers::unicode::NFKC));
+        .make_owned(Box::new(tk::normalizers::unicode::NFKC));
     Ok(normalizer)
 }
 
@@ -117,7 +118,7 @@ fn strip(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
     normalizer
         .borrow_mut(&guard)
         .normalizer
-        .to_owned(Box::new(tk::normalizers::strip::Strip::new(left, right)));
+        .make_owned(Box::new(tk::normalizers::strip::Strip::new(left, right)));
 
     Ok(normalizer)
 }
@@ -153,7 +154,7 @@ fn sequence(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
         .map(|mut normalizer| {
             let guard = cx.lock();
             let mut n = normalizer.borrow_mut(&guard);
-            n.normalizer.to_pointer().unwrap()
+            n.normalizer.make_pointer().unwrap()
         })
         .collect::<Vec<_>>();
 
@@ -162,7 +163,7 @@ fn sequence(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
     normalizer
         .borrow_mut(&guard)
         .normalizer
-        .to_owned(Box::new(tk::normalizers::utils::Sequence::new(normalizers)));
+        .make_owned(Box::new(tk::normalizers::utils::Sequence::new(normalizers)));
     Ok(normalizer)
 }
 
@@ -173,7 +174,7 @@ fn lowercase(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
     normalizer
         .borrow_mut(&guard)
         .normalizer
-        .to_owned(Box::new(tk::normalizers::utils::Lowercase));
+        .make_owned(Box::new(tk::normalizers::utils::Lowercase));
     Ok(normalizer)
 }
 

--- a/bindings/node/native/src/pre_tokenizers.rs
+++ b/bindings/node/native/src/pre_tokenizers.rs
@@ -32,7 +32,7 @@ fn byte_level(mut cx: FunctionContext) -> JsResult<JsPreTokenizer> {
     pretok
         .borrow_mut(&guard)
         .pretok
-        .to_owned(Box::new(byte_level));
+        .make_owned(Box::new(byte_level));
     Ok(pretok)
 }
 
@@ -53,7 +53,7 @@ fn whitespace(mut cx: FunctionContext) -> JsResult<JsPreTokenizer> {
     pretok
         .borrow_mut(&guard)
         .pretok
-        .to_owned(Box::new(tk::pre_tokenizers::whitespace::Whitespace));
+        .make_owned(Box::new(tk::pre_tokenizers::whitespace::Whitespace));
     Ok(pretok)
 }
 
@@ -64,7 +64,7 @@ fn whitespace_split(mut cx: FunctionContext) -> JsResult<JsPreTokenizer> {
     pretok
         .borrow_mut(&guard)
         .pretok
-        .to_owned(Box::new(tk::pre_tokenizers::whitespace::WhitespaceSplit));
+        .make_owned(Box::new(tk::pre_tokenizers::whitespace::WhitespaceSplit));
     Ok(pretok)
 }
 
@@ -75,7 +75,7 @@ fn bert_pre_tokenizer(mut cx: FunctionContext) -> JsResult<JsPreTokenizer> {
     pretok
         .borrow_mut(&guard)
         .pretok
-        .to_owned(Box::new(tk::pre_tokenizers::bert::BertPreTokenizer));
+        .make_owned(Box::new(tk::pre_tokenizers::bert::BertPreTokenizer));
     Ok(pretok)
 }
 
@@ -86,7 +86,7 @@ fn metaspace(mut cx: FunctionContext) -> JsResult<JsPreTokenizer> {
 
     let mut pretok = JsPreTokenizer::new::<_, JsPreTokenizer, _>(&mut cx, vec![])?;
     let guard = cx.lock();
-    pretok.borrow_mut(&guard).pretok.to_owned(Box::new(
+    pretok.borrow_mut(&guard).pretok.make_owned(Box::new(
         tk::pre_tokenizers::metaspace::Metaspace::new(replacement, add_prefix_space),
     ));
     Ok(pretok)
@@ -98,7 +98,7 @@ fn char_delimiter_split(mut cx: FunctionContext) -> JsResult<JsPreTokenizer> {
 
     let mut pretok = JsPreTokenizer::new::<_, JsPreTokenizer, _>(&mut cx, vec![])?;
     let guard = cx.lock();
-    pretok.borrow_mut(&guard).pretok.to_owned(Box::new(
+    pretok.borrow_mut(&guard).pretok.make_owned(Box::new(
         tk::pre_tokenizers::delimiter::CharDelimiterSplit::new(delimiter),
     ));
 

--- a/bindings/node/native/src/processors.rs
+++ b/bindings/node/native/src/processors.rs
@@ -1,6 +1,7 @@
 extern crate tokenizers as tk;
 
 use crate::container::Container;
+use crate::extraction::*;
 use neon::prelude::*;
 
 /// Processor
@@ -21,31 +22,8 @@ declare_types! {
 
 /// bert_processing(sep: [String, number], cls: [String, number])
 fn bert_processing(mut cx: FunctionContext) -> JsResult<JsPostProcessor> {
-    let sep = cx.argument::<JsArray>(0)?;
-    let cls = cx.argument::<JsArray>(1)?;
-    if sep.len() != 2 || cls.len() != 2 {
-        return cx.throw_error("SEP and CLS must be of the form: [String, number]");
-    }
-    let sep: (String, u32) = (
-        sep.get(&mut cx, 0)?
-            .downcast::<JsString>()
-            .or_throw(&mut cx)?
-            .value(),
-        sep.get(&mut cx, 1)?
-            .downcast::<JsNumber>()
-            .or_throw(&mut cx)?
-            .value() as u32,
-    );
-    let cls: (String, u32) = (
-        cls.get(&mut cx, 0)?
-            .downcast::<JsString>()
-            .or_throw(&mut cx)?
-            .value(),
-        cls.get(&mut cx, 1)?
-            .downcast::<JsNumber>()
-            .or_throw(&mut cx)?
-            .value() as u32,
-    );
+    let sep = cx.extract::<(String, u32)>(0)?;
+    let cls = cx.extract::<(String, u32)>(1)?;
 
     let mut processor = JsPostProcessor::new::<_, JsPostProcessor, _>(&mut cx, vec![])?;
     let guard = cx.lock();
@@ -62,44 +40,15 @@ fn bert_processing(mut cx: FunctionContext) -> JsResult<JsPostProcessor> {
 ///   addPrefixSpace: boolean = true
 /// )
 fn roberta_processing(mut cx: FunctionContext) -> JsResult<JsPostProcessor> {
-    let sep = cx.argument::<JsArray>(0)?;
-    let cls = cx.argument::<JsArray>(1)?;
-    if sep.len() != 2 || cls.len() != 2 {
-        return cx.throw_error("SEP and CLS must be of the form: [String, number]");
-    }
-    let sep: (String, u32) = (
-        sep.get(&mut cx, 0)?
-            .downcast::<JsString>()
-            .or_throw(&mut cx)?
-            .value(),
-        sep.get(&mut cx, 1)?
-            .downcast::<JsNumber>()
-            .or_throw(&mut cx)?
-            .value() as u32,
-    );
-    let cls: (String, u32) = (
-        cls.get(&mut cx, 0)?
-            .downcast::<JsString>()
-            .or_throw(&mut cx)?
-            .value(),
-        cls.get(&mut cx, 1)?
-            .downcast::<JsNumber>()
-            .or_throw(&mut cx)?
-            .value() as u32,
-    );
+    let sep = cx.extract::<(String, u32)>(0)?;
+    let cls = cx.extract::<(String, u32)>(1)?;
 
     let mut processor = tk::processors::roberta::RobertaProcessing::new(sep, cls);
-    if let Some(args) = cx.argument_opt(2) {
-        if args.downcast::<JsUndefined>().is_err() {
-            processor =
-                processor.trim_offsets(args.downcast::<JsBoolean>().or_throw(&mut cx)?.value());
-        }
+    if let Some(trim_offsets) = cx.extract_opt::<bool>(2)? {
+        processor = processor.trim_offsets(trim_offsets);
     }
-    if let Some(args) = cx.argument_opt(3) {
-        if args.downcast::<JsUndefined>().is_err() {
-            processor =
-                processor.add_prefix_space(args.downcast::<JsBoolean>().or_throw(&mut cx)?.value());
-        }
+    if let Some(add_prefix_space) = cx.extract_opt::<bool>(3)? {
+        processor = processor.add_prefix_space(add_prefix_space);
     }
 
     let mut js_processor = JsPostProcessor::new::<_, JsPostProcessor, _>(&mut cx, vec![])?;
@@ -115,11 +64,8 @@ fn roberta_processing(mut cx: FunctionContext) -> JsResult<JsPostProcessor> {
 fn bytelevel(mut cx: FunctionContext) -> JsResult<JsPostProcessor> {
     let mut byte_level = tk::processors::byte_level::ByteLevel::default();
 
-    if let Some(args) = cx.argument_opt(0) {
-        if args.downcast::<JsUndefined>().is_err() {
-            byte_level =
-                byte_level.trim_offsets(args.downcast::<JsBoolean>().or_throw(&mut cx)?.value());
-        }
+    if let Some(trim_offsets) = cx.extract_opt::<bool>(0)? {
+        byte_level = byte_level.trim_offsets(trim_offsets);
     }
 
     let mut processor = JsPostProcessor::new::<_, JsPostProcessor, _>(&mut cx, vec![])?;

--- a/bindings/node/native/src/processors.rs
+++ b/bindings/node/native/src/processors.rs
@@ -27,7 +27,7 @@ fn bert_processing(mut cx: FunctionContext) -> JsResult<JsPostProcessor> {
 
     let mut processor = JsPostProcessor::new::<_, JsPostProcessor, _>(&mut cx, vec![])?;
     let guard = cx.lock();
-    processor.borrow_mut(&guard).processor.to_owned(Box::new(
+    processor.borrow_mut(&guard).processor.make_owned(Box::new(
         tk::processors::bert::BertProcessing::new(sep, cls),
     ));
     Ok(processor)
@@ -56,7 +56,7 @@ fn roberta_processing(mut cx: FunctionContext) -> JsResult<JsPostProcessor> {
     js_processor
         .borrow_mut(&guard)
         .processor
-        .to_owned(Box::new(processor));
+        .make_owned(Box::new(processor));
     Ok(js_processor)
 }
 
@@ -73,7 +73,7 @@ fn bytelevel(mut cx: FunctionContext) -> JsResult<JsPostProcessor> {
     processor
         .borrow_mut(&guard)
         .processor
-        .to_owned(Box::new(byte_level));
+        .make_owned(Box::new(byte_level));
     Ok(processor)
 }
 

--- a/bindings/node/native/src/tasks/models.rs
+++ b/bindings/node/native/src/tasks/models.rs
@@ -35,7 +35,7 @@ impl Task for WordPieceFromFilesTask {
         js_model
             .borrow_mut(&guard)
             .model
-            .to_owned(Box::new(wordpiece));
+            .make_owned(Box::new(wordpiece));
 
         Ok(js_model.upcast())
     }
@@ -68,7 +68,7 @@ impl Task for BPEFromFilesTask {
 
         let mut js_model = JsModel::new::<_, JsModel, _>(&mut cx, vec![])?;
         let guard = cx.lock();
-        js_model.borrow_mut(&guard).model.to_owned(Box::new(bpe));
+        js_model.borrow_mut(&guard).model.make_owned(Box::new(bpe));
 
         Ok(js_model.upcast())
     }

--- a/bindings/node/native/src/tasks/tokenizer.rs
+++ b/bindings/node/native/src/tasks/tokenizer.rs
@@ -48,7 +48,7 @@ impl Task for EncodeTask {
                         *add_special_tokens,
                     )
                     .map_err(|e| format!("{}", e))
-                    .map(|encoding| EncodeOutput::Single(encoding))
+                    .map(EncodeOutput::Single)
             }
             EncodeTask::Batch(worker, input, add_special_tokens) => {
                 let mut input: Option<Vec<EncodeInput>> =
@@ -60,7 +60,7 @@ impl Task for EncodeTask {
                         *add_special_tokens,
                     )
                     .map_err(|e| format!("{}", e))
-                    .map(|encodings| EncodeOutput::Batch(encodings))
+                    .map(EncodeOutput::Batch)
             }
         }
     }
@@ -78,7 +78,7 @@ impl Task for EncodeTask {
                 js_encoding
                     .borrow_mut(&guard)
                     .encoding
-                    .to_owned(Box::new(encoding));
+                    .make_owned(Box::new(encoding));
 
                 Ok(js_encoding.upcast())
             }
@@ -92,7 +92,7 @@ impl Task for EncodeTask {
                     js_encoding
                         .borrow_mut(&guard)
                         .encoding
-                        .to_owned(Box::new(encoding));
+                        .make_owned(Box::new(encoding));
 
                     result.set(&mut cx, i as u32, js_encoding)?;
                 }

--- a/bindings/node/native/src/tokenizer.rs
+++ b/bindings/node/native/src/tokenizer.rs
@@ -207,7 +207,7 @@ impl Default for EncodeOptions {
 // Encoding
 
 #[repr(transparent)]
-struct Encoding(tk::Encoding);
+pub struct Encoding(tk::Encoding);
 impl FromJsValue for Encoding {
     fn from_value<'c, C: Context<'c>>(from: Handle<'c, JsValue>, cx: &mut C) -> LibResult<Self> {
         from.downcast::<JsEncoding>()

--- a/bindings/node/native/src/tokenizer.rs
+++ b/bindings/node/native/src/tokenizer.rs
@@ -229,7 +229,7 @@ impl From<Encoding> for tk::Encoding {
 
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "tk::TruncationStrategy", rename_all = "snake_case")]
-enum TruncationStrategyDef {
+pub enum TruncationStrategyDef {
     LongestFirst,
     OnlyFirst,
     OnlySecond,
@@ -241,7 +241,7 @@ enum TruncationStrategyDef {
     rename_all = "camelCase",
     default = "tk::TruncationParams::default"
 )]
-struct TruncationParamsDef {
+pub struct TruncationParamsDef {
     max_length: usize,
     #[serde(with = "TruncationStrategyDef")]
     strategy: tk::TruncationStrategy,
@@ -250,13 +250,13 @@ struct TruncationParamsDef {
 
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct TruncationParams(#[serde(with = "TruncationParamsDef")] tk::TruncationParams);
+pub struct TruncationParams(#[serde(with = "TruncationParamsDef")] pub tk::TruncationParams);
 
 // Padding
 
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "tk::PaddingDirection", rename_all = "camelCase")]
-enum PaddingDirectionDef {
+pub enum PaddingDirectionDef {
     Left,
     Right,
 }
@@ -265,7 +265,7 @@ enum PaddingDirectionDef {
 // we want it to actually be very different from the classic representation.
 // In Rust, we use an enum to define the strategy, but in JS, we just want to have a optional
 // length number => If defined we use the Fixed(n) strategy and otherwise the BatchLongest.
-mod padding_strategy_serde {
+pub mod padding_strategy_serde {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     #[derive(Serialize, Deserialize)]
@@ -307,7 +307,7 @@ mod padding_strategy_serde {
     rename_all = "camelCase",
     default = "tk::PaddingParams::default"
 )]
-struct PaddingParamsDef {
+pub struct PaddingParamsDef {
     #[serde(flatten, with = "padding_strategy_serde")]
     strategy: tk::PaddingStrategy,
     #[serde(with = "PaddingDirectionDef")]
@@ -320,7 +320,7 @@ struct PaddingParamsDef {
 }
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct PaddingParams(#[serde(with = "PaddingParamsDef")] tk::PaddingParams);
+pub struct PaddingParams(#[serde(with = "PaddingParamsDef")] pub tk::PaddingParams);
 
 /// Tokenizer
 pub struct Tokenizer {

--- a/bindings/node/native/src/tokenizer.rs
+++ b/bindings/node/native/src/tokenizer.rs
@@ -358,7 +358,7 @@ declare_types! {
             if let Some(instance) = {
                 let guard = cx.lock();
                 let mut model = model.borrow_mut(&guard);
-                model.model.to_pointer()
+                model.model.make_pointer()
             } {
                 Ok(Tokenizer {
                     tokenizer: tk::Tokenizer::new(instance),
@@ -767,7 +767,7 @@ declare_types! {
             js_encoding
                 .borrow_mut(&guard)
                 .encoding
-                .to_owned(Box::new(encoding));
+                .make_owned(Box::new(encoding));
 
             Ok(js_encoding.upcast())
         }
@@ -794,7 +794,7 @@ declare_types! {
             if let Some(instance) = {
                 let guard = cx.lock();
                 let mut model = model.borrow_mut(&guard);
-                model.model.to_pointer()
+                model.model.make_pointer()
             } {
                 let mut this = cx.this();
                 {
@@ -839,7 +839,7 @@ declare_types! {
             if let Some(instance) = {
                 let guard = cx.lock();
                 let mut normalizer = normalizer.borrow_mut(&guard);
-                normalizer.normalizer.to_pointer()
+                normalizer.normalizer.make_pointer()
             } {
                 let mut this = cx.this();
                 {
@@ -884,7 +884,7 @@ declare_types! {
             if let Some(instance) = {
                 let guard = cx.lock();
                 let mut pretok = pretok.borrow_mut(&guard);
-                pretok.pretok.to_pointer()
+                pretok.pretok.make_pointer()
             } {
                 let mut this = cx.this();
                 {
@@ -930,7 +930,7 @@ declare_types! {
             if let Some(instance) = {
                 let guard = cx.lock();
                 let mut processor = processor.borrow_mut(&guard);
-                processor.processor.to_pointer()
+                processor.processor.make_pointer()
             } {
                 let mut this = cx.this();
                 {
@@ -975,7 +975,7 @@ declare_types! {
             if let Some(instance) = {
                 let guard = cx.lock();
                 let mut decoder = decoder.borrow_mut(&guard);
-                decoder.decoder.to_pointer()
+                decoder.decoder.make_pointer()
             } {
                 let mut this = cx.this();
                 {

--- a/bindings/node/native/src/tokenizer.rs
+++ b/bindings/node/native/src/tokenizer.rs
@@ -337,6 +337,19 @@ impl Tokenizer {
     }
 }
 
+macro_rules! check_tokenizer_can_be_modified {
+    ($cx: expr) => {
+        let this = $cx.this();
+        let guard = $cx.lock();
+        let running = std::sync::Arc::strong_count(&this.borrow(&guard).running_task);
+        if running > 1 {
+            return Err(
+                Error("Cannot modify the tokenizer while there are running tasks".into()).into(),
+            );
+        }
+    };
+}
+
 declare_types! {
     pub class JsTokenizer for Tokenizer {
         init(mut cx) {
@@ -383,12 +396,10 @@ declare_types! {
 
         method runningTasks(mut cx) {
             // runningTasks(): number
-            let running = {
-                let this = cx.this();
-                let guard = cx.lock();
-                let count = std::sync::Arc::strong_count(&this.borrow(&guard).running_task);
-                if count > 0 { count - 1 } else { 0 }
-            };
+            let this = cx.this();
+            let guard = cx.lock();
+            let count = std::sync::Arc::strong_count(&this.borrow(&guard).running_task);
+            let running = if count > 0 { count - 1 } else { 0 };
             Ok(cx.number(running as f64).upcast())
         }
 
@@ -777,17 +788,7 @@ declare_types! {
 
         method setModel(mut cx) {
             // setModel(model: JsModel)
-
-            let running = {
-                let this = cx.this();
-                let guard = cx.lock();
-                let count = std::sync::Arc::strong_count(&this.borrow(&guard).running_task);
-                count
-            };
-            if running > 1 {
-                println!("{} running tasks", running - 1);
-                return cx.throw_error("Cannot modify the tokenizer while there are running tasks");
-            }
+            check_tokenizer_can_be_modified!(cx);
 
             let mut model = cx.argument::<JsModel>(0)?;
             if let Some(instance) = {
@@ -832,17 +833,7 @@ declare_types! {
 
         method setNormalizer(mut cx) {
             // setNormalizer(normalizer: Normalizer)
-
-            let running = {
-                let this = cx.this();
-                let guard = cx.lock();
-                let count = std::sync::Arc::strong_count(&this.borrow(&guard).running_task);
-                count
-            };
-            if running > 1 {
-                println!("{} running tasks", running - 1);
-                return cx.throw_error("Cannot modify the tokenizer while there are running tasks");
-            }
+            check_tokenizer_can_be_modified!(cx);
 
             let mut normalizer = cx.argument::<JsNormalizer>(0)?;
             if let Some(instance) = {
@@ -887,17 +878,7 @@ declare_types! {
 
         method setPreTokenizer(mut cx) {
             // setPreTokenizer(pretokenizer: PreTokenizer)
-
-            let running = {
-                let this = cx.this();
-                let guard = cx.lock();
-                let count = std::sync::Arc::strong_count(&this.borrow(&guard).running_task);
-                count
-            };
-            if running > 1 {
-                println!("{} running tasks", running - 1);
-                return cx.throw_error("Cannot modify the tokenizer while there are running tasks");
-            }
+            check_tokenizer_can_be_modified!(cx);
 
             let mut pretok = cx.argument::<JsPreTokenizer>(0)?;
             if let Some(instance) = {
@@ -943,17 +924,7 @@ declare_types! {
 
         method setPostProcessor(mut cx) {
             // setPostProcessor(processor: PostProcessor)
-
-            let running = {
-                let this = cx.this();
-                let guard = cx.lock();
-                let count = std::sync::Arc::strong_count(&this.borrow(&guard).running_task);
-                count
-            };
-            if running > 1 {
-                println!("{} running tasks", running - 1);
-                return cx.throw_error("Cannot modify the tokenizer while there are running tasks");
-            }
+            check_tokenizer_can_be_modified!(cx);
 
             let mut processor = cx.argument::<JsPostProcessor>(0)?;
             if let Some(instance) = {
@@ -998,17 +969,7 @@ declare_types! {
 
         method setDecoder(mut cx) {
             // setDecoder(decoder: Decoder)
-
-            let running = {
-                let this = cx.this();
-                let guard = cx.lock();
-                let count = std::sync::Arc::strong_count(&this.borrow(&guard).running_task);
-                count
-            };
-            if running > 1 {
-                println!("{} running tasks", running - 1);
-                return cx.throw_error("Cannot modify the tokenizer while there are running tasks");
-            }
+            check_tokenizer_can_be_modified!(cx);
 
             let mut decoder = cx.argument::<JsDecoder>(0)?;
             if let Some(instance) = {

--- a/bindings/node/native/src/trainers.rs
+++ b/bindings/node/native/src/trainers.rs
@@ -112,7 +112,7 @@ fn bpe_trainer(mut cx: FunctionContext) -> JsResult<JsTrainer> {
     js_trainer
         .borrow_mut(&guard)
         .trainer
-        .to_owned(Box::new(trainer));
+        .make_owned(Box::new(trainer));
 
     Ok(js_trainer)
 }
@@ -207,7 +207,7 @@ fn wordpiece_trainer(mut cx: FunctionContext) -> JsResult<JsTrainer> {
     js_trainer
         .borrow_mut(&guard)
         .trainer
-        .to_owned(Box::new(trainer));
+        .make_owned(Box::new(trainer));
 
     Ok(js_trainer)
 }

--- a/bindings/node/native/src/utils.rs
+++ b/bindings/node/native/src/utils.rs
@@ -1,11 +1,13 @@
 extern crate tokenizers as tk;
 
 use crate::encoding::JsEncoding;
+use crate::extraction::*;
+use crate::tokenizer::Encoding;
 use neon::prelude::*;
 
 /// slice(s: string, start?: number, end?: number)
 fn slice(mut cx: FunctionContext) -> JsResult<JsString> {
-    let s = cx.argument::<JsString>(0)?.value();
+    let s = cx.extract::<String>(0)?;
     let len = s.chars().count();
 
     let get_index = |x: i32| -> usize {
@@ -16,27 +18,8 @@ fn slice(mut cx: FunctionContext) -> JsResult<JsString> {
         }
     };
 
-    let begin_index = if let Some(begin_arg) = cx.argument_opt(1) {
-        if begin_arg.downcast::<JsUndefined>().is_err() {
-            let begin = begin_arg.downcast::<JsNumber>().or_throw(&mut cx)?.value() as i32;
-            get_index(begin)
-        } else {
-            0
-        }
-    } else {
-        0
-    };
-
-    let end_index = if let Some(end_arg) = cx.argument_opt(2) {
-        if end_arg.downcast::<JsUndefined>().is_err() {
-            let end = end_arg.downcast::<JsNumber>().or_throw(&mut cx)?.value() as i32;
-            get_index(end)
-        } else {
-            len
-        }
-    } else {
-        len
-    };
+    let begin_index = get_index(cx.extract_opt::<i32>(1)?.unwrap_or(0));
+    let end_index = get_index(cx.extract_opt::<i32>(2)?.unwrap_or(len as i32));
 
     if let Some(slice) = tk::tokenizer::get_range_of(&s, begin_index..end_index) {
         Ok(cx.string(slice))
@@ -47,33 +30,12 @@ fn slice(mut cx: FunctionContext) -> JsResult<JsString> {
 
 /// merge_encodings(encodings: Encoding[], growing_offsets: boolean = false): Encoding
 fn merge_encodings(mut cx: FunctionContext) -> JsResult<JsEncoding> {
-    let encodings = cx
-        .argument::<JsArray>(0)?
-        .to_vec(&mut cx)?
+    let encodings: Vec<tk::Encoding> = cx
+        .extract_vec::<Encoding>(0)?
         .into_iter()
-        .map(|item| {
-            let encoding = item.downcast::<JsEncoding>().or_throw(&mut cx)?;
-
-            let guard = cx.lock();
-            let encoding = encoding
-                .borrow(&guard)
-                .encoding
-                .execute(|e| *e.unwrap().clone());
-
-            Ok(encoding)
-        })
-        .collect::<Result<Vec<_>, neon::result::Throw>>()
-        .map_err(|e| cx.throw_error::<_, ()>(format!("{}", e)).unwrap_err())?;
-
-    let growing_offsets = if let Some(arg) = cx.argument_opt(1) {
-        if arg.downcast::<JsUndefined>().is_err() {
-            arg.downcast::<JsBoolean>().or_throw(&mut cx)?.value()
-        } else {
-            false
-        }
-    } else {
-        false
-    };
+        .map(|e| e.into())
+        .collect();
+    let growing_offsets = cx.extract_opt::<bool>(1)?.unwrap_or(false);
 
     let new_encoding = tk::tokenizer::Encoding::merge(encodings.as_slice(), growing_offsets);
     let mut js_encoding = JsEncoding::new::<_, JsEncoding, _>(&mut cx, vec![])?;

--- a/bindings/node/native/src/utils.rs
+++ b/bindings/node/native/src/utils.rs
@@ -44,7 +44,7 @@ fn merge_encodings(mut cx: FunctionContext) -> JsResult<JsEncoding> {
     js_encoding
         .borrow_mut(&guard)
         .encoding
-        .to_owned(Box::new(new_encoding));
+        .make_owned(Box::new(new_encoding));
 
     Ok(js_encoding)
 }


### PR DESCRIPTION
In this PR, we leverage all the extraction methods that we introduced with #249. This leads to code that is a lot clearer and easier to read. Updating the node bindings after this PR should be much more enjoyable than before.

We also take advantage of this PR to fix all the Clippy lint warnings that existed to date and enable this check in the CI.