### PR TITLE
CI - Support macOS 10.11+

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   rust_publish:
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.10
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   rust_publish:
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.10
+      MACOSX_DEPLOYMENT_TARGET: 10.11
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -69,6 +69,8 @@ jobs:
 
   create_wheels_others_64bit:
     name: Create wheels for other OSes
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.10
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -70,7 +70,7 @@ jobs:
   create_wheels_others_64bit:
     name: Create wheels for other OSes
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.10
+      MACOSX_DEPLOYMENT_TARGET: 10.11
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -104,7 +104,7 @@ jobs:
       - name: Rename wheels
         shell: bash
         working-directory: ./bindings/python/dist
-        run: for file in *.whl ; do mv $file ${file//macosx_10_15/macosx_10_10} ; done
+        run: for file in *.whl ; do mv $file ${file//macosx_10_15/macosx_10_11} ; done
 
       - name: Upload wheels
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.10
+      MACOSX_DEPLOYMENT_TARGET: 10.11
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.10
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]


### PR DESCRIPTION
cc #321 

Make sure we support older version of macOS even when building with the latest (10.15). We cannot support versions before 10.11 though, because of some features that are supported only starting from Xcode 8.0