### PR TITLE
[WIP] train from memory.

### DIFF
--- a/bindings/python/examples/train_datasets.py
+++ b/bindings/python/examples/train_datasets.py
@@ -1,0 +1,33 @@
+import datasets
+from tokenizers import normalizers, pre_tokenizers, Tokenizer, models, trainers
+import tqdm
+
+
+def main():
+    dataset = datasets.load_dataset("wikitext", "wikitext-103-raw-v1")
+    bpe_tokenizer = Tokenizer(models.BPE())
+    bpe_tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+    bpe_tokenizer.normalizer = normalizers.Lowercase()
+    trainer = trainers.BpeTrainer(show_progress=True)
+
+    def data_iterator():
+        L = len(dataset["train"])
+        B = 30000
+        for i in tqdm.tqdm(range(0, L, B)):
+            batch = dataset["train"][i : i + B]
+            # print("H", end="", flush=True)
+            yield "".join(batch["text"])
+
+    bpe_tokenizer.train_from_iterator(trainer, data_iterator())
+
+
+def main2():
+    trainer = trainers.BpeTrainer(show_progress=True)
+    bpe_tokenizer = Tokenizer(models.BPE())
+    bpe_tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+    bpe_tokenizer.normalizer = normalizers.Lowercase()
+    bpe_tokenizer.train(trainer, ["/home/nicolas/data/wikitext-103-raw/wiki.train.raw"])
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/python/tests/bindings/test_trainers.py
+++ b/bindings/python/tests/bindings/test_trainers.py
@@ -12,6 +12,41 @@ from tokenizers import (
 )
 from ..utils import data_dir, train_files
 
+ZEN_OF_PYTHON = """
+[CLS] The Zen of Python, by Tim Peters [SEP]
+[CLS] Beautiful is better than ugly. [SEP]
+[CLS] Explicit is better than implicit. [SEP]
+[CLS] Simple is better than complex. [SEP]
+[CLS] Complex is better than complicated. [SEP]
+[CLS] Flat is better than nested. [SEP]
+[CLS] Sparse is better than dense. [SEP]
+[CLS] Readability counts. [SEP]
+[CLS] Special cases aren't special enough to break the rules. [SEP]
+[CLS] Although practicality beats purity. [SEP]
+[CLS] Errors should never pass silently. [SEP]
+[CLS] Unless explicitly silenced. [SEP]
+[CLS] In the face of ambiguity, refuse the temptation to guess. [SEP]
+[CLS] There should be one-- and preferably only one --obvious way to do it. [SEP]
+[CLS] Although that way may not be obvious at first unless you're Dutch. [SEP]
+[CLS] Now is better than never. [SEP]
+[CLS] Although never is often better than *right* now. [SEP]
+[CLS] If the implementation is hard to explain, it's a bad idea. [SEP]
+[CLS] If the implementation is easy to explain, it may be a good idea. [SEP]
+[CLS] Namespaces are one honking great idea -- let's do more of those! [SEP]
+"""
+
+
+class TestTrain:
+    def test_train_from_memory(self):
+        bpe_tokenizer = Tokenizer(models.BPE())
+        bpe_tokenizer.normalizer = normalizers.Lowercase()
+        trainer = trainers.BpeTrainer(show_progress=False)
+
+        def data_iterator():
+            yield ZEN_OF_PYTHON
+
+        bpe_tokenizer.train_from_iterator(trainer, data_iterator())
+
 
 class TestUnigram:
     def test_train(self, train_files):
@@ -46,30 +81,7 @@ class TestUnigram:
     def test_train_with_special_tokens(self):
         filename = "tests/data/dummy-unigram-special_tokens-train.txt"
         with open(filename, "w") as f:
-            f.write(
-                """
-[CLS] The Zen of Python, by Tim Peters [SEP]
-[CLS] Beautiful is better than ugly. [SEP]
-[CLS] Explicit is better than implicit. [SEP]
-[CLS] Simple is better than complex. [SEP]
-[CLS] Complex is better than complicated. [SEP]
-[CLS] Flat is better than nested. [SEP]
-[CLS] Sparse is better than dense. [SEP]
-[CLS] Readability counts. [SEP]
-[CLS] Special cases aren't special enough to break the rules. [SEP]
-[CLS] Although practicality beats purity. [SEP]
-[CLS] Errors should never pass silently. [SEP]
-[CLS] Unless explicitly silenced. [SEP]
-[CLS] In the face of ambiguity, refuse the temptation to guess. [SEP]
-[CLS] There should be one-- and preferably only one --obvious way to do it. [SEP]
-[CLS] Although that way may not be obvious at first unless you're Dutch. [SEP]
-[CLS] Now is better than never. [SEP]
-[CLS] Although never is often better than *right* now. [SEP]
-[CLS] If the implementation is hard to explain, it's a bad idea. [SEP]
-[CLS] If the implementation is easy to explain, it may be a good idea. [SEP]
-[CLS] Namespaces are one honking great idea -- let's do more of those! [SEP]
-            """
-            )
+            f.write(ZEN_OF_PYTHON)
 
         tokenizer = Tokenizer(models.Unigram())
         trainer = trainers.UnigramTrainer(


### PR DESCRIPTION
First attempt to train from memory.

Nice things:
- It works
- It's relatively simple
- It enables shifting paradigm so that `feed_train_chunk` could start to
  directly feed some inner struct of `Trainer` (pairs for BPE, sentences
for Unigram) and bypass `word_counts` later.
- `datasets` training is somehow as fast as from raw file (~20% slowdown
on wikitext-103-raw ?).

Negatives:
- Puts burden on the caller to feed chunks
large enough that parallelization actually achieves something.
- Adds a new item in `Tokenizer` struct that does not really belong (it
belongs to the trainer and could be different from words, but this state
is temporary).
- In the case of `datasets` we are still having a slowdown because we
have to recreate a `string` chunk for a list of strings that gets
splitted later.
- We are accepting only strings, not raw bytes which does incur some
overhead but really not the focus here.
- `{train|train_and_replace}_{from_files|from_buffer}` is starting to get a bit silly.

Still missing:
- Adding the docs
- Rust tests.
- Node bindings

Fixes #198 