### PR TITLE
Last missing pieces for Unigram + ByteLevel

### DIFF
--- a/bindings/python/py_src/tokenizers/trainers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/trainers/__init__.pyi
@@ -46,7 +46,7 @@ class BpeTrainer(Trainer):
             initial_alphabet: List[str]:
                 A list of characters to include in the initial alphabet, even
                 if not seen in the training dataset.
-                If the strings contains more than one character, only the first one
+                If the strings contain more than one character, only the first one
                 is kept.
 
             continuing_subword_prefix: Optional[str]:
@@ -98,7 +98,7 @@ class WordPieceTrainer(Trainer):
             initial_alphabet: List[str]:
                 A list of characters to include in the initial alphabet, even
                 if not seen in the training dataset.
-                If the strings contains more than one character, only the first one
+                If the strings contain more than one character, only the first one
                 is kept.
 
             continuing_subword_prefix: Optional[str]:
@@ -135,6 +135,12 @@ class UnigramTrainer(Trainer):
 
             special_tokens: List[Union[str, AddedToken]]:
                 A list of special tokens the model should know of.
+
+            initial_alphabet: List[str]:
+                A list of characters to include in the initial alphabet, even
+                if not seen in the training dataset.
+                If the strings contain more than one character, only the first one
+                is kept.
 
         Returns:
             Trainer

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -416,9 +416,8 @@ pub struct PyUnigram {}
 impl PyUnigram {
     #[new]
     fn new(vocab: Option<Vec<(String, f64)>>, unk_id: Option<usize>) -> PyResult<(Self, PyModel)> {
-        if vocab.is_some() && unk_id.is_none() || vocab.is_none() && unk_id.is_some() {}
         match (vocab, unk_id) {
-            (Some(vocab), Some(unk_id)) => {
+            (Some(vocab), unk_id) => {
                 let model = Unigram::from(vocab, unk_id).map_err(|e| {
                     exceptions::PyException::new_err(format!("Error while loading Unigram: {}", e))
                 })?;

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -193,6 +193,17 @@ impl PyUnigramTrainer {
                     "unk_token" => builder.unk_token(val.extract()?),
                     "max_piece_length" => builder.max_piece_length(val.extract()?),
                     "seed_size" => builder.seed_size(val.extract()?),
+                    "initial_alphabet" => {
+                        let alphabet: Vec<String> = val.extract()?;
+                        builder.initial_alphabet(
+                            alphabet
+                                .into_iter()
+                                .map(|s| s.chars().next())
+                                .filter(|c| c.is_some())
+                                .map(|c| c.unwrap())
+                                .collect(),
+                        )
+                    }
                     "special_tokens" => builder.special_tokens(
                         val.cast_as::<PyList>()?
                             .into_iter()

--- a/bindings/python/tests/bindings/test_trainers.py
+++ b/bindings/python/tests/bindings/test_trainers.py
@@ -42,3 +42,53 @@ class TestUnigram:
 
         trainer = trainers.BpeTrainer(special_tokens=["<unk>"], show_progress=False)
         bpe_tokenizer.train(trainer, [train_files["small"]])
+
+    def test_train_with_special_tokens(self):
+        filename = "tests/data/dummy-unigram-special_tokens-train.txt"
+        with open(filename, "w") as f:
+            f.write(
+                """
+[CLS] The Zen of Python, by Tim Peters [SEP]
+[CLS] Beautiful is better than ugly. [SEP]
+[CLS] Explicit is better than implicit. [SEP]
+[CLS] Simple is better than complex. [SEP]
+[CLS] Complex is better than complicated. [SEP]
+[CLS] Flat is better than nested. [SEP]
+[CLS] Sparse is better than dense. [SEP]
+[CLS] Readability counts. [SEP]
+[CLS] Special cases aren't special enough to break the rules. [SEP]
+[CLS] Although practicality beats purity. [SEP]
+[CLS] Errors should never pass silently. [SEP]
+[CLS] Unless explicitly silenced. [SEP]
+[CLS] In the face of ambiguity, refuse the temptation to guess. [SEP]
+[CLS] There should be one-- and preferably only one --obvious way to do it. [SEP]
+[CLS] Although that way may not be obvious at first unless you're Dutch. [SEP]
+[CLS] Now is better than never. [SEP]
+[CLS] Although never is often better than *right* now. [SEP]
+[CLS] If the implementation is hard to explain, it's a bad idea. [SEP]
+[CLS] If the implementation is easy to explain, it may be a good idea. [SEP]
+[CLS] Namespaces are one honking great idea -- let's do more of those! [SEP]
+            """
+            )
+
+        tokenizer = Tokenizer(models.Unigram())
+        trainer = trainers.UnigramTrainer(
+            show_progress=False, special_tokens=["[PAD]", "[SEP]", "[CLS]"], unk_token="[UNK]"
+        )
+
+        tokenizer.train(trainer, [filename])
+
+        assert tokenizer.encode("[CLS] This is a test [SEP]").tokens == [
+            "[CLS]",
+            " T",
+            "h",
+            "i",
+            "s",
+            " is ",
+            "a",
+            " ",
+            "t",
+            "es",
+            "t ",
+            "[SEP]",
+        ]

--- a/tokenizers/src/models/unigram/lattice.rs
+++ b/tokenizers/src/models/unigram/lattice.rs
@@ -58,7 +58,6 @@ pub struct Lattice<'a> {
     pub(super) end_nodes: Vec<Vec<NodeRef>>,
     bos_id: usize,
     eos_id: usize,
-    unk_id: usize,
 }
 
 impl std::fmt::Display for Lattice<'_> {
@@ -136,7 +135,7 @@ fn log_sum_exp(x: f64, y: f64, init_mode: bool) -> f64 {
 }
 
 impl<'a> Lattice<'a> {
-    pub fn from(sentence: &'a str, unk_id: usize, bos_id: usize, eos_id: usize) -> Lattice<'a> {
+    pub fn from(sentence: &'a str, bos_id: usize, eos_id: usize) -> Lattice<'a> {
         let len = sentence.bytes().count();
         let k_reserved_node_size = 16;
         // We are adding 2 tokens, bos and eos
@@ -161,7 +160,6 @@ impl<'a> Lattice<'a> {
             end_nodes,
             bos_id,
             eos_id,
-            unk_id,
         }
     }
 
@@ -439,16 +437,16 @@ mod tests {
 
     #[test]
     fn set_sentence() {
-        let lattice = Lattice::from("", 0, 1, 2);
+        let lattice = Lattice::from("", 1, 2);
 
         assert_eq!(lattice.len(), 0);
 
-        let lattice = Lattice::from("", 0, 1, 2);
+        let lattice = Lattice::from("", 1, 2);
         assert_eq!(lattice.len(), 0);
         assert_eq!(lattice.sentence(), "");
         assert_eq!(lattice.surface(0), "");
 
-        let lattice = Lattice::from("test", 0, 1, 2);
+        let lattice = Lattice::from("test", 1, 2);
         assert_eq!(lattice.len(), 4);
         assert_eq!(lattice.sentence(), "test");
         assert_eq!(lattice.surface(0), "test");
@@ -470,7 +468,7 @@ mod tests {
             eos.borrow().id
         );
 
-        let lattice = Lattice::from("テストab", 0, 1, 2);
+        let lattice = Lattice::from("テストab", 1, 2);
         assert_eq!(lattice.len(), 11);
         assert_eq!(lattice.sentence(), "テストab");
         assert_eq!(lattice.surface(0), "テストab");
@@ -482,7 +480,7 @@ mod tests {
 
     #[test]
     fn insert_test() {
-        let mut lattice = Lattice::from("ABあい", 0, 1, 2);
+        let mut lattice = Lattice::from("ABあい", 1, 2);
 
         lattice.insert(0, 1, 0.0, 3);
         lattice.insert(1, 1, 0.0, 4);
@@ -573,7 +571,7 @@ mod tests {
 
     #[test]
     fn test_viterbi() {
-        let mut lattice = Lattice::from("ABC", 0, 1, 2);
+        let mut lattice = Lattice::from("ABC", 1, 2);
         assert_eq!(lattice.viterbi(), vec![]);
         // Still incomplete
         lattice.insert(0, 1, 0.0, 3);
@@ -586,7 +584,7 @@ mod tests {
 
     #[test]
     fn test_viterbi2() {
-        let mut lattice = Lattice::from("ABC", 0, 1, 2);
+        let mut lattice = Lattice::from("ABC", 1, 2);
 
         lattice.insert(0, 1, 0.0, 3);
         lattice.insert(1, 1, 0.0, 4);
@@ -606,7 +604,7 @@ mod tests {
 
     #[test]
     fn test_nbest() {
-        let mut lattice = Lattice::from("ABC", 0, 1, 2);
+        let mut lattice = Lattice::from("ABC", 1, 2);
         lattice.insert(0, 1, 0.0, 3);
         lattice.insert(1, 1, 0.0, 4);
         lattice.insert(2, 1, 0.0, 5);
@@ -641,7 +639,7 @@ mod tests {
 
     #[test]
     fn test_populate() {
-        let mut lattice = Lattice::from("ABC", 0, 1, 2);
+        let mut lattice = Lattice::from("ABC", 1, 2);
         lattice.insert(0, 1, 1.0, 3); // A
         lattice.insert(1, 1, 1.2, 4); // B
         lattice.insert(2, 1, 2.5, 5); // C

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -53,8 +53,8 @@ impl Clone for Unigram {
 
 impl std::fmt::Debug for Unigram {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        fmt.debug_struct("BPE")
-            .field("vocab", &self.vocab.len())
+        fmt.debug_struct("Unigram")
+            .field("vocab", &self.vocab)
             .field("unk_id", &self.unk_id)
             .finish()
     }

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -18,7 +18,7 @@ pub struct Unigram {
     cache: Cache<String, Vec<String>>,
     trie: Trie<u8>,
     pub min_score: f64,
-    pub(super) unk_id: usize,
+    pub(super) unk_id: Option<usize>,
     pub(super) bos_id: usize,
     pub(super) eos_id: usize,
 
@@ -54,7 +54,7 @@ impl Clone for Unigram {
 impl std::fmt::Debug for Unigram {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         fmt.debug_struct("Unigram")
-            .field("vocab", &self.vocab)
+            .field("vocab", &self.vocab.len())
             .field("unk_id", &self.unk_id)
             .finish()
     }
@@ -66,6 +66,7 @@ static K_UNK_PENALTY: f64 = 10.0;
 pub enum UnigramError {
     EmptyVocabulary,
     UnkIdNotInVocabulary,
+    MissingUnkId,
 }
 
 impl std::fmt::Display for UnigramError {
@@ -77,6 +78,9 @@ impl std::fmt::Display for UnigramError {
             UnigramError::UnkIdNotInVocabulary => {
                 write!(f, "The `unk_id` is larger than vocabulary size")
             }
+            UnigramError::MissingUnkId => {
+                write!(f, "Encountered an unknown token but `unk_id` is missing")
+            }
         }
     }
 }
@@ -86,7 +90,7 @@ impl std::error::Error for UnigramError {}
 impl Default for Unigram {
     fn default() -> Self {
         let vocab = vec![("<unk>".to_string(), 0.0)];
-        Self::from(vocab, 0).unwrap()
+        Self::from(vocab, Some(0)).unwrap()
     }
 }
 
@@ -97,16 +101,18 @@ impl Unigram {
     /// unk_id, is the index within the vocabulary.
     /// For now `Unigram` *requires* at least `unk` because we might find a never seen char.
     /// Further versions might allow that part to be hidden.
-    pub fn from(vocab: Vec<(String, f64)>, unk_id: usize) -> Result<Self> {
+    pub fn from(vocab: Vec<(String, f64)>, unk_id: Option<usize>) -> Result<Self> {
         let n = vocab.len();
         let mut token_to_ids: TokenMap = HashMap::new();
         let mut builder = TrieBuilder::default();
 
-        if vocab.is_empty() {
-            return Err(Box::new(UnigramError::EmptyVocabulary));
-        }
-        if unk_id >= vocab.len() {
-            return Err(Box::new(UnigramError::UnkIdNotInVocabulary));
+        if let Some(unk_id) = unk_id {
+            if vocab.is_empty() {
+                return Err(Box::new(UnigramError::EmptyVocabulary));
+            }
+            if unk_id >= vocab.len() {
+                return Err(Box::new(UnigramError::UnkIdNotInVocabulary));
+            }
         }
 
         let bos_id = n + 1;
@@ -187,7 +193,9 @@ impl Unigram {
             }
 
             if !has_single_node {
-                lattice.insert(begin_pos, mblen, unk_score, self.unk_id);
+                if let Some(unk_id) = self.unk_id {
+                    lattice.insert(begin_pos, mblen, unk_score, unk_id);
+                }
             }
             begin_pos += mblen
         }
@@ -209,28 +217,28 @@ impl Unigram {
     ///     ("abc".to_string(), 5.0),
     ///     ("abcd".to_string(), 10.0),
     /// ];
-    /// let model = Unigram::from(pieces, 0).unwrap();
-    /// let result = model.encode("abcdacdxx");
+    /// let model = Unigram::from(pieces, Some(0)).unwrap();
+    /// let result = model.encode("abcdacdxx").unwrap();
     /// assert_eq!(result, vec!["abcd", "a", "cd", "xx"]);
     /// ```
-    pub fn encode(&self, sentence: &str) -> Vec<String> {
+    pub fn encode(&self, sentence: &str) -> Result<Vec<String>> {
         if sentence.is_empty() {
-            return vec![];
+            return Ok(vec![]);
         }
         if let Some(result) = self.cache.get(sentence) {
-            result.to_vec()
+            Ok(result.to_vec())
         } else {
             let result = if self.is_optimized {
-                self.encode_optimized(sentence)
+                self.encode_optimized(sentence)?
             } else {
-                self.encode_unoptimized(sentence)
+                self.encode_unoptimized(sentence)?
             };
             self.cache.set(sentence.to_owned(), result.clone());
-            result
+            Ok(result)
         }
     }
 
-    fn encode_optimized(&self, sentence: &str) -> Vec<String> {
+    fn encode_optimized(&self, sentence: &str) -> Result<Vec<String>> {
         // https://github.com/google/sentencepiece/blob/d48247191a6d50e469ed1a4a36e877befffd1851/src/unigram_model.cc#L600
         #[derive(Debug, Clone)]
         struct BestPathNode {
@@ -290,7 +298,7 @@ impl Unigram {
                 {
                     target_node.best_path_score = candidate_best_path_score;
                     target_node.starts_at = Some(starts_at);
-                    target_node.id = self.unk_id;
+                    target_node.id = self.unk_id.ok_or(UnigramError::MissingUnkId)?;
                 }
             }
             starts_at += mblen
@@ -301,16 +309,9 @@ impl Unigram {
         while ends_at > 0 {
             let node = &best_path_ends_at[ends_at];
             let starts_at = node.starts_at.unwrap();
-            if self.fuse_unk && node.id == self.unk_id {
+            if self.fuse_unk && node.id == self.unk_id.ok_or(UnigramError::MissingUnkId)? {
                 token.push(
-                    String::from_utf8(
-                        sentence
-                            .bytes()
-                            .skip(starts_at)
-                            .take(ends_at - starts_at)
-                            .collect(),
-                    )
-                    .unwrap(),
+                    String::from_utf8(sentence[starts_at..ends_at].as_bytes().to_vec()).unwrap(),
                 );
             } else {
                 if !token.is_empty() {
@@ -319,14 +320,7 @@ impl Unigram {
                     token = vec![];
                 }
                 results.push(
-                    String::from_utf8(
-                        sentence
-                            .bytes()
-                            .skip(starts_at)
-                            .take(ends_at - starts_at)
-                            .collect(),
-                    )
-                    .unwrap(),
+                    String::from_utf8(sentence[starts_at..ends_at].as_bytes().to_vec()).unwrap(),
                 );
             }
             ends_at = starts_at;
@@ -336,18 +330,18 @@ impl Unigram {
             results.push(token.concat());
         }
         results.reverse();
-        results
+        Ok(results)
     }
 
-    fn encode_unoptimized(&self, sentence: &str) -> Vec<String> {
-        let mut lattice = Lattice::from(sentence, self.unk_id, self.bos_id, self.eos_id);
+    fn encode_unoptimized(&self, sentence: &str) -> Result<Vec<String>> {
+        let mut lattice = Lattice::from(sentence, self.bos_id, self.eos_id);
         self.populate_nodes(&mut lattice);
         if self.fuse_unk {
             let mut results = vec![];
             let mut token = String::new();
             for node in lattice.viterbi().iter() {
                 let item = lattice.piece(&node.borrow());
-                if node.borrow().id == self.unk_id {
+                if node.borrow().id == self.unk_id.ok_or(UnigramError::MissingUnkId)? {
                     token.push_str(&item);
                 } else {
                     if !token.is_empty() {
@@ -360,9 +354,9 @@ impl Unigram {
             if !token.is_empty() {
                 results.push(token);
             }
-            results
+            Ok(results)
         } else {
-            lattice.tokens()
+            Ok(lattice.tokens())
         }
     }
 
@@ -416,21 +410,20 @@ impl Model for Unigram {
     }
 
     fn tokenize(&self, sentence: &str) -> Result<Vec<Token>> {
-        let tokens = self.encode(sentence);
+        let str_tokens = self.encode(sentence)?;
         let mut offset = 0;
-        Ok(tokens
-            .iter()
-            .map(|string| {
-                let id: u32 = match self.token_to_ids.get(string) {
-                    Some(id) => *id,
-                    None => self.unk_id as u32,
-                };
-                let len = string.len();
-                let offsets = (offset, offset + len);
-                offset += len;
-                Token::new(id, string.to_string(), offsets)
-            })
-            .collect())
+        let mut tokens = Vec::with_capacity(str_tokens.len());
+        for string in str_tokens {
+            let id: u32 = match self.token_to_ids.get(&string) {
+                Some(id) => *id,
+                None => self.unk_id.ok_or(UnigramError::MissingUnkId)? as u32,
+            };
+            let len = string.len();
+            let offsets = (offset, offset + len);
+            offset += len;
+            tokens.push(Token::new(id, string, offsets));
+        }
+        Ok(tokens)
     }
 
     fn token_to_id(&self, token: &str) -> Option<u32> {
@@ -465,9 +458,9 @@ mod tests {
     #[test]
     fn test_populate_nodes_unk() {
         let pieces = vec![("<unk>".to_string(), 0.0)];
-        let model = Unigram::from(pieces, 0).unwrap();
+        let model = Unigram::from(pieces, Some(0)).unwrap();
 
-        let mut lattice = Lattice::from("abc", 0, model.bos_id, model.eos_id);
+        let mut lattice = Lattice::from("abc", model.bos_id, model.eos_id);
         model.populate_nodes(&mut lattice);
 
         assert_eq!(lattice.begin_nodes[0].len(), 1);
@@ -490,9 +483,9 @@ mod tests {
             ("ab".to_string(), 0.3),
             ("bc".to_string(), 0.4),
         ];
-        let model = Unigram::from(pieces, 0).unwrap();
+        let model = Unigram::from(pieces, Some(0)).unwrap();
 
-        let mut lattice = Lattice::from("abc", 0, model.bos_id, model.eos_id);
+        let mut lattice = Lattice::from("abc", model.bos_id, model.eos_id);
         model.populate_nodes(&mut lattice);
 
         assert_eq!(lattice.begin_nodes[0].len(), 2); // a, ab
@@ -527,8 +520,8 @@ mod tests {
             ("abcd".to_string(), 10.0),
         ];
 
-        let model = Unigram::from(sentencepieces, 0).unwrap();
-        let result = model.encode("abcd");
+        let model = Unigram::from(sentencepieces, Some(0)).unwrap();
+        let result = model.encode("abcd").unwrap();
         assert_eq!(result, vec!["abcd"]);
     }
 
@@ -549,35 +542,41 @@ mod tests {
             ("qr".to_string(), -0.5),
         ];
 
-        let mut model = Unigram::from(sentencepieces, 0).unwrap();
+        let mut model = Unigram::from(sentencepieces, Some(0)).unwrap();
 
         for is_optimized in &[true, false] {
             model.set_optimized(*is_optimized);
             println!("IsOptimized {:?}", is_optimized);
-            assert_eq!(model.encode("abc"), vec!["abc"]);
-            assert_eq!(model.encode("AB"), vec!["AB"]);
+            assert_eq!(model.encode("abc").unwrap(), vec!["abc"]);
+            assert_eq!(model.encode("AB").unwrap(), vec!["AB"]);
 
             model.set_fuse_unk(false);
-            assert_eq!(model.encode("AB"), vec!["A", "B"]);
+            assert_eq!(model.encode("AB").unwrap(), vec!["A", "B"]);
             model.set_fuse_unk(true);
-            assert_eq!(model.encode("AB"), vec!["AB"]);
+            assert_eq!(model.encode("AB").unwrap(), vec!["AB"]);
 
-            assert_eq!(model.encode("abcd"), vec!["ab", "cd"]);
-            assert_eq!(model.encode("abcc"), vec!["abc", "c"]);
+            assert_eq!(model.encode("abcd").unwrap(), vec!["ab", "cd"]);
+            assert_eq!(model.encode("abcc").unwrap(), vec!["abc", "c"]);
             assert_eq!(
-                model.encode("xabcabaabcdd"),
+                model.encode("xabcabaabcdd").unwrap(),
                 vec!["x", "abc", "ab", "a", "ab", "cd", "d"]
             );
             model.set_fuse_unk(false);
-            assert_eq!(model.encode("xyz東京"), vec!["x", "y", "z", "東", "京"]);
+            assert_eq!(
+                model.encode("xyz東京").unwrap(),
+                vec!["x", "y", "z", "東", "京"]
+            );
             model.set_fuse_unk(true);
-            assert_eq!(model.encode("xyz東京"), vec!["xyz東京"]);
+            assert_eq!(model.encode("xyz東京").unwrap(), vec!["xyz東京"]);
 
             // User encoded in original version
-            assert_eq!(model.encode("ABC"), vec!["ABC"]);
-            assert_eq!(model.encode("abABCcd"), vec!["ab", "ABC", "cd"]);
-            assert_eq!(model.encode("ababcdabcdcd"), vec!["ab", "abcdabcd", "cd"]);
-            assert_eq!(model.encode("abqrcd"), vec!["ab", "q", "r", "cd"]);
+            assert_eq!(model.encode("ABC").unwrap(), vec!["ABC"]);
+            assert_eq!(model.encode("abABCcd").unwrap(), vec!["ab", "ABC", "cd"]);
+            assert_eq!(
+                model.encode("ababcdabcdcd").unwrap(),
+                vec!["ab", "abcdabcd", "cd"]
+            );
+            assert_eq!(model.encode("abqrcd").unwrap(), vec!["ab", "q", "r", "cd"]);
         }
     }
 }

--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -52,10 +52,11 @@ fn test_train_unigram_from_file() {
 
     let trainer = UnigramTrainer::builder()
         .show_progress(false)
+        .unk_token(Some("<unk>".into()))
         .build()
         .unwrap();
     let (model, _) = trainer.train(word_counts).unwrap();
-    assert_eq!(model.get_vocab_size(), 719);
+    assert_eq!(model.get_vocab_size(), 717);
 }
 
 #[cfg(not(debug_assertions))]


### PR DESCRIPTION
In order to fully support the byte-level and its idea of not having an unk token, we need to support the `initial_alphabet`.
Also adds the ability to add `special_tokens`.