### PR TITLE
Fix Metaspace serialization & Python constructor

### DIFF
--- a/bindings/node/native/src/extraction.rs
+++ b/bindings/node/native/src/extraction.rs
@@ -89,10 +89,9 @@ impl<'c, T: neon::object::This> Extract for CallContext<'c, T> {
         self.argument_opt(pos)
             .map(|v| {
                 let vec = v.downcast::<JsArray>()?.to_vec(self)?;
-                Ok(vec
-                    .into_iter()
+                vec.into_iter()
                     .map(|v| E::from_value(v, self))
-                    .collect::<LibResult<Vec<_>>>()?)
+                    .collect::<LibResult<Vec<_>>>()
             })
             .map_or(Ok(None), |v| v.map(Some))
     }

--- a/bindings/node/native/src/lib.rs
+++ b/bindings/node/native/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 // We need to allow these to use !declare_types
 #![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::upper_case_acronyms)]
 
 extern crate neon;
 extern crate neon_serde;

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#652]: Fix offsets for `Precompiled` corner case
 - [#656]: Fix BPE `continuing_subword_prefix`
+- [#674]: Fix `Metaspace` serialization problems
 
 ## [0.10.1]
 
@@ -308,6 +309,7 @@ delimiter (Works like `.split(delimiter)`)
 - Fix a bug that was causing crashes in Python 3.5
 
 
+[#674]: https://github.com/huggingface/tokenizers/pull/674
 [#656]: https://github.com/huggingface/tokenizers/pull/656
 [#652]: https://github.com/huggingface/tokenizers/pull/652
 [#621]: https://github.com/huggingface/tokenizers/pull/621

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -23,10 +23,9 @@ impl Display for PyError {
 impl std::error::Error for PyError {}
 
 pub struct ToPyResult<T>(pub Result<T>);
-impl<T> std::convert::Into<PyResult<T>> for ToPyResult<T> {
-    fn into(self) -> PyResult<T> {
-        self.0
-            .map_err(|e| exceptions::PyException::new_err(format!("{}", e)))
+impl<T> From<ToPyResult<T>> for PyResult<T> {
+    fn from(v: ToPyResult<T>) -> Self {
+        v.0.map_err(|e| exceptions::PyException::new_err(format!("{}", e)))
     }
 }
 impl<T> ToPyResult<T> {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::all)]
+#![allow(clippy::upper_case_acronyms)]
 
 extern crate tokenizers as tk;
 

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -464,8 +464,12 @@ impl PyMetaspace {
     }
 
     #[new]
-    #[args(replacement = "PyChar('▁')", add_prefix_space = "true")]
-    fn new(replacement: PyChar, add_prefix_space: bool) -> (Self, PyPreTokenizer) {
+    #[args(replacement = "PyChar('▁')", add_prefix_space = "true", _kwargs = "**")]
+    fn new(
+        replacement: PyChar,
+        add_prefix_space: bool,
+        _kwargs: Option<&PyDict>,
+    ) -> (Self, PyPreTokenizer) {
         (
             PyMetaspace {},
             Metaspace::new(replacement.0, add_prefix_space).into(),

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::all)]
+#![allow(clippy::upper_case_acronyms)]
 #![doc(html_favicon_url = "https://huggingface.co/favicon.ico")]
 #![doc(html_logo_url = "https://huggingface.co/landing/assets/huggingface_logo.svg")]
 

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -252,7 +252,7 @@ impl Unigram {
             /// The starting position (in utf-8) of this node. The entire best
             /// path can be constructed by backtracking along this link.
             starts_at: Option<usize>,
-        };
+        }
         impl Default for BestPathNode {
             fn default() -> Self {
                 Self {

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -100,6 +100,15 @@ mod tests {
             serde_json::from_str::<Metaspace>(metaspace_s).unwrap(),
             metaspace
         );
+
+        // Also check it can deserialize previous versions
+        let metaspace = Metaspace::new('_', true);
+        let metaspace_s =
+            r#"{"type":"Metaspace","str_rep":"_","replacement":"_","add_prefix_space":true}"#;
+        assert_eq!(
+            serde_json::from_str::<Metaspace>(metaspace_s).unwrap(),
+            metaspace
+        );
     }
 
     #[test]

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -44,16 +44,16 @@ impl PostProcessor for BertProcessing {
             return PostProcessor::default_process(encoding, pair_encoding, add_special_tokens);
         }
 
-        let ids = [&[self.cls.1], &encoding.get_ids()[..], &[self.sep.1]].concat();
-        let type_ids = [&[0], &encoding.get_type_ids()[..], &[0]].concat();
+        let ids = [&[self.cls.1], encoding.get_ids(), &[self.sep.1]].concat();
+        let type_ids = [&[0], encoding.get_type_ids(), &[0]].concat();
         let tokens = [
             &[self.cls.0.clone()],
-            &encoding.get_tokens()[..],
+            encoding.get_tokens(),
             &[self.sep.0.clone()],
         ]
         .concat();
-        let words = [&[None], &encoding.get_word_ids()[..], &[None]].concat();
-        let offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
+        let words = [&[None], encoding.get_word_ids(), &[None]].concat();
+        let offsets = [&[(0, 0)], encoding.get_offsets(), &[(0, 0)]].concat();
         let special_tokens = [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
         let attention_mask = vec![1; ids.len()];
 
@@ -72,16 +72,16 @@ impl PostProcessor for BertProcessing {
                 .take_overflowing()
                 .into_iter()
                 .map(|encoding| {
-                    let ids = [&[self.cls.1], &encoding.get_ids()[..], &[self.sep.1]].concat();
-                    let type_ids = [&[0], &encoding.get_type_ids()[..], &[0]].concat();
+                    let ids = [&[self.cls.1], encoding.get_ids(), &[self.sep.1]].concat();
+                    let type_ids = [&[0], encoding.get_type_ids(), &[0]].concat();
                     let tokens = [
                         &[self.cls.0.clone()],
-                        &encoding.get_tokens()[..],
+                        encoding.get_tokens(),
                         &[self.sep.0.clone()],
                     ]
                     .concat();
-                    let words = [&[None], &encoding.get_word_ids()[..], &[None]].concat();
-                    let offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
+                    let words = [&[None], encoding.get_word_ids(), &[None]].concat();
+                    let offsets = [&[(0, 0)], encoding.get_offsets(), &[(0, 0)]].concat();
                     let special_tokens =
                         [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
                     let attention_mask = vec![1; ids.len()];
@@ -106,11 +106,11 @@ impl PostProcessor for BertProcessing {
         );
 
         if let Some(mut encoding) = pair_encoding {
-            let pair_ids = [&encoding.get_ids()[..], &[self.sep.1]].concat();
-            let pair_type_ids = [&encoding.get_type_ids()[..], &[1]].concat();
-            let pair_tokens = [&encoding.get_tokens()[..], &[self.sep.0.clone()]].concat();
-            let pair_words = [&encoding.get_word_ids()[..], &[None]].concat();
-            let pair_offsets = [&encoding.get_offsets()[..], &[(0, 0)]].concat();
+            let pair_ids = [encoding.get_ids(), &[self.sep.1]].concat();
+            let pair_type_ids = [encoding.get_type_ids(), &[1]].concat();
+            let pair_tokens = [encoding.get_tokens(), &[self.sep.0.clone()]].concat();
+            let pair_words = [encoding.get_word_ids(), &[None]].concat();
+            let pair_offsets = [encoding.get_offsets(), &[(0, 0)]].concat();
             let pair_special_tokens =
                 [&vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
             let pair_attention_mask = vec![1; pair_ids.len()];
@@ -130,12 +130,11 @@ impl PostProcessor for BertProcessing {
                     .take_overflowing()
                     .into_iter()
                     .map(|encoding| {
-                        let pair_ids = [&encoding.get_ids()[..], &[self.sep.1]].concat();
-                        let pair_type_ids = [&encoding.get_type_ids()[..], &[1]].concat();
-                        let pair_tokens =
-                            [&encoding.get_tokens()[..], &[self.sep.0.clone()]].concat();
-                        let pair_words = [&encoding.get_word_ids()[..], &[None]].concat();
-                        let pair_offsets = [&encoding.get_offsets()[..], &[(0, 0)]].concat();
+                        let pair_ids = [encoding.get_ids(), &[self.sep.1]].concat();
+                        let pair_type_ids = [encoding.get_type_ids(), &[1]].concat();
+                        let pair_tokens = [encoding.get_tokens(), &[self.sep.0.clone()]].concat();
+                        let pair_words = [encoding.get_word_ids(), &[None]].concat();
+                        let pair_offsets = [encoding.get_offsets(), &[(0, 0)]].concat();
                         let pair_special_tokens =
                             [&vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
                         let pair_attention_mask = vec![1; pair_ids.len()];

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -77,16 +77,16 @@ impl PostProcessor for RobertaProcessing {
             return PostProcessor::default_process(encoding, pair_encoding, add_special_tokens);
         }
 
-        let ids = [&[self.cls.1], &encoding.get_ids()[..], &[self.sep.1]].concat();
-        let type_ids = [&[0], &encoding.get_type_ids()[..], &[0]].concat();
+        let ids = [&[self.cls.1], encoding.get_ids(), &[self.sep.1]].concat();
+        let type_ids = [&[0], encoding.get_type_ids(), &[0]].concat();
         let tokens = [
             &[self.cls.0.clone()],
-            &encoding.get_tokens()[..],
+            encoding.get_tokens(),
             &[self.sep.0.clone()],
         ]
         .concat();
-        let words = [&[None], &encoding.get_word_ids()[..], &[None]].concat();
-        let offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
+        let words = [&[None], encoding.get_word_ids(), &[None]].concat();
+        let offsets = [&[(0, 0)], encoding.get_offsets(), &[(0, 0)]].concat();
         let special_tokens = [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
         let attention_mask = vec![1; ids.len()];
 
@@ -105,16 +105,16 @@ impl PostProcessor for RobertaProcessing {
                 .take_overflowing()
                 .into_iter()
                 .map(|encoding| {
-                    let ids = [&[self.cls.1], &encoding.get_ids()[..], &[self.sep.1]].concat();
-                    let type_ids = [&[0], &encoding.get_type_ids()[..], &[0]].concat();
+                    let ids = [&[self.cls.1], encoding.get_ids(), &[self.sep.1]].concat();
+                    let type_ids = [&[0], encoding.get_type_ids(), &[0]].concat();
                     let tokens = [
                         &[self.cls.0.clone()],
-                        &encoding.get_tokens()[..],
+                        encoding.get_tokens(),
                         &[self.sep.0.clone()],
                     ]
                     .concat();
-                    let words = [&[None], &encoding.get_word_ids()[..], &[None]].concat();
-                    let offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
+                    let words = [&[None], encoding.get_word_ids(), &[None]].concat();
+                    let offsets = [&[(0, 0)], encoding.get_offsets(), &[(0, 0)]].concat();
                     let special_tokens =
                         [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
                     let attention_mask = vec![1; ids.len()];
@@ -139,16 +139,16 @@ impl PostProcessor for RobertaProcessing {
         );
 
         if let Some(mut encoding) = pair_encoding {
-            let pair_ids = [&[self.sep.1], &encoding.get_ids()[..], &[self.sep.1]].concat();
+            let pair_ids = [&[self.sep.1], encoding.get_ids(), &[self.sep.1]].concat();
             let pair_type_ids = vec![0; encoding.get_ids().len() + 2];
             let pair_tokens = [
                 &[self.sep.0.clone()],
-                &encoding.get_tokens()[..],
+                encoding.get_tokens(),
                 &[self.sep.0.clone()],
             ]
             .concat();
-            let pair_words = [&[None], &encoding.get_word_ids()[..], &[None]].concat();
-            let pair_offsets = [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
+            let pair_words = [&[None], encoding.get_word_ids(), &[None]].concat();
+            let pair_offsets = [&[(0, 0)], encoding.get_offsets(), &[(0, 0)]].concat();
             let pair_special_tokens =
                 [&[1], &vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
             let pair_attention_mask = vec![1; pair_ids.len()];
@@ -168,18 +168,16 @@ impl PostProcessor for RobertaProcessing {
                     .take_overflowing()
                     .into_iter()
                     .map(|encoding| {
-                        let pair_ids =
-                            [&[self.sep.1], &encoding.get_ids()[..], &[self.sep.1]].concat();
+                        let pair_ids = [&[self.sep.1], encoding.get_ids(), &[self.sep.1]].concat();
                         let pair_type_ids = vec![0; encoding.get_ids().len() + 2];
                         let pair_tokens = [
                             &[self.sep.0.clone()],
-                            &encoding.get_tokens()[..],
+                            encoding.get_tokens(),
                             &[self.sep.0.clone()],
                         ]
                         .concat();
-                        let pair_words = [&[None], &encoding.get_word_ids()[..], &[None]].concat();
-                        let pair_offsets =
-                            [&[(0, 0)], &encoding.get_offsets()[..], &[(0, 0)]].concat();
+                        let pair_words = [&[None], encoding.get_word_ids(), &[None]].concat();
+                        let pair_offsets = [&[(0, 0)], encoding.get_offsets(), &[(0, 0)]].concat();
                         let pair_special_tokens =
                             [&[1], &vec![0u32; encoding.get_type_ids().len()][..], &[1]].concat();
                         let pair_attention_mask = vec![1; pair_ids.len()];

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -526,15 +526,13 @@ impl TemplateProcessing {
             .take_overflowing()
             .into_iter()
             .flat_map(|encoding| {
-                let mut overflowings = vec![];
-
                 // 1. The pair itself
-                overflowings.push(self.apply_template(
+                let mut overflowings = vec![self.apply_template(
                     template,
                     encoding.clone(),
                     pair.clone(),
                     add_special_tokens,
-                ));
+                )];
 
                 // 2. Its overflowings
                 for other_o in &pair_overflowing {


### PR DESCRIPTION
Fix #673 

This PR makes the following changes:
- Make sure Metaspace doesn't serialize its `str_rep` field, which is used only during runtime and can be built from others when instantiated.
- Fix backward compatibility in the Metaspace constructor in Python, by accepting kwargs. 