### PR TITLE
Improve Encoding mappings for pairs of sequence

### DIFF
--- a/bindings/node/lib/bindings/__mocks__/vocab.txt
+++ b/bindings/node/lib/bindings/__mocks__/vocab.txt
@@ -3,5 +3,7 @@ name
 is
 jo
 ##hn
+what
+yours
 pair
 [UNK]

--- a/bindings/node/lib/bindings/raw-encoding.d.ts
+++ b/bindings/node/lib/bindings/raw-encoding.d.ts
@@ -5,52 +5,78 @@ import { PaddingDirection } from "./enums";
  */
 export interface RawEncoding {
   /**
-   * Get the encoded tokens corresponding to the word at the given index in the input
-   * sequence, with the form [startToken, endToken+1]
-   * @param word The position of a word in the input sequence
+   * Get the encoded tokens corresponding to the word at the given index in one of the input
+   * sequences, with the form [startToken, endToken+1]
+   * @param word The position of a word in one of the input sequences
+   * @param seqId The index of the input sequence that contains said word
    * @since 0.7.0
    */
-  wordToTokens(word: number): [number, number] | undefined;
+  wordToTokens(word: number, seqId?: number): [number, number] | undefined;
 
   /**
    * Get the offsets of the word at the given index in the input sequence
    * @param word The index of the word in the input sequence
+   * @param seqId The index of the input sequence that contains said word
    * @since 0.7.0
    */
-  wordToChars(word: number): [number, number] | undefined;
+  wordToChars(word: number, seqId?: number): [number, number] | undefined;
+
+  /**
+   * Get the index of the sequence that contains the given token
+   * @param token The index of the token in the encoded sequence
+   */
+  tokenToSequence(token: number): number | undefined;
 
   /**
    * Get the offsets of the token at the given index
+   * If this encoding represents only one sequence, then only the offsets are returned.
+   * If this encoding represents more than one sequence, then it returns a tuple with the sequence
+   *   id in the first part
    * @param token The index of the token in the encoded sequence
    * @since 0.7.0
    */
-  tokenToChars(token: number): [number, number] | undefined;
+  tokenToChars(token: number): [number, number] | [number, [number, number]] | undefined;
 
   /**
    * Get the word that contains the token at the given index
+   * If this encoding represents only one sequence, then only the offsets are returned.
+   * If this encoding represents more than one sequence, then it returns a tuple with the sequence
+   *   id in the first part
    * @param token The index of the token  in the encoded sequence
    * @since 0.7.0
    */
-  tokenToWord(token: number): number | undefined;
+  tokenToWord(token: number): number | [number, number] | undefined;
 
   /**
    * Find the index of the token at the position of the given char
-   * @param pos The position of a char in the input string
+   * @param pos The position of a char in one of the input strings
+   * @param seqId The index of the input sequence that contains said char
    * @since 0.6.0
    */
-  charToToken(pos: number): number | undefined;
+  charToToken(pos: number, seqId?: number): number | undefined;
 
   /**
    * Get the word that contains the given char
    * @param pos The position of a char in the input string
+   * @param seqId The index of the input sequence that contains said char
    * @since 0.7.0
    */
-  charToWord(pos: number): number | undefined;
+  charToWord(pos: number, seqId?: number): number | undefined;
 
   /**
    * Returns the attention mask
    */
   getAttentionMask(): number[];
+
+  /**
+   * Returns the number of sequences
+   */
+  getNSequences(): number;
+
+  /**
+   * Set the sequence id for this encoding
+   */
+  setSequenceId(seqId: number): undefined;
 
   /**
    * Returns the tokenized ids

--- a/bindings/node/lib/bindings/raw-encoding.d.ts
+++ b/bindings/node/lib/bindings/raw-encoding.d.ts
@@ -124,6 +124,11 @@ export interface RawEncoding {
   getWords(): (number | undefined)[];
 
   /**
+   * The sequences indices
+   */
+  getSequences(): (number | undefined)[];
+
+  /**
    * Pad the current Encoding at the given length
    *
    * @param length The length at which to pad

--- a/bindings/node/lib/bindings/raw-encoding.d.ts
+++ b/bindings/node/lib/bindings/raw-encoding.d.ts
@@ -29,23 +29,27 @@ export interface RawEncoding {
 
   /**
    * Get the offsets of the token at the given index
-   * If this encoding represents only one sequence, then only the offsets are returned.
-   * If this encoding represents more than one sequence, then it returns a tuple with the sequence
-   *   id in the first part
+   *
+   * The returned offsets are related to the input sequence that contains the
+   * token.  In order to determine in which input sequence it belongs, you
+   * must call `tokenToSequence`.
+   *
    * @param token The index of the token in the encoded sequence
    * @since 0.7.0
    */
-  tokenToChars(token: number): [number, number] | [number, [number, number]] | undefined;
+  tokenToChars(token: number): [number, number] | undefined;
 
   /**
    * Get the word that contains the token at the given index
-   * If this encoding represents only one sequence, then only the offsets are returned.
-   * If this encoding represents more than one sequence, then it returns a tuple with the sequence
-   *   id in the first part
+   *
+   * The returned index is related to the input sequence that contains the
+   * token.  In order to determine in which input sequence it belongs, you
+   * must call `tokenToSequence`.
+   *
    * @param token The index of the token  in the encoded sequence
    * @since 0.7.0
    */
-  tokenToWord(token: number): number | [number, number] | undefined;
+  tokenToWord(token: number): number | undefined;
 
   /**
    * Find the index of the token at the position of the given char

--- a/bindings/node/lib/bindings/raw-encoding.test.ts
+++ b/bindings/node/lib/bindings/raw-encoding.test.ts
@@ -160,8 +160,8 @@ describe("RawEncoding", () => {
     });
 
     it("returns the correct offsets with pair sequences", () => {
-      expect(encodingDual.tokenToChars(3)).toEqual([0, [11, 13]]);
-      expect(encodingDual.tokenToChars(7)).toEqual([1, [8, 13]]);
+      expect(encodingDual.tokenToChars(3)).toEqual([11, 13]);
+      expect(encodingDual.tokenToChars(7)).toEqual([8, 13]);
     });
 
     it("returns undefined when out of range token", () => {
@@ -177,8 +177,8 @@ describe("RawEncoding", () => {
     });
 
     it("returns the correct index with pair sequences", () => {
-      expect(encodingDual.tokenToWord(3)).toEqual([0, 3]);
-      expect(encodingDual.tokenToWord(7)).toEqual([1, 2]);
+      expect(encodingDual.tokenToWord(3)).toEqual(3);
+      expect(encodingDual.tokenToWord(7)).toEqual(2);
     });
 
     it("returns undefined when out of range token", () => {

--- a/bindings/node/lib/bindings/raw-encoding.test.ts
+++ b/bindings/node/lib/bindings/raw-encoding.test.ts
@@ -112,6 +112,13 @@ describe("RawEncoding", () => {
     });
   });
 
+  describe("getSequences", () => {
+    it("returns the correct list of indexes", () => {
+      expect(encoding.getSequences()).toEqual([0, 0, 0, 0, 0]);
+      expect(encodingDual.getSequences()).toEqual([0, 0, 0, 0, 0, 1, 1, 1, 1]);
+    });
+  });
+
   describe("wordToTokens", () => {
     it("returns the correct indexes", () => {
       const indexes = encoding.wordToTokens(3);

--- a/bindings/node/lib/implementations/encoding.ts
+++ b/bindings/node/lib/implementations/encoding.ts
@@ -29,6 +29,17 @@ export class Encoding {
   }
 
   /**
+   * Number of sequences
+   */
+  get nSequences(): number {
+    return this._rawEncoding.getNSequences();
+  }
+
+  setSequenceId(seqId: number) {
+    return this._rawEncoding.setSequenceId(seqId);
+  }
+
+  /**
    * Attention mask
    */
   get attentionMask(): number[] {
@@ -141,48 +152,76 @@ export class Encoding {
   }
 
   /**
-   * Get the encoded tokens corresponding to the word at the given index in the input
-   * sequence, with the form [startToken, endToken+1]
-   * @param word The position of a word in the input sequence
+   * Get the encoded tokens corresponding to the word at the given index in one of the input
+   * sequences, with the form [startToken, endToken+1]
+   * @param word The position of a word in one of the input sequences
+   * @param seqId The index of the input sequence that contains said word
    * @since 0.7.0
    */
-  wordToTokens(word: number): [number, number] | undefined {
-    return this._rawEncoding.wordToTokens(word);
+  wordToTokens(word: number, seqId?: number): [number, number] | undefined {
+    return this._rawEncoding.wordToTokens(word, seqId);
   }
 
   /**
    * Get the offsets of the word at the given index in the input sequence
    * @param word The index of the word in the input sequence
+   * @param seqId The index of the input sequence that contains said word
    * @since 0.7.0
    */
-  wordToChars(word: number): [number, number] | undefined {
-    return this._rawEncoding.wordToChars(word);
+  wordToChars(word: number, seqId?: number): [number, number] | undefined {
+    return this._rawEncoding.wordToChars(word, seqId);
+  }
+
+  /**
+   * Get the index of the sequence that contains the given token
+   * @param token The index of the token in the encoded sequence
+   */
+  tokenToSequence(token: number): number | undefined {
+    return this._rawEncoding.tokenToSequence(token);
   }
 
   /**
    * Get the offsets of the token at the given index
+   * If this encoding represents only one sequence, then only the offsets are returned.
+   * If this encoding represents more than one sequence, then it returns a tuple with the sequence
+   *   id in the first part
    * @param token The index of the token in the encoded sequence
    * @since 0.7.0
    */
-  tokenToChars(token: number): [number, number] | undefined {
+  tokenToChars(token: number): [number, number] | [number, [number, number]] | undefined {
     return this._rawEncoding.tokenToChars(token);
   }
 
   /**
    * Get the word that contains the token at the given index
+   * If this encoding represents only one sequence, then only the offsets are returned.
+   * If this encoding represents more than one sequence, then it returns a tuple with the sequence
+   *   id in the first part
    * @param token The index of the token  in the encoded sequence
    * @since 0.7.0
    */
-  tokenToWord(token: number): number | undefined {
+  tokenToWord(token: number): number | [number, number] | undefined {
     return this._rawEncoding.tokenToWord(token);
   }
 
   /**
    * Find the index of the token at the position of the given char
-   * @param pos The position of a char in the input string
+   * @param pos The position of a char in one of the input strings
+   * @param seqId The index of the input sequence that contains said char
+   * @since 0.6.0
    */
-  charToToken(pos: number): number | undefined {
-    return this._rawEncoding.charToToken(pos);
+  charToToken(pos: number, seqId?: number): number | undefined {
+    return this._rawEncoding.charToToken(pos, seqId);
+  }
+
+  /**
+   * Get the word that contains the given char
+   * @param pos The position of a char in the input string
+   * @param seqId The index of the input sequence that contains said char
+   * @since 0.7.0
+   */
+  charToWord(pos: number, seqId?: number): number | undefined {
+    return this._rawEncoding.charToWord(pos, seqId);
   }
 
   /**

--- a/bindings/node/lib/implementations/encoding.ts
+++ b/bindings/node/lib/implementations/encoding.ts
@@ -182,25 +182,29 @@ export class Encoding {
 
   /**
    * Get the offsets of the token at the given index
-   * If this encoding represents only one sequence, then only the offsets are returned.
-   * If this encoding represents more than one sequence, then it returns a tuple with the sequence
-   *   id in the first part
+   *
+   * The returned offsets are related to the input sequence that contains the
+   * token.  In order to determine in which input sequence it belongs, you
+   * must call `tokenToSequence`.
+   *
    * @param token The index of the token in the encoded sequence
    * @since 0.7.0
    */
-  tokenToChars(token: number): [number, number] | [number, [number, number]] | undefined {
+  tokenToChars(token: number): [number, number] | undefined {
     return this._rawEncoding.tokenToChars(token);
   }
 
   /**
    * Get the word that contains the token at the given index
-   * If this encoding represents only one sequence, then only the offsets are returned.
-   * If this encoding represents more than one sequence, then it returns a tuple with the sequence
-   *   id in the first part
+   *
+   * The returned index is related to the input sequence that contains the
+   * token.  In order to determine in which input sequence it belongs, you
+   * must call `tokenToSequence`.
+   *
    * @param token The index of the token  in the encoded sequence
    * @since 0.7.0
    */
-  tokenToWord(token: number): number | [number, number] | undefined {
+  tokenToWord(token: number): number | undefined {
     return this._rawEncoding.tokenToWord(token);
   }
 

--- a/bindings/node/lib/implementations/encoding.ts
+++ b/bindings/node/lib/implementations/encoding.ts
@@ -11,6 +11,7 @@ export class Encoding {
   private _tokens?: string[];
   private _typeIds?: number[];
   private _wordIndexes?: (number | undefined)[];
+  private _sequenceIndexes?: (number | undefined)[];
 
   constructor(private _rawEncoding: RawEncoding) {}
 
@@ -149,6 +150,14 @@ export class Encoding {
     }
 
     return (this._wordIndexes = this._rawEncoding.getWords());
+  }
+
+  get sequenceIndexes(): (number | undefined)[] {
+    if (this._sequenceIndexes) {
+      return this._sequenceIndexes;
+    }
+
+    return (this._sequenceIndexes = this._rawEncoding.getSequences());
   }
 
   /**

--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -115,7 +115,7 @@ declare_types! {
         }
 
         method getWords(mut cx) {
-            // getWords(): number[]
+            // getWords(): (number | undefined)[]
 
             let this = cx.this();
             let guard = cx.lock();
@@ -123,6 +123,18 @@ declare_types! {
                 .encoding.as_ref().expect("Uninitialized Encoding")
                 .get_words()
                 .to_vec();
+
+            Ok(neon_serde::to_value(&mut cx, &ids)?)
+        }
+
+        method getSequences(mut cx) {
+            // getSequences(): (number | undefined)[]
+
+            let this = cx.this();
+            let guard = cx.lock();
+            let ids = this.borrow(&guard)
+                .encoding.as_ref().expect("Uninitialized Encoding")
+                .get_sequences();
 
             Ok(neon_serde::to_value(&mut cx, &ids)?)
         }

--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -233,21 +233,12 @@ declare_types! {
             let this = cx.this();
             let guard = cx.lock();
 
-            let (res, n_seq) = {
-                let borrowed = this.borrow(&guard);
-                let encoding = borrowed.encoding.as_ref().expect("Uninitialized Encoding");
+            let res = this.borrow(&guard)
+                .encoding.as_ref().expect("Uninitialized Encoding")
+                .token_to_chars(token);
 
-                let res = encoding.token_to_chars(token);
-                let n_seq = encoding.n_sequences();
-                (res, n_seq)
-            };
-
-            if let Some((seq_id, offsets)) = res {
-                if n_seq > 1 {
-                    Ok(neon_serde::to_value(&mut cx, &(seq_id, offsets))?)
-                } else {
-                    Ok(neon_serde::to_value(&mut cx, &offsets)?)
-                }
+            if let Some((_, offsets)) = res {
+                Ok(neon_serde::to_value(&mut cx, &offsets)?)
             } else {
                 Ok(cx.undefined().upcast())
             }
@@ -261,21 +252,12 @@ declare_types! {
             let this = cx.this();
             let guard = cx.lock();
 
-            let (res, n_seq) = {
-                let borrowed = this.borrow(&guard);
-                let encoding = borrowed.encoding.as_ref().expect("Uninitialized Encoding");
+            let res = this.borrow(&guard)
+                .encoding.as_ref().expect("Uninitialized Encoding")
+                .token_to_word(token);
 
-                let res = encoding.token_to_word(token);
-                let n_seq = encoding.n_sequences();
-                (res, n_seq)
-            };
-
-            if let Some((seq_id, index)) = res {
-                if n_seq > 1 {
-                    Ok(neon_serde::to_value(&mut cx, &(seq_id, index))?)
-                } else {
-                    Ok(cx.number(index as f64).upcast())
-                }
+            if let Some((_, index)) = res {
+                Ok(cx.number(index as f64).upcast())
             } else {
                 Ok(cx.undefined().upcast())
             }

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -327,6 +327,17 @@ class Encoding:
         """
         pass
     @property
+    def sequences(self) -> List[Optional[int]]:
+        """The generated sequence indices.
+
+        They represent the index of the input sequence associated to each token.
+        The sequence id can be None if the token is not related to any input sequence,
+        like for example with special tokens.
+
+        Returns:
+            A :obj:`List` of :obj:`Optional[int]`: A list of optional sequence index.
+        """
+    @property
     def type_ids(self) -> List[int]:
         """The generated type IDs
 

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -275,6 +275,21 @@ class Encoding:
         """
         pass
     @property
+    def n_sequences(self) -> int:
+        """The number of sequences represented
+
+        Returns:
+            :obj:`int`: The number of sequences in this :class:`~tokenizers.Encoding`
+        """
+        pass
+    def set_sequence_id(self, sequence_index: int):
+        """Set the given sequence index
+
+        Set the given sequence index for the whole range of tokens contained in this
+        :class:`~tokenizers.Encoding`.
+        """
+        pass
+    @property
     def ids(self) -> List[int]:
         """The generated IDs
 
@@ -368,68 +383,110 @@ class Encoding:
         maximum length.
         """
         pass
-    def word_to_tokens(self, word_index: int) -> Optional[Tuple[int, int]]:
+    def word_to_tokens(self, word_index: int, sequence_index: int = 0) -> Optional[Tuple[int, int]]:
         """Get the encoded tokens corresponding to the word at the given index
-        in the input sequence.
+        in one of the input sequences.
 
         Args:
             word_index (:obj:`int`):
-                The index of a word in the input sequence.
+                The index of a word in one of the input sequences.
+            sequence_index (:obj:`int`, defaults to :obj:`0`):
+                The index of the sequence that contains the target word
 
         Returns:
             :obj:`Tuple[int, int]`: The range of tokens: :obj:`(first, last + 1)`
         """
         pass
-    def word_to_chars(self, word_index: int) -> Optional[Offsets]:
-        """Get the offsets of the word at the given index in the input sequence.
+    def word_to_chars(self, word_index: int, sequence_index: int = 0) -> Optional[Offsets]:
+        """Get the offsets of the word at the given index in one of the input sequences.
 
         Args:
             word_index (:obj:`int`):
-                The index of a word in the input sequence.
+                The index of a word in one of the input sequences.
+            sequence_index (:obj:`int`, defaults to :obj:`0`):
+                The index of the sequence that contains the target word
 
         Returns:
             :obj:`Tuple[int, int]`: The range of characters (span) :obj:`(first, last + 1)`
         """
         pass
-    def token_to_chars(self, token_index: int) -> Optional[Offsets]:
-        """Get the offsets of the token at the given index
+    def token_to_sequence(self, token_index: int) -> Optional[int]:
+        """Get the index of the sequence represented by the given token.
+
+        In the general use case, this method returns :obj:`0` for a single sequence or
+        the first sequence of a pair, and :obj:`1` for the second sequence of a pair
 
         Args:
             token_index (:obj:`int`):
                 The index of a token in the encoded sequence.
 
         Returns:
-            :obj:`Tuple[int, int]`: The token offsets :obj:`(first, last + 1)`
+            :obj:`int`: The sequence id of the given token
         """
         pass
-    def token_to_word(self, token_index: int) -> Optional[int]:
+    def token_to_chars(self, token_index: int) -> Optional[Union[Offsets, Tuple[int, Offsets]]]:
+        """Get the offsets of the token at the given index.
+
+        If the :class:`~tokenizers.Encoding` represents multiple sequences (namely
+        a pair of sequences), then this method returns a Tuple with both the relevant
+        sequence index, and the offsets.
+
+        Args:
+            token_index (:obj:`int`):
+                The index of a token in the encoded sequence.
+
+        Returns:
+            :obj:`Tuple[int, int]` or :obj:`Tuple[int, Tuple[int, int]]`:
+
+            - For a single sequence: the token offsets:
+              :obj:`Tuple[int, int]` of the form :obj:`(first, last + 1)`
+
+            - For pairs of sequence: A tuple with the sequence index, and the token offsets:
+              :obj:`Tuple[int, Tuple[int, int]]` with offsets of the form :obj:`(first, last + 1)`
+
+        """
+        pass
+    def token_to_word(self, token_index: int) -> Optional[Union[int, Tuple[int, int]]]:
         """Get the word that contains the token at the given index
 
+        If the :class:`~tokenizers.Encoding` represents multiple sequences (namely
+        a pair of sequences), then this method returns a Tuple with both the relevant
+        sequence index, and the word index.
+
         Args:
             token_index (:obj:`int`):
                 The index of a token in the encoded sequence.
 
         Returns:
-            :obj:`int`: The index of the word in the input sequence.
+            :obj:`int` or :obj:`Tuple[int, int]`:
+
+            - For a single sequence: The index of the word in the input sequence: :obj:`int`
+            - For pairs of sequence: A tuple with the sequence index, and the index of the word
+              in the said sequence: :obj:`Tuple[int, int]`
+
         """
         pass
-    def char_to_token(self, pos: int) -> Optional[int]:
-        """Get the token that contains the char at the given position
+    def char_to_token(self, pos: int, sequence_index: int = 0) -> Optional[int]:
+        """Get the token that contains the char at the given position in the input sequence.
 
         Args:
             char_pos (:obj:`int`):
                 The position of a char in the input string
+            sequence_index (:obj:`int`, defaults to :obj:`0`):
+                The index of the sequence that contains the target char
 
         Returns:
             :obj:`int`: The index of the token that contains this char in the encoded sequence
         """
         pass
-    def char_to_word(self, pos: int) -> Optional[int]:
-        """Get the word that contains the char at the given position
+    def char_to_word(self, pos: int, sequence_index: int = 0) -> Optional[int]:
+        """Get the word that contains the char at the given position in the input sequence.
 
         Args:
             char_pos (:obj:`int`):
                 The position of a char in the input string
+            sequence_index (:obj:`int`, defaults to :obj:`0`):
+                The index of the sequence that contains the target char
 
         Returns:
             :obj:`int`: The index of the word that contains this char in the input sequence
@@ -464,6 +521,9 @@ class Encoding:
         pass
     def truncate(self, max_length: int, stride: Optional[int] = 0):
         """Truncate the :class:`~tokenizers.Encoding` at the given length
+
+        If this :class:`~tokenizers.Encoding` represents multiple sequences, when truncating
+        this information is lost. It will be considered as representing a single sequence.
 
         Args:
             max_length (:obj:`int`):

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -424,46 +424,34 @@ class Encoding:
             :obj:`int`: The sequence id of the given token
         """
         pass
-    def token_to_chars(self, token_index: int) -> Optional[Union[Offsets, Tuple[int, Offsets]]]:
+    def token_to_chars(self, token_index: int) -> Optional[Offsets]:
         """Get the offsets of the token at the given index.
 
-        If the :class:`~tokenizers.Encoding` represents multiple sequences (namely
-        a pair of sequences), then this method returns a Tuple with both the relevant
-        sequence index, and the offsets.
+        The returned offsets are related to the input sequence that contains the
+        token.  In order to determine in which input sequence it belongs, you
+        must call :meth:`~tokenizers.Encoding.token_to_sequence()`.
 
         Args:
             token_index (:obj:`int`):
                 The index of a token in the encoded sequence.
 
         Returns:
-            :obj:`Tuple[int, int]` or :obj:`Tuple[int, Tuple[int, int]]`:
-
-            - For a single sequence: the token offsets:
-              :obj:`Tuple[int, int]` of the form :obj:`(first, last + 1)`
-
-            - For pairs of sequence: A tuple with the sequence index, and the token offsets:
-              :obj:`Tuple[int, Tuple[int, int]]` with offsets of the form :obj:`(first, last + 1)`
-
+            :obj:`Tuple[int, int]`: The token offsets :obj:`(first, last + 1)`
         """
         pass
-    def token_to_word(self, token_index: int) -> Optional[Union[int, Tuple[int, int]]]:
-        """Get the word that contains the token at the given index
+    def token_to_word(self, token_index: int) -> Optional[int]:
+        """Get the index of the word that contains the token in one of the input sequences.
 
-        If the :class:`~tokenizers.Encoding` represents multiple sequences (namely
-        a pair of sequences), then this method returns a Tuple with both the relevant
-        sequence index, and the word index.
+        The returned word index is related to the input sequence that contains
+        the token.  In order to determine in which input sequence it belongs, you
+        must call :meth:`~tokenizers.Encoding.token_to_sequence()`.
 
         Args:
             token_index (:obj:`int`):
                 The index of a token in the encoded sequence.
 
         Returns:
-            :obj:`int` or :obj:`Tuple[int, int]`:
-
-            - For a single sequence: The index of the word in the input sequence: :obj:`int`
-            - For pairs of sequence: A tuple with the sequence index, and the index of the word
-              in the said sequence: :obj:`Tuple[int, int]`
-
+            :obj:`int`: The index of the word in the relevant input sequence.
         """
         pass
     def char_to_token(self, pos: int, sequence_index: int = 0) -> Optional[int]:

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -152,6 +152,19 @@ impl PyEncoding {
         self.encoding.get_words().to_vec()
     }
 
+    /// The generated sequence indices.
+    ///
+    /// They represent the index of the input sequence associated to each token.
+    /// The sequence id can be None if the token is not related to any input sequence,
+    /// like for example with special tokens.
+    ///
+    /// Returns:
+    ///     A :obj:`List` of :obj:`Optional[int]`: A list of optional sequence index.
+    #[getter]
+    fn get_sequences(&self) -> Vec<Option<usize>> {
+        self.encoding.get_sequences()
+    }
+
     /// The generated type IDs
     ///
     /// Generally used for tasks like sequence classification or question answering,

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -270,62 +270,38 @@ impl PyEncoding {
 
     /// Get the offsets of the token at the given index.
     ///
-    /// If the :class:`~tokenizers.Encoding` represents multiple sequences (namely
-    /// a pair of sequences), then this method returns a Tuple with both the relevant
-    /// sequence index, and the offsets.
+    /// The returned offsets are related to the input sequence that contains the
+    /// token.  In order to determine in which input sequence it belongs, you
+    /// must call :meth:`~tokenizers.Encoding.token_to_sequence()`.
     ///
     /// Args:
     ///     token_index (:obj:`int`):
     ///         The index of a token in the encoded sequence.
     ///
     /// Returns:
-    ///     :obj:`Tuple[int, int]` or :obj:`Tuple[int, Tuple[int, int]]`:
-    ///
-    ///     - For a single sequence: the token offsets:
-    ///       :obj:`Tuple[int, int]` of the form :obj:`(first, last + 1)`
-    ///
-    ///     - For pairs of sequence: A tuple with the sequence index, and the token offsets:
-    ///       :obj:`Tuple[int, Tuple[int, int]]` with offsets of the form :obj:`(first, last + 1)`
-    ///
+    ///     :obj:`Tuple[int, int]`: The token offsets :obj:`(first, last + 1)`
     #[text_signature = "($self, token_index)"]
-    fn token_to_chars(&self, token_index: usize) -> Option<PyObject> {
-        let (seq_idx, offsets) = self.encoding.token_to_chars(token_index)?;
-        Python::with_gil(|py| {
-            if self.encoding.n_sequences() > 1 {
-                Some((seq_idx, offsets).to_object(py))
-            } else {
-                Some(offsets.to_object(py))
-            }
-        })
+    fn token_to_chars(&self, token_index: usize) -> Option<Offsets> {
+        let (_, offsets) = self.encoding.token_to_chars(token_index)?;
+        Some(offsets)
     }
 
-    /// Get the word that contains the token at the given index
+    /// Get the index of the word that contains the token in one of the input sequences.
     ///
-    /// If the :class:`~tokenizers.Encoding` represents multiple sequences (namely
-    /// a pair of sequences), then this method returns a Tuple with both the relevant
-    /// sequence index, and the word index.
+    /// The returned word index is related to the input sequence that contains
+    /// the token.  In order to determine in which input sequence it belongs, you
+    /// must call :meth:`~tokenizers.Encoding.token_to_sequence()`.
     ///
     /// Args:
     ///     token_index (:obj:`int`):
     ///         The index of a token in the encoded sequence.
     ///
     /// Returns:
-    ///     :obj:`int` or :obj:`Tuple[int, int]`:
-    ///
-    ///     - For a single sequence: The index of the word in the input sequence: :obj:`int`
-    ///     - For pairs of sequence: A tuple with the sequence index, and the index of the word
-    ///       in the said sequence: :obj:`Tuple[int, int]`
-    ///
+    ///     :obj:`int`: The index of the word in the relevant input sequence.
     #[text_signature = "($self, token_index)"]
-    fn token_to_word(&self, token_index: usize) -> Option<PyObject> {
-        let (seq_idx, word_idx) = self.encoding.token_to_word(token_index)?;
-        Python::with_gil(|py| {
-            if self.encoding.n_sequences() > 1 {
-                Some((seq_idx, word_idx).to_object(py))
-            } else {
-                Some(word_idx.to_object(py))
-            }
-        })
+    fn token_to_word(&self, token_index: usize) -> Option<u32> {
+        let (_, word_idx) = self.encoding.token_to_word(token_index)?;
+        Some(word_idx)
     }
 
     /// Get the token that contains the char at the given position in the input sequence.

--- a/bindings/python/tests/bindings/test_encoding.py
+++ b/bindings/python/tests/bindings/test_encoding.py
@@ -65,9 +65,9 @@ class TestEncoding:
 
         assert single.token_to_chars(0) == None
         assert single.token_to_chars(2) == (2, 6)
-        assert pair.token_to_chars(2) == (0, (2, 6))
+        assert pair.token_to_chars(2) == (2, 6)
         assert pair.token_to_chars(5) == None
-        assert pair.token_to_chars(6) == (1, (0, 2))
+        assert pair.token_to_chars(6) == (0, 2)
 
     def test_token_to_word(self, encodings):
         single, pair = encodings
@@ -75,11 +75,11 @@ class TestEncoding:
         assert single.token_to_word(0) == None
         assert single.token_to_word(1) == 0
         assert single.token_to_word(4) == 2
-        assert pair.token_to_word(1) == (0, 0)
-        assert pair.token_to_word(4) == (0, 2)
+        assert pair.token_to_word(1) == 0
+        assert pair.token_to_word(4) == 2
         assert pair.token_to_word(5) == None
-        assert pair.token_to_word(6) == (1, 0)
-        assert pair.token_to_word(7) == (1, 1)
+        assert pair.token_to_word(6) == 0
+        assert pair.token_to_word(7) == 1
 
     def test_char_to_token(self, encodings):
         single, pair = encodings

--- a/bindings/python/tests/bindings/test_encoding.py
+++ b/bindings/python/tests/bindings/test_encoding.py
@@ -12,6 +12,12 @@ class TestEncoding:
         pair_encoding = tokenizer.encode("I love HuggingFace", "Do you?")
         return single_encoding, pair_encoding
 
+    def test_sequences(self, encodings):
+        single, pair = encodings
+
+        assert single.sequences == [None, 0, 0, 0, 0, None]
+        assert pair.sequences == [None, 0, 0, 0, 0, None, 1, 1, 1, None]
+
     def test_n_sequences(self, encodings):
         single, pair = encodings
         assert single.n_sequences == 1

--- a/bindings/python/tests/bindings/test_encoding.py
+++ b/bindings/python/tests/bindings/test_encoding.py
@@ -1,0 +1,102 @@
+import pytest
+from ..utils import data_dir, bert_files
+
+from tokenizers import BertWordPieceTokenizer
+
+
+class TestEncoding:
+    @pytest.fixture(scope="class")
+    def encodings(self, bert_files):
+        tokenizer = BertWordPieceTokenizer.from_file(bert_files["vocab"])
+        single_encoding = tokenizer.encode("I love HuggingFace")
+        pair_encoding = tokenizer.encode("I love HuggingFace", "Do you?")
+        return single_encoding, pair_encoding
+
+    def test_n_sequences(self, encodings):
+        single, pair = encodings
+        assert single.n_sequences == 1
+        assert pair.n_sequences == 2
+
+    def test_word_to_tokens(self, encodings):
+        single, pair = encodings
+
+        assert single.tokens == ["[CLS]", "i", "love", "hugging", "##face", "[SEP]"]
+        assert single.word_to_tokens(0) == (1, 2)
+
+        assert pair.tokens == [
+            "[CLS]",
+            "i",
+            "love",
+            "hugging",
+            "##face",
+            "[SEP]",
+            "do",
+            "you",
+            "?",
+            "[SEP]",
+        ]
+        assert pair.word_to_tokens(0) == (1, 2)
+        assert pair.word_to_tokens(0, 0) == (1, 2)
+        assert pair.word_to_tokens(6, 0) == None
+        assert pair.word_to_tokens(0, 1) == (6, 7)
+
+    def test_word_to_chars(self, encodings):
+        single, pair = encodings
+
+        assert single.word_to_chars(2) == (7, 18)
+        assert pair.word_to_chars(2) == (7, 18)
+        assert pair.word_to_chars(2, 0) == (7, 18)
+        assert pair.word_to_chars(2, 1) == (6, 7)
+
+    def test_token_to_sequence(self, encodings):
+        single, pair = encodings
+
+        assert single.token_to_sequence(2) == 0
+        assert pair.token_to_sequence(2) == 0
+        assert pair.token_to_sequence(0) == None
+        assert pair.token_to_sequence(5) == None
+        assert pair.token_to_sequence(6) == 1
+        assert pair.token_to_sequence(8) == 1
+        assert pair.token_to_sequence(9) == None
+        assert pair.token_to_sequence(1200) == None
+
+    def test_token_to_chars(self, encodings):
+        single, pair = encodings
+
+        assert single.token_to_chars(0) == None
+        assert single.token_to_chars(2) == (2, 6)
+        assert pair.token_to_chars(2) == (0, (2, 6))
+        assert pair.token_to_chars(5) == None
+        assert pair.token_to_chars(6) == (1, (0, 2))
+
+    def test_token_to_word(self, encodings):
+        single, pair = encodings
+
+        assert single.token_to_word(0) == None
+        assert single.token_to_word(1) == 0
+        assert single.token_to_word(4) == 2
+        assert pair.token_to_word(1) == (0, 0)
+        assert pair.token_to_word(4) == (0, 2)
+        assert pair.token_to_word(5) == None
+        assert pair.token_to_word(6) == (1, 0)
+        assert pair.token_to_word(7) == (1, 1)
+
+    def test_char_to_token(self, encodings):
+        single, pair = encodings
+
+        assert single.char_to_token(0) == 1
+        assert pair.char_to_token(0) == 1
+        assert pair.char_to_token(0, 0) == 1
+        assert pair.char_to_token(1, 0) == None
+        assert pair.char_to_token(0, 1) == 6
+        assert pair.char_to_token(2, 1) == None
+
+    def test_char_to_word(self, encodings):
+        single, pair = encodings
+
+        assert single.char_to_word(0) == 0
+        assert single.char_to_word(1) == None
+        assert pair.char_to_word(2) == 1
+        assert pair.char_to_word(2, 0) == 1
+        assert pair.char_to_word(2, 1) == None
+        assert pair.char_to_word(3, 1) == 1

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -202,11 +202,12 @@ pub fn process_offsets(encoding: &mut Encoding, add_prefix_space: bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::ByteLevel;
+    use super::*;
     use crate::tokenizer::{
         Decoder, Encoding, OffsetReferential, OffsetType, PostProcessor, PreTokenizedString,
         PreTokenizer,
     };
+    use std::iter::FromIterator;
 
     #[test]
     fn pre_tokenization() {
@@ -384,7 +385,7 @@ mod tests {
     #[test]
     fn processor_trims_offsets() {
         let start = Encoding::new(
-            vec![],
+            vec![0; 5],
             vec![],
             vec![
                 "Ġ".into(),
@@ -398,9 +399,10 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            HashMap::new(),
         );
         let expected = Encoding::new(
-            vec![],
+            vec![0; 5],
             vec![],
             vec![
                 "Ġ".into(),
@@ -414,6 +416,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            HashMap::new(),
         );
 
         let bytelevel = ByteLevel::default().trim_offsets(true);
@@ -422,7 +425,23 @@ mod tests {
             bytelevel.process(start.clone(), None, false).unwrap()
         );
 
-        let mut pair_expected = expected.clone();
+        let mut pair_expected = Encoding::new(
+            vec![0; 5],
+            vec![],
+            vec![
+                "Ġ".into(),
+                "ĠĠĠĠHelloĠĠ".into(),
+                "ĠĠHello".into(),
+                "HelloĠĠ".into(),
+                "ĠĠĠĠ".into(),
+            ],
+            vec![],
+            vec![(0, 0), (4, 9), (13, 18), (18, 23), (29, 29)],
+            vec![],
+            vec![],
+            vec![],
+            HashMap::from_iter(vec![(0, 0..5), (1, 5..10)]),
+        );
         pair_expected.merge_with(expected, false);
         assert_eq!(
             pair_expected,

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -1,5 +1,7 @@
 use crate::tokenizer::{Encoding, PostProcessor, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::iter::FromIterator;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "type")]
@@ -55,6 +57,9 @@ impl PostProcessor for BertProcessing {
         let special_tokens = [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
         let attention_mask = vec![1; ids.len()];
 
+        // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't contain
+        // the special tokens.
+        let sequence_ranges = HashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
         let mut new_encoding = Encoding::new(
             ids,
             type_ids,
@@ -81,6 +86,9 @@ impl PostProcessor for BertProcessing {
                         [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
                     let attention_mask = vec![1; ids.len()];
 
+                    // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't
+                    // contain the special tokens.
+                    let sequence_ranges = HashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
                     Encoding::new(
                         ids,
                         type_ids,
@@ -90,9 +98,11 @@ impl PostProcessor for BertProcessing {
                         special_tokens,
                         attention_mask,
                         vec![],
+                        sequence_ranges,
                     )
                 })
                 .collect(),
+            sequence_ranges,
         );
 
         if let Some(mut encoding) = pair_encoding {
@@ -105,6 +115,9 @@ impl PostProcessor for BertProcessing {
                 [&vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
             let pair_attention_mask = vec![1; pair_ids.len()];
 
+            // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't contain
+            // the special tokens.
+            let pair_sequence_ranges = HashMap::from_iter(vec![(1, 0..pair_ids.len() - 1)]);
             let new_pair_encoding = Encoding::new(
                 pair_ids,
                 pair_type_ids,
@@ -127,6 +140,10 @@ impl PostProcessor for BertProcessing {
                             [&vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
                         let pair_attention_mask = vec![1; pair_ids.len()];
 
+                        // For compatibility with `TemplateProcessing`, the sequence_ranges
+                        // shouldn't contain the special tokens.
+                        let pair_sequence_ranges =
+                            HashMap::from_iter(vec![(1, 0..pair_ids.len() - 1)]);
                         Encoding::new(
                             pair_ids,
                             pair_type_ids,
@@ -136,9 +153,11 @@ impl PostProcessor for BertProcessing {
                             pair_special_tokens,
                             pair_attention_mask,
                             vec![],
+                            pair_sequence_ranges,
                         )
                     })
                     .collect(),
+                pair_sequence_ranges,
             );
 
             new_encoding.merge_with(new_pair_encoding, false);

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -1,6 +1,8 @@
 use crate::processors::byte_level::process_offsets;
 use crate::tokenizer::{Encoding, PostProcessor, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::iter::FromIterator;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "type")]
@@ -88,6 +90,9 @@ impl PostProcessor for RobertaProcessing {
         let special_tokens = [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
         let attention_mask = vec![1; ids.len()];
 
+        // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't contain
+        // the special tokens.
+        let sequence_ranges = HashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
         let mut new_encoding = Encoding::new(
             ids,
             type_ids,
@@ -114,6 +119,9 @@ impl PostProcessor for RobertaProcessing {
                         [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
                     let attention_mask = vec![1; ids.len()];
 
+                    // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't
+                    // contain the special tokens.
+                    let sequence_ranges = HashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
                     Encoding::new(
                         ids,
                         type_ids,
@@ -123,9 +131,11 @@ impl PostProcessor for RobertaProcessing {
                         special_tokens,
                         attention_mask,
                         vec![],
+                        sequence_ranges,
                     )
                 })
                 .collect(),
+            sequence_ranges,
         );
 
         if let Some(mut encoding) = pair_encoding {
@@ -143,6 +153,9 @@ impl PostProcessor for RobertaProcessing {
                 [&[1], &vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
             let pair_attention_mask = vec![1; pair_ids.len()];
 
+            // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't contain
+            // the special tokens.
+            let pair_sequence_ranges = HashMap::from_iter(vec![(1, 1..pair_ids.len() - 1)]);
             let new_pair_encoding = Encoding::new(
                 pair_ids,
                 pair_type_ids,
@@ -171,6 +184,10 @@ impl PostProcessor for RobertaProcessing {
                             [&[1], &vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
                         let pair_attention_mask = vec![1; pair_ids.len()];
 
+                        // For compatibility with `TemplateProcessing`, the sequence_ranges
+                        // shouldn't contain the special tokens.
+                        let pair_sequence_ranges =
+                            HashMap::from_iter(vec![(1, 1..pair_ids.len() - 1)]);
                         Encoding::new(
                             pair_ids,
                             pair_type_ids,
@@ -180,9 +197,11 @@ impl PostProcessor for RobertaProcessing {
                             pair_special_tokens,
                             pair_attention_mask,
                             vec![],
+                            pair_sequence_ranges,
                         )
                     })
                     .collect(),
+                pair_sequence_ranges,
             );
 
             new_encoding.merge_with(new_pair_encoding, false);

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -129,6 +129,16 @@ impl Encoding {
         &self.words
     }
 
+    pub fn get_sequences(&self) -> Vec<Option<usize>> {
+        let mut sequences = vec![None; self.len()];
+        for seq_id in 0..self.n_sequences() {
+            let range = self.sequence_range(seq_id);
+            let seq_len = range.len();
+            sequences.splice(range, std::iter::repeat(Some(seq_id)).take(seq_len));
+        }
+        sequences
+    }
+
     pub fn get_words_mut(&mut self) -> &mut [Option<u32>] {
         &mut self.words
     }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -105,7 +105,9 @@ impl dyn PostProcessor {
     ) -> Result<Encoding> {
         match pair_encoding {
             None => Ok(encoding),
-            Some(pair) => {
+            Some(mut pair) => {
+                encoding.set_sequence_id(0);
+                pair.set_sequence_id(1);
                 encoding.merge_with(pair, false);
                 Ok(encoding)
             }

--- a/tokenizers/src/utils/padding.rs
+++ b/tokenizers/src/utils/padding.rs
@@ -84,6 +84,7 @@ pub fn pad_encodings(encodings: &mut [Encoding], params: &PaddingParams) -> Resu
 mod tests {
     use super::*;
     use crate::tokenizer::Encoding;
+    use std::collections::HashMap;
 
     #[test]
     fn pad_to_multiple() {
@@ -98,6 +99,7 @@ mod tests {
                     vec![],
                     vec![],
                     vec![],
+                    HashMap::new(),
                 ),
                 Encoding::new(
                     vec![0, 1, 2],
@@ -108,6 +110,7 @@ mod tests {
                     vec![],
                     vec![],
                     vec![],
+                    HashMap::new(),
                 ),
             ]
         }

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -165,6 +165,7 @@ pub fn truncate_encodings(
 mod tests {
     use super::*;
     use crate::tokenizer::Encoding;
+    use std::collections::HashMap;
 
     fn get_empty() -> Encoding {
         Encoding::new(
@@ -176,6 +177,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            HashMap::new(),
         )
     }
 
@@ -189,6 +191,7 @@ mod tests {
             vec![0, 0],
             vec![1, 1],
             vec![],
+            HashMap::new(),
         )
     }
 
@@ -207,6 +210,7 @@ mod tests {
             vec![0, 0, 0, 0],
             vec![1, 1, 1, 1],
             vec![],
+            HashMap::new(),
         )
     }
 
@@ -247,6 +251,7 @@ mod tests {
             vec![0, 0, 0, 0, 0, 0, 0, 0],
             vec![1, 1, 1, 1, 1, 1, 1, 1],
             vec![],
+            HashMap::new(),
         )
     }
 


### PR DESCRIPTION
Fix #486 

Improve the mappings `XX_to_XX` methods by adding support for pairs of sequence:
- `token_to_XX` methods now return a tuple with the sequence index and the expected result for pairs of sequence
- `char_to_XX` and `word_to_XX` now accept a new argument `sequence_index` to specify the target input sequence
- Also add a `token_to_sequence` method that can tell for any token, the associated input sequence.