### PR TITLE
Cache based on Cargo.lock.

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Node 12.x
         uses: actions/setup-node@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -88,13 +88,13 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache Cargo Build Target
         uses: actions/cache@v1
         with:
           path: ./bindings/python/target
-          key: ${{ runner.os }}-cargo-python-build-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-python-build-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Lint with RustFmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,18 +29,6 @@ jobs:
       - if: matrix.os == 'ubuntu-latest'
         run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
 
-      - name: Cache Cargo Registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Cache Cargo Build Target
-        uses: actions/cache@v1
-        with:
-          path: tokenizers/target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.toml') }}
-
       - name: Build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
The lock-file should be more accurate in caching the correct dependencies than `Cargo.toml`.

I think the failing Rust MacOS jobs are due to incorrect caching. As long as `Cargo.toml` isn't changed, the dependencies stay the same for every build since the same cache hits are returned. While I'm not sure why the builds started to fail, I think they kept failing because the same (faulty) dependencies kept being retrieved. Removing the cache for the library should resolve such issues in the future. 

The previously suggestion to use `Cargo.lock`  as a key for the Rust library would only make sense if `cargo update` is executed as the first step to ensure `Cargo.lock` exists with up-to-date dependencies.