### PR TITLE
Improve BertNormalizer behavior

### DIFF
--- a/bindings/node/lib/bindings/normalizers.d.ts
+++ b/bindings/node/lib/bindings/normalizers.d.ts
@@ -24,7 +24,7 @@ export interface BertNormalizerOptions {
   lowercase?: boolean;
   /**
    * Whether to strip all accents.
-   * @default true
+   * @default undefined
    */
   stripAccents?: boolean;
 }

--- a/bindings/node/native/src/normalizers.rs
+++ b/bindings/node/native/src/normalizers.rs
@@ -25,7 +25,7 @@ declare_types! {
 struct BertNormalizerOptions {
     clean_text: bool,
     handle_chinese_chars: bool,
-    strip_accents: bool,
+    strip_accents: Option<bool>,
     lowercase: bool,
 }
 impl Default for BertNormalizerOptions {
@@ -33,7 +33,7 @@ impl Default for BertNormalizerOptions {
         Self {
             clean_text: true,
             handle_chinese_chars: true,
-            strip_accents: true,
+            strip_accents: None,
             lowercase: true,
         }
     }

--- a/bindings/python/src/normalizers.rs
+++ b/bindings/python/src/normalizers.rs
@@ -51,7 +51,7 @@ impl BertNormalizer {
     fn new(kwargs: Option<&PyDict>) -> PyResult<(Self, Normalizer)> {
         let mut clean_text = true;
         let mut handle_chinese_chars = true;
-        let mut strip_accents = true;
+        let mut strip_accents = None;
         let mut lowercase = true;
 
         if let Some(kwargs) = kwargs {

--- a/bindings/python/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/tokenizers/implementations/bert_wordpiece.py
@@ -21,7 +21,7 @@ class BertWordPieceTokenizer(BaseTokenizer):
         mask_token: Union[str, AddedToken] = "[MASK]",
         clean_text: bool = True,
         handle_chinese_chars: bool = True,
-        strip_accents: bool = True,
+        strip_accents: Optional[bool] = None,
         lowercase: bool = True,
         wordpieces_prefix: str = "##",
     ):

--- a/bindings/python/tokenizers/normalizers/__init__.pyi
+++ b/bindings/python/tokenizers/normalizers/__init__.pyi
@@ -18,7 +18,7 @@ class BertNormalizer(Normalizer):
         self,
         clean_text: Optional[bool] = True,
         handle_chinese_chars: Optional[bool] = True,
-        strip_accents: Optional[bool] = True,
+        strip_accents: Optional[bool] = None,
         lowercase: Optional[bool] = True,
     ) -> None:
         """ Instantiate a BertNormalizer with the given options.
@@ -32,7 +32,8 @@ class BertNormalizer(Normalizer):
                 Whether to handle chinese chars by putting spaces around them.
 
             strip_accents: (`optional`) boolean:
-                Whether to strip all accents.
+                Whether to strip all accents. If this option is not specified (ie == None),
+                then it will be determined by the value for `lowercase` (as in the original Bert).
 
             lowercase: (`optional`) boolean:
                 Whether to lowercase.

--- a/tokenizers/src/normalizers/bert.rs
+++ b/tokenizers/src/normalizers/bert.rs
@@ -57,7 +57,7 @@ pub struct BertNormalizer {
     /// Whether to put spaces around chinese characters so they get split
     handle_chinese_chars: bool,
     /// Whether to strip accents
-    strip_accents: bool,
+    strip_accents: Option<bool>,
     /// Whether to lowercase the input
     lowercase: bool,
 }
@@ -67,7 +67,7 @@ impl Default for BertNormalizer {
         Self {
             clean_text: true,
             handle_chinese_chars: true,
-            strip_accents: true,
+            strip_accents: None,
             lowercase: true,
         }
     }
@@ -77,7 +77,7 @@ impl BertNormalizer {
     pub fn new(
         clean_text: bool,
         handle_chinese_chars: bool,
-        strip_accents: bool,
+        strip_accents: Option<bool>,
         lowercase: bool,
     ) -> Self {
         BertNormalizer {
@@ -124,7 +124,8 @@ impl Normalizer for BertNormalizer {
         if self.handle_chinese_chars {
             self.do_handle_chinese_chars(&mut normalized);
         }
-        if self.strip_accents {
+        let strip_accents = self.strip_accents.unwrap_or(self.lowercase);
+        if strip_accents {
             self.do_strip_accents(&mut normalized);
         }
         if self.lowercase {


### PR DESCRIPTION
The option `strip_accents` is now optional, and if it is not specified, the Normalizer will keep the same behavior as the original implementation: We strip accents when we lowercase.