### PR TITLE
Rust - Fix Serialization when tokens are part of original vocab

### DIFF
--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -459,8 +459,6 @@ impl Serialize for AddedVocabulary {
     where
         S: Serializer,
     {
-        let mut vocabulary = serializer.serialize_seq(Some(self.added_tokens_map.len()))?;
-
         let mut added_tokens = self
             .added_tokens_map_r
             .iter()
@@ -473,6 +471,7 @@ impl Serialize for AddedVocabulary {
         // We need to have these added tokens ordered by ascending ID
         added_tokens.sort_unstable_by_key(|o| o.id);
 
+        let mut vocabulary = serializer.serialize_seq(Some(added_tokens.len()))?;
         for token in added_tokens {
             vocabulary.serialize_element(&token)?;
         }


### PR DESCRIPTION
When we add only special tokens, which are all parts of the original vocabulary, `self.added_tokens_map.len()` was 0, leading to a weird serialization.

For example, for Bert it was producing:
```json
[],{"id":0,"special":true,"content": ...
```