### PR TITLE
Fix UnigramTrainer

### DIFF
--- a/bindings/python/tests/bindings/test_trainers.py
+++ b/bindings/python/tests/bindings/test_trainers.py
@@ -87,8 +87,8 @@ class TestUnigram:
             " is ",
             "a",
             " ",
-            "t",
-            "es",
+            "te",
+            "s",
             "t ",
             "[SEP]",
         ]

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -309,7 +309,10 @@ impl Unigram {
         while ends_at > 0 {
             let node = &best_path_ends_at[ends_at];
             let starts_at = node.starts_at.unwrap();
-            if self.fuse_unk && node.id == self.unk_id.ok_or(UnigramError::MissingUnkId)? {
+            if self.fuse_unk
+                && self.unk_id.is_some()
+                && node.id == self.unk_id.ok_or(UnigramError::MissingUnkId)?
+            {
                 token.push(
                     String::from_utf8(sentence[starts_at..ends_at].as_bytes().to_vec()).unwrap(),
                 );

--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -52,11 +52,11 @@ fn test_train_unigram_from_file() {
 
     let trainer = UnigramTrainer::builder()
         .show_progress(false)
-        .unk_token(Some("<unk>".into()))
+        .unk_token(Some("<UNK>".into()))
         .build()
         .unwrap();
     let (model, _) = trainer.train(word_counts).unwrap();
-    assert_eq!(model.get_vocab_size(), 717);
+    assert_eq!(model.get_vocab_size(), 719);
 }
 
 #[cfg(not(debug_assertions))]


### PR DESCRIPTION
The `UnigramTrainer` was failing in some cases. It actually needs to keep the `unk_id` during training, even if we don't want to keep it afterward.