### PR TITLE
Python - Improve training with iterators

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -66,12 +66,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,43 +107,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
-
-[[package]]
-name = "crossbeam"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel 0.5.0",
- "crossbeam-deque 0.8.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-queue",
- "crossbeam-utils 0.8.0",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -158,20 +122,9 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
- "crossbeam-epoch 0.8.2",
- "crossbeam-utils 0.7.2",
+ "crossbeam-epoch",
+ "crossbeam-utils",
  "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -181,36 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
+ "cfg-if",
+ "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
-dependencies = [
- "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.0",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2a58563f049aa3bae172bc4120f093b5901161c629f280a1f40ba55317d774"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -220,19 +149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
- "const_fn",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -352,7 +269,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -433,7 +350,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -496,7 +413,7 @@ checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if",
  "ryu",
  "static_assertions",
 ]
@@ -522,7 +439,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -629,7 +546,7 @@ name = "numpy"
 version = "0.11.0"
 source = "git+https://github.com/pyo3/rust-numpy/?rev=e331befa27fede78d4662edf08fa0508db39be01#e331befa27fede78d4662edf08fa0508db39be01"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "ndarray",
  "num-complex",
@@ -676,7 +593,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "cloudabi",
  "instant",
  "libc",
@@ -838,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
 dependencies = [
  "autocfg",
- "crossbeam-deque 0.7.3",
+ "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -859,9 +776,9 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
 dependencies = [
- "crossbeam-channel 0.4.4",
- "crossbeam-deque 0.7.3",
- "crossbeam-utils 0.7.2",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -995,7 +912,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "rand",
  "redox_syscall",
@@ -1078,7 +995,6 @@ dependencies = [
 name = "tokenizers-python"
 version = "0.10.0-rc1"
 dependencies = [
- "crossbeam",
  "env_logger",
  "itertools 0.9.0",
  "libc",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -18,7 +18,6 @@ pyo3 = "0.12"
 numpy = { git = "https://github.com/pyo3/rust-numpy/", rev = "e331befa27fede78d4662edf08fa0508db39be01" }
 ndarray = "0.13"
 onig = { version = "6.0", default-features = false }
-crossbeam = "0.8"
 itertools = "0.9"
 
 [dependencies.tokenizers]

--- a/bindings/python/src/utils/iterators.rs
+++ b/bindings/python/src/utils/iterators.rs
@@ -1,0 +1,133 @@
+use pyo3::prelude::*;
+use pyo3::{AsPyPointer, PyNativeType};
+use std::collections::VecDeque;
+
+/// An simple iterator that can be instantiated with a specified length.
+/// We use this with iterators that don't have a size_hint but we might
+/// know its size. This is useful with progress bars for example.
+pub struct MaybeSizedIterator<I> {
+    length: Option<usize>,
+    iter: I,
+}
+
+impl<I> MaybeSizedIterator<I>
+where
+    I: Iterator,
+{
+    pub fn new(iter: I, length: Option<usize>) -> Self {
+        Self { iter, length }
+    }
+}
+
+impl<I> Iterator for MaybeSizedIterator<I>
+where
+    I: Iterator,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.length.unwrap_or(0), None)
+    }
+}
+
+/// A buffered iterator that takes care of locking the GIL only when needed.
+/// The `PyIterator` provided by PyO3 keeps a Python GIL token all along
+/// and thus doesn't allow us to release the GIL to allow having other threads.
+///
+/// This iterator serves two purposes:
+///   - First, as opposed to the `pyo3::PyIterator`, it is Send and can easily be parallelized
+///   - Second, this let us release the GIL between two refills of the buffer, allowing other
+///     Python threads to work
+pub struct PyBufferedIterator<T, F> {
+    iter: Option<Py<PyAny>>,
+    converter: F,
+    buffer: VecDeque<PyResult<T>>,
+    size: usize,
+}
+
+impl<T, F, I> PyBufferedIterator<T, F>
+where
+    F: Fn(&PyAny) -> I,
+    I: IntoIterator<Item = PyResult<T>>,
+{
+    /// Create a new PyBufferedIterator using the provided Python object.
+    /// This object must implement the Python Iterator Protocol, and an error will
+    /// be return if the contract is not respected.
+    ///
+    /// The `converter` provides a way to convert each item in the iterator into
+    /// something that doesn't embed a 'py token and thus allows the GIL to be released
+    ///
+    /// The `buffer_size` represents the number of items that we buffer before we
+    /// need to acquire the GIL again.
+    pub fn new(iter: &PyAny, converter: F, buffer_size: usize) -> PyResult<Self> {
+        let py = iter.py();
+        let iter: Py<PyAny> = unsafe {
+            py.from_borrowed_ptr_or_err::<PyAny>(pyo3::ffi::PyObject_GetIter(iter.as_ptr()))?
+                .to_object(py)
+        };
+
+        Ok(Self {
+            iter: Some(iter),
+            converter,
+            buffer: VecDeque::with_capacity(buffer_size),
+            size: buffer_size,
+        })
+    }
+
+    /// Refill the buffer, and set `self.iter` as `None` if nothing more to get
+    fn refill(&mut self) -> PyResult<()> {
+        if self.iter.is_none() {
+            return Ok(());
+        }
+
+        Python::with_gil(|py| loop {
+            if self.buffer.len() >= self.size {
+                return Ok(());
+            }
+
+            match unsafe {
+                py.from_owned_ptr_or_opt::<PyAny>(pyo3::ffi::PyIter_Next(
+                    self.iter.as_ref().unwrap().as_ref(py).as_ptr(),
+                ))
+            } {
+                Some(obj) => self.buffer.extend((self.converter)(obj)),
+                None => {
+                    if PyErr::occurred(py) {
+                        return Err(PyErr::fetch(py));
+                    } else {
+                        self.iter = None;
+                    }
+                }
+            };
+
+            if self.iter.is_none() {
+                return Ok(());
+            }
+        })
+    }
+}
+
+impl<T, F, I> Iterator for PyBufferedIterator<T, F>
+where
+    F: Fn(&PyAny) -> I,
+    I: IntoIterator<Item = PyResult<T>>,
+{
+    type Item = PyResult<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.buffer.is_empty() {
+            self.buffer.pop_front()
+        } else if self.iter.is_some() {
+            if let Err(e) = self.refill() {
+                return Some(Err(e));
+            }
+            self.next()
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
Fix #558 

Introduces a new `PyBufferedIterator` that actually let us have an iterator that fits both requirements:
  - Having a `Send` iterator to use with `Tokenizer::train_from_iterator`
  - Releasing the GIL to allow custom Python components.

This iterator locks the GIL only to refill its internal buffer and converts all the items into something that does not depends on the GIL. It is then safe to parallelize this iterator, with one of the threads sometimes refilling as needed.

There is no significant difference in terms of performance as compared to the previous version, even when using `String` instead of `&str`.