### PR TITLE
Fix SentencePiece tokenizers conversion

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           python -m venv .env
           source .env/bin/activate
-          pip install pytest requests setuptools_rust numpy datasets
+          pip install pytest requests setuptools_rust numpy "pyarrow<3.0.0" datasets
           python setup.py develop
 
       - name: Check style

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- [#616]: Fix SentencePiece tokenizers conversion
+
 ## [0.10.0]
 
 ### Added
@@ -22,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `tokenizer.model.dropout = 0.1`)
 - [#538]: The API Reference has been improved and is now up-to-date.
 
-## Fixed
+### Fixed
 - [#519]: During training, the `Model` is now trained in-place. This fixes several bugs that were
 forcing to reload the `Model` after a training.
 - [#539]: Fix `BaseTokenizer` enable_truncation docstring
@@ -293,6 +298,7 @@ delimiter (Works like `.split(delimiter)`)
 - Fix a bug that was causing crashes in Python 3.5
 
 
+[#616]: https://github.com/huggingface/tokenizers/pull/616
 [#590]: https://github.com/huggingface/tokenizers/pull/590
 [#574]: https://github.com/huggingface/tokenizers/pull/574
 [#544]: https://github.com/huggingface/tokenizers/pull/544

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
@@ -1,11 +1,4 @@
-from tokenizers import (
-    Tokenizer,
-    AddedToken,
-    pre_tokenizers,
-    decoders,
-    trainers,
-    normalizers,
-)
+from tokenizers import Tokenizer, AddedToken, pre_tokenizers, decoders, trainers, normalizers, Regex
 import os
 from tokenizers.models import Unigram
 import json
@@ -33,18 +26,10 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
             tokenizer = Tokenizer(Unigram())
 
         tokenizer.normalizer = normalizers.Sequence(
-            [
-                normalizers.Nmt(),
-                normalizers.NFKC(),
-            ]
+            [normalizers.Nmt(), normalizers.NFKC(), normalizers.Replace(Regex(" {2,}"), " ")]
         )
-        tokenizer.pre_tokenizer = pre_tokenizers.Sequence(
-            [
-                pre_tokenizers.WhitespaceSplit(),
-                pre_tokenizers.Metaspace(
-                    replacement=replacement, add_prefix_space=add_prefix_space
-                ),
-            ]
+        tokenizer.pre_tokenizer = pre_tokenizers.Metaspace(
+            replacement=replacement, add_prefix_space=add_prefix_space
         )
         tokenizer.decoder = decoders.Metaspace(
             replacement=replacement, add_prefix_space=add_prefix_space
@@ -124,14 +109,14 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
 
         tokenizer = Tokenizer(Unigram(vocab, unk_id))
 
-        tokenizer.normalizer = normalizers.Precompiled(precompiled_charsmap)
-        tokenizer.pre_tokenizer = pre_tokenizers.Sequence(
+        tokenizer.normalizer = normalizers.Sequence(
             [
-                pre_tokenizers.WhitespaceSplit(),
-                pre_tokenizers.Metaspace(
-                    replacement=replacement, add_prefix_space=add_prefix_space
-                ),
+                normalizers.Precompiled(precompiled_charsmap),
+                normalizers.Replace(Regex(" {2,}"), " "),
             ]
+        )
+        tokenizer.pre_tokenizer = pre_tokenizers.Metaspace(
+            replacement=replacement, add_prefix_space=add_prefix_space
         )
         tokenizer.decoder = decoders.Metaspace(
             replacement=replacement, add_prefix_space=add_prefix_space

--- a/bindings/python/scripts/spm_parity_check.py
+++ b/bindings/python/scripts/spm_parity_check.py
@@ -131,12 +131,12 @@ def check_diff(spm_diff, tok_diff, sp, tok):
     if spm_diff == list(reversed(tok_diff)):
         # AAA -> AA+A vs A+AA case.
         return True
-    # elif len(spm_diff) == len(tok_diff) and tok.decode(spm_diff) == tok.decode(
-    #     tok_diff
-    # ):
-    #     # Second order OK
-    #     # Barrich -> Barr + ich vs Bar + rich
-    #     return True
+    elif len(spm_diff) == len(tok_diff) and tok.decode(spm_diff) == tok.decode(
+        tok_diff
+    ):
+        # Second order OK
+        # Barrich -> Barr + ich vs Bar + rich
+        return True
     spm_reencoded = sp.encode(sp.decode(spm_diff))
     tok_reencoded = tok.encode(tok.decode(spm_diff)).ids
     if spm_reencoded != spm_diff and spm_reencoded == tok_reencoded:
@@ -265,7 +265,7 @@ def check_encode(args):
             else:
                 perfect += 1
 
-            assert ids == encoded.ids, f"line {i}: {line} : {ids} != {encoded.ids}"
+            assert ids == encoded.ids, f"line {i}: {line} : \n\n{ids}\n{encoded.ids}\n{list(zip(encoded.ids, encoded.tokens))}"
 
     print(f"({perfect} / {imperfect} / {wrong} ----- {perfect + imperfect + wrong})")
     total = perfect + imperfect + wrong

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -40,11 +40,11 @@ impl Default for Metaspace {
 impl PreTokenizer for Metaspace {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
         pretokenized.split(|_, mut normalized| {
+            normalized.replace(' ', &self.str_rep)?;
             if self.add_prefix_space && !normalized.get().starts_with(self.replacement) {
                 normalized.prepend(&self.str_rep);
             }
 
-            normalized.replace(' ', &self.str_rep)?;
             normalized.split(self.replacement, SplitDelimiterBehavior::MergedWithNext)
         })
     }


### PR DESCRIPTION
There is a bug in offset mapping that actually affects **all** the fast tokenizers converted from SentencePiece. During the pre-tokenization step, we first split everything on whitespaces (`WhitespaceSplit` pre-tokenizer), and in a second step, we add the `▁` character in front of each word (`Metaspace` pre-tokenizer). This process is accurate in terms of tokenization, but it makes the offset tracking very difficult:
 - All the whitespaces get removed, so we won't have any token pointing back to them.
 - We add a "new" `▁` in front of each word, so these tokens actually point back to the beginning of each word: the first character.

### How we fix it

The initial idea of using the `WhitespaceSplit` in a first step was simply to deduplicate the whitespaces but since it leads to loss of information we replace it with the following process:
 - Normalization step that replaces groups of whitespaces with a single one, effectively mapping the single whitespace to the group in the original input.
 - Pretokenization step: we just keep the `Metaspace` pre-tokenizer.


Related to https://github.com/huggingface/transformers/issues/9633 and https://github.com/huggingface/transformers/issues/9637