### PR TITLE
Fix RobertaProcessing deserialization in PostProcessorWrapper

### DIFF
--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -40,7 +40,7 @@ lazy_static! {
         bytes_char().into_iter().map(|(c, b)| (b, c)).collect();
 }
 
-#[derive(Deserialize, Serialize, Copy, Clone, Debug)]
+#[derive(Deserialize, Serialize, Copy, Clone, Debug, PartialEq)]
 /// Provides all the necessary steps to handle the BPE tokenization at the byte-level. Takes care
 /// of all the required processing steps to transform a UTF-8 string as needed before and after the
 /// BPE model does its job.

--- a/tokenizers/src/processors/mod.rs
+++ b/tokenizers/src/processors/mod.rs
@@ -13,12 +13,13 @@ use crate::processors::roberta::RobertaProcessing;
 use crate::processors::template::TemplateProcessing;
 use crate::{Encoding, PostProcessor, Result};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(untagged)]
 pub enum PostProcessorWrapper {
+    // Roberta must be before Bert for deserialization (serde does not validate tags)
+    Roberta(RobertaProcessing),
     Bert(BertProcessing),
     ByteLevel(ByteLevel),
-    Roberta(RobertaProcessing),
     Template(TemplateProcessing),
 }
 
@@ -59,3 +60,34 @@ impl_enum_from!(BertProcessing, PostProcessorWrapper, Bert);
 impl_enum_from!(ByteLevel, PostProcessorWrapper, ByteLevel);
 impl_enum_from!(RobertaProcessing, PostProcessorWrapper, Roberta);
 impl_enum_from!(TemplateProcessing, PostProcessorWrapper, Template);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_bert_roberta_correctly() {
+        let roberta = RobertaProcessing::default();
+        let roberta_r = r#"{
+            "type":"RobertaProcessing",
+            "sep":["</s>",2],
+            "cls":["<s>",0],
+            "trim_offsets":true,
+            "add_prefix_space":true
+        }"#
+        .replace(char::is_whitespace, "");
+        assert_eq!(serde_json::to_string(&roberta).unwrap(), roberta_r);
+        assert_eq!(
+            serde_json::from_str::<PostProcessorWrapper>(&roberta_r).unwrap(),
+            PostProcessorWrapper::Roberta(roberta)
+        );
+
+        let bert = BertProcessing::default();
+        let bert_r = r#"{"type":"BertProcessing","sep":["[SEP]",102],"cls":["[CLS]",101]}"#;
+        assert_eq!(serde_json::to_string(&bert).unwrap(), bert_r);
+        assert_eq!(
+            serde_json::from_str::<PostProcessorWrapper>(bert_r).unwrap(),
+            PostProcessorWrapper::Bert(bert)
+        );
+    }
+}


### PR DESCRIPTION
When loading a `Tokenizer` from a json file, if it contains a `RobertaProcessing`, it ends up deserialized as a `BertProcessing`.

This happens because serde does not validate tags, when wrapped in an `untagged` enum (just like we do for `PostProcessorWrapper`).