### PR TITLE
add ability to disable parallelism

### DIFF
--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -268,7 +268,7 @@ declare_types! {
                     params.pad_id,
                     params.pad_type_id,
                     &params.pad_token,
-                    params.direction
+                    params.direction,
                     true
                 );
             });

--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -355,7 +355,7 @@ declare_types! {
             let mut this = cx.this();
             let guard = cx.lock();
             this.borrow_mut(&guard).encoding.execute_mut(|encoding| {
-                encoding.unwrap().pad(length, pad_id, pad_type_id, &pad_token, direction);
+                encoding.unwrap().pad(length, pad_id, pad_type_id, &pad_token, direction, true);
             });
 
             Ok(cx.undefined().upcast())

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -17,6 +17,8 @@ This adds some methods to easily save/load an entire tokenizer (`from_str`, `fro
 activation of the Tensor Cores, while ensuring padding to a multiple of 8. Use with
 `enable_padding(pad_to_multiple_of=8)` for example.
 - [#298]: Ability to get the currently set truncation/padding params
+- [#187]: Added the ability to disable parallelism in the Rust lib, which will
+avoid the dead-locking issue with Python subprocesses.
 
 ### Changed
 - Improved errors generated during truncation: When the provided max length is too low are

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -160,7 +160,7 @@ impl Encoding {
         let mut pad_type_id = 0;
         let mut pad_token = "[PAD]";
         let mut direction = PaddingDirection::Right;
-        let mut parallelism = false;
+        let mut parallelism = true;
 
         if let Some(kwargs) = kwargs {
             for (key, value) in kwargs {

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -160,6 +160,7 @@ impl Encoding {
         let mut pad_type_id = 0;
         let mut pad_token = "[PAD]";
         let mut direction = PaddingDirection::Right;
+        let mut parallelism = false;
 
         if let Some(kwargs) = kwargs {
             for (key, value) in kwargs {
@@ -182,13 +183,19 @@ impl Encoding {
                     "pad_type_id" => pad_type_id = value.extract()?,
                     "pad_token" => pad_token = value.extract()?,
                     _ => println!("Ignored unknown kwarg option {}", key),
+                    "parallelism" => parallelism = value.extract()?,
                 }
             }
         }
 
-        Ok(self
-            .encoding
-            .pad(length, pad_id, pad_type_id, pad_token, direction))
+        Ok(self.encoding.pad(
+            length,
+            pad_id,
+            pad_type_id,
+            pad_token,
+            direction,
+            parallelism,
+        ))
     }
 
     #[args(kwargs = "**")]

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -182,8 +182,8 @@ impl Encoding {
                     "pad_id" => pad_id = value.extract()?,
                     "pad_type_id" => pad_type_id = value.extract()?,
                     "pad_token" => pad_token = value.extract()?,
-                    _ => println!("Ignored unknown kwarg option {}", key),
                     "parallelism" => parallelism = value.extract()?,
+                    _ => println!("Ignored unknown kwarg option {}", key),
                 }
             }
         }

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -713,4 +713,14 @@ impl Tokenizer {
             ))
         }
     }
+
+    #[getter]
+    fn get_parallelism(&self) -> bool {
+        self.tokenizer.get_parallelism()
+    }
+
+    #[setter]
+    fn set_parallelism(&mut self, parallelism: bool) {
+        self.tokenizer.with_parallelism(parallelism);
+    }
 }

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -81,9 +81,7 @@ class TestTokenizer:
         added = tokenizer.add_tokens(["my", "name", "is", "john"])
         assert added == 4
 
-        added = tokenizer.add_tokens(
-            [AddedToken("the"), AddedToken("quick", rstrip=True)]
-        )
+        added = tokenizer.add_tokens([AddedToken("the"), AddedToken("quick", rstrip=True)])
         assert added == 2
 
     def test_add_special_tokens(self):
@@ -94,9 +92,7 @@ class TestTokenizer:
         assert added == 4
 
         # Can add special tokens as `AddedToken`
-        added = tokenizer.add_special_tokens(
-            [AddedToken("the"), AddedToken("quick", rstrip=True)]
-        )
+        added = tokenizer.add_special_tokens([AddedToken("the"), AddedToken("quick", rstrip=True)])
         assert added == 2
 
     def test_encode(self):
@@ -124,9 +120,7 @@ class TestTokenizer:
         assert output.tokens == ["my", "name", "is", "john"]
 
         # Can encode a batch with both a single sequence and a pair of sequences
-        output = tokenizer.encode_batch(
-            ["my name is john", ("my name is john", "pair")]
-        )
+        output = tokenizer.encode_batch(["my name is john", ("my name is john", "pair")])
         assert len(output) == 2
 
     def test_encode_formats(self, bert_files):
@@ -148,9 +142,7 @@ class TestTokenizer:
         ]
         output = tokenizer.encode(["my", "name", "is", "john"], is_pretokenized=True)
         assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
-        output = tokenizer.encode(
-            ["my", "name", "is", "john"], ["pair"], is_pretokenized=True
-        )
+        output = tokenizer.encode(["my", "name", "is", "john"], ["pair"], is_pretokenized=True)
         assert output.tokens == [
             "[CLS]",
             "my",
@@ -165,9 +157,7 @@ class TestTokenizer:
         output = tokenizer.encode_batch(["My name is John", "My name is Georges"])
         assert output[0].tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
         assert output[1].tokens == ["[CLS]", "my", "name", "is", "georges", "[SEP]"]
-        output = tokenizer.encode_batch(
-            [("my name is john", "pair"), ("my name is john", "pair")]
-        )
+        output = tokenizer.encode_batch([("my name is john", "pair"), ("my name is john", "pair")])
         assert output[0].tokens == [
             "[CLS]",
             "my",
@@ -188,9 +178,7 @@ class TestTokenizer:
             "pair",
             "[SEP]",
         ]
-        output = tokenizer.encode_batch(
-            [["my", "name", "is", "john"]], is_pretokenized=True
-        )
+        output = tokenizer.encode_batch([["my", "name", "is", "john"]], is_pretokenized=True)
         assert output[0].tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
 
         # Mal formed
@@ -210,14 +198,11 @@ class TestTokenizer:
 
         tokenizer.pre_tokenizer = ByteLevel(add_prefix_space=True)
         tokenizer.post_processor = RobertaProcessing(
-            ("</s>", tokenizer.token_to_id("</s>")),
-            ("<s>", tokenizer.token_to_id("<s>")),
+            ("</s>", tokenizer.token_to_id("</s>")), ("<s>", tokenizer.token_to_id("<s>")),
         )
 
         # Can encode with special tokens
-        output_with_specials = tokenizer.encode(
-            "My name is John", add_special_tokens=True
-        )
+        output_with_specials = tokenizer.encode("My name is John", add_special_tokens=True)
         assert output_with_specials.tokens == [
             "<s>",
             "ĠMy",
@@ -228,9 +213,7 @@ class TestTokenizer:
         ]
 
         # Can encode without special tokens
-        output_without_specials = tokenizer.encode(
-            "My name is John", add_special_tokens=False
-        )
+        output_without_specials = tokenizer.encode("My name is John", add_special_tokens=False)
         assert output_without_specials.tokens == ["ĠMy", "Ġname", "Ġis", "ĠJohn"]
 
     def test_truncation(self):

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -1,3 +1,4 @@
+from multiprocessing import Process
 import pickle
 import pytest
 from ..utils import data_dir, roberta_files, bert_files
@@ -125,18 +126,54 @@ class TestTokenizer:
         output = tokenizer.encode("my name is john")
         assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
         output = tokenizer.encode("my name is john", "pair")
-        assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]", "pair", "[SEP]"]
+        assert output.tokens == [
+            "[CLS]",
+            "my",
+            "name",
+            "is",
+            "john",
+            "[SEP]",
+            "pair",
+            "[SEP]",
+        ]
         output = tokenizer.encode(["my", "name", "is", "john"], is_pretokenized=True)
         assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
         output = tokenizer.encode(["my", "name", "is", "john"], ["pair"], is_pretokenized=True)
-        assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]", "pair", "[SEP]"]
+        assert output.tokens == [
+            "[CLS]",
+            "my",
+            "name",
+            "is",
+            "john",
+            "[SEP]",
+            "pair",
+            "[SEP]",
+        ]
 
         output = tokenizer.encode_batch(["My name is John", "My name is Georges"])
         assert output[0].tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
         assert output[1].tokens == ["[CLS]", "my", "name", "is", "georges", "[SEP]"]
         output = tokenizer.encode_batch([("my name is john", "pair"), ("my name is john", "pair")])
-        assert output[0].tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]", "pair", "[SEP]"]
-        assert output[1].tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]", "pair", "[SEP]"]
+        assert output[0].tokens == [
+            "[CLS]",
+            "my",
+            "name",
+            "is",
+            "john",
+            "[SEP]",
+            "pair",
+            "[SEP]",
+        ]
+        assert output[1].tokens == [
+            "[CLS]",
+            "my",
+            "name",
+            "is",
+            "john",
+            "[SEP]",
+            "pair",
+            "[SEP]",
+        ]
         output = tokenizer.encode_batch([["my", "name", "is", "john"]], is_pretokenized=True)
         assert output[0].tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
 
@@ -162,7 +199,14 @@ class TestTokenizer:
 
         # Can encode with special tokens
         output_with_specials = tokenizer.encode("My name is John", add_special_tokens=True)
-        assert output_with_specials.tokens == ["<s>", "ĠMy", "Ġname", "Ġis", "ĠJohn", "</s>"]
+        assert output_with_specials.tokens == [
+            "<s>",
+            "ĠMy",
+            "Ġname",
+            "Ġis",
+            "ĠJohn",
+            "</s>",
+        ]
 
         # Can encode without special tokens
         output_without_specials = tokenizer.encode("My name is John", add_special_tokens=False)
@@ -269,3 +313,33 @@ class TestTokenizer:
         # Can post process a pair of encodings
         output = tokenizer.post_process(encoding, pair_encoding)
         assert output.tokens == ["my", "pair", "[PAD]", "[PAD]"]
+
+    def test_encode_in_subprocess_with_disable_parallelism(self):
+        """
+        This test ensures that disabling parallelism avoid dead locks when the
+        same tokenizer is used after forking.
+        """
+        tokenizer = Tokenizer(BPE())
+        # It's essential to this test that we call 'encode' or 'encode_batch'
+        # before the fork. This causes the main process to "lock" some resources
+        # provided by the Rust "rayon" crate that are needed for parallel processing.
+        tokenizer.encode("Hi")
+        tokenizer.encode_batch(["hi", "there"])
+
+        def encode():
+            tokenizer.parallelism = False  # Comment out this line to see how this test can fail.
+            tokenizer.encode("Hi")
+            tokenizer.encode_batch(["hi", "there"])
+
+        p = Process(target=encode)
+        p.start()
+        p.join(timeout=1)
+
+        # At this point the process should have successfully exited.
+        # If the subprocess is still alive, the test have failed.
+        # But we want terminate that process anyway otherwise pytest might hang forever.
+        if p.is_alive():
+            p.terminate()
+            assert False, "tokenizer in sub process caused dead lock"
+
+        assert p.exitcode == 0

--- a/bindings/python/tests/implementations/test_bert_wordpiece.py
+++ b/bindings/python/tests/implementations/test_bert_wordpiece.py
@@ -1,4 +1,4 @@
-from ..utils import data_dir, bert_files
+from ..utils import data_dir, bert_files, encode_in_subprocess_with_parallelism_disabled
 from tokenizers import BertWordPieceTokenizer
 
 
@@ -9,8 +9,26 @@ class TestBertWordPieceBPE:
         # Encode with special tokens by default
         output = tokenizer.encode("My name is John", "pair")
         assert output.ids == [101, 2026, 2171, 2003, 2198, 102, 3940, 102]
-        assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]", "pair", "[SEP]"]
-        assert output.offsets == [(0, 0), (0, 2), (3, 7), (8, 10), (11, 15), (0, 0), (0, 4), (0, 0)]
+        assert output.tokens == [
+            "[CLS]",
+            "my",
+            "name",
+            "is",
+            "john",
+            "[SEP]",
+            "pair",
+            "[SEP]",
+        ]
+        assert output.offsets == [
+            (0, 0),
+            (0, 2),
+            (3, 7),
+            (8, 10),
+            (11, 15),
+            (0, 0),
+            (0, 4),
+            (0, 0),
+        ]
         assert output.type_ids == [0, 0, 0, 0, 0, 0, 1, 1]
 
         # Can encode without the special tokens
@@ -19,3 +37,7 @@ class TestBertWordPieceBPE:
         assert output.tokens == ["my", "name", "is", "john", "pair"]
         assert output.offsets == [(0, 2), (3, 7), (8, 10), (11, 15), (0, 4)]
         assert output.type_ids == [0, 0, 0, 0, 1]
+
+    def test_encode_in_subprocess_with_parallelism_disabled(self, bert_files):
+        tokenizer = BertWordPieceTokenizer(bert_files["vocab"])
+        encode_in_subprocess_with_parallelism_disabled(tokenizer)

--- a/bindings/python/tests/implementations/test_bert_wordpiece.py
+++ b/bindings/python/tests/implementations/test_bert_wordpiece.py
@@ -41,3 +41,7 @@ class TestBertWordPieceBPE:
     def test_encode_in_subprocess_with_parallelism_disabled(self, bert_files):
         tokenizer = BertWordPieceTokenizer(bert_files["vocab"])
         encode_in_subprocess_with_parallelism_disabled(tokenizer)
+
+    def test_init_with_parallism_disabled(self, bert_files):
+        tokenizer = BertWordPieceTokenizer(bert_files["vocab"], parallelism=False)
+        assert tokenizer._tokenizer.parallelism is False

--- a/bindings/python/tests/implementations/test_byte_level_bpe.py
+++ b/bindings/python/tests/implementations/test_byte_level_bpe.py
@@ -8,9 +8,7 @@ from tokenizers import ByteLevelBPETokenizer
 
 class TestByteLevelBPE:
     def test_basic_encode(self, roberta_files):
-        tokenizer = ByteLevelBPETokenizer(
-            roberta_files["vocab"], roberta_files["merges"]
-        )
+        tokenizer = ByteLevelBPETokenizer(roberta_files["vocab"], roberta_files["merges"])
         output = tokenizer.encode("The quick brown fox jumps over the lazy dog")
 
         assert output.ids == [133, 2119, 6219, 23602, 13855, 81, 5, 22414, 2335]
@@ -69,10 +67,7 @@ class TestByteLevelBPE:
 
     def test_lowerspace(self, roberta_files):
         tokenizer = ByteLevelBPETokenizer(
-            roberta_files["vocab"],
-            roberta_files["merges"],
-            add_prefix_space=True,
-            lowercase=True,
+            roberta_files["vocab"], roberta_files["merges"], add_prefix_space=True, lowercase=True,
         )
         output = tokenizer.encode("The Quick Brown Fox Jumps Over The Lazy Dog")
 
@@ -91,9 +86,6 @@ class TestByteLevelBPE:
 
     def test_encode_in_subprocess_with_parallelism_disabled(self, roberta_files):
         tokenizer = ByteLevelBPETokenizer(
-            roberta_files["vocab"],
-            roberta_files["merges"],
-            add_prefix_space=True,
-            lowercase=True,
+            roberta_files["vocab"], roberta_files["merges"], add_prefix_space=True, lowercase=True,
         )
         encode_in_subprocess_with_parallelism_disabled(tokenizer)

--- a/bindings/python/tests/implementations/test_byte_level_bpe.py
+++ b/bindings/python/tests/implementations/test_byte_level_bpe.py
@@ -1,10 +1,16 @@
-from ..utils import data_dir, roberta_files
+from ..utils import (
+    data_dir,
+    roberta_files,
+    encode_in_subprocess_with_parallelism_disabled,
+)
 from tokenizers import ByteLevelBPETokenizer
 
 
 class TestByteLevelBPE:
     def test_basic_encode(self, roberta_files):
-        tokenizer = ByteLevelBPETokenizer(roberta_files["vocab"], roberta_files["merges"])
+        tokenizer = ByteLevelBPETokenizer(
+            roberta_files["vocab"], roberta_files["merges"]
+        )
         output = tokenizer.encode("The quick brown fox jumps over the lazy dog")
 
         assert output.ids == [133, 2119, 6219, 23602, 13855, 81, 5, 22414, 2335]
@@ -63,7 +69,10 @@ class TestByteLevelBPE:
 
     def test_lowerspace(self, roberta_files):
         tokenizer = ByteLevelBPETokenizer(
-            roberta_files["vocab"], roberta_files["merges"], add_prefix_space=True, lowercase=True
+            roberta_files["vocab"],
+            roberta_files["merges"],
+            add_prefix_space=True,
+            lowercase=True,
         )
         output = tokenizer.encode("The Quick Brown Fox Jumps Over The Lazy Dog")
 
@@ -79,3 +88,12 @@ class TestByteLevelBPE:
             "Ġlazy",
             "Ġdog",
         ]
+
+    def test_encode_in_subprocess_with_parallelism_disabled(self, roberta_files):
+        tokenizer = ByteLevelBPETokenizer(
+            roberta_files["vocab"],
+            roberta_files["merges"],
+            add_prefix_space=True,
+            lowercase=True,
+        )
+        encode_in_subprocess_with_parallelism_disabled(tokenizer)

--- a/bindings/python/tests/implementations/test_char_bpe.py
+++ b/bindings/python/tests/implementations/test_char_bpe.py
@@ -35,9 +35,7 @@ class TestBertWordPieceBPE:
         assert output.type_ids == [0, 0, 0, 0, 0, 0, 0, 1]
 
     def test_lowercase(self, openai_files):
-        tokenizer = CharBPETokenizer(
-            openai_files["vocab"], openai_files["merges"], lowercase=True
-        )
+        tokenizer = CharBPETokenizer(openai_files["vocab"], openai_files["merges"], lowercase=True)
         output = tokenizer.encode("My name is John", "pair", add_special_tokens=False)
         assert output.ids == [547, 1362, 544, 2476, 2688]
         assert output.tokens == ["my</w>", "name</w>", "is</w>", "john</w>", "pair</w>"]
@@ -45,14 +43,10 @@ class TestBertWordPieceBPE:
         assert output.type_ids == [0, 0, 0, 0, 1]
 
     def test_decoding(self, openai_files):
-        tokenizer = CharBPETokenizer(
-            openai_files["vocab"], openai_files["merges"], lowercase=True
-        )
+        tokenizer = CharBPETokenizer(openai_files["vocab"], openai_files["merges"], lowercase=True)
         decoded = tokenizer.decode(tokenizer.encode("my name is john").ids)
         assert decoded == "my name is john"
 
     def test_encode_in_subprocess_with_parallelism_disabled(self, openai_files):
-        tokenizer = CharBPETokenizer(
-            openai_files["vocab"], openai_files["merges"], lowercase=True
-        )
+        tokenizer = CharBPETokenizer(openai_files["vocab"], openai_files["merges"], lowercase=True)
         encode_in_subprocess_with_parallelism_disabled(tokenizer)

--- a/bindings/python/tests/implementations/test_char_bpe.py
+++ b/bindings/python/tests/implementations/test_char_bpe.py
@@ -1,4 +1,8 @@
-from ..utils import data_dir, openai_files
+from ..utils import (
+    data_dir,
+    openai_files,
+    encode_in_subprocess_with_parallelism_disabled,
+)
 from tokenizers import CharBPETokenizer
 
 
@@ -31,7 +35,9 @@ class TestBertWordPieceBPE:
         assert output.type_ids == [0, 0, 0, 0, 0, 0, 0, 1]
 
     def test_lowercase(self, openai_files):
-        tokenizer = CharBPETokenizer(openai_files["vocab"], openai_files["merges"], lowercase=True)
+        tokenizer = CharBPETokenizer(
+            openai_files["vocab"], openai_files["merges"], lowercase=True
+        )
         output = tokenizer.encode("My name is John", "pair", add_special_tokens=False)
         assert output.ids == [547, 1362, 544, 2476, 2688]
         assert output.tokens == ["my</w>", "name</w>", "is</w>", "john</w>", "pair</w>"]
@@ -39,6 +45,14 @@ class TestBertWordPieceBPE:
         assert output.type_ids == [0, 0, 0, 0, 1]
 
     def test_decoding(self, openai_files):
-        tokenizer = CharBPETokenizer(openai_files["vocab"], openai_files["merges"], lowercase=True)
+        tokenizer = CharBPETokenizer(
+            openai_files["vocab"], openai_files["merges"], lowercase=True
+        )
         decoded = tokenizer.decode(tokenizer.encode("my name is john").ids)
         assert decoded == "my name is john"
+
+    def test_encode_in_subprocess_with_parallelism_disabled(self, openai_files):
+        tokenizer = CharBPETokenizer(
+            openai_files["vocab"], openai_files["merges"], lowercase=True
+        )
+        encode_in_subprocess_with_parallelism_disabled(tokenizer)

--- a/bindings/python/tests/utils.py
+++ b/bindings/python/tests/utils.py
@@ -71,9 +71,7 @@ def encode_in_subprocess_with_parallelism_disabled(tokenizer):
     tokenizer.encode_batch(["hi", "there"])
 
     def encode():
-        tokenizer.parallelism = (
-            False  # Comment out this line to see how this test can fail.
-        )
+        tokenizer.parallelism = False  # Comment out this line to see how this test can fail.
         tokenizer.encode("Hi")
         tokenizer.encode_batch(["hi", "there"])
 

--- a/bindings/python/tokenizers/__init__.pyi
+++ b/bindings/python/tokenizers/__init__.pyi
@@ -160,6 +160,7 @@ class Encoding:
         pad_type_id: Optional[int] = 0,
         pad_token: Optional[str] = "[PAD]",
         direction: Optional[str] = "right",
+        parallelism: bool = True,
     ):
         """ Pad the current Encoding at the given length
 
@@ -178,6 +179,9 @@ class Encoding:
 
             pad_token: (`optional`) str:
                 The pad token to be used when padding
+
+            parallelism: (`optional`) bool:
+                Whether or not to enable parallelism.
         """
         pass
     def truncate(self, max_length: int, stride: Optional[int] = 0):

--- a/bindings/python/tokenizers/__init__.pyi
+++ b/bindings/python/tokenizers/__init__.pyi
@@ -622,3 +622,11 @@ class Tokenizer:
             The resulting Encoding
         """
         pass
+    @property
+    def parallelism(self) -> bool:
+        """ Check whether or not parallelism is enabled """
+        pass
+    @parallelism.setter
+    def parallelism(self, parallelism: bool):
+        """ Enable or disable parallelism """
+        pass

--- a/bindings/python/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/tokenizers/implementations/base_tokenizer.py
@@ -106,7 +106,7 @@ class BaseTokenizer:
         return self._tokenizer.padding
 
     def enable_truncation(
-        self, max_length: int, stride: Optional[int] = 0, strategy: Optional[str] = "longest_first"
+        self, max_length: int, stride: Optional[int] = 0, strategy: Optional[str] = "longest_first",
     ):
         """ Change the truncation options
 
@@ -344,7 +344,7 @@ class BaseTokenizer:
         return self._tokenizer.to_str(pretty)
 
     def post_process(
-        self, encoding: Encoding, pair: Optional[Encoding] = None, add_special_tokens: bool = True
+        self, encoding: Encoding, pair: Optional[Encoding] = None, add_special_tokens: bool = True,
     ) -> Encoding:
         """ Apply all the post-processing steps to the given encodings.
 
@@ -367,3 +367,11 @@ class BaseTokenizer:
             The resulting Encoding
         """
         return self._tokenizer.post_process(encoding, pair, add_special_tokens)
+
+    @property
+    def parallelism(self) -> bool:
+        return self._tokenizer.parallelism
+
+    @parallelism.setter
+    def parallelism(self, parallelism: bool) -> None:
+        self._tokenizer.parallelism = parallelism

--- a/bindings/python/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/tokenizers/implementations/base_tokenizer.py
@@ -10,6 +10,8 @@ class BaseTokenizer:
     def __init__(self, tokenizer: Tokenizer, parameters=None):
         self._tokenizer = tokenizer
         self._parameters = parameters if parameters is not None else {}
+        if "parallelism" in self._parameters:
+            self._tokenizer.parallelism = self._parameters["parallelism"]
 
     def __repr__(self):
         return "Tokenizer(vocabulary_size={}, {})".format(

--- a/bindings/python/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/tokenizers/implementations/bert_wordpiece.py
@@ -24,6 +24,7 @@ class BertWordPieceTokenizer(BaseTokenizer):
         strip_accents: bool = True,
         lowercase: bool = True,
         wordpieces_prefix: str = "##",
+        parallelism: bool = True,
     ):
 
         if vocab_file is not None:
@@ -76,6 +77,7 @@ class BertWordPieceTokenizer(BaseTokenizer):
             "strip_accents": strip_accents,
             "lowercase": lowercase,
             "wordpieces_prefix": wordpieces_prefix,
+            "parallelism": parallelism,
         }
 
         super().__init__(tokenizer, parameters)

--- a/bindings/python/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/byte_level_bpe.py
@@ -1,4 +1,11 @@
-from tokenizers import Tokenizer, AddedToken, pre_tokenizers, decoders, trainers, processors
+from tokenizers import (
+    Tokenizer,
+    AddedToken,
+    pre_tokenizers,
+    decoders,
+    trainers,
+    processors,
+)
 from tokenizers.models import BPE
 from tokenizers.normalizers import unicode_normalizer_from_str, Lowercase, Sequence
 from .base_tokenizer import BaseTokenizer
@@ -23,6 +30,7 @@ class ByteLevelBPETokenizer(BaseTokenizer):
         continuing_subword_prefix: Optional[str] = None,
         end_of_word_suffix: Optional[str] = None,
         trim_offsets: bool = False,
+        parallelism: bool = True,
     ):
         if vocab_file is not None and merges_file is not None:
             tokenizer = Tokenizer(
@@ -66,6 +74,7 @@ class ByteLevelBPETokenizer(BaseTokenizer):
             "continuing_subword_prefix": continuing_subword_prefix,
             "end_of_word_suffix": end_of_word_suffix,
             "trim_offsets": trim_offsets,
+            "parallelism": parallelism,
         }
 
         super().__init__(tokenizer, parameters)

--- a/bindings/python/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/tokenizers/implementations/char_level_bpe.py
@@ -1,6 +1,11 @@
 from .. import Tokenizer, AddedToken, pre_tokenizers, decoders, trainers
 from ..models import BPE
-from ..normalizers import Sequence, Lowercase, unicode_normalizer_from_str, BertNormalizer
+from ..normalizers import (
+    Sequence,
+    Lowercase,
+    unicode_normalizer_from_str,
+    BertNormalizer,
+)
 from .base_tokenizer import BaseTokenizer
 
 from typing import Optional, List, Union
@@ -33,6 +38,7 @@ class CharBPETokenizer(BaseTokenizer):
         unicode_normalizer: Optional[str] = None,
         bert_normalizer: bool = True,
         split_on_whitespace_only: bool = False,
+        parallelism: bool = True,
     ):
         if vocab_file is not None and merges_file is not None:
             tokenizer = Tokenizer(
@@ -85,6 +91,7 @@ class CharBPETokenizer(BaseTokenizer):
             "unicode_normalizer": unicode_normalizer,
             "bert_normalizer": bert_normalizer,
             "split_on_whitespace_only": split_on_whitespace_only,
+            "parallelism": parallelism,
         }
 
         super().__init__(tokenizer, parameters)

--- a/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/tokenizers/implementations/sentencepiece_bpe.py
@@ -20,6 +20,7 @@ class SentencePieceBPETokenizer(BaseTokenizer):
         replacement: str = "▁",
         add_prefix_space: bool = True,
         dropout: Optional[float] = None,
+        parallelism: bool = True,
     ):
         if vocab_file is not None and merges_file is not None:
             tokenizer = Tokenizer(
@@ -45,6 +46,7 @@ class SentencePieceBPETokenizer(BaseTokenizer):
             "replacement": replacement,
             "add_prefix_space": add_prefix_space,
             "dropout": dropout,
+            "parallelism": parallelism,
         }
 
         super().__init__(tokenizer, parameters)

--- a/tokenizers/CHANGELOG.md
+++ b/tokenizers/CHANGELOG.md
@@ -39,6 +39,8 @@ using serde. It is now easy to save/load an entire tokenizer.
 - [#289]: Ability to pad to a multiple of a specified value. This is especially useful to ensure
 activation of the Tensor Cores, while ensuring padding to a multiple of 8.
 - [#298]: Ability to get the currently set truncation/padding params
+- [#187]: Added an option to the `Tokenizer` struct to disable parallelism through `rayon`. This can be used
+to avoid the dead-locking issue with Python subprocesses.
 
 ### How to migrate
 - Replace any `XXX_to_YYY_offsets()` method call by any of the new ones.

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -360,11 +360,32 @@ impl Encoding {
         pad_type_id: u32,
         pad_token: &str,
         direction: PaddingDirection,
+        parallelism: bool,
     ) {
         // Dispatch call to all the overflowings first
-        self.overflowing.par_iter_mut().for_each(|encoding| {
-            encoding.pad(target_length, pad_id, pad_type_id, pad_token, direction)
-        });
+        if parallelism {
+            self.overflowing.par_iter_mut().for_each(|encoding| {
+                encoding.pad(
+                    target_length,
+                    pad_id,
+                    pad_type_id,
+                    pad_token,
+                    direction,
+                    parallelism,
+                )
+            });
+        } else {
+            self.overflowing.iter_mut().for_each(|encoding| {
+                encoding.pad(
+                    target_length,
+                    pad_id,
+                    pad_type_id,
+                    pad_token,
+                    direction,
+                    parallelism,
+                )
+            });
+        }
 
         // Then check if we should pad ourself
         if self.ids.len() >= target_length {


### PR DESCRIPTION
Addresses #187. Python tokenizers will now work within a sub-process as long as you disable parallelism:


```python
import sys
from multiprocessing import Process
from tokenizers.implementations import ByteLevelBPETokenizer

tok = ByteLevelBPETokenizer()
tok.encode("hi")
tok.encode_batch(["hi", "there"])


def encode():
    # Disabling parallelism is key to avoiding a dead lock within a sub-process.
    tok.parallelism = False
    print(tok.encode("hi"))
    print(tok.encode_batch(["hi", "there"]))


p = Process(target=encode)
p.start()

p.join(timeout=1)
if p.is_alive():
    print("process is hanging, killing now")
    p.terminate()
    sys.exit(1)
```

---

My original idea of having a custom trait for parallel iterators that would wrap `rayon` turned out to be way too complicated.

So instead I just added a `bool` option called `parallelism` to the `Tokenizer` struct, and threw in a check for this everywhere that `into_par_iter()` (or anything else like that from `rayon`) is used. So when `parallelism` is `false`, the non-parallel version (such as `into_iter()`) is used.