### PR TITLE
Clean up various normalization methods.

### DIFF
--- a/tokenizers/src/normalizers/bert.rs
+++ b/tokenizers/src/normalizers/bert.rs
@@ -90,7 +90,7 @@ impl BertNormalizer {
 
     fn do_clean_text(&self, normalized: &mut NormalizedString) {
         normalized
-            .filter(|c| !(*c as usize == 0 || *c as usize == 0xfffd || is_control(*c)))
+            .filter(|c| !(c as usize == 0 || c as usize == 0xfffd || is_control(c)))
             .map(|c| if is_whitespace(c) { ' ' } else { c });
     }
 
@@ -117,19 +117,19 @@ impl BertNormalizer {
 
 #[typetag::serde]
 impl Normalizer for BertNormalizer {
-    fn normalize(&self, mut normalized: &mut NormalizedString) -> Result<()> {
+    fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
         if self.clean_text {
-            self.do_clean_text(&mut normalized);
+            self.do_clean_text(normalized);
         }
         if self.handle_chinese_chars {
-            self.do_handle_chinese_chars(&mut normalized);
+            self.do_handle_chinese_chars(normalized);
         }
         let strip_accents = self.strip_accents.unwrap_or(self.lowercase);
         if strip_accents {
-            self.do_strip_accents(&mut normalized);
+            self.do_strip_accents(normalized);
         }
         if self.lowercase {
-            self.do_lowercase(&mut normalized);
+            self.do_lowercase(normalized);
         }
 
         Ok(())

--- a/tokenizers/src/pre_tokenizers/bert.rs
+++ b/tokenizers/src/pre_tokenizers/bert.rs
@@ -7,7 +7,7 @@ fn is_bert_punc(x: char) -> bool {
 }
 
 /// Split the given string as the `should_split` predicate dictates. Keep track of the offsets
-fn split_on<F: Fn(&char) -> bool>(
+fn split_on<F: Fn(char) -> bool>(
     s: &str,
     should_split: F,
     include_split_token: bool,
@@ -16,7 +16,7 @@ fn split_on<F: Fn(&char) -> bool>(
     let mut offset = 0;
     let mut word = Vec::with_capacity(50);
     s.chars().for_each(|c| {
-        if should_split(&c) {
+        if should_split(c) {
             if !word.is_empty() {
                 let offsets = (offset - word.len(), offset);
                 words.push((word.drain(0..).collect::<String>(), offsets));
@@ -24,7 +24,7 @@ fn split_on<F: Fn(&char) -> bool>(
             if include_split_token {
                 words.push((c.to_string(), (offset, offset + 1)));
             }
-        } else if !should_split(&c) {
+        } else if !should_split(c) {
             word.push(c);
         }
         offset += 1;
@@ -45,9 +45,9 @@ pub struct BertPreTokenizer;
 impl PreTokenizer for BertPreTokenizer {
     fn pre_tokenize(&self, normalized: &mut NormalizedString) -> Result<Vec<(String, Offsets)>> {
         let mut split_tokens = vec![];
-        for (token, offsets) in split_on(normalized.get(), |c| char::is_whitespace(*c), false) {
+        for (token, offsets) in split_on(normalized.get(), char::is_whitespace, false) {
             split_tokens.extend(
-                split_on(&token, |c| is_bert_punc(*c), true)
+                split_on(&token, is_bert_punc, true)
                     .into_iter()
                     .map(|(tok, off)| (tok, (off.0 + offsets.0, off.1 + offsets.0))),
             );

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -62,7 +62,7 @@ impl Decoder for Metaspace {
             .iter()
             .flat_map(|t| t.chars())
             .enumerate()
-            .map(|(i, c)| {
+            .filter_map(|(i, c)| {
                 if c == self.replacement {
                     if i == 0 && self.add_prefix_space {
                         None
@@ -73,8 +73,6 @@ impl Decoder for Metaspace {
                     Some(c)
                 }
             })
-            .filter(|c| c.is_some())
-            .map(|c| c.unwrap())
             .collect::<String>())
     }
 }

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -326,9 +326,9 @@ impl Encoding {
         let starting_word = self
             .words
             .iter()
-            .filter(|w| w.is_some())
-            .map(|w| w.unwrap())
+            .cloned()
             .max()
+            .flatten()
             .map_or(0, |w| w + 1);
         self.words.extend(
             pair.words

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -549,7 +549,7 @@ impl Tokenizer {
     pub fn decode(&self, ids: Vec<u32>, skip_special_tokens: bool) -> Result<String> {
         let tokens = ids
             .into_iter()
-            .map(|id| {
+            .filter_map(|id| {
                 self.added_vocabulary
                     .id_to_token(id, self.model.as_ref())
                     .filter(|token| {
@@ -557,8 +557,6 @@ impl Tokenizer {
                     })
                     .map(|t| t.to_owned())
             })
-            .filter(|token| token.is_some())
-            .map(|id| id.unwrap())
             .collect::<Vec<_>>();
 
         if let Some(decoder) = &self.decoder {

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -368,35 +368,25 @@ impl NormalizedString {
         }
 
         // Split normalized
-        let byte_index = self
-            .normalized
-            .chars()
-            .enumerate()
-            .map(|(i, c)| if i < at { Some(c.len_utf8()) } else { None })
-            .fuse()
-            .filter(|c| c.is_some())
-            .map(|c| c.unwrap())
-            .sum::<usize>();
+        let byte_index = self.normalized.chars().enumerate().fold(0, |acc, (i, c)| {
+            if i < at {
+                acc + c.len_utf8()
+            } else {
+                acc
+            }
+        });
         let normalized = self.normalized.split_off(byte_index);
         let alignments = self.alignments.split_off(at);
 
         // Split original
         let original_at = self.alignments.last().map(|(_, end)| *end).unwrap_or(0);
-        let original_byte_index = self
-            .original
-            .chars()
-            .enumerate()
-            .map(|(i, c)| {
-                if i < original_at {
-                    Some(c.len_utf8())
-                } else {
-                    None
-                }
-            })
-            .fuse()
-            .filter(|c| c.is_some())
-            .map(|c| c.unwrap())
-            .sum::<usize>();
+        let original_byte_index = self.original.chars().enumerate().fold(0, |acc, (i, c)| {
+            if i < original_at {
+                acc + c.len_utf8()
+            } else {
+                acc
+            }
+        });
         let original = self.original.split_off(original_byte_index);
 
         NormalizedString {
@@ -455,7 +445,7 @@ impl NormalizedString {
                 .normalized
                 .chars()
                 .enumerate()
-                .map(|(i, c)| {
+                .filter_map(|(i, c)| {
                     if i < leading_spaces || i >= self.len() - trailing_spaces {
                         None
                     } else if i == self.len() - trailing_spaces - 1 {
@@ -464,8 +454,6 @@ impl NormalizedString {
                         Some((c, 0))
                     }
                 })
-                .filter(|o| o.is_some())
-                .map(|o| o.unwrap())
                 .collect::<Vec<_>>();
             self.transform(transformation.into_iter(), leading_spaces);
         }

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::ops::{Bound, RangeBounds};
 use unicode_normalization_alignments::UnicodeNormalization;
 
@@ -232,46 +231,30 @@ impl NormalizedString {
     /// We treat any value above `1` as `1`.
     pub fn transform<I: Iterator<Item = (char, isize)>>(&mut self, dest: I, initial_offset: usize) {
         let mut offset = -(initial_offset as isize);
-        let (ch, alignments): (Vec<_>, Vec<_>) = dest
+        let (normalized, alignments): (String, Vec<_>) = dest
             .enumerate()
             .map(|(index, (c, changes))| {
-                let uof = if offset < 0 {
-                    -offset as usize
-                } else {
-                    offset as usize
-                };
                 // A positive offset means we added characters. So we need to remove this offset
                 // from the current index to find out the previous id
-                let idx = if offset < 0 { index + uof } else { index - uof };
-                let align = match changes.cmp(&0) {
-                    // This is a newly inserted character, so we use the alignment from the
-                    // previous one
-                    Ordering::Greater => {
-                        offset += 1;
-                        if idx < 1 {
-                            Some((0, 0))
-                        } else {
-                            self.alignments.get(idx - 1).copied()
-                        }
+                let idx = (index as isize - offset) as usize;
+                offset += changes;
+                let align = if changes.is_positive() {
+                    if idx < 1 {
+                        (0, 0)
+                    } else {
+                        // This is a newly inserted character, so we use the alignment from the
+                        // previous one
+                        self.alignments[idx - 1]
                     }
-                    // No changes required here
-                    Ordering::Equal => self.alignments.get(idx).copied(),
-                    // Some characters where removed, nothing to change in alignments
-                    Ordering::Less => {
-                        offset += changes;
-                        self.alignments.get(idx).copied()
-                    }
+                } else {
+                    self.alignments[idx]
                 };
-
                 // Then we keep only the char for string reconstruction
-                (
-                    c,
-                    align.expect("Bad alignement in NormalizedString::transform"),
-                )
+                (c, align)
             })
             .unzip();
         self.alignments = alignments;
-        self.normalized = ch.iter().collect::<String>();
+        self.normalized = normalized;
     }
 
     /// Applies NFD normalization
@@ -299,18 +282,14 @@ impl NormalizedString {
     }
 
     /// Applies filtering over our characters
-    pub fn filter<F: Fn(&char) -> bool>(&mut self, filter: F) -> &mut Self {
-        let mut removed: usize = 0;
-        let mut filtered = self
+    pub fn filter<F: Fn(char) -> bool>(&mut self, keep: F) -> &mut Self {
+        let mut removed = 0;
+        let filtered = self
             .normalized
             .chars()
-            // We need to collect here to be able to reverse the iterator because Char is not ended
-            .collect::<Vec<_>>()
-            .into_iter()
             .rev()
             .map(|c| {
-                let keep = filter(&c);
-                if keep {
+                if keep(c) {
                     if removed > 0 {
                         let res = (c, -(removed as isize));
                         removed = 0;
@@ -324,13 +303,7 @@ impl NormalizedString {
                 }
             })
             .collect::<Vec<_>>();
-        // For some reason, if we use rev, and unwrap directly, some parts of the tuples we return
-        // above get mixed up... So we collect first, then reverse in place
-        filtered.reverse();
-        self.transform(
-            filtered.iter().filter(|o| o.is_some()).map(|o| o.unwrap()),
-            removed,
-        );
+        self.transform(filtered.into_iter().rev().filter_map(|o| o), removed);
         self
     }
 
@@ -585,7 +558,7 @@ mod tests {
     #[test]
     fn removed_chars() {
         let mut n = NormalizedString::from("élégant");
-        n.filter(|c| *c != 'n');
+        n.filter(|c| c != 'n');
         assert_eq!(
             &n.alignments,
             &[(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (6, 7)]
@@ -595,7 +568,7 @@ mod tests {
     #[test]
     fn mixed_addition_and_removal() {
         let mut n = NormalizedString::from("élégant");
-        n.nfd().filter(|c| !c.is_mark_nonspacing() && *c != 'n');
+        n.nfd().filter(|c| !c.is_mark_nonspacing() && c != 'n');
         assert_eq!(
             &n.alignments,
             &[(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (6, 7)]
@@ -623,7 +596,7 @@ mod tests {
     #[test]
     fn original_range() {
         let mut n = NormalizedString::from("Hello_______ World!");
-        n.filter(|c| *c != '_').lowercase();
+        n.filter(|c| c != '_').lowercase();
         let world_n = n.get_range(Range::Normalized(6..11)).unwrap();
         let world_o = n.get_range_original(Range::Normalized(6..11)).unwrap();
         assert_eq!(world_n, "world");


### PR DESCRIPTION
Rust 1.45 added a new clippy lint for empty ranges, that led to failing CI builds which are now addressed by the first commit in this PR.

**edit:** Looks like are some additional new lints in the node bindings...

----------
Clean up various normalization methods.

* `char` is `Copy`, therefore filter can take `char` by value
* `Char` is double ended, no need to collect before `rev()`
* clearer name for filter condition
* reverse iterator instead of reversing a vec in-place
* replace `filter(|o| o.is_some()).map(|o| o.unwrap())` with single
  `filter_map`
* simplify logic in `transform`
* directly collect transformation into `String`, skipping the
  `Vec<char>` first

--------------

Simplify some iterators.

* replace `.filter(|x| x.is_some()).map(|x| x.unwrap())` with
  `filter_map` calls
* replace some reducers with `fold` instead of mapping, filtering
  and summing

---------------

Make BERT pre tokenizer closure take chars by value.

char is `Copy`, can be passed by value.