### PR TITLE
Ability to train from memory

### DIFF
--- a/bindings/node/native/src/tokenizer.rs
+++ b/bindings/node/native/src/tokenizer.rs
@@ -749,7 +749,7 @@ declare_types! {
             // train(files: string[], trainer?: Trainer)
 
             let files = cx.extract::<Vec<String>>(0)?;
-            let trainer = if let Some(val) = cx.argument_opt(1) {
+            let mut trainer = if let Some(val) = cx.argument_opt(1) {
                 let js_trainer = val.downcast::<JsTrainer>().or_throw(&mut cx)?;
                 let guard = cx.lock();
 
@@ -768,7 +768,7 @@ declare_types! {
 
             this.borrow_mut(&guard)
                 .tokenizer.write().unwrap()
-                .train(&trainer, files)
+                .train_from_files(&mut trainer, files)
                 .map_err(|e| Error(format!("{}", e)))?;
 
             Ok(cx.undefined().upcast())

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1080,6 +1080,7 @@ version = "0.9.4"
 dependencies = [
  "crossbeam",
  "env_logger",
+ "itertools 0.9.0",
  "libc",
  "ndarray",
  "numpy",

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -66,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,13 +113,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+
+[[package]]
+name = "crossbeam"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel 0.5.0",
+ "crossbeam-deque 0.8.0",
+ "crossbeam-epoch 0.9.0",
+ "crossbeam-queue",
+ "crossbeam-utils 0.8.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -122,9 +158,20 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch 0.9.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -134,12 +181,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "const_fn",
+ "crossbeam-utils 0.8.0",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2a58563f049aa3bae172bc4120f093b5901161c629f280a1f40ba55317d774"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -149,7 +220,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "const_fn",
  "lazy_static",
 ]
 
@@ -269,7 +352,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -350,7 +433,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -413,7 +496,7 @@ checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "ryu",
  "static_assertions",
 ]
@@ -439,7 +522,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -546,7 +629,7 @@ name = "numpy"
 version = "0.11.0"
 source = "git+https://github.com/pyo3/rust-numpy/?rev=e331befa27fede78d4662edf08fa0508db39be01#e331befa27fede78d4662edf08fa0508db39be01"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "ndarray",
  "num-complex",
@@ -593,7 +676,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi",
  "instant",
  "libc",
@@ -755,7 +838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
 dependencies = [
  "autocfg",
- "crossbeam-deque",
+ "crossbeam-deque 0.7.3",
  "either",
  "rayon-core",
 ]
@@ -776,9 +859,9 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
 dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-channel 0.4.4",
+ "crossbeam-deque 0.7.3",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "num_cpus",
 ]
@@ -912,7 +995,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
  "redox_syscall",
@@ -995,6 +1078,7 @@ dependencies = [
 name = "tokenizers-python"
 version = "0.9.4"
 dependencies = [
+ "crossbeam",
  "env_logger",
  "libc",
  "ndarray",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -18,6 +18,7 @@ pyo3 = "0.12"
 numpy = { git = "https://github.com/pyo3/rust-numpy/", rev = "e331befa27fede78d4662edf08fa0508db39be01" }
 ndarray = "0.13"
 onig = { version = "6.0", default-features = false }
+crossbeam = "0.8"
 
 [dependencies.tokenizers]
 version = "*"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -19,6 +19,7 @@ numpy = { git = "https://github.com/pyo3/rust-numpy/", rev = "e331befa27fede78d4
 ndarray = "0.13"
 onig = { version = "6.0", default-features = false }
 crossbeam = "0.8"
+itertools = "0.9"
 
 [dependencies.tokenizers]
 version = "*"

--- a/bindings/python/examples/train_with_datasets.py
+++ b/bindings/python/examples/train_with_datasets.py
@@ -1,0 +1,19 @@
+import datasets
+from tokenizers import normalizers, pre_tokenizers, Tokenizer, models, trainers
+
+# Build a tokenizer
+bpe_tokenizer = Tokenizer(models.BPE())
+bpe_tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+bpe_tokenizer.normalizer = normalizers.Lowercase()
+
+# Initialize a dataset
+dataset = datasets.load_dataset("wikitext", "wikitext-103-raw-v1")
+
+# Build an iterator over this dataset
+def batch_iterator():
+    batch_length = 1000
+    for i in range(0, len(dataset["train"]), batch_length):
+        yield dataset["train"][i : i + batch_length]["text"]
+
+# And finally train
+bpe_tokenizer.train_from_iterator(batch_iterator(), length=len(dataset["train"]))

--- a/bindings/python/examples/train_with_datasets.py
+++ b/bindings/python/examples/train_with_datasets.py
@@ -15,5 +15,6 @@ def batch_iterator():
     for i in range(0, len(dataset["train"]), batch_length):
         yield dataset["train"][i : i + batch_length]["text"]
 
+
 # And finally train
 bpe_tokenizer.train_from_iterator(batch_iterator(), length=len(dataset["train"]))

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -1022,6 +1022,45 @@ class Tokenizer:
             :obj:`Optional[int]`: An optional id, :obj:`None` if out of vocabulary
         """
         pass
+    def train(self, files, trainer=None):
+        """
+        Train the Tokenizer using the given files.
+
+        Reads the files line by line, while keeping all the whitespace, even new lines.
+        If you want to train from data store in-memory, you can check
+        :meth:`~tokenizers.Tokenizer.train_from_iterator`
+
+        Args:
+            files (:obj:`List[str]`):
+                A list of path to the files that we should use for training
+
+            trainer (:obj:`~tokenizers.trainers.Trainer`, `optional`):
+                An optional trainer that should be used to train our Model
+        """
+        pass
+    def train_from_iterator(self, iterator, trainer=None, length=None):
+        """
+        Train the Tokenizer using the provided iterator.
+
+        You can provide anything that is a Python Iterator
+
+            * A list of sequences :obj:`List[str]`
+            * A generator that yields :obj:`str` or :obj:`List[str]`
+            * A Numpy array of strings
+            * ...
+
+        Args:
+            iterator (:obj:`Iterator`):
+                Any iterator over strings or list of strings
+
+            trainer (:obj:`~tokenizers.trainers.Trainer`, `optional`):
+                An optional trainer that should be used to train our Model
+
+            length (:obj:`int`, `optional`):
+                The total number of sequences in the iterator. This is used to
+                provide meaningful progress tracking
+        """
+        pass
     @property
     def truncation(self):
         """

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1102,10 +1102,13 @@ impl PyTokenizer {
             //  - A string
             iterator.iter()?.flat_map(|seq| match seq {
                 Ok(s) => {
-                    if let Ok(iter) = s.iter() {
-                        itertools::Either::Left(iter.map(|i| i?.extract::<&str>()))
+                    if let Ok(s) = s.downcast::<PyString>() {
+                        itertools::Either::Right(std::iter::once(s.to_str()))
                     } else {
-                        itertools::Either::Right(std::iter::once(s.extract::<&str>()))
+                        match s.iter() {
+                            Ok(iter) => itertools::Either::Left(iter.map(|i| i?.extract::<&str>())),
+                            Err(e) => itertools::Either::Right(std::iter::once(Err(e))),
+                        }
                     }
                 }
                 Err(e) => itertools::Either::Right(std::iter::once(Err(e))),

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1068,7 +1068,20 @@ impl PyTokenizer {
         Ok(self.tokenizer.add_special_tokens(&tokens))
     }
 
+    /// Train the Tokenizer using the given files.
+    ///
+    /// Reads the files line by line, while keeping all the whitespace, even new lines.
+    /// If you want to train from data store in-memory, you can check
+    /// :meth:`~tokenizers.Tokenizer.train_from_iterator`
+    ///
+    /// Args:
+    ///     files (:obj:`List[str]`):
+    ///         A list of path to the files that we should use for training
+    ///
+    ///     trainer (:obj:`~tokenizers.trainers.Trainer`, `optional`):
+    ///         An optional trainer that should be used to train our Model
     #[args(trainer = "None")]
+    #[text_signature = "(self, files, trainer = None)"]
     fn train(&mut self, files: Vec<String>, trainer: Option<&mut PyTrainer>) -> PyResult<()> {
         let mut trainer =
             trainer.map_or_else(|| self.tokenizer.get_model().get_trainer(), |t| t.clone());
@@ -1084,7 +1097,27 @@ impl PyTokenizer {
         })
     }
 
+    /// Train the Tokenizer using the provided iterator.
+    ///
+    /// You can provide anything that is a Python Iterator
+    ///
+    ///     * A list of sequences :obj:`List[str]`
+    ///     * A generator that yields :obj:`str` or :obj:`List[str]`
+    ///     * A Numpy array of strings
+    ///     * ...
+    ///
+    /// Args:
+    ///     iterator (:obj:`Iterator`):
+    ///         Any iterator over strings or list of strings
+    ///
+    ///     trainer (:obj:`~tokenizers.trainers.Trainer`, `optional`):
+    ///         An optional trainer that should be used to train our Model
+    ///
+    ///     length (:obj:`int`, `optional`):
+    ///         The total number of sequences in the iterator. This is used to
+    ///         provide meaningful progress tracking
     #[args(trainer = "None", length = "None")]
+    #[text_signature = "(self, iterator, trainer=None, length=None)"]
     fn train_from_iterator(
         &mut self,
         iterator: &PyAny,

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use pyo3::exceptions;
@@ -50,19 +49,20 @@ impl Trainer for PyTrainer {
         self.trainer.read().unwrap().should_show_progress()
     }
 
-    fn train(
-        &self,
-        words: HashMap<String, u32>,
-        model: &mut PyModel,
-    ) -> tk::Result<Vec<tk::AddedToken>> {
+    fn train(&self, model: &mut PyModel) -> tk::Result<Vec<tk::AddedToken>> {
         self.trainer
             .read()
             .unwrap()
-            .train(words, &mut model.model.write().unwrap())
+            .train(&mut model.model.write().unwrap())
     }
 
-    fn process_tokens(&self, words: &mut HashMap<String, u32>, tokens: Vec<String>) {
-        self.trainer.read().unwrap().process_tokens(words, tokens)
+    fn feed<I, S, F>(&mut self, iterator: I, process: F) -> tk::Result<()>
+    where
+        I: Iterator<Item = S> + Send,
+        S: AsRef<str> + Send,
+        F: Fn(&str) -> tk::Result<Vec<String>> + Sync,
+    {
+        self.trainer.write().unwrap().feed(iterator, process)
     }
 }
 

--- a/bindings/python/src/utils/mod.rs
+++ b/bindings/python/src/utils/mod.rs
@@ -12,6 +12,75 @@ pub use normalization::*;
 pub use pretokenization::*;
 pub use regex::*;
 
+// PySendIterator
+
+use std::sync::mpsc::{sync_channel, IntoIter};
+use tk::utils::iter::ResultShunt;
+
+pub struct MaybeSizedIterator<I> {
+    length: Option<usize>,
+    iter: I,
+}
+
+impl<I> Iterator for MaybeSizedIterator<I>
+where
+    I: Iterator,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.length.unwrap_or(0), None)
+    }
+}
+
+pub struct PySendIterator<I: Iterator> {
+    iter: I,
+    length: Option<usize>,
+}
+
+impl<I, T> PySendIterator<I>
+where
+    I: Iterator<Item = PyResult<T>>,
+    T: Send,
+{
+    pub fn new(iter: I, length: Option<usize>) -> Self {
+        PySendIterator { iter, length }
+    }
+
+    pub fn execute<F>(self, mut scope: F) -> PyResult<()>
+    where
+        F: FnMut(MaybeSizedIterator<IntoIter<T>>) -> PyResult<()> + Send + Sync,
+    {
+        let (send, recv) = sync_channel(256);
+        let mut sender = Some(send);
+
+        crossbeam::thread::scope(|s| {
+            let length = self.length;
+            s.spawn(move |_| {
+                scope(MaybeSizedIterator {
+                    length,
+                    iter: recv.into_iter(),
+                })
+            });
+
+            ResultShunt::process(self.iter, |iter| {
+                if let Some(send) = sender.take() {
+                    for i in iter {
+                        send.send(i)
+                            .map_err(|e| exceptions::PyException::new_err(e.to_string()))?;
+                    }
+                }
+                Ok(())
+            })?
+        })
+        .unwrap()
+    }
+}
+
 // PyChar
 // This type is a temporary hack to accept `char` as argument
 // To be removed once https://github.com/PyO3/pyo3/pull/1282 has been released

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -71,7 +71,7 @@ use std::path::Path;
 fn main() -> Result<()> {
     let vocab_size: usize = 100;
 
-    let trainer = BpeTrainerBuilder::new()
+    let mut trainer = BpeTrainerBuilder::new()
         .show_progress(true)
         .vocab_size(vocab_size)
         .min_frequency(0)
@@ -97,8 +97,8 @@ fn main() -> Result<()> {
 
     let pretty = false;
     tokenizer
-        .train(
-            &trainer,
+        .train_from_files(
+            &mut trainer,
             vec!["path/to/vocab.txt".to_string()],
         )?
         .save("tokenizer.json", pretty)?;

--- a/tokenizers/benches/bert_benchmark.rs
+++ b/tokenizers/benches/bert_benchmark.rs
@@ -70,7 +70,7 @@ pub fn bench_bert(c: &mut Criterion) {
 }
 
 fn bench_train(c: &mut Criterion) {
-    let trainer = WordPieceTrainerBuilder::default()
+    let mut trainer = WordPieceTrainerBuilder::default()
         .show_progress(false)
         .build();
     type Tok = TokenizerImpl<
@@ -87,7 +87,7 @@ fn bench_train(c: &mut Criterion) {
             iter_bench_train(
                 iters,
                 &mut tokenizer,
-                &trainer,
+                &mut trainer,
                 vec!["data/small.txt".to_string()],
             )
         })
@@ -100,7 +100,7 @@ fn bench_train(c: &mut Criterion) {
             iter_bench_train(
                 iters,
                 &mut tokenizer,
-                &trainer,
+                &mut trainer,
                 vec!["data/big.txt".to_string()],
             )
         })

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -69,7 +69,7 @@ fn bench_gpt2(c: &mut Criterion) {
 }
 
 fn bench_train(c: &mut Criterion) {
-    let trainer: TrainerWrapper = BpeTrainerBuilder::default()
+    let mut trainer: TrainerWrapper = BpeTrainerBuilder::default()
         .show_progress(false)
         .build()
         .into();
@@ -80,7 +80,7 @@ fn bench_train(c: &mut Criterion) {
             iter_bench_train(
                 iters,
                 &mut tokenizer,
-                &trainer,
+                &mut trainer,
                 vec!["data/small.txt".to_string()],
             )
         })
@@ -93,7 +93,7 @@ fn bench_train(c: &mut Criterion) {
             iter_bench_train(
                 iters,
                 &mut tokenizer,
-                &trainer,
+                &mut trainer,
                 vec!["data/big.txt".to_string()],
             )
         })

--- a/tokenizers/benches/common/mod.rs
+++ b/tokenizers/benches/common/mod.rs
@@ -61,7 +61,7 @@ where
 pub fn iter_bench_train<T, M, N, PT, PP, D>(
     iters: u64,
     tokenizer: &mut TokenizerImpl<M, N, PT, PP, D>,
-    trainer: &T,
+    trainer: &mut T,
     files: Vec<String>,
 ) -> Duration
 where
@@ -75,7 +75,7 @@ where
     let mut duration = Duration::new(0, 0);
     for _i in 0..iters {
         let start = Instant::now();
-        tokenizer.train(trainer, files.clone()).unwrap();
+        tokenizer.train_from_files(trainer, files.clone()).unwrap();
         duration = duration.checked_add(start.elapsed()).unwrap();
     }
     duration

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -58,7 +58,7 @@
 //! fn main() -> Result<()> {
 //!     let vocab_size: usize = 100;
 //!
-//!     let trainer = BpeTrainerBuilder::new()
+//!     let mut trainer = BpeTrainerBuilder::new()
 //!         .show_progress(true)
 //!         .vocab_size(vocab_size)
 //!         .min_frequency(0)
@@ -84,8 +84,8 @@
 //!
 //!     let pretty = false;
 //!     tokenizer
-//!         .train(
-//!             &trainer,
+//!         .train_from_files(
+//!             &mut trainer,
 //!             vec!["path/to/vocab.txt".to_string()],
 //!         )?
 //!         .save("tokenizer.json", pretty)?;

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -133,6 +133,7 @@ impl BpeTrainerBuilder {
             initial_alphabet: self.config.initial_alphabet,
             continuing_subword_prefix: self.config.continuing_subword_prefix,
             end_of_word_suffix: self.config.end_of_word_suffix,
+            words: HashMap::new(),
         }
     }
 }
@@ -174,6 +175,8 @@ pub struct BpeTrainer {
     pub continuing_subword_prefix: Option<String>,
     /// An optional suffix to caracterize and end-of-word subword
     pub end_of_word_suffix: Option<String>,
+
+    words: HashMap<String, u32>,
 }
 
 impl Default for BpeTrainer {
@@ -407,9 +410,9 @@ impl BpeTrainer {
             )
     }
 
-    pub fn train(
+    pub fn do_train(
         &self,
-        word_counts: HashMap<String, u32>,
+        word_counts: &HashMap<String, u32>,
         model: &mut BPE,
     ) -> Result<Vec<AddedToken>> {
         let mut word_to_id: HashMap<String, u32> = HashMap::with_capacity(self.vocab_size);
@@ -425,14 +428,14 @@ impl BpeTrainer {
         //
         // 2. Compute the initial alphabet
         //
-        self.compute_alphabet(&word_counts, &mut word_to_id, &mut id_to_word);
+        self.compute_alphabet(word_counts, &mut word_to_id, &mut id_to_word);
 
         //
         // 3. Tokenize words
         //
         self.update_progress(&progress, word_counts.len(), "Tokenize words");
         let (words, counts) =
-            self.tokenize_words(&word_counts, &mut word_to_id, &mut id_to_word, &progress);
+            self.tokenize_words(word_counts, &mut word_to_id, &mut id_to_word, &progress);
         self.finalize_progress(&progress, words.len());
 
         //
@@ -586,13 +589,44 @@ impl Trainer for BpeTrainer {
     type Model = BPE;
 
     /// Train a BPE model
-    fn train(&self, word_counts: HashMap<String, u32>, model: &mut BPE) -> Result<Vec<AddedToken>> {
-        self.train(word_counts, model)
+    fn train(&self, model: &mut BPE) -> Result<Vec<AddedToken>> {
+        self.do_train(&self.words, model)
     }
 
     /// Whether we should show progress
     fn should_show_progress(&self) -> bool {
         self.show_progress
+    }
+
+    fn feed<I, S, F>(&mut self, iterator: I, process: F) -> Result<()>
+    where
+        I: Iterator<Item = S> + Send,
+        S: AsRef<str> + Send,
+        F: Fn(&str) -> Result<Vec<String>> + Sync,
+    {
+        let words: Result<HashMap<String, u32>> = iterator
+            .maybe_par_bridge()
+            .map(|sequence| {
+                let words = process(sequence.as_ref())?;
+                let mut map = HashMap::new();
+                for word in words {
+                    map.entry(word).and_modify(|c| *c += 1).or_insert(1);
+                }
+                Ok(map)
+            })
+            .reduce(
+                || Ok(HashMap::new()),
+                |acc, ws| {
+                    let mut acc = acc?;
+                    for (k, v) in ws? {
+                        acc.entry(k).and_modify(|c| *c += v).or_insert(v);
+                    }
+                    Ok(acc)
+                },
+            );
+
+        self.words = words?;
+        Ok(())
     }
 }
 
@@ -624,7 +658,7 @@ mod tests {
             .min_frequency(2)
             .build();
         let mut model = BPE::default();
-        trainer.train(word_counts, &mut model).unwrap();
+        trainer.do_train(&word_counts, &mut model).unwrap();
 
         // Vocab should contain all of the characters from the `word_counts` mapping
         // as well as three merges: 're', 'are', and 'is'.

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -138,22 +138,21 @@ impl BpeTrainerBuilder {
     }
 }
 
-/// In charge of training a `BPE` model from a mapping of words to word counts.
+/// In charge of training a `BPE` model
 ///
 /// # Examples
 ///
 /// ```
-/// use std::collections::HashMap;
 /// use tokenizers::tokenizer::Trainer;
 /// use tokenizers::models::bpe::{BPE, BpeTrainer};
 ///
-/// let word_counts: HashMap<String, u32> = [
-///     (String::from("Hello"), 1),
-///     (String::from("World"), 1),
-/// ].iter().cloned().collect();
-/// let trainer = BpeTrainer::default();
+/// let sequences = vec![ "Hello", "World" ];
+///
+/// let mut trainer = BpeTrainer::default();
+/// trainer.feed(sequences.iter(), |s| Ok(vec![s.to_owned()]));
+///
 /// let mut model = BPE::default();
-/// let special_tokens = trainer.train(word_counts, &mut model).unwrap();
+/// let special_tokens = trainer.train(&mut model).unwrap();
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -532,11 +532,15 @@ mod tests {
         fn should_show_progress(&self) -> bool {
             true
         }
-        fn train(
-            &self,
-            _words: HashMap<String, u32>,
-            _model: &mut ModelMock,
-        ) -> Result<Vec<AddedToken>> {
+        fn train(&self, _model: &mut ModelMock) -> Result<Vec<AddedToken>> {
+            unimplemented!()
+        }
+        fn feed<I, S, F>(&mut self, _iterator: I, _process: F) -> Result<()>
+        where
+            I: Iterator<Item = S> + Send,
+            S: AsRef<str> + Send,
+            F: Fn(&str) -> Result<Vec<String>> + Sync,
+        {
             unimplemented!()
         }
     }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -131,20 +131,13 @@ pub trait Trainer {
     fn should_show_progress(&self) -> bool;
     /// The actual training method. This will return a new trained Model as well as a list
     /// of `special_tokens` to be added directly to the tokenizer along with the model.
-    fn train(
-        &self,
-        words: HashMap<String, u32>,
-        model: &mut Self::Model,
-    ) -> Result<Vec<AddedToken>>;
-    /// Process a bunch of token, counting them as relevant.
-    fn process_tokens(&self, words: &mut HashMap<String, u32>, tokens: Vec<String>) {
-        for token in tokens {
-            words
-                .entry(token.clone())
-                .and_modify(|c| *c += 1)
-                .or_insert(1);
-        }
-    }
+    fn train(&self, model: &mut Self::Model) -> Result<Vec<AddedToken>>;
+    /// Process an iterator of sequences already pre-processed by the Tokenizer
+    fn feed<I, S, F>(&mut self, iterator: I, process: F) -> Result<()>
+    where
+        I: Iterator<Item = S> + Send,
+        S: AsRef<str> + Send,
+        F: Fn(&str) -> Result<Vec<String>> + Sync;
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -969,99 +962,74 @@ where
             .collect()
     }
 
-    /// Train a model and replace our current Model, using the given Trainer
-    fn word_count<MN, T>(&self, trainer: &T, files: Vec<String>) -> Result<HashMap<String, u32>>
+    pub fn train_from_files<T>(&mut self, trainer: &mut T, files: Vec<String>) -> Result<&mut Self>
     where
-        T: Trainer<Model = MN> + Sync,
-        MN: Model,
+        T: Trainer<Model = M> + Sync,
     {
         let max_read = 1_000_000;
-        let mut len = 0;
-        for file in files.iter() {
-            len += File::open(file)
-                .and_then(|f| f.metadata())
-                .map(|m| m.len())?;
-        }
+        use crate::utils::iter::ResultShunt;
+        ResultShunt::process(
+            files.into_iter().flat_map(|filename| {
+                match File::open(filename) {
+                    Ok(file) => {
+                        let file = BufReader::with_capacity(max_read, file);
+                        // We read new lines using this API instead of the Lines Iterator
+                        // on purpose. We want to keep the `\n` and potential `\r` between each lines
+                        // We use an iterator to be able to chain with par_bridge.
+                        itertools::Either::Left(file.lines_with_ending())
+                    }
+                    Err(e) => itertools::Either::Right(std::iter::once(Err(e))),
+                }
+            }),
+            |iter| self.train(trainer, iter).map(|_| {}),
+        )??;
+        Ok(self)
+    }
 
+    /// Train a model and replace our current Model, using the given Trainer
+    pub fn train<T, I, S>(&mut self, trainer: &mut T, sequences: I) -> Result<&mut Self>
+    where
+        T: Trainer<Model = M> + Sync,
+        I: Iterator<Item = S> + Send,
+        S: AsRef<str> + Send,
+    {
+        let (lower, upper) = sequences.size_hint();
+        let len = upper.unwrap_or(lower) as u64;
         let progress = if trainer.should_show_progress() {
             let progress = ProgressBar::new(len);
             progress.set_style(
                 ProgressStyle::default_bar()
-                    .template("[{elapsed_precise}] {msg:<40!} {wide_bar} {percent:>19!}"),
+                    .template("[{elapsed_precise}] {msg:<40!} {wide_bar} {pos:<9!}/{len:>9!}"),
             );
-            progress.set_message(&format!("Reading files ({:.2} Mo)", len / 1_000_000));
+            progress.set_message("Pre-processing sequences");
             progress.set_draw_delta(len / 100); // Redraw only every 2%
             Some(progress)
         } else {
             None
         };
-        let words = files
-            .into_iter()
-            .map(|filename| -> Result<HashMap<String, u32>> {
-                let file = File::open(filename)?;
-                let file = BufReader::with_capacity(max_read, file);
-                // We read new lines using this API instead of the Lines Iterator
-                // on purpose. We want to keep the `\n` and potential `\r` between each lines
-                // We use an iterator to be able to chain with par_bridge.
-                file.lines_with_ending()
-                    .maybe_par_bridge()
-                    .map_with(
-                        &progress,
-                        |progress, line| -> Result<HashMap<String, u32>> {
-                            let newline = line?;
-                            let b = newline.len();
-                            let mut words = HashMap::new();
-                            let normalized = self.do_normalize(newline)?;
-                            let pre_tokenized = self.do_pre_tokenize(normalized)?;
-                            trainer.process_tokens(
-                                &mut words,
-                                pre_tokenized
-                                    .get_splits(OffsetReferential::Original, OffsetType::Byte)
-                                    .into_iter()
-                                    .map(|(s, _, _)| s.to_owned())
-                                    .collect(),
-                            );
 
-                            if let Some(pbar) = progress {
-                                pbar.inc(b as u64);
-                            }
-                            Ok(words)
-                        },
-                    )
-                    .reduce(
-                        || Ok(HashMap::new()),
-                        |acc, ws| {
-                            let mut acc = acc?;
-                            for (k, v) in ws? {
-                                acc.entry(k).and_modify(|c| *c += v).or_insert(v);
-                            }
-                            Ok(acc)
-                        },
-                    )
-            })
-            .try_fold(
-                HashMap::new(),
-                |mut acc, ws| -> Result<HashMap<String, u32>> {
-                    for (k, v) in ws? {
-                        acc.entry(k).and_modify(|c| *c += v).or_insert(v);
-                    }
-                    Ok(acc)
-                },
-            )?;
+        trainer.feed(
+            sequences.map(|s| {
+                // if let Some(progress) = &progress {
+                //     progress.inc(1)
+                // }
+                s
+            }),
+            |seq| {
+                let normalized = self.do_normalize(seq.as_ref())?;
+                let pre_tokenized = self.do_pre_tokenize(normalized)?;
+                Ok(pre_tokenized
+                    .get_splits(OffsetReferential::Original, OffsetType::Byte)
+                    .into_iter()
+                    .map(|(s, _, _)| s.to_owned())
+                    .collect())
+            },
+        )?;
         if let Some(pbar) = progress {
             pbar.finish();
         }
-        Ok(words)
-    }
 
-    /// Train a model and replace our current Model, using the given Trainer
-    pub fn train<T>(&mut self, trainer: &T, files: Vec<String>) -> Result<&mut Self>
-    where
-        T: Trainer<Model = M> + Sync,
-    {
-        let words = self.word_count(trainer, files)?;
-
-        let special_tokens = trainer.train(words, &mut self.model)?;
+        let special_tokens = trainer.train(&mut self.model)?;
         self.add_special_tokens(&special_tokens);
 
         Ok(self)

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -20,7 +20,7 @@ fn train_tokenizer() {
         .build()
         .unwrap();
 
-    let trainer = BpeTrainerBuilder::new()
+    let mut trainer = BpeTrainerBuilder::new()
         .show_progress(false)
         .vocab_size(vocab_size)
         .min_frequency(0)
@@ -35,7 +35,7 @@ fn train_tokenizer() {
 
     let pretty = true;
     tokenizer
-        .train(&trainer, vec!["data/small.txt".to_string()])
+        .train_from_files(&mut trainer, vec!["data/small.txt".to_string()])
         .unwrap()
         .save("data/tokenizer.json", pretty)
         .unwrap();
@@ -80,7 +80,7 @@ fn quicktour_slow_train() -> tokenizers::Result<()> {
     // START quicktour_init_trainer
     use tokenizers::models::bpe::BpeTrainer;
 
-    let trainer = BpeTrainer::builder()
+    let mut trainer = BpeTrainer::builder()
         .special_tokens(vec![
             AddedToken::from("[UNK]", true),
             AddedToken::from("[CLS]", true),
@@ -102,7 +102,7 @@ fn quicktour_slow_train() -> tokenizers::Result<()> {
         "data/wikitext-103-raw/wiki.test.raw".into(),
         "data/wikitext-103-raw/wiki.valid.raw".into(),
     ];
-    tokenizer.train(&trainer, files)?;
+    tokenizer.train_from_files(&mut trainer, files)?;
     // END quicktour_train
     // START quicktour_save
     tokenizer.save("data/tokenizer-wiki.json", false)?;
@@ -403,7 +403,7 @@ fn train_pipeline_bert() -> tokenizers::Result<()> {
     // START bert_train_tokenizer
     use tokenizers::models::{wordpiece::WordPieceTrainer, TrainerWrapper};
 
-    let trainer: TrainerWrapper = WordPieceTrainer::builder()
+    let mut trainer: TrainerWrapper = WordPieceTrainer::builder()
         .vocab_size(30_522)
         .special_tokens(vec![
             AddedToken::from("[UNK]", true),
@@ -419,7 +419,7 @@ fn train_pipeline_bert() -> tokenizers::Result<()> {
         "data/wikitext-103-raw/wiki.test.raw".into(),
         "data/wikitext-103-raw/wiki.valid.raw".into(),
     ];
-    bert_tokenizer.train(&trainer, files)?;
+    bert_tokenizer.train_from_files(&mut trainer, files)?;
 
     bert_tokenizer.save("data/bert-wiki.json", false)?;
     // END bert_train_tokenizer

--- a/tokenizers/tests/training.rs
+++ b/tokenizers/tests/training.rs
@@ -20,9 +20,9 @@ fn bpe_values_after_training() {
     )
     .build()
     .unwrap();
-    let trainer = tokenizer.get_model().get_trainer();
+    let mut trainer = tokenizer.get_model().get_trainer();
     tokenizer
-        .train(&trainer, vec!["./data/small.txt".to_string()])
+        .train_from_files(&mut trainer, vec!["./data/small.txt".to_string()])
         .unwrap();
     assert_eq!(tokenizer.get_model().dropout, Some(0.1));
     assert_eq!(tokenizer.get_model().unk_token, Some("[UNK]".to_string()));

--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use tokenizers::models::unigram::Lattice;
 use tokenizers::models::unigram::Unigram;
 use tokenizers::models::unigram::UnigramTrainer;
-use tokenizers::tokenizer::{Model, Trainer};
+use tokenizers::tokenizer::Model;
 
 #[test]
 fn test_unigram_from_file() {
@@ -56,7 +56,12 @@ fn test_train_unigram_from_file() {
         .build()
         .unwrap();
     let mut model = Unigram::default();
-    trainer.train(word_counts, &mut model).unwrap();
+
+    let sentences: Vec<_> = word_counts
+        .iter()
+        .map(|(s, i)| (s.to_owned(), *i))
+        .collect();
+    trainer.do_train(sentences, &mut model).unwrap();
     assert_eq!(model.get_vocab_size(), 719);
 }
 


### PR DESCRIPTION
Adds the ability to train from an `Iterator` in Rust, and anything that can be used as an iterator in Python too.

Training a tokenizer using `datasets` or a `List[str]` roughly takes as much time as training from files (cf `examples/train_with_datasets.py`)

Fix #198 & Fix #524 

Still need to add:
 - [x] Documentation (API Reference + examples)