### PR TITLE
Fixing 1.47 complaints from clippy.

### DIFF
--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::all)]
+#![allow(clippy::needless_collect)]
 #![doc(html_favicon_url = "https://huggingface.co/favicon.ico")]
 #![doc(html_logo_url = "https://huggingface.co/landing/assets/huggingface_logo.svg")]
 

--- a/tokenizers/src/utils/parallelism.rs
+++ b/tokenizers/src/utils/parallelism.rs
@@ -26,10 +26,7 @@ pub fn get_parallelism() -> bool {
     match std::env::var(ENV_VARIABLE) {
         Ok(mut v) => {
             v.make_ascii_lowercase();
-            match v.as_ref() {
-                "" | "off" | "false" | "f" | "no" | "n" | "0" => false,
-                _ => true,
-            }
+            !matches!(v.as_ref(), "" | "off" | "false" | "f" | "no" | "n" | "0")
         }
         Err(_) => true, // If we couldn't get the variable, we use the default
     }


### PR DESCRIPTION
needless_collect seems to be off because removing them
*will* cause some borrow checker complaints. We might be able
to correct those better, but probably not everywhere.