### PR TITLE
Making cache layer common to BPE and Unigram.

### DIFF
--- a/tokenizers/src/models/bpe/mod.rs
+++ b/tokenizers/src/models/bpe/mod.rs
@@ -1,7 +1,6 @@
 //! [Byte Pair Encoding](https://www.aclweb.org/anthology/P16-1162/) model.
 use std::{convert::From, io, iter, mem};
 
-mod cache;
 mod model;
 mod serialization;
 mod trainer;
@@ -111,7 +110,6 @@ where
 }
 
 // Re-export
-pub use cache::*;
 pub use model::*;
 pub use trainer::*;
 use word::*;

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -1,5 +1,6 @@
-use super::{super::OrderedVocabIter, Cache, Error, Pair, Word, DEFAULT_CACHE_CAPACITY};
+use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::tokenizer::{Model, Result, Token};
+use crate::utils::cache::{Cache, DEFAULT_CACHE_CAPACITY};
 use crate::utils::iter::ResultShunt;
 use serde_json::Value;
 use std::borrow::Cow;

--- a/tokenizers/src/utils/cache.rs
+++ b/tokenizers/src/utils/cache.rs
@@ -11,7 +11,7 @@ pub static DEFAULT_CACHE_CAPACITY: usize = 10_000;
 /// The goal is clearly not the accuracy of the content, both get and set
 /// are not guaranteed to actually get or set.
 #[derive(Debug)]
-pub(super) struct Cache<K, V>
+pub(crate) struct Cache<K, V>
 where
     K: Eq + Hash + Clone,
     V: Clone,
@@ -47,23 +47,23 @@ where
     V: Clone,
 {
     /// Create new `Cache` with the given capacity.
-    pub(super) fn new(capacity: usize) -> Self {
+    pub(crate) fn new(capacity: usize) -> Self {
         let map = RwLock::new(HashMap::with_capacity(capacity));
         Cache { map, capacity }
     }
 
     /// Create a fresh `Cache` with the same configuration.
-    pub(super) fn fresh(&self) -> Self {
+    pub(crate) fn fresh(&self) -> Self {
         Self::new(self.capacity)
     }
 
     /// Clear the cache.
-    pub(super) fn clear(&self) {
+    pub(crate) fn clear(&self) {
         self.map.write().unwrap().clear();
     }
 
     #[allow(dead_code)]
-    pub(super) fn get_values<'a, I, Q>(&self, keys_iter: I) -> Option<Vec<Option<V>>>
+    pub(crate) fn get_values<'a, I, Q>(&self, keys_iter: I) -> Option<Vec<Option<V>>>
     where
         I: Iterator<Item = &'a Q>,
         K: Borrow<Q>,
@@ -76,7 +76,7 @@ where
         }
     }
 
-    pub(super) fn get<Q>(&self, key: &Q) -> Option<V>
+    pub(crate) fn get<Q>(&self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -88,7 +88,7 @@ where
         }
     }
 
-    pub(super) fn set_values<I>(&self, entries: I)
+    pub(crate) fn set_values<I>(&self, entries: I)
     where
         I: IntoIterator<Item = (K, V)>,
     {
@@ -112,7 +112,7 @@ where
         }
     }
 
-    pub(super) fn set(&self, key: K, value: V) {
+    pub(crate) fn set(&self, key: K, value: V) {
         self.set_values(std::iter::once((key, value)))
     }
 }

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod iter;
 pub mod padding;
 pub mod parallelism;


### PR DESCRIPTION
And add a cache layer to Unigram.

It will probably have to be removed (or bypassed) when sampling is enabled.