### PR TITLE
Update Python bindings README.md

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -138,7 +138,7 @@ tokenizer.post_processor = processors.ByteLevel(trim_offsets=True)
 
 # And then train
 trainer = trainers.BpeTrainer(vocab_size=20000, min_frequency=2)
-tokenizer.train([
+tokenizer.train(files=[
 	"./path/to/dataset/1.txt",
 	"./path/to/dataset/2.txt",
 	"./path/to/dataset/3.txt"


### PR DESCRIPTION
>>> tokenizer.train(["./path/to/dataset/1.txt"], trainer=trainer)

Fix the "PyTokenizer.train() got multiple values for argument: trainer" error when the "files" parameter is missing