### PR TITLE
Replace Normalizer can use Regex

### DIFF
--- a/bindings/node/native/src/normalizers.rs
+++ b/bindings/node/native/src/normalizers.rs
@@ -216,8 +216,11 @@ fn replace(mut cx: FunctionContext) -> JsResult<JsNormalizer> {
     let content: String = cx.extract::<String>(1)?;
     let mut normalizer = JsNormalizer::new::<_, JsNormalizer, _>(&mut cx, vec![])?;
     let guard = cx.lock();
-    normalizer.borrow_mut(&guard).normalizer =
-        Some(tk::normalizers::replace::Replace::new(pattern, content).into());
+    normalizer.borrow_mut(&guard).normalizer = Some(
+        tk::normalizers::replace::Replace::new(pattern, content)
+            .map_err(|e| Error(e.to_string()))?
+            .into(),
+    );
     Ok(normalizer)
 }
 

--- a/bindings/python/src/normalizers.rs
+++ b/bindings/python/src/normalizers.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::*;
 
 use crate::error::ToPyResult;
-use crate::utils::{PyNormalizedString, PyNormalizedStringRefMut};
+use crate::utils::{PyNormalizedString, PyNormalizedStringRefMut, PyPattern};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tk::normalizers::{
@@ -425,8 +425,11 @@ pub struct PyReplace {}
 #[pymethods]
 impl PyReplace {
     #[new]
-    fn new(pattern: String, content: String) -> PyResult<(Self, PyNormalizer)> {
-        Ok((PyReplace {}, Replace::new(pattern, content).into()))
+    fn new(pattern: PyPattern, content: String) -> PyResult<(Self, PyNormalizer)> {
+        Ok((
+            PyReplace {},
+            ToPyResult(Replace::new(pattern, content)).into_py()?.into(),
+        ))
     }
 }
 

--- a/bindings/python/src/utils/normalization.rs
+++ b/bindings/python/src/utils/normalization.rs
@@ -35,6 +35,15 @@ impl Pattern for PyPattern<'_> {
     }
 }
 
+impl From<PyPattern<'_>> for tk::normalizers::replace::ReplacePattern {
+    fn from(pattern: PyPattern<'_>) -> Self {
+        match pattern {
+            PyPattern::Str(s) => Self::String(s.to_owned()),
+            PyPattern::Regex(r) => Python::with_gil(|py| Self::Regex(r.borrow(py).pattern.clone())),
+        }
+    }
+}
+
 #[derive(Debug, Clone, FromPyObject)]
 pub enum PyRange<'s> {
     #[pyo3(annotation = "int")]

--- a/bindings/python/src/utils/regex.rs
+++ b/bindings/python/src/utils/regex.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 #[pyclass(module = "tokenizers", name=Regex)]
 pub struct PyRegex {
     pub inner: Regex,
+    pub pattern: String,
 }
 
 #[pymethods]
@@ -14,6 +15,7 @@ impl PyRegex {
         Ok(Self {
             inner: Regex::new(s)
                 .map_err(|e| exceptions::PyException::new_err(e.description().to_owned()))?,
+            pattern: s.to_owned(),
         })
     }
 }

--- a/tokenizers/src/normalizers/replace.rs
+++ b/tokenizers/src/normalizers/replace.rs
@@ -1,24 +1,85 @@
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
+use onig::Regex;
 use serde::{Deserialize, Serialize};
 
-/// This normalizer will take a `pattern` (for now only a String)
-/// and replace every occurrence with `content`.
-#[derive(Deserialize, Serialize, Clone, Debug)]
+/// Represents the different patterns that `Replace` can use
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ReplacePattern {
+    String(String),
+    Regex(String),
+}
+
+impl From<String> for ReplacePattern {
+    fn from(v: String) -> Self {
+        ReplacePattern::String(v)
+    }
+}
+
+impl From<&str> for ReplacePattern {
+    fn from(v: &str) -> Self {
+        ReplacePattern::String(v.to_owned())
+    }
+}
+
+/// We use this custom deserializer to provided the value for `regex` for `Replace`
+#[doc(hidden)]
+#[derive(Deserialize)]
 #[serde(tag = "type")]
-pub struct Replace {
-    pattern: String,
+struct ReplaceDeserializer {
+    pattern: ReplacePattern,
     content: String,
 }
 
+impl std::convert::TryFrom<ReplaceDeserializer> for Replace {
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn try_from(v: ReplaceDeserializer) -> Result<Self> {
+        Replace::new(v.pattern, v.content)
+    }
+}
+
+/// This normalizer will take a `pattern` (for now only a String)
+/// and replace every occurrence with `content`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", try_from = "ReplaceDeserializer")]
+pub struct Replace {
+    pattern: ReplacePattern,
+    content: String,
+    #[serde(skip)]
+    regex: Regex,
+}
+
+impl Clone for Replace {
+    fn clone(&self) -> Self {
+        Replace::new(self.pattern.clone(), &self.content).unwrap()
+    }
+}
+
+impl PartialEq for Replace {
+    fn eq(&self, other: &Replace) -> bool {
+        self.pattern == other.pattern && self.content == other.content
+    }
+}
+
 impl Replace {
-    pub fn new(pattern: String, content: String) -> Self {
-        Self { pattern, content }
+    pub fn new<I: Into<ReplacePattern>, C: Into<String>>(pattern: I, content: C) -> Result<Self> {
+        let pattern: ReplacePattern = pattern.into();
+        let regex = match &pattern {
+            ReplacePattern::String(s) => Regex::new(&regex::escape(s))?,
+            ReplacePattern::Regex(r) => Regex::new(r)?,
+        };
+
+        Ok(Self {
+            pattern,
+            content: content.into(),
+            regex,
+        })
     }
 }
 
 impl Normalizer for Replace {
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        normalized.replace(&self.pattern, &self.content)
+        normalized.replace(&self.regex, &self.content)
     }
 }
 
@@ -32,10 +93,35 @@ mod tests {
         let normalized = "This is a \"test\"";
 
         let mut n = NormalizedString::from(original);
-        Replace::new("''".to_string(), "\"".to_string())
+        Replace::new("''", "\"").unwrap().normalize(&mut n).unwrap();
+
+        assert_eq!(&n.get(), &normalized);
+    }
+
+    #[test]
+    fn test_replace_regex() {
+        let original = "This     is   a         test";
+        let normalized = "This is a test";
+
+        let mut n = NormalizedString::from(original);
+        Replace::new(ReplacePattern::Regex(r"\s+".into()), ' ')
+            .unwrap()
             .normalize(&mut n)
             .unwrap();
 
         assert_eq!(&n.get(), &normalized);
+    }
+
+    #[test]
+    fn serialization() {
+        let replace = Replace::new("Hello", "Hey").unwrap();
+        let replace_s = r#"{"type":"Replace","pattern":{"String":"Hello"},"content":"Hey"}"#;
+        assert_eq!(serde_json::to_string(&replace).unwrap(), replace_s);
+        assert_eq!(serde_json::from_str::<Replace>(replace_s).unwrap(), replace);
+
+        let replace = Replace::new(ReplacePattern::Regex(r"\s+".into()), ' ').unwrap();
+        let replace_s = r#"{"type":"Replace","pattern":{"Regex":"\\s+"},"content":" "}"#;
+        assert_eq!(serde_json::to_string(&replace).unwrap(), replace_s);
+        assert_eq!(serde_json::from_str::<Replace>(replace_s).unwrap(), replace);
     }
 }


### PR DESCRIPTION
Adds the ability to replace using regular expressions on the `Replace` normalizer.

There are no bindings for the regex pattern for node at the moment, but a they need a big refresh anyway. Let's keep it outside of the scope for now.