### PR TITLE
Add `fuse_unk` option to SentencePieceBPETokenizer

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -23,7 +23,9 @@ class SentencePieceBPETokenizer(BaseTokenizer):
         fuse_unk: Optional[bool] = False,
     ):
         if vocab is not None and merges is not None:
-            tokenizer = Tokenizer(BPE(vocab, merges, dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))
+            tokenizer = Tokenizer(
+                BPE(vocab, merges, dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk)
+            )
         else:
             tokenizer = Tokenizer(BPE())
 

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -20,9 +20,10 @@ class SentencePieceBPETokenizer(BaseTokenizer):
         replacement: str = "▁",
         add_prefix_space: bool = True,
         dropout: Optional[float] = None,
+        fuse_unk: Optional[bool] = False,
     ):
         if vocab is not None and merges is not None:
-            tokenizer = Tokenizer(BPE(vocab, merges, dropout=dropout, unk_token=unk_token))
+            tokenizer = Tokenizer(BPE(vocab, merges, dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))
         else:
             tokenizer = Tokenizer(BPE())
 


### PR DESCRIPTION
Since original SentencePiece can [merge](https://github.com/google/sentencepiece/blob/33a977f8fab881e6ea2adf7b9241035481651007/src/sentencepiece_processor.cc#L393) successive `<unk>` tokens into single `<unk>` token, 
I think SentencePieceBPETokenizer of tokenizers also needs to support this option.
I looked through python binding codes, then find [`fuse_unk`](https://github.com/huggingface/tokenizers/blob/6e364cb685858dab4d19a8ac79176588053c8c0e/bindings/python/src/models.rs#L234) is the option implemented for this.

When I use the current code, I would get the following result

```python
>>> sentence = "꿿뀷뜛 정말 맛있어"
>>> sp.EncodeAsPieces(sentence)
꿿뀷뜛 ▁정말 ▁맛 있어  # it is actually '<unk> ▁정말 ▁맛 있어', there is recovery option for <unk> in SentencePiece
>>> tokenizer.encode(sentence).tokens
<unk> <unk> <unk> ▁정말 ▁맛 있어
```

After I changed the code, I can get result

```python
>>> sentence = "꿿뀷뜛 정말 맛있어"
>>> sp.EncodeAsPieces(sentence)
꿿뀷뜛 ▁정말 ▁맛 있어  # it is actually '<unk> ▁정말 ▁맛 있어', there is recovery option for <unk> in SentencePiece
>>> tokenizer.encode(sentence).tokens  # it is initialized with `fuse_unk=True` option
<unk> ▁정말 ▁맛 있어
```

[`SpmConverter`](https://github.com/huggingface/tokenizers/blob/dcb3bba235fc04895435c5f3e307327cdb80475b/bindings/python/scripts/convert.py#L84) also use this option, but manually with `BPE` constructor.

Please review this PR for SentencePieceBPETokenizer user :) 