### PR TITLE
Rust - NormalizedString - Fix offsets when adding new chars

### DIFF
--- a/tokenizers/src/normalizers/bert.rs
+++ b/tokenizers/src/normalizers/bert.rs
@@ -136,3 +136,22 @@ impl Normalizer for BertNormalizer {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_chinese_chars() {
+        let mut normalized = NormalizedString::from("野口里佳 Noguchi Rika");
+        let normalizer = BertNormalizer {
+            handle_chinese_chars: true,
+            lowercase: false,
+            clean_text: false,
+            strip_accents: Some(false),
+        };
+
+        normalizer.normalize(&mut normalized).unwrap();
+        assert_eq!(normalized.get(), " 野  口  里  佳  Noguchi Rika");
+    }
+}


### PR DESCRIPTION
New characters should have alignments of length 0 since they don't correspond to anything from the original string. This led to a bug where slicing the normalized string gave multiple times the same part of the original string.

Fix #367 