### PR TITLE
Improve Model serialization/deserialization

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#616]: Fix SentencePiece tokenizers conversion
 - [#617]: Fix offsets produced by Precompiled Normalizer (used by tokenizers converted from SPM)
 - [#618]: Fix Normalizer.normalize with `PyNormalizedStringRefMut`
+- [#620]: Fix serialization/deserialization for overlapping models
 
 ## [0.10.0]
 
@@ -300,6 +301,7 @@ delimiter (Works like `.split(delimiter)`)
 - Fix a bug that was causing crashes in Python 3.5
 
 
+[#620]: https://github.com/huggingface/tokenizers/pull/620
 [#618]: https://github.com/huggingface/tokenizers/pull/618
 [#617]: https://github.com/huggingface/tokenizers/pull/617
 [#616]: https://github.com/huggingface/tokenizers/pull/616

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -11,9 +11,10 @@ impl Serialize for BPE {
     where
         S: Serializer,
     {
-        let mut model = serializer.serialize_struct("BPE", 6)?;
+        let mut model = serializer.serialize_struct("BPE", 8)?;
 
         // Start by small fields
+        model.serialize_field("type", "BPE")?;
         model.serialize_field("dropout", &self.dropout)?;
         model.serialize_field("unk_token", &self.unk_token)?;
         model.serialize_field("continuing_subword_prefix", &self.continuing_subword_prefix)?;
@@ -48,6 +49,7 @@ impl<'de> Deserialize<'de> for BPE {
         deserializer.deserialize_struct(
             "BPE",
             &[
+                "type",
                 "dropout",
                 "unk_token",
                 "continuing_subword_prefix",
@@ -105,6 +107,15 @@ impl<'de> Visitor<'de> for BPEVisitor {
                 }
                 "vocab" => vocab = Some(map.next_value()?),
                 "merges" => merges = Some(map.next_value()?),
+                "type" => match map.next_value()? {
+                    "BPE" => {}
+                    u => {
+                        return Err(serde::de::Error::invalid_value(
+                            serde::de::Unexpected::Str(u),
+                            &"BPE",
+                        ))
+                    }
+                },
                 _ => {}
             }
         }

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -41,8 +41,10 @@ impl<'a> Serialize for OrderedVocabIter<'a> {
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum ModelWrapper {
-    WordPiece(WordPiece),
     BPE(BPE),
+    // WordPiece must stay before WordLevel here for deserialization (for retrocompatibility
+    // with the versions not including the "type"), since WordLevel is a subset of WordPiece
+    WordPiece(WordPiece),
     WordLevel(WordLevel),
     Unigram(Unigram),
 }

--- a/tokenizers/src/models/unigram/serialization.rs
+++ b/tokenizers/src/models/unigram/serialization.rs
@@ -10,8 +10,9 @@ impl Serialize for Unigram {
     where
         S: Serializer,
     {
-        let mut model = serializer.serialize_struct("Unigram", 2)?;
+        let mut model = serializer.serialize_struct("Unigram", 3)?;
 
+        model.serialize_field("type", "Unigram")?;
         model.serialize_field("unk_id", &self.unk_id)?;
         model.serialize_field("vocab", &self.vocab)?;
 
@@ -24,7 +25,7 @@ impl<'de> Deserialize<'de> for Unigram {
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_struct("Unigram", &["vocab", "unk_id"], UnigramVisitor)
+        deserializer.deserialize_struct("Unigram", &["type", "vocab", "unk_id"], UnigramVisitor)
     }
 }
 
@@ -48,6 +49,15 @@ impl<'de> Visitor<'de> for UnigramVisitor {
                     unk_id = map.next_value()?;
                 }
                 "vocab" => vocab = Some(map.next_value()?),
+                "type" => match map.next_value()? {
+                    "Unigram" => {}
+                    u => {
+                        return Err(serde::de::Error::invalid_value(
+                            serde::de::Unexpected::Str(u),
+                            &"Unigram",
+                        ))
+                    }
+                },
                 _ => (),
             }
         }

--- a/tokenizers/src/models/wordlevel/serialization.rs
+++ b/tokenizers/src/models/wordlevel/serialization.rs
@@ -4,14 +4,16 @@ use serde::{
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
+use std::collections::HashSet;
 
 impl Serialize for WordLevel {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut model = serializer.serialize_struct("WordLevel", 2)?;
+        let mut model = serializer.serialize_struct("WordLevel", 3)?;
         let ordered_vocab = OrderedVocabIter::new(&self.vocab_r);
+        model.serialize_field("type", "WordLevel")?;
         model.serialize_field("vocab", &ordered_vocab)?;
         model.serialize_field("unk_token", &self.unk_token)?;
         model.end()
@@ -23,7 +25,11 @@ impl<'de> Deserialize<'de> for WordLevel {
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_struct("WordLevel", &["vocab", "unk_token"], WordLevelVisitor)
+        deserializer.deserialize_struct(
+            "WordLevel",
+            &["type", "vocab", "unk_token"],
+            WordLevelVisitor,
+        )
     }
 }
 
@@ -40,13 +46,66 @@ impl<'de> Visitor<'de> for WordLevelVisitor {
         V: MapAccess<'de>,
     {
         let mut builder = WordLevelBuilder::new();
+        let mut missing_fields = vec![
+            // for retrocompatibility the "type" field is not mandatory
+            "unk_token",
+            "vocab",
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>();
         while let Some(key) = map.next_key::<String>()? {
             match key.as_ref() {
                 "vocab" => builder = builder.vocab(map.next_value()?),
                 "unk_token" => builder = builder.unk_token(map.next_value()?),
+                "type" => match map.next_value()? {
+                    "WordLevel" => {}
+                    u => {
+                        return Err(serde::de::Error::invalid_value(
+                            serde::de::Unexpected::Str(u),
+                            &"WordLevel",
+                        ))
+                    }
+                },
                 _ => {}
             }
+            missing_fields.remove::<str>(&key);
         }
-        Ok(builder.build().map_err(serde::de::Error::custom)?)
+
+        if !missing_fields.is_empty() {
+            Err(serde::de::Error::missing_field(
+                missing_fields.iter().next().unwrap(),
+            ))
+        } else {
+            Ok(builder.build().map_err(serde::de::Error::custom)?)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde() {
+        let wl = WordLevel::default();
+        let wl_s = r#"{"type":"WordLevel","vocab":{},"unk_token":"<unk>"}"#;
+
+        assert_eq!(serde_json::to_string(&wl).unwrap(), wl_s);
+        assert_eq!(serde_json::from_str::<WordLevel>(wl_s).unwrap(), wl);
+    }
+
+    #[test]
+    fn deserialization_should_fail() {
+        let missing_unk = r#"{"type":"WordLevel","vocab":{}}"#;
+        assert!(serde_json::from_str::<WordLevel>(missing_unk)
+            .unwrap_err()
+            .to_string()
+            .starts_with("missing field `unk_token`"));
+
+        let wrong_type = r#"{"type":"WordPiece","vocab":{}}"#;
+        assert!(serde_json::from_str::<WordLevel>(wrong_type)
+            .unwrap_err()
+            .to_string()
+            .starts_with("invalid value: string \"WordPiece\", expected WordLevel"));
     }
 }

--- a/tokenizers/src/models/wordpiece/serialization.rs
+++ b/tokenizers/src/models/wordpiece/serialization.rs
@@ -4,15 +4,17 @@ use serde::{
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
+use std::collections::HashSet;
 
 impl Serialize for WordPiece {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut model = serializer.serialize_struct("WordPiece", 4)?;
+        let mut model = serializer.serialize_struct("WordPiece", 5)?;
 
         // Small fields first
+        model.serialize_field("type", "WordPiece")?;
         model.serialize_field("unk_token", &self.unk_token)?;
         model.serialize_field("continuing_subword_prefix", &self.continuing_subword_prefix)?;
         model.serialize_field("max_input_chars_per_word", &self.max_input_chars_per_word)?;
@@ -33,6 +35,7 @@ impl<'de> Deserialize<'de> for WordPiece {
         deserializer.deserialize_struct(
             "WordPiece",
             &[
+                "type",
                 "unk_token",
                 "continuing_subword_prefix",
                 "max_input_chars_per_word",
@@ -56,6 +59,16 @@ impl<'de> Visitor<'de> for WordPieceVisitor {
         V: MapAccess<'de>,
     {
         let mut builder = WordPieceBuilder::new();
+        let mut missing_fields = vec![
+            // for retrocompatibility the "type" field is not mandatory
+            "unk_token",
+            "continuing_subword_prefix",
+            "max_input_chars_per_word",
+            "vocab",
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>();
+
         while let Some(key) = map.next_key::<String>()? {
             match key.as_ref() {
                 "unk_token" => builder = builder.unk_token(map.next_value()?),
@@ -66,9 +79,70 @@ impl<'de> Visitor<'de> for WordPieceVisitor {
                     builder = builder.max_input_chars_per_word(map.next_value()?)
                 }
                 "vocab" => builder = builder.vocab(map.next_value()?),
+                "type" => match map.next_value()? {
+                    "WordPiece" => {}
+                    u => {
+                        return Err(serde::de::Error::invalid_value(
+                            serde::de::Unexpected::Str(u),
+                            &"WordPiece",
+                        ))
+                    }
+                },
                 _ => {}
             }
+            missing_fields.remove::<str>(&key);
         }
-        Ok(builder.build().map_err(serde::de::Error::custom)?)
+
+        if !missing_fields.is_empty() {
+            Err(serde::de::Error::missing_field(
+                missing_fields.iter().next().unwrap(),
+            ))
+        } else {
+            Ok(builder.build().map_err(serde::de::Error::custom)?)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde() {
+        let wp = WordPiece::default();
+        let wp_s = "{\
+            \"type\":\"WordPiece\",\
+            \"unk_token\":\"[UNK]\",\
+            \"continuing_subword_prefix\":\"##\",\
+            \"max_input_chars_per_word\":100,\
+            \"vocab\":{}\
+        }";
+
+        assert_eq!(serde_json::to_string(&wp).unwrap(), wp_s);
+        assert_eq!(serde_json::from_str::<WordPiece>(wp_s).unwrap(), wp);
+    }
+
+    #[test]
+    fn deserialization_should_fail() {
+        let missing_unk = "{\
+            \"type\":\"WordPiece\",\
+            \"continuing_subword_prefix\":\"##\",\
+            \"max_input_chars_per_word\":100,\
+            \"vocab\":{}\
+        }";
+        assert!(serde_json::from_str::<WordPiece>(missing_unk)
+            .unwrap_err()
+            .to_string()
+            .starts_with("missing field `unk_token`"));
+
+        let wrong_type = "{\
+            \"type\":\"WordLevel\",\
+            \"unk_token\":\"[UNK]\",\
+            \"vocab\":{}\
+        }";
+        assert!(serde_json::from_str::<WordPiece>(wrong_type)
+            .unwrap_err()
+            .to_string()
+            .starts_with("invalid value: string \"WordLevel\", expected WordPiece"));
     }
 }


### PR DESCRIPTION
Fix #600 

As we manually implement `Serialize` and `Deserialize` for the various models, we didn't include the `#[serde(tag = "type")]` we use everywhere else, so when deserializing we can only know what Model it is based on the various fields we see.
This used to work fine as long as these models were different enough, but it is not the case anymore with `WordPiece` and `WordLevel` that can be deserialized from the same serialized json.

This PR fixes this by adding the `type` in the serialization process, and using it if it is defined. This is also backward compatible because we don't make it mandatory, but we add a layer of verification based on the presence of the fields (mainly for `WordPiece` and `WordLevel`).