### PR TITLE
Improve PreTokenizer and Model interfaces

### DIFF
--- a/bindings/node/native/Cargo.lock
+++ b/bindings/node/native/Cargo.lock
@@ -282,6 +282,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,7 +593,7 @@ version = "0.1.0"
 source = "git+https://github.com/n1t0/rayon-cond#c56e4f1ded0fcb92eac70e0533703bba3ca2983f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.8.2",
  "rayon",
 ]
 
@@ -749,6 +758,7 @@ version = "0.10.1"
 dependencies = [
  "clap",
  "indicatif",
+ "itertools 0.9.0",
  "lazy_static",
  "onig",
  "rand",

--- a/bindings/node/native/src/pre_tokenizers.rs
+++ b/bindings/node/native/src/pre_tokenizers.rs
@@ -50,10 +50,9 @@ fn byte_level_alphabet(mut cx: FunctionContext) -> JsResult<JsValue> {
 fn whitespace(mut cx: FunctionContext) -> JsResult<JsPreTokenizer> {
     let mut pretok = JsPreTokenizer::new::<_, JsPreTokenizer, _>(&mut cx, vec![])?;
     let guard = cx.lock();
-    pretok
-        .borrow_mut(&guard)
-        .pretok
-        .make_owned(Box::new(tk::pre_tokenizers::whitespace::Whitespace));
+    pretok.borrow_mut(&guard).pretok.make_owned(Box::new(
+        tk::pre_tokenizers::whitespace::Whitespace::default(),
+    ));
     Ok(pretok)
 }
 

--- a/bindings/node/native/src/utils.rs
+++ b/bindings/node/native/src/utils.rs
@@ -21,7 +21,7 @@ fn slice(mut cx: FunctionContext) -> JsResult<JsString> {
     let begin_index = get_index(cx.extract_opt::<i32>(1)?.unwrap_or(0));
     let end_index = get_index(cx.extract_opt::<i32>(2)?.unwrap_or(len as i32));
 
-    if let Some(slice) = tk::tokenizer::get_range_of(&s, begin_index..end_index) {
+    if let Some(slice) = tk::tokenizer::normalizer::get_range_of(&s, begin_index..end_index) {
         Ok(cx.string(slice))
     } else {
         cx.throw_error("Error in offsets")
@@ -37,7 +37,7 @@ fn merge_encodings(mut cx: FunctionContext) -> JsResult<JsEncoding> {
         .collect();
     let growing_offsets = cx.extract_opt::<bool>(1)?.unwrap_or(false);
 
-    let new_encoding = tk::tokenizer::Encoding::merge(encodings.as_slice(), growing_offsets);
+    let new_encoding = tk::tokenizer::Encoding::merge(encodings, growing_offsets);
     let mut js_encoding = JsEncoding::new::<_, JsEncoding, _>(&mut cx, vec![])?;
 
     let guard = cx.lock();

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -253,6 +253,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +633,7 @@ version = "0.10.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "onig 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -765,6 +774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum inventory 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "82d3f4b90287725c97b17478c60dda0c6324e7c84ee1ed72fb9179d0fdf13956"
 "checksum inventory-impl 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9092a4fefc9d503e9287ef137f03180a6e7d1b04c419563171ee14947c5e80ec"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+"checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"

--- a/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
@@ -1,5 +1,4 @@
 from tokenizers import Tokenizer, Encoding, AddedToken, InputSequence, EncodeInput
-from tokenizers.models import TokenizedSequence, TokenizedSequenceWithOffsets
 
 from typing import List, Union, Tuple, Optional, Dict
 

--- a/bindings/python/py_src/tokenizers/models/__init__.py
+++ b/bindings/python/py_src/tokenizers/models/__init__.py
@@ -2,9 +2,6 @@ from typing import List, Tuple
 
 from .. import models, Offsets
 
-TokenizedSequence = List[str]
-TokenizedSequenceWithOffsets = List[Tuple[str, Offsets]]
-
 Model = models.Model
 BPE = models.BPE
 WordPiece = models.WordPiece

--- a/bindings/python/py_src/tokenizers/models/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/models/__init__.pyi
@@ -1,9 +1,6 @@
 from .. import Encoding, Offsets
 from typing import List, Optional, Union, Tuple
 
-TokenizedSequence = List[str]
-TokenizedSequenceWithOffsets = List[Tuple[str, Offsets]]
-
 class Model:
     """ Base class for all models
 
@@ -17,57 +14,6 @@ class Model:
         Save the current model in the given folder, using the given name for the various
         files that will get created.
         Any file with the same name that already exist in this folder will be overwritten.
-        """
-        pass
-    def encode(
-        self, sequence: Union[TokenizedSequence, TokenizedSequenceWithOffsets], type_id: int = 0
-    ) -> Encoding:
-        """ Encode the given sequence.
-
-        A sequence can either be:
-            - `TokenizedSequence`: (`List[str]`)
-            - `TokenizedSequenceWithOffsets: (`List[Tuple[str, Offsets]]`) where Offsets is
-            a Tuple[int, int].
-
-        If the Offsets are not provided, they will be automatically generated, making the hypothesis
-        that all the tokens in the `TokenizedSequence` are contiguous in the original string.
-
-        Args:
-            sequence: Union[TokenizedSequence, TokenizedSequenceWithOffsets]
-                Either a TokenizedSequence or a TokenizedSequenceWithOffsets
-
-            type_id: int:
-                The type id of the given sequence
-
-        Returns:
-            An Encoding
-        """
-        pass
-    def encode_batch(
-        self,
-        sequences: Union[List[TokenizedSequence], List[TokenizedSequenceWithOffsets]],
-        type_id: int = 0,
-    ) -> List[Encoding]:
-        """ Encode the given batch of sequence.
-
-        A sequence can either be:
-            - `TokenizedSequence`: (`List[str]`)
-            - `TokenizedSequenceWithOffsets: (`List[Tuple[str, Offsets]]`) where Offsets is
-            a Tuple[int, int].
-
-        If the Offsets are not provided, they will be automatically generated, making the hypothesis
-        that all the tokens in the `TokenizedSequence` are contiguous in the original string.
-
-        Args:
-            sequences: Union[List[TokenizedSequence], List[TokenizedSequenceWithOffsets]]
-                A list of sequence. Each sequence is either a TokenizedSequence or a
-                TokenizedSequenceWithOffsets
-
-            type_id: int:
-                The type if of the given sequence
-
-        Returns:
-            A list of Encoding
         """
         pass
 

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -75,11 +75,7 @@ impl Encoding {
     #[args(growing_offsets = true)]
     fn merge(encodings: Vec<PyRef<Encoding>>, growing_offsets: bool) -> Encoding {
         tk::tokenizer::Encoding::merge(
-            encodings
-                .into_iter()
-                .map(|e| e.encoding.clone())
-                .collect::<Vec<_>>()
-                .as_slice(),
+            encodings.into_iter().map(|e| e.encoding.clone()),
             growing_offsets,
         )
         .into()

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -27,3 +27,8 @@ impl<T> std::convert::Into<PyResult<T>> for ToPyResult<T> {
             .map_err(|e| exceptions::Exception::py_err(format!("{}", e)))
     }
 }
+impl<T> ToPyResult<T> {
+    pub fn into_py(self) -> PyResult<T> {
+        self.into()
+    }
+}

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -1,78 +1,11 @@
 extern crate tokenizers as tk;
 
-use super::encoding::Encoding;
 use super::error::ToPyResult;
 use super::utils::Container;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
 use std::path::Path;
-use tk::parallelism::*;
-
-#[pyclass]
-struct EncodeInput {
-    sequence: Vec<(String, (usize, usize))>,
-}
-impl EncodeInput {
-    pub fn into_input(self) -> Vec<(String, (usize, usize))> {
-        self.sequence
-    }
-}
-
-impl<'source> FromPyObject<'source> for EncodeInput {
-    fn extract(ob: &'source PyAny) -> PyResult<Self> {
-        let sequence: &PyList = ob.downcast()?;
-
-        enum Mode {
-            NoOffsets,
-            Offsets,
-        };
-        let mode = sequence
-            .iter()
-            .next()
-            .map(|item| {
-                if item.extract::<String>().is_ok() {
-                    Ok(Mode::NoOffsets)
-                } else if item.extract::<(String, (usize, usize))>().is_ok() {
-                    Ok(Mode::Offsets)
-                } else {
-                    Err(exceptions::ValueError::py_err(
-                        "Input must be a list[str] or list[(str, (int, int))]",
-                    ))
-                }
-            })
-            .unwrap()?;
-
-        let mut total_len = 0;
-        let sequence = sequence
-            .iter()
-            .enumerate()
-            .map(|(i, item)| match mode {
-                Mode::NoOffsets => item
-                    .extract::<String>()
-                    .map_err(|_| {
-                        exceptions::ValueError::py_err(format!(
-                            "Value at index {} should be a `str`",
-                            i
-                        ))
-                    })
-                    .map(|s| {
-                        let len = s.chars().count();
-                        total_len += len;
-                        (s, (total_len - len, total_len))
-                    }),
-                Mode::Offsets => item.extract::<(String, (usize, usize))>().map_err(|_| {
-                    exceptions::ValueError::py_err(format!(
-                        "Value at index {} should be a `(str, (int, int))`",
-                        i
-                    ))
-                }),
-            })
-            .collect::<Result<Vec<_>, PyErr>>()?;
-
-        Ok(EncodeInput { sequence })
-    }
-}
 
 /// A Model represents some tokenization algorithm like BPE or Word
 /// This class cannot be constructed directly. Please use one of the concrete models.
@@ -132,42 +65,6 @@ impl Model {
             .into_iter()
             .map(|path| path.to_string_lossy().into_owned())
             .collect())
-    }
-
-    #[args(type_id = 0)]
-    fn encode(&self, sequence: EncodeInput, type_id: u32) -> PyResult<Encoding> {
-        let sequence = sequence.into_input();
-
-        if sequence.is_empty() {
-            return Ok(tk::tokenizer::Encoding::default().into());
-        }
-
-        ToPyResult(self.model.execute(|model| {
-            model
-                .tokenize(sequence)
-                .map(|tokens| tk::tokenizer::Encoding::from_tokens(tokens, type_id).into())
-        }))
-        .into()
-    }
-
-    #[args(type_id = 0)]
-    fn encode_batch(&self, sequences: Vec<EncodeInput>, type_id: u32) -> PyResult<Vec<Encoding>> {
-        ToPyResult(self.model.execute(|model| {
-            sequences
-                .into_maybe_par_iter()
-                .map(|sequence| {
-                    let sequence = sequence.into_input();
-                    if sequence.is_empty() {
-                        Ok(tk::tokenizer::Encoding::default().into())
-                    } else {
-                        model.tokenize(sequence).map(|tokens| {
-                            tk::tokenizer::Encoding::from_tokens(tokens, type_id).into()
-                        })
-                    }
-                })
-                .collect::<Result<_, _>>()
-        }))
-        .into()
     }
 }
 

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -1,12 +1,11 @@
 extern crate tokenizers as tk;
 
-use super::error::{PyError, ToPyResult};
+use super::error::ToPyResult;
 use super::utils::Container;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use tk::tokenizer::{Offsets, Result};
+use tk::tokenizer::Offsets;
 
 #[pyclass(dict, module = "tokenizers.pre_tokenizers")]
 pub struct PreTokenizer {
@@ -14,13 +13,13 @@ pub struct PreTokenizer {
 }
 #[pymethods]
 impl PreTokenizer {
-    #[staticmethod]
-    fn custom(pretok: PyObject) -> PyResult<Self> {
-        let py_pretok = PyPreTokenizer::new(pretok)?;
-        Ok(PreTokenizer {
-            pretok: Container::Owned(Box::new(py_pretok)),
-        })
-    }
+    // #[staticmethod]
+    // fn custom(pretok: PyObject) -> PyResult<Self> {
+    //     let py_pretok = PyPreTokenizer::new(pretok)?;
+    //     Ok(PreTokenizer {
+    //         pretok: Container::Owned(Box::new(py_pretok)),
+    //     })
+    // }
 
     fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
         let data = self
@@ -52,13 +51,20 @@ impl PreTokenizer {
     }
 
     fn pre_tokenize(&self, s: &str) -> PyResult<Vec<(String, Offsets)>> {
-        // TODO: Expose the NormalizedString
-        let mut normalized = tk::tokenizer::NormalizedString::from(s);
+        // TODO: Expose the PreTokenizedString
+        let mut pretokenized = tk::tokenizer::PreTokenizedString::from(s);
+
         ToPyResult(
             self.pretok
-                .execute(|pretok| pretok.pre_tokenize(&mut normalized)),
+                .execute(|pretok| pretok.pre_tokenize(&mut pretokenized)),
         )
-        .into()
+        .into_py()?;
+
+        Ok(pretokenized
+            .get_normalized(true)
+            .into_iter()
+            .map(|(s, o)| (s.to_owned(), o))
+            .collect())
     }
 }
 
@@ -108,7 +114,9 @@ impl Whitespace {
         Ok((
             Whitespace {},
             PreTokenizer {
-                pretok: Container::Owned(Box::new(tk::pre_tokenizers::whitespace::Whitespace)),
+                pretok: Container::Owned(Box::new(
+                    tk::pre_tokenizers::whitespace::Whitespace::default(),
+                )),
             },
         ))
     }
@@ -209,64 +217,64 @@ impl Metaspace {
     }
 }
 
-struct PyPreTokenizer {
-    class: PyObject,
-}
-
-impl PyPreTokenizer {
-    pub fn new(class: PyObject) -> PyResult<Self> {
-        Ok(PyPreTokenizer { class })
-    }
-}
-
-#[typetag::serde]
-impl tk::tokenizer::PreTokenizer for PyPreTokenizer {
-    fn pre_tokenize(
-        &self,
-        sentence: &mut tk::tokenizer::NormalizedString,
-    ) -> Result<Vec<(String, Offsets)>> {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-
-        let args = PyTuple::new(py, &[sentence.get()]);
-        match self.class.call_method(py, "pre_tokenize", args, None) {
-            Ok(res) => Ok(res
-                .cast_as::<PyList>(py)
-                .map_err(|_| {
-                    PyError::from("`pre_tokenize is expected to return a List[(str, (uint, uint))]")
-                })?
-                .extract::<Vec<(String, Offsets)>>()
-                .map_err(|_| {
-                    PyError::from(
-                        "`pre_tokenize` is expected to return a List[(str, (uint, uint))]",
-                    )
-                })?),
-            Err(e) => {
-                e.print(py);
-                Err(Box::new(PyError::from(
-                    "Error while calling `pre_tokenize`",
-                )))
-            }
-        }
-    }
-}
-
-impl Serialize for PyPreTokenizer {
-    fn serialize<S>(&self, _serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        Err(serde::ser::Error::custom(
-            "Custom PyPreTokenizer cannot be serialized",
-        ))
-    }
-}
-
-impl<'de> Deserialize<'de> for PyPreTokenizer {
-    fn deserialize<D>(_deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        unimplemented!("PyPreTokenizer cannot be deserialized")
-    }
-}
+// struct PyPreTokenizer {
+//     class: PyObject,
+// }
+//
+// impl PyPreTokenizer {
+//     pub fn new(class: PyObject) -> PyResult<Self> {
+//         Ok(PyPreTokenizer { class })
+//     }
+// }
+//
+// #[typetag::serde]
+// impl tk::tokenizer::PreTokenizer for PyPreTokenizer {
+//     fn pre_tokenize(
+//         &self,
+//         sentence: &mut tk::tokenizer::NormalizedString,
+//     ) -> Result<Vec<(String, Offsets)>> {
+//         let gil = Python::acquire_gil();
+//         let py = gil.python();
+//
+//         let args = PyTuple::new(py, &[sentence.get()]);
+//         match self.class.call_method(py, "pre_tokenize", args, None) {
+//             Ok(res) => Ok(res
+//                 .cast_as::<PyList>(py)
+//                 .map_err(|_| {
+//                     PyError::from("`pre_tokenize is expected to return a List[(str, (uint, uint))]")
+//                 })?
+//                 .extract::<Vec<(String, Offsets)>>()
+//                 .map_err(|_| {
+//                     PyError::from(
+//                         "`pre_tokenize` is expected to return a List[(str, (uint, uint))]",
+//                     )
+//                 })?),
+//             Err(e) => {
+//                 e.print(py);
+//                 Err(Box::new(PyError::from(
+//                     "Error while calling `pre_tokenize`",
+//                 )))
+//             }
+//         }
+//     }
+// }
+//
+// impl Serialize for PyPreTokenizer {
+//     fn serialize<S>(&self, _serializer: S) -> std::result::Result<S::Ok, S::Error>
+//     where
+//         S: Serializer,
+//     {
+//         Err(serde::ser::Error::custom(
+//             "Custom PyPreTokenizer cannot be serialized",
+//         ))
+//     }
+// }
+//
+// impl<'de> Deserialize<'de> for PyPreTokenizer {
+//     fn deserialize<D>(_deserializer: D) -> std::result::Result<Self, D::Error>
+//     where
+//         D: Deserializer<'de>,
+//     {
+//         unimplemented!("PyPreTokenizer cannot be deserialized")
+//     }
+// }

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -61,7 +61,7 @@ impl PreTokenizer {
         .into_py()?;
 
         Ok(pretokenized
-            .get_normalized(true)
+            .get_normalized(tk::OffsetReferential::Original)
             .into_iter()
             .map(|(s, o)| (s.to_owned(), o))
             .collect())

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -44,6 +44,7 @@ clap = "2.33"
 unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 indicatif = "0.14"
+itertools = "0.9"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -113,7 +113,7 @@ fn iter_bench_train(
 
 fn bench_train(c: &mut Criterion) {
     let mut tokenizer = Tokenizer::new(Box::new(BPE::default()));
-    tokenizer.with_pre_tokenizer(Box::new(Whitespace));
+    tokenizer.with_pre_tokenizer(Box::new(Whitespace::default()));
 
     let trainer: Box<dyn Trainer> =
         Box::new(BpeTrainerBuilder::default().show_progress(false).build());

--- a/tokenizers/src/models/bpe/cache.rs
+++ b/tokenizers/src/models/bpe/cache.rs
@@ -75,6 +75,18 @@ where
         }
     }
 
+    pub(super) fn get<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        if let Ok(ref mut cache) = self.map.try_read() {
+            cache.get(key).cloned()
+        } else {
+            None
+        }
+    }
+
     pub(super) fn set_values<I>(&self, entries: I)
     where
         I: IntoIterator<Item = (K, V)>,
@@ -97,5 +109,9 @@ where
             let free = self.capacity - cache.len();
             cache.extend(entries.into_iter().take(free));
         }
+    }
+
+    pub(super) fn set(&self, key: K, value: V) {
+        self.set_values(std::iter::once((key, value)))
     }
 }

--- a/tokenizers/src/models/bpe/cache.rs
+++ b/tokenizers/src/models/bpe/cache.rs
@@ -62,6 +62,7 @@ where
         self.map.write().unwrap().clear();
     }
 
+    #[allow(dead_code)]
     pub(super) fn get_values<'a, I, Q>(&self, keys_iter: I) -> Option<Vec<Option<V>>>
     where
         I: Iterator<Item = &'a Q>,

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -344,9 +344,9 @@ impl BPE {
         } else {
             let word = self.merge_word(sequence)?;
             let ret = self.word_to_tokens(&word).collect();
-            self.cache
-                .as_ref()
-                .map(|c| c.set(sequence.to_owned(), word));
+            if let Some(ref cache) = self.cache {
+                cache.set(sequence.to_owned(), word);
+            }
             Ok(ret)
         }
     }

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -144,25 +144,16 @@ impl Default for WordLevel {
 
 #[typetag::serde]
 impl Model for WordLevel {
-    fn tokenize(&self, tokens: Vec<(String, (usize, usize))>) -> Result<Vec<Token>> {
-        let mut output_tokens = vec![];
-
-        for (index, (token, initial_offsets)) in tokens.into_iter().enumerate() {
-            let t = Token {
-                id: *self
-                    .vocab
-                    .get(&*token)
-                    .or_else(|| self.vocab.get(&*self.unk_token))
-                    .ok_or(Error::MissingUnkToken)?,
-                value: token,
-                offsets: initial_offsets,
-                word: index as u32,
-            };
-
-            output_tokens.push(t);
-        }
-
-        Ok(output_tokens)
+    fn tokenize(&self, token: &str) -> Result<Vec<Token>> {
+        Ok(vec![Token {
+            id: *self
+                .vocab
+                .get(&*token)
+                .or_else(|| self.vocab.get(&*self.unk_token))
+                .ok_or(Error::MissingUnkToken)?,
+            value: token.to_owned(),
+            offsets: (0, token.chars().count()),
+        }])
     }
 
     fn token_to_id(&self, token: &str) -> Option<u32> {

--- a/tokenizers/src/pre_tokenizers/bert.rs
+++ b/tokenizers/src/pre_tokenizers/bert.rs
@@ -1,4 +1,4 @@
-use crate::tokenizer::{Offsets, PreTokenizedString, PreTokenizer, Result};
+use crate::tokenizer::{Offsets, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use serde::{Deserialize, Serialize};
 use unicode_categories::UnicodeCategories;
 
@@ -44,10 +44,10 @@ pub struct BertPreTokenizer;
 #[typetag::serde]
 impl PreTokenizer for BertPreTokenizer {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
-        pretokenized.split(|_, substr| {
-            let mut parts = vec![];
-            todo!();
-            parts
+        pretokenized.split(|_, sub| {
+            sub.split(char::is_whitespace, SplitDelimiterBehavior::Removed)
+                .into_iter()
+                .flat_map(|sub| sub.split(is_bert_punc, SplitDelimiterBehavior::Isolated))
         })
 
         // let mut split_tokens = vec![];

--- a/tokenizers/src/pre_tokenizers/bert.rs
+++ b/tokenizers/src/pre_tokenizers/bert.rs
@@ -1,4 +1,4 @@
-use crate::tokenizer::{NormalizedString, Offsets, PreTokenizer, Result};
+use crate::tokenizer::{Offsets, PreTokenizedString, PreTokenizer, Result};
 use serde::{Deserialize, Serialize};
 use unicode_categories::UnicodeCategories;
 
@@ -43,16 +43,22 @@ pub struct BertPreTokenizer;
 
 #[typetag::serde]
 impl PreTokenizer for BertPreTokenizer {
-    fn pre_tokenize(&self, normalized: &mut NormalizedString) -> Result<Vec<(String, Offsets)>> {
-        let mut split_tokens = vec![];
-        for (token, offsets) in split_on(normalized.get(), char::is_whitespace, false) {
-            split_tokens.extend(
-                split_on(&token, is_bert_punc, true)
-                    .into_iter()
-                    .map(|(tok, off)| (tok, (off.0 + offsets.0, off.1 + offsets.0))),
-            );
-        }
-        Ok(split_tokens)
+    fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
+        pretokenized.split(|_, substr| {
+            let mut parts = vec![];
+            todo!();
+            parts
+        })
+
+        // let mut split_tokens = vec![];
+        // for (token, offsets) in split_on(normalized.get(), char::is_whitespace, false) {
+        //     split_tokens.extend(
+        //         split_on(&token, is_bert_punc, true)
+        //             .into_iter()
+        //             .map(|(tok, off)| (tok, (off.0 + offsets.0, off.1 + offsets.0))),
+        //     );
+        // }
+        // Ok(split_tokens)
     }
 }
 
@@ -63,20 +69,20 @@ mod tests {
     #[test]
     fn basic() {
         let pretok = BertPreTokenizer;
-        let mut input = NormalizedString::from("Hey friend!     How are you?!?");
-        let res = pretok.pre_tokenize(&mut input).unwrap();
+        let mut pretokenized: PreTokenizedString = "Hey friend!     How are you?!?".into();
+        pretok.pre_tokenize(&mut pretokenized).unwrap();
         assert_eq!(
-            &res,
-            &[
-                ("Hey".into(), (0, 3)),
-                ("friend".into(), (4, 10)),
-                ("!".into(), (10, 11)),
-                ("How".into(), (16, 19)),
-                ("are".into(), (20, 23)),
-                ("you".into(), (24, 27)),
-                ("?".into(), (27, 28)),
-                ("!".into(), (28, 29)),
-                ("?".into(), (29, 30)),
+            pretokenized.get_normalized(),
+            vec![
+                ("Hey", (0, 3)),
+                ("friend", (4, 10)),
+                ("!", (10, 11)),
+                ("How", (16, 19)),
+                ("are", (20, 23)),
+                ("you", (24, 27)),
+                ("?", (27, 28)),
+                ("!", (28, 29)),
+                ("?", (29, 30)),
             ]
         );
     }

--- a/tokenizers/src/pre_tokenizers/bert.rs
+++ b/tokenizers/src/pre_tokenizers/bert.rs
@@ -39,7 +39,7 @@ mod tests {
         let mut pretokenized: PreTokenizedString = "Hey friend!     How are you?!?".into();
         pretok.pre_tokenize(&mut pretokenized).unwrap();
         assert_eq!(
-            pretokenized.get_normalized(),
+            pretokenized.get_normalized(true),
             vec![
                 ("Hey", (0, 3)),
                 ("", (3, 4)),

--- a/tokenizers/src/pre_tokenizers/bert.rs
+++ b/tokenizers/src/pre_tokenizers/bert.rs
@@ -32,6 +32,7 @@ impl PreTokenizer for BertPreTokenizer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::OffsetReferential;
 
     #[test]
     fn basic() {
@@ -39,7 +40,7 @@ mod tests {
         let mut pretokenized: PreTokenizedString = "Hey friend!     How are you?!?".into();
         pretok.pre_tokenize(&mut pretokenized).unwrap();
         assert_eq!(
-            pretokenized.get_normalized(true),
+            pretokenized.get_normalized(OffsetReferential::Original),
             vec![
                 ("Hey", (0, 3)),
                 ("", (3, 4)),

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -91,7 +91,8 @@ impl PreTokenizer for ByteLevel {
                 normalized.prepend(" ");
             }
 
-            RE.find_iter(normalized.get())
+            Ok(RE
+                .find_iter(normalized.get())
                 .map(|(start, end)| {
                     let mut part = normalized
                         .slice_bytes(Range::Normalized(start..end))
@@ -115,7 +116,7 @@ impl PreTokenizer for ByteLevel {
 
                     part
                 })
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>())
         })
     }
 }

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -228,7 +228,7 @@ mod tests {
         let mut pretokenized: PreTokenizedString = "Hello my friend, how is your day going?".into();
         bytelevel.pre_tokenize(&mut pretokenized).unwrap();
         assert_eq!(
-            pretokenized.get_normalized(),
+            pretokenized.get_normalized(true),
             vec![
                 ("Hello", (0, 5)),
                 ("Ġmy", (5, 8)),
@@ -273,7 +273,7 @@ mod tests {
             let mut pretokenized = PreTokenizedString::from(*s);
             bytelevel.pre_tokenize(&mut pretokenized).unwrap();
             assert_eq!(
-                pretokenized.get_normalized(),
+                pretokenized.get_normalized(false),
                 vec![
                     ("ĠHello", (0, 6)),
                     ("Ġmy", (6, 9)),
@@ -317,7 +317,7 @@ mod tests {
         bytelevel.pre_tokenize(&mut pretokenized).unwrap();
 
         assert_eq!(
-            pretokenized.get_normalized(),
+            pretokenized.get_normalized(true),
             vec![
                 ("Hello", (0, 5)),
                 ("Ġthere", (5, 11)),
@@ -335,7 +335,7 @@ mod tests {
         bytelevel.pre_tokenize(&mut pretokenized).unwrap();
 
         assert_eq!(
-            pretokenized.get_normalized(),
+            pretokenized.get_normalized(true),
             vec![
                 ("Hello", (0, 5)),
                 ("Ġthere", (5, 11)),
@@ -352,8 +352,12 @@ mod tests {
         bytelevel.pre_tokenize(&mut pretokenized).unwrap();
 
         assert_eq!(
-            pretokenized.get_normalized(),
-            vec![("i", (0, 1)), ("âŃ¢", (1, 4)), ("j", (4, 5)),]
+            pretokenized.get_normalized(true),
+            vec![("i", (0, 1)), ("âŃ¢", (1, 2)), ("j", (2, 3))]
+        );
+        assert_eq!(
+            pretokenized.get_normalized(false),
+            vec![("i", (0, 1)), ("âŃ¢", (1, 4)), ("j", (4, 5))]
         );
         assert_eq!(
             pretokenized

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -1,5 +1,5 @@
 use crate::tokenizer::{
-    Decoder, Encoding, PostProcessor, PreTokenizedString, PreTokenizer, Range, Result,
+    normalizer::Range, Decoder, Encoding, PostProcessor, PreTokenizedString, PreTokenizer, Result,
 };
 use onig::Regex;
 use serde::{Deserialize, Serialize};
@@ -217,7 +217,8 @@ pub fn process_offsets(encoding: &mut Encoding, add_prefix_space: bool) {
 mod tests {
     use super::ByteLevel;
     use crate::tokenizer::{
-        Decoder, Encoding, NormalizedString, PostProcessor, PreTokenizedString, PreTokenizer, Range,
+        normalizer::Range, Decoder, Encoding, NormalizedString, PostProcessor, PreTokenizedString,
+        PreTokenizer,
     };
 
     #[test]

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -218,8 +218,8 @@ pub fn process_offsets(encoding: &mut Encoding, add_prefix_space: bool) {
 mod tests {
     use super::ByteLevel;
     use crate::tokenizer::{
-        normalizer::Range, Decoder, Encoding, NormalizedString, PostProcessor, PreTokenizedString,
-        PreTokenizer,
+        normalizer::Range, Decoder, Encoding, NormalizedString, OffsetReferential, PostProcessor,
+        PreTokenizedString, PreTokenizer,
     };
 
     #[test]
@@ -228,7 +228,7 @@ mod tests {
         let mut pretokenized: PreTokenizedString = "Hello my friend, how is your day going?".into();
         bytelevel.pre_tokenize(&mut pretokenized).unwrap();
         assert_eq!(
-            pretokenized.get_normalized(true),
+            pretokenized.get_normalized(OffsetReferential::Original),
             vec![
                 ("Hello", (0, 5)),
                 ("Ġmy", (5, 8)),
@@ -273,7 +273,7 @@ mod tests {
             let mut pretokenized = PreTokenizedString::from(*s);
             bytelevel.pre_tokenize(&mut pretokenized).unwrap();
             assert_eq!(
-                pretokenized.get_normalized(false),
+                pretokenized.get_normalized(OffsetReferential::Normalized),
                 vec![
                     ("ĠHello", (0, 6)),
                     ("Ġmy", (6, 9)),
@@ -317,7 +317,7 @@ mod tests {
         bytelevel.pre_tokenize(&mut pretokenized).unwrap();
 
         assert_eq!(
-            pretokenized.get_normalized(true),
+            pretokenized.get_normalized(OffsetReferential::Original),
             vec![
                 ("Hello", (0, 5)),
                 ("Ġthere", (5, 11)),
@@ -335,7 +335,7 @@ mod tests {
         bytelevel.pre_tokenize(&mut pretokenized).unwrap();
 
         assert_eq!(
-            pretokenized.get_normalized(true),
+            pretokenized.get_normalized(OffsetReferential::Original),
             vec![
                 ("Hello", (0, 5)),
                 ("Ġthere", (5, 11)),
@@ -352,11 +352,11 @@ mod tests {
         bytelevel.pre_tokenize(&mut pretokenized).unwrap();
 
         assert_eq!(
-            pretokenized.get_normalized(true),
+            pretokenized.get_normalized(OffsetReferential::Original),
             vec![("i", (0, 1)), ("âŃ¢", (1, 2)), ("j", (2, 3))]
         );
         assert_eq!(
-            pretokenized.get_normalized(false),
+            pretokenized.get_normalized(OffsetReferential::Normalized),
             vec![("i", (0, 1)), ("âŃ¢", (1, 4)), ("j", (4, 5))]
         );
         assert_eq!(

--- a/tokenizers/src/pre_tokenizers/delimiter.rs
+++ b/tokenizers/src/pre_tokenizers/delimiter.rs
@@ -1,4 +1,4 @@
-use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result};
+use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -15,6 +15,9 @@ impl CharDelimiterSplit {
 #[typetag::serde]
 impl PreTokenizer for CharDelimiterSplit {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
-        pretokenized.split(|_, normalized| normalized.split(self.delimiter))
+        // TODO: Maybe add the option to specify the behavior
+        pretokenized.split(|_, normalized| {
+            normalized.split(self.delimiter, SplitDelimiterBehavior::Removed)
+        })
     }
 }

--- a/tokenizers/src/pre_tokenizers/delimiter.rs
+++ b/tokenizers/src/pre_tokenizers/delimiter.rs
@@ -1,4 +1,4 @@
-use crate::tokenizer::{NormalizedString, Offsets, PreTokenizer, Result};
+use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -14,27 +14,7 @@ impl CharDelimiterSplit {
 
 #[typetag::serde]
 impl PreTokenizer for CharDelimiterSplit {
-    fn pre_tokenize(&self, normalized: &mut NormalizedString) -> Result<Vec<(String, Offsets)>> {
-        let mut words = vec![];
-        let mut word = Vec::with_capacity(1000);
-        let mut offset = 0;
-
-        normalized.get().chars().for_each(|c| {
-            if c == self.delimiter {
-                if !word.is_empty() {
-                    let offsets = (offset - word.len(), offset);
-                    words.push((word.drain(0..).collect::<String>(), offsets));
-                }
-            } else {
-                word.push(c);
-            }
-            offset += 1;
-        });
-        if !word.is_empty() {
-            let offsets = (offset - word.len(), offset);
-            words.push((word.drain(0..).collect::<String>(), offsets));
-        }
-
-        Ok(words)
+    fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
+        pretokenized.split(|_, normalized| normalized.split(self.delimiter))
     }
 }

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -38,8 +38,8 @@ impl PreTokenizer for Metaspace {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
         let replacement = self.replacement.to_string();
         pretokenized.split(|_, normalized| {
-            normalized
-                .split(' ', SplitDelimiterBehavior::MergedWithNext)
+            Ok(normalized
+                .split(' ', SplitDelimiterBehavior::MergedWithNext)?
                 .into_iter()
                 .enumerate()
                 .map(|(i, mut normalized)| {
@@ -48,7 +48,7 @@ impl PreTokenizer for Metaspace {
                         normalized.prepend(&replacement);
                     }
                     normalized
-                })
+                }))
         })
     }
 }

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -1,4 +1,4 @@
-use crate::tokenizer::{Decoder, NormalizedString, Offsets, PreTokenizer, Result};
+use crate::tokenizer::{Decoder, PreTokenizedString, PreTokenizer, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -26,32 +26,20 @@ impl Default for Metaspace {
 
 #[typetag::serde]
 impl PreTokenizer for Metaspace {
-    fn pre_tokenize(&self, normalized: &mut NormalizedString) -> Result<Vec<(String, Offsets)>> {
-        if self.add_prefix_space && !normalized.get().starts_with(' ') {
-            normalized.prepend(" ");
-        }
-
-        let mut words = vec![];
-        let mut word = Vec::with_capacity(1000);
-        let mut offset = 0;
-        normalized.get().chars().for_each(|c| {
-            if c.is_whitespace() {
-                if !word.is_empty() {
-                    let offsets = (offset - word.len(), offset);
-                    words.push((word.drain(0..).collect::<String>(), offsets));
-                }
-                word.push(self.replacement)
-            } else {
-                word.push(c);
-            }
-            offset += 1;
-        });
-        if !word.is_empty() {
-            let offsets = (offset - word.len(), offset);
-            words.push((word.drain(0..).collect::<String>(), offsets));
-        }
-
-        Ok(words)
+    fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
+        let replacement = self.replacement.to_string();
+        pretokenized.split(|_, normalized| {
+            normalized
+                .split(' ')
+                .into_iter()
+                .enumerate()
+                .map(|(i, mut normalized)| {
+                    if i > 0 || (i == 0 && self.add_prefix_space) {
+                        normalized.prepend(&replacement);
+                    }
+                    normalized
+                })
+        })
     }
 }
 
@@ -84,26 +72,26 @@ mod tests {
     #[test]
     fn basic() {
         let pretok = Metaspace::new('▁', true);
-        let mut input = NormalizedString::from("Hey friend!");
-        let res = pretok.pre_tokenize(&mut input).unwrap();
+        let mut pretokenized = PreTokenizedString::from("Hey friend!");
+        pretok.pre_tokenize(&mut pretokenized).unwrap();
         assert_eq!(
-            &res,
-            &[("▁Hey".into(), (0, 4)), ("▁friend!".into(), (4, 12)),]
+            pretokenized.get_normalized(),
+            vec![("▁Hey", (0, 4)), ("▁friend!", (4, 12))]
         );
     }
 
     #[test]
     fn multiple_spaces() {
         let pretok = Metaspace::new('▁', true);
-        let mut input = NormalizedString::from("Hey   friend!");
-        let res = pretok.pre_tokenize(&mut input).unwrap();
+        let mut pretokenized = PreTokenizedString::from("Hey   friend!");
+        pretok.pre_tokenize(&mut pretokenized).unwrap();
         assert_eq!(
-            &res,
-            &[
-                ("▁Hey".into(), (0, 4)),
-                ("▁".into(), (4, 5)),
-                ("▁".into(), (5, 6)),
-                ("▁friend!".into(), (6, 14)),
+            pretokenized.get_normalized(),
+            vec![
+                ("▁Hey", (0, 4)),
+                ("▁", (4, 5)),
+                ("▁", (5, 6)),
+                ("▁friend!", (6, 14)),
             ]
         );
     }

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -60,14 +60,22 @@ mod tests {
         let tests = vec![
             (
                 "Hey man!",
-                vec![("Hey", (0, 3)), ("man", (4, 7)), ("!", (7, 8))],
+                vec![
+                    ("Hey", (0, 3)),
+                    ("", (3, 4)),
+                    ("man", (4, 7)),
+                    ("!", (7, 8)),
+                ],
             ),
             (
                 "How are you doing?",
                 vec![
                     ("How", (0, 3)),
+                    ("", (3, 4)),
                     ("are", (4, 7)),
+                    ("", (7, 8)),
                     ("you", (8, 11)),
+                    ("", (11, 12)),
                     ("doing", (12, 17)),
                     ("?", (17, 18)),
                 ],
@@ -84,10 +92,19 @@ mod tests {
     #[test]
     fn whitespace_split() {
         let tests = vec![
-            ("Hey man!", vec![("Hey", (0, 3)), ("man!", (4, 8))]),
+            (
+                "Hey man!",
+                vec![("Hey", (0, 3)), ("", (3, 4)), ("man!", (4, 8))],
+            ),
             (
                 "Hey, man, Good?",
-                vec![("Hey,", (0, 4)), ("man,", (5, 9)), ("Good?", (10, 15))],
+                vec![
+                    ("Hey,", (0, 4)),
+                    ("", (4, 5)),
+                    ("man,", (5, 9)),
+                    ("", (9, 10)),
+                    ("Good?", (10, 15)),
+                ],
             ),
         ];
         let pretok = WhitespaceSplit;

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -72,6 +72,7 @@ mod tests {
                     ("?", (17, 18)),
                 ],
             ),
+            ("\n", vec![("", (0, 1))]),
         ];
         let pretok = Whitespace::default();
         for (s, res) in tests {

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -1,4 +1,4 @@
-use crate::tokenizer::{NormalizedString, Offsets, PreTokenizer, Result};
+use crate::tokenizer::{PreTokenizedString, PreTokenizer, Range, Result};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
@@ -6,25 +6,22 @@ use serde::{Deserialize, Serialize};
 pub struct Whitespace;
 #[typetag::serde]
 impl PreTokenizer for Whitespace {
-    fn pre_tokenize(&self, normalized: &mut NormalizedString) -> Result<Vec<(String, Offsets)>> {
+    fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
         lazy_static! {
             static ref RE: Regex = Regex::new(r"\w+|[^\w\s]+").unwrap();
         }
-        Ok(RE
-            .captures_iter(normalized.get())
-            .flat_map(|captures| {
-                captures
-                    .iter()
-                    .map(|m| {
-                        m.map(|capture| {
-                            let (start, end) = (capture.start(), capture.end());
-                            (normalized.get()[start..end].to_owned(), (start, end))
-                        })
-                        .unwrap_or_else(|| (String::from(""), (0, 0)))
-                    })
-                    .collect::<Vec<(String, Offsets)>>()
-            })
-            .collect())
+
+        pretokenized.split(|_, normalized| {
+            RE.find_iter(&normalized.get())
+                .map(|m| {
+                    let (start, end) = (m.start(), m.end());
+                    println!("{:?}\t{:?}", start, end);
+                    normalized
+                        .slice_bytes(Range::Normalized(start..end))
+                        .expect("Whitespace cannot split according to regex")
+                })
+                .collect::<Vec<_>>()
+        })
     }
 }
 
@@ -32,28 +29,8 @@ impl PreTokenizer for Whitespace {
 pub struct WhitespaceSplit;
 #[typetag::serde]
 impl PreTokenizer for WhitespaceSplit {
-    fn pre_tokenize(&self, normalized: &mut NormalizedString) -> Result<Vec<(String, Offsets)>> {
-        let mut words = vec![];
-        let mut word = Vec::with_capacity(1000);
-        let mut offset = 0;
-
-        normalized.get().chars().for_each(|c| {
-            if c.is_whitespace() {
-                if !word.is_empty() {
-                    let offsets = (offset - word.len(), offset);
-                    words.push((word.drain(0..).collect::<String>(), offsets));
-                }
-            } else {
-                word.push(c);
-            }
-            offset += 1;
-        });
-        if !word.is_empty() {
-            let offsets = (offset - word.len(), offset);
-            words.push((word.drain(0..).collect::<String>(), offsets));
-        }
-
-        Ok(words)
+    fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
+        pretokenized.split(|_, normalized| normalized.split(' '))
     }
 }
 
@@ -67,50 +44,41 @@ mod tests {
         let tests = vec![
             (
                 "Hey man!",
-                vec![
-                    ("Hey".into(), (0, 3)),
-                    ("man".into(), (4, 7)),
-                    ("!".into(), (7, 8)),
-                ],
+                vec![("Hey", (0, 3)), ("man", (4, 7)), ("!", (7, 8))],
             ),
             (
                 "How are you doing?",
                 vec![
-                    ("How".into(), (0, 3)),
-                    ("are".into(), (4, 7)),
-                    ("you".into(), (8, 11)),
-                    ("doing".into(), (12, 17)),
-                    ("?".into(), (17, 18)),
+                    ("How", (0, 3)),
+                    ("are", (4, 7)),
+                    ("you", (8, 11)),
+                    ("doing", (12, 17)),
+                    ("?", (17, 18)),
                 ],
             ),
         ];
         let pretok = Whitespace;
         for (s, res) in tests {
-            let mut input = NormalizedString::from(s);
-            assert_eq!(pretok.pre_tokenize(&mut input).unwrap(), res);
+            let mut pretokenized = PreTokenizedString::from(s);
+            pretok.pre_tokenize(&mut pretokenized).unwrap();
+            assert_eq!(pretokenized.get_normalized(), res);
         }
     }
 
     #[test]
     fn whitespace_split() {
         let tests = vec![
-            (
-                "Hey man!",
-                vec![("Hey".into(), (0, 3)), ("man!".into(), (4, 8))],
-            ),
+            ("Hey man!", vec![("Hey", (0, 3)), ("man!", (4, 8))]),
             (
                 "Hey, man, Good?",
-                vec![
-                    ("Hey,".into(), (0, 4)),
-                    ("man,".into(), (5, 9)),
-                    ("Good?".into(), (10, 15)),
-                ],
+                vec![("Hey,", (0, 4)), ("man,", (5, 9)), ("Good?", (10, 15))],
             ),
         ];
         let pretok = WhitespaceSplit;
         for (s, res) in tests {
-            let mut input = NormalizedString::from(s);
-            assert_eq!(pretok.pre_tokenize(&mut input).unwrap(), res);
+            let mut pretokenized = PreTokenizedString::from(s);
+            pretok.pre_tokenize(&mut pretokenized).unwrap();
+            assert_eq!(pretokenized.get_normalized(), res);
         }
     }
 }

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -85,7 +85,7 @@ mod tests {
         for (s, res) in tests {
             let mut pretokenized = PreTokenizedString::from(s);
             pretok.pre_tokenize(&mut pretokenized).unwrap();
-            assert_eq!(pretokenized.get_normalized(), res);
+            assert_eq!(pretokenized.get_normalized(true), res);
         }
     }
 
@@ -111,7 +111,7 @@ mod tests {
         for (s, res) in tests {
             let mut pretokenized = PreTokenizedString::from(s);
             pretok.pre_tokenize(&mut pretokenized).unwrap();
-            assert_eq!(pretokenized.get_normalized(), res);
+            assert_eq!(pretokenized.get_normalized(true), res);
         }
     }
 }

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -45,7 +45,7 @@ impl PreTokenizer for WhitespaceSplit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tokenizer::PreTokenizer;
+    use crate::{OffsetReferential, PreTokenizer};
 
     #[test]
     fn basic() {
@@ -77,7 +77,10 @@ mod tests {
         for (s, res) in tests {
             let mut pretokenized = PreTokenizedString::from(s);
             pretok.pre_tokenize(&mut pretokenized).unwrap();
-            assert_eq!(pretokenized.get_normalized(true), res);
+            assert_eq!(
+                pretokenized.get_normalized(OffsetReferential::Original),
+                res
+            );
         }
     }
 
@@ -103,7 +106,10 @@ mod tests {
         for (s, res) in tests {
             let mut pretokenized = PreTokenizedString::from(s);
             pretok.pre_tokenize(&mut pretokenized).unwrap();
-            assert_eq!(pretokenized.get_normalized(true), res);
+            assert_eq!(
+                pretokenized.get_normalized(OffsetReferential::Original),
+                res
+            );
         }
     }
 }

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -27,15 +27,6 @@ impl PreTokenizer for Whitespace {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
         pretokenized.split(|_, normalized| {
             normalized.split(Invert(&self.re), SplitDelimiterBehavior::Removed)
-            //RE.find_iter(&normalized.get())
-            //    .map(|m| {
-            //        let (start, end) = (m.start(), m.end());
-            //        println!("{:?}\t{:?}", start, end);
-            //        normalized
-            //            .slice_bytes(Range::Normalized(start..end))
-            //            .expect("Whitespace cannot split according to regex")
-            //    })
-            //    .collect::<Vec<_>>()
         })
     }
 }
@@ -43,10 +34,11 @@ impl PreTokenizer for Whitespace {
 #[derive(Serialize, Deserialize)]
 pub struct WhitespaceSplit;
 #[typetag::serde]
-#[deprecated = "Prefer using DelimiterSplit, specifying the relevant delimiter"]
 impl PreTokenizer for WhitespaceSplit {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
-        pretokenized.split(|_, normalized| normalized.split(' ', SplitDelimiterBehavior::Removed))
+        pretokenized.split(|_, normalized| {
+            normalized.split(char::is_whitespace, SplitDelimiterBehavior::Removed)
+        })
     }
 }
 

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -442,7 +442,7 @@ impl AddedVocabulary {
             .split(|_, sequence| {
                 let (idcs, split) = self.split_with_indices(sequence, &self.split_re);
                 indices = idcs;
-                split
+                Ok(split)
             })
             .expect("AddedVocabulary bad split");
 
@@ -452,14 +452,14 @@ impl AddedVocabulary {
             .split(|i, mut sequence| {
                 if let Some(id) = indices[i] {
                     multi_indices.push(vec![Some(id)]);
-                    itertools::Either::Left(std::iter::once(sequence))
+                    Ok(itertools::Either::Left(std::iter::once(sequence)))
                 } else {
                     normalizer.map(|n| n.normalize(&mut sequence));
 
                     let (idcs, split) =
                         self.split_with_indices(sequence, &self.split_normalized_re);
                     multi_indices.push(idcs);
-                    itertools::Either::Right(split)
+                    Ok(itertools::Either::Right(split))
                 }
             })
             .expect("AddedVocabulary bad split");

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -1,4 +1,4 @@
-use super::{Model, NormalizedString, Normalizer, Offsets, PreTokenizedString, Range};
+use super::{normalizer::Range, Model, NormalizedString, Normalizer, Offsets, PreTokenizedString};
 use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
 use std::collections::{HashMap, HashSet};
 

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -671,7 +671,7 @@ mod tests {
         assert_eq!(
             result
                 .iter()
-                .map(|(normalized, offsets, id)| (normalized.get(), id))
+                .map(|(normalized, _, id)| (normalized.get(), id))
                 .collect::<Vec<_>>(),
             vec![
                 ("[CLS]", &Some(2)),
@@ -716,7 +716,7 @@ mod tests {
         assert_eq!(
             result
                 .iter()
-                .map(|(normalized, offsets, id)| (normalized.get(), id))
+                .map(|(normalized, _, id)| (normalized.get(), id))
                 .collect::<Vec<_>>(),
             vec![
                 ("[CLS]", &Some(3)),

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -472,7 +472,7 @@ impl AddedVocabulary {
             .map(|(substring, id)| {
                 (
                     substring.normalized,
-                    substring.offsets,
+                    substring.original_offsets,
                     id.map(|i| i as u32),
                 )
             })

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -454,24 +454,22 @@ impl AddedVocabulary {
         pretokenized
             .split(|i, mut sequence| {
                 if let Some(id) = indices[i] {
-                    multi_indices.push(vec![Some(id)]);
+                    multi_indices.push(Some(id));
                     Ok(itertools::Either::Left(std::iter::once(sequence)))
                 } else {
                     normalizer.map(|n| n.normalize(&mut sequence));
 
                     let (idcs, split) =
                         self.split_with_indices(sequence, &self.split_normalized_re);
-                    multi_indices.push(idcs);
+                    multi_indices.extend(idcs);
                     Ok(itertools::Either::Right(split))
                 }
             })
             .expect("AddedVocabulary bad split");
 
-        let indices = multi_indices.into_iter().flatten().collect::<Vec<_>>();
-
         pretokenized
             .into_iter()
-            .zip(indices)
+            .zip(multi_indices)
             .map(|(substring, id)| {
                 (
                     substring.normalized,

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -390,6 +390,9 @@ impl AddedVocabulary {
                 splits.push((None, (end, sentence.len())));
             }
         }
+        if splits.is_empty() {
+            splits.push((None, (0, sentence.len())));
+        }
 
         splits
     }
@@ -412,7 +415,7 @@ impl AddedVocabulary {
             indices,
             offsets.into_iter().map(move |(start, end)| {
                 sentence
-                    .slice(Range::Normalized(start..end))
+                    .slice_bytes(Range::Normalized(start..end))
                     .expect("Error while extracting normalized Range")
             }),
         )

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -47,6 +47,19 @@ impl Encoding {
         }
     }
 
+    pub fn with_capacity(len: usize) -> Self {
+        Encoding {
+            ids: Vec::with_capacity(len),
+            type_ids: Vec::with_capacity(len),
+            tokens: Vec::with_capacity(len),
+            words: Vec::with_capacity(len),
+            offsets: Vec::with_capacity(len),
+            special_tokens_mask: Vec::with_capacity(len),
+            attention_mask: Vec::with_capacity(len),
+            overflowing: vec![],
+        }
+    }
+
     pub fn from_tokens(tokens: Vec<Token>, type_id: u32) -> Self {
         let length = tokens.len();
         let (ids, tokens, offsets) = tokens.into_iter().fold(
@@ -401,6 +414,27 @@ impl Encoding {
 impl std::iter::FromIterator<Encoding> for Encoding {
     fn from_iter<I: IntoIterator<Item = Encoding>>(iter: I) -> Self {
         Self::merge(iter, false)
+    }
+}
+
+impl std::iter::FromIterator<(u32, String, (usize, usize), Option<u32>, u32)> for Encoding {
+    fn from_iter<I: IntoIterator<Item = (u32, String, (usize, usize), Option<u32>, u32)>>(
+        iter: I,
+    ) -> Self {
+        let items = iter.into_iter();
+        let (lower, upper) = items.size_hint();
+        let length = upper.unwrap_or(lower);
+        let mut encoding = Self::with_capacity(length);
+
+        for (id, token, offsets, word, type_id) in items {
+            encoding.ids.push(id);
+            encoding.tokens.push(token);
+            encoding.offsets.push(offsets);
+            encoding.type_ids.push(type_id);
+            encoding.words.push(word);
+        }
+
+        encoding
     }
 }
 

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -276,20 +276,30 @@ impl Encoding {
     }
 
     /// Merge all Encodings together
-    pub fn merge(encodings: &[Encoding], growing_offsets: bool) -> Encoding {
-        if encodings.is_empty() {
-            return Encoding::default();
+    pub fn merge<I: IntoIterator<Item = Encoding>>(encodings: I, growing_offsets: bool) -> Self {
+        let mut encoding = Encoding::default();
+
+        for sub in encodings {
+            encoding.merge_with(sub, growing_offsets);
         }
 
-        let (firsts, others) = encodings.split_at(1);
-        let mut first: Encoding = firsts[0].clone();
-
-        for encoding in others {
-            first.merge_with(encoding.clone(), growing_offsets);
-        }
-
-        first
+        encoding
     }
+
+    // pub fn merge(encodings: &[Encoding], growing_offsets: bool) -> Encoding {
+    //     if encodings.is_empty() {
+    //         return Encoding::default();
+    //     }
+
+    //     let (firsts, others) = encodings.split_at(1);
+    //     let mut first: Encoding = firsts[0].clone();
+
+    //     for encoding in others {
+    //         first.merge_with(encoding.clone(), growing_offsets);
+    //     }
+
+    //     first
+    // }
 
     /// Merge ourself with the given `Encoding`. Happens in place.
     pub fn merge_with(&mut self, pair: Encoding, growing_offsets: bool) {
@@ -415,6 +425,12 @@ impl Encoding {
                 self.offsets.extend((0..pad_length).map(|_| (0, 0)));
             }
         }
+    }
+}
+
+impl std::iter::FromIterator<Encoding> for Encoding {
+    fn from_iter<I: IntoIterator<Item = Encoding>>(iter: I) -> Self {
+        Self::merge(iter, false)
     }
 }
 

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -330,20 +330,7 @@ impl Encoding {
         self.ids.extend(pair.ids);
         self.type_ids.extend(pair.type_ids);
         self.tokens.extend(pair.tokens);
-
-        let starting_word = self
-            .words
-            .iter()
-            .cloned()
-            .max()
-            .flatten()
-            .map_or(0, |w| w + 1);
-        self.words.extend(
-            pair.words
-                .into_iter()
-                .map(|w| w.map(|w| w + starting_word))
-                .collect::<Vec<_>>(),
-        );
+        self.words.extend(pair.words);
 
         let starting_offset = if growing_offsets {
             self.offsets.last().map_or(0, |o| o.1)
@@ -483,7 +470,7 @@ mod tests {
                 ids: vec![1, 2],
                 type_ids: vec![0, 1],
                 tokens: vec![String::from("Hello "), String::from("World!")],
-                words: vec![Some(0), Some(1)],
+                words: vec![Some(0), Some(0)],
                 offsets: vec![(0, 6), (6, 12)],
                 special_tokens_mask: vec![0, 0],
                 attention_mask: vec![1, 1],

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -49,19 +49,17 @@ impl Encoding {
 
     pub fn from_tokens(tokens: Vec<Token>, type_id: u32) -> Self {
         let length = tokens.len();
-        let (ids, tokens, offsets, words) = tokens.into_iter().fold(
+        let (ids, tokens, offsets) = tokens.into_iter().fold(
             (
                 Vec::with_capacity(length),
                 Vec::with_capacity(length),
                 Vec::with_capacity(length),
-                Vec::with_capacity(length),
             ),
-            |(mut ids, mut tokens, mut offsets, mut words), t| {
+            |(mut ids, mut tokens, mut offsets), t| {
                 ids.push(t.id);
                 tokens.push(t.value);
                 offsets.push(t.offsets);
-                words.push(Some(t.word));
-                (ids, tokens, offsets, words)
+                (ids, tokens, offsets)
             },
         );
 
@@ -69,7 +67,7 @@ impl Encoding {
             ids,
             tokens,
             offsets,
-            words,
+            words: vec![None; length],
             type_ids: vec![type_id; length],
             attention_mask: vec![1; length],
             special_tokens_mask: vec![0; length],

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -284,21 +284,6 @@ impl Encoding {
         encoding
     }
 
-    // pub fn merge(encodings: &[Encoding], growing_offsets: bool) -> Encoding {
-    //     if encodings.is_empty() {
-    //         return Encoding::default();
-    //     }
-
-    //     let (firsts, others) = encodings.split_at(1);
-    //     let mut first: Encoding = firsts[0].clone();
-
-    //     for encoding in others {
-    //         first.merge_with(encoding.clone(), growing_offsets);
-    //     }
-
-    //     first
-    // }
-
     /// Merge ourself with the given `Encoding`. Happens in place.
     pub fn merge_with(&mut self, pair: Encoding, growing_offsets: bool) {
         // Handle merging the overflowing parts too: Combine them all

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -387,7 +387,6 @@ impl Tokenizer {
         let mut normalized = self
             .added_vocabulary
             .extract_and_normalize(self.normalizer.as_deref(), sentence)
-            .into_iter()
             .map(|(mut sentence, id)| -> Result<NormalizedString> {
                 if id.is_some() {
                     Ok(sentence)
@@ -419,7 +418,6 @@ impl Tokenizer {
             let results = self
                 .added_vocabulary
                 .extract_and_normalize(self.normalizer.as_deref(), &subseq)
-                .into_iter()
                 .map(
                     |(mut normalized, id)| -> Result<(Encoding, NormalizedString)> {
                         if let Some(id) = id {

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -31,7 +31,7 @@ mod serialization;
 
 pub use added_vocabulary::*;
 pub use encoding::*;
-pub use normalizer::{NormalizedString, SplitDelimiterBehavior};
+pub use normalizer::{NormalizedString, OffsetReferential, SplitDelimiterBehavior};
 pub use pre_tokenizer::*;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
@@ -423,6 +423,7 @@ impl Tokenizer {
                     .added_vocabulary
                     .extract_and_normalize(self.normalizer.as_deref(), &subseq)
                     .map(|(normalized, original_offsets, id)| match id {
+                        // This is an added token, no need to tokenize, we have the ID
                         Some(id) => {
                             let mut encoding = Encoding::from_tokens(
                                 vec![Token::new(
@@ -435,6 +436,7 @@ impl Tokenizer {
                             encoding.get_words_mut()[0] = Some(0);
                             Ok(encoding)
                         }
+                        // Let's tokenize
                         None => self.do_tokenize(
                             self.do_pre_tokenize(normalized)?,
                             original_offsets,
@@ -673,45 +675,40 @@ impl Tokenizer {
     ) -> Result<Encoding> {
         let pretokenized: PreTokenizedString = pretokenized.into();
 
-        let mut empty_words = 0;
         pretokenized
             .into_iter()
+            .filter(|substr| !substr.normalized.is_empty())
             .enumerate()
-            .map(|(word_idx, substr)| {
-                if substr.normalized.is_empty() {
-                    empty_words += 1;
-                    return Ok(Encoding::default());
+            .flat_map(|(word_idx, substr)| {
+                match self.model.tokenize(substr.normalized.get()) {
+                    Ok(tokens) => {
+                        itertools::Either::Left(tokens.into_iter().map(move |token| {
+                            // We convert the normalized offsets back to the original
+                            let converted_offsets = substr
+                                .normalized
+                                .convert_offsets(Range::Normalized(
+                                    token.offsets.0..token.offsets.1,
+                                ))
+                                .map_or(token.offsets, |range| {
+                                    (
+                                        original_offsets.0
+                                            + substr.original_offsets.0
+                                            + range.start,
+                                        original_offsets.0 + substr.original_offsets.0 + range.end,
+                                    )
+                                });
+
+                            Ok((
+                                token.id,
+                                token.value,
+                                converted_offsets,
+                                Some(word_idx as u32),
+                                type_id,
+                            ))
+                        }))
+                    }
+                    Err(e) => itertools::Either::Right(std::iter::once(Err(e))),
                 }
-
-                let mut tokens = self.model.tokenize(substr.normalized.get())?;
-
-                // Update the offsets to match the original input
-                tokens.iter_mut().for_each(|token| {
-                    // We convert the normalized offsets back to the original
-                    let converted_offsets = substr
-                        .normalized
-                        .convert_offsets(Range::Normalized(token.offsets.0..token.offsets.1))
-                        .map_or(token.offsets, |range| {
-                            (
-                                original_offsets.0 + substr.original_offsets.0 + range.start,
-                                original_offsets.0 + substr.original_offsets.0 + range.end,
-                            )
-                        });
-
-                    // And we update the token to these original offsets, applying the original offset
-                    // of the sequence we just tokenized.
-                    token.offsets = converted_offsets;
-                });
-
-                // Then build the encoding from these tokens, setting the `words` as relevant
-                let mut encoding = Encoding::from_tokens(tokens, type_id);
-                encoding.get_words_mut().iter_mut().for_each(|word| {
-                    // empty words are generally spaces, and other things
-                    // that were normalized out, so we dont want to count them in.
-                    *word = Some(word_idx as u32 - empty_words);
-                });
-
-                Ok(encoding)
             })
             .collect()
     }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -443,7 +443,7 @@ impl Tokenizer {
                     })
                     .collect::<Result<Vec<Encoding>>>()?;
 
-                // At this point, the words are good for each sub encoding,
+                // At this point, the `words` are good for each sub encoding independently,
                 // but we need to make them grow sequentially.
                 let mut subseq_encoding: Encoding =
                     encodings

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -13,6 +13,7 @@ pub use crate::utils::iter::LinesWithEnding;
 pub use crate::utils::padding::{pad_encodings, PaddingDirection, PaddingParams, PaddingStrategy};
 pub use crate::utils::truncation::{truncate_encodings, TruncationParams, TruncationStrategy};
 use indicatif::{ProgressBar, ProgressStyle};
+use normalizer::Range;
 use std::{
     collections::HashMap,
     fs::File,
@@ -23,13 +24,14 @@ use std::{
 
 mod added_vocabulary;
 mod encoding;
-mod normalizer;
-mod pre_tokenizer;
+pub mod normalizer;
+pub mod pattern;
+pub mod pre_tokenizer;
 mod serialization;
 
 pub use added_vocabulary::*;
 pub use encoding::*;
-pub use normalizer::*;
+pub use normalizer::{NormalizedString, SplitDelimiterBehavior};
 pub use pre_tokenizer::*;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -443,7 +443,9 @@ impl Tokenizer {
                 // relevant index from the given input, not determined by the pre-tokenization step
                 if pre_tokenized {
                     subseq_encoding.get_words_mut().iter_mut().for_each(|word| {
-                        word.as_mut().map(|w| *w = subseq_idx as u32);
+                        if let Some(ref mut word) = word {
+                            *word = subseq_idx as u32;
+                        }
                     });
                 }
 
@@ -662,17 +664,19 @@ impl Tokenizer {
                 // Update the offsets to match the original input
                 tokens.iter_mut().for_each(|token| {
                     // We convert the normalized offsets back to the original
-                    let original_o = substr
+                    let converted_offsets = substr
                         .normalized
                         .convert_offsets(Range::Normalized(token.offsets.0..token.offsets.1))
-                        .map_or(token.offsets, |range| (range.start, range.end));
+                        .map_or(token.offsets, |range| {
+                            (
+                                original_offsets.0 + substr.original_offsets.0 + range.start,
+                                original_offsets.0 + substr.original_offsets.0 + range.end,
+                            )
+                        });
 
                     // And we update the token to these original offsets, applying the original offset
                     // of the sequence we just tokenized.
-                    token.offsets = (
-                        original_o.0 + original_offsets.0,
-                        original_o.1 + original_offsets.0,
-                    );
+                    token.offsets = converted_offsets;
                 });
 
                 // Then build the encoding from these tokens, setting the `words` as relevant

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -36,6 +36,7 @@ pub use pre_tokenizer::*;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T> = std::result::Result<T, Error>;
+pub type ByteOffsets = (usize, usize);
 pub type Offsets = (usize, usize);
 
 use crate::utils::parallelism::*;

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -61,15 +61,6 @@ pub struct NormalizedString {
 }
 
 impl NormalizedString {
-    /// Create a NormalizedString from the given str
-    pub fn from(s: &str) -> Self {
-        NormalizedString {
-            original: s.to_owned(),
-            normalized: s.to_owned(),
-            alignments: (0..s.chars().count()).map(|v| (v, v + 1)).collect(),
-        }
-    }
-
     /// Return the normalized string
     pub fn get(&self) -> &str {
         &self.normalized
@@ -362,7 +353,7 @@ impl NormalizedString {
     /// Split off ourselves, returning a new Self that contains the range [at, len).
     /// self will then contain the range [0, at).
     /// The provided `at` indexes on `char` not bytes.
-    pub fn split_off(&mut self, at: usize) -> Self {
+    fn ssplit_off(&mut self, at: usize) -> Self {
         if at > self.len() {
             return NormalizedString::from("");
         }
@@ -504,6 +495,33 @@ pub fn get_range_of<T: RangeBounds<usize>>(s: &str, range: T) -> Option<&str> {
             .nth(end as usize)
             .unwrap_or_else(|| s.len());
         Some(&s[start_b..end_b])
+    }
+}
+
+impl From<String> for NormalizedString {
+    fn from(s: String) -> Self {
+        let len = s.chars().count();
+        Self {
+            original: s.clone(),
+            normalized: s,
+            alignments: (0..len).map(|v| (v, v + 1)).collect(),
+        }
+    }
+}
+
+impl From<&str> for NormalizedString {
+    fn from(s: &str) -> Self {
+        Self::from(s.to_owned())
+    }
+}
+
+impl std::iter::FromIterator<NormalizedString> for NormalizedString {
+    fn from_iter<I: IntoIterator<Item = NormalizedString>>(iter: I) -> NormalizedString {
+        let mut normalized: NormalizedString = "".into();
+        for sub in iter {
+            normalized.merge_with(&sub)
+        }
+        normalized
     }
 }
 

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -5,6 +5,12 @@ use crate::{Offsets, Result};
 use std::ops::{Bound, RangeBounds};
 use unicode_normalization_alignments::UnicodeNormalization;
 
+/// The possible offsets referential
+pub enum OffsetReferential {
+    Original,
+    Normalized,
+}
+
 /// Represents a Range usable by the NormalizedString to index its content.
 /// A Range can use indices relative to either the `Original` or the `Normalized` string
 #[derive(Debug, Clone)]
@@ -300,11 +306,11 @@ impl NormalizedString {
 
         Some(Self {
             original: get_range_of(&self.original, r_original)
-                .unwrap_or("")
-                .to_owned(),
+                .unwrap_or_default()
+                .into(),
             normalized: get_range_of(&self.normalized, r_normalized.clone())
-                .unwrap_or("")
-                .to_owned(),
+                .unwrap_or_default()
+                .into(),
             alignments: self
                 .alignments
                 .get(r_normalized)?
@@ -462,7 +468,7 @@ impl NormalizedString {
     pub fn replace<P: Pattern>(&mut self, pattern: P, content: &str) -> Result<()> {
         let matches = pattern.find_matches(&self.normalized)?;
 
-        let (normalized, alignments): (Vec<char>, Vec<Offsets>) = matches
+        let (normalized, alignments): (String, Vec<Offsets>) = matches
             .into_iter()
             .flat_map(|((start, end), is_match)| {
                 let len = end - start;
@@ -490,7 +496,7 @@ impl NormalizedString {
             })
             .unzip();
 
-        self.normalized = normalized.into_iter().collect();
+        self.normalized = normalized;
         self.alignments = alignments;
 
         Ok(())

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -231,7 +231,11 @@ impl NormalizedString {
             ),
         };
 
-        let (mut start, mut end) = (None, None);
+        let (mut start, mut end) = if r == (0..0) {
+            (Some(0), Some(0))
+        } else {
+            (None, None)
+        };
         s.char_indices()
             .enumerate()
             .take_while(|(_, (b, _))| *b < r.end)

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -443,15 +443,15 @@ impl NormalizedString {
 
     /// Merge with the given NormalizedString by appending it to self
     pub fn merge_with(&mut self, other: &NormalizedString) {
+        let shift_len = self.len_original();
         self.original.push_str(&other.original);
-        let len = self.len() - 1;
+        self.normalized.push_str(&other.normalized);
         self.alignments.extend(
             other
                 .alignments
                 .iter()
-                .map(|(start, end)| (start + len, end + len)),
+                .map(|(start, end)| (start + shift_len, end + shift_len)),
         );
-        self.normalized.push_str(&other.normalized);
     }
 
     /// Remove any leading space(s) of the normalized string
@@ -824,16 +824,36 @@ mod tests {
 
     #[test]
     fn merge() {
+        // Merge unmodified
+        let s = NormalizedString::from("A sentence that will be merged");
+        let mut merged = NormalizedString::from("A sentence");
+        let s2 = NormalizedString::from(" that will");
+        let s3 = NormalizedString::from(" be merged");
+        merged.merge_with(&s2);
+        merged.merge_with(&s3);
+        assert_eq!(s, merged);
+
+        // Merge grown normalized
         let mut s = NormalizedString::from("A sentence that will be merged");
         s.prepend(" ");
-
         let mut merged = NormalizedString::from("A sentence");
         let s2 = NormalizedString::from(" that will");
         let s3 = NormalizedString::from(" be merged");
         merged.prepend(" ");
         merged.merge_with(&s2);
         merged.merge_with(&s3);
+        assert_eq!(s, merged);
 
+        // Merge shrinked normalized
+        let mut s = NormalizedString::from("  A sentence that will be merged  ");
+        s.strip();
+        let mut merged = NormalizedString::from("  A sentence");
+        merged.strip();
+        let s2 = NormalizedString::from(" that will");
+        let mut s3 = NormalizedString::from(" be merged  ");
+        s3.rstrip();
+        merged.merge_with(&s2);
+        merged.merge_with(&s3);
         assert_eq!(s, merged);
     }
 

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -147,19 +147,28 @@ impl NormalizedString {
 
                 Some(start..end?)
             }
-            Range::Normalized(_) => self
-                .alignments
-                .get(range.into_full_range(self.len()))
-                .map(|alignments| {
-                    if alignments.is_empty() {
-                        None
-                    } else {
-                        let start = alignments[0].0;
-                        let end = alignments[alignments.len() - 1].1;
-                        Some(start..end)
-                    }
-                })
-                .flatten(),
+            Range::Normalized(_) => {
+                // If we target 0..0 on an empty normalized string, we want to return the
+                // entire original one
+                let range = range.into_full_range(self.len());
+
+                if self.alignments.is_empty() && range == (0..0) {
+                    Some(0..self.len_original())
+                } else {
+                    self.alignments
+                        .get(range)
+                        .map(|alignments| {
+                            if alignments.is_empty() {
+                                None
+                            } else {
+                                let start = alignments[0].0;
+                                let end = alignments[alignments.len() - 1].1;
+                                Some(start..end)
+                            }
+                        })
+                        .flatten()
+                }
+            }
         }
     }
 

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::reversed_empty_ranges)]
 
-use super::Offsets;
+use crate::pattern::Pattern;
+use crate::Offsets;
 use std::ops::{Bound, RangeBounds};
 use unicode_normalization_alignments::UnicodeNormalization;
 
@@ -45,21 +46,35 @@ where
     }
 }
 
-/// A `NormalizedString` takes care of processing an "original" string to modify it and obtain a
-/// "normalized" string. It keeps both version of the string, alignments information between both
-/// and provides an interface to retrieve ranges of each string, using offsets from any of them.
+/// Defines the expected behavior for the delimiter of a Split Pattern
+/// When splitting on `'-'` for example, with input `the-final-countdown`:
+///  - Removed => `[ "the", "final", "countdown" ]`
+///  - Isolated => `[ "the", "-", "final", "-", "countdown" ]`
+///  - MergedWithPrevious => `[ "the-", "final-", "countdown" ]`
+///  - MergedWithNext => `[ "the", "-final", "-countdown" ]`
+pub enum SplitDelimiterBehavior {
+    Removed,
+    Isolated,
+    MergedWithPrevious,
+    MergedWithNext,
+}
+
+/// A `NormalizedString` takes care of processing an "original" string to modify
+/// it and obtain a "normalized" string. It keeps both version of the string,
+/// alignments information between both and provides an interface to retrieve
+/// ranges of each string, using offsets from any of them.
 ///
-/// It is possible to retrieve a part of the original string, by indexing it with offsets from the
-/// normalized one, and the other way around too. It is also possible to convert offsets from one
-/// referential to the other one easily.
+/// It is possible to retrieve a part of the original string, by indexing it with
+/// offsets from the normalized one, and the other way around too. It is also
+/// possible to convert offsets from one referential to the other one easily.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct NormalizedString {
     /// The original version of the string, before any modification
     original: String,
     /// The normalized version of the string, after all modifications
     normalized: String,
-    /// Mapping from normalized string to original one: (start, end) for each character of the
-    /// normalized string
+    /// Mapping from normalized string to original one: (start, end) for each
+    /// character of the normalized string
     alignments: Vec<(usize, usize)>,
 }
 
@@ -148,7 +163,7 @@ impl NormalizedString {
         }
     }
 
-    /// Return a range of the normalized string (indexing on char not bytes)
+    /// Return a range of the normalized string (indexing on char, not bytes)
     pub fn get_range<T>(&self, range: Range<T>) -> Option<&str>
     where
         T: RangeBounds<usize> + Clone,
@@ -162,7 +177,7 @@ impl NormalizedString {
         }
     }
 
-    /// Return a range of the original string (indexing on char not bytes)
+    /// Return a range of the original string (indexing on char, not bytes)
     pub fn get_range_original<T>(&self, range: Range<T>) -> Option<&str>
     where
         T: RangeBounds<usize> + Clone,
@@ -434,15 +449,23 @@ impl NormalizedString {
         self
     }
 
-    /// Split ourselves in many subparts. Specify whether the delimiter parts should
-    /// be included or not.
+    /// Replace anything that matches the pattern with the given content.
+    pub fn replace<P: Pattern>(&mut self, pattern: P, content: &str) {
+        todo!()
+    }
+
+    /// Split ourselves in many subparts. Specify what to do with the delimiter.
     ///
     /// This method will always ensure that the entire `self` is covered in the
     /// produced subparts. This means that the delimiter parts will also be included,
     /// and will appear empty if we don't want to include them (their `original`
-    /// part will still be present).
-    // TODO: How can we accept some sort of std::str::pattern::Pattern
-    pub fn split(self, c: char) -> Vec<NormalizedString> {
+    /// part will still be present). It should always be possible to merge all the
+    /// subparts back to the original `NormalizedString`
+    pub fn split<P: Pattern>(
+        self,
+        pattern: P,
+        behavior: SplitDelimiterBehavior,
+    ) -> Vec<NormalizedString> {
         todo!()
     }
 

--- a/tokenizers/src/tokenizer/pattern.rs
+++ b/tokenizers/src/tokenizer/pattern.rs
@@ -28,7 +28,7 @@ impl Pattern for &str {
 impl Pattern for &Regex {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
         if inside.is_empty() {
-            return Ok(vec![]);
+            return Ok(vec![((0, 0), false)]);
         }
 
         // Find initial matches
@@ -69,7 +69,7 @@ where
 {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
         if inside.is_empty() {
-            return Ok(vec![]);
+            return Ok(vec![((0, 0), false)]);
         }
 
         let mut last_offset = 0;
@@ -145,7 +145,7 @@ mod tests {
         do_test!("aba", 'a' => vec![((0, 1), true), ((1, 2), false), ((2, 3), true)]);
         do_test!("bbbba", 'a' => vec![((0, 4), false), ((4, 5), true)]);
         do_test!("aabbb", 'a' => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
-        do_test!("", 'a' => vec![]);
+        do_test!("", 'a' => vec![((0, 0), false)]);
     }
 
     #[test]
@@ -157,7 +157,7 @@ mod tests {
         do_test!("aabbab", "ab" =>
             vec![((0, 1), false), ((1, 3), true), ((3, 4), false), ((4, 6), true)]
         );
-        do_test!("", "" => vec![]);
+        do_test!("", "" => vec![((0, 0), false)]);
     }
 
     #[test]
@@ -166,7 +166,7 @@ mod tests {
         do_test!("aba", is_b => vec![((0, 1), false), ((1, 2), true), ((2, 3), false)]);
         do_test!("aaaab", is_b => vec![((0, 4), false), ((4, 5), true)]);
         do_test!("bbaaa", is_b => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
-        do_test!("", is_b => vec![]);
+        do_test!("", is_b => vec![((0, 0), false)]);
     }
 
     #[test]
@@ -176,6 +176,6 @@ mod tests {
         do_test!("   a   b   ", &is_whitespace =>
             vec![((0, 3), true), ((3, 4), false), ((4, 7), true), ((7, 8), false), ((8, 11), true)]
         );
-        do_test!("", &is_whitespace => vec![]);
+        do_test!("", &is_whitespace => vec![((0, 0), false)]);
     }
 }

--- a/tokenizers/src/tokenizer/pattern.rs
+++ b/tokenizers/src/tokenizer/pattern.rs
@@ -134,14 +134,14 @@ mod tests {
     #[test]
     fn char() {
         do_test!("aba", 'a' => vec![((0, 1), true), ((1, 2), false), ((2, 3), true)]);
-        do_test!("bbbba", 'a' => vec![((0, 5), false), ((5, 6), true)]);
+        do_test!("bbbba", 'a' => vec![((0, 4), false), ((4, 5), true)]);
         do_test!("aabbb", 'a' => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
     }
 
     #[test]
     fn str() {
         do_test!("aba", "a" => vec![((0, 1), true), ((1, 2), false), ((2, 3), true)]);
-        do_test!("bbbba", "a" => vec![((0, 5), false), ((5, 6), true)]);
+        do_test!("bbbba", "a" => vec![((0, 4), false), ((4, 5), true)]);
         do_test!("aabbb", "a" => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
         do_test!("aabbb", "ab" => vec![((0, 1), false), ((1, 3), true), ((3, 5), false)]);
         do_test!("aabbab", "ab" =>
@@ -153,9 +153,8 @@ mod tests {
     fn functions() {
         let is_b = |c| c == 'b';
         do_test!("aba", is_b => vec![((0, 1), false), ((1, 2), true), ((2, 3), false)]);
-        do_test!("aaaab", is_b => vec![((0, 5), false), ((5, 6), true)]);
+        do_test!("aaaab", is_b => vec![((0, 4), false), ((4, 5), true)]);
         do_test!("bbaaa", is_b => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
-        do_test!("bbaaa", is_b => vec![((0, 1), false), ((1, 3), true), ((3, 5), false)]);
     }
 
     #[test]
@@ -163,7 +162,7 @@ mod tests {
         let is_whitespace = Regex::new(r"\s+").unwrap();
         do_test!("a   b", &is_whitespace => vec![((0, 1), false), ((1, 4), true), ((4, 5), false)]);
         do_test!("   a   b   ", &is_whitespace =>
-            vec![((0, 4), true), ((4, 5), false), ((5, 8), true), ((8, 9), false), ((9, 12), true)]
+            vec![((0, 3), true), ((3, 4), false), ((4, 7), true), ((7, 8), false), ((8, 11), true)]
         );
     }
 }

--- a/tokenizers/src/tokenizer/pattern.rs
+++ b/tokenizers/src/tokenizer/pattern.rs
@@ -27,6 +27,10 @@ impl Pattern for &str {
 
 impl Pattern for &Regex {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
+        if inside.is_empty() {
+            return Ok(vec![]);
+        }
+
         // Find initial matches
         let matches = self
             .find_iter(inside)
@@ -48,6 +52,7 @@ impl Pattern for &Regex {
                 splits
             })
             .collect::<Vec<_>>();
+
         if let Some(((_, end), _)) = splits.iter().last().copied() {
             if end < inside.len() {
                 splits.push(((end, inside.len()), false));
@@ -63,6 +68,10 @@ where
     F: Fn(char) -> bool,
 {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
+        if inside.is_empty() {
+            return Ok(vec![]);
+        }
+
         let mut last_offset = 0;
         let mut last_seen = 0;
 
@@ -125,7 +134,7 @@ mod tests {
                 Invert($pattern).find_matches($inside).unwrap(),
                 $result
                     .into_iter()
-                    .map(|(offsets, flag)| (offsets, !flag))
+                    .map(|v: (Offsets, bool)| (v.0, !v.1))
                     .collect::<Vec<_>>()
             );
         };
@@ -136,6 +145,7 @@ mod tests {
         do_test!("aba", 'a' => vec![((0, 1), true), ((1, 2), false), ((2, 3), true)]);
         do_test!("bbbba", 'a' => vec![((0, 4), false), ((4, 5), true)]);
         do_test!("aabbb", 'a' => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
+        do_test!("", 'a' => vec![]);
     }
 
     #[test]
@@ -147,6 +157,7 @@ mod tests {
         do_test!("aabbab", "ab" =>
             vec![((0, 1), false), ((1, 3), true), ((3, 4), false), ((4, 6), true)]
         );
+        do_test!("", "" => vec![]);
     }
 
     #[test]
@@ -155,6 +166,7 @@ mod tests {
         do_test!("aba", is_b => vec![((0, 1), false), ((1, 2), true), ((2, 3), false)]);
         do_test!("aaaab", is_b => vec![((0, 4), false), ((4, 5), true)]);
         do_test!("bbaaa", is_b => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
+        do_test!("", is_b => vec![]);
     }
 
     #[test]
@@ -164,5 +176,6 @@ mod tests {
         do_test!("   a   b   ", &is_whitespace =>
             vec![((0, 3), true), ((3, 4), false), ((4, 7), true), ((7, 8), false), ((8, 11), true)]
         );
+        do_test!("", &is_whitespace => vec![]);
     }
 }

--- a/tokenizers/src/tokenizer/pattern.rs
+++ b/tokenizers/src/tokenizer/pattern.rs
@@ -1,0 +1,47 @@
+use crate::Offsets;
+use regex::Regex;
+
+/// Pattern used to split a NormalizedString
+pub trait Pattern {
+    /// Slice the given string in a list of pattern match positions, with
+    /// a boolean indicating whether this is a match or not.
+    ///
+    /// This method *must* cover the whole string in its outputs, with
+    /// contiguous ordered slices.
+    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)>;
+}
+
+impl Pattern for char {
+    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)> {
+        todo!()
+    }
+}
+
+impl Pattern for &str {
+    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)> {
+        todo!()
+    }
+}
+
+impl Pattern for &Regex {
+    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)> {
+        todo!()
+    }
+}
+
+impl<F> Pattern for F
+where
+    F: Fn(char) -> bool,
+{
+    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)> {
+        todo!()
+    }
+}
+pub struct Invert<P: Pattern>(pub P);
+/// When the given Regex matches words instead of the delimiter,
+/// we use the `Reverse` helper to invert the delimiter flags
+impl<P: Pattern> Pattern for Invert<P> {
+    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)> {
+        todo!()
+    }
+}

--- a/tokenizers/src/tokenizer/pattern.rs
+++ b/tokenizers/src/tokenizer/pattern.rs
@@ -1,4 +1,4 @@
-use crate::Offsets;
+use crate::{Offsets, Result};
 use regex::Regex;
 
 /// Pattern used to split a NormalizedString
@@ -8,24 +8,53 @@ pub trait Pattern {
     ///
     /// This method *must* cover the whole string in its outputs, with
     /// contiguous ordered slices.
-    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)>;
+    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>>;
 }
 
 impl Pattern for char {
-    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)> {
-        todo!()
+    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
+        let is_char = |c: char| -> bool { c == *self };
+        is_char.find_matches(inside)
     }
 }
 
 impl Pattern for &str {
-    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)> {
-        todo!()
+    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
+        let re = Regex::new(&regex::escape(self))?;
+        (&re).find_matches(inside)
     }
 }
 
 impl Pattern for &Regex {
-    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)> {
-        todo!()
+    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
+        // Find initial matches
+        let matches = self
+            .find_iter(inside)
+            .map(|m| ((m.start(), m.end()), true))
+            .collect::<Vec<_>>();
+
+        // Then add missing splits inbetween
+        let mut start_offset = 0;
+        let mut splits = matches
+            .into_iter()
+            .flat_map(|((start, end), flag)| {
+                let mut splits = vec![];
+                if start_offset < start {
+                    splits.push(((start_offset, start), false));
+                }
+                splits.push(((start, end), flag));
+                start_offset = end;
+
+                splits
+            })
+            .collect::<Vec<_>>();
+        if let Some(((_, end), _)) = splits.iter().last().copied() {
+            if end < inside.len() {
+                splits.push(((end, inside.len()), false));
+            }
+        }
+
+        Ok(splits)
     }
 }
 
@@ -33,15 +62,108 @@ impl<F> Pattern for F
 where
     F: Fn(char) -> bool,
 {
-    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)> {
-        todo!()
+    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
+        let mut last_offset = 0;
+        let mut last_seen = 0;
+
+        let mut matches = inside
+            .chars()
+            .enumerate()
+            .flat_map(|(i, c)| {
+                last_seen = i;
+                if self(c) {
+                    let mut events = Vec::with_capacity(2);
+                    if last_offset < i {
+                        // We need to emit what was before this match
+                        events.push(((last_offset, i), false));
+                    }
+                    events.push(((i, i + 1), true));
+                    last_offset = i + 1;
+                    events
+                } else {
+                    vec![]
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // Do not forget the last potential split
+        if last_seen >= last_offset {
+            matches.push(((last_offset, last_seen + 1), false));
+        }
+
+        Ok(matches)
     }
 }
+
+/// Invert the `is_match` flags for the wrapped Pattern. This is usefull
+/// for example when we use a regex that matches words instead of a delimiter,
+/// and we want to match the delimiter.
 pub struct Invert<P: Pattern>(pub P);
-/// When the given Regex matches words instead of the delimiter,
-/// we use the `Reverse` helper to invert the delimiter flags
 impl<P: Pattern> Pattern for Invert<P> {
-    fn find_matches(&self, inside: &str) -> Vec<(Offsets, bool)> {
-        todo!()
+    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
+        Ok(self
+            .0
+            .find_matches(inside)?
+            .into_iter()
+            .map(|(offsets, flag)| (offsets, !flag))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    macro_rules! do_test {
+        ($inside: expr, $pattern: expr => @ERROR) => {
+            assert!($pattern.find_matches($inside).is_err());
+        };
+        ($inside: expr, $pattern: expr => $result: expr) => {
+            assert_eq!($pattern.find_matches($inside).unwrap(), $result);
+            assert_eq!(
+                Invert($pattern).find_matches($inside).unwrap(),
+                $result
+                    .into_iter()
+                    .map(|(offsets, flag)| (offsets, !flag))
+                    .collect::<Vec<_>>()
+            );
+        };
+    }
+
+    #[test]
+    fn char() {
+        do_test!("aba", 'a' => vec![((0, 1), true), ((1, 2), false), ((2, 3), true)]);
+        do_test!("bbbba", 'a' => vec![((0, 5), false), ((5, 6), true)]);
+        do_test!("aabbb", 'a' => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
+    }
+
+    #[test]
+    fn str() {
+        do_test!("aba", "a" => vec![((0, 1), true), ((1, 2), false), ((2, 3), true)]);
+        do_test!("bbbba", "a" => vec![((0, 5), false), ((5, 6), true)]);
+        do_test!("aabbb", "a" => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
+        do_test!("aabbb", "ab" => vec![((0, 1), false), ((1, 3), true), ((3, 5), false)]);
+        do_test!("aabbab", "ab" =>
+            vec![((0, 1), false), ((1, 3), true), ((3, 4), false), ((4, 6), true)]
+        );
+    }
+
+    #[test]
+    fn functions() {
+        let is_b = |c| c == 'b';
+        do_test!("aba", is_b => vec![((0, 1), false), ((1, 2), true), ((2, 3), false)]);
+        do_test!("aaaab", is_b => vec![((0, 5), false), ((5, 6), true)]);
+        do_test!("bbaaa", is_b => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
+        do_test!("bbaaa", is_b => vec![((0, 1), false), ((1, 3), true), ((3, 5), false)]);
+    }
+
+    #[test]
+    fn regex() {
+        let is_whitespace = Regex::new(r"\s+").unwrap();
+        do_test!("a   b", &is_whitespace => vec![((0, 1), false), ((1, 4), true), ((4, 5), false)]);
+        do_test!("   a   b   ", &is_whitespace =>
+            vec![((0, 4), true), ((4, 5), false), ((5, 8), true), ((8, 9), false), ((9, 12), true)]
+        );
     }
 }

--- a/tokenizers/src/tokenizer/pre_tokenizer.rs
+++ b/tokenizers/src/tokenizer/pre_tokenizer.rs
@@ -92,17 +92,24 @@ impl PreTokenizedString {
         self.into_iter()
     }
 
-    /// Returns a list of normalized string and their `original` offsets
-    pub fn get_normalized(&self) -> Vec<(&str, Offsets)> {
+    /// Returns a list of normalized string and the associated offsets,
+    /// either in original or normalized referential
+    pub fn get_normalized(&self, original: bool) -> Vec<(&str, Offsets)> {
+        let mut offset = 0;
         self.iter()
             .map(|sub| {
-                (
-                    sub.normalized.get(),
+                let offsets = if original {
                     (
                         sub.original_offsets.0,
                         sub.original_offsets.0 + sub.normalized.len_original(),
-                    ),
-                )
+                    )
+                } else {
+                    let len = sub.normalized.len();
+                    offset += len;
+                    (offset - len, offset)
+                };
+
+                (sub.normalized.get(), offsets)
             })
             .collect()
     }

--- a/tokenizers/src/tokenizer/pre_tokenizer.rs
+++ b/tokenizers/src/tokenizer/pre_tokenizer.rs
@@ -92,6 +92,7 @@ impl PreTokenizedString {
         self.into_iter()
     }
 
+    /// Returns a list of normalized string and their `original` offsets
     pub fn get_normalized(&self) -> Vec<(&str, Offsets)> {
         self.iter()
             .map(|sub| {
@@ -99,7 +100,7 @@ impl PreTokenizedString {
                     sub.normalized.get(),
                     (
                         sub.original_offsets.0,
-                        sub.original_offsets.0 + sub.normalized.len(),
+                        sub.original_offsets.0 + sub.normalized.len_original(),
                     ),
                 )
             })

--- a/tokenizers/src/tokenizer/pre_tokenizer.rs
+++ b/tokenizers/src/tokenizer/pre_tokenizer.rs
@@ -48,6 +48,7 @@ impl PreTokenizedString {
             .enumerate()
             .flat_map(|(i, sub)| {
                 let original_len = sub.normalized.len_original();
+                let original_offsets = sub.original_offsets;
 
                 let mut new_len = 0;
                 let res = split_fn(i, sub.normalized);
@@ -62,7 +63,10 @@ impl PreTokenizedString {
                         let len = normalized.len_original();
                         let new_s = SubString {
                             normalized,
-                            original_offsets: (new_len, new_len + len),
+                            original_offsets: (
+                                original_offsets.0 + new_len,
+                                original_offsets.0 + new_len + len,
+                            ),
                         };
                         new_len += len;
                         new_s

--- a/tokenizers/src/tokenizer/pre_tokenizer.rs
+++ b/tokenizers/src/tokenizer/pre_tokenizer.rs
@@ -1,0 +1,97 @@
+use crate::{NormalizedString, Offsets, Result};
+
+pub struct SubString {
+    /// The underlying `NormalizedString`. Each SubString is represented by a `NormalizedString`
+    /// and in the end we might be carrying a lot of SubString representing various parts of the
+    /// original input string.
+    pub normalized: NormalizedString,
+    /// Offsets of the `NormalizedString` in the `original` input string. These are useful to find
+    /// the `original` offsets in the input string, as opposed to the `original` offsets in the
+    /// sub-part of the input string represented by `NormalizedString`
+    pub offsets: Offsets,
+}
+
+/// A `PreTokenizedString` takes care of splitting the input string in multiple `SubString`, while
+/// ensuring that they form a coherend group. This let us keep track of the offsets during the whole
+/// normalization and pre-tokenization steps.
+pub struct PreTokenizedString {
+    parts: Vec<SubString>,
+}
+
+impl PreTokenizedString {
+    /// Split the `PreTokenizedString` by providing a `split_fn` in charge of splitting each
+    /// substring (`NormalizedString`) into multiple parts.
+    ///
+    /// `split_fn` takes a `NormalizedString` and is in charge of returning an iterator over
+    /// the produced `NormalizedString`. `split_fn` is free of modifying these `NormalizedString`
+    /// as relevant.
+    ///
+    /// There are only one constraint that *MUST* be respected:
+    /// > The produced `NormalizedString`, if combined together, must have the same `original` string
+    /// as the original one given to `split_fn`. This concretely means that for the offset tracking
+    /// to work as expected, `split_fn` must produce "splits" of the original string.
+    pub fn split<F, U>(&mut self, split_fn: F) -> Result<()>
+    where
+        F: FnMut(usize, NormalizedString) -> U,
+        U: IntoIterator<Item = NormalizedString>,
+    {
+        todo!()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<SubString> {
+        self.into_iter()
+    }
+
+    /// Merge back to a NormalizedString
+    pub fn into_merged(self) -> NormalizedString {
+        let offsets = (0, self.parts.iter().last().map_or(0, |sub| sub.offsets.1));
+        let normalized: NormalizedString = self.into_iter().map(|sub| sub.normalized).collect();
+        assert_eq!(offsets, (0, normalized.len_original()));
+        normalized
+    }
+}
+
+impl From<NormalizedString> for PreTokenizedString {
+    fn from(s: NormalizedString) -> Self {
+        let offsets = (0, s.len_original());
+        Self {
+            parts: vec![SubString {
+                normalized: s,
+                offsets,
+            }],
+        }
+    }
+}
+
+impl From<&str> for PreTokenizedString {
+    fn from(s: &str) -> Self {
+        let normalized: NormalizedString = s.into();
+        normalized.into()
+    }
+}
+
+impl From<String> for PreTokenizedString {
+    fn from(s: String) -> Self {
+        let normalized: NormalizedString = s.into();
+        normalized.into()
+    }
+}
+
+impl IntoIterator for PreTokenizedString {
+    type Item = SubString;
+    type IntoIter = std::vec::IntoIter<SubString>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.parts.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a PreTokenizedString {
+    type Item = &'a SubString;
+    type IntoIter = std::slice::Iter<'a, SubString>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.parts.iter()
+    }
+}
+

--- a/tokenizers/tests/offsets.rs
+++ b/tokenizers/tests/offsets.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::*;
-use tokenizers::tokenizer::{get_range_of, AddedToken};
+use tokenizers::tokenizer::{normalizer::get_range_of, AddedToken};
 
 macro_rules! check_offsets {
     ($input: expr, $output:expr, $offset:expr, $result:expr) => {
@@ -84,13 +84,14 @@ fn byte_level_double_sequence() {
             Some(1),
             Some(2),
             Some(3),
-            Some(4),
-            Some(5),
-            Some(6),
-            Some(7),
-            Some(8)
+            Some(0),
+            Some(1),
+            Some(2),
+            Some(3),
+            Some(4)
         ]
     );
+    assert_eq!(output.get_type_ids(), &[0, 0, 0, 0, 1, 1, 1, 1, 1]);
 
     // When trimming offsets
     let tokenizer = get_byte_level(true, true);
@@ -176,5 +177,17 @@ fn split_on_added_tokens_bert() {
     assert_eq!(
         output.get_tokens(),
         &["yesterday", "i", "saw", "a", "[MASK]", "far", "away"]
+    );
+    assert_eq!(
+        output.get_words(),
+        &[
+            Some(0),
+            Some(1),
+            Some(2),
+            Some(3),
+            Some(4),
+            Some(5),
+            Some(6)
+        ]
     );
 }


### PR DESCRIPTION
In this refactor, we take care of the following problems:

- We cannot have multiple pre-tokenizers. This is problematic since it will be way easier in the future to combine multiple small `PreTokenizer` instead of building multiple big ones.
- The logic to keep track of offsets is hard to understand and spread in many different places
- Same for the logic keeping track of `words`

### What changed

- Adds a `PreTokenizedString` who is in charge of splitting the string in multiple parts, keeping track of all the offsets, and being able to reconstruct them in the end. This entity actually manages a bunch of `NormalizedString`, and all the information necessary to reconstruct the input string from those.
- The `PreTokenizer` now handles a mutable `PreTokenizedString`, just like the `Normalizer` handles a `NormalizedString`. This lets us actually have multiple `PreTokenizer` since we can split multiple times a same `PreTokenizedString`
- The `AddedVocabulary` now uses the `PreTokenizedString` logic to manage the splitting and keep track of the offsets.
- The `NormalizedString` can now `replace` and `split`. Both of these take a `Pattern` (`char`, `Fn(char) -> bool`, `&str` or `Regex`), either to replace it or to split on it.
- Simplify the interface of the `Model::tokenize` method. Before this PR, it used to handle keeping track of `words` and `offsets` way more than necessary. We extract a lot of this logic and give it back to the `Tokenizer` since this should be shared logic anyway. Now a `Model` only takes a string slice and returns a bunch of `Token`, simple.
- The `Token` does not keep track of the words anymore.
- The `Encoding` does not increase the offsets/words when merging with others. It is now the responsibility of the caller to manage these since there is no good default.
- Improved QoL with easy conversion to `NormalizedString` and `PreTokenizedString` from `&str` & `String`. We also add the ability to `collect` a `Iterator<Item = NormalizedString>` into a `NormalizedString`, same for `Iterator<Item = Encoding>` to `Encoding`.
- Adds a lot of tests, and fixes many bugs.

### Other notes

- The `PyPreTokenizer` needs a complete rework for compatibility with this, but it needed to be reworked anyway, so this is out of scope for this PR.
- The `encode` and `encode_batch` method don't really make sense as-is on the `Model` in the Python bindings. We'll need to add them back while ensuring it matches the API we have on Rust's side.