### PR TITLE
Fixed Dead Link: Build your own #435

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -118,7 +118,7 @@ All of these can be used and trained as explained above!
 
 Whenever these provided tokenizers don't give you enough freedom, you can build your own tokenizer,
 by putting all the different parts you need together.
-You can how we implemented the [provided tokenizers](https://github.com/huggingface/tokenizers/tree/master/bindings/python/tokenizers/implementations) and adapt them easily to your own needs.
+You can how we implemented the [provided tokenizers](https://github.com/huggingface/tokenizers/tree/master/bindings/python/tests/implementations) and adapt them easily to your own needs.
 
 #### Building a byte-level BPE
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -118,7 +118,7 @@ All of these can be used and trained as explained above!
 
 Whenever these provided tokenizers don't give you enough freedom, you can build your own tokenizer,
 by putting all the different parts you need together.
-You can how we implemented the [provided tokenizers](https://github.com/huggingface/tokenizers/tree/master/bindings/python/tests/implementations) and adapt them easily to your own needs.
+You can check how we implemented the [provided tokenizers](https://github.com/huggingface/tokenizers/tree/master/bindings/python/py_src/tokenizers/implementations) and adapt them easily to your own needs.
 
 #### Building a byte-level BPE
 


### PR DESCRIPTION
Fix #435 

Changed the dead link (https://github.com/huggingface/tokenizers/tree/master/bindings/python/tokenizers/implementations) 
by (https://github.com/huggingface/tokenizers/tree/master/bindings/python/tests/implementations)