### PR TITLE
Make LongestFirst truncation constant time and consistent

### DIFF
--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -215,17 +215,7 @@ impl Encoding {
         }
 
         if max_len == 0 {
-            let o = Encoding {
-                ids: self.get_ids().to_vec(),
-                type_ids: self.get_type_ids().to_vec(),
-                tokens: self.get_tokens().to_vec(),
-                words: self.get_words().to_vec(),
-                offsets: self.get_offsets().to_vec(),
-                special_tokens_mask: self.get_special_tokens_mask().to_vec(),
-                attention_mask: self.get_attention_mask().to_vec(),
-                overflowing: self.get_overflowing().to_vec(),
-            };
-            *self = Encoding::with_capacity(0);
+            let o = std::mem::replace(self, Encoding::with_capacity(0));
             self.overflowing.push(o);
             return;
         }

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -208,13 +208,27 @@ impl Encoding {
 
     /// Truncate the current `Encoding`.
     ///
-    /// Panic if `stride >= max_len` or `max_len == 0`.
+    /// Panic if `stride >= max_len`
     pub fn truncate(&mut self, max_len: usize, stride: usize) {
         if max_len >= self.ids.len() {
             return;
         }
-        // We only truncate if max_len > 0, it makes no sense otherwise
-        assert!(max_len > 0);
+
+        if max_len == 0 {
+            let o = Encoding {
+                ids: self.get_ids().to_vec(),
+                type_ids: self.get_type_ids().to_vec(),
+                tokens: self.get_tokens().to_vec(),
+                words: self.get_words().to_vec(),
+                offsets: self.get_offsets().to_vec(),
+                special_tokens_mask: self.get_special_tokens_mask().to_vec(),
+                attention_mask: self.get_attention_mask().to_vec(),
+                overflowing: self.get_overflowing().to_vec(),
+            };
+            *self = Encoding::with_capacity(0);
+            self.overflowing.push(o);
+            return;
+        }
 
         // Get the main overflowing part
         let o_ids = self.ids.split_off(max_len);
@@ -536,6 +550,52 @@ mod tests {
                     offsets: vec![(11, 12)],
                     special_tokens_mask: vec![0],
                     attention_mask: vec![1],
+                    overflowing: vec![],
+                }]
+            }
+        );
+    }
+
+    #[test]
+    fn truncate_to_empty() {
+        let mut a = Encoding {
+            ids: vec![1, 2, 3],
+            type_ids: vec![0, 0, 0],
+            tokens: vec![
+                String::from("Hello"),
+                String::from("World"),
+                String::from("!"),
+            ],
+            words: vec![Some(0), Some(1), Some(2)],
+            offsets: vec![(0, 5), (6, 11), (11, 12)],
+            special_tokens_mask: vec![0, 0, 0],
+            attention_mask: vec![1, 1, 1],
+            overflowing: vec![],
+        };
+        a.truncate(0, 0);
+
+        assert_eq!(
+            a,
+            Encoding {
+                ids: vec![],
+                type_ids: vec![],
+                tokens: vec![],
+                words: vec![],
+                offsets: vec![],
+                special_tokens_mask: vec![],
+                attention_mask: vec![],
+                overflowing: vec![Encoding {
+                    ids: vec![1, 2, 3],
+                    type_ids: vec![0, 0, 0],
+                    tokens: vec![
+                        String::from("Hello"),
+                        String::from("World"),
+                        String::from("!"),
+                    ],
+                    words: vec![Some(0), Some(1), Some(2)],
+                    offsets: vec![(0, 5), (6, 11), (11, 12)],
+                    special_tokens_mask: vec![0, 0, 0],
+                    attention_mask: vec![1, 1, 1],
                     overflowing: vec![],
                 }]
             }

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -1,5 +1,7 @@
 use crate::tokenizer::{Encoding, Result};
 use serde::{Deserialize, Serialize};
+use std::cmp;
+use std::mem;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TruncationParams {
@@ -87,23 +89,52 @@ pub fn truncate_encodings(
 
     match params.strategy {
         TruncationStrategy::LongestFirst => {
-            let mut n_first = encoding.get_ids().len();
-            let mut n_second = pair_encoding.as_ref().map_or(0, |e| e.get_ids().len());
-            for _ in 0..to_remove {
-                if n_first > n_second {
-                    n_first -= 1;
-                } else {
-                    n_second -= 1;
+            if let Some(other_encoding) = pair_encoding.as_mut() {
+                // Assuming n1 <= n2, there are 3 cases
+                // Case 1:
+                //   No truncation needs to be performed.
+                //   This scenario is handled before the match.
+                // Case 2:
+                //   Only the longer input needs to be truncated.
+                //   n1 = n1
+                //   n2 = max_length - n1
+                // Case 3:
+                //   Both inputs must be truncated.
+                //   n1 = max_length / 2
+                //   n2 = n1 + max_length % 2
+
+                let mut n1 = encoding.get_ids().len();
+                let mut n2 = other_encoding.get_ids().len();
+                let mut swap = false;
+
+                // Ensure n1 is the length of the shortest input
+                if n1 > n2 {
+                    swap = true;
+                    mem::swap(&mut n1, &mut n2);
                 }
-            }
 
-            if n_first == 0 || (pair_encoding.is_some() && n_second == 0) {
-                return Err(Box::new(TruncationError::MaxLengthTooLow));
-            }
+                if n1 > params.max_length {
+                    // This needs to be a special case
+                    // to avoid max_length - n1 < 0
+                    // since n1 and n2 are unsigned
+                    n2 = n1;
+                } else {
+                    n2 = cmp::max(n1, params.max_length - n1);
+                }
 
-            encoding.truncate(n_first, params.stride);
-            if let Some(encoding) = pair_encoding.as_mut() {
-                encoding.truncate(n_second, params.stride);
+                if n1 + n2 > params.max_length {
+                    n1 = params.max_length / 2;
+                    n2 = n1 + params.max_length % 2;
+                }
+
+                // Swap lengths if we swapped previosuly
+                if swap {
+                    mem::swap(&mut n1, &mut n2);
+                }
+                encoding.truncate(n1, params.stride);
+                other_encoding.truncate(n2, params.stride);
+            } else {
+                encoding.truncate(total_length - to_remove, params.stride);
             }
         }
         TruncationStrategy::OnlyFirst | TruncationStrategy::OnlySecond => {
@@ -123,6 +154,140 @@ pub fn truncate_encodings(
             }
         }
     }
-
     Ok((encoding, pair_encoding))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokenizer::Encoding;
+
+    fn get_empty() -> Encoding {
+        Encoding::new(
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        )
+    }
+
+    fn get_short() -> Encoding {
+        Encoding::new(
+            vec![1, 2],
+            vec![0, 0],
+            vec![String::from("a"), String::from("b")],
+            vec![Some(0), Some(1)],
+            vec![(0, 1), (1, 2)],
+            vec![0, 0],
+            vec![1, 1],
+            vec![],
+        )
+    }
+
+    fn get_medium() -> Encoding {
+        Encoding::new(
+            vec![3, 4, 5, 6],
+            vec![0, 0, 0, 0],
+            vec![
+                String::from("d"),
+                String::from("e"),
+                String::from("f"),
+                String::from("g"),
+            ],
+            vec![Some(0), Some(1), Some(2), Some(3)],
+            vec![(0, 1), (1, 2), (2, 3), (3, 4)],
+            vec![0, 0, 0, 0],
+            vec![1, 1, 1, 1],
+            vec![],
+        )
+    }
+
+    fn get_long() -> Encoding {
+        Encoding::new(
+            vec![7, 8, 9, 10, 11, 12, 13, 14],
+            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            vec![
+                String::from("h"),
+                String::from("i"),
+                String::from("j"),
+                String::from("k"),
+                String::from("l"),
+                String::from("m"),
+                String::from("n"),
+                String::from("o"),
+            ],
+            vec![
+                Some(0),
+                Some(1),
+                Some(2),
+                Some(3),
+                Some(4),
+                Some(5),
+                Some(6),
+                Some(7),
+            ],
+            vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+                (4, 5),
+                (5, 6),
+                (6, 7),
+                (6, 8),
+            ],
+            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            vec![1, 1, 1, 1, 1, 1, 1, 1],
+            vec![],
+        )
+    }
+
+    fn truncatate_and_assert(
+        encoding1: Encoding,
+        encoding2: Encoding,
+        params: &TruncationParams,
+        n1: usize,
+        n2: usize,
+    ) {
+        match truncate_encodings(encoding1, Some(encoding2), &params) {
+            Ok((e1, Some(e2))) => {
+                assert!(e1.get_ids().len() == n1);
+                assert!(e2.get_ids().len() == n2);
+            }
+            _ => panic!(),
+        };
+    }
+
+    #[test]
+    fn truncate_encodings_longest_first() {
+        let params = TruncationParams {
+            max_length: 7,
+            strategy: TruncationStrategy::LongestFirst,
+            stride: 0,
+        };
+
+        truncatate_and_assert(get_empty(), get_empty(), &params, 0, 0);
+        truncatate_and_assert(get_empty(), get_short(), &params, 0, 2);
+        truncatate_and_assert(get_empty(), get_medium(), &params, 0, 4);
+        truncatate_and_assert(get_empty(), get_long(), &params, 0, 7);
+
+        truncatate_and_assert(get_short(), get_empty(), &params, 2, 0);
+        truncatate_and_assert(get_short(), get_short(), &params, 2, 2);
+        truncatate_and_assert(get_short(), get_medium(), &params, 2, 4);
+        truncatate_and_assert(get_short(), get_long(), &params, 2, 5);
+
+        truncatate_and_assert(get_medium(), get_empty(), &params, 4, 0);
+        truncatate_and_assert(get_medium(), get_short(), &params, 4, 2);
+        truncatate_and_assert(get_medium(), get_medium(), &params, 3, 4);
+        truncatate_and_assert(get_medium(), get_long(), &params, 3, 4);
+
+        truncatate_and_assert(get_long(), get_empty(), &params, 7, 0);
+        truncatate_and_assert(get_long(), get_short(), &params, 5, 2);
+        truncatate_and_assert(get_long(), get_medium(), &params, 4, 3);
+        truncatate_and_assert(get_long(), get_long(), &params, 3, 4);
+    }
 }

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -250,7 +250,7 @@ mod tests {
         )
     }
 
-    fn truncatate_and_assert(
+    fn truncate_and_assert(
         encoding1: Encoding,
         encoding2: Encoding,
         params: &TruncationParams,
@@ -274,25 +274,25 @@ mod tests {
             stride: 0,
         };
 
-        truncatate_and_assert(get_empty(), get_empty(), &params, 0, 0);
-        truncatate_and_assert(get_empty(), get_short(), &params, 0, 2);
-        truncatate_and_assert(get_empty(), get_medium(), &params, 0, 4);
-        truncatate_and_assert(get_empty(), get_long(), &params, 0, 7);
+        truncate_and_assert(get_empty(), get_empty(), &params, 0, 0);
+        truncate_and_assert(get_empty(), get_short(), &params, 0, 2);
+        truncate_and_assert(get_empty(), get_medium(), &params, 0, 4);
+        truncate_and_assert(get_empty(), get_long(), &params, 0, 7);
 
-        truncatate_and_assert(get_short(), get_empty(), &params, 2, 0);
-        truncatate_and_assert(get_short(), get_short(), &params, 2, 2);
-        truncatate_and_assert(get_short(), get_medium(), &params, 2, 4);
-        truncatate_and_assert(get_short(), get_long(), &params, 2, 5);
+        truncate_and_assert(get_short(), get_empty(), &params, 2, 0);
+        truncate_and_assert(get_short(), get_short(), &params, 2, 2);
+        truncate_and_assert(get_short(), get_medium(), &params, 2, 4);
+        truncate_and_assert(get_short(), get_long(), &params, 2, 5);
 
-        truncatate_and_assert(get_medium(), get_empty(), &params, 4, 0);
-        truncatate_and_assert(get_medium(), get_short(), &params, 4, 2);
-        truncatate_and_assert(get_medium(), get_medium(), &params, 3, 4);
-        truncatate_and_assert(get_medium(), get_long(), &params, 3, 4);
+        truncate_and_assert(get_medium(), get_empty(), &params, 4, 0);
+        truncate_and_assert(get_medium(), get_short(), &params, 4, 2);
+        truncate_and_assert(get_medium(), get_medium(), &params, 3, 4);
+        truncate_and_assert(get_medium(), get_long(), &params, 3, 4);
 
-        truncatate_and_assert(get_long(), get_empty(), &params, 7, 0);
-        truncatate_and_assert(get_long(), get_short(), &params, 5, 2);
-        truncatate_and_assert(get_long(), get_medium(), &params, 4, 3);
-        truncatate_and_assert(get_long(), get_long(), &params, 3, 4);
+        truncate_and_assert(get_long(), get_empty(), &params, 7, 0);
+        truncate_and_assert(get_long(), get_short(), &params, 5, 2);
+        truncate_and_assert(get_long(), get_medium(), &params, 4, 3);
+        truncate_and_assert(get_long(), get_long(), &params, 3, 4);
     }
 
     #[test]
@@ -303,8 +303,8 @@ mod tests {
             stride: 0,
         };
 
-        truncatate_and_assert(get_empty(), get_short(), &params, 0, 0);
-        truncatate_and_assert(get_medium(), get_medium(), &params, 0, 0);
-        truncatate_and_assert(get_long(), get_long(), &params, 0, 0);
+        truncate_and_assert(get_empty(), get_short(), &params, 0, 0);
+        truncate_and_assert(get_medium(), get_medium(), &params, 0, 0);
+        truncate_and_assert(get_long(), get_long(), &params, 0, 0);
     }
 }

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -73,7 +73,11 @@ pub fn truncate_encodings(
     params: &TruncationParams,
 ) -> Result<(Encoding, Option<Encoding>)> {
     if params.max_length == 0 {
-        return Err(Box::new(TruncationError::MaxLengthTooLow));
+        encoding.truncate(0, params.stride);
+        if let Some(other_encoding) = pair_encoding.as_mut() {
+            other_encoding.truncate(0, params.stride);
+        }
+        return Ok((encoding, pair_encoding));
     }
 
     let total_length = encoding.get_ids().len()
@@ -289,5 +293,18 @@ mod tests {
         truncatate_and_assert(get_long(), get_short(), &params, 5, 2);
         truncatate_and_assert(get_long(), get_medium(), &params, 4, 3);
         truncatate_and_assert(get_long(), get_long(), &params, 3, 4);
+    }
+
+    #[test]
+    fn truncate_encodings_empty() {
+        let params = TruncationParams {
+            max_length: 0,
+            strategy: TruncationStrategy::LongestFirst,
+            stride: 0,
+        };
+
+        truncatate_and_assert(get_empty(), get_short(), &params, 0, 0);
+        truncatate_and_assert(get_medium(), get_medium(), &params, 0, 0);
+        truncatate_and_assert(get_long(), get_long(), &params, 0, 0);
     }
 }


### PR DESCRIPTION
This PR addresses a consistency issue with the handling of empty input when truncating pairs with the `TruncationStrategy::LongestFirst`, https://github.com/huggingface/tokenizers/issues/381 and https://github.com/huggingface/transformers/issues/6669. It also makes the algorithm constant time and adds tests (previously there were none).