### PR TITLE
makes from_file() method static

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/py_src/tokenizers/implementations/bert_wordpiece.py
@@ -80,6 +80,7 @@ class BertWordPieceTokenizer(BaseTokenizer):
 
         super().__init__(tokenizer, parameters)
 
+    @staticmethod
     def from_file(vocab: str, **kwargs):
         vocab = WordPiece.read_file(vocab)
         return BertWordPieceTokenizer(vocab, **kwargs)


### PR DESCRIPTION
`from_file()` method should be static in `BerWordPieceTokenizer`. 