### PR TITLE
Include license in PyPI package

### DIFF
--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,6 +1,7 @@
 include Cargo.toml
 include pyproject.toml
 include rust-toolchain
+include ../../LICENSE
 recursive-include src *
 recursive-include tokenizers-lib *
 recursive-exclude tokenizers-lib/target *


### PR DESCRIPTION
Changes:
- Add license to MANIFEST.in to include it in PyPI package.