### PR TITLE
Trainer improvements

### DIFF
--- a/bindings/node/examples/documentation/pipeline.test.ts
+++ b/bindings/node/examples/documentation/pipeline.test.ts
@@ -94,7 +94,7 @@ describe("pipelineExample", () => {
         let { Tokenizer } = require("tokenizers/bindings/tokenizer");
         let { WordPiece } = require("tokenizers/bindings/models");
 
-        let bertTokenizer = new Tokenizer(WordPiece.empty());
+        let bertTokenizer = new Tokenizer(WordPiece.init({}, { unkToken: "[UNK]" }));
         // END bert_setup_tokenizer
         // START bert_setup_normalizer
         let { sequenceNormalizer, lowercaseNormalizer, nfdNormalizer, stripAccentsNormalizer }
@@ -120,20 +120,13 @@ describe("pipelineExample", () => {
         // END bert_setup_processor
         // START bert_train_tokenizer
         let { wordPieceTrainer } = require("tokenizers/bindings/trainers");
-        let { promisify } = require("util");
 
         let trainer = wordPieceTrainer({
             vocabSize: 30522,
             specialTokens: ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"]
         });
         let files = ["test", "train", "valid"].map(split => `data/wikitext-103-raw/wiki.${split}.raw`);
-        bertTokenizer.train(trainer, files);
-
-        let modelFiles = bertTokenizer.getModel().save("data", "bert-wiki");
-        let fromFile = promisify(WordPiece.fromFile);
-        bertTokenizer.setModel(await fromFile(modelFiles[0], {
-            unkToken: "[UNK]"
-        }));
+        bertTokenizer.train(files, trainer);
 
         bertTokenizer.save("data/bert-wiki.json")
         // END bert_train_tokenizer

--- a/bindings/node/examples/documentation/quicktour.test.ts
+++ b/bindings/node/examples/documentation/quicktour.test.ts
@@ -16,7 +16,7 @@ describe("quicktourExample", () => {
         let { Tokenizer } = require("tokenizers/bindings/tokenizer");
         let { BPE } = require("tokenizers/bindings/models");
 
-        let tokenizer = new Tokenizer(BPE.empty());
+        let tokenizer = new Tokenizer(BPE.init({}, [], { unkToken: "[UNK]" }));
         // END init_tokenizer
         // START init_trainer
         let { bpeTrainer } = require("tokenizers/bindings/trainers");
@@ -32,17 +32,8 @@ describe("quicktourExample", () => {
         // END init_pretok
         // START train
         let files = ["test", "train", "valid"].map(split => `data/wikitext-103-raw/wiki.${split}.raw`);
-        tokenizer.train(trainer, files);
+        tokenizer.train(files, trainer);
         // END train
-        // START reload_model
-        let { promisify } = require("util");
-
-        let modelFiles = tokenizer.getModel().save("data", "wiki");
-        let fromFile = promisify(BPE.fromFile);
-        tokenizer.setModel(await fromFile(modelFiles[0], modelFiles[1], {
-            unkToken: "[UNK]"
-        }));
-        // END reload_model
         // START save
         tokenizer.save("data/tokenizer-wiki.json");
         // END save

--- a/bindings/node/lib/bindings/trainers.d.ts
+++ b/bindings/node/lib/bindings/trainers.d.ts
@@ -63,6 +63,35 @@ export function bpeTrainer(options?: TrainerOptions): Trainer;
  */
 export function wordPieceTrainer(options?: TrainerOptions): Trainer;
 
+export interface WordLevelTrainerOptions {
+  /**
+   * The minimum frequency a pair should have in order to be merged.
+   * @default 2
+   */
+  minFrequency?: number;
+  /**
+   * Whether to show progress bars while training.
+   * @default true
+   */
+  showProgress?: boolean;
+  /**
+   * A list of special tokens the model should know of.
+   * @default []
+   */
+  specialTokens?: (string | AddedToken)[];
+  /**
+   * The size of the final vocabulary, including all tokens and alphabet.
+   * @default 30000
+   */
+  vocabSize?: number;
+}
+
+/**
+ * Instantiate a new WordLevel Trainer
+ * @param [options] WordLevel Trainer options
+ */
+export function wordLevelTrainer(options?: WordLevelTrainerOptions): Trainer;
+
 export interface UnigramTrainerOptions {
   vocabSize?: number;
   nSubIterations?: number;

--- a/bindings/node/lib/bindings/trainers.js
+++ b/bindings/node/lib/bindings/trainers.js
@@ -3,5 +3,6 @@ const native = require("./native");
 module.exports = {
   bpeTrainer: native.trainers_BPETrainer,
   wordPieceTrainer: native.trainers_WordPieceTrainer,
+  wordLevelTrainer: native.trainers_WordLevelTrainer,
   unigramTrainer: native.trainers_UnigramTrainer,
 };

--- a/bindings/node/native/src/tasks/models.rs
+++ b/bindings/node/native/src/tasks/models.rs
@@ -2,7 +2,7 @@ extern crate tokenizers as tk;
 
 use crate::models::*;
 use neon::prelude::*;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use tk::models::bpe::{BpeBuilder, BPE};
 use tk::models::wordlevel::{WordLevel, WordLevelBuilder};
 use tk::models::wordpiece::{WordPiece, WordPieceBuilder};
@@ -34,7 +34,7 @@ impl Task for WordPieceFromFilesTask {
 
         let mut js_model = JsModel::new::<_, JsModel, _>(&mut cx, vec![])?;
         let guard = cx.lock();
-        js_model.borrow_mut(&guard).model = Some(Arc::new(wordpiece.into()));
+        js_model.borrow_mut(&guard).model = Some(Arc::new(RwLock::new(wordpiece.into())));
 
         Ok(js_model.upcast())
     }
@@ -67,7 +67,7 @@ impl Task for WordLevelFromFilesTask {
 
         let mut js_model = JsModel::new::<_, JsModel, _>(&mut cx, vec![])?;
         let guard = cx.lock();
-        js_model.borrow_mut(&guard).model = Some(Arc::new(wordlevel.into()));
+        js_model.borrow_mut(&guard).model = Some(Arc::new(RwLock::new(wordlevel.into())));
 
         Ok(js_model.upcast())
     }
@@ -100,7 +100,7 @@ impl Task for BPEFromFilesTask {
 
         let mut js_model = JsModel::new::<_, JsModel, _>(&mut cx, vec![])?;
         let guard = cx.lock();
-        js_model.borrow_mut(&guard).model = Some(Arc::new(bpe.into()));
+        js_model.borrow_mut(&guard).model = Some(Arc::new(RwLock::new(bpe.into())));
 
         Ok(js_model.upcast())
     }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -138,11 +138,11 @@ tokenizer.post_processor = processors.ByteLevel(trim_offsets=True)
 
 # And then train
 trainer = trainers.BpeTrainer(vocab_size=20000, min_frequency=2)
-tokenizer.train(trainer, [
+tokenizer.train([
 	"./path/to/dataset/1.txt",
 	"./path/to/dataset/2.txt",
 	"./path/to/dataset/3.txt"
-])
+], trainer=trainer)
 
 # And Save it
 tokenizer.save("byte-level-bpe.tokenizer.json", pretty=True)

--- a/bindings/python/py_src/tokenizers/implementations/bert_wordpiece.py
+++ b/bindings/python/py_src/tokenizers/implementations/bert_wordpiece.py
@@ -115,4 +115,4 @@ class BertWordPieceTokenizer(BaseTokenizer):
         )
         if isinstance(files, str):
             files = [files]
-        self._tokenizer.train(trainer, files)
+        self._tokenizer.train(files, trainer=trainer)

--- a/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
@@ -101,4 +101,4 @@ class ByteLevelBPETokenizer(BaseTokenizer):
         )
         if isinstance(files, str):
             files = [files]
-        self._tokenizer.train(trainer, files)
+        self._tokenizer.train(files, trainer=trainer)

--- a/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
@@ -123,4 +123,4 @@ class CharBPETokenizer(BaseTokenizer):
         )
         if isinstance(files, str):
             files = [files]
-        self._tokenizer.train(trainer, files)
+        self._tokenizer.train(files, trainer=trainer)

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -74,4 +74,4 @@ class SentencePieceBPETokenizer(BaseTokenizer):
         )
         if isinstance(files, str):
             files = [files]
-        self._tokenizer.train(trainer, files)
+        self._tokenizer.train(files, trainer=trainer)

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
@@ -75,7 +75,7 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
 
         if isinstance(files, str):
             files = [files]
-        self._tokenizer.train(trainer, files)
+        self._tokenizer.train(files, trainer=trainer)
 
     @staticmethod
     def from_spm(filename: str):

--- a/bindings/python/py_src/tokenizers/trainers/__init__.py
+++ b/bindings/python/py_src/tokenizers/trainers/__init__.py
@@ -4,4 +4,5 @@ from .. import trainers
 Trainer = trainers.Trainer
 BpeTrainer = trainers.BpeTrainer
 UnigramTrainer = trainers.UnigramTrainer
+WordLevelTrainer = trainers.WordLevelTrainer
 WordPieceTrainer = trainers.WordPieceTrainer

--- a/bindings/python/py_src/tokenizers/trainers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/trainers/__init__.pyi
@@ -83,6 +83,27 @@ class UnigramTrainer(Trainer):
     def __init__(self, vocab_size=8000, show_progress=True, special_tokens=[]):
         pass
 
+class WordLevelTrainer(Trainer):
+    """
+    Capable of training a WorldLevel model
+
+    Args:
+        vocab_size: unsigned int:
+            The size of the final vocabulary, including all tokens and alphabet.
+
+        min_frequency: unsigned int:
+            The minimum frequency a pair should have in order to be merged.
+
+        show_progress: boolean:
+            Whether to show progress bars while training.
+
+        special_tokens: List[Union[str, AddedToken]]:
+            A list of special tokens the model should know of.
+
+    Returns:
+        Trainer
+    """
+
 class WordPieceTrainer(Trainer):
     """
     Capable of training a WordPiece model

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -44,6 +44,7 @@ fn trainers(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<trainers::PyTrainer>()?;
     m.add_class::<trainers::PyBpeTrainer>()?;
     m.add_class::<trainers::PyWordPieceTrainer>()?;
+    m.add_class::<trainers::PyWordLevelTrainer>()?;
     m.add_class::<trainers::PyUnigramTrainer>()?;
     Ok(())
 }

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -581,12 +581,12 @@ mod test {
         match *py_model.model.as_ref().read().unwrap() {
             ModelWrapper::BPE(_) => (),
             _ => panic!("Expected Bert postprocessor."),
-        }
+        };
 
         let py_model: PyModel = serde_json::from_str(&rs_wrapper_ser).unwrap();
         match *py_model.model.as_ref().read().unwrap() {
             ModelWrapper::BPE(_) => (),
             _ => panic!("Expected Bert postprocessor."),
-        }
+        };
     }
 }

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::token::PyToken;
+use crate::trainers::PyTrainer;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
@@ -45,6 +46,8 @@ impl PyModel {
 }
 
 impl Model for PyModel {
+    type Trainer = PyTrainer;
+
     fn tokenize(&self, tokens: &str) -> tk::Result<Vec<Token>> {
         self.model.tokenize(tokens)
     }
@@ -67,6 +70,10 @@ impl Model for PyModel {
 
     fn save(&self, folder: &Path, name: Option<&str>) -> tk::Result<Vec<PathBuf>> {
         self.model.save(folder, name)
+    }
+
+    fn get_trainer(&self) -> Self::Trainer {
+        self.model.get_trainer().into()
     }
 }
 
@@ -141,6 +148,10 @@ impl PyModel {
             .into_iter()
             .map(|path| path.to_string_lossy().into_owned())
             .collect())
+    }
+
+    fn get_trainer(&self) -> PyResult<PyObject> {
+        PyTrainer::from(self.model.get_trainer()).get_as_subtype()
     }
 }
 

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use crate::token::PyToken;
 use crate::trainers::PyTrainer;
@@ -24,11 +24,11 @@ use super::error::{deprecation_warning, ToPyResult};
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PyModel {
     #[serde(flatten)]
-    pub model: Arc<ModelWrapper>,
+    pub model: Arc<RwLock<ModelWrapper>>,
 }
 
 impl PyModel {
-    pub(crate) fn new(model: Arc<ModelWrapper>) -> Self {
+    pub(crate) fn new(model: Arc<RwLock<ModelWrapper>>) -> Self {
         PyModel { model }
     }
 
@@ -36,7 +36,7 @@ impl PyModel {
         let base = self.clone();
         let gil = Python::acquire_gil();
         let py = gil.python();
-        Ok(match self.model.as_ref() {
+        Ok(match *self.model.as_ref().read().unwrap() {
             ModelWrapper::BPE(_) => Py::new(py, (PyBPE {}, base))?.into_py(py),
             ModelWrapper::WordPiece(_) => Py::new(py, (PyWordPiece {}, base))?.into_py(py),
             ModelWrapper::WordLevel(_) => Py::new(py, (PyWordLevel {}, base))?.into_py(py),
@@ -49,31 +49,31 @@ impl Model for PyModel {
     type Trainer = PyTrainer;
 
     fn tokenize(&self, tokens: &str) -> tk::Result<Vec<Token>> {
-        self.model.tokenize(tokens)
+        self.model.read().unwrap().tokenize(tokens)
     }
 
     fn token_to_id(&self, token: &str) -> Option<u32> {
-        self.model.token_to_id(token)
+        self.model.read().unwrap().token_to_id(token)
     }
 
-    fn id_to_token(&self, id: u32) -> Option<&str> {
-        self.model.id_to_token(id)
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        self.model.read().unwrap().id_to_token(id)
     }
 
-    fn get_vocab(&self) -> &HashMap<String, u32> {
-        self.model.get_vocab()
+    fn get_vocab(&self) -> HashMap<String, u32> {
+        self.model.read().unwrap().get_vocab()
     }
 
     fn get_vocab_size(&self) -> usize {
-        self.model.get_vocab_size()
+        self.model.read().unwrap().get_vocab_size()
     }
 
     fn save(&self, folder: &Path, name: Option<&str>) -> tk::Result<Vec<PathBuf>> {
-        self.model.save(folder, name)
+        self.model.read().unwrap().save(folder, name)
     }
 
     fn get_trainer(&self) -> Self::Trainer {
-        self.model.get_trainer().into()
+        self.model.read().unwrap().get_trainer().into()
     }
 }
 
@@ -84,7 +84,7 @@ impl PyModel {
         // Instantiate a default empty model. This doesn't really make sense, but we need
         // to be able to instantiate an empty model for pickle capabilities.
         Ok(PyModel {
-            model: Arc::new(BPE::default().into()),
+            model: Arc::new(RwLock::new(BPE::default().into())),
         })
     }
 
@@ -116,7 +116,7 @@ impl PyModel {
     /// Tokenize the given sequence
     #[text_signature = "(self, tokens)"]
     fn tokenize(&self, tokens: &str) -> PyResult<Vec<PyToken>> {
-        Ok(ToPyResult(self.model.tokenize(tokens))
+        Ok(ToPyResult(self.model.read().unwrap().tokenize(tokens))
             .into_py()?
             .into_iter()
             .map(|t| t.into())
@@ -126,13 +126,13 @@ impl PyModel {
     /// Returns the id associated with the given token
     #[text_signature = "(self, tokens)"]
     fn token_to_id(&self, token: &str) -> Option<u32> {
-        self.model.token_to_id(token)
+        self.model.read().unwrap().token_to_id(token)
     }
 
     /// Returns the token associated with the given id
     #[text_signature = "(self, id)"]
-    fn id_to_token(&self, id: u32) -> Option<&str> {
-        self.model.id_to_token(id)
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        self.model.read().unwrap().id_to_token(id)
     }
 
     /// Save the current model
@@ -142,7 +142,8 @@ impl PyModel {
     /// Any file with the same name that already exist in this folder will be overwritten.
     #[text_signature = "(self, folder, name)"]
     fn save(&self, folder: &str, name: Option<&str>) -> PyResult<Vec<String>> {
-        let saved: PyResult<Vec<_>> = ToPyResult(self.model.save(Path::new(folder), name)).into();
+        let saved: PyResult<Vec<_>> =
+            ToPyResult(self.model.read().unwrap().save(Path::new(folder), name)).into();
 
         Ok(saved?
             .into_iter()
@@ -151,7 +152,7 @@ impl PyModel {
     }
 
     fn get_trainer(&self) -> PyResult<PyObject> {
-        PyTrainer::from(self.model.get_trainer()).get_as_subtype()
+        PyTrainer::from(self.model.read().unwrap().get_trainer()).get_as_subtype()
     }
 }
 
@@ -219,7 +220,7 @@ impl PyBPE {
                 "Error while initializing BPE: {}",
                 e
             ))),
-            Ok(bpe) => Ok((PyBPE {}, PyModel::new(Arc::new(bpe.into())))),
+            Ok(bpe) => Ok((PyBPE {}, PyModel::new(Arc::new(RwLock::new(bpe.into()))))),
         }
     }
 }
@@ -360,7 +361,10 @@ impl PyWordPiece {
                 "Error while initializing WordPiece: {}",
                 e
             ))),
-            Ok(wordpiece) => Ok((PyWordPiece {}, PyModel::new(Arc::new(wordpiece.into())))),
+            Ok(wordpiece) => Ok((
+                PyWordPiece {},
+                PyModel::new(Arc::new(RwLock::new(wordpiece.into()))),
+            )),
         }
     }
 }
@@ -476,11 +480,14 @@ impl PyWordLevel {
                 }
             };
 
-            Ok((PyWordLevel {}, PyModel::new(Arc::new(model.into()))))
+            Ok((
+                PyWordLevel {},
+                PyModel::new(Arc::new(RwLock::new(model.into()))),
+            ))
         } else {
             Ok((
                 PyWordLevel {},
-                PyModel::new(Arc::new(WordLevel::default().into())),
+                PyModel::new(Arc::new(RwLock::new(WordLevel::default().into()))),
             ))
         }
     }
@@ -523,11 +530,14 @@ impl PyUnigram {
                 let model = Unigram::from(vocab, unk_id).map_err(|e| {
                     exceptions::PyException::new_err(format!("Error while loading Unigram: {}", e))
                 })?;
-                Ok((PyUnigram {}, PyModel::new(Arc::new(model.into()))))
+                Ok((
+                    PyUnigram {},
+                    PyModel::new(Arc::new(RwLock::new(model.into()))),
+                ))
             }
             (None, None) => Ok((
                 PyUnigram {},
-                PyModel::new(Arc::new(Unigram::default().into())),
+                PyModel::new(Arc::new(RwLock::new(Unigram::default().into()))),
             )),
             _ => Err(exceptions::PyValueError::new_err(
                 "`vocab` and `unk_id` must be both specified",
@@ -540,13 +550,13 @@ impl PyUnigram {
 mod test {
     use crate::models::PyModel;
     use pyo3::prelude::*;
-    use std::sync::Arc;
+    use std::sync::{Arc, RwLock};
     use tk::models::bpe::BPE;
     use tk::models::ModelWrapper;
 
     #[test]
     fn get_subtype() {
-        let py_model = PyModel::new(Arc::new(BPE::default().into()));
+        let py_model = PyModel::new(Arc::new(RwLock::new(BPE::default().into())));
         let py_bpe = py_model.get_as_subtype().unwrap();
         let gil = Python::acquire_gil();
         assert_eq!(
@@ -562,19 +572,19 @@ mod test {
         let rs_wrapper: ModelWrapper = rs_bpe.into();
         let rs_wrapper_ser = serde_json::to_string(&rs_wrapper).unwrap();
 
-        let py_model = PyModel::new(Arc::new(rs_wrapper));
+        let py_model = PyModel::new(Arc::new(RwLock::new(rs_wrapper)));
         let py_ser = serde_json::to_string(&py_model).unwrap();
         assert_eq!(py_ser, rs_bpe_ser);
         assert_eq!(py_ser, rs_wrapper_ser);
 
         let py_model: PyModel = serde_json::from_str(&rs_bpe_ser).unwrap();
-        match py_model.model.as_ref() {
+        match *py_model.model.as_ref().read().unwrap() {
             ModelWrapper::BPE(_) => (),
             _ => panic!("Expected Bert postprocessor."),
         }
 
         let py_model: PyModel = serde_json::from_str(&rs_wrapper_ser).unwrap();
-        match py_model.model.as_ref() {
+        match *py_model.model.as_ref().read().unwrap() {
             ModelWrapper::BPE(_) => (),
             _ => panic!("Expected Bert postprocessor."),
         }

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use numpy::PyArray1;
 use pyo3::exceptions;
@@ -457,7 +457,8 @@ impl PyTokenizer {
     }
 
     fn __getnewargs__<'p>(&self, py: Python<'p>) -> PyResult<&'p PyTuple> {
-        let model: PyObject = PyModel::new(Arc::new(BPE::default().into())).into_py(py);
+        let model: PyObject =
+            PyModel::new(Arc::new(RwLock::new(BPE::default().into()))).into_py(py);
         let args = PyTuple::new(py, vec![model]);
         Ok(args)
     }
@@ -965,7 +966,7 @@ impl PyTokenizer {
     /// Returns:
     ///     :obj:`Optional[str]`: An optional token, :obj:`None` if out of vocabulary
     #[text_signature = "(self, id)"]
-    fn id_to_token(&self, id: u32) -> Option<&str> {
+    fn id_to_token(&self, id: u32) -> Option<String> {
         self.tokenizer.id_to_token(id)
     }
 

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -8,7 +8,7 @@ use pyo3::types::*;
 use pyo3::PyObjectProtocol;
 use tk::models::bpe::BPE;
 use tk::tokenizer::{
-    PaddingDirection, PaddingParams, PaddingStrategy, PostProcessor, TokenizerImpl,
+    Model, PaddingDirection, PaddingParams, PaddingStrategy, PostProcessor, TokenizerImpl,
     TruncationParams, TruncationStrategy,
 };
 use tokenizers as tk;
@@ -1039,10 +1039,13 @@ impl PyTokenizer {
         Ok(self.tokenizer.add_special_tokens(&tokens))
     }
 
-    fn train(&mut self, trainer: &PyTrainer, files: Vec<String>) -> PyResult<()> {
-        let gil = Python::acquire_gil();
-        gil.python()
-            .allow_threads(|| ToPyResult(self.tokenizer.train_and_replace(trainer, files)).into())
+    #[args(trainer = "None")]
+    fn train(&mut self, files: Vec<String>, trainer: Option<&PyTrainer>) -> PyResult<()> {
+        let trainer =
+            trainer.map_or_else(|| self.tokenizer.get_model().get_trainer(), |t| t.clone());
+        Python::with_gil(|py| {
+            py.allow_threads(|| ToPyResult(self.tokenizer.train_and_replace(&trainer, files)).into())
+        })
     }
 
     /// Apply all the post-processing steps to the given encodings.

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1044,7 +1044,7 @@ impl PyTokenizer {
         let trainer =
             trainer.map_or_else(|| self.tokenizer.get_model().get_trainer(), |t| t.clone());
         Python::with_gil(|py| {
-            py.allow_threads(|| ToPyResult(self.tokenizer.train_and_replace(&trainer, files)).into())
+            py.allow_threads(|| ToPyResult(self.tokenizer.train(&trainer, files)).into())
         })
     }
 

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -84,11 +84,13 @@ impl Trainer for PyTrainer {
         self.trainer.should_show_progress()
     }
 
-    fn train(&self, words: HashMap<String, u32>) -> tk::Result<(PyModel, Vec<tk::AddedToken>)> {
-        self.trainer.train(words).map(|(m, t)| {
-            let m = PyModel { model: Arc::new(m) };
-            (m, t)
-        })
+    fn train(
+        &self,
+        words: HashMap<String, u32>,
+        model: &mut PyModel,
+    ) -> tk::Result<Vec<tk::AddedToken>> {
+        todo!("FIX THIS");
+        self.trainer.train(words, &mut model.model)
     }
 
     fn process_tokens(&self, words: &mut HashMap<String, u32>, tokens: Vec<String>) {

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -89,8 +89,7 @@ impl Trainer for PyTrainer {
         words: HashMap<String, u32>,
         model: &mut PyModel,
     ) -> tk::Result<Vec<tk::AddedToken>> {
-        todo!("FIX THIS");
-        self.trainer.train(words, &mut model.model)
+        self.trainer.train(words, &mut model.model.write().unwrap())
     }
 
     fn process_tokens(&self, words: &mut HashMap<String, u32>, tokens: Vec<String>) {

--- a/bindings/python/tests/bindings/test_trainers.py
+++ b/bindings/python/tests/bindings/test_trainers.py
@@ -41,7 +41,7 @@ class TestUnigram:
             del os.environ["TOKENIZERS_PARALLELISM"]
 
         trainer = trainers.BpeTrainer(special_tokens=["<unk>"], show_progress=False)
-        bpe_tokenizer.train(trainer, [train_files["small"]])
+        bpe_tokenizer.train([train_files["small"]], trainer=trainer)
 
     def test_train_with_special_tokens(self):
         filename = "tests/data/dummy-unigram-special_tokens-train.txt"
@@ -76,7 +76,7 @@ class TestUnigram:
             show_progress=False, special_tokens=["[PAD]", "[SEP]", "[CLS]"], unk_token="[UNK]"
         )
 
-        tokenizer.train(trainer, [filename])
+        tokenizer.train([filename], trainer=trainer)
 
         assert tokenizer.encode("[CLS] This is a test [SEP]").tokens == [
             "[CLS]",

--- a/bindings/python/tests/bindings/test_trainers.py
+++ b/bindings/python/tests/bindings/test_trainers.py
@@ -92,3 +92,10 @@ class TestUnigram:
             "t ",
             "[SEP]",
         ]
+
+    def test_cannot_train_different_model(self):
+        tokenizer = Tokenizer(models.BPE())
+        trainer = trainers.UnigramTrainer(show_progress=False)
+
+        with pytest.raises(Exception, match="UnigramTrainer can only train a Unigram"):
+            tokenizer.train([], trainer)

--- a/bindings/python/tests/documentation/test_pipeline.py
+++ b/bindings/python/tests/documentation/test_pipeline.py
@@ -2,8 +2,13 @@ from ..utils import data_dir, doc_wiki_tokenizer, doc_pipeline_bert_tokenizer
 from tokenizers import Tokenizer
 
 
+disable_printing = True
+original_print = print
+
+
 def print(*args, **kwargs):
-    pass
+    if not disable_printing:
+        original_print(*args, **kwargs)
 
 
 class TestPipeline:
@@ -103,7 +108,7 @@ class TestPipeline:
         from tokenizers import Tokenizer
         from tokenizers.models import WordPiece
 
-        bert_tokenizer = Tokenizer(WordPiece())
+        bert_tokenizer = Tokenizer(WordPiece(unk_token="[UNK]"))
         # END bert_setup_tokenizer
         # START bert_setup_normalizer
         from tokenizers import normalizers
@@ -135,10 +140,7 @@ class TestPipeline:
             vocab_size=30522, special_tokens=["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"]
         )
         files = [f"data/wikitext-103-raw/wiki.{split}.raw" for split in ["test", "train", "valid"]]
-        bert_tokenizer.train(trainer, files)
-
-        model_files = bert_tokenizer.model.save("data", "bert-wiki")
-        bert_tokenizer.model = WordPiece.from_file(*model_files, unk_token="[UNK]")
+        bert_tokenizer.train(files, trainer)
 
         bert_tokenizer.save("data/bert-wiki.json")
         # END bert_train_tokenizer
@@ -173,6 +175,7 @@ if __name__ == "__main__":
     from zipfile import ZipFile
     import os
 
+    disable_printing = False
     if not os.path.isdir("data/wikitext-103-raw"):
         print("Downloading wikitext-103...")
         wiki_text, _ = request.urlretrieve(

--- a/bindings/python/tests/documentation/test_quicktour.py
+++ b/bindings/python/tests/documentation/test_quicktour.py
@@ -4,6 +4,14 @@ from tokenizers.models import BPE
 from tokenizers.trainers import BpeTrainer
 from tokenizers.pre_tokenizers import Whitespace
 
+disable_printing = True
+original_print = print
+
+
+def print(*args, **kwargs):
+    if not disable_printing:
+        original_print(*args, **kwargs)
+
 
 class TestQuicktour:
     # This method contains everything we don't want to run
@@ -13,12 +21,8 @@ class TestQuicktour:
 
         # START train
         files = [f"data/wikitext-103-raw/wiki.{split}.raw" for split in ["test", "train", "valid"]]
-        tokenizer.train(trainer, files)
+        tokenizer.train(files, trainer)
         # END train
-        # START reload_model
-        files = tokenizer.model.save("data", "wiki")
-        tokenizer.model = BPE.from_file(*files, unk_token="[UNK]")
-        # END reload_model
         # START save
         tokenizer.save("data/tokenizer-wiki.json")
         # END save
@@ -29,7 +33,7 @@ class TestQuicktour:
         from tokenizers import Tokenizer
         from tokenizers.models import BPE
 
-        tokenizer = Tokenizer(BPE())
+        tokenizer = Tokenizer(BPE(unk_token="[UNK]"))
         # END init_tokenizer
         # START init_trainer
         from tokenizers.trainers import BpeTrainer
@@ -181,6 +185,7 @@ if __name__ == "__main__":
     from zipfile import ZipFile
     import os
 
+    disable_printing = False
     if not os.path.isdir("data/wikitext-103-raw"):
         print("Downloading wikitext-103...")
         wiki_text, _ = request.urlretrieve(

--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -202,35 +202,7 @@ to use:
         :end-before: END train
         :dedent: 8
 
-This should only take a few seconds to train our tokenizer on the full wikitext dataset! Once this
-is done, we need to save the model and reinstantiate it with the unknown token, or this token won't
-be used. This will be simplified in a further release, to let you set the :entity:`unk_token` when
-first instantiating the model.
-
-.. only:: python
-
-    .. literalinclude:: ../../bindings/python/tests/documentation/test_quicktour.py
-        :language: python
-        :start-after: START reload_model
-        :end-before: END reload_model
-        :dedent: 8
-
-.. only:: rust
-
-    .. literalinclude:: ../../tokenizers/tests/documentation.rs
-        :language: rust
-        :start-after: START quicktour_reload_model
-        :end-before: END quicktour_reload_model
-        :dedent: 4
-
-.. only:: node
-
-    .. literalinclude:: ../../bindings/node/examples/documentation/quicktour.test.ts
-        :language: javascript
-        :start-after: START reload_model
-        :end-before: END reload_model
-        :dedent: 8
-
+This should only take a few seconds to train our tokenizer on the full wikitext dataset!
 To save the tokenizer in one file that contains all its configuration and vocabulary, just use the
 :entity:`Tokenizer.save` method:
 

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -84,7 +84,7 @@ fn main() -> Result<()> {
         ])
         .build();
 
-    let tokenizer = TokenizerBuilder::new()
+    let mut tokenizer = TokenizerBuilder::new()
         .with_model(BPE::default())
         .with_normalizer(Some(Sequence::new(vec![
             Strip::new(true, true).into(),

--- a/tokenizers/benches/common/mod.rs
+++ b/tokenizers/benches/common/mod.rs
@@ -75,7 +75,7 @@ where
     let mut duration = Duration::new(0, 0);
     for _i in 0..iters {
         let start = Instant::now();
-        tokenizer.train_and_replace(trainer, files.clone()).unwrap();
+        tokenizer.train(trainer, files.clone()).unwrap();
         duration = duration.checked_add(start.elapsed()).unwrap();
     }
     duration

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -43,7 +43,7 @@
 //! ```
 //!
 //! ## Training and serialization example
-//!  
+//!
 //! ```no_run
 //! use tokenizers::decoders::DecoderWrapper;
 //! use tokenizers::models::bpe::{BpeTrainerBuilder, BPE};
@@ -71,7 +71,7 @@
 //!         ])
 //!         .build();
 //!
-//!     let tokenizer = TokenizerBuilder::new()
+//!     let mut tokenizer = TokenizerBuilder::new()
 //!         .with_model(BPE::default())
 //!         .with_normalizer(Some(Sequence::new(vec![
 //!             Strip::new(true, true).into(),

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -1,4 +1,4 @@
-use super::{super::OrderedVocabIter, Error, Pair, Word};
+use super::{super::OrderedVocabIter, trainer::BpeTrainer, Error, Pair, Word};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, DEFAULT_CACHE_CAPACITY};
 use crate::utils::iter::ResultShunt;
@@ -415,6 +415,8 @@ impl BPE {
 }
 
 impl Model for BPE {
+    type Trainer = BpeTrainer;
+
     fn get_vocab(&self) -> &HashMap<String, u32> {
         &self.vocab
     }
@@ -486,6 +488,10 @@ impl Model for BPE {
         )?;
 
         Ok(vec![vocab_path, merges_path])
+    }
+
+    fn get_trainer(&self) -> BpeTrainer {
+        BpeTrainer::default()
     }
 }
 

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -189,15 +189,15 @@ pub struct BPE {
     cache: Option<Cache<String, Word>>,
     /// Dropout probability for merges. 0 = no dropout is the default. At 1.0, tokenization will
     /// perform no merges, so the result will just be characters.
-    pub(super) dropout: Option<f32>,
+    pub dropout: Option<f32>,
     /// The unknown token to be used when we encounter an unknown char
-    pub(super) unk_token: Option<String>,
+    pub unk_token: Option<String>,
     /// An optional prefix to use on any subword that exist only behind another one
-    pub(super) continuing_subword_prefix: Option<String>,
+    pub continuing_subword_prefix: Option<String>,
     /// An optional suffix to caracterize and end-of-word subword
-    pub(super) end_of_word_suffix: Option<String>,
+    pub end_of_word_suffix: Option<String>,
     /// Do multiple unk tokens get fused
-    pub(super) fuse_unk: bool,
+    pub fuse_unk: bool,
 }
 
 impl std::fmt::Debug for BPE {

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -318,8 +318,8 @@ impl BPE {
         }
     }
 
-    pub fn get_vocab(&self) -> &Vocab {
-        &self.vocab
+    pub fn get_vocab(&self) -> Vocab {
+        self.vocab.clone()
     }
 
     pub fn get_unk_token(&self) -> &Option<String> {
@@ -417,8 +417,8 @@ impl BPE {
 impl Model for BPE {
     type Trainer = BpeTrainer;
 
-    fn get_vocab(&self) -> &HashMap<String, u32> {
-        &self.vocab
+    fn get_vocab(&self) -> HashMap<String, u32> {
+        self.vocab.clone()
     }
 
     fn get_vocab_size(&self) -> usize {
@@ -442,8 +442,8 @@ impl Model for BPE {
         self.vocab.get(token).copied()
     }
 
-    fn id_to_token(&self, id: u32) -> Option<&str> {
-        self.vocab_r.get(&id).map(String::as_ref)
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        self.vocab_r.get(&id).cloned()
     }
 
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>> {

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -583,18 +583,7 @@ impl Trainer for BpeTrainer {
 
     /// Train a BPE model
     fn train(&self, word_counts: HashMap<String, u32>) -> Result<(BPE, Vec<AddedToken>)> {
-        let (bpe, tokens) = self.train(word_counts)?;
-        Ok((bpe, tokens))
-    }
-
-    /// Process a bunch of tokens, counting them
-    fn process_tokens(&self, words: &mut HashMap<String, u32>, tokens: Vec<String>) {
-        for token in tokens {
-            words
-                .entry(token.clone())
-                .and_modify(|c| *c += 1)
-                .or_insert(1);
-        }
+        self.train(word_counts)
     }
 
     /// Whether we should show progress

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -153,19 +153,19 @@ impl Trainer for TrainerWrapper {
         match self {
             TrainerWrapper::BpeTrainer(t) => match model {
                 ModelWrapper::BPE(bpe) => t.train(words, bpe),
-                _ => unreachable!(),
+                _ => Err("BpeTrainer can only train a BPE".into()),
             },
             TrainerWrapper::WordPieceTrainer(t) => match model {
                 ModelWrapper::WordPiece(wp) => t.train(words, wp),
-                _ => unreachable!(),
+                _ => Err("WordPieceTrainer can only train a WordPiece".into()),
             },
             TrainerWrapper::WordLevelTrainer(t) => match model {
                 ModelWrapper::WordLevel(wl) => t.train(words, wl),
-                _ => unreachable!(),
+                _ => Err("WordLevelTrainer can only train a WordLevel".into()),
             },
             TrainerWrapper::UnigramTrainer(t) => match model {
                 ModelWrapper::Unigram(u) => t.train(words, u),
-                _ => unreachable!(),
+                _ => Err("UnigramTrainer can only train a Unigram".into()),
             },
         }
     }
@@ -184,3 +184,17 @@ impl_enum_from!(BpeTrainer, TrainerWrapper, BpeTrainer);
 impl_enum_from!(WordPieceTrainer, TrainerWrapper, WordPieceTrainer);
 impl_enum_from!(UnigramTrainer, TrainerWrapper, UnigramTrainer);
 impl_enum_from!(WordLevelTrainer, TrainerWrapper, WordLevelTrainer);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trainer_wrapper_train_model_wrapper() {
+        let trainer = TrainerWrapper::BpeTrainer(BpeTrainer::default());
+        let mut model = ModelWrapper::Unigram(Unigram::default());
+
+        let result = trainer.train(HashMap::new(), &mut model);
+        assert!(result.is_err());
+    }
+}

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -145,12 +145,28 @@ impl Trainer for TrainerWrapper {
         }
     }
 
-    fn train(&self, words: HashMap<String, u32>) -> Result<(Self::Model, Vec<AddedToken>)> {
+    fn train(
+        &self,
+        words: HashMap<String, u32>,
+        model: &mut ModelWrapper,
+    ) -> Result<Vec<AddedToken>> {
         match self {
-            TrainerWrapper::BpeTrainer(bpe) => bpe.train(words).map(|(m, t)| (m.into(), t)),
-            TrainerWrapper::WordPieceTrainer(wpt) => wpt.train(words).map(|(m, t)| (m.into(), t)),
-            TrainerWrapper::WordLevelTrainer(wpt) => wpt.train(words).map(|(m, t)| (m.into(), t)),
-            TrainerWrapper::UnigramTrainer(wpt) => wpt.train(words).map(|(m, t)| (m.into(), t)),
+            TrainerWrapper::BpeTrainer(t) => match model {
+                ModelWrapper::BPE(bpe) => t.train(words, bpe),
+                _ => unreachable!(),
+            },
+            TrainerWrapper::WordPieceTrainer(t) => match model {
+                ModelWrapper::WordPiece(wp) => t.train(words, wp),
+                _ => unreachable!(),
+            },
+            TrainerWrapper::WordLevelTrainer(t) => match model {
+                ModelWrapper::WordLevel(wl) => t.train(words, wl),
+                _ => unreachable!(),
+            },
+            TrainerWrapper::UnigramTrainer(t) => match model {
+                ModelWrapper::Unigram(u) => t.train(words, u),
+                _ => unreachable!(),
+            },
         }
     }
 

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -75,7 +75,7 @@ impl Model for ModelWrapper {
         }
     }
 
-    fn id_to_token(&self, id: u32) -> Option<&str> {
+    fn id_to_token(&self, id: u32) -> Option<String> {
         use ModelWrapper::*;
         match self {
             WordLevel(t) => t.id_to_token(id),
@@ -85,7 +85,7 @@ impl Model for ModelWrapper {
         }
     }
 
-    fn get_vocab(&self) -> &HashMap<String, u32> {
+    fn get_vocab(&self) -> HashMap<String, u32> {
         use ModelWrapper::*;
         match self {
             WordLevel(t) => t.get_vocab(),

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -409,8 +409,8 @@ impl<'a> Iterator for UnigramIterator<'a> {
 impl Model for Unigram {
     type Trainer = UnigramTrainer;
 
-    fn get_vocab(&self) -> &HashMap<String, u32> {
-        &self.token_to_ids
+    fn get_vocab(&self) -> HashMap<String, u32> {
+        self.token_to_ids.clone()
     }
 
     fn get_vocab_size(&self) -> usize {
@@ -438,9 +438,9 @@ impl Model for Unigram {
         self.token_to_ids.get(token).copied()
     }
 
-    fn id_to_token(&self, id: u32) -> Option<&str> {
+    fn id_to_token(&self, id: u32) -> Option<String> {
         match self.vocab.get(id as usize) {
-            Some(item) => Some(&item.0),
+            Some(item) => Some(item.0.clone()),
             None => None,
         }
     }

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -1,5 +1,8 @@
-use crate::models::unigram::lattice::Lattice;
-use crate::models::unigram::trie::{Trie, TrieBuilder};
+use super::{
+    lattice::Lattice,
+    trainer::UnigramTrainer,
+    trie::{Trie, TrieBuilder},
+};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::Cache;
 
@@ -404,6 +407,8 @@ impl<'a> Iterator for UnigramIterator<'a> {
 }
 
 impl Model for Unigram {
+    type Trainer = UnigramTrainer;
+
     fn get_vocab(&self) -> &HashMap<String, u32> {
         &self.token_to_ids
     }
@@ -451,6 +456,10 @@ impl Model for Unigram {
         let string = serde_json::to_string_pretty(self)?;
         std::fs::write(&fullpath, string)?;
         Ok(vec![fullpath])
+    }
+
+    fn get_trainer(&self) -> Self::Trainer {
+        UnigramTrainer::default()
     }
 }
 

--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -60,6 +60,12 @@ pub struct UnigramTrainer {
     seed_size: usize,
 }
 
+impl Default for UnigramTrainer {
+    fn default() -> Self {
+        Self::builder().build().unwrap()
+    }
+}
+
 impl UnigramTrainer {
     pub fn builder() -> UnigramTrainerBuilder {
         UnigramTrainerBuilder::default()

--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -531,16 +531,6 @@ impl Trainer for UnigramTrainer {
         self._train(sentences)
     }
 
-    /// Process a bunch of tokens, counting them
-    fn process_tokens(&self, words: &mut HashMap<String, u32>, tokens: Vec<String>) {
-        for token in tokens {
-            words
-                .entry(token.clone())
-                .and_modify(|c| *c += 1)
-                .or_insert(1);
-        }
-    }
-
     /// Whether we should show progress
     fn should_show_progress(&self) -> bool {
         self.show_progress

--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -450,7 +450,7 @@ impl UnigramTrainer {
             .collect();
         new_pieces
     }
-    pub fn _train(&self, sentences: Vec<Sentence>) -> Result<(Unigram, Vec<AddedToken>)> {
+    pub fn _train(&self, sentences: Vec<Sentence>, model: &mut Unigram) -> Result<Vec<AddedToken>> {
         let progress = self.setup_progress();
         //
         // 1. Compute frequent substrings
@@ -484,22 +484,22 @@ impl UnigramTrainer {
         let expected_updates = expected_loops as usize * self.n_sub_iterations as usize;
         self.update_progress(&progress, expected_updates, "EM training");
         let required_chars = self.required_chars(&sentences);
-        let mut model = Unigram::from(pieces.clone(), Some(0))?;
+        let mut new_model = Unigram::from(pieces.clone(), Some(0))?;
         loop {
             // Sub-EM iteration.
             for _iter in 0..self.n_sub_iterations {
                 // Executes E step
-                let (_objective, _num_tokens, expected) = self.run_e_step(&model, &sentences);
+                let (_objective, _num_tokens, expected) = self.run_e_step(&new_model, &sentences);
 
                 // Executes M step.
                 pieces = self.run_m_step(&pieces, &expected);
-                model = Unigram::from(pieces.clone(), Some(0))?;
+                new_model = Unigram::from(pieces.clone(), Some(0))?;
 
                 // Useful comment for checking compatibility with spm
                 debug!(
                     "Em iter={} size={} obj={} num_tokens={} num_tokens/piece={}",
                     _iter,
-                    model.len(),
+                    new_model.len(),
                     _objective,
                     _num_tokens,
                     _num_tokens as f64 / model.len() as f64
@@ -516,15 +516,15 @@ impl UnigramTrainer {
             }
 
             // Prunes pieces.
-            pieces = self.prune_sentence_pieces(&model, &pieces, &sentences);
-            model = Unigram::from(pieces.clone(), Some(0))?;
+            pieces = self.prune_sentence_pieces(&new_model, &pieces, &sentences);
+            new_model = Unigram::from(pieces.clone(), Some(0))?;
         }
         self.finalize_progress(&progress, expected_updates);
 
         // Finally, adjusts the size of sentencepices to be |vocab_size|.
-        model = self.finalize(model, required_chars)?;
+        *model = self.finalize(new_model, required_chars)?;
 
-        Ok((model, self.special_tokens.clone()))
+        Ok(self.special_tokens.clone())
     }
 }
 
@@ -532,9 +532,13 @@ impl Trainer for UnigramTrainer {
     type Model = Unigram;
 
     /// Train a Unigram model
-    fn train(&self, word_counts: HashMap<String, u32>) -> Result<(Self::Model, Vec<AddedToken>)> {
+    fn train(
+        &self,
+        word_counts: HashMap<String, u32>,
+        model: &mut Unigram,
+    ) -> Result<Vec<AddedToken>> {
         let sentences: Vec<_> = word_counts.into_iter().collect();
-        self._train(sentences)
+        self._train(sentences, model)
     }
 
     /// Whether we should show progress
@@ -633,11 +637,12 @@ mod tests {
             .build()
             .unwrap();
 
-        let (unigram, _) = trainer
-            .train(HashMap::from_iter(vec![
-                ("The".into(), 12),
-                ("are".into(), 11),
-            ]))
+        let mut unigram = Unigram::default();
+        trainer
+            .train(
+                HashMap::from_iter(vec![("The".into(), 12), ("are".into(), 11)]),
+                &mut unigram,
+            )
             .unwrap();
 
         let mut pieces = unigram.iter();
@@ -657,11 +662,12 @@ mod tests {
             .build()
             .unwrap();
 
-        let (unigram, _) = trainer
-            .train(HashMap::from_iter(vec![
-                ("The".into(), 12),
-                ("are".into(), 11),
-            ]))
+        let mut unigram = Unigram::default();
+        trainer
+            .train(
+                HashMap::from_iter(vec![("The".into(), 12), ("are".into(), 11)]),
+                &mut unigram,
+            )
             .unwrap();
 
         let mut pieces = unigram.iter();
@@ -675,11 +681,12 @@ mod tests {
             .build()
             .unwrap();
 
-        let (unigram, _) = trainer
-            .train(HashMap::from_iter(vec![
-                ("The".into(), 12),
-                ("are".into(), 11),
-            ]))
+        let mut unigram = Unigram::default();
+        trainer
+            .train(
+                HashMap::from_iter(vec![("The".into(), 12), ("are".into(), 11)]),
+                &mut unigram,
+            )
             .unwrap();
 
         let mut pieces = unigram.iter();
@@ -697,11 +704,12 @@ mod tests {
             .build()
             .unwrap();
 
-        let (unigram, _) = trainer
-            .train(HashMap::from_iter(vec![
-                ("The".into(), 12),
-                ("are".into(), 11),
-            ]))
+        let mut unigram = Unigram::default();
+        trainer
+            .train(
+                HashMap::from_iter(vec![("The".into(), 12), ("are".into(), 11)]),
+                &mut unigram,
+            )
             .unwrap();
 
         let mut pieces = unigram.iter();

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -183,12 +183,12 @@ impl Model for WordLevel {
         self.vocab.get(token).copied()
     }
 
-    fn id_to_token(&self, id: u32) -> Option<&str> {
-        self.vocab_r.get(&id).map(String::as_ref)
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        self.vocab_r.get(&id).cloned()
     }
 
-    fn get_vocab(&self) -> &HashMap<String, u32> {
-        &self.vocab
+    fn get_vocab(&self) -> HashMap<String, u32> {
+        self.vocab.clone()
     }
 
     fn get_vocab_size(&self) -> usize {

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -8,6 +8,10 @@ use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
 mod serialization;
+mod trainer;
+
+// Re-export
+pub use trainer::*;
 
 type Vocab = HashMap<String, u32>;
 

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -165,6 +165,8 @@ impl Default for WordLevel {
 }
 
 impl Model for WordLevel {
+    type Trainer = WordLevelTrainer;
+
     fn tokenize(&self, token: &str) -> Result<Vec<Token>> {
         Ok(vec![Token {
             id: *self
@@ -209,5 +211,9 @@ impl Model for WordLevel {
         vocab_file.write_all(&serialized.as_bytes())?;
 
         Ok(vec![vocab_path])
+    }
+
+    fn get_trainer(&self) -> Self::Trainer {
+        WordLevelTrainer::default()
     }
 }

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -2,15 +2,20 @@ use super::WordLevel;
 use crate::{AddedToken, Result, Trainer};
 use std::collections::HashMap;
 
+#[derive(Debug, Clone, Builder)]
 pub struct WordLevelTrainer {
     /// The minimum frequency a word must have to be part of the vocabulary
-    pub min_frequency: u32,
+    #[builder(default)]
+    min_frequency: u32,
     /// The target vocabulary size
-    pub vocab_size: usize,
+    #[builder(default)]
+    vocab_size: usize,
     /// Whether to show progress while training
-    pub show_progress: bool,
+    #[builder(default)]
+    show_progress: bool,
     /// A list of special tokens that the model should know of
-    pub special_tokens: Vec<AddedToken>,
+    #[builder(default)]
+    special_tokens: Vec<AddedToken>,
 }
 
 impl Default for WordLevelTrainer {
@@ -25,6 +30,10 @@ impl Default for WordLevelTrainer {
 }
 
 impl WordLevelTrainer {
+    pub fn builder() -> WordLevelTrainerBuilder {
+        WordLevelTrainerBuilder::default()
+    }
+
     fn train(
         &self,
         word_counts: HashMap<String, u32>,

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -1,0 +1,116 @@
+use super::WordLevel;
+use crate::{AddedToken, Result, Trainer};
+use std::collections::HashMap;
+
+pub struct WordLevelTrainer {
+    /// The minimum frequency a word must have to be part of the vocabulary
+    pub min_frequency: u32,
+    /// The target vocabulary size
+    pub vocab_size: usize,
+    /// Whether to show progress while training
+    pub show_progress: bool,
+    /// A list of special tokens that the model should know of
+    pub special_tokens: Vec<AddedToken>,
+}
+
+impl Default for WordLevelTrainer {
+    fn default() -> Self {
+        Self {
+            min_frequency: 0,
+            vocab_size: 30_000,
+            show_progress: true,
+            special_tokens: vec![],
+        }
+    }
+}
+
+impl WordLevelTrainer {
+    fn train(&self, word_counts: HashMap<String, u32>) -> Result<(WordLevel, Vec<AddedToken>)> {
+        let mut ordered_counts = word_counts.into_iter().collect::<Vec<_>>();
+        ordered_counts.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+        let word_level = WordLevel::builder()
+            .vocab(
+                self.special_tokens
+                    .iter()
+                    .map(|token| token.content.clone())
+                    .chain(
+                        ordered_counts
+                            .into_iter()
+                            .filter(|(_, n)| *n >= self.min_frequency)
+                            .map(|(w, _)| w),
+                    )
+                    .take(self.vocab_size)
+                    .enumerate()
+                    .map(|(i, w)| (w, i as u32))
+                    .collect(),
+            )
+            .build();
+
+        Ok((word_level, self.special_tokens.clone()))
+    }
+}
+
+impl Trainer for WordLevelTrainer {
+    type Model = WordLevel;
+
+    /// Train a WordLevel model
+    fn train(&self, word_counts: HashMap<String, u32>) -> Result<(WordLevel, Vec<AddedToken>)> {
+        self.train(word_counts)
+    }
+
+    /// Whether we should show progress
+    fn should_show_progress(&self) -> bool {
+        self.show_progress
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_train() {
+        let word_counts: HashMap<String, u32> = [
+            ("the".into(), 25),
+            ("roses".into(), 22),
+            ("are".into(), 24),
+            ("red".into(), 12),
+            ("voilets".into(), 10),
+            ("blue".into(), 16),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        let mut trainer = WordLevelTrainer::default();
+        trainer.vocab_size = 5;
+
+        let (model, _) = trainer.train(word_counts.clone()).unwrap();
+        let expected_vocab: HashMap<String, u32> = [
+            ("the".into(), 0),
+            ("are".into(), 1),
+            ("roses".into(), 2),
+            ("blue".into(), 3),
+            ("red".into(), 4),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        assert_eq!(model.vocab, expected_vocab);
+
+        // If we specify a min_frequency
+        trainer.min_frequency = 15;
+        let (model, _) = trainer.train(word_counts).unwrap();
+        let expected_vocab: HashMap<String, u32> = [
+            ("the".into(), 0),
+            ("are".into(), 1),
+            ("roses".into(), 2),
+            ("blue".into(), 3),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        assert_eq!(model.vocab, expected_vocab);
+    }
+}

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -185,10 +185,7 @@ impl WordPiece {
 
     /// Create a `WordPiece` model from a `BPE` model.
     pub fn from_bpe(bpe: &BPE) -> Self {
-        let mut wp = Self::builder()
-            .vocab(bpe.get_vocab().clone())
-            .build()
-            .unwrap();
+        let mut wp = Self::builder().vocab(bpe.get_vocab()).build().unwrap();
         if let Some(unk) = bpe.get_unk_token() {
             wp.unk_token = unk.to_owned();
         }
@@ -202,8 +199,8 @@ impl WordPiece {
 impl Model for WordPiece {
     type Trainer = WordPieceTrainer;
 
-    fn get_vocab(&self) -> &HashMap<String, u32> {
-        &self.vocab
+    fn get_vocab(&self) -> HashMap<String, u32> {
+        self.vocab.clone()
     }
 
     fn get_vocab_size(&self) -> usize {
@@ -275,8 +272,8 @@ impl Model for WordPiece {
         self.vocab.get(token).copied()
     }
 
-    fn id_to_token(&self, id: u32) -> Option<&str> {
-        self.vocab_r.get(&id).map(String::as_ref)
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        self.vocab_r.get(&id).cloned()
     }
 
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>> {

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -200,6 +200,8 @@ impl WordPiece {
 }
 
 impl Model for WordPiece {
+    type Trainer = WordPieceTrainer;
+
     fn get_vocab(&self) -> &HashMap<String, u32> {
         &self.vocab
     }
@@ -298,6 +300,10 @@ impl Model for WordPiece {
         )?;
 
         Ok(vec![vocab_path])
+    }
+
+    fn get_trainer(&self) -> Self::Trainer {
+        WordPieceTrainer::builder().build()
     }
 }
 

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -202,10 +202,10 @@ impl AddedVocabulary {
     }
 
     /// Get the token matching the given id if it exists
-    pub fn id_to_token<'s>(&'s self, id: u32, model: &'s impl Model) -> Option<&'s str> {
+    pub fn id_to_token(&self, id: u32, model: &impl Model) -> Option<String> {
         self.added_tokens_map_r
             .get(&id)
-            .map(|t| t.content.as_ref())
+            .map(|t| t.content.clone())
             .or_else(|| model.id_to_token(id))
     }
 
@@ -550,11 +550,11 @@ mod tests {
         fn token_to_id(&self, token: &str) -> Option<u32> {
             self.vocab.get(token).copied()
         }
-        fn id_to_token(&self, id: u32) -> Option<&str> {
-            self.vocab_r.get(&id).map(String::as_ref)
+        fn id_to_token(&self, id: u32) -> Option<String> {
+            self.vocab_r.get(&id).cloned()
         }
-        fn get_vocab(&self) -> &HashMap<String, u32> {
-            &self.vocab
+        fn get_vocab(&self) -> HashMap<String, u32> {
+            self.vocab.clone()
         }
         fn get_vocab_size(&self) -> usize {
             self.vocab.len()

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -499,7 +499,7 @@ mod tests {
     use super::*;
     use crate::normalizers::utils::Lowercase;
     use crate::normalizers::NormalizerWrapper;
-    use crate::{OffsetReferential, OffsetType, Result, Token};
+    use crate::{OffsetReferential, OffsetType, Result, Token, Trainer};
     use std::path::{Path, PathBuf};
 
     #[derive(Serialize, Deserialize)]
@@ -526,7 +526,20 @@ mod tests {
         }
     }
 
+    struct TrainerMock;
+    impl Trainer for TrainerMock {
+        type Model = ModelMock;
+        fn should_show_progress(&self) -> bool {
+            true
+        }
+        fn train(&self, _words: HashMap<String, u32>) -> Result<(ModelMock, Vec<AddedToken>)> {
+            unimplemented!()
+        }
+    }
+
     impl Model for ModelMock {
+        type Trainer = TrainerMock;
+
         fn tokenize(&self, _sequence: &str) -> Result<Vec<Token>> {
             unimplemented!()
         }
@@ -544,6 +557,9 @@ mod tests {
         }
         fn save(&self, _folder: &Path, _name: Option<&str>) -> Result<Vec<PathBuf>> {
             unimplemented!()
+        }
+        fn get_trainer(&self) -> Self::Trainer {
+            TrainerMock
         }
     }
 

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -532,7 +532,11 @@ mod tests {
         fn should_show_progress(&self) -> bool {
             true
         }
-        fn train(&self, _words: HashMap<String, u32>) -> Result<(ModelMock, Vec<AddedToken>)> {
+        fn train(
+            &self,
+            _words: HashMap<String, u32>,
+            _model: &mut ModelMock,
+        ) -> Result<Vec<AddedToken>> {
             unimplemented!()
         }
     }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -585,7 +585,7 @@ where
 
     /// Get the vocabulary
     pub fn get_vocab(&self, with_added_tokens: bool) -> HashMap<String, u32> {
-        let mut final_vocab = self.model.get_vocab().clone();
+        let mut final_vocab = self.model.get_vocab();
 
         if with_added_tokens {
             let added_vocab = self.added_vocabulary.get_vocab();
@@ -763,7 +763,6 @@ where
                     .filter(|token| {
                         !skip_special_tokens || !self.added_vocabulary.is_special_token(token)
                     })
-                    .map(|t| t.to_owned())
             })
             .collect::<Vec<_>>();
 

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -68,6 +68,7 @@ pub trait PreTokenizer {
 
 /// Represents a model used during Tokenization (like BPE or Word or Unigram).
 pub trait Model {
+    type Trainer: Trainer + Sync;
     /// Tokenize the given sequence into multiple underlying `Token`. The `offsets` on the `Token`
     /// are expected to be relative to the given sequence.
     fn tokenize(&self, sequence: &str) -> Result<Vec<Token>>;
@@ -82,6 +83,8 @@ pub trait Model {
     /// Save the current `Model` in the given folder, using the given `prefix` for the various
     /// files that need to be saved.
     fn save(&self, folder: &Path, prefix: Option<&str>) -> Result<Vec<PathBuf>>;
+    /// Get an instance of a Trainer capable of training this Model
+    fn get_trainer(&self) -> <Self as Model>::Trainer;
 }
 
 /// A `PostProcessor` has the responsibility to post process an encoded output of the `Tokenizer`.

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -1056,7 +1056,7 @@ where
     }
 
     /// Train a model and replace our current Model, using the given Trainer
-    pub fn train<T>(&mut self, trainer: &T, files: Vec<String>) -> Result<()>
+    pub fn train<T>(&mut self, trainer: &T, files: Vec<String>) -> Result<&mut Self>
     where
         T: Trainer<Model = M> + Sync,
     {
@@ -1065,7 +1065,7 @@ where
         let special_tokens = trainer.train(words, &mut self.model)?;
         self.add_special_tokens(&special_tokens);
 
-        Ok(())
+        Ok(self)
     }
 }
 

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -133,7 +133,14 @@ pub trait Trainer {
         words: HashMap<String, u32>,
     ) -> Result<(<Self as Trainer>::Model, Vec<AddedToken>)>;
     /// Process a bunch of token, counting them as relevant.
-    fn process_tokens(&self, words: &mut HashMap<String, u32>, tokens: Vec<String>);
+    fn process_tokens(&self, words: &mut HashMap<String, u32>, tokens: Vec<String>) {
+        for token in tokens {
+            words
+                .entry(token.clone())
+                .and_modify(|c| *c += 1)
+                .or_insert(1);
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -75,9 +75,9 @@ pub trait Model {
     /// Find the ID associated to a string token
     fn token_to_id(&self, token: &str) -> Option<u32>;
     /// Find the string token associated to an ID
-    fn id_to_token(&self, id: u32) -> Option<&str>;
+    fn id_to_token(&self, id: u32) -> Option<String>;
     /// Retrieve the entire vocabulary mapping (token -> ID)
-    fn get_vocab(&self) -> &HashMap<String, u32>;
+    fn get_vocab(&self) -> HashMap<String, u32>;
     /// Retrieve the size of the vocabulary
     fn get_vocab_size(&self) -> usize;
     /// Save the current `Model` in the given folder, using the given `prefix` for the various
@@ -616,7 +616,7 @@ where
     }
 
     /// Converts an id to the corresponding token.
-    pub fn id_to_token(&self, id: u32) -> Option<&str> {
+    pub fn id_to_token(&self, id: u32) -> Option<String> {
         self.added_vocabulary.id_to_token(id, &self.model)
     }
 

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -70,7 +70,12 @@ fn quicktour_slow_train() -> tokenizers::Result<()> {
         PreTokenizerWrapper,
         PostProcessorWrapper,
         DecoderWrapper,
-    > = TokenizerImpl::new(BPE::default());
+    > = TokenizerImpl::new(
+        BPE::builder()
+            .unk_token("[UNK]".to_string())
+            .build()
+            .unwrap(),
+    );
     // END quicktour_init_tokenizer
     // START quicktour_init_trainer
     use tokenizers::models::bpe::BpeTrainer;
@@ -99,22 +104,6 @@ fn quicktour_slow_train() -> tokenizers::Result<()> {
     ];
     tokenizer.train(&trainer, files)?;
     // END quicktour_train
-    // START quicktour_reload_model
-    use std::path::Path;
-    use tokenizers::Model;
-
-    let saved_files = tokenizer
-        .get_model()
-        .save(&Path::new("data"), Some("wiki"))?;
-    tokenizer.with_model(
-        BPE::from_file(
-            saved_files[0].to_str().unwrap(),
-            &saved_files[1].to_str().unwrap(),
-        )
-        .unk_token("[UNK]".to_string())
-        .build()?,
-    );
-    // END quicktour_reload_model
     // START quicktour_save
     tokenizer.save("data/tokenizer-wiki.json", false)?;
     // END quicktour_save
@@ -375,7 +364,12 @@ fn train_pipeline_bert() -> tokenizers::Result<()> {
     use tokenizers::models::wordpiece::WordPiece;
     use tokenizers::Tokenizer;
 
-    let mut bert_tokenizer = Tokenizer::new(WordPiece::default());
+    let mut bert_tokenizer = Tokenizer::new(
+        WordPiece::builder()
+            .unk_token("[UNK]".to_string())
+            .build()
+            .unwrap(),
+    );
     // END bert_setup_tokenizer
     // START bert_setup_normalizer
     use tokenizers::normalizers::utils::Sequence as NormalizerSequence;
@@ -407,9 +401,7 @@ fn train_pipeline_bert() -> tokenizers::Result<()> {
     );
     // END bert_setup_processor
     // START bert_train_tokenizer
-    use std::path::Path;
     use tokenizers::models::{wordpiece::WordPieceTrainer, TrainerWrapper};
-    use tokenizers::Model;
 
     let trainer: TrainerWrapper = WordPieceTrainer::builder()
         .vocab_size(30_522)
@@ -428,16 +420,6 @@ fn train_pipeline_bert() -> tokenizers::Result<()> {
         "data/wikitext-103-raw/wiki.valid.raw".into(),
     ];
     bert_tokenizer.train(&trainer, files)?;
-
-    let model_files = bert_tokenizer
-        .get_model()
-        .save(&Path::new("data"), Some("bert-wiki"))?;
-    bert_tokenizer.with_model(
-        WordPiece::from_file(model_files[0].to_str().unwrap())
-            .unk_token("[UNK]".to_string())
-            .build()
-            .unwrap(),
-    );
 
     bert_tokenizer.save("data/bert-wiki.json", false)?;
     // END bert_train_tokenizer

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -8,7 +8,7 @@ use tokenizers::{Tokenizer, TokenizerImpl};
 #[test]
 fn train_tokenizer() {
     let vocab_size: usize = 100;
-    let tokenizer = TokenizerBuilder::new()
+    let mut tokenizer = TokenizerBuilder::new()
         .with_model(BPE::default())
         .with_normalizer(Some(Sequence::new(vec![
             Strip::new(true, true).into(),
@@ -97,7 +97,7 @@ fn quicktour_slow_train() -> tokenizers::Result<()> {
         "data/wikitext-103-raw/wiki.test.raw".into(),
         "data/wikitext-103-raw/wiki.valid.raw".into(),
     ];
-    tokenizer.train_and_replace(&trainer, files)?;
+    tokenizer.train(&trainer, files)?;
     // END quicktour_train
     // START quicktour_reload_model
     use std::path::Path;
@@ -427,7 +427,7 @@ fn train_pipeline_bert() -> tokenizers::Result<()> {
         "data/wikitext-103-raw/wiki.test.raw".into(),
         "data/wikitext-103-raw/wiki.valid.raw".into(),
     ];
-    bert_tokenizer.train_and_replace(&trainer, files)?;
+    bert_tokenizer.train(&trainer, files)?;
 
     let model_files = bert_tokenizer
         .get_model()

--- a/tokenizers/tests/training.rs
+++ b/tokenizers/tests/training.rs
@@ -1,0 +1,29 @@
+use tokenizers::models::bpe::BPE;
+use tokenizers::{DecoderWrapper, NormalizerWrapper, PostProcessorWrapper, PreTokenizerWrapper};
+use tokenizers::{Model, TokenizerBuilder};
+
+#[test]
+fn bpe_values_after_training() {
+    let mut tokenizer = TokenizerBuilder::<
+        BPE,
+        NormalizerWrapper,
+        PreTokenizerWrapper,
+        PostProcessorWrapper,
+        DecoderWrapper,
+    >::default()
+    .with_model(
+        BPE::builder()
+            .unk_token("[UNK]".to_string())
+            .dropout(0.1)
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+    let trainer = tokenizer.get_model().get_trainer();
+    tokenizer
+        .train(&trainer, vec!["./data/small.txt".to_string()])
+        .unwrap();
+    assert_eq!(tokenizer.get_model().dropout, Some(0.1));
+    assert_eq!(tokenizer.get_model().unk_token, Some("[UNK]".to_string()));
+}

--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -55,7 +55,8 @@ fn test_train_unigram_from_file() {
         .unk_token(Some("<UNK>".into()))
         .build()
         .unwrap();
-    let (model, _) = trainer.train(word_counts).unwrap();
+    let mut model = Unigram::default();
+    trainer.train(word_counts, &mut model).unwrap();
     assert_eq!(model.get_vocab_size(), 719);
 }
 


### PR DESCRIPTION
- Add a `WordLevelTrainer` (Fix #265)
- Add a default impl for `Trainer::process_tokens`
- Each `Model` can now return its associated trainer with `get_trainer`. This removes the need to provide a trainer in Python (could be optional on Rust too) (Fix #527)
- The `Model` on the `Tokenizer` now gets trained in-place. This allows keeping its customization (dropout, unk_token, ...) while just training it. That's also more in line with the role of the trainer, which is to train a Model, not to build one. (Fix #201 & Fix #526)
- This makes us wrap the `Model` in a `RwLock` on the Python's side. This is something that we'll have to do anyway very soon to provide the ability to customize the components properties in Python.

Missing before merge:
 - [x] Node bindings
 - [x] Update parts of the docs where we reload the `Model` after training
 - [x] Update parts of the docs where `Tokenizer.train` is used