### PR TITLE
typo: from_files() renamed to from_file()

### DIFF
--- a/bindings/python/tests/documentation/test_quicktour.py
+++ b/bindings/python/tests/documentation/test_quicktour.py
@@ -17,7 +17,7 @@ class TestQuicktour:
         # END train
         # START reload_model
         files = tokenizer.model.save("data", "wiki")
-        tokenizer.model = BPE.from_files(*files, unk_token="[UNK]")
+        tokenizer.model = BPE.from_file(*files, unk_token="[UNK]")
         # END reload_model
         # START save
         tokenizer.save("data/tokenizer-wiki.json")


### PR DESCRIPTION
`BPE` model doesn't have any method called `from_files()`.
It should be changed to `from_file()` instead. This exists in Quicktour doc too.