### PR TITLE
Python - Mutable components

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#542]: Add Split pre-tokenizer to easily split using a pattern
 
+### Changed
+- [#530]: The various attributes on each component can be get/set
+
 ## [0.9.4]
 
 ### Fixed
@@ -276,6 +279,7 @@ delimiter (Works like `.split(delimiter)`)
 
 
 [#542]: https://github.com/huggingface/tokenizers/pull/542
+[#530]: https://github.com/huggingface/tokenizers/pull/530
 [#506]: https://github.com/huggingface/tokenizers/pull/506
 [#500]: https://github.com/huggingface/tokenizers/pull/500
 [#498]: https://github.com/huggingface/tokenizers/pull/498

--- a/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
@@ -417,12 +417,37 @@ class Split(PreTokenizer):
         pass
     def pre_tokenize(self, pretok):
         """
-        Pre tokenize the given PreTokenizedString in-place
+        Pre-tokenize a :class:`~tokenizers.PyPreTokenizedString` in-place
+
+        This method allows to modify a :class:`~tokenizers.PreTokenizedString` to
+        keep track of the pre-tokenization, and leverage the capabilities of the
+        :class:`~tokenizers.PreTokenizedString`. If you just want to see the result of
+        the pre-tokenization of a raw string, you can use
+        :meth:`~tokenizers.pre_tokenizers.PreTokenizer.pre_tokenize_str`
+
+        Args:
+            pretok (:class:`~tokenizers.PreTokenizedString):
+                The pre-tokenized string on which to apply this
+                :class:`~tokenizers.pre_tokenizers.PreTokenizer`
         """
         pass
     def pre_tokenize_str(self, sequence):
         """
-        Pre tokenize the given sequence
+        Pre tokenize the given string
+
+        This method provides a way to visualize the effect of a
+        :class:`~tokenizers.pre_tokenizers.PreTokenizer` but it does not keep track of the
+        alignment, nor does it provide all the capabilities of the
+        :class:`~tokenizers.PreTokenizedString`. If you need some of these, you can use
+        :meth:`~tokenizers.pre_tokenizers.PreTokenizer.pre_tokenize`
+
+        Args:
+            sequence (:obj:`str`):
+                A string to pre-tokeize
+
+        Returns:
+            :obj:`List[Tuple[str, Offsets]]`:
+                A list of tuple with the pre-tokenized parts and their offsets
         """
         pass
 

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -115,7 +115,7 @@ macro_rules! getter {
         } else {
             unreachable!()
         }
-    }}
+    }};
 }
 
 macro_rules! setter {

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -33,7 +33,7 @@ impl PyObjectProtocol for PyEncoding {
 
 #[pyproto]
 impl PySequenceProtocol for PyEncoding {
-    fn __len__(self) -> PyResult<usize> {
+    fn __len__(&self) -> PyResult<usize> {
         Ok(self.encoding.len())
     }
 }

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -700,56 +700,59 @@ impl PyWordPiece {
 #[text_signature = "(self, vocab, unk_token)"]
 pub struct PyWordLevel {}
 
-impl PyWordLevel {
-    fn get_unk(kwargs: Option<&PyDict>) -> PyResult<String> {
-        let mut unk_token = String::from("<unk>");
-
-        if let Some(kwargs) = kwargs {
-            for (key, val) in kwargs {
-                let key: &str = key.extract()?;
-                match key {
-                    "unk_token" => unk_token = val.extract()?,
-                    _ => println!("Ignored unknown kwargs option {}", key),
-                }
-            }
-        }
-        Ok(unk_token)
-    }
-}
-
 #[pymethods]
 impl PyWordLevel {
+    #[getter]
+    fn get_unk_token(self_: PyRef<Self>) -> String {
+        let super_ = self_.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::WordLevel(ref wl) = *model {
+            wl.unk_token.clone()
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[setter]
+    fn set_unk_token(self_: PyRef<Self>, unk_token: String) {
+        let super_ = self_.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::WordLevel(ref mut wl) = *model {
+            wl.unk_token = unk_token;
+        }
+    }
+
     #[new]
-    #[args(kwargs = "**")]
-    fn new(vocab: Option<PyVocab>, kwargs: Option<&PyDict>) -> PyResult<(Self, PyModel)> {
-        let unk_token = PyWordLevel::get_unk(kwargs)?;
+    #[args(unk_token = "None")]
+    fn new(vocab: Option<PyVocab>, unk_token: Option<String>) -> PyResult<(Self, PyModel)> {
+        let mut builder = WordLevel::builder();
 
         if let Some(vocab) = vocab {
-            let model = match vocab {
-                PyVocab::Vocab(vocab) => WordLevel::builder()
-                    .vocab(vocab)
-                    .unk_token(unk_token)
-                    .build()
-                    .expect("Can only fail when loading from files"),
+            match vocab {
+                PyVocab::Vocab(vocab) => {
+                    builder = builder.vocab(vocab);
+                }
                 PyVocab::Filename(vocab_filename) => {
                     deprecation_warning(
                         "0.9.0",
                         "WordLevel.__init__ will not create from files anymore, \
                             try `WordLevel.from_file` instead",
                     )?;
-                    WordLevel::from_file(vocab_filename, unk_token).map_err(|e| {
-                        exceptions::PyException::new_err(format!(
-                            "Error while loading WordLevel: {}",
-                            e
-                        ))
-                    })?
+                    builder = builder.files(vocab_filename.to_string());
                 }
             };
-
-            Ok((PyWordLevel {}, model.into()))
-        } else {
-            Ok((PyWordLevel {}, WordLevel::default().into()))
         }
+        if let Some(unk_token) = unk_token {
+            builder = builder.unk_token(unk_token);
+        }
+
+        Ok((
+            PyWordLevel {},
+            builder
+                .build()
+                .map_err(|e| exceptions::PyException::new_err(e.to_string()))?
+                .into(),
+        ))
     }
 
     /// Read a :obj:`vocab.json`
@@ -790,17 +793,20 @@ impl PyWordLevel {
     /// Returns:
     ///     :class:`~tokenizers.models.WordLevel`: And instance of WordLevel loaded from file
     #[classmethod]
-    #[args(kwargs = "**")]
+    #[args(unk_token = "None")]
     fn from_file(
         _cls: &PyType,
         py: Python,
         vocab: &str,
-        kwargs: Option<&PyDict>,
+        unk_token: Option<String>,
     ) -> PyResult<Py<Self>> {
         let vocab = WordLevel::read_file(vocab).map_err(|e| {
             exceptions::PyException::new_err(format!("Error while reading WordLevel file: {}", e))
         })?;
-        Py::new(py, PyWordLevel::new(Some(PyVocab::Vocab(vocab)), kwargs)?)
+        Py::new(
+            py,
+            PyWordLevel::new(Some(PyVocab::Vocab(vocab)), unk_token)?,
+        )
     }
 }
 

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -287,6 +287,109 @@ enum PyMerges<'a> {
 
 #[pymethods]
 impl PyBPE {
+    #[getter]
+    fn get_dropout(self_: PyRef<Self>) -> Option<f64> {
+        let super_ = self_.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::BPE(ref bpe) = *model {
+            bpe.dropout.map(|d| d as f64)
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[setter]
+    fn set_dropout(self_: PyRef<Self>, dropout: Option<f32>) {
+        let super_ = self_.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::BPE(ref mut bpe) = *model {
+            bpe.dropout = dropout;
+        }
+    }
+
+    #[getter]
+    fn get_unk_token(self_: PyRef<Self>) -> Option<String> {
+        let super_ = self_.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::BPE(ref bpe) = *model {
+            bpe.unk_token.clone()
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[setter]
+    fn set_unk_token(self_: PyRef<Self>, unk_token: Option<String>) {
+        let super_ = self_.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::BPE(ref mut bpe) = *model {
+            bpe.unk_token = unk_token;
+        }
+    }
+
+    #[getter]
+    fn get_continuing_subword_prefix(self_: PyRef<Self>) -> Option<String> {
+        let super_ = self_.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::BPE(ref bpe) = *model {
+            bpe.continuing_subword_prefix.clone()
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[setter]
+    fn set_continuing_subword_prefix(
+        self_: PyRef<Self>,
+        continuing_subword_prefix: Option<String>,
+    ) {
+        let super_ = self_.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::BPE(ref mut bpe) = *model {
+            bpe.continuing_subword_prefix = continuing_subword_prefix;
+        }
+    }
+
+    #[getter]
+    fn get_end_of_word_suffix(self_: PyRef<Self>) -> Option<String> {
+        let super_ = self_.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::BPE(ref bpe) = *model {
+            bpe.end_of_word_suffix.clone()
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[setter]
+    fn set_end_of_word_suffix(self_: PyRef<Self>, end_of_word_suffix: Option<String>) {
+        let super_ = self_.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::BPE(ref mut bpe) = *model {
+            bpe.end_of_word_suffix = end_of_word_suffix;
+        }
+    }
+
+    #[getter]
+    fn get_fuse_unk(self_: PyRef<Self>) -> bool {
+        let super_ = self_.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::BPE(ref bpe) = *model {
+            bpe.fuse_unk
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[setter]
+    fn set_fuse_unk(self_: PyRef<Self>, fuse_unk: bool) {
+        let super_ = self_.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::BPE(ref mut bpe) = *model {
+            bpe.fuse_unk = fuse_unk;
+        }
+    }
+
     #[new]
     #[args(kwargs = "**")]
     fn new(

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -549,6 +549,66 @@ impl PyWordPiece {
 
 #[pymethods]
 impl PyWordPiece {
+    #[getter]
+    fn get_unk_token(self_: PyRef<Self>) -> String {
+        let super_ = self_.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::WordPiece(ref wp) = *model {
+            wp.unk_token.clone()
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[setter]
+    fn set_unk_token(self_: PyRef<Self>, unk_token: String) {
+        let super_ = self_.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::WordPiece(ref mut wp) = *model {
+            wp.unk_token = unk_token;
+        }
+    }
+
+    #[getter]
+    fn get_continuing_subword_prefix(self_: PyRef<Self>) -> String {
+        let super_ = self_.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::WordPiece(ref wp) = *model {
+            wp.continuing_subword_prefix.clone()
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[setter]
+    fn set_continuing_subword_prefix(self_: PyRef<Self>, continuing_subword_prefix: String) {
+        let super_ = self_.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::WordPiece(ref mut wp) = *model {
+            wp.continuing_subword_prefix = continuing_subword_prefix;
+        }
+    }
+
+    #[getter]
+    fn get_max_input_chars_per_word(self_: PyRef<Self>) -> usize {
+        let super_ = self_.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::WordPiece(ref wp) = *model {
+            wp.max_input_chars_per_word
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[setter]
+    fn set_max_input_chars_per_word(self_: PyRef<Self>, max: usize) {
+        let super_ = self_.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::WordPiece(ref mut wp) = *model {
+            wp.max_input_chars_per_word = max;
+        }
+    }
+
     #[new]
     #[args(kwargs = "**")]
     fn new(vocab: Option<PyVocab>, kwargs: Option<&PyDict>) -> PyResult<(Self, PyModel)> {

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -274,6 +274,28 @@ impl PyBPE {
     }
 }
 
+macro_rules! getter {
+    ($self: ident, $variant: ident, $($name: tt)+) => {{
+        let super_ = $self.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::$variant(ref mo) = *model {
+            mo.$($name)+
+        } else {
+            unreachable!()
+        }
+    }};
+}
+
+macro_rules! setter {
+    ($self: ident, $variant: ident, $name: ident, $value: expr) => {{
+        let super_ = $self.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::$variant(ref mut mo) = *model {
+            mo.$name = $value;
+        }
+    }};
+}
+
 #[derive(FromPyObject)]
 enum PyVocab<'a> {
     Vocab(Vocab),
@@ -288,54 +310,28 @@ enum PyMerges<'a> {
 #[pymethods]
 impl PyBPE {
     #[getter]
-    fn get_dropout(self_: PyRef<Self>) -> Option<f64> {
-        let super_ = self_.as_ref();
-        let model = super_.model.read().unwrap();
-        if let ModelWrapper::BPE(ref bpe) = *model {
-            bpe.dropout.map(|d| d as f64)
-        } else {
-            unreachable!()
-        }
+    fn get_dropout(self_: PyRef<Self>) -> Option<f32> {
+        getter!(self_, BPE, dropout)
     }
 
     #[setter]
     fn set_dropout(self_: PyRef<Self>, dropout: Option<f32>) {
-        let super_ = self_.as_ref();
-        let mut model = super_.model.write().unwrap();
-        if let ModelWrapper::BPE(ref mut bpe) = *model {
-            bpe.dropout = dropout;
-        }
+        setter!(self_, BPE, dropout, dropout);
     }
 
     #[getter]
     fn get_unk_token(self_: PyRef<Self>) -> Option<String> {
-        let super_ = self_.as_ref();
-        let model = super_.model.read().unwrap();
-        if let ModelWrapper::BPE(ref bpe) = *model {
-            bpe.unk_token.clone()
-        } else {
-            unreachable!()
-        }
+        getter!(self_, BPE, unk_token.clone())
     }
 
     #[setter]
     fn set_unk_token(self_: PyRef<Self>, unk_token: Option<String>) {
-        let super_ = self_.as_ref();
-        let mut model = super_.model.write().unwrap();
-        if let ModelWrapper::BPE(ref mut bpe) = *model {
-            bpe.unk_token = unk_token;
-        }
+        setter!(self_, BPE, unk_token, unk_token);
     }
 
     #[getter]
     fn get_continuing_subword_prefix(self_: PyRef<Self>) -> Option<String> {
-        let super_ = self_.as_ref();
-        let model = super_.model.read().unwrap();
-        if let ModelWrapper::BPE(ref bpe) = *model {
-            bpe.continuing_subword_prefix.clone()
-        } else {
-            unreachable!()
-        }
+        getter!(self_, BPE, continuing_subword_prefix.clone())
     }
 
     #[setter]
@@ -343,51 +339,32 @@ impl PyBPE {
         self_: PyRef<Self>,
         continuing_subword_prefix: Option<String>,
     ) {
-        let super_ = self_.as_ref();
-        let mut model = super_.model.write().unwrap();
-        if let ModelWrapper::BPE(ref mut bpe) = *model {
-            bpe.continuing_subword_prefix = continuing_subword_prefix;
-        }
+        setter!(
+            self_,
+            BPE,
+            continuing_subword_prefix,
+            continuing_subword_prefix
+        );
     }
 
     #[getter]
     fn get_end_of_word_suffix(self_: PyRef<Self>) -> Option<String> {
-        let super_ = self_.as_ref();
-        let model = super_.model.read().unwrap();
-        if let ModelWrapper::BPE(ref bpe) = *model {
-            bpe.end_of_word_suffix.clone()
-        } else {
-            unreachable!()
-        }
+        getter!(self_, BPE, end_of_word_suffix.clone())
     }
 
     #[setter]
     fn set_end_of_word_suffix(self_: PyRef<Self>, end_of_word_suffix: Option<String>) {
-        let super_ = self_.as_ref();
-        let mut model = super_.model.write().unwrap();
-        if let ModelWrapper::BPE(ref mut bpe) = *model {
-            bpe.end_of_word_suffix = end_of_word_suffix;
-        }
+        setter!(self_, BPE, end_of_word_suffix, end_of_word_suffix);
     }
 
     #[getter]
     fn get_fuse_unk(self_: PyRef<Self>) -> bool {
-        let super_ = self_.as_ref();
-        let model = super_.model.read().unwrap();
-        if let ModelWrapper::BPE(ref bpe) = *model {
-            bpe.fuse_unk
-        } else {
-            unreachable!()
-        }
+        getter!(self_, BPE, fuse_unk)
     }
 
     #[setter]
     fn set_fuse_unk(self_: PyRef<Self>, fuse_unk: bool) {
-        let super_ = self_.as_ref();
-        let mut model = super_.model.write().unwrap();
-        if let ModelWrapper::BPE(ref mut bpe) = *model {
-            bpe.fuse_unk = fuse_unk;
-        }
+        setter!(self_, BPE, fuse_unk, fuse_unk);
     }
 
     #[new]
@@ -551,62 +528,37 @@ impl PyWordPiece {
 impl PyWordPiece {
     #[getter]
     fn get_unk_token(self_: PyRef<Self>) -> String {
-        let super_ = self_.as_ref();
-        let model = super_.model.read().unwrap();
-        if let ModelWrapper::WordPiece(ref wp) = *model {
-            wp.unk_token.clone()
-        } else {
-            unreachable!()
-        }
+        getter!(self_, WordPiece, unk_token.clone())
     }
 
     #[setter]
     fn set_unk_token(self_: PyRef<Self>, unk_token: String) {
-        let super_ = self_.as_ref();
-        let mut model = super_.model.write().unwrap();
-        if let ModelWrapper::WordPiece(ref mut wp) = *model {
-            wp.unk_token = unk_token;
-        }
+        setter!(self_, WordPiece, unk_token, unk_token);
     }
 
     #[getter]
     fn get_continuing_subword_prefix(self_: PyRef<Self>) -> String {
-        let super_ = self_.as_ref();
-        let model = super_.model.read().unwrap();
-        if let ModelWrapper::WordPiece(ref wp) = *model {
-            wp.continuing_subword_prefix.clone()
-        } else {
-            unreachable!()
-        }
+        getter!(self_, WordPiece, continuing_subword_prefix.clone())
     }
 
     #[setter]
     fn set_continuing_subword_prefix(self_: PyRef<Self>, continuing_subword_prefix: String) {
-        let super_ = self_.as_ref();
-        let mut model = super_.model.write().unwrap();
-        if let ModelWrapper::WordPiece(ref mut wp) = *model {
-            wp.continuing_subword_prefix = continuing_subword_prefix;
-        }
+        setter!(
+            self_,
+            WordPiece,
+            continuing_subword_prefix,
+            continuing_subword_prefix
+        );
     }
 
     #[getter]
     fn get_max_input_chars_per_word(self_: PyRef<Self>) -> usize {
-        let super_ = self_.as_ref();
-        let model = super_.model.read().unwrap();
-        if let ModelWrapper::WordPiece(ref wp) = *model {
-            wp.max_input_chars_per_word
-        } else {
-            unreachable!()
-        }
+        getter!(self_, WordPiece, max_input_chars_per_word)
     }
 
     #[setter]
     fn set_max_input_chars_per_word(self_: PyRef<Self>, max: usize) {
-        let super_ = self_.as_ref();
-        let mut model = super_.model.write().unwrap();
-        if let ModelWrapper::WordPiece(ref mut wp) = *model {
-            wp.max_input_chars_per_word = max;
-        }
+        setter!(self_, WordPiece, max_input_chars_per_word, max);
     }
 
     #[new]
@@ -704,22 +656,12 @@ pub struct PyWordLevel {}
 impl PyWordLevel {
     #[getter]
     fn get_unk_token(self_: PyRef<Self>) -> String {
-        let super_ = self_.as_ref();
-        let model = super_.model.read().unwrap();
-        if let ModelWrapper::WordLevel(ref wl) = *model {
-            wl.unk_token.clone()
-        } else {
-            unreachable!()
-        }
+        getter!(self_, WordLevel, unk_token.clone())
     }
 
     #[setter]
     fn set_unk_token(self_: PyRef<Self>, unk_token: String) {
-        let super_ = self_.as_ref();
-        let mut model = super_.model.write().unwrap();
-        if let ModelWrapper::WordLevel(ref mut wl) = *model {
-            wl.unk_token = unk_token;
-        }
+        setter!(self_, WordLevel, unk_token, unk_token);
     }
 
     #[new]

--- a/bindings/python/src/normalizers.rs
+++ b/bindings/python/src/normalizers.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, RwLock};
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
+use pyo3::PySequenceProtocol;
 
 use crate::error::ToPyResult;
 use crate::utils::{PyNormalizedString, PyNormalizedStringRefMut, PyPattern};
@@ -338,6 +339,13 @@ impl PySequence {
 
     fn __getnewargs__<'p>(&self, py: Python<'p>) -> PyResult<&'p PyTuple> {
         Ok(PyTuple::new(py, &[PyList::empty(py)]))
+    }
+}
+
+#[pyproto]
+impl PySequenceProtocol for PySequence {
+    fn __len__(&self) -> usize {
+        0
     }
 }
 

--- a/bindings/python/src/normalizers.rs
+++ b/bindings/python/src/normalizers.rs
@@ -146,6 +146,34 @@ impl PyNormalizer {
     }
 }
 
+macro_rules! getter {
+    ($self: ident, $variant: ident, $name: ident) => {{
+        let super_ = $self.as_ref();
+        if let PyNormalizerTypeWrapper::Single(ref norm) = super_.normalizer {
+            let wrapper = norm.read().unwrap();
+            if let PyNormalizerWrapper::Wrapped(NormalizerWrapper::$variant(o)) = *wrapper {
+                o.$name
+            } else {
+                unreachable!()
+            }
+        } else {
+            unreachable!()
+        }
+    }};
+}
+
+macro_rules! setter {
+    ($self: ident, $variant: ident, $name: ident, $value: expr) => {{
+        let super_ = $self.as_ref();
+        if let PyNormalizerTypeWrapper::Single(ref norm) = super_.normalizer {
+            let mut wrapper = norm.write().unwrap();
+            if let PyNormalizerWrapper::Wrapped(NormalizerWrapper::$variant(ref mut o)) = *wrapper {
+                o.$name = $value;
+            }
+        }
+    }};
+}
+
 /// BertNormalizer
 ///
 /// Takes care of normalizing raw text before giving it to a Bert model.
@@ -170,6 +198,51 @@ impl PyNormalizer {
 pub struct PyBertNormalizer {}
 #[pymethods]
 impl PyBertNormalizer {
+    #[getter]
+    fn get_clean_text(self_: PyRef<Self>) -> bool {
+        getter!(self_, BertNormalizer, clean_text)
+    }
+
+    #[setter]
+    fn set_clean_text(self_: PyRef<Self>, clean_text: bool) {
+        setter!(self_, BertNormalizer, clean_text, clean_text);
+    }
+
+    #[getter]
+    fn get_handle_chinese_chars(self_: PyRef<Self>) -> bool {
+        getter!(self_, BertNormalizer, handle_chinese_chars)
+    }
+
+    #[setter]
+    fn set_handle_chinese_chars(self_: PyRef<Self>, handle_chinese_chars: bool) {
+        setter!(
+            self_,
+            BertNormalizer,
+            handle_chinese_chars,
+            handle_chinese_chars
+        );
+    }
+
+    #[getter]
+    fn get_strip_accents(self_: PyRef<Self>) -> Option<bool> {
+        getter!(self_, BertNormalizer, strip_accents)
+    }
+
+    #[setter]
+    fn set_strip_accents(self_: PyRef<Self>, strip_accents: Option<bool>) {
+        setter!(self_, BertNormalizer, strip_accents, strip_accents);
+    }
+
+    #[getter]
+    fn get_lowercase(self_: PyRef<Self>) -> bool {
+        getter!(self_, BertNormalizer, lowercase)
+    }
+
+    #[setter]
+    fn set_lowercase(self_: PyRef<Self>, lowercase: bool) {
+        setter!(self_, BertNormalizer, lowercase, lowercase)
+    }
+
     #[new]
     #[args(
         clean_text = "true",

--- a/bindings/python/src/normalizers.rs
+++ b/bindings/python/src/normalizers.rs
@@ -359,6 +359,26 @@ impl PyLowercase {
 pub struct PyStrip {}
 #[pymethods]
 impl PyStrip {
+    #[getter]
+    fn get_left(self_: PyRef<Self>) -> bool {
+        getter!(self_, StripNormalizer, strip_left)
+    }
+
+    #[setter]
+    fn set_left(self_: PyRef<Self>, left: bool) {
+        setter!(self_, StripNormalizer, strip_left, left)
+    }
+
+    #[getter]
+    fn get_right(self_: PyRef<Self>) -> bool {
+        getter!(self_, StripNormalizer, strip_right)
+    }
+
+    #[setter]
+    fn set_right(self_: PyRef<Self>, right: bool) {
+        setter!(self_, StripNormalizer, strip_right, right)
+    }
+
     #[new]
     #[args(left = "true", right = "true")]
     fn new(left: bool, right: bool) -> PyResult<(Self, PyNormalizer)> {

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -179,6 +179,45 @@ impl PyPreTokenizer {
     }
 }
 
+macro_rules! getter {
+    ($self: ident, $variant: ident, $($name: tt)+) => {{
+        let super_ = $self.as_ref();
+        if let PyPreTokenizerTypeWrapper::Single(ref single) = super_.pretok {
+            if let PyPreTokenizerWrapper::Wrapped(PreTokenizerWrapper::$variant(ref pretok)) =
+                *single.read().unwrap() {
+                    pretok.$($name)+
+                } else {
+                    unreachable!()
+                }
+        } else {
+            unreachable!()
+        }
+    }};
+}
+
+macro_rules! setter {
+    ($self: ident, $variant: ident, $name: ident, $value: expr) => {{
+        let super_ = $self.as_ref();
+        if let PyPreTokenizerTypeWrapper::Single(ref single) = super_.pretok {
+            if let PyPreTokenizerWrapper::Wrapped(PreTokenizerWrapper::$variant(ref mut pretok)) =
+                *single.write().unwrap()
+            {
+                pretok.$name = $value;
+            }
+        }
+    }};
+    ($self: ident, $variant: ident, @$name: ident, $value: expr) => {{
+        let super_ = $self.as_ref();
+        if let PyPreTokenizerTypeWrapper::Single(ref single) = super_.pretok {
+            if let PyPreTokenizerWrapper::Wrapped(PreTokenizerWrapper::$variant(ref mut pretok)) =
+                *single.write().unwrap()
+            {
+                pretok.$name($value);
+            }
+        }
+    }};
+}
+
 /// ByteLevel PreTokenizer
 ///
 /// This pre-tokenizer takes care of replacing all bytes of the given string
@@ -193,6 +232,16 @@ impl PyPreTokenizer {
 pub struct PyByteLevel {}
 #[pymethods]
 impl PyByteLevel {
+    #[getter]
+    fn get_add_prefix_space(self_: PyRef<Self>) -> bool {
+        getter!(self_, ByteLevel, add_prefix_space)
+    }
+
+    #[setter]
+    fn set_add_prefix_space(self_: PyRef<Self>, add_prefix_space: bool) {
+        setter!(self_, ByteLevel, add_prefix_space, add_prefix_space);
+    }
+
     #[new]
     #[args(add_prefix_space = "true")]
     fn new(add_prefix_space: bool) -> PyResult<(Self, PyPreTokenizer)> {
@@ -297,6 +346,16 @@ impl PySplit {
 pub struct PyCharDelimiterSplit {}
 #[pymethods]
 impl PyCharDelimiterSplit {
+    #[getter]
+    fn get_delimiter(self_: PyRef<Self>) -> String {
+        getter!(self_, Delimiter, delimiter.to_string())
+    }
+
+    #[setter]
+    fn set_delimiter(self_: PyRef<Self>, delimiter: PyChar) {
+        setter!(self_, Delimiter, delimiter, delimiter.0);
+    }
+
     #[new]
     pub fn new(delimiter: PyChar) -> PyResult<(Self, PyPreTokenizer)> {
         Ok((
@@ -384,6 +443,26 @@ impl PySequence {
 pub struct PyMetaspace {}
 #[pymethods]
 impl PyMetaspace {
+    #[getter]
+    fn get_replacement(self_: PyRef<Self>) -> String {
+        getter!(self_, Metaspace, get_replacement().to_string())
+    }
+
+    #[setter]
+    fn set_replacement(self_: PyRef<Self>, replacement: PyChar) {
+        setter!(self_, Metaspace, @set_replacement, replacement.0);
+    }
+
+    #[getter]
+    fn get_add_prefix_space(self_: PyRef<Self>) -> bool {
+        getter!(self_, Metaspace, add_prefix_space)
+    }
+
+    #[setter]
+    fn set_add_prefix_space(self_: PyRef<Self>, add_prefix_space: bool) {
+        setter!(self_, Metaspace, add_prefix_space, add_prefix_space);
+    }
+
     #[new]
     #[args(replacement = "PyChar('▁')", add_prefix_space = "true")]
     fn new(replacement: PyChar, add_prefix_space: bool) -> PyResult<(Self, PyPreTokenizer)> {
@@ -410,6 +489,16 @@ impl PyMetaspace {
 pub struct PyDigits {}
 #[pymethods]
 impl PyDigits {
+    #[getter]
+    fn get_individual_digits(self_: PyRef<Self>) -> bool {
+        getter!(self_, Digits, individual_digits)
+    }
+
+    #[setter]
+    fn set_individual_digits(self_: PyRef<Self>, individual_digits: bool) {
+        setter!(self_, Digits, individual_digits, individual_digits);
+    }
+
     #[new]
     #[args(individual_digits = false)]
     fn new(individual_digits: bool) -> PyResult<(Self, PyPreTokenizer)> {

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1181,8 +1181,8 @@ mod test {
     fn serialize() {
         let mut tokenizer = Tokenizer::new(PyModel::from(BPE::default()));
         tokenizer.with_normalizer(PyNormalizer::new(PyNormalizerTypeWrapper::Sequence(vec![
-            Arc::new(NFKC.into()),
-            Arc::new(Lowercase.into()),
+            Arc::new(RwLock::new(NFKC.into())),
+            Arc::new(RwLock::new(Lowercase.into())),
         ])));
 
         let tmp = NamedTempFile::new().unwrap().into_temp_path();

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
 
 use numpy::PyArray1;
 use pyo3::exceptions;
@@ -457,8 +456,7 @@ impl PyTokenizer {
     }
 
     fn __getnewargs__<'p>(&self, py: Python<'p>) -> PyResult<&'p PyTuple> {
-        let model: PyObject =
-            PyModel::new(Arc::new(RwLock::new(BPE::default().into()))).into_py(py);
+        let model = PyModel::from(BPE::default()).into_py(py);
         let args = PyTuple::new(py, vec![model]);
         Ok(args)
     }
@@ -1181,9 +1179,7 @@ mod test {
 
     #[test]
     fn serialize() {
-        let mut tokenizer = Tokenizer::new(PyModel::new(Arc::new(RwLock::new(
-            tk::models::bpe::BPE::default().into(),
-        ))));
+        let mut tokenizer = Tokenizer::new(PyModel::from(BPE::default()));
         tokenizer.with_normalizer(PyNormalizer::new(PyNormalizerTypeWrapper::Sequence(vec![
             Arc::new(NFKC.into()),
             Arc::new(Lowercase.into()),

--- a/bindings/python/tests/bindings/test_decoders.py
+++ b/bindings/python/tests/bindings/test_decoders.py
@@ -33,6 +33,18 @@ class TestWordPiece:
         assert decoder.decode(["My", "na", "__me", "is", "Jo", "__hn"]) == "My name is John"
         assert decoder.decode(["I", "'m", "Jo", "__hn"]) == "I 'm John"
 
+    def test_can_modify(self):
+        decoder = WordPiece(prefix="$$", cleanup=False)
+
+        assert decoder.prefix == "$$"
+        assert decoder.cleanup == False
+
+        # Modify these
+        decoder.prefix = "__"
+        assert decoder.prefix == "__"
+        decoder.cleanup = True
+        assert decoder.cleanup == True
+
 
 class TestMetaspace:
     def test_instantiate(self):
@@ -51,6 +63,18 @@ class TestMetaspace:
         decoder = Metaspace(replacement="-", add_prefix_space=False)
         assert decoder.decode(["-My", "-name", "-is", "-John"]) == " My name is John"
 
+    def test_can_modify(self):
+        decoder = Metaspace(replacement="*", add_prefix_space=False)
+
+        assert decoder.replacement == "*"
+        assert decoder.add_prefix_space == False
+
+        # Modify these
+        decoder.replacement = "&"
+        assert decoder.replacement == "&"
+        decoder.add_prefix_space = True
+        assert decoder.add_prefix_space == True
+
 
 class TestBPEDecoder:
     def test_instantiate(self):
@@ -68,3 +92,12 @@ class TestBPEDecoder:
         )
         decoder = BPEDecoder(suffix="_")
         assert decoder.decode(["My_", "na", "me_", "is_", "Jo", "hn_"]) == "My name is John"
+
+    def test_can_modify(self):
+        decoder = BPEDecoder(suffix="123")
+
+        assert decoder.suffix == "123"
+
+        # Modify these
+        decoder.suffix = "</w>"
+        assert decoder.suffix == "</w>"

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -39,6 +39,33 @@ class TestBPE:
                 BPE,
             )
 
+    def test_can_modify(self):
+        model = BPE(
+            dropout=0.5,
+            unk_token="[UNK]",
+            continuing_subword_prefix="__prefix__",
+            end_of_word_suffix="__suffix__",
+            fuse_unk=False,
+        )
+
+        assert model.dropout == 0.5
+        assert model.unk_token == "[UNK]"
+        assert model.continuing_subword_prefix == "__prefix__"
+        assert model.end_of_word_suffix == "__suffix__"
+        assert model.fuse_unk == False
+
+        # Modify these
+        model.dropout = 0.1
+        assert pytest.approx(model.dropout) == 0.1
+        model.unk_token = "<unk>"
+        assert model.unk_token == "<unk>"
+        model.continuing_subword_prefix = None
+        assert model.continuing_subword_prefix == None
+        model.end_of_word_suffix = "suff"
+        assert model.end_of_word_suffix == "suff"
+        model.fuse_unk = True
+        assert model.fuse_unk == True
+
 
 class TestWordPiece:
     def test_instantiate(self, bert_files):

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -84,6 +84,25 @@ class TestWordPiece:
         with pytest.deprecated_call():
             assert isinstance(pickle.loads(pickle.dumps(WordPiece(bert_files["vocab"]))), WordPiece)
 
+    def test_can_modify(self):
+        model = WordPiece(
+            unk_token="<oov>",
+            continuing_subword_prefix="__prefix__",
+            max_input_chars_per_word=200,
+        )
+
+        assert model.unk_token == "<oov>"
+        assert model.continuing_subword_prefix == "__prefix__"
+        assert model.max_input_chars_per_word == 200
+
+        # Modify these
+        model.unk_token = "<unk>"
+        assert model.unk_token == "<unk>"
+        model.continuing_subword_prefix = "$$$"
+        assert model.continuing_subword_prefix == "$$$"
+        model.max_input_chars_per_word = 10
+        assert model.max_input_chars_per_word == 10
+
 
 class TestWordLevel:
     def test_instantiate(self, roberta_files):

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -120,3 +120,12 @@ class TestWordLevel:
             assert isinstance(WordLevel(roberta_files["vocab"]), Model)
         with pytest.deprecated_call():
             assert isinstance(WordLevel(roberta_files["vocab"]), WordLevel)
+
+    def test_can_modify(self):
+        model = WordLevel(unk_token="<oov>")
+
+        assert model.unk_token == "<oov>"
+
+        # Modify these
+        model.unk_token = "<unk>"
+        assert model.unk_token == "<unk>"

--- a/bindings/python/tests/bindings/test_normalizers.py
+++ b/bindings/python/tests/bindings/test_normalizers.py
@@ -44,6 +44,26 @@ class TestBertNormalizer:
         output = normalizer.normalize_str("Héllò")
         assert output == "héllò"
 
+    def test_can_modify(self):
+        normalizer = BertNormalizer(
+            clean_text=True, handle_chinese_chars=True, strip_accents=True, lowercase=True
+        )
+
+        assert normalizer.clean_text == True
+        assert normalizer.handle_chinese_chars == True
+        assert normalizer.strip_accents == True
+        assert normalizer.lowercase == True
+
+        # Modify these
+        normalizer.clean_text = False
+        assert normalizer.clean_text == False
+        normalizer.handle_chinese_chars = False
+        assert normalizer.handle_chinese_chars == False
+        normalizer.strip_accents = None
+        assert normalizer.strip_accents == None
+        normalizer.lowercase = False
+        assert normalizer.lowercase == False
+
 
 class TestSequence:
     def test_instantiate(self):

--- a/bindings/python/tests/bindings/test_normalizers.py
+++ b/bindings/python/tests/bindings/test_normalizers.py
@@ -115,6 +115,18 @@ class TestStrip:
         output = normalizer.normalize_str("  hello  ")
         assert output == "hello"
 
+    def test_can_modify(self):
+        normalizer = Strip(left=True, right=True)
+
+        assert normalizer.left == True
+        assert normalizer.right == True
+
+        # Modify these
+        normalizer.left = False
+        assert normalizer.left == False
+        normalizer.right = False
+        assert normalizer.right == False
+
 
 class TestCustomNormalizer:
     class BadCustomNormalizer:

--- a/bindings/python/tests/bindings/test_pre_tokenizers.py
+++ b/bindings/python/tests/bindings/test_pre_tokenizers.py
@@ -30,6 +30,15 @@ class TestByteLevel:
         assert isinstance(ByteLevel.alphabet(), list)
         assert len(ByteLevel.alphabet()) == 256
 
+    def test_can_modify(self):
+        pretok = ByteLevel(add_prefix_space=False)
+
+        assert pretok.add_prefix_space == False
+
+        # Modify these
+        pretok.add_prefix_space = True
+        assert pretok.add_prefix_space == True
+
 
 class TestSplit:
     def test_instantiate(self):
@@ -82,6 +91,18 @@ class TestMetaspace:
         assert isinstance(Metaspace(), Metaspace)
         assert isinstance(pickle.loads(pickle.dumps(Metaspace())), Metaspace)
 
+    def test_can_modify(self):
+        pretok = Metaspace(replacement="$", add_prefix_space=False)
+
+        assert pretok.replacement == "$"
+        assert pretok.add_prefix_space == False
+
+        # Modify these
+        pretok.replacement = "%"
+        assert pretok.replacement == "%"
+        pretok.add_prefix_space = True
+        assert pretok.add_prefix_space == True
+
 
 class TestCharDelimiterSplit:
     def test_instantiate(self):
@@ -91,6 +112,14 @@ class TestCharDelimiterSplit:
         assert isinstance(CharDelimiterSplit(" "), PreTokenizer)
         assert isinstance(CharDelimiterSplit(" "), CharDelimiterSplit)
         assert isinstance(pickle.loads(pickle.dumps(CharDelimiterSplit("-"))), CharDelimiterSplit)
+
+    def test_can_modify(self):
+        pretok = CharDelimiterSplit("@")
+        assert pretok.delimiter == "@"
+
+        # Modify these
+        pretok.delimiter = "!"
+        assert pretok.delimiter == "!"
 
 
 class TestPunctuation:
@@ -137,6 +166,14 @@ class TestDigits:
         assert isinstance(Digits(True), Digits)
         assert isinstance(Digits(False), Digits)
         assert isinstance(pickle.loads(pickle.dumps(Digits())), Digits)
+
+    def test_can_modify(self):
+        pretok = Digits(individual_digits=False)
+        assert pretok.individual_digits == False
+
+        # Modify these
+        pretok.individual_digits = True
+        assert pretok.individual_digits == True
 
 
 class TestUnicodeScripts:

--- a/bindings/python/tests/bindings/test_trainers.py
+++ b/bindings/python/tests/bindings/test_trainers.py
@@ -4,6 +4,7 @@ import pickle
 
 from tokenizers import (
     SentencePieceUnigramTokenizer,
+    AddedToken,
     models,
     pre_tokenizers,
     normalizers,
@@ -11,6 +12,119 @@ from tokenizers import (
     trainers,
 )
 from ..utils import data_dir, train_files
+
+
+class TestBPETrainer:
+    def test_can_modify(self):
+        trainer = trainers.BpeTrainer(
+            vocab_size=12345,
+            min_frequency=12,
+            show_progress=False,
+            special_tokens=["1", "2"],
+            limit_alphabet=13,
+            initial_alphabet=["a", "b", "c"],
+            continuing_subword_prefix="pref",
+            end_of_word_suffix="suf",
+        )
+
+        assert trainer.vocab_size == 12345
+        assert trainer.min_frequency == 12
+        assert trainer.show_progress == False
+        assert trainer.special_tokens == [
+            AddedToken("1"),
+            AddedToken("2"),
+        ]
+        assert trainer.limit_alphabet == 13
+        assert sorted(trainer.initial_alphabet) == ["a", "b", "c"]
+        assert trainer.continuing_subword_prefix == "pref"
+        assert trainer.end_of_word_suffix == "suf"
+
+        # Modify these
+        trainer.vocab_size = 20000
+        assert trainer.vocab_size == 20000
+        trainer.min_frequency = 1
+        assert trainer.min_frequency == 1
+        trainer.show_progress = True
+        assert trainer.show_progress == True
+        trainer.special_tokens = []
+        assert trainer.special_tokens == []
+        trainer.limit_alphabet = None
+        assert trainer.limit_alphabet == None
+        trainer.initial_alphabet = ["d", "z"]
+        assert sorted(trainer.initial_alphabet) == ["d", "z"]
+        trainer.continuing_subword_prefix = None
+        assert trainer.continuing_subword_prefix == None
+        trainer.end_of_word_suffix = None
+        assert trainer.continuing_subword_prefix == None
+
+
+class TestWordPieceTrainer:
+    def test_can_modify(self):
+        trainer = trainers.WordPieceTrainer(
+            vocab_size=12345,
+            min_frequency=12,
+            show_progress=False,
+            special_tokens=["1", "2"],
+            limit_alphabet=13,
+            initial_alphabet=["a", "b", "c"],
+            continuing_subword_prefix="pref",
+            end_of_word_suffix="suf",
+        )
+
+        assert trainer.vocab_size == 12345
+        assert trainer.min_frequency == 12
+        assert trainer.show_progress == False
+        assert trainer.special_tokens == [
+            AddedToken("1"),
+            AddedToken("2"),
+        ]
+        assert trainer.limit_alphabet == 13
+        assert sorted(trainer.initial_alphabet) == ["a", "b", "c"]
+        assert trainer.continuing_subword_prefix == "pref"
+        assert trainer.end_of_word_suffix == "suf"
+
+        # Modify these
+        trainer.vocab_size = 20000
+        assert trainer.vocab_size == 20000
+        trainer.min_frequency = 1
+        assert trainer.min_frequency == 1
+        trainer.show_progress = True
+        assert trainer.show_progress == True
+        trainer.special_tokens = []
+        assert trainer.special_tokens == []
+        trainer.limit_alphabet = None
+        assert trainer.limit_alphabet == None
+        trainer.initial_alphabet = ["d", "z"]
+        assert sorted(trainer.initial_alphabet) == ["d", "z"]
+        trainer.continuing_subword_prefix = None
+        assert trainer.continuing_subword_prefix == None
+        trainer.end_of_word_suffix = None
+        assert trainer.continuing_subword_prefix == None
+
+
+class TestWordLevelTrainer:
+    def test_can_modify(self):
+        trainer = trainers.WordLevelTrainer(
+            vocab_size=12345, min_frequency=12, show_progress=False, special_tokens=["1", "2"]
+        )
+
+        assert trainer.vocab_size == 12345
+        assert trainer.min_frequency == 12
+        assert trainer.show_progress == False
+        assert trainer.special_tokens == [
+            AddedToken("1"),
+            AddedToken("2"),
+        ]
+
+        # Modify these
+        trainer.vocab_size = 20000
+        assert trainer.vocab_size == 20000
+        trainer.min_frequency = 1
+        assert trainer.min_frequency == 1
+        trainer.show_progress = True
+        assert trainer.show_progress == True
+        trainer.special_tokens = []
+        assert trainer.special_tokens == []
 
 
 class TestUnigram:
@@ -99,3 +213,29 @@ class TestUnigram:
 
         with pytest.raises(Exception, match="UnigramTrainer can only train a Unigram"):
             tokenizer.train([], trainer)
+
+    def test_can_modify(self):
+        trainer = trainers.UnigramTrainer(
+            vocab_size=12345,
+            show_progress=False,
+            special_tokens=["1", AddedToken("2", lstrip=True)],
+            initial_alphabet=["a", "b", "c"],
+        )
+
+        assert trainer.vocab_size == 12345
+        assert trainer.show_progress == False
+        assert trainer.special_tokens == [
+            AddedToken("1", normalized=False),
+            AddedToken("2", lstrip=True, normalized=False),
+        ]
+        assert sorted(trainer.initial_alphabet) == ["a", "b", "c"]
+
+        # Modify these
+        trainer.vocab_size = 20000
+        assert trainer.vocab_size == 20000
+        trainer.show_progress = True
+        assert trainer.show_progress == True
+        trainer.special_tokens = []
+        assert trainer.special_tokens == []
+        trainer.initial_alphabet = ["d", "z"]
+        assert sorted(trainer.initial_alphabet) == ["d", "z"]

--- a/tokenizers/src/decoders/bpe.rs
+++ b/tokenizers/src/decoders/bpe.rs
@@ -6,8 +6,9 @@ use serde::{Deserialize, Serialize};
 /// Allows decoding Original BPE by joining all the tokens and then replacing
 /// the suffix used to identify end-of-words by whitespaces
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub struct BPEDecoder {
-    suffix: String,
+    pub suffix: String,
 }
 
 impl BPEDecoder {

--- a/tokenizers/src/decoders/wordpiece.rs
+++ b/tokenizers/src/decoders/wordpiece.rs
@@ -6,11 +6,12 @@ use serde::{Deserialize, Serialize};
 /// The WordPiece decoder takes care of decoding a list of wordpiece tokens
 /// back into a readable string.
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub struct WordPiece {
     /// The prefix to be used for continuing subwords
-    prefix: String,
+    pub prefix: String,
     /// Whether to cleanup some tokenization artifacts (spaces before punctuation, ...)
-    cleanup: bool,
+    pub cleanup: bool,
 }
 
 impl WordPiece {

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -154,24 +154,26 @@ impl BpeTrainerBuilder {
 /// let mut model = BPE::default();
 /// let special_tokens = trainer.train(word_counts, &mut model).unwrap();
 /// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BpeTrainer {
     /// The minimum frequency a pair must have to produce a merge operation
-    min_frequency: u32,
+    pub min_frequency: u32,
     /// The target vocabulary size
-    vocab_size: usize,
+    pub vocab_size: usize,
     /// Whether to show progress while training
-    show_progress: bool,
+    pub show_progress: bool,
     /// A list of special tokens that the model should know of
-    special_tokens: Vec<AddedToken>,
+    pub special_tokens: Vec<AddedToken>,
     /// Whether to limit the number of initial tokens that can be kept before computing merges
-    limit_alphabet: Option<usize>,
+    pub limit_alphabet: Option<usize>,
     /// The initial alphabet we want absolutely to include. This allows to cover
     /// some characters that are not necessarily in the training set
-    initial_alphabet: HashSet<char>,
+    pub initial_alphabet: HashSet<char>,
     /// An optional prefix to use on any subword that exist only behind another one
-    continuing_subword_prefix: Option<String>,
+    pub continuing_subword_prefix: Option<String>,
     /// An optional suffix to caracterize and end-of-word subword
-    end_of_word_suffix: Option<String>,
+    pub end_of_word_suffix: Option<String>,
 }
 
 impl Default for BpeTrainer {

--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -36,28 +36,29 @@ fn to_log_prob(pieces: &mut [SentencePiece]) {
 }
 
 /// A `UnigramTrainer` can train a `Unigram` model from `word_counts`.
+#[non_exhaustive]
 #[derive(Builder, Debug, Clone)]
 pub struct UnigramTrainer {
     #[builder(default = "true")]
-    show_progress: bool,
+    pub show_progress: bool,
     #[builder(default = "8000")]
-    vocab_size: u32,
+    pub vocab_size: u32,
     #[builder(default = "2")]
-    n_sub_iterations: u32,
+    pub n_sub_iterations: u32,
     #[builder(default = "0.75")]
-    shrinking_factor: f64,
+    pub shrinking_factor: f64,
     #[builder(default = "vec![]")]
-    special_tokens: Vec<AddedToken>,
+    pub special_tokens: Vec<AddedToken>,
     #[builder(default = "HashSet::new()")]
-    initial_alphabet: HashSet<char>,
+    pub initial_alphabet: HashSet<char>,
 
     #[builder(default = "None")]
-    unk_token: Option<String>,
+    pub unk_token: Option<String>,
 
     #[builder(default = "16")]
-    max_piece_length: usize,
+    pub max_piece_length: usize,
     #[builder(default = "1_000_000")]
-    seed_size: usize,
+    pub seed_size: usize,
 }
 
 impl Default for UnigramTrainer {

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -107,7 +107,7 @@ impl WordLevelBuilder {
 pub struct WordLevel {
     vocab: HashMap<String, u32>,
     vocab_r: HashMap<u32, String>,
-    unk_token: String,
+    pub unk_token: String,
 }
 
 impl std::fmt::Debug for WordLevel {

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -2,20 +2,21 @@ use super::WordLevel;
 use crate::{AddedToken, Result, Trainer};
 use std::collections::HashMap;
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Builder)]
 pub struct WordLevelTrainer {
     /// The minimum frequency a word must have to be part of the vocabulary
     #[builder(default)]
-    min_frequency: u32,
+    pub min_frequency: u32,
     /// The target vocabulary size
     #[builder(default)]
-    vocab_size: usize,
+    pub vocab_size: usize,
     /// Whether to show progress while training
     #[builder(default)]
-    show_progress: bool,
+    pub show_progress: bool,
     /// A list of special tokens that the model should know of
     #[builder(default)]
-    special_tokens: Vec<AddedToken>,
+    pub special_tokens: Vec<AddedToken>,
 }
 
 impl Default for WordLevelTrainer {

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -130,9 +130,9 @@ impl WordPieceBuilder {
 pub struct WordPiece {
     vocab: Vocab,
     vocab_r: VocabR,
-    unk_token: String,
-    continuing_subword_prefix: String,
-    max_input_chars_per_word: usize,
+    pub unk_token: String,
+    pub continuing_subword_prefix: String,
+    pub max_input_chars_per_word: usize,
 }
 
 impl std::fmt::Debug for WordPiece {

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -85,6 +85,70 @@ pub struct WordPieceTrainer {
 }
 
 impl WordPieceTrainer {
+    pub fn min_frequency(&self) -> u32 {
+        self.bpe_trainer.min_frequency
+    }
+
+    pub fn set_min_frequency(&mut self, freq: u32) {
+        self.bpe_trainer.min_frequency = freq;
+    }
+
+    pub fn vocab_size(&self) -> usize {
+        self.bpe_trainer.vocab_size
+    }
+
+    pub fn set_vocab_size(&mut self, size: usize) {
+        self.bpe_trainer.vocab_size = size;
+    }
+
+    pub fn show_progress(&self) -> bool {
+        self.bpe_trainer.show_progress
+    }
+
+    pub fn set_show_progress(&mut self, show_progress: bool) {
+        self.bpe_trainer.show_progress = show_progress;
+    }
+
+    pub fn special_tokens(&self) -> &[AddedToken] {
+        &self.bpe_trainer.special_tokens
+    }
+
+    pub fn set_special_tokens(&mut self, special_tokens: Vec<AddedToken>) {
+        self.bpe_trainer.special_tokens = special_tokens;
+    }
+
+    pub fn limit_alphabet(&self) -> Option<usize> {
+        self.bpe_trainer.limit_alphabet
+    }
+
+    pub fn set_limit_alphabet(&mut self, limit: Option<usize>) {
+        self.bpe_trainer.limit_alphabet = limit;
+    }
+
+    pub fn initial_alphabet(&self) -> &HashSet<char> {
+        &self.bpe_trainer.initial_alphabet
+    }
+
+    pub fn set_initial_alphabet(&mut self, alphabet: HashSet<char>) {
+        self.bpe_trainer.initial_alphabet = alphabet;
+    }
+
+    pub fn continuing_subword_prefix(&self) -> &Option<String> {
+        &self.bpe_trainer.continuing_subword_prefix
+    }
+
+    pub fn set_continuing_subword_prefix(&mut self, prefix: Option<String>) {
+        self.bpe_trainer.continuing_subword_prefix = prefix;
+    }
+
+    pub fn end_of_word_suffix(&self) -> &Option<String> {
+        &self.bpe_trainer.end_of_word_suffix
+    }
+
+    pub fn set_end_of_word_suffix(&mut self, suffix: Option<String>) {
+        self.bpe_trainer.end_of_word_suffix = suffix;
+    }
+
     pub fn builder() -> WordPieceTrainerBuilder {
         WordPieceTrainerBuilder::default()
     }

--- a/tokenizers/src/normalizers/bert.rs
+++ b/tokenizers/src/normalizers/bert.rs
@@ -51,17 +51,18 @@ fn is_chinese_char(c: char) -> bool {
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub struct BertNormalizer {
     /// Whether to do the bert basic cleaning:
     ///   1. Remove any control characters
     ///   2. Replace all sorts of whitespace by the classic one ` `
-    clean_text: bool,
+    pub clean_text: bool,
     /// Whether to put spaces around chinese characters so they get split
-    handle_chinese_chars: bool,
+    pub handle_chinese_chars: bool,
     /// Whether to strip accents
-    strip_accents: Option<bool>,
+    pub strip_accents: Option<bool>,
     /// Whether to lowercase the input
-    lowercase: bool,
+    pub lowercase: bool,
 }
 
 impl Default for BertNormalizer {

--- a/tokenizers/src/normalizers/strip.rs
+++ b/tokenizers/src/normalizers/strip.rs
@@ -4,9 +4,10 @@ use unicode_normalization_alignments::char::is_combining_mark;
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub struct Strip {
-    strip_left: bool,
-    strip_right: bool,
+    pub strip_left: bool,
+    pub strip_right: bool,
 }
 
 impl Strip {

--- a/tokenizers/src/normalizers/utils.rs
+++ b/tokenizers/src/normalizers/utils.rs
@@ -19,6 +19,10 @@ impl Sequence {
     pub fn get_normalizers(&self) -> &[NormalizerWrapper] {
         &self.normalizers
     }
+
+    pub fn get_normalizers_mut(&mut self) -> &mut [NormalizerWrapper] {
+        &mut self.normalizers
+    }
 }
 
 impl Normalizer for Sequence {

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -45,12 +45,13 @@ lazy_static! {
 /// of all the required processing steps to transform a UTF-8 string as needed before and after the
 /// BPE model does its job.
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub struct ByteLevel {
     /// Whether to add a leading space to the first word. This allows to treat the leading word
     /// just as any other word.
-    add_prefix_space: bool,
+    pub add_prefix_space: bool,
     /// Whether the post processing step should trim offsets to avoid including whitespaces.
-    trim_offsets: bool,
+    pub trim_offsets: bool,
 }
 impl Default for ByteLevel {
     fn default() -> Self {

--- a/tokenizers/src/pre_tokenizers/delimiter.rs
+++ b/tokenizers/src/pre_tokenizers/delimiter.rs
@@ -4,8 +4,9 @@ use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterB
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub struct CharDelimiterSplit {
-    delimiter: char,
+    pub delimiter: char,
 }
 
 impl CharDelimiterSplit {

--- a/tokenizers/src/pre_tokenizers/digits.rs
+++ b/tokenizers/src/pre_tokenizers/digits.rs
@@ -6,8 +6,9 @@ use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterB
 /// Pre tokenizes the numbers into single tokens. If individual_digits is set
 /// to true, then all digits are splitted into individual tokens.
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub struct Digits {
-    individual_digits: bool,
+    pub individual_digits: bool,
 }
 
 impl Digits {

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -9,7 +9,7 @@ use crate::tokenizer::{Decoder, PreTokenizedString, PreTokenizer, Result, SplitD
 pub struct Metaspace {
     replacement: char,
     str_rep: String,
-    add_prefix_space: bool,
+    pub add_prefix_space: bool,
 }
 
 impl Metaspace {
@@ -19,6 +19,15 @@ impl Metaspace {
             str_rep: replacement.to_string(),
             add_prefix_space,
         }
+    }
+
+    pub fn get_replacement(&self) -> char {
+        self.replacement
+    }
+
+    pub fn set_replacement(&mut self, replacement: char) {
+        self.replacement = replacement;
+        self.str_rep = replacement.to_string();
     }
 }
 


### PR DESCRIPTION
Add the ability to get/set the attributes of the python components. I ran some tests and the overhead seems absolutely reasonable. While encoding a 500MB file with both BERT and GPT-2 tokenizers, I measured a ~2% difference.

Fix #536

This PR doesn't cover:
- Processors: The `TemplateProcessing` is a bit tricky to do right, and will require some work. We can live without them for now.
- Sequences: This also requires some work to do right and will be handled in a separate PR. We'll also have to wait for https://github.com/PyO3/pyo3/issues/1206 to be able to access the base class `Normalizer` or `PreTokenizer` from the associated `PySequence`.