### PR TITLE
Fix WordLevelTrainer default values

### DIFF
--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -7,13 +7,13 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Builder)]
 pub struct WordLevelTrainer {
     /// The minimum frequency a word must have to be part of the vocabulary
-    #[builder(default)]
+    #[builder(default = "0")]
     pub min_frequency: u32,
     /// The target vocabulary size
-    #[builder(default)]
+    #[builder(default = "30_000")]
     pub vocab_size: usize,
     /// Whether to show progress while training
-    #[builder(default)]
+    #[builder(default = "true")]
     pub show_progress: bool,
     /// A list of special tokens that the model should know of
     #[builder(default)]
@@ -25,13 +25,7 @@ pub struct WordLevelTrainer {
 
 impl Default for WordLevelTrainer {
     fn default() -> Self {
-        Self {
-            min_frequency: 0,
-            vocab_size: 30_000,
-            show_progress: true,
-            special_tokens: vec![],
-            words: HashMap::new(),
-        }
+        Self::builder().build().unwrap()
     }
 }
 


### PR DESCRIPTION
Fix https://github.com/huggingface/tokenizers/issues/553

Initially I thought the derive_builder default values would be those from the `Default` impl of the `WordLevelTrainer` but it actually uses the default values for each member. Used the same pattern that we use in `Unigram` to fix it.