### PR TITLE
Rust - add a CTCDecoder as a seperate mod

### DIFF
--- a/tokenizers/src/decoders/ctc.rs
+++ b/tokenizers/src/decoders/ctc.rs
@@ -1,0 +1,101 @@
+use crate::decoders::wordpiece;
+use crate::tokenizer::{Decoder, Result};
+
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Clone, Debug, Serialize)]
+/// The CTC (Connectionist Temporal Classification) decoder takes care
+/// of sanitizing a list of inputs token.
+/// Due to some alignement problem the output of some model can come with duplicated token.
+#[serde(tag = "type")]
+#[non_exhaustive]
+pub struct CTCDecoder {
+    /// The pad token used during training. It should be removed as it's used as CTC-blank token.
+    pub pad_token: String,
+    /// The word delimiter token used during training. It will be replace by a <space>
+    pub word_delimiter_token: String,
+    /// Whether to cleanup some tokenization artifacts (spaces before punctuation, ...)
+    pub cleanup: bool,
+}
+
+impl CTCDecoder {
+    pub fn new(pad_token: String, word_delimiter_token: String, cleanup: bool) -> Self {
+        Self {
+            pad_token,
+            word_delimiter_token,
+            cleanup,
+        }
+    }
+}
+
+impl Default for CTCDecoder {
+    fn default() -> Self {
+        Self {
+            pad_token: "<pad>".to_string(),
+            word_delimiter_token: "|".to_string(),
+            cleanup: true,
+        }
+    }
+}
+
+impl Decoder for CTCDecoder {
+    fn decode(&self, tokens: Vec<String>) -> Result<String> {
+        let mut output = tokens
+            .into_iter()
+            .dedup()
+            .join("")
+            .replace(&self.pad_token, "");
+        if self.cleanup {
+            output = wordpiece::cleanup(output).replace(&self.word_delimiter_token, " ");
+        }
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn handmade_sample() {
+        let ctc_decoder = CTCDecoder::default();
+        let id_to_string_result = "<pad> <pad> h e e l l <pad> l o o o <pad>"
+            .split(" ")
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            ctc_decoder.decode(id_to_string_result).unwrap(),
+            "hello".to_string()
+        );
+    }
+    #[test]
+    fn handmade_with_delimiter_sample() {
+        let ctc_decoder = CTCDecoder::default();
+        let id_to_string_result = "<pad> <pad> h e e l l <pad> l o o o <pad> <pad> | <pad> w o o o r <pad> <pad> l l d <pad> <pad> <pad> <pad>"
+            .split(" ")
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            ctc_decoder.decode(id_to_string_result).unwrap(),
+            "hello world".to_string()
+        );
+    }
+    #[test]
+    fn librispeech_sample() {
+        let ctc_decoder = CTCDecoder::default();
+        let id_to_string_result = "<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> A | | <pad> M <pad> <pad> <pad> <pad> A <pad> <pad> N <pad> <pad> <pad> | | | <pad> <pad> <pad> <pad> S <pad> <pad> <pad> A I <pad> D D | | T T <pad> O <pad> | | T H E E | | | <pad> U U <pad> N N <pad> I <pad> <pad> V <pad> <pad> <pad> E R R <pad> <pad> <pad> S E E | | <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> S S <pad> <pad> <pad> <pad> I <pad> R R <pad> <pad> | | | <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> I <pad> <pad> <pad> | <pad> <pad> <pad> E X <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> I <pad> S <pad> <pad> T <pad> <pad> | | <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>".split(" ").map(|s| s.to_string()).collect();
+        assert_eq!(
+            ctc_decoder.decode(id_to_string_result).unwrap(),
+            "A MAN SAID TO THE UNIVERSE SIR I EXIST ".to_string()
+        );
+    }
+    #[test]
+    fn another_librispeech_sample() {
+        let ctc_decoder = CTCDecoder::default();
+        let id_to_string_result = "<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> H <pad> I <pad> S S | | <pad> <pad> <pad> I N <pad> <pad> S <pad> T T <pad> <pad> A N C C T <pad> | | | | | <pad> <pad> <pad> <pad> P <pad> <pad> <pad> <pad> A <pad> <pad> N N N <pad> <pad> I <pad> C <pad> <pad> | | <pad> W <pad> <pad> A S <pad> | | <pad> <pad> <pad> F <pad> <pad> O L <pad> <pad> L L O O W E E D | | <pad> B <pad> <pad> <pad> Y <pad> | | | A | | <pad> S S S <pad> M M <pad> <pad> <pad> A L L <pad> <pad> <pad> <pad> L <pad> | | | <pad> <pad> <pad> <pad> S H H <pad> <pad> <pad> <pad> A R R <pad> <pad> P <pad> <pad> | <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> B <pad> <pad> L L <pad> <pad> <pad> <pad> <pad> O W W <pad> <pad> | | | <pad> <pad> <pad> <pad> <pad> <pad> <pad> H <pad> <pad> <pad> <pad> <pad> <pad> <pad> I G H H | | <pad> <pad> O N <pad> | | H <pad> I S S | | <pad> <pad> C H H <pad> <pad> <pad> E <pad> S S <pad> T T <pad> <pad> | | | <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>".split(" ").map(|s| s.to_string()).collect();
+        assert_eq!(
+            ctc_decoder.decode(id_to_string_result).unwrap(),
+            "HIS INSTANCT PANIC WAS FOLLOWED BY A SMALL SHARP BLOW HIGH ON HIS CHEST ".to_string()
+        );
+    }
+}

--- a/tokenizers/src/decoders/mod.rs
+++ b/tokenizers/src/decoders/mod.rs
@@ -1,4 +1,5 @@
 pub mod bpe;
+pub mod ctc;
 pub mod wordpiece;
 
 // Re-export these as decoders
@@ -8,6 +9,7 @@ pub use super::pre_tokenizers::metaspace;
 use serde::{Deserialize, Serialize};
 
 use crate::decoders::bpe::BPEDecoder;
+use crate::decoders::ctc::CTCDecoder;
 use crate::decoders::wordpiece::WordPiece;
 use crate::pre_tokenizers::byte_level::ByteLevel;
 use crate::pre_tokenizers::metaspace::Metaspace;
@@ -20,6 +22,7 @@ pub enum DecoderWrapper {
     ByteLevel(ByteLevel),
     WordPiece(WordPiece),
     Metaspace(Metaspace),
+    CTC(CTCDecoder),
 }
 
 impl Decoder for DecoderWrapper {
@@ -29,6 +32,7 @@ impl Decoder for DecoderWrapper {
             DecoderWrapper::ByteLevel(bl) => bl.decode(tokens),
             DecoderWrapper::Metaspace(ms) => ms.decode(tokens),
             DecoderWrapper::WordPiece(wp) => wp.decode(tokens),
+            DecoderWrapper::CTC(ctc) => ctc.decode(tokens),
         }
     }
 }
@@ -37,3 +41,4 @@ impl_enum_from!(BPEDecoder, DecoderWrapper, BPE);
 impl_enum_from!(ByteLevel, DecoderWrapper, ByteLevel);
 impl_enum_from!(Metaspace, DecoderWrapper, Metaspace);
 impl_enum_from!(WordPiece, DecoderWrapper, WordPiece);
+impl_enum_from!(CTCDecoder, DecoderWrapper, CTC);

--- a/tokenizers/src/decoders/wordpiece.rs
+++ b/tokenizers/src/decoders/wordpiece.rs
@@ -28,23 +28,27 @@ impl Default for WordPiece {
         }
     }
 }
+pub fn cleanup(dirty_input: String) -> String {
+    let clean_input = dirty_input
+        .replace(" .", ".")
+        .replace(" ?", "?")
+        .replace(" !", "!")
+        .replace(" ,", ",")
+        .replace(" ' ", "'")
+        .replace(" n't", "n't")
+        .replace(" 'm", "'m")
+        .replace(" do not", " don't")
+        .replace(" 's", "'s")
+        .replace(" 've", "'ve")
+        .replace(" 're", "'re");
+    clean_input
+}
 
 impl Decoder for WordPiece {
     fn decode(&self, tokens: Vec<String>) -> Result<String> {
         let mut output = tokens.join(" ").replace(&format!(" {}", self.prefix), "");
         if self.cleanup {
-            output = output
-                .replace(" .", ".")
-                .replace(" ?", "?")
-                .replace(" !", "!")
-                .replace(" ,", ",")
-                .replace(" ' ", "'")
-                .replace(" n't", "n't")
-                .replace(" 'm", "'m")
-                .replace(" do not", " don't")
-                .replace(" 's", "'s")
-                .replace(" 've", "'ve")
-                .replace(" 're", "'re");
+            output = cleanup(output);
         }
 
         Ok(output)


### PR DESCRIPTION
A first implementation to help on #667 

It's currently a separate module that impl the trait `Decoder` 