### PR TITLE
Improve additionnal vocabulary management

### DIFF
--- a/bindings/node/lib/bindings/tokenizer.d.ts
+++ b/bindings/node/lib/bindings/tokenizer.d.ts
@@ -392,6 +392,14 @@ export interface AddedTokenOptions {
    * @default False
    */
   singleWord?: boolean;
+  /**
+   * Whether this token should match on the normalized version of the text. For example
+   * with the added token `yesterday` and a normalizer in charge of lowercasing the text,
+   * the input `I saw a lion Yesterday` would match the token.
+   * This is False for special tokens by default, true otherwise
+   * @default True
+   */
+  normalized?: boolean;
 }
 
 /**
@@ -404,9 +412,10 @@ export class AddedToken {
   /**
    * Instantiate a new AddedToken
    * @param content The content of the token
+   * @param special Whether this is a special token
    * @param [options] Options for the token
    */
-  constructor(content: string, options?: AddedTokenOptions);
+  constructor(content: string, special: boolean, options?: AddedTokenOptions);
 
   /**
    * Get the content of the AddedToken

--- a/bindings/node/lib/bindings/tokenizer.test.ts
+++ b/bindings/node/lib/bindings/tokenizer.test.ts
@@ -32,17 +32,17 @@ import {
 
 describe("AddedToken", () => {
   it("instantiates with only content", () => {
-    const addToken = new AddedToken("test");
+    const addToken = new AddedToken("test", false);
     expect(addToken.constructor.name).toEqual("AddedToken");
   });
 
   it("instantiates with empty options", () => {
-    const addToken = new AddedToken("test", {});
+    const addToken = new AddedToken("test", false, {});
     expect(addToken.constructor.name).toEqual("AddedToken");
   });
 
   it("instantiates with options", () => {
-    const addToken = new AddedToken("test", {
+    const addToken = new AddedToken("test", false, {
       leftStrip: true,
       rightStrip: true,
       singleWord: true
@@ -52,7 +52,7 @@ describe("AddedToken", () => {
 
   describe("getContent", () => {
     it("returns the string content of AddedToken", () => {
-      const addedToken = new AddedToken("test");
+      const addedToken = new AddedToken("test", false);
       expect(addedToken.getContent()).toEqual("test");
     });
   });
@@ -107,7 +107,7 @@ describe("Tokenizer", () => {
     it("accepts a list of AddedToken as new tokens when initial model is empty", () => {
       const model = BPE.empty();
       const tokenizer = new Tokenizer(model);
-      const addedToken = new AddedToken("test");
+      const addedToken = new AddedToken("test", false);
 
       const nbAdd = tokenizer.addTokens([addedToken]);
       expect(nbAdd).toBe(1);
@@ -132,7 +132,7 @@ describe("Tokenizer", () => {
 
       const model = BPE.empty();
       tokenizer = new Tokenizer(model);
-      tokenizer.addTokens(["my", "name", "is", "john", new AddedToken("pair")]);
+      tokenizer.addTokens(["my", "name", "is", "john", new AddedToken("pair", false)]);
 
       encode = promisify(tokenizer.encode.bind(tokenizer));
       encodeBatch = promisify(tokenizer.encodeBatch.bind(tokenizer));

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#286]: Fix various crash when training a BPE model
+- [#309]: Fixed a few bugs related to additional vocabulary/tokens
 
 ### Added
 - [#272]: Serialization of the `Tokenizer` and all the parts (`PreTokenizer`, `Normalizer`, ...).
@@ -27,6 +28,9 @@ the argument `is_pretokenized=True` must be specified.
 processing of each file
 - [#280]: Use `onig` for byte-level pre-tokenization to remove all the differences with the original
 implementation from GPT-2
+- [#309]: Improved the management of the additional vocabulary. This introduces an option
+`normalized`, controlling whether a token should be extracted from the normalized version of the
+input text.
 
 ## [0.7.0]
 
@@ -186,6 +190,7 @@ delimiter (Works like `.split(delimiter)`)
 - Fix a bug with the IDs associated with added tokens.
 - Fix a bug that was causing crashes in Python 3.5
 
+[#309]: https://github.com/huggingface/tokenizers/pull/309
 [#289]: https://github.com/huggingface/tokenizers/pull/289
 [#286]: https://github.com/huggingface/tokenizers/pull/286
 [#280]: https://github.com/huggingface/tokenizers/pull/280

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -85,11 +85,12 @@ impl PyObjectProtocol for AddedToken {
         };
 
         Ok(format!(
-            "AddedToken(\"{}\", rstrip={}, lstrip={}, single_word={})",
+            "AddedToken(\"{}\", rstrip={}, lstrip={}, single_word={}, normalized={})",
             self.token.content,
             bool_to_python(self.token.rstrip),
             bool_to_python(self.token.lstrip),
-            bool_to_python(self.token.single_word)
+            bool_to_python(self.token.single_word),
+            bool_to_python(self.token.normalized)
         ))
     }
 }

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -29,7 +29,7 @@ impl AddedToken {
     #[new]
     #[args(kwargs = "**")]
     fn new(content: &str, is_special_token: bool, kwargs: Option<&PyDict>) -> PyResult<Self> {
-        let mut token = tk::tokenizer::AddedToken::from(content.to_owned(), is_special_token);
+        let mut token = tk::tokenizer::AddedToken::from(content, is_special_token);
 
         if let Some(kwargs) = kwargs {
             for (key, value) in kwargs {

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -12,7 +12,7 @@ from tokenizers.implementations import BertWordPieceTokenizer
 
 class TestAddedToken:
     def test_instantiate_with_content_only(self):
-        added_token = AddedToken("<mask>")
+        added_token = AddedToken("<mask>", True)
         assert type(added_token) == AddedToken
         assert str(added_token) == "<mask>"
         assert (
@@ -24,19 +24,19 @@ class TestAddedToken:
         assert added_token.single_word == False
 
     def test_can_set_rstrip(self):
-        added_token = AddedToken("<mask>", rstrip=True)
+        added_token = AddedToken("<mask>", True, rstrip=True)
         assert added_token.rstrip == True
         assert added_token.lstrip == False
         assert added_token.single_word == False
 
     def test_can_set_lstrip(self):
-        added_token = AddedToken("<mask>", lstrip=True)
+        added_token = AddedToken("<mask>", True, lstrip=True)
         assert added_token.rstrip == False
         assert added_token.lstrip == True
         assert added_token.single_word == False
 
     def test_can_set_single_world(self):
-        added_token = AddedToken("<mask>", single_word=True)
+        added_token = AddedToken("<mask>", True, single_word=True)
         assert added_token.rstrip == False
         assert added_token.lstrip == False
         assert added_token.single_word == True
@@ -76,7 +76,9 @@ class TestTokenizer:
         added = tokenizer.add_tokens(["my", "name", "is", "john"])
         assert added == 4
 
-        added = tokenizer.add_tokens([AddedToken("the"), AddedToken("quick", rstrip=True)])
+        added = tokenizer.add_tokens(
+            [AddedToken("the", False), AddedToken("quick", False, rstrip=True)]
+        )
         assert added == 2
 
     def test_add_special_tokens(self):
@@ -87,7 +89,9 @@ class TestTokenizer:
         assert added == 4
 
         # Can add special tokens as `AddedToken`
-        added = tokenizer.add_special_tokens([AddedToken("the"), AddedToken("quick", rstrip=True)])
+        added = tokenizer.add_special_tokens(
+            [AddedToken("the", False), AddedToken("quick", False, rstrip=True)]
+        )
         assert added == 2
 
     def test_encode(self):

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -22,6 +22,8 @@ class TestAddedToken:
         assert added_token.rstrip == False
         assert added_token.lstrip == False
         assert added_token.single_word == False
+        assert added_token.normalized == False
+        assert isinstance(pickle.loads(pickle.dumps(added_token)), AddedToken)
 
     def test_can_set_rstrip(self):
         added_token = AddedToken("<mask>", True, rstrip=True)
@@ -40,6 +42,19 @@ class TestAddedToken:
         assert added_token.rstrip == False
         assert added_token.lstrip == False
         assert added_token.single_word == True
+
+    def test_can_set_normalized(self):
+        added_token = AddedToken("<mask>", True, normalized=True)
+        assert added_token.rstrip == False
+        assert added_token.lstrip == False
+        assert added_token.single_word == False
+        assert added_token.normalized == True
+
+    def test_second_argument_defines_normalized(self):
+        added_token = AddedToken("<mask>", True)
+        assert added_token.normalized == False
+        added_token = AddedToken("<mask>", False)
+        assert added_token.normalized == True
 
 
 class TestTokenizer:

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -17,7 +17,7 @@ class TestAddedToken:
         assert str(added_token) == "<mask>"
         assert (
             repr(added_token)
-            == 'AddedToken("<mask>", rstrip=False, lstrip=False, single_word=False)'
+            == 'AddedToken("<mask>", rstrip=False, lstrip=False, single_word=False, normalized=False)'
         )
         assert added_token.rstrip == False
         assert added_token.lstrip == False

--- a/bindings/python/tokenizers/__init__.pyi
+++ b/bindings/python/tokenizers/__init__.pyi
@@ -200,7 +200,13 @@ class AddedToken:
     """
 
     def __new__(
-        cls, content: str, single_word: bool = False, lstrip: bool = False, rstrip: bool = False,
+        cls,
+        content: str,
+        is_special_token: bool,
+        single_word: bool = False,
+        lstrip: bool = False,
+        rstrip: bool = False,
+        normalized: bool = True,
     ) -> AddedToken:
         """ Instantiate a new AddedToken
 
@@ -208,19 +214,30 @@ class AddedToken:
             content: str:
                 The content of the token
 
+            is_special_token: bool:
+                Whether this token is a special token. This has an impact on the default value for
+                `normalized` which is False for special tokens, but True for others.
+
             single_word: bool
-                Whether this token should only match against single word. If True,
-                this token will never match inside of a word.
+                Whether this token should only match against single words. If True,
+                this token will never match inside of a word. For example the token `ing` would
+                match on `tokenizing` if this option if False, but not if this option is True.
 
             lstrip: bool
                 Whether this token should strip all potential whitespaces on the left side.
-                If True, this token will greedily match any whitespace on the left and then strip
-                them out.
+                If True, this token will greedily match any whitespace on the left. For example,
+                if we try to match the token `[MASK]` with lstrip=True, in the text `I saw a [MASK]`
+                we will match on ` [MASK]`.
 
             rstrip: bool
                 Whether this token should strip all potential whitespaces on the right side.
-                If True, this token will greedily match any whitespace on the right and then strip
-                them out.
+                If True, this token will greedily match any whitespace on the right. It works just
+                like lstrip, but on the right.
+
+            normalized: bool:
+                Whether this token should be match the normalized version of the input text. For
+                example, with the added token `yesterday` and a normalizer in charge of lowercasing
+                the text, the token could be extract from the input `I saw a lion Yesterday`.
         """
         pass
 

--- a/tokenizers/CHANGELOG.md
+++ b/tokenizers/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#236]: Fix a bug with offsets being shifted when there are sub-sequences (Usually with
 special tokens and/or added tokens in the sequence).
 - [#286]: Fix various crash when training a BPE model
+- [#309]: Fixed a few bugs related to additional vocabulary/tokens
 
 ### Changed
 - [#234]: Completely changed the alignement mappings available on `Encoding`. Previous mappings
@@ -30,6 +31,9 @@ pre-tokenized inputs.
 processing of each file
 - [#280]: Use `onig` for byte-level pre-tokenization to remove all the differences with the original
 implementation from GPT-2
+- [#309]: Improved the management of the additional vocabulary. This introduces an option
+`normalized`, controlling whether a token should be extracted from the normalized version of the
+input text.
 
 ### Added
 - [#236]: RobertaProcessing is now also taking care of trimming offsets, and works just as ByteLevel
@@ -113,6 +117,7 @@ advised, but that's not the question)
 split up in multiple bytes
 - [#174]: The `LongestFirst` truncation strategy had a bug
 
+[#309]: https://github.com/huggingface/tokenizers/pull/309
 [#298]: https://github.com/huggingface/tokenizers/pull/298
 [#289]: https://github.com/huggingface/tokenizers/pull/289
 [#286]: https://github.com/huggingface/tokenizers/pull/286

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -9,7 +9,7 @@
         <img alt="GitHub" src="https://img.shields.io/github/license/huggingface/tokenizers.svg?color=blue">
     </a>
     <a href="https://docs.rs/tokenizers/">
-        <img alt="Doc" src="https://docs.rs/tokenizers/badge.svg">    
+        <img alt="Doc" src="https://docs.rs/tokenizers/badge.svg">
     </a>
 </p>
 <br>
@@ -56,22 +56,22 @@ fn main() -> Result<()>{
             .vocab_size(vocab_size)
             .min_frequency(0)
             .special_tokens(vec![
-                AddedToken::from("<s>".into()),
-                AddedToken::from("<pad>".into()),
-                AddedToken::from("</s>".into()),
-                AddedToken::from("<unk>".into()),
-                AddedToken::from("<mask>".into()),
+                AddedToken::from("<s>", true),
+                AddedToken::from("<pad>", true),
+                AddedToken::from("</s>", true),
+                AddedToken::from("<unk>", true),
+                AddedToken::from("<mask>", true),
             ])
             .build(),
     );
-                                                                  
+
     let mut tokenizer = Tokenizer::new(Box::new(BPE::default()));
     tokenizer.with_normalizer(Box::new(Sequence::new(vec![
         Box::new(Strip::new(true, true)),
         Box::new(NFC),
     ])));
     tokenizer.with_pre_tokenizer(Box::new(ByteLevel::default()));
-                                                                  
+
     tokenizer.train(&trainer, vec!["/path/to/train.txt".to_string()])?;
     tokenizer.save("/path/to/trained_tokenizer", true)?;
 
@@ -86,7 +86,7 @@ use tokenizers::Result;
 use tokenizers::tokenizer::Tokenizer;
 
 fn main() -> Result<()>{
-                                                                  
+
     let tokenizer = Tokenizer::from_file("/path/to/trained_tokenizer")?;
 
     let sample_encoding = tokenizer.encode("Huggingface", false)?;

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -17,9 +17,8 @@ fn create_gpt2_tokenizer(bpe: BPE) -> Tokenizer {
     let mut tokenizer = Tokenizer::new(Box::new(bpe));
     tokenizer.with_pre_tokenizer(Box::new(ByteLevel::default()));
     tokenizer.with_decoder(Box::new(ByteLevel::default()));
-    tokenizer.add_tokens(&[AddedToken::from(String::from("ing"), false).single_word(false)]);
-    tokenizer
-        .add_special_tokens(&[AddedToken::from(String::from("[ENT]"), true).single_word(true)]);
+    tokenizer.add_tokens(&[AddedToken::from("ing", false).single_word(false)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("[ENT]", true).single_word(true)]);
     tokenizer
 }
 

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -17,10 +17,9 @@ fn create_gpt2_tokenizer(bpe: BPE) -> Tokenizer {
     let mut tokenizer = Tokenizer::new(Box::new(bpe));
     tokenizer.with_pre_tokenizer(Box::new(ByteLevel::default()));
     tokenizer.with_decoder(Box::new(ByteLevel::default()));
-    tokenizer.add_tokens(&[
-        AddedToken::from(String::from("ing")).single_word(false),
-        AddedToken::from(String::from("[ENT]")).single_word(true),
-    ]);
+    tokenizer.add_tokens(&[AddedToken::from(String::from("ing"), false).single_word(false)]);
+    tokenizer
+        .add_special_tokens(&[AddedToken::from(String::from("[ENT]"), true).single_word(true)]);
     tokenizer
 }
 

--- a/tokenizers/src/cli.rs
+++ b/tokenizers/src/cli.rs
@@ -21,10 +21,9 @@ fn shell(matches: &ArgMatches) -> Result<()> {
     tokenizer.with_pre_tokenizer(Box::new(ByteLevel::default()));
     tokenizer.with_decoder(Box::new(ByteLevel::default()));
 
-    tokenizer.add_tokens(&[
-        AddedToken::from(String::from("ing")).single_word(false),
-        AddedToken::from(String::from("[ENT]")).single_word(true),
-    ]);
+    tokenizer.add_tokens(&[AddedToken::from(String::from("ing"), false).single_word(false)]);
+    tokenizer
+        .add_special_tokens(&[AddedToken::from(String::from("[ENT]"), true).single_word(true)]);
 
     let stdin = io::stdin();
     let mut handle = stdin.lock();

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -433,8 +433,8 @@ impl Model for BPE {
         self.vocab.get(token).copied()
     }
 
-    fn id_to_token(&self, id: u32) -> Option<String> {
-        self.vocab_r.get(&id).cloned()
+    fn id_to_token(&self, id: u32) -> Option<&str> {
+        self.vocab_r.get(&id).map(String::as_ref)
     }
 
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>> {

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -169,8 +169,8 @@ impl Model for WordLevel {
         self.vocab.get(token).copied()
     }
 
-    fn id_to_token(&self, id: u32) -> Option<String> {
-        self.vocab_r.get(&id).cloned()
+    fn id_to_token(&self, id: u32) -> Option<&str> {
+        self.vocab_r.get(&id).map(String::as_ref)
     }
 
     fn get_vocab(&self) -> &HashMap<String, u32> {

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -283,8 +283,8 @@ impl Model for WordPiece {
         self.vocab.get(token).copied()
     }
 
-    fn id_to_token(&self, id: u32) -> Option<String> {
-        self.vocab_r.get(&id).cloned()
+    fn id_to_token(&self, id: u32) -> Option<&str> {
+        self.vocab_r.get(&id).map(String::as_ref)
     }
 
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>> {

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -154,14 +154,20 @@ impl PreTokenizer for ByteLevel {
 #[typetag::serde]
 impl Decoder for ByteLevel {
     fn decode(&self, tokens: Vec<String>) -> Result<String> {
-        Ok(String::from_utf8_lossy(
-            &tokens
-                .join("")
-                .chars()
-                .map(|c| CHAR_BYTES[&c])
-                .collect::<Vec<_>>(),
-        )
-        .into_owned())
+        let toks = tokens
+            .into_iter()
+            .flat_map(|t| {
+                t.chars()
+                    .try_fold(vec![], |mut acc, c| {
+                        CHAR_BYTES.get(&c).map(|b| {
+                            acc.push(*b);
+                            acc
+                        })
+                    })
+                    .unwrap_or_else(|| t.as_bytes().to_vec())
+            })
+            .collect::<Vec<_>>();
+        Ok(String::from_utf8_lossy(&toks).into_owned())
     }
 }
 
@@ -432,6 +438,24 @@ mod tests {
             bytelevel
                 .process(start.clone(), Some(start), false)
                 .unwrap()
+        );
+    }
+
+    #[test]
+    fn decode_unknown_characters() {
+        let byte_level = ByteLevel::default();
+        assert_eq!(
+            byte_level
+                .decode(vec![
+                    "Hello".into(),
+                    "Ġthere".into(),
+                    "Ġdear".into(),
+                    "Ġfriend!".into(),
+                    "Ġ".into(),
+                    "[PA D]".into()
+                ])
+                .unwrap(),
+            "Hello there dear friend! [PA D]"
         );
     }
 }

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -1,0 +1,482 @@
+use super::{Model, NormalizedString, Normalizer, Range};
+use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
+use std::collections::{HashMap, HashSet};
+
+/// Represent a token added by the user on top of the existing Model vocabulary.
+/// AddedToken can be configured to specify the behavior they should have in various situations
+/// like:
+///   - Whether they should only match single words
+///   - Whether to include any whitespace on its left or right
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddedToken {
+    /// The content of the added token
+    pub content: String,
+    /// Whether this token must be a single word or can break words
+    pub single_word: bool,
+    /// Whether this token should strip whitespaces on its left
+    pub lstrip: bool,
+    /// Whether this token should strip whitespaces on its right
+    pub rstrip: bool,
+    /// Whether this token should be normalized
+    pub normalized: bool,
+}
+impl AddedToken {
+    /// Build this token from the given content, specifying if it is intented to be a
+    /// special token. Special tokens are not normalized by default.
+    pub fn from(content: String, special_token: bool) -> Self {
+        AddedToken {
+            content,
+            normalized: !special_token,
+            ..Default::default()
+        }
+    }
+    /// Specify whether this token should only match on whole single words, and never
+    /// part of a word.
+    pub fn single_word(mut self, single_word: bool) -> Self {
+        self.single_word = single_word;
+        self
+    }
+    /// Specify whether this token should include all the whitespaces on its left, in
+    /// order to strip them out.
+    pub fn lstrip(mut self, lstrip: bool) -> Self {
+        self.lstrip = lstrip;
+        self
+    }
+    /// Specify whether this token should include all the whitespaces on its right, in
+    /// order to strip them out.
+    pub fn rstrip(mut self, rstrip: bool) -> Self {
+        self.rstrip = rstrip;
+        self
+    }
+    /// Specify whether this token should be normalized, and/or match against its normalized
+    /// version in the input text.
+    pub fn normalized(mut self, normalized: bool) -> Self {
+        self.normalized = normalized;
+        self
+    }
+    /// Retrive the pattern built for this token, according to all the specified parameters.
+    pub fn get_pattern(&self, normalizer: Option<&dyn Normalizer>) -> String {
+        let mut r = if self.single_word {
+            let first_b = self
+                .content
+                .chars()
+                .next()
+                .map(|c| {
+                    if regex_syntax::is_word_character(c) {
+                        r"\b"
+                    } else {
+                        ""
+                    }
+                })
+                .unwrap();
+            let last_b = self
+                .content
+                .chars()
+                .last()
+                .map(|c| {
+                    if regex_syntax::is_word_character(c) {
+                        r"\b"
+                    } else {
+                        ""
+                    }
+                })
+                .unwrap();
+
+            // Normalize the content
+            let mut content = NormalizedString::from(&self.content);
+            normalizer.map(|n| n.normalize(&mut content));
+            format!(r"{}{}{}", first_b, regex::escape(content.get()), last_b)
+        } else {
+            regex::escape(&self.content)
+        };
+
+        if self.lstrip && self.rstrip {
+            r = format!(r"(\s)?{}(\s)?", r);
+        } else if self.lstrip {
+            r = format!(r"(\s)?{}", r);
+        } else if self.rstrip {
+            r = format!(r"{}(\s)?", r);
+        }
+
+        r
+    }
+}
+impl Default for AddedToken {
+    fn default() -> Self {
+        AddedToken {
+            content: String::new(),
+            single_word: false,
+            lstrip: false,
+            rstrip: false,
+            normalized: false,
+        }
+    }
+}
+// We only want to hash on the content. AddedToken cannot be added multiple times with different
+// options
+impl std::hash::Hash for AddedToken {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.content.hash(state);
+    }
+}
+impl std::cmp::PartialEq for AddedToken {
+    fn eq(&self, other: &Self) -> bool {
+        self.content == other.content
+    }
+}
+impl std::cmp::Eq for AddedToken {}
+
+type MatchingSet = (regex::RegexSet, Vec<u32>);
+
+///
+/// A vocabulary built on top of the Model
+///
+/// This provides a way to add new vocabulary to a Tokenizer that has already been trained,
+/// in a previous process, maybe by someone else. This is especially interesting in the case
+/// of fine-tunings, where we want to finetune a model while adding some new functionalities
+/// using some new special tokens, or maybe add some tokens in the case of unknown tokens, etc.
+///
+/// One of the reasons we need to handle these tokens outside of the model is simply that
+/// for many models, it is not possible to add new tokens after the training process. For example,
+/// using BPE, the training process generates merges pairs along the vocabulary, and any token
+/// in the vocabulary can be decomposed in other tokens, down to the original alphabet. If we
+/// were to add new tokens after this training process, we couldn't make sure the merges pairs
+/// exist as required.
+///
+pub(super) struct AddedVocabulary {
+    /// The size of the original vocabulary. This is what we use to determine the new
+    /// ids we need to generate
+    original_vocab_size: usize,
+    /// Contains the mapping from String to ID as the user intended it. This map
+    /// contains both special tokens and classic added tokens.
+    added_tokens_map: HashMap<String, u32>,
+    /// Contains the mapping from ID to AddedToken for all the added tokens, both special
+    /// and classic.
+    added_tokens_map_r: HashMap<u32, AddedToken>,
+    /// Contains only the classic AddedToken, in the specific order the user gave them.
+    added_tokens: Vec<AddedToken>,
+    /// Contains only the special AddedToken, in the specific order the user gave them.
+    special_tokens: Vec<AddedToken>,
+    /// A Set, containing all the special token for easy access while decoding. This let's
+    /// use remove them easily with an O(1) complexity.
+    special_tokens_set: HashSet<String>,
+    /// A RegexSet containing all the non-normalized patterns used to split on AddedTokens
+    split_re: MatchingSet,
+    /// A RegexSet containing all the normalized patterns used to split on AddedTokens
+    split_normalized_re: MatchingSet,
+}
+
+impl AddedVocabulary {
+    pub fn new(original_vocab_size: usize) -> Self {
+        Self {
+            original_vocab_size,
+            added_tokens_map: HashMap::new(),
+            added_tokens_map_r: HashMap::new(),
+            added_tokens: vec![],
+            special_tokens: vec![],
+            special_tokens_set: HashSet::new(),
+            split_re: (regex::RegexSet::new::<_, &&str>(&[]).unwrap(), vec![]),
+            split_normalized_re: (regex::RegexSet::new::<_, &&str>(&[]).unwrap(), vec![]),
+        }
+    }
+
+    /// Sets the original vocabulary size. We need this value to return IDs that
+    /// are shifted according to the original vocabulary.
+    pub fn update_original_vocab_size(&mut self, size: usize) {
+        self.original_vocab_size = size;
+    }
+
+    /// Size of the additional vocabulary
+    pub fn len(&self) -> usize {
+        self.added_tokens_map.len()
+    }
+
+    /// Get the additional vocabulary
+    pub fn get_vocab(&self) -> &HashMap<String, u32> {
+        &self.added_tokens_map
+    }
+
+    /// Get the id matching one of our token if it exists
+    pub fn token_to_id(&self, token: &str) -> Option<&u32> {
+        self.added_tokens_map.get(token)
+    }
+
+    /// Get the token matching the given id if it exists
+    pub fn id_to_token(&self, id: u32) -> Option<&str> {
+        self.added_tokens_map_r.get(&id).map(|t| t.content.as_ref())
+    }
+
+    /// Check if a token is a special token
+    pub fn is_special_token(&self, token: &str) -> bool {
+        self.special_tokens_set.contains(token)
+    }
+
+    /// Add some special tokens to the vocabulary
+    pub fn add_special_tokens(
+        &mut self,
+        tokens: &[AddedToken],
+        model: &dyn Model,
+        normalizer: Option<&dyn Normalizer>,
+    ) -> usize {
+        for token in tokens {
+            if !self.special_tokens_set.contains(&token.content) {
+                self.special_tokens.push(token.to_owned());
+                self.special_tokens_set.insert(token.content.clone());
+            }
+        }
+        let added = self.add_tokens(&tokens, model, normalizer);
+
+        self.refresh_added_tokens(normalizer);
+
+        added
+    }
+
+    /// Add some tokens to the vocabulary
+    pub fn add_tokens(
+        &mut self,
+        tokens: &[AddedToken],
+        model: &dyn Model,
+        normalizer: Option<&dyn Normalizer>,
+    ) -> usize {
+        let mut ignored = 0;
+        for token in tokens {
+            if token.content.is_empty() {
+                ignored += 1;
+                continue;
+            }
+
+            let id = if let Some(id) = model.token_to_id(&token.content) {
+                ignored += 1;
+                id
+            } else {
+                let new_id = (self.original_vocab_size + self.added_tokens_map.len()) as u32;
+                self.added_tokens_map.insert(token.content.clone(), new_id);
+
+                if !self.special_tokens_set.contains(&token.content) {
+                    self.added_tokens.push(token.clone());
+                }
+
+                new_id
+            };
+
+            // Update the current revert operation
+            self.added_tokens_map_r
+                .entry(id)
+                .and_modify(|t| *t = token.clone())
+                .or_insert_with(|| token.clone());
+        }
+
+        self.refresh_added_tokens(normalizer);
+
+        // Return the number of added tokens
+        tokens.len() - ignored
+    }
+
+    /// Reconstruct our internal RegexSet when new tokens are added to the vocabulary.
+    ///
+    /// We keep two different RegexSet, one that will take care of matching against the
+    /// non-normalized string, and one matching against the normalized one.
+    fn refresh_added_tokens(&mut self, normalizer: Option<&dyn Normalizer>) {
+        type TupleTokenId<'a> = (&'a AddedToken, u32);
+        let (normalized, non_normalized): (Vec<TupleTokenId>, Vec<TupleTokenId>) = self
+            .special_tokens
+            .iter()
+            .chain(self.added_tokens.iter())
+            // TODO: Fix this: special tokens that are part of the original vocabulary are
+            // not part of the `self.added_tokens_map` and so it crashes.
+            .map(|token| (token, self.added_tokens_map[&token.content]))
+            .partition(|(token, _)| token.normalized);
+
+        let (tokens, ids): (Vec<&AddedToken>, Vec<u32>) = non_normalized.into_iter().unzip();
+        self.split_re = (
+            regex::RegexSet::new(tokens.iter().map(|t| t.get_pattern(normalizer))).unwrap(),
+            ids,
+        );
+
+        let (tokens, ids): (Vec<&AddedToken>, Vec<u32>) = normalized.into_iter().unzip();
+        self.split_normalized_re = (
+            regex::RegexSet::new(tokens.iter().map(|t| t.get_pattern(normalizer))).unwrap(),
+            ids,
+        );
+    }
+
+    /// TODO: Add doc string here
+    fn extract(
+        &self,
+        sentence: NormalizedString,
+        split_re: &MatchingSet,
+    ) -> Vec<(NormalizedString, Option<u32>)> {
+        let mut matches = split_re
+            .0
+            .matches(sentence.get())
+            .into_iter()
+            .flat_map(|idx| {
+                regex::Regex::new(&split_re.0.patterns()[idx])
+                    .unwrap()
+                    .find_iter(sentence.get())
+                    .map(|m| (idx, (m.start(), m.end())))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        // We sort all the matches by their start and then by their pattern id
+        matches.sort_by(
+            |(idxa, (sa, _)), (idxb, (sb, _))| {
+                if sa != sb {
+                    sa.cmp(sb)
+                } else {
+                    idxa.cmp(idxb)
+                }
+            },
+        );
+
+        // Select the matches (if some are overlapping) we want to keep
+        let mut i = 0;
+        let mut current_offset = 0;
+        let mut splits = Vec::with_capacity(matches.len());
+        while i < matches.len() {
+            let (idx, (start, end)) = matches[i];
+
+            // current match is before the currentt offset, let's skip it
+            if start < current_offset {
+                i += 1;
+                continue;
+            }
+
+            // Find out if we have overlapping neighbors. If so, we keep the one with the lowest
+            // idx, and apply it, then continue. All others will be skipped since `current_offset`
+            // will have been increased
+            if i + 1 < matches.len() {
+                if let Some((idx, (s, e))) = matches[i..]
+                    .iter()
+                    .take_while(|(_, (s, e))| *s < end && start < *e)
+                    .min() // Order on idx first
+                    .copied()
+                {
+                    splits.push((idx, (s, e)));
+                    current_offset = e;
+                    i += 1;
+                    continue;
+                }
+            }
+
+            // We didn't find overlapping neighbors, apply ourself
+            splits.push((idx, (start, end)));
+            current_offset = end;
+            i += 1;
+        }
+
+        // We also insert the splits that are inbetween the added tokens, to split the entire string
+        let mut start_offset = 0;
+        let mut splits = splits
+            .into_iter()
+            .flat_map(|(idx, (start, end))| {
+                let mut splits = vec![];
+                if start_offset < start {
+                    splits.push((None, (start_offset, start)));
+                }
+                splits.push((Some(idx), (start, end)));
+                start_offset = end;
+
+                splits
+            })
+            .collect::<Vec<_>>();
+        if let Some((_, (_, end))) = splits.iter().last().copied() {
+            if end < sentence.get().len() {
+                splits.push((None, (end, sentence.get().len())));
+            }
+        }
+
+        if splits.is_empty() {
+            vec![(sentence, None)]
+        } else {
+            splits
+                .into_iter()
+                .map(|(idx, (start, end))| {
+                    // TODO: Check this works
+                    let normalized = sentence
+                        .slice_bytes(Range::Normalized(start..end))
+                        .expect("Error while extracting normalized Range");
+
+                    // Find out the associated AddedToken, and its id
+                    let id = idx.map(|idx| split_re.1[idx]);
+
+                    (normalized, id)
+                })
+                .collect()
+        }
+    }
+
+    /// Extract the additional vocabulary from the given sentence, normalizing it along the way.
+    ///
+    /// Some tokens should match against their normalized representation, as well as the
+    /// non-normalized one. For example, when we expect to extract the token `yesterday` in the
+    /// input sentence `I read a book Yesterday`, if the normalizer is supposed to lowercase
+    /// everything, we expect a match.
+    ///
+    /// This method returns a `Vec` of `(NormalizedString, Option<u32>)`, where the optional `u32`
+    /// contains the relevant ID if this is an additional token.
+    pub fn extract_and_normalize(
+        &self,
+        normalizer: Option<&dyn Normalizer>,
+        sentence: &str,
+    ) -> Vec<(NormalizedString, Option<u32>)> {
+        // 1. We extract all the non-normalized tokens from the non-normalized string
+        let pieces = self.extract(NormalizedString::from(sentence), &self.split_re);
+
+        // 2. Then extract the normalized tokens from the normalized pieces of the string
+        pieces
+            .into_iter()
+            .flat_map(|(mut normalized, id)| {
+                if id.is_some() {
+                    // If the piece has an associated ID, we already extracted something,
+                    // so we just return it
+                    vec![(normalized, id)]
+                } else {
+                    // Otherwise, we need to normalized the string, and then proceed to extracting
+                    normalizer.map(|n| n.normalize(&mut normalized));
+                    self.extract(normalized, &self.split_normalized_re)
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct AddedTokenWithId {
+    /// The id assigned to this token
+    pub id: u32,
+    /// Whether this is a special token
+    pub special: bool,
+
+    #[serde(flatten)]
+    /// The target AddedToken
+    pub token: AddedToken,
+}
+
+impl Serialize for AddedVocabulary {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut vocabulary = serializer.serialize_seq(Some(self.added_tokens_map.len()))?;
+
+        let mut added_tokens = self
+            .added_tokens_map_r
+            .iter()
+            .map(|(id, token)| AddedTokenWithId {
+                id: *id,
+                special: self.special_tokens_set.contains(&token.content),
+                token: token.clone(),
+            })
+            .collect::<Vec<_>>();
+        // We need to have these added tokens ordered by ascending ID
+        added_tokens.sort_unstable_by_key(|o| o.id);
+
+        for token in added_tokens {
+            vocabulary.serialize_element(&token)?;
+        }
+
+        vocabulary.end()
+    }
+}

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -376,16 +376,12 @@ impl Tokenizer {
     /// Converts a token in the corresponding id.
     pub fn token_to_id(&self, token: &str) -> Option<u32> {
         self.added_vocabulary
-            .token_to_id(token)
-            .copied()
-            .or_else(|| self.model.token_to_id(token))
+            .token_to_id(token, self.model.as_ref())
     }
 
     /// Converts an id to the corresponding token.
     pub fn id_to_token(&self, id: u32) -> Option<&str> {
-        self.added_vocabulary
-            .id_to_token(id)
-            .or_else(|| self.model.id_to_token(id))
+        self.added_vocabulary.id_to_token(id, self.model.as_ref())
     }
 
     /// Normalize the given sentence and return the corresponding normalized string
@@ -556,13 +552,8 @@ impl Tokenizer {
         let tokens = ids
             .into_iter()
             .map(|id| {
-                let token = if let Some(token) = self.added_vocabulary.id_to_token(id) {
-                    Some(token)
-                } else {
-                    self.model.id_to_token(id)
-                };
-
-                token
+                self.added_vocabulary
+                    .id_to_token(id, self.model.as_ref())
                     .filter(|token| {
                         !skip_special_tokens || !self.added_vocabulary.is_special_token(token)
                     })

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -211,7 +211,6 @@ impl std::str::FromStr for Tokenizer {
 impl Tokenizer {
     /// Instantiate a new Tokenizer, with the given Model
     pub fn new(model: Box<dyn Model>) -> Self {
-        let original_vocab_size = model.get_vocab_size();
         Tokenizer {
             normalizer: None,
             pre_tokenizer: None,
@@ -219,7 +218,7 @@ impl Tokenizer {
             post_processor: None,
             decoder: None,
 
-            added_vocabulary: AddedVocabulary::new(original_vocab_size),
+            added_vocabulary: AddedVocabulary::new(),
 
             truncation: None,
             padding: None,
@@ -303,8 +302,6 @@ impl Tokenizer {
     /// Set the model
     pub fn with_model(&mut self, model: Box<dyn Model>) -> &Self {
         self.model = model;
-        self.added_vocabulary
-            .update_original_vocab_size(self.model.get_vocab_size());
         self
     }
 
@@ -669,8 +666,6 @@ impl Tokenizer {
 
         let (model, special_tokens) = trainer.train(words)?;
         self.model = model;
-        self.added_vocabulary
-            .update_original_vocab_size(self.model.get_vocab_size());
         self.add_special_tokens(&special_tokens);
 
         Ok(())

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -15,19 +15,20 @@ pub use crate::utils::padding::{pad_encodings, PaddingDirection, PaddingParams, 
 pub use crate::utils::truncation::{truncate_encodings, TruncationParams, TruncationStrategy};
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
-use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fs::File,
     io::prelude::*,
     io::BufReader,
     path::{Path, PathBuf},
 };
 
+mod added_vocabulary;
 mod encoding;
 mod normalizer;
 mod serialization;
 
+pub use added_vocabulary::*;
 pub use encoding::*;
 pub use normalizer::*;
 
@@ -56,7 +57,7 @@ pub trait PreTokenizer: Send + Sync {
 pub trait Model: Send + Sync {
     fn tokenize(&self, tokens: Vec<(String, Offsets)>) -> Result<Vec<Token>>;
     fn token_to_id(&self, token: &str) -> Option<u32>;
-    fn id_to_token(&self, id: u32) -> Option<String>;
+    fn id_to_token(&self, id: u32) -> Option<&str>;
     fn get_vocab(&self) -> &HashMap<String, u32>;
     fn get_vocab_size(&self) -> usize;
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>>;
@@ -182,102 +183,6 @@ impl<I1: Into<InputSequence>, I2: Into<InputSequence>> From<(I1, I2)> for Encode
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AddedToken {
-    /// The content of the added token
-    pub content: String,
-    /// Whether this token must be a single word or can break words
-    pub single_word: bool,
-    /// Whether this token should strip whitespaces on its left
-    pub lstrip: bool,
-    /// Whether this token should strip whitespaces on its right
-    pub rstrip: bool,
-}
-impl AddedToken {
-    pub fn from(content: String) -> Self {
-        AddedToken {
-            content,
-            ..Default::default()
-        }
-    }
-    pub fn single_word(mut self, single_word: bool) -> Self {
-        self.single_word = single_word;
-        self
-    }
-    pub fn lstrip(mut self, lstrip: bool) -> Self {
-        self.lstrip = lstrip;
-        self
-    }
-    pub fn rstrip(mut self, rstrip: bool) -> Self {
-        self.rstrip = rstrip;
-        self
-    }
-    pub fn get_pattern(&self) -> String {
-        let mut r = if self.single_word {
-            let first_b = self
-                .content
-                .chars()
-                .next()
-                .map(|c| {
-                    if regex_syntax::is_word_character(c) {
-                        r"\b"
-                    } else {
-                        ""
-                    }
-                })
-                .unwrap();
-            let last_b = self
-                .content
-                .chars()
-                .last()
-                .map(|c| {
-                    if regex_syntax::is_word_character(c) {
-                        r"\b"
-                    } else {
-                        ""
-                    }
-                })
-                .unwrap();
-            format!(r"{}{}{}", first_b, regex::escape(&self.content), last_b)
-        } else {
-            regex::escape(&self.content)
-        };
-
-        if self.lstrip && self.rstrip {
-            r = format!(r"(\s)?{}(\s)?", r);
-        } else if self.lstrip {
-            r = format!(r"(\s)?{}", r);
-        } else if self.rstrip {
-            r = format!(r"{}(\s)?", r);
-        }
-
-        r
-    }
-}
-impl Default for AddedToken {
-    fn default() -> Self {
-        AddedToken {
-            content: String::new(),
-            single_word: false,
-            lstrip: false,
-            rstrip: false,
-        }
-    }
-}
-// We only want to hash on the content. AddedToken cannot be added multiple times with different
-// options
-impl std::hash::Hash for AddedToken {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.content.hash(state);
-    }
-}
-impl std::cmp::PartialEq for AddedToken {
-    fn eq(&self, other: &Self) -> bool {
-        self.content == other.content
-    }
-}
-impl std::cmp::Eq for AddedToken {}
-
 /// A `Tokenizer` is capable of encoding/decoding any text.
 pub struct Tokenizer {
     // Tokenizer parts
@@ -288,21 +193,7 @@ pub struct Tokenizer {
     decoder: Option<Box<dyn Decoder>>,
 
     // Added Vocabulary capabilities
-    /// Contains the mapping from String to ID as the user intended it. This map
-    /// contains both special tokens and classic added tokens.
-    added_tokens_map: HashMap<String, u32>,
-    /// Contains the mapping from ID to AddedToken for all the added tokens, both special
-    /// and classic.
-    added_tokens_map_r: HashMap<u32, AddedToken>,
-    /// Contains only the classic AddedToken, in the specific order the user gave them.
-    added_tokens: Vec<AddedToken>,
-    /// Contains only the special AddedToken, in the specific order the user gave them.
-    special_tokens: Vec<AddedToken>,
-    /// A Set, containing all the special token for easy access while decoding. This let's
-    /// use remove them easily with an O(1) complexity.
-    special_tokens_set: HashSet<String>,
-    /// A RegexSet containing all the patterns used to split on AddedTokens
-    split_re: regex::RegexSet,
+    added_vocabulary: AddedVocabulary,
 
     // General processing parameters
     truncation: Option<TruncationParams>,
@@ -327,12 +218,7 @@ impl Tokenizer {
             post_processor: None,
             decoder: None,
 
-            added_tokens_map: HashMap::new(),
-            added_tokens_map_r: HashMap::new(),
-            added_tokens: vec![],
-            special_tokens: vec![],
-            special_tokens_set: HashSet::new(),
-            split_re: regex::RegexSet::new::<_, &&str>(&[]).unwrap(),
+            added_vocabulary: AddedVocabulary::new(),
 
             truncation: None,
             padding: None,
@@ -461,10 +347,13 @@ impl Tokenizer {
     pub fn get_vocab(&self, with_added_tokens: bool) -> HashMap<String, u32> {
         let mut final_vocab = self.model.get_vocab().clone();
 
-        if with_added_tokens && !self.added_tokens_map.is_empty() {
-            final_vocab.reserve(self.added_tokens_map.len());
-            for (token, id) in &self.added_tokens_map {
-                final_vocab.insert(token.clone(), *id);
+        if with_added_tokens {
+            let added_vocab = self.added_vocabulary.get_vocab();
+            if !added_vocab.is_empty() {
+                final_vocab.reserve(added_vocab.len());
+                for (token, id) in added_vocab {
+                    final_vocab.insert(token.clone(), *id);
+                }
             }
         }
 
@@ -475,7 +364,7 @@ impl Tokenizer {
     pub fn get_vocab_size(&self, with_added_tokens: bool) -> usize {
         self.model.get_vocab_size()
             + if with_added_tokens {
-                self.added_tokens_map.len()
+                self.added_vocabulary.len()
             } else {
                 0
             }
@@ -483,26 +372,24 @@ impl Tokenizer {
 
     /// Converts a token in the corresponding id.
     pub fn token_to_id(&self, token: &str) -> Option<u32> {
-        if let Some(id) = self.added_tokens_map.get(token) {
-            Some(*id)
-        } else {
-            self.model.token_to_id(token)
-        }
+        self.added_vocabulary
+            .token_to_id(token)
+            .copied()
+            .or_else(|| self.model.token_to_id(token))
     }
 
     /// Converts an id to the corresponding token.
-    pub fn id_to_token(&self, id: u32) -> Option<String> {
-        if let Some(token) = self.added_tokens_map_r.get(&id) {
-            Some(token.content.clone())
-        } else {
-            self.model.id_to_token(id)
-        }
+    pub fn id_to_token(&self, id: u32) -> Option<&str> {
+        self.added_vocabulary
+            .id_to_token(id)
+            .or_else(|| self.model.id_to_token(id))
     }
 
     /// Normalize the given sentence and return the corresponding normalized string
     pub fn normalize(&self, sentence: &str) -> Result<NormalizedString> {
         let mut normalized = self
-            .split_on_added_tokens(sentence)
+            .added_vocabulary
+            .extract(sentence)
             .into_iter()
             .map(|(sentence, id)| -> Result<NormalizedString> {
                 if id.is_some() {
@@ -534,7 +421,7 @@ impl Tokenizer {
 
         let mut sequence_encodings = vec![];
         for subseq in sequence {
-            let results = self.split_on_added_tokens(&subseq).into_iter().map(
+            let results = self.added_vocabulary.extract(&subseq).into_iter().map(
                 |(sentence, id)| -> Result<(Encoding, NormalizedString)> {
                     if let Some(id) = id {
                         Ok((
@@ -666,15 +553,17 @@ impl Tokenizer {
         let tokens = ids
             .into_iter()
             .map(|id| {
-                let token = if let Some(token) = self.added_tokens_map_r.get(&id) {
-                    Some(token.content.to_owned())
+                let token = if let Some(token) = self.added_vocabulary.id_to_token(id) {
+                    Some(token)
                 } else {
                     self.model.id_to_token(id)
                 };
 
-                token.filter(|token| {
-                    !skip_special_tokens || !self.special_tokens_set.contains(token)
-                })
+                token
+                    .filter(|token| {
+                        !skip_special_tokens || !self.added_vocabulary.is_special_token(token)
+                    })
+                    .map(|t| t.to_owned())
             })
             .filter(|token| token.is_some())
             .map(|id| id.unwrap())
@@ -863,174 +752,13 @@ impl Tokenizer {
     /// Register the given tokens as special tokens. This is especially useful for removing
     /// these special tokens while decoding
     pub fn add_special_tokens(&mut self, tokens: &[AddedToken]) -> usize {
-        for token in tokens {
-            if !self.special_tokens_set.contains(&token.content) {
-                self.special_tokens.push(token.to_owned());
-                self.special_tokens_set.insert(token.content.clone());
-            }
-        }
-        let added = self.add_tokens(&tokens);
-
-        self.refresh_added_tokens();
-
-        added
+        self.added_vocabulary
+            .add_special_tokens(tokens, self.model.as_ref())
     }
 
     /// Add the given tokens to the added vocabulary
     pub fn add_tokens(&mut self, tokens: &[AddedToken]) -> usize {
-        let mut ignored = 0;
-        for token in tokens {
-            if token.content.is_empty() {
-                ignored += 1;
-                continue;
-            }
-
-            let id = if let Some(id) = self.token_to_id(&token.content) {
-                ignored += 1;
-                id
-            } else {
-                let new_id = (self.model.get_vocab_size() + self.added_tokens_map.len()) as u32;
-                self.added_tokens_map.insert(token.content.clone(), new_id);
-
-                if !self.special_tokens_set.contains(&token.content) {
-                    self.added_tokens.push(token.clone());
-                }
-
-                new_id
-            };
-
-            // Update the current revert operation
-            self.added_tokens_map_r
-                .entry(id)
-                .and_modify(|t| *t = token.clone())
-                .or_insert_with(|| token.clone());
-        }
-
-        self.refresh_added_tokens();
-
-        // Return the number of added tokens
-        tokens.len() - ignored
-    }
-
-    fn refresh_added_tokens(&mut self) {
-        self.split_re = regex::RegexSet::new(
-            self.special_tokens
-                .iter()
-                .chain(self.added_tokens.iter())
-                .map(|token| token.get_pattern()),
-        )
-        .unwrap();
-    }
-
-    /// Split the given sentence on multiple parts, finding the added tokens and their id in
-    /// the process
-    fn split_on_added_tokens(&self, sentence: &str) -> Vec<(NormalizedString, Option<u32>)> {
-        let mut matches = self
-            .split_re
-            .matches(sentence)
-            .into_iter()
-            .flat_map(|idx| {
-                regex::Regex::new(&self.split_re.patterns()[idx])
-                    .unwrap()
-                    .find_iter(&sentence)
-                    .map(|m| (idx, (m.start(), m.end())))
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-
-        // We sort all the matches by their start and then by their pattern id
-        matches.sort_by(
-            |(idxa, (sa, _)), (idxb, (sb, _))| {
-                if sa != sb {
-                    sa.cmp(sb)
-                } else {
-                    idxa.cmp(idxb)
-                }
-            },
-        );
-
-        // Select the matches (if some are overlapping) we want to keep
-        let mut i = 0;
-        let mut current_offset = 0;
-        let mut splits = Vec::with_capacity(matches.len());
-        while i < matches.len() {
-            let (idx, (start, end)) = matches[i];
-
-            // current match is before the currentt offset, let's skip it
-            if start < current_offset {
-                i += 1;
-                continue;
-            }
-
-            // Find out if we have overlapping neighbors. If so, we keep the one with the lowest
-            // idx, and apply it, then continue. All others will be skipped since `current_offset`
-            // will have been increased
-            if i + 1 < matches.len() {
-                if let Some((idx, (s, e))) = matches[i..]
-                    .iter()
-                    .take_while(|(_, (s, e))| *s < end && start < *e)
-                    .min() // Order on idx first
-                    .copied()
-                {
-                    splits.push((idx, (s, e)));
-                    current_offset = e;
-                    i += 1;
-                    continue;
-                }
-            }
-
-            // We didn't find overlapping neighbors, apply ourself
-            splits.push((idx, (start, end)));
-            current_offset = end;
-            i += 1;
-        }
-
-        // We also insert the splits that are inbetween the added tokens, to split the entire string
-        let mut start_offset = 0;
-        let mut splits = splits
-            .into_iter()
-            .flat_map(|(idx, (start, end))| {
-                let mut splits = vec![];
-                if start_offset < start {
-                    splits.push((None, (start_offset, start)));
-                }
-                splits.push((Some(idx), (start, end)));
-                start_offset = end;
-
-                splits
-            })
-            .collect::<Vec<_>>();
-        if let Some((_, (_, end))) = splits.iter().last().copied() {
-            if end < sentence.len() {
-                splits.push((None, (end, sentence.len())));
-            }
-        }
-
-        if splits.is_empty() {
-            vec![(NormalizedString::from(sentence), None)]
-        } else {
-            splits
-                .into_iter()
-                .map(|(idx, (start, end))| unsafe {
-                    let s = sentence.get_unchecked(start..end).to_owned();
-                    let normalized = NormalizedString::from(&s);
-
-                    // Find out the associated AddedToken, and its id
-                    let id = if let Some(idx) = idx {
-                        let added = if idx >= self.special_tokens.len() {
-                            &self.added_tokens[idx - self.special_tokens.len()]
-                        } else {
-                            &self.special_tokens[idx]
-                        };
-
-                        self.token_to_id(&added.content)
-                    } else {
-                        None
-                    };
-
-                    (normalized, id)
-                })
-                .collect()
-        }
+        self.added_vocabulary
+            .add_tokens(tokens, self.model.as_ref())
     }
 }

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -50,7 +50,7 @@ where
 /// It is possible to retrieve a part of the original string, by indexing it with offsets from the
 /// normalized one, and the other way around too. It is also possible to convert offsets from one
 /// referential to the other one easily.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NormalizedString {
     /// The original version of the string, before any modification
     original: String,
@@ -59,12 +59,6 @@ pub struct NormalizedString {
     /// Mapping from normalized string to original one: (start, end) for each character of the
     /// normalized string
     alignments: Vec<(usize, usize)>,
-}
-
-impl std::cmp::PartialEq for NormalizedString {
-    fn eq(&self, other: &NormalizedString) -> bool {
-        self.normalized == other.normalized
-    }
 }
 
 impl NormalizedString {
@@ -441,7 +435,7 @@ impl NormalizedString {
     /// Merge with the given NormalizedString by appending it to self
     pub fn merge_with(&mut self, other: &NormalizedString) {
         self.original.push_str(&other.original);
-        let len = self.len();
+        let len = self.len() - 1;
         self.alignments.extend(
             other
                 .alignments
@@ -879,7 +873,7 @@ mod tests {
             Some(NormalizedString {
                 original: "𝕞𝕠𝕣𝕟𝕚𝕟𝕘".to_string(),
                 normalized: "morning".to_string(),
-                alignments: vec![(5, 6), (6, 7), (7, 8), (8, 9), (9, 10), (10, 11), (11, 12)]
+                alignments: vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
             })
         );
         assert_eq!(

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -4,15 +4,15 @@ use unicode_normalization_alignments::UnicodeNormalization;
 
 /// Represents a Range usable by the NormalizedString to index its content.
 /// A Range can use indices relative to either the `Original` or the `Normalized` string
-#[derive(Debug, Clone, Copy)]
-pub enum Range<T: RangeBounds<usize>> {
+#[derive(Debug, Clone)]
+pub enum Range<T: RangeBounds<usize> + Clone> {
     Original(T),
     Normalized(T),
 }
 
 impl<T> Range<T>
 where
-    T: RangeBounds<usize>,
+    T: RangeBounds<usize> + Clone,
 {
     /// Unwrap the underlying range
     fn unwrap(self) -> T {
@@ -89,21 +89,19 @@ impl NormalizedString {
 
     /// Convert the given offsets range from one referential to the other one:
     /// `Original => Normalized` or `Normalized => Original`
-    pub fn convert_offsets<T: RangeBounds<usize>>(
-        &self,
-        range: Range<T>,
-    ) -> Option<std::ops::Range<usize>> {
+    pub fn convert_offsets<T>(&self, range: Range<T>) -> Option<std::ops::Range<usize>>
+    where
+        T: RangeBounds<usize> + Clone,
+    {
         match range {
             Range::Original(_) => {
                 let (mut start, mut end) = (0, 0);
                 let r = range.into_full_range(self.alignments.last().map_or(0, |(_, e)| *e));
-                println!("{:?}\t{:?}", r, self.alignments);
                 self.alignments
                     .iter()
                     .enumerate()
                     .take_while(|(_, alignment)| r.end >= alignment.1)
                     .for_each(|(i, alignment)| {
-                        println!("{:?}", alignment);
                         if alignment.0 <= r.start {
                             start = i;
                         }
@@ -130,7 +128,10 @@ impl NormalizedString {
     }
 
     /// Return a range of the normalized string (indexing on char not bytes)
-    pub fn get_range<T: RangeBounds<usize>>(&self, range: Range<T>) -> Option<&str> {
+    pub fn get_range<T>(&self, range: Range<T>) -> Option<&str>
+    where
+        T: RangeBounds<usize> + Clone,
+    {
         match range {
             Range::Original(_) => self
                 .convert_offsets(range)
@@ -141,7 +142,10 @@ impl NormalizedString {
     }
 
     /// Return a range of the original string (indexing on char not bytes)
-    pub fn get_range_original<T: RangeBounds<usize>>(&self, range: Range<T>) -> Option<&str> {
+    pub fn get_range_original<T>(&self, range: Range<T>) -> Option<&str>
+    where
+        T: RangeBounds<usize> + Clone,
+    {
         match range {
             Range::Original(r) => get_range_of(&self.original, r),
             Range::Normalized(_) => self
@@ -149,6 +153,73 @@ impl NormalizedString {
                 .map(|r| get_range_of(&self.original, r))
                 .flatten(),
         }
+    }
+
+    /// Return a new NormalizedString that contains only the specified range, indexing on bytes
+    pub fn slice_bytes<T>(&self, range: Range<T>) -> Option<NormalizedString>
+    where
+        T: RangeBounds<usize> + Clone,
+    {
+        let (r, s) = match range {
+            Range::Original(_) => (
+                range.clone().into_full_range(self.original.len()),
+                &self.original,
+            ),
+            Range::Normalized(_) => (
+                range.clone().into_full_range(self.normalized.len()),
+                &self.normalized,
+            ),
+        };
+
+        let (mut start, mut end) = (None, None);
+        s.char_indices()
+            .enumerate()
+            .take_while(|(_, (b, _))| *b < r.end)
+            .filter(|(_, (b, _))| *b >= r.start)
+            .for_each(|(i, (b, c))| {
+                if b == r.start {
+                    start = Some(i);
+                }
+                if b + c.len_utf8() == r.end {
+                    end = Some(i + 1);
+                }
+            });
+
+        match range {
+            Range::Original(_) => self.slice(Range::Original(start?..end?)),
+            Range::Normalized(_) => self.slice(Range::Normalized(start?..end?)),
+        }
+    }
+
+    /// Return a new NormalizedString that contains only the specified range, indexing on char
+    pub fn slice<T>(&self, range: Range<T>) -> Option<NormalizedString>
+    where
+        T: RangeBounds<usize> + Clone,
+    {
+        let r_original = match range {
+            Range::Original(_) => range.clone().into_full_range(self.len_original()),
+            Range::Normalized(_) => self.convert_offsets(range.clone())?,
+        };
+        let r_normalized = match range {
+            Range::Original(_) => self.convert_offsets(range)?,
+            Range::Normalized(_) => range.into_full_range(self.len()),
+        };
+
+        // We need to shift the alignments according to the part of the original string that we
+        // keep
+        let alignment_shift = r_original.start;
+
+        Some(Self {
+            original: get_range_of(&self.original, r_original)?.to_owned(),
+            normalized: get_range_of(&self.normalized, r_normalized.clone())?.to_owned(),
+            alignments: self
+                .alignments
+                .get(r_normalized)?
+                .to_vec()
+                .iter()
+                .map(|(start, end)| (start - alignment_shift, end - alignment_shift))
+                .collect(),
+        })
     }
 
     /// Applies transformations to the current normalized version, updating the current
@@ -735,5 +806,90 @@ mod tests {
         merged.merge_with(&s3);
 
         assert_eq!(s, merged);
+    }
+
+    #[test]
+    fn slice() {
+        let mut s = NormalizedString::from("𝔾𝕠𝕠𝕕 𝕞𝕠𝕣𝕟𝕚𝕟𝕘");
+        s.nfkc();
+
+        assert_eq!(
+            s.slice(Range::Original(0..4)),
+            Some(NormalizedString {
+                original: "𝔾𝕠𝕠𝕕".to_string(),
+                normalized: "Good".to_string(),
+                alignments: vec![(0, 1), (1, 2), (2, 3), (3, 4)]
+            })
+        );
+        assert_eq!(
+            s.slice(Range::Normalized(0..4)),
+            Some(NormalizedString {
+                original: "𝔾𝕠𝕠𝕕".to_string(),
+                normalized: "Good".to_string(),
+                alignments: vec![(0, 1), (1, 2), (2, 3), (3, 4)]
+            })
+        );
+
+        // Make sure the sliced NormalizedString is still aligned as expected
+        let mut s = NormalizedString::from("   Good Morning!   ");
+        s.strip();
+
+        // If we keep the whole slice
+        let slice = s.slice(Range::Original(..)).unwrap();
+        assert_eq!(
+            slice.get_range_original(Range::Normalized(0..4)),
+            Some("Good")
+        );
+        let slice = s.slice(Range::Normalized(..)).unwrap();
+        assert_eq!(
+            slice.get_range_original(Range::Normalized(0..4)),
+            Some("Good")
+        );
+
+        // If we keep after the modified piece
+        let slice = s.slice(Range::Original(4..15)).unwrap();
+        assert_eq!(
+            slice.get_range_original(Range::Normalized(0..3)),
+            Some("ood")
+        );
+
+        // If we keep only the modified piece
+        let slice = s.slice(Range::Original(3..16)).unwrap();
+        assert_eq!(
+            slice.get_range_original(Range::Normalized(0..4)),
+            Some("Good")
+        );
+    }
+
+    #[test]
+    fn slice_bytes() {
+        let mut s = NormalizedString::from("𝔾𝕠𝕠𝕕 𝕞𝕠𝕣𝕟𝕚𝕟𝕘");
+        s.nfkc();
+
+        assert_eq!(
+            s.slice_bytes(Range::Original(0..16)),
+            Some(NormalizedString {
+                original: "𝔾𝕠𝕠𝕕".to_string(),
+                normalized: "Good".to_string(),
+                alignments: vec![(0, 1), (1, 2), (2, 3), (3, 4)]
+            })
+        );
+        assert_eq!(
+            s.slice_bytes(Range::Original(17..)),
+            Some(NormalizedString {
+                original: "𝕞𝕠𝕣𝕟𝕚𝕟𝕘".to_string(),
+                normalized: "morning".to_string(),
+                alignments: vec![(5, 6), (6, 7), (7, 8), (8, 9), (9, 10), (10, 11), (11, 12)]
+            })
+        );
+        assert_eq!(
+            s.slice_bytes(Range::Normalized(0..4)),
+            Some(NormalizedString {
+                original: "𝔾𝕠𝕠𝕕".to_string(),
+                normalized: "Good".to_string(),
+                alignments: vec![(0, 1), (1, 2), (2, 3), (3, 4)]
+            })
+        );
+        assert_eq!(s.slice_bytes(Range::Original(0..10)), None);
     }
 }

--- a/tokenizers/tests/added_tokens.rs
+++ b/tokenizers/tests/added_tokens.rs
@@ -9,8 +9,8 @@ fn add_tokens() {
 
     assert_eq!(
         tokenizer.add_special_tokens(&[
-            AddedToken::from("<cls>".into(), true),
-            AddedToken::from("<sep>".into(), true)
+            AddedToken::from("<cls>", true),
+            AddedToken::from("<sep>", true)
         ]),
         2
     );
@@ -19,8 +19,8 @@ fn add_tokens() {
 
     assert_eq!(
         tokenizer.add_tokens(&[
-            AddedToken::from("hello".into(), false),
-            AddedToken::from("world".into(), false)
+            AddedToken::from("hello", false),
+            AddedToken::from("world", false)
         ]),
         2
     );
@@ -31,7 +31,7 @@ fn add_tokens() {
 #[test]
 fn lstrip_tokens() {
     let mut tokenizer = get_byte_level(true, false);
-    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into(), true).lstrip(true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("<mask>", true).lstrip(true)]);
 
     let input = "I saw a <mask> 😺";
     let output = tokenizer.encode(input, false).unwrap();
@@ -49,7 +49,7 @@ fn lstrip_tokens() {
 #[test]
 fn rstrip_tokens() {
     let mut tokenizer = get_byte_level(false, false);
-    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into(), true).rstrip(true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("<mask>", true).rstrip(true)]);
 
     let input = "I saw a <mask> 😺";
     let output = tokenizer.encode(input, false).unwrap();
@@ -62,7 +62,7 @@ fn rstrip_tokens() {
     // When `add_prefix_space = true` rstrip cannot work as a prefix space is added
     // to the next token
     let mut tokenizer = get_byte_level(true, false);
-    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into(), true).rstrip(true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("<mask>", true).rstrip(true)]);
 
     let input = "I saw a <mask> 😺";
     let output = tokenizer.encode(input, false).unwrap();
@@ -77,7 +77,7 @@ fn rstrip_tokens() {
 fn single_word_tokens() {
     // If `single_word = true` it shouldn't split `dancing`
     let mut tokenizer = get_byte_level(false, false);
-    tokenizer.add_special_tokens(&[AddedToken::from("ing".into(), true).single_word(true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing", true).single_word(true)]);
 
     let input = "I like dancing";
     let output = tokenizer.encode(input, false).unwrap();
@@ -86,7 +86,7 @@ fn single_word_tokens() {
 
     // If `single_word = false` it should split `dancing`
     let mut tokenizer = get_byte_level(false, false);
-    tokenizer.add_special_tokens(&[AddedToken::from("ing".into(), true).single_word(false)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing", true).single_word(false)]);
 
     let input = "I like dancing";
     let output = tokenizer.encode(input, false).unwrap();
@@ -98,9 +98,9 @@ fn single_word_tokens() {
 fn overlapping_tokens() {
     let mut tokenizer = get_byte_level(false, false);
 
-    tokenizer.add_special_tokens(&[AddedToken::from("danc".into(), true)]);
-    tokenizer.add_special_tokens(&[AddedToken::from("nci".into(), true)]);
-    tokenizer.add_special_tokens(&[AddedToken::from("ing".into(), true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("danc", true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("nci", true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing", true)]);
 
     let input = "I like dancing";
     let output = tokenizer.encode(input, false).unwrap();
@@ -109,10 +109,10 @@ fn overlapping_tokens() {
 
     let mut tokenizer = get_byte_level(false, false);
 
-    tokenizer.add_special_tokens(&[AddedToken::from("nci".into(), true)]);
-    tokenizer.add_special_tokens(&[AddedToken::from("danc".into(), true)]);
-    tokenizer.add_special_tokens(&[AddedToken::from("ing".into(), true)]);
-    tokenizer.add_special_tokens(&[AddedToken::from("ike".into(), true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("nci", true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("danc", true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing", true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ike", true)]);
 
     let output = tokenizer.encode(input, false).unwrap();
 

--- a/tokenizers/tests/added_tokens.rs
+++ b/tokenizers/tests/added_tokens.rs
@@ -9,8 +9,8 @@ fn add_tokens() {
 
     assert_eq!(
         tokenizer.add_special_tokens(&[
-            AddedToken::from("<cls>".into()),
-            AddedToken::from("<sep>".into())
+            AddedToken::from("<cls>".into(), true),
+            AddedToken::from("<sep>".into(), true)
         ]),
         2
     );
@@ -19,8 +19,8 @@ fn add_tokens() {
 
     assert_eq!(
         tokenizer.add_tokens(&[
-            AddedToken::from("hello".into()),
-            AddedToken::from("world".into())
+            AddedToken::from("hello".into(), false),
+            AddedToken::from("world".into(), false)
         ]),
         2
     );
@@ -31,7 +31,7 @@ fn add_tokens() {
 #[test]
 fn lstrip_tokens() {
     let mut tokenizer = get_byte_level(true, false);
-    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into()).lstrip(true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into(), true).lstrip(true)]);
 
     let input = "I saw a <mask> 😺";
     let output = tokenizer.encode(input, false).unwrap();
@@ -49,7 +49,7 @@ fn lstrip_tokens() {
 #[test]
 fn rstrip_tokens() {
     let mut tokenizer = get_byte_level(false, false);
-    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into()).rstrip(true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into(), true).rstrip(true)]);
 
     let input = "I saw a <mask> 😺";
     let output = tokenizer.encode(input, false).unwrap();
@@ -62,7 +62,7 @@ fn rstrip_tokens() {
     // When `add_prefix_space = true` rstrip cannot work as a prefix space is added
     // to the next token
     let mut tokenizer = get_byte_level(true, false);
-    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into()).rstrip(true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("<mask>".into(), true).rstrip(true)]);
 
     let input = "I saw a <mask> 😺";
     let output = tokenizer.encode(input, false).unwrap();
@@ -77,7 +77,7 @@ fn rstrip_tokens() {
 fn single_word_tokens() {
     // If `single_word = true` it shouldn't split `dancing`
     let mut tokenizer = get_byte_level(false, false);
-    tokenizer.add_special_tokens(&[AddedToken::from("ing".into()).single_word(true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing".into(), true).single_word(true)]);
 
     let input = "I like dancing";
     let output = tokenizer.encode(input, false).unwrap();
@@ -86,7 +86,7 @@ fn single_word_tokens() {
 
     // If `single_word = false` it should split `dancing`
     let mut tokenizer = get_byte_level(false, false);
-    tokenizer.add_special_tokens(&[AddedToken::from("ing".into()).single_word(false)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing".into(), true).single_word(false)]);
 
     let input = "I like dancing";
     let output = tokenizer.encode(input, false).unwrap();
@@ -98,9 +98,9 @@ fn single_word_tokens() {
 fn overlapping_tokens() {
     let mut tokenizer = get_byte_level(false, false);
 
-    tokenizer.add_special_tokens(&[AddedToken::from("danc".into())]);
-    tokenizer.add_special_tokens(&[AddedToken::from("nci".into())]);
-    tokenizer.add_special_tokens(&[AddedToken::from("ing".into())]);
+    tokenizer.add_special_tokens(&[AddedToken::from("danc".into(), true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("nci".into(), true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing".into(), true)]);
 
     let input = "I like dancing";
     let output = tokenizer.encode(input, false).unwrap();
@@ -109,10 +109,10 @@ fn overlapping_tokens() {
 
     let mut tokenizer = get_byte_level(false, false);
 
-    tokenizer.add_special_tokens(&[AddedToken::from("nci".into())]);
-    tokenizer.add_special_tokens(&[AddedToken::from("danc".into())]);
-    tokenizer.add_special_tokens(&[AddedToken::from("ing".into())]);
-    tokenizer.add_special_tokens(&[AddedToken::from("ike".into())]);
+    tokenizer.add_special_tokens(&[AddedToken::from("nci".into(), true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("danc".into(), true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ing".into(), true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("ike".into(), true)]);
 
     let output = tokenizer.encode(input, false).unwrap();
 

--- a/tokenizers/tests/offsets.rs
+++ b/tokenizers/tests/offsets.rs
@@ -158,7 +158,7 @@ fn split_on_added_tokens_bert() {
     let input = "Yesterday I saw a [MASK] far away";
 
     let mut tokenizer = get_bert();
-    tokenizer.add_special_tokens(&[AddedToken::from("[MASK]".into())]);
+    tokenizer.add_special_tokens(&[AddedToken::from("[MASK]".into(), true)]);
     let output = tokenizer.encode(input, false).unwrap();
 
     assert_eq!(

--- a/tokenizers/tests/offsets.rs
+++ b/tokenizers/tests/offsets.rs
@@ -158,7 +158,7 @@ fn split_on_added_tokens_bert() {
     let input = "Yesterday I saw a [MASK] far away";
 
     let mut tokenizer = get_bert();
-    tokenizer.add_special_tokens(&[AddedToken::from("[MASK]".into(), true)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("[MASK]", true)]);
     let output = tokenizer.encode(input, false).unwrap();
 
     assert_eq!(


### PR DESCRIPTION
Fix #302 

- Extracted Additional vocabulary from `Tokenizer`
- Added `normalized` option, to handle cases where the tokens should be extracted from the normalized version of the text. For example, when adding a token like `yesterday`, we expect it to match in the input text `Yesterday I saw a cat` if we have a `Lowercase` `Normalizer`.
- Added missing tests

This brings a breaking change, where `AddedToken` now requires a second argument `is_special_token: bool`, that is used to set the default `normalized` behavior. Special tokens shouldn't be normalized, and just extracted as given, while normal tokens should be normalized by default. The `normalized` behavior can be manually set on any token to override the default.