### PR TITLE
Add progress bar feature flag

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -47,7 +47,7 @@ clap = "2.33"
 unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 unicode-segmentation = "1.6"
-indicatif = "0.14"
+indicatif = { version = "0.15", optional = true }
 itertools = "0.9"
 log = "0.4"
 esaxx-rs = "0.1"
@@ -58,3 +58,7 @@ spm_precompiled = "0.1"
 criterion = "0.3"
 tempfile = "3.1"
 assert_approx_eq = "1.1"
+
+[features]
+default = ["progressbar"]
+progressbar = ["indicatif"]

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
     let vocab_size: usize = 100;
 
     let trainer = BpeTrainerBuilder::new()
-        .show_progress(true)
+        .show_progress(true) // requires "progressbar" feature
         .vocab_size(vocab_size)
         .min_frequency(0)
         .special_tokens(vec![
@@ -113,3 +113,9 @@ fn main() -> Result<()> {
 by the total number of core/threads your CPU provides but this can be tuned by setting the `RAYON_RS_NUM_CPUS`
 environment variable. As an example setting `RAYON_RS_NUM_CPUS=4` will allocate a maximum of 4 threads.
 **_Please note this behavior may evolve in the future_**
+
+## Features
+
+- **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
+  compilation for certain targets is not supported by the [termios](https://crates.io/crates/termios)
+  dependency of the [indicatif](https://crates.io/crates/indicatif) progress bar.

--- a/tokenizers/benches/bert_benchmark.rs
+++ b/tokenizers/benches/bert_benchmark.rs
@@ -70,9 +70,12 @@ pub fn bench_bert(c: &mut Criterion) {
 }
 
 fn bench_train(c: &mut Criterion) {
+    #[cfg(feature = "progressbar")]
     let trainer = WordPieceTrainerBuilder::default()
         .show_progress(false)
         .build();
+    #[cfg(not(feature = "progressbar"))]
+    let trainer = WordPieceTrainerBuilder::default().build();
     type Tok = TokenizerImpl<
         WordPiece,
         NormalizerWrapper,

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -69,10 +69,13 @@ fn bench_gpt2(c: &mut Criterion) {
 }
 
 fn bench_train(c: &mut Criterion) {
+    #[cfg(feature = "progressbar")]
     let trainer: TrainerWrapper = BpeTrainerBuilder::default()
         .show_progress(false)
         .build()
         .into();
+    #[cfg(not(feature = "progressbar"))]
+    let trainer: TrainerWrapper = BpeTrainerBuilder::default().build().into();
     let mut tokenizer = Tokenizer::new(BPE::default()).into_inner();
     tokenizer.with_pre_tokenizer(Whitespace::default());
     c.bench_function("BPE Train vocabulary (small)", |b| {

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -57,10 +57,12 @@
 //! use std::path::Path;
 //!
 //! fn main() -> Result<()> {
+//!     # #[cfg(feature = "progressbar")]
+//!     # {
 //!     let vocab_size: usize = 100;
 //!
 //!     let trainer = BpeTrainerBuilder::new()
-//!         .show_progress(true)
+//!         .show_progress(true) // requires "progressbar" feature
 //!         .vocab_size(vocab_size)
 //!         .min_frequency(0)
 //!         .special_tokens(vec![
@@ -90,6 +92,7 @@
 //!         )?
 //!         .get_model()
 //!         .save(Path::new("result-folder"), Some("some-prefix"))?;
+//!    # }
 //!
 //!     Ok(())
 //! }
@@ -101,6 +104,12 @@
 //! by the total number of core/threads your CPU provides but this can be tuned by setting the `RAYON_RS_NUM_CPUS`
 //! environment variable. As an example setting `RAYON_RS_NUM_CPUS=4` will allocate a maximum of 4 threads.
 //! **_Please note this behavior may evolve in the future_**
+//!
+//! # Features
+//!
+//! - **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
+//! compilation for certain targets is not supported by the [termios](https://crates.io/crates/termios)
+//! dependency of the [indicatif](https://crates.io/crates/indicatif) progress bar.
 
 #[macro_use]
 extern crate log;

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -3,6 +3,7 @@
 use super::{Pair, WithFirstLastIterator, Word, BPE};
 use crate::parallelism::*;
 use crate::tokenizer::{AddedToken, Result, Trainer};
+#[cfg(feature = "progressbar")]
 use indicatif::{ProgressBar, ProgressStyle};
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
@@ -37,6 +38,7 @@ impl Ord for Merge {
 struct Config {
     min_frequency: u32,
     vocab_size: usize,
+    #[cfg(feature = "progressbar")]
     show_progress: bool,
     special_tokens: Vec<AddedToken>,
     limit_alphabet: Option<usize>,
@@ -57,6 +59,7 @@ impl Default for BpeTrainerBuilder {
             config: Config {
                 min_frequency: 0,
                 vocab_size: 30000,
+                #[cfg(feature = "progressbar")]
                 show_progress: true,
                 special_tokens: vec![],
                 limit_alphabet: None,
@@ -86,6 +89,7 @@ impl BpeTrainerBuilder {
         self
     }
 
+    #[cfg(feature = "progressbar")]
     /// Set whether to show progress
     pub fn show_progress(mut self, show: bool) -> Self {
         self.config.show_progress = show;
@@ -127,6 +131,7 @@ impl BpeTrainerBuilder {
         BpeTrainer {
             min_frequency: self.config.min_frequency,
             vocab_size: self.config.vocab_size,
+            #[cfg(feature = "progressbar")]
             show_progress: self.config.show_progress,
             special_tokens: self.config.special_tokens,
             limit_alphabet: self.config.limit_alphabet,
@@ -158,6 +163,7 @@ pub struct BpeTrainer {
     min_frequency: u32,
     /// The target vocabulary size
     vocab_size: usize,
+    #[cfg(feature = "progressbar")]
     /// Whether to show progress while training
     show_progress: bool,
     /// A list of special tokens that the model should know of
@@ -192,6 +198,7 @@ impl BpeTrainer {
         BpeTrainerBuilder::new()
     }
 
+    #[cfg(feature = "progressbar")]
     /// Setup a progress bar if asked to show progress
     fn setup_progress(&self) -> Option<ProgressBar> {
         if self.show_progress {
@@ -206,6 +213,7 @@ impl BpeTrainer {
         }
     }
 
+    #[cfg(feature = "progressbar")]
     /// Set the progress bar in the finish state
     fn finalize_progress(&self, p: &Option<ProgressBar>, final_len: usize) {
         if let Some(p) = p {
@@ -215,6 +223,7 @@ impl BpeTrainer {
         }
     }
 
+    #[cfg(feature = "progressbar")]
     /// Update the progress bar with the new provided length and message
     fn update_progress(&self, p: &Option<ProgressBar>, len: usize, message: &str) {
         if let Some(p) = p {
@@ -300,7 +309,7 @@ impl BpeTrainer {
         wc: &HashMap<String, u32>,
         w2id: &mut HashMap<String, u32>,
         id2w: &mut Vec<String>,
-        p: &Option<ProgressBar>,
+        #[cfg(feature = "progressbar")] p: &Option<ProgressBar>,
     ) -> (Vec<Word>, Vec<u32>) {
         let mut words: Vec<Word> = Vec::with_capacity(wc.len());
         let mut counts: Vec<u32> = Vec::with_capacity(wc.len());
@@ -337,6 +346,7 @@ impl BpeTrainer {
             }
             words.push(current_word);
 
+            #[cfg(feature = "progressbar")]
             if let Some(p) = p {
                 p.inc(1);
             }
@@ -349,7 +359,7 @@ impl BpeTrainer {
         &self,
         words: &[Word],
         counts: &[u32],
-        p: &Option<ProgressBar>,
+        #[cfg(feature = "progressbar")] p: &Option<ProgressBar>,
     ) -> (HashMap<Pair, i32>, HashMap<Pair, HashSet<usize>>) {
         words
             .maybe_par_iter()
@@ -381,6 +391,7 @@ impl BpeTrainer {
                     *pair_counts.get_mut(&cur_pair).unwrap() += count as i32;
                 }
 
+                #[cfg(feature = "progressbar")]
                 if let Some(p) = &p {
                     p.inc(1);
                 }
@@ -408,6 +419,7 @@ impl BpeTrainer {
         let mut word_to_id: HashMap<String, u32> = HashMap::with_capacity(self.vocab_size);
         let mut id_to_word: Vec<String> = Vec::with_capacity(self.vocab_size);
 
+        #[cfg(feature = "progressbar")]
         let progress = self.setup_progress();
 
         //
@@ -423,16 +435,29 @@ impl BpeTrainer {
         //
         // 3. Tokenize words
         //
+        #[cfg(feature = "progressbar")]
         self.update_progress(&progress, word_counts.len(), "Tokenize words");
-        let (words, counts) =
-            self.tokenize_words(&word_counts, &mut word_to_id, &mut id_to_word, &progress);
+        let (words, counts) = self.tokenize_words(
+            &word_counts,
+            &mut word_to_id,
+            &mut id_to_word,
+            #[cfg(feature = "progressbar")]
+            &progress,
+        );
+        #[cfg(feature = "progressbar")]
         self.finalize_progress(&progress, words.len());
 
         //
         // 4. Count pairs in words
         //
+        #[cfg(feature = "progressbar")]
         self.update_progress(&progress, words.len(), "Count pairs");
-        let (mut pair_counts, mut where_to_update) = self.count_pairs(&words, &counts, &progress);
+        let (mut pair_counts, mut where_to_update) = self.count_pairs(
+            &words,
+            &counts,
+            #[cfg(feature = "progressbar")]
+            &progress,
+        );
         // Insert them in the queue
         let mut queue = BinaryHeap::with_capacity(pair_counts.len());
         where_to_update.drain().for_each(|(pair, pos)| {
@@ -445,11 +470,13 @@ impl BpeTrainer {
                 });
             }
         });
+        #[cfg(feature = "progressbar")]
         self.finalize_progress(&progress, words.len());
 
         //
         // 5. Do merges
         //
+        #[cfg(feature = "progressbar")]
         self.update_progress(&progress, self.vocab_size, "Compute merges");
         let mut merges: Vec<(Pair, u32)> = vec![];
         loop {
@@ -545,10 +572,12 @@ impl BpeTrainer {
                 }
             });
 
+            #[cfg(feature = "progressbar")]
             if let Some(p) = &progress {
                 p.inc(1);
             }
         }
+        #[cfg(feature = "progressbar")]
         self.finalize_progress(&progress, merges.len());
 
         let mut builder = BPE::builder().vocab_and_merges(
@@ -597,6 +626,7 @@ impl Trainer for BpeTrainer {
         }
     }
 
+    #[cfg(feature = "progressbar")]
     /// Whether we should show progress
     fn should_show_progress(&self) -> bool {
         self.show_progress
@@ -626,10 +656,13 @@ mod tests {
         .iter()
         .cloned()
         .collect();
+        #[cfg(feature = "progressbar")]
         let trainer = BpeTrainer::builder()
             .show_progress(false)
             .min_frequency(2)
             .build();
+        #[cfg(not(feature = "progressbar"))]
+        let trainer = BpeTrainer::builder().min_frequency(2).build();
         let (model, _) = trainer.train(word_counts).unwrap();
 
         // Vocab should contain all of the characters from the `word_counts` mapping

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -123,6 +123,7 @@ pub enum TrainerWrapper {
 impl Trainer for TrainerWrapper {
     type Model = ModelWrapper;
 
+    #[cfg(feature = "progressbar")]
     fn should_show_progress(&self) -> bool {
         match self {
             TrainerWrapper::BpeTrainer(bpe) => bpe.should_show_progress(),

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -35,6 +35,7 @@ impl WordPieceTrainerBuilder {
         self
     }
 
+    #[cfg(feature = "progressbar")]
     /// Set whether to show progress
     pub fn show_progress(mut self, show: bool) -> Self {
         self.bpe_trainer_builder = self.bpe_trainer_builder.show_progress(show);
@@ -107,6 +108,7 @@ impl Trainer for WordPieceTrainer {
         self.bpe_trainer.process_tokens(&mut words, tokens)
     }
 
+    #[cfg(feature = "progressbar")]
     fn should_show_progress(&self) -> bool {
         self.bpe_trainer.should_show_progress()
     }

--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -50,10 +50,13 @@ fn test_train_unigram_from_file() {
 
     // println!("Words counts {:?}", word_counts);
 
+    #[cfg(feature = "progressbar")]
     let trainer = UnigramTrainer::builder()
         .show_progress(false)
         .build()
         .unwrap();
+    #[cfg(not(feature = "progressbar"))]
+    let trainer = UnigramTrainer::builder().build().unwrap();
     let (model, _) = trainer.train(word_counts).unwrap();
     assert_eq!(model.get_vocab_size(), 719);
 }


### PR DESCRIPTION
Fixes #270.

We ran into the same issue as #270 while compiling for ios targets and decided to provide a pr. This pr introduces the `progressbar` feature flag, which makes the `indicatif` dependencies and its usage optional (but it's still set as default to avoid breaking changes).