### PR TITLE
Pin docutils

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.6
 
       - name: Install dependencies
-        run: pip install sphinx sphinx_rtd_theme setuptools-rust
+        run: pip install sphinx sphinx_rtd_theme setuptools-rust docutils==0.16.0
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: 3.6
 
       - name: Install Python dependencies
-        run: pip install sphinx sphinx_rtd_theme setuptools-rust
+        run: pip install sphinx sphinx_rtd_theme setuptools-rust docutils==0.16.0
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The latest release of docutils makes the doc render pretty badly, so we had to pin it to 0.16 in the other HF repos. Not sure why I don't see the same thing happening to the docs of Tokenizers though.