### PR TITLE
Fixed `BPE.read_files` -> `BPE.read_file` in SentencePieceBPETokenizer

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -49,7 +49,7 @@ class SentencePieceBPETokenizer(BaseTokenizer):
 
     @staticmethod
     def from_file(vocab_filename: str, merges_filename: str, **kwargs):
-        vocab, merges = BPE.read_files(vocab_filename, merges_filename)
+        vocab, merges = BPE.read_file(vocab_filename, merges_filename)
         return SentencePieceBPETokenizer(vocab, merges, **kwargs)
 
     def train(


### PR DESCRIPTION
Fixed a line that was apparently forgotten to replace (`read_files` -> `read_file`) in #430 