### PR TITLE
Fix SPM conversions

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [#686]: Fix SPM conversion process for whitespace deduplication
+
 ### Added
 - [#693]: Add a CTC Decoder for Wave2Vec models
 

--- a/bindings/python/scripts/convert.py
+++ b/bindings/python/scripts/convert.py
@@ -131,7 +131,7 @@ class AlbertConverter(SpmConverter):
         ]
 
     def normalizer(self, proto):
-        normalizers = [Replace("``", '"'), Replace("''", '"'), Replace(Regex(" {2,}"), " ")]
+        normalizers = [Replace("``", '"'), Replace("''", '"')]
         if not self.original_tokenizer.keep_accents:
             normalizers.append(NFKD())
             normalizers.append(StripAccents())
@@ -140,6 +140,7 @@ class AlbertConverter(SpmConverter):
 
         precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
         normalizers.append(Precompiled(precompiled_charsmap))
+        normalizers.append(Replace(Regex(" {2,}"), " "))
         return Sequence(normalizers)
 
     def post_processor(self, tokenizer):
@@ -267,7 +268,7 @@ class XLNetConverter(SpmConverter):
         ]
 
     def normalizer(self, proto):
-        normalizers = [Replace("``", '"'), Replace("''", '"'), Replace(Regex(" {2,}"), " ")]
+        normalizers = [Replace("``", '"'), Replace("''", '"')]
         if not self.original_tokenizer.keep_accents:
             normalizers.append(NFKD())
             normalizers.append(StripAccents())
@@ -276,6 +277,7 @@ class XLNetConverter(SpmConverter):
 
         precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
         normalizers.append(Precompiled(precompiled_charsmap))
+        normalizers.append(Replace(Regex(" {2,}"), " "))
         return Sequence(normalizers)
 
     def post_processor(self, tokenizer):


### PR DESCRIPTION
This PR fixes an issue with the SPM converters (ALBERT and XLNet) where it would replace some characters by whitespace - after removing double whitespace occurrences. This meant that if double whitespace were to appear thanks to this replacement, they would be kept until the end of encoding, leading to a mismatch between SentencePiece and tokenizers.

Fixes https://github.com/huggingface/transformers/pull/11358