### PR TITLE
Python - Fix breaking change in Model.save

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
@@ -309,17 +309,17 @@ class BaseTokenizer:
         """
         return self._tokenizer.id_to_token(id)
 
-    def save_model(self, directory: str, name: Optional[str] = None):
+    def save_model(self, directory: str, prefix: Optional[str] = None):
         """Save the current model to the given directory
 
         Args:
             directory: str:
                 A path to the destination directory
 
-            name: (Optional) str:
-                The name of the tokenizer, to be used in the saved files
+            prefix: (Optional) str:
+                An optional prefix, used to prefix each file name
         """
-        return self._tokenizer.model.save(directory, name=name)
+        return self._tokenizer.model.save(directory, prefix=prefix)
 
     def save(self, path: str, pretty: bool = False):
         """Save the current Tokenizer at the given path

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -183,7 +183,22 @@ impl PyModel {
     /// Returns:
     ///     :obj:`List[str]`: The list of saved files
     #[text_signature = "(self, folder, prefix)"]
-    fn save(&self, folder: &str, prefix: Option<&str>) -> PyResult<Vec<String>> {
+    fn save<'a>(
+        &self,
+        folder: &str,
+        mut prefix: Option<&'a str>,
+        name: Option<&'a str>,
+    ) -> PyResult<Vec<String>> {
+        if name.is_some() {
+            deprecation_warning(
+                "0.10.0",
+                "Parameter `name` of Model.save has been renamed `prefix`",
+            )?;
+            if prefix.is_none() {
+                prefix = name;
+            }
+        }
+
         let saved: PyResult<Vec<_>> =
             ToPyResult(self.model.read().unwrap().save(Path::new(folder), prefix)).into();
 


### PR DESCRIPTION
While writing the documentation, I renamed the parameter `name` to `prefix` for clarity. This PR ensures we can still use `name` while giving a deprecation warning telling to update to `prefix`.