### PR TITLE
Improve template processing

### DIFF
--- a/bindings/python/py_src/tokenizers/processors/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/processors/__init__.pyi
@@ -149,7 +149,7 @@ class TemplateProcessing(PostProcessor):
     might lead to unexpected results.
     """
 
-    def __init__(self, single: Template, seq_b: Template, special_tokens: Tokens) -> None:
+    def __init__(self, single: Template, pair: Template, special_tokens: Tokens) -> None:
         """Instantiate a new TemplateProcessing
 
         Args:

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -17,6 +17,7 @@ class TestBPE:
         assert isinstance(BPE.from_file(roberta_files["vocab"], roberta_files["merges"]), BPE)
         with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
             BPE(vocab=vocab)
+        with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
             BPE(merges=merges)
 
         assert isinstance(
@@ -30,6 +31,7 @@ class TestBPE:
 
         with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
             BPE(vocab=roberta_files["vocab"])
+        with pytest.raises(ValueError, match="`vocab` and `merges` must be both specified"):
             BPE(merges=roberta_files["merges"])
         with pytest.deprecated_call():
             assert isinstance(

--- a/bindings/python/tests/bindings/test_processors.py
+++ b/bindings/python/tests/bindings/test_processors.py
@@ -136,6 +136,20 @@ class TestTemplateProcessing:
         assert isinstance(bert, TemplateProcessing)
         assert isinstance(pickle.loads(pickle.dumps(bert)), TemplateProcessing)
 
+        # It is absolutely legal to have tokens with spaces in the name:
+        processor = TemplateProcessing(
+            single=["[ C L S ]", "Token with space"],
+            special_tokens=[("[ C L S ]", 0), ("Token with space", 1)],
+        )
+        # Sequence identifiers must be well formed:
+        with pytest.raises(Exception, match="Cannot build Piece"):
+            processor = TemplateProcessing(single="[CLS] $$ [SEP]")
+        with pytest.raises(Exception, match="Cannot build Piece"):
+            processor = TemplateProcessing(single="[CLS] $A: [SEP]")
+        # Special tokens must be provided when used in template:
+        with pytest.raises(Exception, match="Missing SpecialToken\(s\) with id\(s\)"):
+            processor = TemplateProcessing(single=["[CLS]"])
+
     def test_bert_parity(self):
         tokenizer = Tokenizer(BPE())
         tokenizer.add_special_tokens(["[SEP]", "[CLS]"])

--- a/bindings/python/tests/bindings/test_processors.py
+++ b/bindings/python/tests/bindings/test_processors.py
@@ -88,15 +88,15 @@ class TestByteLevelProcessing:
 class TestTemplateProcessing:
     def get_bert(self):
         return TemplateProcessing(
-            seq_a=["[CLS]", "$0", "[SEP]"],
-            seq_b=["$1", "[SEP]"],
+            single=["[CLS]", "$0", "[SEP]"],
+            pair=["[CLS]", "$A", "[SEP]", "$B:1", "[SEP]:1"],
             special_tokens=[("[CLS]", 1), ("[SEP]", 0)],
         )
 
     def get_roberta(self):
         return TemplateProcessing(
-            seq_a="<s> $0 </s>",
-            seq_b="</s> $0 </s>",
+            single="<s> $0 </s>",
+            pair="<s> $A </s> </s> $B </s>",
             special_tokens=[("<s>", 0), ("</s>", 1)],
         )
 
@@ -113,19 +113,17 @@ class TestTemplateProcessing:
         # [822, 10]
 
         return TemplateProcessing(
-            seq_a=["Q", "$0"],
-            seq_b=["C", "$1"],
+            single=["$0"],
+            pair=["Q", "$A", "C", "$B"],
             special_tokens=[
                 {
                     "id": "Q",
                     "ids": [2625, 10],
-                    "type_ids": [None, None],
                     "tokens": ["_question", ":"],
                 },
                 {
                     "id": "C",
                     "ids": [822, 10],
-                    "type_ids": [None, None],
                     "tokens": ["_context", ":"],
                 },
             ],

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -263,12 +263,16 @@ class TestTokenizer:
         # Mal formed
         with pytest.raises(TypeError, match="TextInputSequence must be str"):
             tokenizer.encode([["my", "name"]])
+        with pytest.raises(TypeError, match="TextInputSequence must be str"):
             tokenizer.encode("My name is john", [["pair"]])
+        with pytest.raises(TypeError, match="TextInputSequence must be str"):
             tokenizer.encode("my name is john", ["pair"])
 
         with pytest.raises(TypeError, match="InputSequence must be Union[List[str]"):
             tokenizer.encode("My name is john", is_pretokenized=True)
+        with pytest.raises(TypeError, match="InputSequence must be Union[List[str]"):
             tokenizer.encode("My name is john", ["pair"], is_pretokenized=True)
+        with pytest.raises(TypeError, match="InputSequence must be Union[List[str]"):
             tokenizer.encode(["My", "name", "is", "John"], "pair", is_pretokenized=True)
 
     def test_encode_add_special_tokens(self, roberta_files):


### PR DESCRIPTION
The current version of the `TemplateProcessing` lets us define two sequences `seq_a` and `seq_b`, that end up being concatenated when both are provided. This is actually quite limiting when the template for a pair of sequences is more complicated. (ie XLNet)

This PR modifies the API to actually provide two templates `single` and `pair`, that will be used as relevant, thus allowing for a lot more freedom.