### PR TITLE
Python - Prepare pre-release 0.10.0rc1

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0rc1]
 
 ### Added
+- [#508]: Add a Visualizer for notebooks to help understand how the tokenizers work
 - [#519]: Add a `WordLevelTrainer` used to train a `WordLevel` model
 - [#533]: Add support for conda builds
 - [#542]: Add Split pre-tokenizer to easily split using a pattern
@@ -298,6 +299,7 @@ delimiter (Works like `.split(delimiter)`)
 [#530]: https://github.com/huggingface/tokenizers/pull/530
 [#519]: https://github.com/huggingface/tokenizers/pull/519
 [#509]: https://github.com/huggingface/tokenizers/pull/509
+[#508]: https://github.com/huggingface/tokenizers/pull/508
 [#506]: https://github.com/huggingface/tokenizers/pull/506
 [#500]: https://github.com/huggingface/tokenizers/pull/500
 [#498]: https://github.com/huggingface/tokenizers/pull/498

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "tokenizers-python"
-version = "0.9.4"
+version = "0.10.0-rc1"
 dependencies = [
  "crossbeam",
  "env_logger",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokenizers-python"
-version = "0.9.4"
+version = "0.10.0-rc1"
 authors = ["Anthony MOI <m.anthony.moi@gmail.com>"]
 edition = "2018"
 

--- a/bindings/python/py_src/tokenizers/__init__.py
+++ b/bindings/python/py_src/tokenizers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.4"
+__version__ = "0.10.0rc1"
 
 from typing import Tuple, Union, Tuple, List
 from enum import Enum

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -6,7 +6,7 @@ extras["testing"] = ["pytest"]
 
 setup(
     name="tokenizers",
-    version="0.9.4",
+    version="0.10.0rc1",
     description="Fast and Customizable Tokenizers",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Missing before 0.10 final release:
 - [ ] Update the docs with some `datasets` example and `train_from_iterator`
 - [ ] Update the `deploy_docs.sh` script with the latest stable and tag for this version