### PR TITLE
Make the APIs uniform (build from memory by default in the constructor).

### DIFF
--- a/bindings/node/lib/bindings/models.d.ts
+++ b/bindings/node/lib/bindings/models.d.ts
@@ -49,7 +49,7 @@ export namespace BPE {
    * @param options BPE model options
    * @param __callback Callback called when model is loaded
    */
-  export function fromFiles(
+  export function fromFile(
     vocab: string,
     merges: string,
     options: BPEOptions,
@@ -62,7 +62,7 @@ export namespace BPE {
    * @param merges Path to a merge file
    * @param __callback Callback called when model is loaded
    */
-  export function fromFiles(
+  export function fromFile(
     vocab: string,
     merges: string,
     __callback: (err: Error, encoding: Model) => void
@@ -100,7 +100,7 @@ export namespace WordPiece {
    * @param options WordPiece model options
    * @param __callback Callback called when model is loaded
    */
-  export function fromFiles(
+  export function fromFile(
     vocab: string,
     options: WordPieceOptions,
     __callback: (err: Error, encoding: Model) => void
@@ -111,7 +111,7 @@ export namespace WordPiece {
    * @param vocab Path to a vocabulary file
    * @param __callback Callback called when model is loaded
    */
-  export function fromFiles(
+  export function fromFile(
     vocab: string,
     __callback: (err: Error, encoding: Model) => void
   ): void;

--- a/bindings/node/lib/bindings/models.js
+++ b/bindings/node/lib/bindings/models.js
@@ -2,10 +2,12 @@ const native = require("./native");
 
 module.exports = {
   BPE: {
+    init: native.models_BPE_init,
     fromFiles: native.models_BPE_from_files,
     empty: native.models_BPE_empty,
   },
   WordPiece: {
+    init: native.models_WordPiece_init,
     fromFiles: native.models_WordPiece_from_files,
     empty: native.models_WordPiece_empty,
   },

--- a/bindings/node/lib/bindings/models.js
+++ b/bindings/node/lib/bindings/models.js
@@ -3,12 +3,12 @@ const native = require("./native");
 module.exports = {
   BPE: {
     init: native.models_BPE_init,
-    fromFiles: native.models_BPE_from_files,
+    fromFile: native.models_BPE_from_file,
     empty: native.models_BPE_empty,
   },
   WordPiece: {
     init: native.models_WordPiece_init,
-    fromFiles: native.models_WordPiece_from_files,
+    fromFile: native.models_WordPiece_from_file,
     empty: native.models_WordPiece_empty,
   },
 };

--- a/bindings/node/lib/bindings/models.test.ts
+++ b/bindings/node/lib/bindings/models.test.ts
@@ -6,25 +6,25 @@ import { BPE, WordPiece } from "./models";
 const MOCKS_DIR = __dirname + "/__mocks__";
 
 describe("WordPiece", () => {
-  describe("fromFiles", () => {
+  describe("fromFile", () => {
     it("throws if called with only one argument", () => {
-      expect(() => (WordPiece as any).fromFiles("test")).toThrow("not enough arguments");
+      expect(() => (WordPiece as any).fromFile("test")).toThrow("not enough arguments");
     });
 
     it("throws if called with 2 arguments without a callback as third argument", () => {
-      expect(() => (WordPiece as any).fromFiles("test", {})).toThrow(
+      expect(() => (WordPiece as any).fromFile("test", {})).toThrow(
         "not enough arguments"
       );
     });
 
     describe("when called with 2 correct arguments", () => {
       it("returns `undefined` ", () => {
-        expect(WordPiece.fromFiles(`${MOCKS_DIR}/vocab.txt`, () => {})).toBeUndefined();
+        expect(WordPiece.fromFile(`${MOCKS_DIR}/vocab.txt`, () => {})).toBeUndefined();
       });
 
       it("has its callback called with the loaded model", () => {
         return new Promise((done) => {
-          WordPiece.fromFiles(`${MOCKS_DIR}/vocab.txt`, (err, model) => {
+          WordPiece.fromFile(`${MOCKS_DIR}/vocab.txt`, (err, model) => {
             expect(model).toBeDefined();
             done();
           });
@@ -35,13 +35,13 @@ describe("WordPiece", () => {
     describe("when called with 3 correct arguments", () => {
       it("returns `undefined`", () => {
         expect(
-          WordPiece.fromFiles(`${MOCKS_DIR}/vocab.txt`, {}, () => {})
+          WordPiece.fromFile(`${MOCKS_DIR}/vocab.txt`, {}, () => {})
         ).toBeUndefined();
       });
 
       it("has its callback called with the loaded model", () => {
         return new Promise((done) => {
-          WordPiece.fromFiles(`${MOCKS_DIR}/vocab.txt`, {}, (err, model) => {
+          WordPiece.fromFile(`${MOCKS_DIR}/vocab.txt`, {}, (err, model) => {
             expect(model).toBeDefined();
             done();
           });
@@ -52,13 +52,13 @@ describe("WordPiece", () => {
 });
 
 describe("BPE", () => {
-  describe("fromFiles", () => {
+  describe("fromFile", () => {
     it("throws if called with only two arguments", () => {
-      expect(() => (BPE as any).fromFiles("test", "bis")).toThrow("not enough arguments");
+      expect(() => (BPE as any).fromFile("test", "bis")).toThrow("not enough arguments");
     });
 
     it("throws if called with 3 arguments without a callback as last argument", () => {
-      expect(() => (BPE as any).fromFiles("test", "bis", {})).toThrow(
+      expect(() => (BPE as any).fromFile("test", "bis", {})).toThrow(
         "not enough arguments"
       );
     });
@@ -67,13 +67,13 @@ describe("BPE", () => {
   describe("when called with 3 correct arguments", () => {
     it("returns `undefined`", () => {
       expect(
-        BPE.fromFiles(`${MOCKS_DIR}/vocab.json`, `${MOCKS_DIR}/merges.txt`, () => {})
+        BPE.fromFile(`${MOCKS_DIR}/vocab.json`, `${MOCKS_DIR}/merges.txt`, () => {})
       ).toBeUndefined();
     });
 
     it("has its callback called with the loaded model", () => {
       return new Promise((done) => {
-        BPE.fromFiles(
+        BPE.fromFile(
           `${MOCKS_DIR}/vocab.json`,
           `${MOCKS_DIR}/merges.txt`,
           (err, model) => {
@@ -88,13 +88,13 @@ describe("BPE", () => {
   describe("when called with 4 correct arguments", () => {
     it("returns `undefined`", () => {
       expect(
-        BPE.fromFiles(`${MOCKS_DIR}/vocab.json`, `${MOCKS_DIR}/merges.txt`, {}, () => {})
+        BPE.fromFile(`${MOCKS_DIR}/vocab.json`, `${MOCKS_DIR}/merges.txt`, {}, () => {})
       ).toBeUndefined();
     });
 
     it("has its callback called with the loaded model", () => {
       return new Promise((done) => {
-        BPE.fromFiles(
+        BPE.fromFile(
           `${MOCKS_DIR}/vocab.json`,
           `${MOCKS_DIR}/merges.txt`,
           {},
@@ -108,16 +108,13 @@ describe("BPE", () => {
   });
   describe("When initialized from memory", () => {
     it("returns `undefined`", () => {
-      const merges = new Map();
-      merges.set([0, 1], [0, 2]);
-      expect((BPE as any).init({ a: 0, b: 1, ab: 2 }, merges, () => {})).toBeUndefined();
+      expect(
+        (BPE as any).init({ a: 0, b: 1, ab: 2 }, [["a", "b"]], () => {})
+      ).toBeUndefined();
     });
     it("has its callback called with the loaded model", () => {
       return new Promise((done) => {
-        const merges = new Map();
-        merges.set([0, 1], [0, 2]);
-
-        (BPE as any).init({ a: 0, b: 1, ab: 2 }, merges, (err: any, model: any) => {
+        (BPE as any).init({ a: 0, b: 1, ab: 2 }, [["a", "b"]], (err: any, model: any) => {
           expect(model).toBeDefined();
           done();
         });

--- a/bindings/node/lib/bindings/models.test.ts
+++ b/bindings/node/lib/bindings/models.test.ts
@@ -106,4 +106,22 @@ describe("BPE", () => {
       });
     });
   });
+  describe("When initialized from memory", () => {
+    it("returns `undefined`", () => {
+      const merges = new Map();
+      merges.set([0, 1], [0, 2]);
+      expect((BPE as any).init({ a: 0, b: 1, ab: 2 }, merges, () => {})).toBeUndefined();
+    });
+    it("has its callback called with the loaded model", () => {
+      return new Promise((done) => {
+        const merges = new Map();
+        merges.set([0, 1], [0, 2]);
+
+        (BPE as any).init({ a: 0, b: 1, ab: 2 }, merges, (err: any, model: any) => {
+          expect(model).toBeDefined();
+          done();
+        });
+      });
+    });
+  });
 });

--- a/bindings/node/lib/bindings/raw-encoding.test.ts
+++ b/bindings/node/lib/bindings/raw-encoding.test.ts
@@ -22,7 +22,7 @@ describe("Can modify pretokenizers on the fly", () => {
   let tokenizer: Tokenizer;
 
   beforeAll(async () => {
-    const model = await promisify<string, WordPieceOptions, Model>(WordPiece.fromFiles)(
+    const model = await promisify<string, WordPieceOptions, Model>(WordPiece.fromFile)(
       `${MOCKS_DIR}/vocab.txt`,
       {
         continuingSubwordPrefix: "##",
@@ -60,7 +60,7 @@ describe("RawEncoding", () => {
   ) => Promise<RawEncoding>;
 
   beforeAll(async () => {
-    const model = await promisify<string, WordPieceOptions, Model>(WordPiece.fromFiles)(
+    const model = await promisify<string, WordPieceOptions, Model>(WordPiece.fromFile)(
       `${MOCKS_DIR}/vocab.txt`,
       {
         continuingSubwordPrefix: "##",

--- a/bindings/node/lib/implementations/tokenizers/bert-wordpiece.tokenizer.ts
+++ b/bindings/node/lib/implementations/tokenizers/bert-wordpiece.tokenizer.ts
@@ -132,8 +132,8 @@ export class BertWordPieceTokenizer extends BaseTokenizer<BertTokenizerConfig> {
 
     let model: Model;
     if (opts.vocabFile) {
-      const fromFiles = promisify<string, WordPieceOptions, Model>(WordPiece.fromFiles);
-      model = await fromFiles(opts.vocabFile, {
+      const fromFile = promisify<string, WordPieceOptions, Model>(WordPiece.fromFile);
+      model = await fromFile(opts.vocabFile, {
         unkToken: getTokenContent(opts.unkToken),
         continuingSubwordPrefix: opts.wordpiecesPrefix,
       });

--- a/bindings/node/lib/implementations/tokenizers/bpe.tokenizer.ts
+++ b/bindings/node/lib/implementations/tokenizers/bpe.tokenizer.ts
@@ -108,8 +108,8 @@ export class BPETokenizer extends BaseTokenizer<BPETokenizerConfig> {
         unkToken: unkToken,
       };
 
-      const fromFiles = promisify<string, string, BPEOptions, Model>(BPE.fromFiles);
-      model = await fromFiles(opts.vocabFile, opts.mergesFile, modelOptions);
+      const fromFile = promisify<string, string, BPEOptions, Model>(BPE.fromFile);
+      model = await fromFile(opts.vocabFile, opts.mergesFile, modelOptions);
     } else {
       model = BPE.empty();
     }

--- a/bindings/node/lib/implementations/tokenizers/byte-level-bpe.tokenizer.ts
+++ b/bindings/node/lib/implementations/tokenizers/byte-level-bpe.tokenizer.ts
@@ -93,8 +93,8 @@ export class ByteLevelBPETokenizer extends BaseTokenizer<ByteLevelBPETokenizerCo
 
     let model: Model;
     if (opts.vocabFile && opts.mergesFile) {
-      const fromFiles = promisify<string, string, BPEOptions, Model>(BPE.fromFiles);
-      model = await fromFiles(opts.vocabFile, opts.mergesFile, opts);
+      const fromFile = promisify<string, string, BPEOptions, Model>(BPE.fromFile);
+      model = await fromFile(opts.vocabFile, opts.mergesFile, opts);
     } else {
       model = BPE.empty();
     }

--- a/bindings/node/lib/implementations/tokenizers/sentence-piece-bpe.tokenizer.ts
+++ b/bindings/node/lib/implementations/tokenizers/sentence-piece-bpe.tokenizer.ts
@@ -100,8 +100,8 @@ export class SentencePieceBPETokenizer extends BaseTokenizer<
         unkToken: unkToken,
       };
 
-      const fromFiles = promisify<string, string, BPEOptions, Model>(BPE.fromFiles);
-      model = await fromFiles(opts.vocabFile, opts.mergesFile, modelOptions);
+      const fromFile = promisify<string, string, BPEOptions, Model>(BPE.fromFile);
+      model = await fromFile(opts.vocabFile, opts.mergesFile, modelOptions);
     } else {
       model = BPE.empty();
     }

--- a/bindings/node/native/src/models.rs
+++ b/bindings/node/native/src/models.rs
@@ -128,17 +128,14 @@ impl BpeOptions {
     }
 }
 
-/// bpe_from_files(vocab: String, merges: String, options: {
+/// bpe_init(vocab: Map<String, u32>, merges: Map<(u32, u32), (u32, u32)>, options: {
 ///   cacheCapacity?: number,
 ///   dropout?: number,
 ///   unkToken?: String,
 ///   continuingSubwordPrefix?: String,
 ///   endOfWordSuffix?: String
 /// }, callback)
-pub fn bpe_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-    let vocab = cx.extract::<String>(0)?;
-    let merges = cx.extract::<String>(1)?;
-
+pub fn bpe_init(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let (options, callback) = match cx.extract_opt::<BpeOptions>(2) {
         // Options were there, and extracted
         Ok(Some(options)) => (options, cx.argument::<JsFunction>(3)?),
@@ -147,8 +144,38 @@ pub fn bpe_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         // Options not specified, callback instead
         Err(_) => (BpeOptions::default(), cx.argument::<JsFunction>(2)?),
     };
+    let vocab = cx.extract::<HashMap<String, u32>>(0)?;
+    let merges = cx.extract::<HashMap<(u32, u32), (u32, u32)>>(1)?;
 
+    let mut builder = tk::models::bpe::BPE::builder().vocab_and_merges(vocab, merges);
+
+    builder = options.apply_to_bpe_builder(builder);
+
+    let task = BPEFromFilesTask::new(builder);
+    task.schedule(callback);
+    Ok(cx.undefined())
+}
+
+/// bpe_from_files(vocab: String, merges: String, options: {
+///   cacheCapacity?: number,
+///   dropout?: number,
+///   unkToken?: String,
+///   continuingSubwordPrefix?: String,
+///   endOfWordSuffix?: String
+/// }, callback)
+pub fn bpe_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let (options, callback) = match cx.extract_opt::<BpeOptions>(2) {
+        // Options were there, and extracted
+        Ok(Some(options)) => (options, cx.argument::<JsFunction>(3)?),
+        // Options were undefined or null
+        Ok(None) => (BpeOptions::default(), cx.argument::<JsFunction>(3)?),
+        // Options not specified, callback instead
+        Err(_) => (BpeOptions::default(), cx.argument::<JsFunction>(2)?),
+    };
+    let vocab = cx.extract::<String>(0)?;
+    let merges = cx.extract::<String>(1)?;
     let mut builder = tk::models::bpe::BPE::from_files(&vocab, &merges);
+
     builder = options.apply_to_bpe_builder(builder);
 
     let task = BPEFromFilesTask::new(builder);
@@ -190,14 +217,12 @@ impl WordPieceOptions {
     }
 }
 
-/// wordpiece_from_files(vocab: String, options: {
+/// wordpiece_init(vocab: Map<String, u32>, options: {
 ///   unkToken?: String = "[UNK]",
 ///   maxInputCharsPerWord?: number = 100,
 ///   continuingSubwordPrefix?: "##",
 /// }, callback)
-pub fn wordpiece_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-    let vocab = cx.extract::<String>(0)?;
-
+pub fn wordpiece_init(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let (options, callback) = match cx.extract_opt::<WordPieceOptions>(1) {
         // Options were there, and extracted
         Ok(Some(options)) => (options, cx.argument::<JsFunction>(2)?),
@@ -207,11 +232,36 @@ pub fn wordpiece_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         Err(_) => (WordPieceOptions::default(), cx.argument::<JsFunction>(1)?),
     };
 
-    let mut builder = tk::models::wordpiece::WordPiece::from_files(&vocab);
-    builder = options.apply_to_wordpiece_builder(builder);
+    let vocab = cx.extract::<HashMap<String, u32>>(0)?;
 
+    let mut builder = tk::models::wordpiece::WordPiece::builder().vocab(vocab);
+    builder = options.apply_to_wordpiece_builder(builder);
     let task = WordPieceFromFilesTask::new(builder);
     task.schedule(callback);
+
+    Ok(cx.undefined())
+}
+
+/// wordpiece_from_files(vocab: String, options: {
+///   unkToken?: String = "[UNK]",
+///   maxInputCharsPerWord?: number = 100,
+///   continuingSubwordPrefix?: "##",
+/// }, callback)
+pub fn wordpiece_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let (options, callback) = match cx.extract_opt::<WordPieceOptions>(1) {
+        // Options were there, and extracted
+        Ok(Some(options)) => (options, cx.argument::<JsFunction>(2)?),
+        // Options were undefined or null
+        Ok(None) => (WordPieceOptions::default(), cx.argument::<JsFunction>(2)?),
+        // Options not specified, callback instead
+        Err(_) => (WordPieceOptions::default(), cx.argument::<JsFunction>(1)?),
+    };
+    let vocab = cx.extract::<String>(0)?;
+    let mut builder = tk::models::wordpiece::WordPiece::from_files(&vocab);
+    builder = options.apply_to_wordpiece_builder(builder);
+    let task = WordPieceFromFilesTask::new(builder);
+    task.schedule(callback);
+
     Ok(cx.undefined())
 }
 
@@ -228,8 +278,10 @@ pub fn wordpiece_empty(mut cx: FunctionContext) -> JsResult<JsModel> {
 
 /// Register everything here
 pub fn register(m: &mut ModuleContext, prefix: &str) -> NeonResult<()> {
+    m.export_function(&format!("{}_BPE_init", prefix), bpe_init)?;
     m.export_function(&format!("{}_BPE_from_files", prefix), bpe_from_files)?;
     m.export_function(&format!("{}_BPE_empty", prefix), bpe_empty)?;
+    m.export_function(&format!("{}_WordPiece_init", prefix), wordpiece_init)?;
     m.export_function(
         &format!("{}_WordPiece_from_files", prefix),
         wordpiece_from_files,

--- a/bindings/node/native/src/models.rs
+++ b/bindings/node/native/src/models.rs
@@ -8,7 +8,11 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use tk::models::{bpe::BpeBuilder, wordpiece::WordPieceBuilder, ModelWrapper};
+use tk::models::{
+    bpe::{BpeBuilder, Merges, Vocab},
+    wordpiece::WordPieceBuilder,
+    ModelWrapper,
+};
 use tk::Model as ModelTrait;
 use tk::Token;
 
@@ -144,8 +148,8 @@ pub fn bpe_init(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         // Options not specified, callback instead
         Err(_) => (BpeOptions::default(), cx.argument::<JsFunction>(2)?),
     };
-    let vocab = cx.extract::<HashMap<String, u32>>(0)?;
-    let merges = cx.extract::<HashMap<(u32, u32), (u32, u32)>>(1)?;
+    let vocab = cx.extract::<Vocab>(0)?;
+    let merges = cx.extract::<Merges>(1)?;
 
     let mut builder = tk::models::bpe::BPE::builder().vocab_and_merges(vocab, merges);
 

--- a/bindings/node/native/src/models.rs
+++ b/bindings/node/native/src/models.rs
@@ -156,14 +156,14 @@ pub fn bpe_init(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     Ok(cx.undefined())
 }
 
-/// bpe_from_files(vocab: String, merges: String, options: {
+/// bpe_from_file(vocab: String, merges: String, options: {
 ///   cacheCapacity?: number,
 ///   dropout?: number,
 ///   unkToken?: String,
 ///   continuingSubwordPrefix?: String,
 ///   endOfWordSuffix?: String
 /// }, callback)
-pub fn bpe_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+pub fn bpe_from_file(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let (options, callback) = match cx.extract_opt::<BpeOptions>(2) {
         // Options were there, and extracted
         Ok(Some(options)) => (options, cx.argument::<JsFunction>(3)?),
@@ -174,7 +174,7 @@ pub fn bpe_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     };
     let vocab = cx.extract::<String>(0)?;
     let merges = cx.extract::<String>(1)?;
-    let mut builder = tk::models::bpe::BPE::from_files(&vocab, &merges);
+    let mut builder = tk::models::bpe::BPE::from_file(&vocab, &merges);
 
     builder = options.apply_to_bpe_builder(builder);
 
@@ -242,12 +242,12 @@ pub fn wordpiece_init(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     Ok(cx.undefined())
 }
 
-/// wordpiece_from_files(vocab: String, options: {
+/// wordpiece_from_file(vocab: String, options: {
 ///   unkToken?: String = "[UNK]",
 ///   maxInputCharsPerWord?: number = 100,
 ///   continuingSubwordPrefix?: "##",
 /// }, callback)
-pub fn wordpiece_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+pub fn wordpiece_from_file(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let (options, callback) = match cx.extract_opt::<WordPieceOptions>(1) {
         // Options were there, and extracted
         Ok(Some(options)) => (options, cx.argument::<JsFunction>(2)?),
@@ -257,7 +257,7 @@ pub fn wordpiece_from_files(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         Err(_) => (WordPieceOptions::default(), cx.argument::<JsFunction>(1)?),
     };
     let vocab = cx.extract::<String>(0)?;
-    let mut builder = tk::models::wordpiece::WordPiece::from_files(&vocab);
+    let mut builder = tk::models::wordpiece::WordPiece::from_file(&vocab);
     builder = options.apply_to_wordpiece_builder(builder);
     let task = WordPieceFromFilesTask::new(builder);
     task.schedule(callback);
@@ -279,12 +279,12 @@ pub fn wordpiece_empty(mut cx: FunctionContext) -> JsResult<JsModel> {
 /// Register everything here
 pub fn register(m: &mut ModuleContext, prefix: &str) -> NeonResult<()> {
     m.export_function(&format!("{}_BPE_init", prefix), bpe_init)?;
-    m.export_function(&format!("{}_BPE_from_files", prefix), bpe_from_files)?;
+    m.export_function(&format!("{}_BPE_from_file", prefix), bpe_from_file)?;
     m.export_function(&format!("{}_BPE_empty", prefix), bpe_empty)?;
     m.export_function(&format!("{}_WordPiece_init", prefix), wordpiece_init)?;
     m.export_function(
-        &format!("{}_WordPiece_from_files", prefix),
-        wordpiece_from_files,
+        &format!("{}_WordPiece_from_file", prefix),
+        wordpiece_from_file,
     )?;
     m.export_function(&format!("{}_WordPiece_empty", prefix), wordpiece_empty)?;
     Ok(())

--- a/bindings/python/examples/example.py
+++ b/bindings/python/examples/example.py
@@ -70,17 +70,13 @@ elif args.type == "bert":
 
     tok_r = Tokenizer(WordPiece(args.vocab, unk_token="[UNK]", max_input_chars_per_word=100))
     tok_r.normalizer = BertNormalizer(
-        clean_text=True,
-        handle_chinese_chars=True,
-        strip_accents=True,
-        lowercase=True,
+        clean_text=True, handle_chinese_chars=True, strip_accents=True, lowercase=True,
     )
     # tok_r.pre_tokenizer = pre_tokenizers.Whitespace()
     tok_r.pre_tokenizer = pre_tokenizers.BertPreTokenizer()
     tok_r.decoder = decoders.WordPiece()
     tok_r.post_processor = BertProcessing(
-        ("[SEP]", tok_r.token_to_id("[SEP]")),
-        ("[CLS]", tok_r.token_to_id("[CLS]")),
+        ("[SEP]", tok_r.token_to_id("[SEP]")), ("[CLS]", tok_r.token_to_id("[CLS]")),
     )
 else:
     raise Exception(f"Unknown type {args.type}")

--- a/bindings/python/examples/example.py
+++ b/bindings/python/examples/example.py
@@ -70,13 +70,17 @@ elif args.type == "bert":
 
     tok_r = Tokenizer(WordPiece(args.vocab, unk_token="[UNK]", max_input_chars_per_word=100))
     tok_r.normalizer = BertNormalizer(
-        clean_text=True, handle_chinese_chars=True, strip_accents=True, lowercase=True,
+        clean_text=True,
+        handle_chinese_chars=True,
+        strip_accents=True,
+        lowercase=True,
     )
     # tok_r.pre_tokenizer = pre_tokenizers.Whitespace()
     tok_r.pre_tokenizer = pre_tokenizers.BertPreTokenizer()
     tok_r.decoder = decoders.WordPiece()
     tok_r.post_processor = BertProcessing(
-        ("[SEP]", tok_r.token_to_id("[SEP]")), ("[CLS]", tok_r.token_to_id("[CLS]")),
+        ("[SEP]", tok_r.token_to_id("[SEP]")),
+        ("[CLS]", tok_r.token_to_id("[CLS]")),
     )
 else:
     raise Exception(f"Unknown type {args.type}")

--- a/bindings/python/examples/train_bert_wordpiece.py
+++ b/bindings/python/examples/train_bert_wordpiece.py
@@ -32,10 +32,7 @@ if not files:
 
 # Initialize an empty tokenizer
 tokenizer = BertWordPieceTokenizer(
-    clean_text=True,
-    handle_chinese_chars=True,
-    strip_accents=True,
-    lowercase=True,
+    clean_text=True, handle_chinese_chars=True, strip_accents=True, lowercase=True,
 )
 
 # And then train

--- a/bindings/python/examples/train_bert_wordpiece.py
+++ b/bindings/python/examples/train_bert_wordpiece.py
@@ -32,7 +32,10 @@ if not files:
 
 # Initialize an empty tokenizer
 tokenizer = BertWordPieceTokenizer(
-    clean_text=True, handle_chinese_chars=True, strip_accents=True, lowercase=True,
+    clean_text=True,
+    handle_chinese_chars=True,
+    strip_accents=True,
+    lowercase=True,
 )
 
 # And then train

--- a/bindings/python/py_src/tokenizers/__init__.py
+++ b/bindings/python/py_src/tokenizers/__init__.py
@@ -9,7 +9,8 @@ TextInputSequence = str
 PreTokenizedInputSequence = Union[List[str], Tuple[str]]
 TextEncodeInput = Union[TextInputSequence, Tuple[TextInputSequence, TextInputSequence]]
 PreTokenizedEncodeInput = Union[
-    PreTokenizedInputSequence, Tuple[PreTokenizedInputSequence, PreTokenizedInputSequence],
+    PreTokenizedInputSequence,
+    Tuple[PreTokenizedInputSequence, PreTokenizedInputSequence],
 ]
 
 InputSequence = Union[TextInputSequence, PreTokenizedInputSequence]

--- a/bindings/python/py_src/tokenizers/__init__.py
+++ b/bindings/python/py_src/tokenizers/__init__.py
@@ -9,8 +9,7 @@ TextInputSequence = str
 PreTokenizedInputSequence = Union[List[str], Tuple[str]]
 TextEncodeInput = Union[TextInputSequence, Tuple[TextInputSequence, TextInputSequence]]
 PreTokenizedEncodeInput = Union[
-    PreTokenizedInputSequence,
-    Tuple[PreTokenizedInputSequence, PreTokenizedInputSequence],
+    PreTokenizedInputSequence, Tuple[PreTokenizedInputSequence, PreTokenizedInputSequence],
 ]
 
 InputSequence = Union[TextInputSequence, PreTokenizedInputSequence]

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -21,7 +21,8 @@ TextInputSequence = str
 PreTokenizedInputSequence = Union[List[str], Tuple[str]]
 TextEncodeInput = Union[TextInputSequence, Tuple[TextInputSequence, TextInputSequence]]
 PreTokenizedEncodeInput = Union[
-    PreTokenizedInputSequence, Tuple[PreTokenizedInputSequence, PreTokenizedInputSequence],
+    PreTokenizedInputSequence,
+    Tuple[PreTokenizedInputSequence, PreTokenizedInputSequence],
 ]
 
 InputSequence = Union[TextInputSequence, PreTokenizedInputSequence]
@@ -827,7 +828,10 @@ class Tokenizer:
         """
         pass
     def post_process(
-        self, encoding: Encoding, pair: Optional[Encoding] = None, add_special_tokens: bool = True,
+        self,
+        encoding: Encoding,
+        pair: Optional[Encoding] = None,
+        add_special_tokens: bool = True,
     ) -> Encoding:
         """Apply all the post-processing steps to the given encodings.
 

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -21,8 +21,7 @@ TextInputSequence = str
 PreTokenizedInputSequence = Union[List[str], Tuple[str]]
 TextEncodeInput = Union[TextInputSequence, Tuple[TextInputSequence, TextInputSequence]]
 PreTokenizedEncodeInput = Union[
-    PreTokenizedInputSequence,
-    Tuple[PreTokenizedInputSequence, PreTokenizedInputSequence],
+    PreTokenizedInputSequence, Tuple[PreTokenizedInputSequence, PreTokenizedInputSequence],
 ]
 
 InputSequence = Union[TextInputSequence, PreTokenizedInputSequence]
@@ -828,10 +827,7 @@ class Tokenizer:
         """
         pass
     def post_process(
-        self,
-        encoding: Encoding,
-        pair: Optional[Encoding] = None,
-        add_special_tokens: bool = True,
+        self, encoding: Encoding, pair: Optional[Encoding] = None, add_special_tokens: bool = True,
     ) -> Encoding:
         """Apply all the post-processing steps to the given encodings.
 

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -258,7 +258,7 @@ class Encoding:
 
     @staticmethod
     def merge(encodings: List[Encoding], growing_offsets: bool = True) -> Encoding:
-        """ Merge the list of Encoding into one final Encoding
+        """Merge the list of Encoding into one final Encoding
 
         Args:
             encodings: List[Encoding]:
@@ -289,7 +289,7 @@ class Encoding:
         pass
     @property
     def offsets(self) -> List[Offsets]:
-        """ The offsets.
+        """The offsets.
         These offsets can be used to index any `IndexableString` directly. If you want to
         index the original `str`, make sure to retrieve the converted offsets using the `.offsets`
         method on the `original_str`.
@@ -388,7 +388,7 @@ class Encoding:
         pad_token: Optional[str] = "[PAD]",
         direction: Optional[str] = "right",
     ):
-        """ Pad the current Encoding at the given length
+        """Pad the current Encoding at the given length
 
         Args:
             length: int:
@@ -408,7 +408,7 @@ class Encoding:
         """
         pass
     def truncate(self, max_length: int, stride: Optional[int] = 0):
-        """ Truncate the current Encoding at the given max_length
+        """Truncate the current Encoding at the given max_length
 
         Args:
             max_length: int:
@@ -421,7 +421,7 @@ class Encoding:
         pass
 
 class AddedToken:
-    """ AddedToken represents a token to be added to a Tokenizer
+    """AddedToken represents a token to be added to a Tokenizer
 
     An AddedToken can have special options defining the way it should behave.
     """
@@ -434,7 +434,7 @@ class AddedToken:
         rstrip: bool = False,
         normalized: bool = True,
     ) -> AddedToken:
-        """ Instantiate a new AddedToken
+        """Instantiate a new AddedToken
 
         Args:
             content: str:
@@ -464,7 +464,7 @@ class AddedToken:
         pass
 
 class Tokenizer:
-    """ Tokenizer
+    """Tokenizer
 
     A Tokenizer works as a pipeline, it processes some raw text as input and outputs
     an `Encoding`.
@@ -481,7 +481,7 @@ class Tokenizer:
     """
 
     def __new__(cls, model: models.Model) -> Tokenizer:
-        """ Instantiate a new Tokenizer using the given Model
+        """Instantiate a new Tokenizer using the given Model
 
         Args:
             model: models.Model:
@@ -493,7 +493,7 @@ class Tokenizer:
         pass
     @staticmethod
     def from_str(s: str) -> Tokenizer:
-        """ Instantiate a new Tokenizer from the given JSON string
+        """Instantiate a new Tokenizer from the given JSON string
 
         Args:
             s: str:
@@ -505,7 +505,7 @@ class Tokenizer:
         pass
     @staticmethod
     def from_file(path: str) -> Tokenizer:
-        """ Instantiate a new Tokenizer from the given file
+        """Instantiate a new Tokenizer from the given file
 
         Args:
             path: str:
@@ -517,7 +517,7 @@ class Tokenizer:
         pass
     @staticmethod
     def from_buffer(buffer: bytes) -> Tokenizer:
-        """ Instantiate a new Tokenizer from the given buffer
+        """Instantiate a new Tokenizer from the given buffer
 
         Args:
             buffer: bytes:
@@ -528,7 +528,7 @@ class Tokenizer:
         """
         pass
     def to_str(self, pretty: bool = False) -> str:
-        """ Get a serialized JSON version of the Tokenizer as a str
+        """Get a serialized JSON version of the Tokenizer as a str
 
         Args:
             pretty: bool:
@@ -539,7 +539,7 @@ class Tokenizer:
         """
         pass
     def save(self, path: str, pretty: bool = False):
-        """ Save the Tokenizer as JSON to the given path
+        """Save the Tokenizer as JSON to the given path
 
         Args:
             pretty: bool:
@@ -592,7 +592,7 @@ class Tokenizer:
         """
         pass
     def get_vocab(self, with_added_tokens: bool = True) -> Dict[str, int]:
-        """ Returns the vocabulary
+        """Returns the vocabulary
 
         Args:
             with_added_tokens: boolean:
@@ -603,7 +603,7 @@ class Tokenizer:
         """
         pass
     def get_vocab_size(self, with_added_tokens: bool = True) -> int:
-        """ Returns the size of the vocabulary
+        """Returns the size of the vocabulary
 
         Args:
             with_added_tokens: boolean:
@@ -614,7 +614,7 @@ class Tokenizer:
         """
         pass
     def enable_truncation(self, max_length: int, stride: Optional[int], strategy: Optional[str]):
-        """ Enable the truncation
+        """Enable the truncation
 
         Args:
             max_length: unsigned int:
@@ -633,7 +633,7 @@ class Tokenizer:
         pass
     @property
     def truncation(self) -> Optional[dict]:
-        """ Get the current truncation parameters
+        """Get the current truncation parameters
 
         Returns:
             None if truncation is disabled, a dict with the current truncation parameters if
@@ -649,7 +649,7 @@ class Tokenizer:
         pad_token: Optional[str] = "[PAD]",
         length: Optional[int] = None,
     ):
-        """ Enable the padding
+        """Enable the padding
 
         Args:
             direction: (`optional`) str:
@@ -679,7 +679,7 @@ class Tokenizer:
         pass
     @property
     def padding(self) -> Optional[dict]:
-        """ Get the current padding parameters
+        """Get the current padding parameters
 
         Returns:
             None if padding is disabled, a dict with the currently set parameters
@@ -693,7 +693,7 @@ class Tokenizer:
         is_pretokenized: bool = False,
         add_special_tokens: bool = True,
     ) -> Encoding:
-        """ Encode the given sequence and pair. This method can process raw text sequences as well
+        """Encode the given sequence and pair. This method can process raw text sequences as well
         as already pre-tokenized sequences.
 
         Args:
@@ -721,7 +721,7 @@ class Tokenizer:
         is_pretokenized: bool = False,
         add_special_tokens: bool = True,
     ) -> List[Encoding]:
-        """ Encode the given inputs. This method accept both raw text sequences as well as already
+        """Encode the given inputs. This method accept both raw text sequences as well as already
         pre-tokenized sequences.
 
         Args:
@@ -748,7 +748,7 @@ class Tokenizer:
         """
         pass
     def decode(self, ids: List[int], skip_special_tokens: Optional[bool] = True) -> str:
-        """ Decode the given list of ids to a string sequence
+        """Decode the given list of ids to a string sequence
 
         Args:
             ids: List[unsigned int]:
@@ -764,7 +764,7 @@ class Tokenizer:
     def decode_batch(
         self, sequences: List[List[int]], skip_special_tokens: Optional[bool] = True
     ) -> str:
-        """ Decode the list of sequences to a list of string sequences
+        """Decode the list of sequences to a list of string sequences
 
         Args:
             sequences: List[List[unsigned int]]:
@@ -778,7 +778,7 @@ class Tokenizer:
         """
         pass
     def token_to_id(self, token: str) -> Optional[int]:
-        """ Convert the given token to its corresponding id
+        """Convert the given token to its corresponding id
 
         Args:
             token: str:
@@ -789,7 +789,7 @@ class Tokenizer:
         """
         pass
     def id_to_token(self, id: int) -> Optional[str]:
-        """ Convert the given token id to its corresponding string
+        """Convert the given token id to its corresponding string
 
         Args:
             token: id:
@@ -800,7 +800,7 @@ class Tokenizer:
         """
         pass
     def add_tokens(self, tokens: List[Union[str, AddedToken]]) -> int:
-        """ Add the given tokens to the vocabulary
+        """Add the given tokens to the vocabulary
 
         Args:
             tokens: List[Union[str, AddedToken]]:
@@ -812,7 +812,7 @@ class Tokenizer:
         """
         pass
     def add_special_tokens(self, tokens: List[Union[str, AddedToken]]) -> int:
-        """ Add the given special tokens to the vocabulary, and treat them as special tokens.
+        """Add the given special tokens to the vocabulary, and treat them as special tokens.
 
         The special tokens will never be processed by the model, and will be
         removed while decoding.
@@ -829,7 +829,7 @@ class Tokenizer:
     def post_process(
         self, encoding: Encoding, pair: Optional[Encoding] = None, add_special_tokens: bool = True,
     ) -> Encoding:
-        """ Apply all the post-processing steps to the given encodings.
+        """Apply all the post-processing steps to the given encodings.
 
         The various steps are:
             1. Truncate according to global params (provided to `enable_truncation`)

--- a/bindings/python/py_src/tokenizers/decoders/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/decoders/__init__.pyi
@@ -1,7 +1,7 @@
 from typing import List
 
 class Decoder:
-    """ Base class for all decoders
+    """Base class for all decoders
 
     This class is not supposed to be instantiated directly. Instead, any implementation of
     a Decoder will return an instance of this class when instantiated.
@@ -23,7 +23,7 @@ class WordPiece(Decoder):
 
     @staticmethod
     def __init__(self, prefix: str = "##", cleanup: bool = True) -> Decoder:
-        """ Instantiate a new WordPiece Decoder
+        """Instantiate a new WordPiece Decoder
 
         Args:
             prefix: str:
@@ -38,7 +38,7 @@ class Metaspace(Decoder):
     """ Metaspace decoder """
 
     def __init__(self, replacement: str = "▁", add_prefix_space: bool = True) -> None:
-        """ Instantiate a new Metaspace
+        """Instantiate a new Metaspace
 
         Args:
             replacement: str:
@@ -55,7 +55,7 @@ class BPEDecoder(Decoder):
     """ BPEDecoder """
 
     def __init__(self, suffix: str = "</w>") -> None:
-        """ Instantiate a new BPEDecoder
+        """Instantiate a new BPEDecoder
 
         Args:
             suffix: str:

--- a/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
@@ -25,7 +25,7 @@ class BaseTokenizer:
         return self._tokenizer.num_special_tokens_to_add(is_pair)
 
     def get_vocab(self, with_added_tokens: bool = True) -> Dict[str, int]:
-        """ Returns the vocabulary
+        """Returns the vocabulary
 
         Args:
             with_added_tokens: boolean:
@@ -37,7 +37,7 @@ class BaseTokenizer:
         return self._tokenizer.get_vocab(with_added_tokens=with_added_tokens)
 
     def get_vocab_size(self, with_added_tokens: bool = True) -> int:
-        """ Return the size of vocabulary, with or without added tokens.
+        """Return the size of vocabulary, with or without added tokens.
 
         Args:
             with_added_tokens: (`optional`) bool:
@@ -57,7 +57,7 @@ class BaseTokenizer:
         pad_token: Optional[str] = "[PAD]",
         length: Optional[int] = None,
     ):
-        """ Change the padding strategy
+        """Change the padding strategy
 
         Args:
             direction: (`optional`) str:
@@ -96,7 +96,7 @@ class BaseTokenizer:
 
     @property
     def padding(self) -> Optional[dict]:
-        """ Get the current padding parameters
+        """Get the current padding parameters
 
         Returns:
             None if padding is disabled, a dict with the currently set parameters
@@ -107,7 +107,7 @@ class BaseTokenizer:
     def enable_truncation(
         self, max_length: int, stride: Optional[int] = 0, strategy: Optional[str] = "longest_first"
     ):
-        """ Change the truncation options
+        """Change the truncation options
 
         Args:
             max_length: unsigned int:
@@ -128,7 +128,7 @@ class BaseTokenizer:
 
     @property
     def truncation(self) -> Optional[dict]:
-        """ Get the current truncation parameters
+        """Get the current truncation parameters
 
         Returns:
             None if truncation is disabled, a dict with the current truncation parameters if
@@ -137,7 +137,7 @@ class BaseTokenizer:
         return self._tokenizer.truncation
 
     def add_tokens(self, tokens: List[Union[str, AddedToken]]) -> int:
-        """ Add the given tokens to the vocabulary
+        """Add the given tokens to the vocabulary
 
         Args:
             tokens: List[Union[str, AddedToken]]:
@@ -150,7 +150,7 @@ class BaseTokenizer:
         return self._tokenizer.add_tokens(tokens)
 
     def add_special_tokens(self, special_tokens: List[Union[str, AddedToken]]) -> int:
-        """ Add the given special tokens to the vocabulary, and treat them as special tokens.
+        """Add the given special tokens to the vocabulary, and treat them as special tokens.
 
         The special tokens will never be processed by the model, and will be
         removed while decoding.
@@ -166,7 +166,7 @@ class BaseTokenizer:
         return self._tokenizer.add_special_tokens(special_tokens)
 
     def normalize(self, sequence: str) -> str:
-        """ Normalize the given sequence
+        """Normalize the given sequence
 
         Args:
             sequence: str:
@@ -184,7 +184,7 @@ class BaseTokenizer:
         is_pretokenized: bool = False,
         add_special_tokens: bool = True,
     ) -> Encoding:
-        """ Encode the given sequence and pair. This method can process raw text sequences as well
+        """Encode the given sequence and pair. This method can process raw text sequences as well
         as already pre-tokenized sequences.
 
         Args:
@@ -216,7 +216,7 @@ class BaseTokenizer:
         is_pretokenized: bool = False,
         add_special_tokens: bool = True,
     ) -> List[Encoding]:
-        """ Encode the given inputs. This method accept both raw text sequences as well as already
+        """Encode the given inputs. This method accept both raw text sequences as well as already
         pre-tokenized sequences.
 
         Args:
@@ -248,7 +248,7 @@ class BaseTokenizer:
         return self._tokenizer.encode_batch(inputs, is_pretokenized, add_special_tokens)
 
     def decode(self, ids: List[int], skip_special_tokens: Optional[bool] = True) -> str:
-        """ Decode the given list of ids to a string sequence
+        """Decode the given list of ids to a string sequence
 
         Args:
             ids: List[unsigned int]:
@@ -268,7 +268,7 @@ class BaseTokenizer:
     def decode_batch(
         self, sequences: List[List[int]], skip_special_tokens: Optional[bool] = True
     ) -> str:
-        """ Decode the list of sequences to a list of string sequences
+        """Decode the list of sequences to a list of string sequences
 
         Args:
             sequences: List[List[unsigned int]]:
@@ -286,7 +286,7 @@ class BaseTokenizer:
         return self._tokenizer.decode_batch(sequences, skip_special_tokens=skip_special_tokens)
 
     def token_to_id(self, token: str) -> Optional[int]:
-        """ Convert the given token to its corresponding id
+        """Convert the given token to its corresponding id
 
         Args:
             token: str:
@@ -298,7 +298,7 @@ class BaseTokenizer:
         return self._tokenizer.token_to_id(token)
 
     def id_to_token(self, id: int) -> Optional[str]:
-        """ Convert the given token id to its corresponding string
+        """Convert the given token id to its corresponding string
 
         Args:
             token: id:
@@ -310,7 +310,7 @@ class BaseTokenizer:
         return self._tokenizer.id_to_token(id)
 
     def save_model(self, directory: str, name: Optional[str] = None):
-        """ Save the current model to the given directory
+        """Save the current model to the given directory
 
         Args:
             directory: str:
@@ -322,7 +322,7 @@ class BaseTokenizer:
         return self._tokenizer.model.save(directory, name=name)
 
     def save(self, path: str, pretty: bool = False):
-        """ Save the current Tokenizer at the given path
+        """Save the current Tokenizer at the given path
 
         Args:
             path: str:
@@ -331,7 +331,7 @@ class BaseTokenizer:
         return self._tokenizer.save(path, pretty)
 
     def to_str(self, pretty: bool = False):
-        """ Get a serialized JSON version of the Tokenizer as a str
+        """Get a serialized JSON version of the Tokenizer as a str
 
         Args:
             pretty: bool:
@@ -345,7 +345,7 @@ class BaseTokenizer:
     def post_process(
         self, encoding: Encoding, pair: Optional[Encoding] = None, add_special_tokens: bool = True
     ) -> Encoding:
-        """ Apply all the post-processing steps to the given encodings.
+        """Apply all the post-processing steps to the given encodings.
 
         The various steps are:
             1. Truncate according to global params (provided to `enable_truncation`)

--- a/bindings/python/py_src/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/py_src/tokenizers/implementations/bert_wordpiece.py
@@ -80,6 +80,10 @@ class BertWordPieceTokenizer(BaseTokenizer):
 
         super().__init__(tokenizer, parameters)
 
+    def from_file(vocab: str, **kwargs):
+        vocab = WordPiece.read_file(vocab)
+        return BertWordPieceTokenizer(vocab, **kwargs)
+
     def train(
         self,
         files: Union[str, List[str]],

--- a/bindings/python/py_src/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/py_src/tokenizers/implementations/bert_wordpiece.py
@@ -5,7 +5,7 @@ from tokenizers.pre_tokenizers import BertPreTokenizer
 from tokenizers.processors import BertProcessing
 from .base_tokenizer import BaseTokenizer
 
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict
 
 
 class BertWordPieceTokenizer(BaseTokenizer):
@@ -13,7 +13,7 @@ class BertWordPieceTokenizer(BaseTokenizer):
 
     def __init__(
         self,
-        vocab_file: Optional[str] = None,
+        vocab: Optional[Union[str, Dict[str, int]]] = None,
         unk_token: Union[str, AddedToken] = "[UNK]",
         sep_token: Union[str, AddedToken] = "[SEP]",
         cls_token: Union[str, AddedToken] = "[CLS]",
@@ -26,8 +26,8 @@ class BertWordPieceTokenizer(BaseTokenizer):
         wordpieces_prefix: str = "##",
     ):
 
-        if vocab_file is not None:
-            tokenizer = Tokenizer(WordPiece(vocab_file, unk_token=str(unk_token)))
+        if vocab is not None:
+            tokenizer = Tokenizer(WordPiece(vocab, unk_token=str(unk_token)))
         else:
             tokenizer = Tokenizer(WordPiece(unk_token=str(unk_token)))
 
@@ -51,7 +51,7 @@ class BertWordPieceTokenizer(BaseTokenizer):
         )
         tokenizer.pre_tokenizer = BertPreTokenizer()
 
-        if vocab_file is not None:
+        if vocab is not None:
             sep_token_id = tokenizer.token_to_id(str(sep_token))
             if sep_token_id is None:
                 raise TypeError("sep_token not found in the vocabulary")

--- a/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
@@ -77,6 +77,11 @@ class ByteLevelBPETokenizer(BaseTokenizer):
 
         super().__init__(tokenizer, parameters)
 
+    @staticmethod
+    def from_files(vocab_filename: str, merges_filename: str, **kwargs):
+        vocab, merges = BPE.read_files(vocab_filename, merges_filename)
+        return ByteLevelBPETokenizer(vocab, merges, **kwargs)
+
     def train(
         self,
         files: Union[str, List[str]],

--- a/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
@@ -78,8 +78,8 @@ class ByteLevelBPETokenizer(BaseTokenizer):
         super().__init__(tokenizer, parameters)
 
     @staticmethod
-    def from_files(vocab_filename: str, merges_filename: str, **kwargs):
-        vocab, merges = BPE.read_files(vocab_filename, merges_filename)
+    def from_file(vocab_filename: str, merges_filename: str, **kwargs):
+        vocab, merges = BPE.read_file(vocab_filename, merges_filename)
         return ByteLevelBPETokenizer(vocab, merges, **kwargs)
 
     def train(

--- a/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
@@ -1,21 +1,28 @@
-from tokenizers import Tokenizer, AddedToken, pre_tokenizers, decoders, trainers, processors
+from tokenizers import (
+    Tokenizer,
+    AddedToken,
+    pre_tokenizers,
+    decoders,
+    trainers,
+    processors,
+)
 from tokenizers.models import BPE
 from tokenizers.normalizers import unicode_normalizer_from_str, Lowercase, Sequence
 from .base_tokenizer import BaseTokenizer
 
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict, Tuple
 
 
 class ByteLevelBPETokenizer(BaseTokenizer):
-    """ ByteLevelBPETokenizer
+    """ByteLevelBPETokenizer
 
     Represents a Byte-level BPE as introduced by OpenAI with their GPT-2 model
     """
 
     def __init__(
         self,
-        vocab_file: Optional[str] = None,
-        merges_file: Optional[str] = None,
+        vocab: Optional[Union[str, Dict[str, int]]] = None,
+        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]] = None,
         add_prefix_space: bool = False,
         lowercase: bool = False,
         dropout: Optional[float] = None,
@@ -24,11 +31,11 @@ class ByteLevelBPETokenizer(BaseTokenizer):
         end_of_word_suffix: Optional[str] = None,
         trim_offsets: bool = False,
     ):
-        if vocab_file is not None and merges_file is not None:
+        if vocab is not None and merges is not None:
             tokenizer = Tokenizer(
                 BPE(
-                    vocab_file,
-                    merges_file,
+                    vocab,
+                    merges,
                     dropout=dropout,
                     continuing_subword_prefix=continuing_subword_prefix or "",
                     end_of_word_suffix=end_of_word_suffix or "",

--- a/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
@@ -95,8 +95,8 @@ class CharBPETokenizer(BaseTokenizer):
         super().__init__(tokenizer, parameters)
 
     @staticmethod
-    def from_files(vocab_filename: str, merges_filename: str, **kwargs):
-        vocab, merges = BPE.read_files(vocab_filename, merges_filename)
+    def from_file(vocab_filename: str, merges_filename: str, **kwargs):
+        vocab, merges = BPE.read_file(vocab_filename, merges_filename)
         return CharBPETokenizer(vocab, merges, **kwargs)
 
     def train(

--- a/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
@@ -94,6 +94,11 @@ class CharBPETokenizer(BaseTokenizer):
 
         super().__init__(tokenizer, parameters)
 
+    @staticmethod
+    def from_files(vocab_filename: str, merges_filename: str, **kwargs):
+        vocab, merges = BPE.read_files(vocab_filename, merges_filename)
+        return CharBPETokenizer(vocab, merges, **kwargs)
+
     def train(
         self,
         files: Union[str, List[str]],

--- a/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
@@ -1,31 +1,36 @@
 from .. import Tokenizer, AddedToken, pre_tokenizers, decoders, trainers
 from ..models import BPE
-from ..normalizers import Sequence, Lowercase, unicode_normalizer_from_str, BertNormalizer
+from ..normalizers import (
+    Sequence,
+    Lowercase,
+    unicode_normalizer_from_str,
+    BertNormalizer,
+)
 from .base_tokenizer import BaseTokenizer
 
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict, Tuple
 
 
 class CharBPETokenizer(BaseTokenizer):
-    """ Original BPE Tokenizer
+    """Original BPE Tokenizer
 
-        Represents the BPE algorithm, as introduced by Rico Sennrich
-        (https://arxiv.org/abs/1508.07909)
+    Represents the BPE algorithm, as introduced by Rico Sennrich
+    (https://arxiv.org/abs/1508.07909)
 
-        The defaults settings corresponds to OpenAI GPT BPE tokenizers and differs from the original
-        Sennrich subword-nmt implementation by the following options that you can deactivate:
-            - adding a normalizer to clean up the text (deactivate with `bert_normalizer=False`) by:
-                * removing any control characters and replacing all whitespaces by the classic one.
-                * handle chinese chars by putting spaces around them.
-                * strip all accents.
-            - spitting on punctuation in addition to whitespaces (deactivate it with
-              `split_on_whitespace_only=True`)
+    The defaults settings corresponds to OpenAI GPT BPE tokenizers and differs from the original
+    Sennrich subword-nmt implementation by the following options that you can deactivate:
+        - adding a normalizer to clean up the text (deactivate with `bert_normalizer=False`) by:
+            * removing any control characters and replacing all whitespaces by the classic one.
+            * handle chinese chars by putting spaces around them.
+            * strip all accents.
+        - spitting on punctuation in addition to whitespaces (deactivate it with
+          `split_on_whitespace_only=True`)
     """
 
     def __init__(
         self,
-        vocab_file: Optional[str] = None,
-        merges_file: Optional[str] = None,
+        vocab: Optional[Union[str, Dict[str, int]]] = None,
+        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]] = None,
         unk_token: Union[str, AddedToken] = "<unk>",
         suffix: str = "</w>",
         dropout: Optional[float] = None,
@@ -34,11 +39,11 @@ class CharBPETokenizer(BaseTokenizer):
         bert_normalizer: bool = True,
         split_on_whitespace_only: bool = False,
     ):
-        if vocab_file is not None and merges_file is not None:
+        if vocab is not None and merges is not None:
             tokenizer = Tokenizer(
                 BPE(
-                    vocab_file,
-                    merges_file,
+                    vocab,
+                    merges,
                     dropout=dropout,
                     unk_token=str(unk_token),
                     end_of_word_suffix=suffix,

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -47,6 +47,11 @@ class SentencePieceBPETokenizer(BaseTokenizer):
 
         super().__init__(tokenizer, parameters)
 
+    @staticmethod
+    def from_files(vocab_filename: str, merges_filename: str, **kwargs):
+        vocab, merges = BPE.read_files(vocab_filename, merges_filename)
+        return SentencePieceBPETokenizer(vocab, merges, **kwargs)
+
     def train(
         self,
         files: Union[str, List[str]],

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -48,7 +48,7 @@ class SentencePieceBPETokenizer(BaseTokenizer):
         super().__init__(tokenizer, parameters)
 
     @staticmethod
-    def from_files(vocab_filename: str, merges_filename: str, **kwargs):
+    def from_file(vocab_filename: str, merges_filename: str, **kwargs):
         vocab, merges = BPE.read_files(vocab_filename, merges_filename)
         return SentencePieceBPETokenizer(vocab, merges, **kwargs)
 

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -3,28 +3,26 @@ from tokenizers.models import BPE
 from tokenizers.normalizers import NFKC
 from .base_tokenizer import BaseTokenizer
 
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict, Tuple
 
 
 class SentencePieceBPETokenizer(BaseTokenizer):
-    """ SentencePiece BPE Tokenizer
+    """SentencePiece BPE Tokenizer
 
     Represents the BPE algorithm, with the pretokenization used by SentencePiece
     """
 
     def __init__(
         self,
-        vocab_file: Optional[str] = None,
-        merges_file: Optional[str] = None,
+        vocab: Optional[Union[str, Dict[str, int]]] = None,
+        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]] = None,
         unk_token: Union[str, AddedToken] = "<unk>",
         replacement: str = "▁",
         add_prefix_space: bool = True,
         dropout: Optional[float] = None,
     ):
-        if vocab_file is not None and merges_file is not None:
-            tokenizer = Tokenizer(
-                BPE(vocab_file, merges_file, dropout=dropout, unk_token=unk_token)
-            )
+        if vocab is not None and merges is not None:
+            tokenizer = Tokenizer(BPE(vocab, merges, dropout=dropout, unk_token=unk_token))
         else:
             tokenizer = Tokenizer(BPE())
 

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
@@ -21,10 +21,7 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
     """
 
     def __init__(
-        self,
-        vocab: Optional[str] = None,
-        replacement: str = "▁",
-        add_prefix_space: bool = True,
+        self, vocab: Optional[str] = None, replacement: str = "▁", add_prefix_space: bool = True,
     ):
         if vocab is not None:
             # Let Unigram(..) fail if only one of them is None
@@ -32,12 +29,7 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
         else:
             tokenizer = Tokenizer(Unigram())
 
-        tokenizer.normalizer = normalizers.Sequence(
-            [
-                normalizers.Nmt(),
-                normalizers.NFKC(),
-            ]
-        )
+        tokenizer.normalizer = normalizers.Sequence([normalizers.Nmt(), normalizers.NFKC(),])
         tokenizer.pre_tokenizer = pre_tokenizers.Sequence(
             [
                 pre_tokenizers.WhitespaceSplit(),
@@ -68,9 +60,7 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
         """ Train the model using the given files """
 
         trainer = trainers.UnigramTrainer(
-            vocab_size=vocab_size,
-            special_tokens=special_tokens,
-            show_progress=show_progress,
+            vocab_size=vocab_size, special_tokens=special_tokens, show_progress=show_progress,
         )
 
         if isinstance(files, str):

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
@@ -92,19 +92,10 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
                 "You're trying to run a `Unigram` model but you're file was trained with a different algorithm"
             )
 
-        data = {"unk_id": unk_id, "vocab": vocab}
-
         replacement = "▁"
         add_prefix_space = True
 
-        out_vocab_filename = f"{filename}.json"
-        try:
-            with open(out_vocab_filename, "w") as f:
-                json.dump(data, f, indent=4)
-
-            tokenizer = Tokenizer(Unigram(out_vocab_filename))
-        finally:
-            os.remove(out_vocab_filename)
+        tokenizer = Tokenizer(Unigram(vocab, unk_id))
 
         tokenizer.normalizer = normalizers.Precompiled(precompiled_charsmap)
         tokenizer.pre_tokenizer = pre_tokenizers.Sequence(

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
@@ -21,7 +21,10 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
     """
 
     def __init__(
-        self, vocab: Optional[str] = None, replacement: str = "▁", add_prefix_space: bool = True,
+        self,
+        vocab: Optional[str] = None,
+        replacement: str = "▁",
+        add_prefix_space: bool = True,
     ):
         if vocab is not None:
             # Let Unigram(..) fail if only one of them is None
@@ -29,7 +32,12 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
         else:
             tokenizer = Tokenizer(Unigram())
 
-        tokenizer.normalizer = normalizers.Sequence([normalizers.Nmt(), normalizers.NFKC(),])
+        tokenizer.normalizer = normalizers.Sequence(
+            [
+                normalizers.Nmt(),
+                normalizers.NFKC(),
+            ]
+        )
         tokenizer.pre_tokenizer = pre_tokenizers.Sequence(
             [
                 pre_tokenizers.WhitespaceSplit(),
@@ -60,7 +68,9 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
         """ Train the model using the given files """
 
         trainer = trainers.UnigramTrainer(
-            vocab_size=vocab_size, special_tokens=special_tokens, show_progress=show_progress,
+            vocab_size=vocab_size,
+            special_tokens=special_tokens,
+            show_progress=show_progress,
         )
 
         if isinstance(files, str):

--- a/bindings/python/py_src/tokenizers/models/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/models/__init__.pyi
@@ -29,7 +29,7 @@ class Model:
 class BPE(Model):
     """BytePairEncoding model class
 
-    Instantiate a BPE Model from the given vocab and merges files.
+    Instantiate a BPE Model from the given vocab and merges.
 
     Args:
        vocab: ('`optional`) Dict[str, int]:
@@ -76,12 +76,19 @@ class BPE(Model):
     ):
         pass
     @staticmethod
-    def read_files(vocab_filename: str, merges_filename: str) -> Tuple[Vocab, Merges]:
+    def read_file(vocab_filename: str, merges_filename: str) -> Tuple[Vocab, Merges]:
         pass
     @staticmethod
-    def from_files(vocab_filename: str, merges_filename: str, **kwargs) -> BPE:
-        vocab, merges = BPE.read_files(vocab_filename, merges_filename)
-        return BPE(vocab, merges, **kwargs)
+    def from_file(vocab_filename: str, merges_filename: str, **kwargs) -> BPE:
+        """
+        Convenient method to intialize a BPE from files
+        Roughly equivalent to 
+
+        def from_file(vocab_filename, merges_filenames, **kwargs):
+            vocab, merges = BPE.read_file(vocab_filename, merges_filename)
+            return BPE(vocab, merges, **kwargs)
+        """
+        pass
 
 class WordPiece(Model):
     """WordPiece model class
@@ -107,12 +114,19 @@ class WordPiece(Model):
     ):
         pass
     @staticmethod
-    def read_file(vocab_filename: str) -> Tuple[Vocab]:
+    def read_file(vocab_filename: str) -> Vocab:
         pass
     @staticmethod
-    def from_files(vocab_filename: str, **kwargs) -> WordPiece:
-        vocab = WordPiece.read_files(vocab_filename)
-        return WordPiece(vocab, **kwargs)
+    def from_file(vocab_filename: str, **kwargs) -> WordPiece:
+        """
+        Convenient method to intialize a WordPiece from file
+        Roughly equivalent to 
+
+        def from_file(vocab_filename, **kwargs):
+            vocab, merges = WordPiece.read_file(vocab_filename)
+            return WordPiece(vocab, **kwargs)
+        """
+        pass
 
 class WordLevel(Model):
     """
@@ -131,12 +145,19 @@ class WordLevel(Model):
     def __init__(self, vocab: Optional[Union[str, Dict[str, int]]], unk_token: Optional[str]):
         pass
     @staticmethod
-    def read_file(vocab_filename: str) -> Tuple[Vocab]:
+    def read_file(vocab_filename: str) -> Vocab:
         pass
     @staticmethod
-    def from_files(vocab_filename: str, **kwargs) -> WordLevel:
-        vocab = WordLevel.read_files(vocab_filename)
-        return WordLevel(vocab, **kwargs)
+    def from_file(vocab_filename: str, **kwargs) -> WordLevelg:
+        """
+        Convenient method to intialize a WordLevelg from file
+        Roughly equivalent to 
+
+        def from_file(vocab_filename, **kwargs):
+            vocab, merges = WordLevelg.read_file(vocab_filename)
+            return WordLevelg(vocab, **kwargs)
+        """
+        pass
 
 class Unigram(Model):
     """UnigramEncoding model class

--- a/bindings/python/py_src/tokenizers/models/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/models/__init__.pyi
@@ -62,8 +62,6 @@ class BPE(Model):
        fuse_unk: (`optional`) bool:
            Multiple unk tokens get fused into only 1
     """
-
-    @staticmethod
     def __init__(
         self,
         vocab: Optional[Union[str, Dict[str, int]]],
@@ -76,6 +74,15 @@ class BPE(Model):
         fuse_unk: Optional[bool],
     ):
         pass
+
+    @staticmethod
+    def read_files(vocab_filename: str, merges_filename: str) -> Tuple[Vocab, Merges]:
+        pass
+
+    @staticmethod
+    def from_files(vocab_filename: str, merges_filename: str, **kwargs) -> BPE:
+        vocab, merges = BPE.read_files(vocab_filename, merges_filename) 
+        return BPE(vocab, merges, **kwargs)
 
 class WordPiece(Model):
     """ WordPiece model class
@@ -101,6 +108,15 @@ class WordPiece(Model):
     ):
         pass
 
+    @staticmethod
+    def read_file(vocab_filename: str) -> Tuple[Vocab]:
+        pass
+
+    @staticmethod
+    def from_files(vocab_filename: str, **kwargs) -> WordPiece:
+        vocab = WordPiece.read_files(vocab_filename) 
+        return WordPiece(vocab, **kwargs)
+
 class WordLevel(Model):
     """
     Most simple tokenizer model based on mapping token from a vocab file to their corresponding id.
@@ -117,6 +133,15 @@ class WordLevel(Model):
 
     def __init__(self, vocab: Optional[Union[str, Dict[str, int]]], unk_token: Optional[str]):
         pass
+
+    @staticmethod
+    def read_file(vocab_filename: str) -> Tuple[Vocab]:
+        pass
+
+    @staticmethod
+    def from_files(vocab_filename: str, **kwargs) -> WordLevel:
+        vocab = WordLevel.read_files(vocab_filename) 
+        return WordLevel(vocab, **kwargs)
 
 class Unigram(Model):
     """UnigramEncoding model class

--- a/bindings/python/py_src/tokenizers/models/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/models/__init__.pyi
@@ -1,5 +1,5 @@
 from .. import Encoding, Offsets, Token
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Union, Tuple, Dict
 
 class Model:
     """ Base class for all models
@@ -32,11 +32,15 @@ class BPE(Model):
     Instantiate a BPE Model from the given vocab and merges files.
 
     Args:
-       vocab: ('`optional`) string:
-           Path to a vocabulary JSON file.
+       vocab: ('`optional`) Dict[str, int]:
+           A dictionnary of string keys and their ids {"am": 0,...}
 
        merges: (`optional`) string:
-           Path to a merge file.
+           A dictionnary of pairs of ids as keys and their merge correspondace:
+               {(id_left, id_right): (importance, id_merged), .... }
+               with vocab : {"a": 0, "b": 1", ... "ab": 4} the merge
+               {(0, 1): (0, 4) ,...}
+               corresponds to the "ab" merge, that is the most likely merge (0)
 
        cache_capacity: (`optional`) int:
            The number of words that the BPE cache can contain. The cache allows
@@ -62,8 +66,8 @@ class BPE(Model):
     @staticmethod
     def __init__(
         self,
-        vocab: Optional[str],
-        merges: Optional[str],
+        vocab: Optional[Union[str, Dict[str, int]]],
+        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]],
         cache_capacity: Optional[int],
         dropout: Optional[float],
         unk_token: Optional[str],
@@ -80,7 +84,7 @@ class WordPiece(Model):
 
         Args:
             vocab: (`optional`) string:
-                Path to a vocabulary file.
+                A dictionnary of string keys and their ids {"am": 0,...}
 
             unk_token: (`optional`) str:
                 The unknown token to be used by the model.
@@ -91,7 +95,7 @@ class WordPiece(Model):
 
     def __init__(
         self,
-        vocab: Optional[str],
+        vocab: Optional[Union[str, Dict[str, int]]],
         unk_token: Optional[str],
         max_input_chars_per_word: Optional[int],
     ):
@@ -105,13 +109,13 @@ class WordLevel(Model):
 
         Args:
             vocab: (`optional`) string:
-                Path to a vocabulary file.
+                A dictionnary of string keys and their ids {"am": 0,...}
 
             unk_token: str:
                 The unknown token to be used by the model.
     """
 
-    def __init__(self, vocab: Optional[str], unk_token: Optional[str]):
+    def __init__(self, vocab: Optional[Union[str, Dict[str, int]]], unk_token: Optional[str]):
         pass
 
 class Unigram(Model):
@@ -121,10 +125,10 @@ class Unigram(Model):
 
     Args:
        vocab: ('`optional`) string:
-           Path to a vocabulary JSON file.
+           A list of vocabulary items and their relative score [("am", -0.2442),...]
 
     """
 
     @staticmethod
-    def __init__(self, vocab: Optional[str]):
+    def __init__(self, vocab: Optional[List[Tuple[str, float]]]):
         pass

--- a/bindings/python/py_src/tokenizers/models/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/models/__init__.pyi
@@ -36,11 +36,7 @@ class BPE(Model):
            A dictionnary of string keys and their ids {"am": 0,...}
 
        merges: (`optional`) string:
-           A dictionnary of pairs of ids as keys and their merge correspondace:
-               {(id_left, id_right): (importance, id_merged), .... }
-               with vocab : {"a": 0, "b": 1", ... "ab": 4} the merge
-               {(0, 1): (0, 4) ,...}
-               corresponds to the "ab" merge, that is the most likely merge (0)
+           A list of pairs of tokens [("a", "b"),...]
 
        cache_capacity: (`optional`) int:
            The number of words that the BPE cache can contain. The cache allows
@@ -66,7 +62,7 @@ class BPE(Model):
     def __init__(
         self,
         vocab: Optional[Union[str, Dict[str, int]]],
-        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]],
+        merges: Optional[Union[str, List[Tuple[str, str]]]],
         cache_capacity: Optional[int],
         dropout: Optional[float],
         unk_token: Optional[str],

--- a/bindings/python/py_src/tokenizers/models/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/models/__init__.pyi
@@ -2,7 +2,7 @@ from .. import Encoding, Offsets, Token
 from typing import List, Optional, Union, Tuple, Dict
 
 class Model:
-    """ Base class for all models
+    """Base class for all models
 
     This class is not supposed to be instantiated directly. Instead, any implementation of
     a Model will return a instance of this class when instantiated.
@@ -18,7 +18,7 @@ class Model:
         """ Returns the token associated with the given id """
         pass
     def save(self, folder: str, name: Optional[str] = None) -> List[str]:
-        """ Save the current model
+        """Save the current model
 
         Save the current model in the given folder, using the given name for the various
         files that will get created.
@@ -62,6 +62,7 @@ class BPE(Model):
        fuse_unk: (`optional`) bool:
            Multiple unk tokens get fused into only 1
     """
+
     def __init__(
         self,
         vocab: Optional[Union[str, Dict[str, int]]],
@@ -74,18 +75,16 @@ class BPE(Model):
         fuse_unk: Optional[bool],
     ):
         pass
-
     @staticmethod
     def read_files(vocab_filename: str, merges_filename: str) -> Tuple[Vocab, Merges]:
         pass
-
     @staticmethod
     def from_files(vocab_filename: str, merges_filename: str, **kwargs) -> BPE:
-        vocab, merges = BPE.read_files(vocab_filename, merges_filename) 
+        vocab, merges = BPE.read_files(vocab_filename, merges_filename)
         return BPE(vocab, merges, **kwargs)
 
 class WordPiece(Model):
-    """ WordPiece model class
+    """WordPiece model class
 
     Instantiate a WordPiece Model from the given vocab file.
 
@@ -107,14 +106,12 @@ class WordPiece(Model):
         max_input_chars_per_word: Optional[int],
     ):
         pass
-
     @staticmethod
     def read_file(vocab_filename: str) -> Tuple[Vocab]:
         pass
-
     @staticmethod
     def from_files(vocab_filename: str, **kwargs) -> WordPiece:
-        vocab = WordPiece.read_files(vocab_filename) 
+        vocab = WordPiece.read_files(vocab_filename)
         return WordPiece(vocab, **kwargs)
 
 class WordLevel(Model):
@@ -133,14 +130,12 @@ class WordLevel(Model):
 
     def __init__(self, vocab: Optional[Union[str, Dict[str, int]]], unk_token: Optional[str]):
         pass
-
     @staticmethod
     def read_file(vocab_filename: str) -> Tuple[Vocab]:
         pass
-
     @staticmethod
     def from_files(vocab_filename: str, **kwargs) -> WordLevel:
-        vocab = WordLevel.read_files(vocab_filename) 
+        vocab = WordLevel.read_files(vocab_filename)
         return WordLevel(vocab, **kwargs)
 
 class Unigram(Model):

--- a/bindings/python/py_src/tokenizers/normalizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/normalizers/__init__.pyi
@@ -2,7 +2,7 @@ from .. import NormalizedString
 from typing import Optional, List
 
 class Normalizer:
-    """ Base class for all normalizers
+    """Base class for all normalizers
 
     This class is not supposed to be instantiated directly. Instead, any implementation of a
     Normalizer will return an instance of this class when instantiated.
@@ -16,7 +16,7 @@ class Normalizer:
         pass
 
 class BertNormalizer(Normalizer):
-    """ BertNormalizer
+    """BertNormalizer
 
     Takes care of normalizing raw text before giving it to a Bert model.
     This includes cleaning the text, handling accents, chinese chars and lowercasing
@@ -29,7 +29,7 @@ class BertNormalizer(Normalizer):
         strip_accents: Optional[bool] = None,
         lowercase: Optional[bool] = True,
     ) -> None:
-        """ Instantiate a BertNormalizer with the given options.
+        """Instantiate a BertNormalizer with the given options.
 
         Args:
             clean_text: (`optional`) boolean:
@@ -80,13 +80,13 @@ class NFKC(Normalizer):
         pass
 
 class Sequence(Normalizer):
-    """ Allows concatenating multiple other Normalizer as a Sequence.
+    """Allows concatenating multiple other Normalizer as a Sequence.
 
     All the normalizers run in sequence in the given order
     """
 
     def __init__(self, normalizers: List[Normalizer]) -> None:
-        """ Instantiate a new normalization Sequence using the given normalizers
+        """Instantiate a new normalization Sequence using the given normalizers
 
         Args:
             normalizers: List[Normalizer]:

--- a/bindings/python/py_src/tokenizers/processors/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/processors/__init__.pyi
@@ -2,7 +2,7 @@ from .. import Encoding
 from typing import Tuple, Union, List
 
 class PostProcessor:
-    """ Base class for all post-processors
+    """Base class for all post-processors
 
     This class is not supposed to be instantiated directly. Instead, any implementation of
     a PostProcessor will return an instance of this class when instantiated.
@@ -22,7 +22,7 @@ class PostProcessor:
         pass
 
 class BertProcessing(PostProcessor):
-    """ BertProcessing
+    """BertProcessing
 
     This post-processor takes care of adding the special tokens needed by
     a Bert model:
@@ -31,7 +31,7 @@ class BertProcessing(PostProcessor):
     """
 
     def __init__(self, sep: Tuple[str, int], cls: Tuple[str, int]) -> None:
-        """ Instantiate a new BertProcessing with the given tokens
+        """Instantiate a new BertProcessing with the given tokens
 
         Args:
             sep: Tuple[str, int]:
@@ -46,7 +46,7 @@ class BertProcessing(PostProcessor):
         pass
 
 class RobertaProcessing(PostProcessor):
-    """ RobertaProcessing
+    """RobertaProcessing
 
     This post-processor takes care of adding the special tokens needed by
     a Roberta model:
@@ -66,7 +66,7 @@ class RobertaProcessing(PostProcessor):
         trim_offsets: bool = True,
         add_prefix_space: bool = True,
     ) -> None:
-        """ Instantiate a new RobertaProcessing with the given tokens
+        """Instantiate a new RobertaProcessing with the given tokens
 
         Args:
             sep: Tuple[str, int]:
@@ -88,7 +88,7 @@ class RobertaProcessing(PostProcessor):
         pass
 
 class ByteLevel(PostProcessor):
-    """ ByteLevel Post processing
+    """ByteLevel Post processing
 
     This post-processor takes care of trimming the offsets.
     By default, the ByteLevel BPE might include whitespaces in the produced tokens. If you don't
@@ -96,7 +96,7 @@ class ByteLevel(PostProcessor):
     """
 
     def __init__(self, trim_offsets: bool = True) -> None:
-        """ Instantiate a new ByteLevel
+        """Instantiate a new ByteLevel
 
         Args:
             trim_offsets: bool:
@@ -108,7 +108,7 @@ Template = Union[str, List[str]]
 Tokens = List[Union[Tuple[int, str], Tuple[str, int], dict]]
 
 class TemplateProcessing(PostProcessor):
-    """ TemplateProcessing
+    """TemplateProcessing
 
     Provides a way to specify templates in order to add the special tokens to each
     input sequence as relevant.
@@ -143,7 +143,7 @@ class TemplateProcessing(PostProcessor):
     """
 
     def __init__(self, seq_a: Template, seq_b: Template, special_tokens: Tokens) -> None:
-        """ Instantiate a new TemplateProcessing
+        """Instantiate a new TemplateProcessing
 
         Args:
             seq_a: Template

--- a/bindings/python/py_src/tokenizers/trainers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/trainers/__init__.pyi
@@ -2,14 +2,14 @@ from .. import AddedToken
 from typing import Optional, List, Union
 
 class Trainer:
-    """ Base class for all trainers
+    """Base class for all trainers
 
     This class is not supposed to be instantiated directly. Instead, any implementation of a
     Trainer will return an instance of this class when instantiated.
     """
 
 class BpeTrainer(Trainer):
-    """ BpeTrainer
+    """BpeTrainer
 
     Capable of training a BPE model
     """
@@ -25,7 +25,7 @@ class BpeTrainer(Trainer):
         continuing_subword_prefix: Optional[str] = None,
         end_of_word_suffix: Optional[str] = None,
     ) -> None:
-        """ Instantiate a new BpeTrainer with the given options:
+        """Instantiate a new BpeTrainer with the given options:
 
         Args:
             vocab_size: unsigned int:
@@ -61,7 +61,7 @@ class BpeTrainer(Trainer):
         pass
 
 class WordPieceTrainer(Trainer):
-    """ WordPieceTrainer
+    """WordPieceTrainer
 
     Capable of training a WordPiece model
     """
@@ -77,7 +77,7 @@ class WordPieceTrainer(Trainer):
         continuing_subword_prefix: Optional[str] = "##",
         end_of_word_suffix: Optional[str] = None,
     ) -> Trainer:
-        """ Instantiate a new WordPieceTrainer with the given options:
+        """Instantiate a new WordPieceTrainer with the given options:
 
         Args:
             vocab_size: unsigned int:
@@ -113,7 +113,7 @@ class WordPieceTrainer(Trainer):
         pass
 
 class UnigramTrainer(Trainer):
-    """ UnigramTrainer
+    """UnigramTrainer
 
     Capable of training a Unigram model
     """
@@ -124,7 +124,7 @@ class UnigramTrainer(Trainer):
         show_progress: bool = True,
         special_tokens: List[Union[str, AddedToken]] = [],
     ) -> Trainer:
-        """ Instantiate a new UnigramTrainer with the given options:
+        """Instantiate a new UnigramTrainer with the given options:
 
         Args:
             vocab_size: unsigned int:

--- a/bindings/python/scripts/spm_parity_check.py
+++ b/bindings/python/scripts/spm_parity_check.py
@@ -17,7 +17,11 @@ except Exception:
 def main():
     parser = ArgumentParser("SentencePiece parity checker")
     parser.add_argument(
-        "--input-file", "-i", type=str, required=True, help="Which files do you want to train from",
+        "--input-file",
+        "-i",
+        type=str,
+        required=True,
+        help="Which files do you want to train from",
     )
     parser.add_argument(
         "--model-file",
@@ -28,13 +32,22 @@ def main():
         help="Use a pretrained token file",
     )
     parser.add_argument(
-        "--model-prefix", type=str, default="spm_parity", help="Model prefix for spm_train",
+        "--model-prefix",
+        type=str,
+        default="spm_parity",
+        help="Model prefix for spm_train",
     )
     parser.add_argument(
-        "--vocab-size", "-v", type=int, default=8000, help="Vocab size for spm_train",
+        "--vocab-size",
+        "-v",
+        type=int,
+        default=8000,
+        help="Vocab size for spm_train",
     )
     parser.add_argument(
-        "--verbose", action="store_true", help="Verbosity",
+        "--verbose",
+        action="store_true",
+        help="Verbosity",
     )
     parser.add_argument(
         "--train",
@@ -160,10 +173,14 @@ def check_details(line, spm_ids, tok_ids, sp, tok):
         spms = Counter(spm_ids[first:last])
         toks = Counter(tok_ids[first:last])
 
-        removable_tokens = {spm_ for (spm_, si) in spms.items() if toks.get(spm_, 0) == si}
+        removable_tokens = {
+            spm_ for (spm_, si) in spms.items() if toks.get(spm_, 0) == si
+        }
         min_width = 3
         for i in range(last - first - min_width):
-            if all(spm_ids[first + i + j] in removable_tokens for j in range(min_width)):
+            if all(
+                spm_ids[first + i + j] in removable_tokens for j in range(min_width)
+            ):
                 possible_matches = [
                     k
                     for k in range(last - first - min_width)
@@ -174,7 +191,11 @@ def check_details(line, spm_ids, tok_ids, sp, tok):
                     if check_diff(
                         spm_ids[first : first + i], tok_ids[first : first + j], sp, tok
                     ) and check_details(
-                        line, spm_ids[first + i : last], tok_ids[first + j : last], sp, tok,
+                        line,
+                        spm_ids[first + i : last],
+                        tok_ids[first + j : last],
+                        sp,
+                        tok,
                     ):
                         return True
 
@@ -189,7 +210,9 @@ def check_details(line, spm_ids, tok_ids, sp, tok):
     wrong = tok.decode(spm_ids[first:last])
     print()
     if has_color:
-        print(f"{colored(ok_start, 'grey')}{colored(wrong, 'red')}{colored(ok_end, 'grey')}")
+        print(
+            f"{colored(ok_start, 'grey')}{colored(wrong, 'red')}{colored(ok_end, 'grey')}"
+        )
     else:
         print(wrong)
     return False
@@ -203,17 +226,8 @@ def check_encode(args):
         tok = tokenizers.SentencePieceUnigramTokenizer.from_spm(args.model_file)
     else:
         vocab = [(sp.id_to_piece(i), sp.get_score(i)) for i in range(sp.piece_size())]
-        vocab_filename = f"{args.model_file}.json"
         unk_id = sp.unk_id()
-
-        data = {"unk_id": unk_id, "vocab": vocab}
-        try:
-            with open(vocab_filename, "w") as f:
-                json.dump(data, f, indent=4)
-
-            tok = tokenizers.SentencePieceUnigramTokenizer(vocab_filename)
-        finally:
-            os.remove(vocab_filename)
+        tok = tokenizers.SentencePieceUnigramTokenizer(vocab, unk_id)
 
     perfect = 0
     imperfect = 0
@@ -255,7 +269,9 @@ def check_encode(args):
 
     print(f"({perfect} / {imperfect} / {wrong} ----- {perfect + imperfect + wrong})")
     total = perfect + imperfect + wrong
-    print(f"Accuracy {perfect * 100 / total:.2f} Slowdown : {tok_total_time/ spm_total_time:.2f}")
+    print(
+        f"Accuracy {perfect * 100 / total:.2f} Slowdown : {tok_total_time/ spm_total_time:.2f}"
+    )
 
 
 if __name__ == "__main__":

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -34,3 +34,11 @@ impl<T> ToPyResult<T> {
         self.into()
     }
 }
+
+pub(crate) fn deprecation_warning(version: &str, message: &str) -> PyResult<()> {
+    let gil = pyo3::Python::acquire_gil();
+    let python = gil.python();
+    let deprecation_warning = python.import("builtins")?.get("DeprecationWarning")?;
+    let full_message = format!("Deprecated in {}: {}", version, message);
+    pyo3::PyErr::warn(python, deprecation_warning, &full_message, 0)
+}

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -14,6 +14,7 @@ class TestBPE:
         vocab = {"a": 0, "b": 1, "ab": 2}
         merges = {(0, 1): (0, 2)}
         assert isinstance(BPE(vocab, merges), Model)
+        assert isinstance(BPE.from_file(roberta_files["vocab"], roberta_files["merges"]), BPE)
         with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
             BPE(vocab=vocab)
             BPE(merges=merges)
@@ -42,6 +43,7 @@ class TestWordPiece:
         vocab = {"a": 0, "b": 1, "ab": 2}
         assert isinstance(WordPiece(vocab), Model)
         assert isinstance(WordPiece(vocab), WordPiece)
+        assert isinstance(WordPiece.from_file(bert_files["vocab"]), WordPiece)
         assert isinstance(pickle.loads(pickle.dumps(WordPiece(vocab))), WordPiece)
 
         # Deprecated calls in 0.9
@@ -59,6 +61,7 @@ class TestWordLevel:
         vocab = {"a": 0, "b": 1, "ab": 2}
         assert isinstance(WordLevel(vocab), Model)
         assert isinstance(WordLevel(vocab), WordLevel)
+        assert isinstance(WordLevel.from_file(roberta_files["vocab"]), WordLevel)
 
         # The WordLevel model expects a vocab.json using the same format as roberta
         # so we can just try to load with this file

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -18,10 +18,7 @@ class TestBPE:
             BPE(vocab=vocab)
             BPE(merges=merges)
 
-        assert isinstance(
-            pickle.loads(pickle.dumps(BPE(vocab, merges))),
-            BPE,
-        )
+        assert isinstance(pickle.loads(pickle.dumps(BPE(vocab, merges))), BPE,)
 
         # Deprecated calls in 0.9
         with pytest.deprecated_call():

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -10,28 +10,59 @@ class TestBPE:
     def test_instantiate(self, roberta_files):
         assert isinstance(BPE(), Model)
         assert isinstance(BPE(), BPE)
-        assert isinstance(BPE(roberta_files["vocab"], roberta_files["merges"]), Model)
+
+        vocab = {"a": 0, "b": 1, "ab": 2}
+        merges = {(0, 1): (0, 2)}
+        assert isinstance(BPE(vocab, merges), Model)
+        with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
+            BPE(vocab=vocab)
+            BPE(merges=merges)
+
+        assert isinstance(pickle.loads(pickle.dumps(BPE(vocab, merges))), BPE,)
+
+        # Deprecated calls in 0.9
+        with pytest.deprecated_call():
+            assert isinstance(BPE(roberta_files["vocab"], roberta_files["merges"]), Model)
+
         with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
             BPE(vocab=roberta_files["vocab"])
             BPE(merges=roberta_files["merges"])
-        assert isinstance(
-            pickle.loads(pickle.dumps(BPE(roberta_files["vocab"], roberta_files["merges"]))), BPE
-        )
+        with pytest.deprecated_call():
+            assert isinstance(
+                pickle.loads(pickle.dumps(BPE(roberta_files["vocab"], roberta_files["merges"]))),
+                BPE,
+            )
 
 
 class TestWordPiece:
     def test_instantiate(self, bert_files):
         assert isinstance(WordPiece(), Model)
         assert isinstance(WordPiece(), WordPiece)
-        assert isinstance(WordPiece(bert_files["vocab"]), Model)
-        assert isinstance(pickle.loads(pickle.dumps(WordPiece(bert_files["vocab"]))), WordPiece)
+
+        vocab = {"a": 0, "b": 1, "ab": 2}
+        assert isinstance(WordPiece(vocab), Model)
+        assert isinstance(WordPiece(vocab), WordPiece)
+        assert isinstance(pickle.loads(pickle.dumps(WordPiece(vocab))), WordPiece)
+
+        # Deprecated calls in 0.9
+        with pytest.deprecated_call():
+            assert isinstance(WordPiece(bert_files["vocab"]), Model)
+        with pytest.deprecated_call():
+            assert isinstance(pickle.loads(pickle.dumps(WordPiece(bert_files["vocab"]))), WordPiece)
 
 
 class TestWordLevel:
     def test_instantiate(self, roberta_files):
         assert isinstance(WordLevel(), Model)
         assert isinstance(WordLevel(), WordLevel)
+
+        vocab = {"a": 0, "b": 1, "ab": 2}
+        assert isinstance(WordLevel(vocab), Model)
+        assert isinstance(WordLevel(vocab), WordLevel)
+
         # The WordLevel model expects a vocab.json using the same format as roberta
         # so we can just try to load with this file
-        assert isinstance(WordLevel(roberta_files["vocab"]), Model)
-        assert isinstance(WordLevel(roberta_files["vocab"]), WordLevel)
+        with pytest.deprecated_call():
+            assert isinstance(WordLevel(roberta_files["vocab"]), Model)
+        with pytest.deprecated_call():
+            assert isinstance(WordLevel(roberta_files["vocab"]), WordLevel)

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -18,7 +18,10 @@ class TestBPE:
             BPE(vocab=vocab)
             BPE(merges=merges)
 
-        assert isinstance(pickle.loads(pickle.dumps(BPE(vocab, merges))), BPE,)
+        assert isinstance(
+            pickle.loads(pickle.dumps(BPE(vocab, merges))),
+            BPE,
+        )
 
         # Deprecated calls in 0.9
         with pytest.deprecated_call():

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -12,7 +12,7 @@ class TestBPE:
         assert isinstance(BPE(), BPE)
 
         vocab = {"a": 0, "b": 1, "ab": 2}
-        merges = {(0, 1): (0, 2)}
+        merges = [("a", "b")]
         assert isinstance(BPE(vocab, merges), Model)
         assert isinstance(BPE.from_file(roberta_files["vocab"], roberta_files["merges"]), BPE)
         with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -14,22 +14,33 @@ class TestBPE:
         vocab = {"a": 0, "b": 1, "ab": 2}
         merges = {(0, 1): (0, 2)}
         assert isinstance(BPE(vocab, merges), Model)
-        with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
+        with pytest.raises(
+            ValueError, match="`vocab` and `merges` must be both specified"
+        ):
             BPE(vocab=vocab)
             BPE(merges=merges)
 
-        assert isinstance(pickle.loads(pickle.dumps(BPE(vocab, merges))), BPE,)
+        assert isinstance(
+            pickle.loads(pickle.dumps(BPE(vocab, merges))),
+            BPE,
+        )
 
         # Deprecated calls in 0.9
         with pytest.deprecated_call():
-            assert isinstance(BPE(roberta_files["vocab"], roberta_files["merges"]), Model)
+            assert isinstance(
+                BPE(roberta_files["vocab"], roberta_files["merges"]), Model
+            )
 
-        with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
+        with pytest.raises(
+            ValueError, match="`vocab` and `merges` must be both specified"
+        ):
             BPE(vocab=roberta_files["vocab"])
             BPE(merges=roberta_files["merges"])
         with pytest.deprecated_call():
             assert isinstance(
-                pickle.loads(pickle.dumps(BPE(roberta_files["vocab"], roberta_files["merges"]))),
+                pickle.loads(
+                    pickle.dumps(BPE(roberta_files["vocab"], roberta_files["merges"]))
+                ),
                 BPE,
             )
 
@@ -48,7 +59,9 @@ class TestWordPiece:
         with pytest.deprecated_call():
             assert isinstance(WordPiece(bert_files["vocab"]), Model)
         with pytest.deprecated_call():
-            assert isinstance(pickle.loads(pickle.dumps(WordPiece(bert_files["vocab"]))), WordPiece)
+            assert isinstance(
+                pickle.loads(pickle.dumps(WordPiece(bert_files["vocab"]))), WordPiece
+            )
 
 
 class TestWordLevel:

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -14,33 +14,22 @@ class TestBPE:
         vocab = {"a": 0, "b": 1, "ab": 2}
         merges = {(0, 1): (0, 2)}
         assert isinstance(BPE(vocab, merges), Model)
-        with pytest.raises(
-            ValueError, match="`vocab` and `merges` must be both specified"
-        ):
+        with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
             BPE(vocab=vocab)
             BPE(merges=merges)
 
-        assert isinstance(
-            pickle.loads(pickle.dumps(BPE(vocab, merges))),
-            BPE,
-        )
+        assert isinstance(pickle.loads(pickle.dumps(BPE(vocab, merges))), BPE,)
 
         # Deprecated calls in 0.9
         with pytest.deprecated_call():
-            assert isinstance(
-                BPE(roberta_files["vocab"], roberta_files["merges"]), Model
-            )
+            assert isinstance(BPE(roberta_files["vocab"], roberta_files["merges"]), Model)
 
-        with pytest.raises(
-            ValueError, match="`vocab` and `merges` must be both specified"
-        ):
+        with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
             BPE(vocab=roberta_files["vocab"])
             BPE(merges=roberta_files["merges"])
         with pytest.deprecated_call():
             assert isinstance(
-                pickle.loads(
-                    pickle.dumps(BPE(roberta_files["vocab"], roberta_files["merges"]))
-                ),
+                pickle.loads(pickle.dumps(BPE(roberta_files["vocab"], roberta_files["merges"]))),
                 BPE,
             )
 
@@ -59,9 +48,7 @@ class TestWordPiece:
         with pytest.deprecated_call():
             assert isinstance(WordPiece(bert_files["vocab"]), Model)
         with pytest.deprecated_call():
-            assert isinstance(
-                pickle.loads(pickle.dumps(WordPiece(bert_files["vocab"]))), WordPiece
-            )
+            assert isinstance(pickle.loads(pickle.dumps(WordPiece(bert_files["vocab"]))), WordPiece)
 
 
 class TestWordLevel:

--- a/bindings/python/tests/bindings/test_processors.py
+++ b/bindings/python/tests/bindings/test_processors.py
@@ -22,7 +22,8 @@ class TestBertProcessing:
         assert isinstance(processor, PostProcessor)
         assert isinstance(processor, BertProcessing)
         assert isinstance(
-            pickle.loads(pickle.dumps(BertProcessing(("[SEP]", 0), ("[CLS]", 1)))), BertProcessing,
+            pickle.loads(pickle.dumps(BertProcessing(("[SEP]", 0), ("[CLS]", 1)))),
+            BertProcessing,
         )
 
     def test_processing(self):
@@ -94,7 +95,9 @@ class TestTemplateProcessing:
 
     def get_roberta(self):
         return TemplateProcessing(
-            seq_a="<s> $0 </s>", seq_b="</s> $0 </s>", special_tokens=[("<s>", 0), ("</s>", 1)],
+            seq_a="<s> $0 </s>",
+            seq_b="</s> $0 </s>",
+            special_tokens=[("<s>", 0), ("</s>", 1)],
         )
 
     def get_t5_squad(self):

--- a/bindings/python/tests/bindings/test_processors.py
+++ b/bindings/python/tests/bindings/test_processors.py
@@ -22,8 +22,7 @@ class TestBertProcessing:
         assert isinstance(processor, PostProcessor)
         assert isinstance(processor, BertProcessing)
         assert isinstance(
-            pickle.loads(pickle.dumps(BertProcessing(("[SEP]", 0), ("[CLS]", 1)))),
-            BertProcessing,
+            pickle.loads(pickle.dumps(BertProcessing(("[SEP]", 0), ("[CLS]", 1)))), BertProcessing,
         )
 
     def test_processing(self):
@@ -95,9 +94,7 @@ class TestTemplateProcessing:
 
     def get_roberta(self):
         return TemplateProcessing(
-            seq_a="<s> $0 </s>",
-            seq_b="</s> $0 </s>",
-            special_tokens=[("<s>", 0), ("</s>", 1)],
+            seq_a="<s> $0 </s>", seq_b="</s> $0 </s>", special_tokens=[("<s>", 0), ("</s>", 1)],
         )
 
     def get_t5_squad(self):

--- a/bindings/python/tests/bindings/test_processors.py
+++ b/bindings/python/tests/bindings/test_processors.py
@@ -1,3 +1,4 @@
+import pytest
 import pickle
 
 from ..utils import data_dir, roberta_files
@@ -21,7 +22,7 @@ class TestBertProcessing:
         assert isinstance(processor, PostProcessor)
         assert isinstance(processor, BertProcessing)
         assert isinstance(
-            pickle.loads(pickle.dumps(BertProcessing(("[SEP]", 0), ("[CLS]", 1)))), BertProcessing
+            pickle.loads(pickle.dumps(BertProcessing(("[SEP]", 0), ("[CLS]", 1)))), BertProcessing,
         )
 
     def test_processing(self):
@@ -66,7 +67,9 @@ class TestByteLevelProcessing:
         assert isinstance(pickle.loads(pickle.dumps(ByteLevel())), ByteLevel)
 
     def test_processing(self, roberta_files):
-        tokenizer = Tokenizer(BPE(roberta_files["vocab"], roberta_files["merges"]))
+        # Deprecated in 0.9
+        with pytest.deprecated_call():
+            tokenizer = Tokenizer(BPE(roberta_files["vocab"], roberta_files["merges"]))
         tokenizer.pre_tokenizer = ByteLevelPreTokenizer(add_prefix_space=True)
 
         # Keeps original offsets

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -144,7 +144,9 @@ class TestTokenizer:
         assert output.tokens == ["my", "name", "is", "john"]
 
         # Can encode a batch with both a single sequence and a pair of sequences
-        output = tokenizer.encode_batch(["my name is john", ("my name is john", "pair")])
+        output = tokenizer.encode_batch(
+            ["my name is john", ("my name is john", "pair")]
+        )
         assert len(output) == 2
 
     def test_encode_formats(self, bert_files):
@@ -167,7 +169,9 @@ class TestTokenizer:
         ]
         output = tokenizer.encode(["my", "name", "is", "john"], is_pretokenized=True)
         assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
-        output = tokenizer.encode(["my", "name", "is", "john"], ["pair"], is_pretokenized=True)
+        output = tokenizer.encode(
+            ["my", "name", "is", "john"], ["pair"], is_pretokenized=True
+        )
         assert output.tokens == [
             "[CLS]",
             "my",
@@ -213,13 +217,19 @@ class TestTokenizer:
 
         # Numpy
         test_single(np.array(["My name is John", "My name is Georges"]))
-        test_pair(np.array([("My name is John", "pair"), ("My name is Georges", "pair")]))
-        test_pair(np.array([["My name is John", "pair"], ["My name is Georges", "pair"]]))
+        test_pair(
+            np.array([("My name is John", "pair"), ("My name is Georges", "pair")])
+        )
+        test_pair(
+            np.array([["My name is John", "pair"], ["My name is Georges", "pair"]])
+        )
 
         # PreTokenized inputs
 
         # Lists
-        test_single([["My", "name", "is", "John"], ["My", "name", "is", "Georges"]], True)
+        test_single(
+            [["My", "name", "is", "John"], ["My", "name", "is", "Georges"]], True
+        )
         test_pair(
             [
                 (["My", "name", "is", "John"], ["pair"]),
@@ -236,7 +246,9 @@ class TestTokenizer:
         )
 
         # Tuples
-        test_single((("My", "name", "is", "John"), ("My", "name", "is", "Georges")), True)
+        test_single(
+            (("My", "name", "is", "John"), ("My", "name", "is", "Georges")), True
+        )
         test_pair(
             (
                 (("My", "name", "is", "John"), ("pair",)),
@@ -254,10 +266,12 @@ class TestTokenizer:
 
         # Numpy
         test_single(
-            np.array([["My", "name", "is", "John"], ["My", "name", "is", "Georges"]]), True,
+            np.array([["My", "name", "is", "John"], ["My", "name", "is", "Georges"]]),
+            True,
         )
         test_single(
-            np.array((("My", "name", "is", "John"), ("My", "name", "is", "Georges"))), True,
+            np.array((("My", "name", "is", "John"), ("My", "name", "is", "Georges"))),
+            True,
         )
         test_pair(
             np.array(
@@ -298,11 +312,14 @@ class TestTokenizer:
 
         tokenizer.pre_tokenizer = ByteLevel(add_prefix_space=True)
         tokenizer.post_processor = RobertaProcessing(
-            ("</s>", tokenizer.token_to_id("</s>")), ("<s>", tokenizer.token_to_id("<s>")),
+            ("</s>", tokenizer.token_to_id("</s>")),
+            ("<s>", tokenizer.token_to_id("<s>")),
         )
 
         # Can encode with special tokens
-        output_with_specials = tokenizer.encode("My name is John", add_special_tokens=True)
+        output_with_specials = tokenizer.encode(
+            "My name is John", add_special_tokens=True
+        )
         assert output_with_specials.tokens == [
             "<s>",
             "ĠMy",
@@ -313,7 +330,9 @@ class TestTokenizer:
         ]
 
         # Can encode without special tokens
-        output_without_specials = tokenizer.encode("My name is John", add_special_tokens=False)
+        output_without_specials = tokenizer.encode(
+            "My name is John", add_special_tokens=False
+        )
         assert output_without_specials.tokens == ["ĠMy", "Ġname", "Ġis", "ĠJohn"]
 
     def test_truncation(self):

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -93,11 +93,7 @@ class TestTokenizer:
         added = tokenizer.add_tokens(["my", "name", "is", "john"])
         assert added == 4
 
-        tokens = [
-            AddedToken("the"),
-            AddedToken("quick", normalized=False),
-            AddedToken(),
-        ]
+        tokens = [AddedToken("the"), AddedToken("quick", normalized=False), AddedToken()]
         assert tokens[0].normalized == True
         added = tokenizer.add_tokens(tokens)
         assert added == 2
@@ -155,29 +151,11 @@ class TestTokenizer:
         output = tokenizer.encode("my name is john")
         assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
         output = tokenizer.encode("my name is john", "pair")
-        assert output.tokens == [
-            "[CLS]",
-            "my",
-            "name",
-            "is",
-            "john",
-            "[SEP]",
-            "pair",
-            "[SEP]",
-        ]
+        assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]", "pair", "[SEP]"]
         output = tokenizer.encode(["my", "name", "is", "john"], is_pretokenized=True)
         assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
         output = tokenizer.encode(["my", "name", "is", "john"], ["pair"], is_pretokenized=True)
-        assert output.tokens == [
-            "[CLS]",
-            "my",
-            "name",
-            "is",
-            "john",
-            "[SEP]",
-            "pair",
-            "[SEP]",
-        ]
+        assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]", "pair", "[SEP]"]
 
         # Encode batch
         result_single = [
@@ -303,14 +281,7 @@ class TestTokenizer:
 
         # Can encode with special tokens
         output_with_specials = tokenizer.encode("My name is John", add_special_tokens=True)
-        assert output_with_specials.tokens == [
-            "<s>",
-            "ĠMy",
-            "Ġname",
-            "Ġis",
-            "ĠJohn",
-            "</s>",
-        ]
+        assert output_with_specials.tokens == ["<s>", "ĠMy", "Ġname", "Ġis", "ĠJohn", "</s>"]
 
         # Can encode without special tokens
         output_without_specials = tokenizer.encode("My name is John", add_special_tokens=False)

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -144,9 +144,7 @@ class TestTokenizer:
         assert output.tokens == ["my", "name", "is", "john"]
 
         # Can encode a batch with both a single sequence and a pair of sequences
-        output = tokenizer.encode_batch(
-            ["my name is john", ("my name is john", "pair")]
-        )
+        output = tokenizer.encode_batch(["my name is john", ("my name is john", "pair")])
         assert len(output) == 2
 
     def test_encode_formats(self, bert_files):
@@ -169,9 +167,7 @@ class TestTokenizer:
         ]
         output = tokenizer.encode(["my", "name", "is", "john"], is_pretokenized=True)
         assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]"]
-        output = tokenizer.encode(
-            ["my", "name", "is", "john"], ["pair"], is_pretokenized=True
-        )
+        output = tokenizer.encode(["my", "name", "is", "john"], ["pair"], is_pretokenized=True)
         assert output.tokens == [
             "[CLS]",
             "my",
@@ -217,19 +213,13 @@ class TestTokenizer:
 
         # Numpy
         test_single(np.array(["My name is John", "My name is Georges"]))
-        test_pair(
-            np.array([("My name is John", "pair"), ("My name is Georges", "pair")])
-        )
-        test_pair(
-            np.array([["My name is John", "pair"], ["My name is Georges", "pair"]])
-        )
+        test_pair(np.array([("My name is John", "pair"), ("My name is Georges", "pair")]))
+        test_pair(np.array([["My name is John", "pair"], ["My name is Georges", "pair"]]))
 
         # PreTokenized inputs
 
         # Lists
-        test_single(
-            [["My", "name", "is", "John"], ["My", "name", "is", "Georges"]], True
-        )
+        test_single([["My", "name", "is", "John"], ["My", "name", "is", "Georges"]], True)
         test_pair(
             [
                 (["My", "name", "is", "John"], ["pair"]),
@@ -246,9 +236,7 @@ class TestTokenizer:
         )
 
         # Tuples
-        test_single(
-            (("My", "name", "is", "John"), ("My", "name", "is", "Georges")), True
-        )
+        test_single((("My", "name", "is", "John"), ("My", "name", "is", "Georges")), True)
         test_pair(
             (
                 (("My", "name", "is", "John"), ("pair",)),
@@ -317,9 +305,7 @@ class TestTokenizer:
         )
 
         # Can encode with special tokens
-        output_with_specials = tokenizer.encode(
-            "My name is John", add_special_tokens=True
-        )
+        output_with_specials = tokenizer.encode("My name is John", add_special_tokens=True)
         assert output_with_specials.tokens == [
             "<s>",
             "ĠMy",
@@ -330,9 +316,7 @@ class TestTokenizer:
         ]
 
         # Can encode without special tokens
-        output_without_specials = tokenizer.encode(
-            "My name is John", add_special_tokens=False
-        )
+        output_without_specials = tokenizer.encode("My name is John", add_special_tokens=False)
         assert output_without_specials.tokens == ["ĠMy", "Ġname", "Ġis", "ĠJohn"]
 
     def test_truncation(self):

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -254,12 +254,10 @@ class TestTokenizer:
 
         # Numpy
         test_single(
-            np.array([["My", "name", "is", "John"], ["My", "name", "is", "Georges"]]),
-            True,
+            np.array([["My", "name", "is", "John"], ["My", "name", "is", "Georges"]]), True,
         )
         test_single(
-            np.array((("My", "name", "is", "John"), ("My", "name", "is", "Georges"))),
-            True,
+            np.array((("My", "name", "is", "John"), ("My", "name", "is", "Georges"))), True,
         )
         test_pair(
             np.array(
@@ -300,8 +298,7 @@ class TestTokenizer:
 
         tokenizer.pre_tokenizer = ByteLevel(add_prefix_space=True)
         tokenizer.post_processor = RobertaProcessing(
-            ("</s>", tokenizer.token_to_id("</s>")),
-            ("<s>", tokenizer.token_to_id("<s>")),
+            ("</s>", tokenizer.token_to_id("</s>")), ("<s>", tokenizer.token_to_id("<s>")),
         )
 
         # Can encode with special tokens

--- a/bindings/python/tests/implementations/test_bert_wordpiece.py
+++ b/bindings/python/tests/implementations/test_bert_wordpiece.py
@@ -1,16 +1,36 @@
+import pytest
+
 from ..utils import data_dir, bert_files, multiprocessing_with_parallelism
 from tokenizers import BertWordPieceTokenizer
 
 
 class TestBertWordPieceBPE:
     def test_basic_encode(self, bert_files):
-        tokenizer = BertWordPieceTokenizer(bert_files["vocab"])
+        tokenizer = BertWordPieceTokenizer.from_file(bert_files["vocab"])
 
         # Encode with special tokens by default
         output = tokenizer.encode("My name is John", "pair")
         assert output.ids == [101, 2026, 2171, 2003, 2198, 102, 3940, 102]
-        assert output.tokens == ["[CLS]", "my", "name", "is", "john", "[SEP]", "pair", "[SEP]"]
-        assert output.offsets == [(0, 0), (0, 2), (3, 7), (8, 10), (11, 15), (0, 0), (0, 4), (0, 0)]
+        assert output.tokens == [
+            "[CLS]",
+            "my",
+            "name",
+            "is",
+            "john",
+            "[SEP]",
+            "pair",
+            "[SEP]",
+        ]
+        assert output.offsets == [
+            (0, 0),
+            (0, 2),
+            (3, 7),
+            (8, 10),
+            (11, 15),
+            (0, 0),
+            (0, 4),
+            (0, 0),
+        ]
         assert output.type_ids == [0, 0, 0, 0, 0, 0, 1, 1]
 
         # Can encode without the special tokens
@@ -21,6 +41,6 @@ class TestBertWordPieceBPE:
         assert output.type_ids == [0, 0, 0, 0, 1]
 
     def test_multiprocessing_with_parallelism(self, bert_files):
-        tokenizer = BertWordPieceTokenizer(bert_files["vocab"])
+        tokenizer = BertWordPieceTokenizer.from_file(bert_files["vocab"])
         multiprocessing_with_parallelism(tokenizer, False)
         multiprocessing_with_parallelism(tokenizer, True)

--- a/bindings/python/tests/implementations/test_byte_level_bpe.py
+++ b/bindings/python/tests/implementations/test_byte_level_bpe.py
@@ -1,10 +1,14 @@
+import pytest
+
 from ..utils import data_dir, roberta_files, multiprocessing_with_parallelism
 from tokenizers import ByteLevelBPETokenizer
 
 
 class TestByteLevelBPE:
     def test_basic_encode(self, roberta_files):
-        tokenizer = ByteLevelBPETokenizer(roberta_files["vocab"], roberta_files["merges"])
+        tokenizer = ByteLevelBPETokenizer.from_files(
+            roberta_files["vocab"], roberta_files["merges"]
+        )
         output = tokenizer.encode("The quick brown fox jumps over the lazy dog")
 
         assert output.ids == [133, 2119, 6219, 23602, 13855, 81, 5, 22414, 2335]
@@ -32,7 +36,7 @@ class TestByteLevelBPE:
         ]
 
     def test_add_prefix_space(self, roberta_files):
-        tokenizer = ByteLevelBPETokenizer(
+        tokenizer = ByteLevelBPETokenizer.from_files(
             roberta_files["vocab"], roberta_files["merges"], add_prefix_space=True
         )
         output = tokenizer.encode("The quick brown fox jumps over the lazy dog")
@@ -62,8 +66,8 @@ class TestByteLevelBPE:
         ]
 
     def test_lowerspace(self, roberta_files):
-        tokenizer = ByteLevelBPETokenizer(
-            roberta_files["vocab"], roberta_files["merges"], add_prefix_space=True, lowercase=True
+        tokenizer = ByteLevelBPETokenizer.from_files(
+            roberta_files["vocab"], roberta_files["merges"], add_prefix_space=True, lowercase=True,
         )
         output = tokenizer.encode("The Quick Brown Fox Jumps Over The Lazy Dog")
 
@@ -81,6 +85,8 @@ class TestByteLevelBPE:
         ]
 
     def test_multiprocessing_with_parallelism(self, roberta_files):
-        tokenizer = ByteLevelBPETokenizer(roberta_files["vocab"], roberta_files["merges"])
+        tokenizer = ByteLevelBPETokenizer.from_files(
+            roberta_files["vocab"], roberta_files["merges"]
+        )
         multiprocessing_with_parallelism(tokenizer, False)
         multiprocessing_with_parallelism(tokenizer, True)

--- a/bindings/python/tests/implementations/test_byte_level_bpe.py
+++ b/bindings/python/tests/implementations/test_byte_level_bpe.py
@@ -67,7 +67,10 @@ class TestByteLevelBPE:
 
     def test_lowerspace(self, roberta_files):
         tokenizer = ByteLevelBPETokenizer.from_files(
-            roberta_files["vocab"], roberta_files["merges"], add_prefix_space=True, lowercase=True,
+            roberta_files["vocab"],
+            roberta_files["merges"],
+            add_prefix_space=True,
+            lowercase=True,
         )
         output = tokenizer.encode("The Quick Brown Fox Jumps Over The Lazy Dog")
 

--- a/bindings/python/tests/implementations/test_byte_level_bpe.py
+++ b/bindings/python/tests/implementations/test_byte_level_bpe.py
@@ -67,10 +67,7 @@ class TestByteLevelBPE:
 
     def test_lowerspace(self, roberta_files):
         tokenizer = ByteLevelBPETokenizer.from_files(
-            roberta_files["vocab"],
-            roberta_files["merges"],
-            add_prefix_space=True,
-            lowercase=True,
+            roberta_files["vocab"], roberta_files["merges"], add_prefix_space=True, lowercase=True,
         )
         output = tokenizer.encode("The Quick Brown Fox Jumps Over The Lazy Dog")
 

--- a/bindings/python/tests/implementations/test_byte_level_bpe.py
+++ b/bindings/python/tests/implementations/test_byte_level_bpe.py
@@ -6,9 +6,7 @@ from tokenizers import ByteLevelBPETokenizer
 
 class TestByteLevelBPE:
     def test_basic_encode(self, roberta_files):
-        tokenizer = ByteLevelBPETokenizer.from_files(
-            roberta_files["vocab"], roberta_files["merges"]
-        )
+        tokenizer = ByteLevelBPETokenizer.from_file(roberta_files["vocab"], roberta_files["merges"])
         output = tokenizer.encode("The quick brown fox jumps over the lazy dog")
 
         assert output.ids == [133, 2119, 6219, 23602, 13855, 81, 5, 22414, 2335]
@@ -36,7 +34,7 @@ class TestByteLevelBPE:
         ]
 
     def test_add_prefix_space(self, roberta_files):
-        tokenizer = ByteLevelBPETokenizer.from_files(
+        tokenizer = ByteLevelBPETokenizer.from_file(
             roberta_files["vocab"], roberta_files["merges"], add_prefix_space=True
         )
         output = tokenizer.encode("The quick brown fox jumps over the lazy dog")
@@ -66,7 +64,7 @@ class TestByteLevelBPE:
         ]
 
     def test_lowerspace(self, roberta_files):
-        tokenizer = ByteLevelBPETokenizer.from_files(
+        tokenizer = ByteLevelBPETokenizer.from_file(
             roberta_files["vocab"], roberta_files["merges"], add_prefix_space=True, lowercase=True,
         )
         output = tokenizer.encode("The Quick Brown Fox Jumps Over The Lazy Dog")
@@ -85,8 +83,6 @@ class TestByteLevelBPE:
         ]
 
     def test_multiprocessing_with_parallelism(self, roberta_files):
-        tokenizer = ByteLevelBPETokenizer.from_files(
-            roberta_files["vocab"], roberta_files["merges"]
-        )
+        tokenizer = ByteLevelBPETokenizer.from_file(roberta_files["vocab"], roberta_files["merges"])
         multiprocessing_with_parallelism(tokenizer, False)
         multiprocessing_with_parallelism(tokenizer, True)

--- a/bindings/python/tests/implementations/test_char_bpe.py
+++ b/bindings/python/tests/implementations/test_char_bpe.py
@@ -1,10 +1,12 @@
+import pytest
+
 from ..utils import data_dir, openai_files, multiprocessing_with_parallelism
 from tokenizers import CharBPETokenizer
 
 
 class TestBertWordPieceBPE:
     def test_basic_encode(self, openai_files):
-        tokenizer = CharBPETokenizer(openai_files["vocab"], openai_files["merges"])
+        tokenizer = CharBPETokenizer.from_files(openai_files["vocab"], openai_files["merges"])
 
         output = tokenizer.encode("My name is John", "pair")
         assert output.ids == [0, 253, 1362, 544, 0, 7, 12662, 2688]
@@ -31,7 +33,9 @@ class TestBertWordPieceBPE:
         assert output.type_ids == [0, 0, 0, 0, 0, 0, 0, 1]
 
     def test_lowercase(self, openai_files):
-        tokenizer = CharBPETokenizer(openai_files["vocab"], openai_files["merges"], lowercase=True)
+        tokenizer = CharBPETokenizer.from_files(
+            openai_files["vocab"], openai_files["merges"], lowercase=True
+        )
         output = tokenizer.encode("My name is John", "pair", add_special_tokens=False)
         assert output.ids == [547, 1362, 544, 2476, 2688]
         assert output.tokens == ["my</w>", "name</w>", "is</w>", "john</w>", "pair</w>"]
@@ -39,11 +43,13 @@ class TestBertWordPieceBPE:
         assert output.type_ids == [0, 0, 0, 0, 1]
 
     def test_decoding(self, openai_files):
-        tokenizer = CharBPETokenizer(openai_files["vocab"], openai_files["merges"], lowercase=True)
+        tokenizer = CharBPETokenizer.from_files(
+            openai_files["vocab"], openai_files["merges"], lowercase=True
+        )
         decoded = tokenizer.decode(tokenizer.encode("my name is john").ids)
         assert decoded == "my name is john"
 
     def test_multiprocessing_with_parallelism(self, openai_files):
-        tokenizer = CharBPETokenizer(openai_files["vocab"], openai_files["merges"])
+        tokenizer = CharBPETokenizer.from_files(openai_files["vocab"], openai_files["merges"])
         multiprocessing_with_parallelism(tokenizer, False)
         multiprocessing_with_parallelism(tokenizer, True)

--- a/bindings/python/tests/implementations/test_char_bpe.py
+++ b/bindings/python/tests/implementations/test_char_bpe.py
@@ -6,7 +6,9 @@ from tokenizers import CharBPETokenizer
 
 class TestBertWordPieceBPE:
     def test_basic_encode(self, openai_files):
-        tokenizer = CharBPETokenizer.from_files(openai_files["vocab"], openai_files["merges"])
+        tokenizer = CharBPETokenizer.from_files(
+            openai_files["vocab"], openai_files["merges"]
+        )
 
         output = tokenizer.encode("My name is John", "pair")
         assert output.ids == [0, 253, 1362, 544, 0, 7, 12662, 2688]
@@ -50,6 +52,8 @@ class TestBertWordPieceBPE:
         assert decoded == "my name is john"
 
     def test_multiprocessing_with_parallelism(self, openai_files):
-        tokenizer = CharBPETokenizer.from_files(openai_files["vocab"], openai_files["merges"])
+        tokenizer = CharBPETokenizer.from_files(
+            openai_files["vocab"], openai_files["merges"]
+        )
         multiprocessing_with_parallelism(tokenizer, False)
         multiprocessing_with_parallelism(tokenizer, True)

--- a/bindings/python/tests/implementations/test_char_bpe.py
+++ b/bindings/python/tests/implementations/test_char_bpe.py
@@ -6,9 +6,7 @@ from tokenizers import CharBPETokenizer
 
 class TestBertWordPieceBPE:
     def test_basic_encode(self, openai_files):
-        tokenizer = CharBPETokenizer.from_files(
-            openai_files["vocab"], openai_files["merges"]
-        )
+        tokenizer = CharBPETokenizer.from_files(openai_files["vocab"], openai_files["merges"])
 
         output = tokenizer.encode("My name is John", "pair")
         assert output.ids == [0, 253, 1362, 544, 0, 7, 12662, 2688]
@@ -52,8 +50,6 @@ class TestBertWordPieceBPE:
         assert decoded == "my name is john"
 
     def test_multiprocessing_with_parallelism(self, openai_files):
-        tokenizer = CharBPETokenizer.from_files(
-            openai_files["vocab"], openai_files["merges"]
-        )
+        tokenizer = CharBPETokenizer.from_files(openai_files["vocab"], openai_files["merges"])
         multiprocessing_with_parallelism(tokenizer, False)
         multiprocessing_with_parallelism(tokenizer, True)

--- a/bindings/python/tests/implementations/test_char_bpe.py
+++ b/bindings/python/tests/implementations/test_char_bpe.py
@@ -6,7 +6,7 @@ from tokenizers import CharBPETokenizer
 
 class TestBertWordPieceBPE:
     def test_basic_encode(self, openai_files):
-        tokenizer = CharBPETokenizer.from_files(openai_files["vocab"], openai_files["merges"])
+        tokenizer = CharBPETokenizer.from_file(openai_files["vocab"], openai_files["merges"])
 
         output = tokenizer.encode("My name is John", "pair")
         assert output.ids == [0, 253, 1362, 544, 0, 7, 12662, 2688]
@@ -33,7 +33,7 @@ class TestBertWordPieceBPE:
         assert output.type_ids == [0, 0, 0, 0, 0, 0, 0, 1]
 
     def test_lowercase(self, openai_files):
-        tokenizer = CharBPETokenizer.from_files(
+        tokenizer = CharBPETokenizer.from_file(
             openai_files["vocab"], openai_files["merges"], lowercase=True
         )
         output = tokenizer.encode("My name is John", "pair", add_special_tokens=False)
@@ -43,13 +43,13 @@ class TestBertWordPieceBPE:
         assert output.type_ids == [0, 0, 0, 0, 1]
 
     def test_decoding(self, openai_files):
-        tokenizer = CharBPETokenizer.from_files(
+        tokenizer = CharBPETokenizer.from_file(
             openai_files["vocab"], openai_files["merges"], lowercase=True
         )
         decoded = tokenizer.decode(tokenizer.encode("my name is john").ids)
         assert decoded == "my name is john"
 
     def test_multiprocessing_with_parallelism(self, openai_files):
-        tokenizer = CharBPETokenizer.from_files(openai_files["vocab"], openai_files["merges"])
+        tokenizer = CharBPETokenizer.from_file(openai_files["vocab"], openai_files["merges"])
         multiprocessing_with_parallelism(tokenizer, False)
         multiprocessing_with_parallelism(tokenizer, True)

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -40,7 +40,7 @@ use tokenizers::tokenizer::{Result, Tokenizer, EncodeInput};
 use tokenizers::models::bpe::BPE;
 
 fn main() -> Result<()> {
-    let bpe_builder = BPE::from_files("./path/to/vocab.json", "./path/to/merges.txt");
+    let bpe_builder = BPE::from_file("./path/to/vocab.json", "./path/to/merges.txt");
     let bpe = bpe_builder
         .dropout(0.1)
         .unk_token("[UNK]".into())

--- a/tokenizers/benches/bert_benchmark.rs
+++ b/tokenizers/benches/bert_benchmark.rs
@@ -45,7 +45,7 @@ fn create_bert_tokenizer(wp: WordPiece) -> BertTokenizer {
 }
 
 pub fn bench_bert(c: &mut Criterion) {
-    let wp = WordPiece::from_files("data/bert-base-uncased-vocab.txt")
+    let wp = WordPiece::from_file("data/bert-base-uncased-vocab.txt")
         .build()
         .unwrap();
     let tokenizer = create_bert_tokenizer(wp);

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -30,7 +30,7 @@ fn create_gpt2_tokenizer(bpe: BPE) -> Tokenizer {
 }
 
 fn bench_gpt2(c: &mut Criterion) {
-    let bpe = BPE::from_files("data/gpt2-vocab.json", "data/gpt2-merges.txt")
+    let bpe = BPE::from_file("data/gpt2-vocab.json", "data/gpt2-merges.txt")
         .build()
         .unwrap();
     let tokenizer = create_gpt2_tokenizer(bpe);
@@ -53,7 +53,7 @@ fn bench_gpt2(c: &mut Criterion) {
         b.iter_custom(|iters| iter_bench_encode_batch(iters, tokenizer.deref(), &batches))
     });
 
-    let bpe = BPE::from_files("data/gpt2-vocab.json", "data/gpt2-merges.txt")
+    let bpe = BPE::from_file("data/gpt2-vocab.json", "data/gpt2-merges.txt")
         .cache_capacity(0)
         .build()
         .unwrap();

--- a/tokenizers/src/cli.rs
+++ b/tokenizers/src/cli.rs
@@ -17,7 +17,7 @@ fn shell(matches: &ArgMatches) -> Result<()> {
         .value_of("merges")
         .expect("Must give a merges.txt file");
 
-    let bpe = BPE::from_files(vocab, merges).build()?;
+    let bpe = BPE::from_file(vocab, merges).build()?;
     let mut tokenizer = Tokenizer::new(bpe);
     tokenizer
         .with_pre_tokenizer(ByteLevel::default())

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -27,7 +27,7 @@
 //! use tokenizers::models::bpe::BPE;
 //!
 //! fn main() -> Result<()> {
-//!     let bpe_builder = BPE::from_files("./path/to/vocab.json", "./path/to/merges.txt");
+//!     let bpe_builder = BPE::from_file("./path/to/vocab.json", "./path/to/merges.txt");
 //!     let bpe = bpe_builder
 //!         .dropout(0.1)
 //!         .unk_token("[UNK]".into())

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -12,9 +12,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-type Vocab = HashMap<String, u32>;
+pub type Vocab = HashMap<String, u32>;
 type VocabR = HashMap<u32, String>;
-type Merges = HashMap<Pair, (u32, u32)>;
+pub type Merges = HashMap<Pair, (u32, u32)>;
 
 struct Config {
     files: Option<(String, String)>,

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -117,7 +117,7 @@ impl BpeBuilder {
 
         // Read files if necessary
         if let Some((vocab, merges)) = self.config.files {
-            let (v, m) = BPE::read_files(&vocab, &merges)?;
+            let (v, m) = BPE::read_file(&vocab, &merges)?;
             self.config.vocab = v;
             self.config.merges = m;
         }
@@ -258,12 +258,12 @@ impl BPE {
     }
 
     /// Initialize a BpeBuilder model from vocab and merges files
-    pub fn from_files(vocab: &str, merges: &str) -> BpeBuilder {
+    pub fn from_file(vocab: &str, merges: &str) -> BpeBuilder {
         BPE::builder().files(vocab.to_owned(), merges.to_owned())
     }
 
     /// Read the given files to extract the vocab and merges
-    pub fn read_files(vocab: &str, merges: &str) -> Result<(Vocab, Merges)> {
+    pub fn read_file(vocab: &str, merges: &str) -> Result<(Vocab, Merges)> {
         // Read vocab.json
         let vocab_file = File::open(vocab)?;
         let mut vocab_file = BufReader::new(vocab_file);
@@ -627,8 +627,8 @@ mod tests {
     }
 
     #[test]
-    // Ensure `BPE::from_files` works as expected.
-    fn test_bpe_from_files() {
+    // Ensure `BPE::from_file` works as expected.
+    fn test_bpe_from_file() {
         // Set up vocab file.
         let mut vocab_file = NamedTempFile::new().unwrap();
         vocab_file
@@ -640,7 +640,7 @@ mod tests {
         merges_file.write_all(b"#version: 0.2\na b").unwrap();
 
         // Make sure we can instantiate a BPE model from the files.
-        let builder = BPE::from_files(
+        let builder = BPE::from_file(
             vocab_file.path().to_str().unwrap(),
             merges_file.path().to_str().unwrap(),
         );
@@ -658,7 +658,7 @@ mod tests {
 
     #[test]
     // Ensure `MergeTokenOutOfVocabulary` error is returned when it should be.
-    fn test_bpe_from_files_merge_token_oov() {
+    fn test_bpe_from_file_merge_token_oov() {
         // Set up vocab file.
         let mut vocab_file = NamedTempFile::new().unwrap();
         vocab_file
@@ -669,8 +669,8 @@ mod tests {
         let mut merges_file = NamedTempFile::new().unwrap();
         merges_file.write_all(b"#version: 0.2\na b\na d").unwrap();
 
-        // Ensure the result of BPE::from_files is a MergeTokenOutOfVocabulary error.
-        match BPE::from_files(
+        // Ensure the result of BPE::from_file is a MergeTokenOutOfVocabulary error.
+        match BPE::from_file(
             vocab_file.path().to_str().unwrap(),
             merges_file.path().to_str().unwrap(),
         )
@@ -689,7 +689,7 @@ mod tests {
     #[test]
     // Ensure `BadMerges` error is returned when there is an invalid line in the
     // merges.txt file.
-    fn test_bpe_from_files_bad_merges() {
+    fn test_bpe_from_file_bad_merges() {
         // Set up vocab file.
         let mut vocab_file = NamedTempFile::new().unwrap();
         vocab_file
@@ -700,8 +700,8 @@ mod tests {
         let mut merges_file = NamedTempFile::new().unwrap();
         merges_file.write_all(b"#version: 0.2\na b\nc").unwrap();
 
-        // Ensure the result of BPE::from_files is a BadMerges error.
-        match BPE::from_files(
+        // Ensure the result of BPE::from_file is a BadMerges error.
+        match BPE::from_file(
             vocab_file.path().to_str().unwrap(),
             merges_file.path().to_str().unwrap(),
         )

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -555,8 +555,12 @@ impl BpeTrainer {
             word_to_id,
             merges
                 .into_iter()
-                .enumerate()
-                .map(|(index, (pair, new_id))| (pair, (index as u32, new_id)))
+                .map(|((a_id, b_id), _)| {
+                    (
+                        id_to_word[a_id as usize].clone(),
+                        id_to_word[b_id as usize].clone(),
+                    )
+                })
                 .collect(),
         );
         if let Some(prefix) = &self.continuing_subword_prefix {

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -101,7 +101,7 @@ impl std::fmt::Debug for WordLevel {
 }
 
 impl WordLevel {
-    fn builder() -> WordLevelBuilder {
+    pub fn builder() -> WordLevelBuilder {
         WordLevelBuilder::new()
     }
 

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -107,7 +107,7 @@ impl WordLevel {
         WordLevelBuilder::new()
     }
 
-    pub fn read_files(vocab_path: &str) -> Result<Vocab> {
+    pub fn read_file(vocab_path: &str) -> Result<Vocab> {
         let vocab_file = File::open(vocab_path)?;
         let mut vocab_file = BufReader::new(vocab_file);
         let mut buffer = String::new();
@@ -131,8 +131,8 @@ impl WordLevel {
     }
 
     /// Initialize a WordLevel model from vocab and merges file.
-    pub fn from_files(vocab_path: &str, unk_token: String) -> Result<WordLevel> {
-        let vocab = WordLevel::read_files(vocab_path)?;
+    pub fn from_file(vocab_path: &str, unk_token: String) -> Result<WordLevel> {
+        let vocab = WordLevel::read_file(vocab_path)?;
         Ok(Self::builder().vocab(vocab).unk_token(unk_token).build())
     }
 }

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 
 mod serialization;
 
+type Vocab = HashMap<String, u32>;
+
 #[derive(Debug)]
 pub enum Error {
     MissingUnkToken,
@@ -105,9 +107,7 @@ impl WordLevel {
         WordLevelBuilder::new()
     }
 
-    /// Initialize a WordLevel model from vocab and merges file.
-    pub fn from_files(vocab_path: &str, unk_token: String) -> Result<WordLevel> {
-        // Read vocab.json
+    pub fn read_files(vocab_path: &str) -> Result<Vocab> {
         let vocab_file = File::open(vocab_path)?;
         let mut vocab_file = BufReader::new(vocab_file);
         let mut buffer = String::new();
@@ -127,7 +127,12 @@ impl WordLevel {
             }
             _ => return Err(Box::new(Error::BadVocabulary)),
         };
+        Ok(vocab)
+    }
 
+    /// Initialize a WordLevel model from vocab and merges file.
+    pub fn from_files(vocab_path: &str, unk_token: String) -> Result<WordLevel> {
+        let vocab = WordLevel::read_files(vocab_path)?;
         Ok(Self::builder().vocab(vocab).unk_token(unk_token).build())
     }
 }

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -103,7 +103,7 @@ impl WordPieceBuilder {
     /// Contructs a `WordPiece` model that uses the `WordPieceBuilder`'s configuration.
     pub fn build(mut self) -> Result<WordPiece> {
         if let Some(vocab) = self.config.files {
-            self.config.vocab = WordPiece::read_files(&vocab)?;
+            self.config.vocab = WordPiece::read_file(&vocab)?;
         }
 
         let vocab_r = self
@@ -165,7 +165,7 @@ impl WordPiece {
     }
 
     /// Read the given files to extract the vocab
-    pub fn read_files(vocab: &str) -> Result<Vocab> {
+    pub fn read_file(vocab: &str) -> Result<Vocab> {
         let file = File::open(vocab)?;
         let file = BufReader::new(file);
 
@@ -179,7 +179,7 @@ impl WordPiece {
     }
 
     /// Initialize a `WordPiece` model from a vocab mapping file.
-    pub fn from_files(vocab: &str) -> WordPieceBuilder {
+    pub fn from_file(vocab: &str) -> WordPieceBuilder {
         WordPiece::builder().files(vocab.to_owned())
     }
 

--- a/tokenizers/tests/common/mod.rs
+++ b/tokenizers/tests/common/mod.rs
@@ -14,7 +14,7 @@ pub fn get_empty() -> Tokenizer {
 
 #[allow(dead_code)]
 pub fn get_byte_level_bpe() -> BPE {
-    BPE::from_files("data/gpt2-vocab.json", "data/gpt2-merges.txt")
+    BPE::from_file("data/gpt2-vocab.json", "data/gpt2-merges.txt")
         .build()
         .expect("Files not found, run `make test` to download these files")
 }
@@ -32,7 +32,7 @@ pub fn get_byte_level(add_prefix_space: bool, trim_offsets: bool) -> Tokenizer {
 
 #[allow(dead_code)]
 pub fn get_bert_wordpiece() -> WordPiece {
-    WordPiece::from_files("data/bert-base-uncased-vocab.txt")
+    WordPiece::from_file("data/bert-base-uncased-vocab.txt")
         .build()
         .expect("Files not found, run `make test` to download these files")
 }

--- a/tokenizers/tests/serialization.rs
+++ b/tokenizers/tests/serialization.rs
@@ -36,7 +36,7 @@ fn wordpiece_serde() {
 
 #[test]
 fn wordlevel_serde() {
-    let wordlevel = WordLevel::from_files("data/gpt2-vocab.json", "<unk>".into()).unwrap();
+    let wordlevel = WordLevel::from_file("data/gpt2-vocab.json", "<unk>".into()).unwrap();
     let ser = serde_json::to_string(&wordlevel).unwrap();
     let de = serde_json::from_str(&ser).unwrap();
     assert_eq!(wordlevel, de);


### PR DESCRIPTION
Added `from_file(s)` helper functions.

Fixes #409 