### PR TITLE
Update sentencepiece_model_pb2.py URL

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
@@ -87,7 +87,7 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
             import sentencepiece_model_pb2 as model
         except Exception:
             raise Exception(
-                "You don't seem to have the required protobuf file, in order to use this function you need to run `pip install protobuf` and `wget https://raw.githubusercontent.com/google/sentencepiece/master/python/sentencepiece_model_pb2.py` for us to be able to read the intrinsics of your spm_file. `pip install sentencepiece` is not required."
+                "You don't seem to have the required protobuf file, in order to use this function you need to run `pip install protobuf` and `wget https://raw.githubusercontent.com/google/sentencepiece/master/python/src/sentencepiece/sentencepiece_model_pb2.py` for us to be able to read the intrinsics of your spm_file. `pip install sentencepiece` is not required."
             )
 
         m = model.ModelProto()


### PR DESCRIPTION
Update the URL to `sentencepiece_model_pb2.py` in the `from_spm` error message.