### PR TITLE
Remove support for Python 3.5

### DIFF
--- a/.github/workflows/python-release-conda.yml
+++ b/.github/workflows/python-release-conda.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python: [3.6, 3.7, 3.8, 3.9]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,9 +1,9 @@
 name: Python Release
 
-on:
-  push:
-    tags:
-      - python-v*
+on: [push]
+#  push:
+#    tags:
+#      - python-v*
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -30,7 +30,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python: [3.6, 3.7, 3.8, 3.9]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-10.15]
-        python: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python: [3.6, 3.7, 3.8, 3.9]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -113,33 +113,33 @@ jobs:
           pip install awscli
           aws s3 sync --exact-timestamps ./bindings/python/dist "s3://tokenizers-releases/python/$DIST_DIR"
 
-  upload_package:
-    name: Upload package to PyPi
-    runs-on: ubuntu-latest
-    needs: [create_wheels_manylinux, create_wheels_windows_32bit, create_wheels_others_64bit]
+          # upload_package:
+          #   name: Upload package to PyPi
+          #   runs-on: ubuntu-latest
+          #   needs: [create_wheels_manylinux, create_wheels_windows_32bit, create_wheels_others_64bit]
 
-    steps:
-      - uses: actions/checkout@v1
+          #   steps:
+          #     - uses: actions/checkout@v1
 
-      - name: Install Python
-        uses: actions/setup-python@v1
+          #     - name: Install Python
+          #       uses: actions/setup-python@v1
 
-      - name: Retrieve all wheels
-        shell: bash
-        run: |
-          pip install awscli
-          aws s3 sync "s3://tokenizers-releases/python/$DIST_DIR" ./bindings/python/dist
+          #     - name: Retrieve all wheels
+          #       shell: bash
+          #       run: |
+          #         pip install awscli
+          #         aws s3 sync "s3://tokenizers-releases/python/$DIST_DIR" ./bindings/python/dist
 
-      - name: Install dependencies
-        run: |
-          pip install setuptools wheel setuptools-rust
+          #     - name: Install dependencies
+          #       run: |
+          #         pip install setuptools wheel setuptools-rust
 
-      - name: Create source distribution
-        working-directory: ./bindings/python
-        run: sh build-sdist.sh
+          #     - name: Create source distribution
+          #       working-directory: ./bindings/python
+          #       run: sh build-sdist.sh
 
-      - name: Upload to PyPi
-        working-directory: ./bindings/python
-        run: |
-          pip install twine
-          twine upload dist/* -u __token__ -p "$PYPI_TOKEN"
+          #     - name: Upload to PyPi
+          #       working-directory: ./bindings/python
+          #       run: |
+          #         pip install twine
+          #         twine upload dist/* -u __token__ -p "$PYPI_TOKEN"

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,9 +1,9 @@
 name: Python Release
 
-on: [push]
-#  push:
-#    tags:
-#      - python-v*
+on:
+  push:
+    tags:
+      - python-v*
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -113,33 +113,33 @@ jobs:
           pip install awscli
           aws s3 sync --exact-timestamps ./bindings/python/dist "s3://tokenizers-releases/python/$DIST_DIR"
 
-          # upload_package:
-          #   name: Upload package to PyPi
-          #   runs-on: ubuntu-latest
-          #   needs: [create_wheels_manylinux, create_wheels_windows_32bit, create_wheels_others_64bit]
+  upload_package:
+    name: Upload package to PyPi
+    runs-on: ubuntu-latest
+    needs: [create_wheels_manylinux, create_wheels_windows_32bit, create_wheels_others_64bit]
 
-          #   steps:
-          #     - uses: actions/checkout@v1
+    steps:
+      - uses: actions/checkout@v1
 
-          #     - name: Install Python
-          #       uses: actions/setup-python@v1
+      - name: Install Python
+        uses: actions/setup-python@v1
 
-          #     - name: Retrieve all wheels
-          #       shell: bash
-          #       run: |
-          #         pip install awscli
-          #         aws s3 sync "s3://tokenizers-releases/python/$DIST_DIR" ./bindings/python/dist
+      - name: Retrieve all wheels
+        shell: bash
+        run: |
+          pip install awscli
+          aws s3 sync "s3://tokenizers-releases/python/$DIST_DIR" ./bindings/python/dist
 
-          #     - name: Install dependencies
-          #       run: |
-          #         pip install setuptools wheel setuptools-rust
+      - name: Install dependencies
+        run: |
+          pip install setuptools wheel setuptools-rust
 
-          #     - name: Create source distribution
-          #       working-directory: ./bindings/python
-          #       run: sh build-sdist.sh
+      - name: Create source distribution
+        working-directory: ./bindings/python
+        run: sh build-sdist.sh
 
-          #     - name: Upload to PyPi
-          #       working-directory: ./bindings/python
-          #       run: |
-          #         pip install twine
-          #         twine upload dist/* -u __token__ -p "$PYPI_TOKEN"
+      - name: Upload to PyPi
+        working-directory: ./bindings/python
+        run: |
+          pip install twine
+          twine upload dist/* -u __token__ -p "$PYPI_TOKEN"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#693]: Add a CTC Decoder for Wave2Vec models
 
+### Removed
+- [#714]: Removed support for Python 3.5
+
 ## [0.10.2]
 
 ### Fixed
@@ -318,6 +321,7 @@ delimiter (Works like `.split(delimiter)`)
 - Fix a bug that was causing crashes in Python 3.5
 
 
+[#714]: https://github.com/huggingface/tokenizers/pull/714
 [#707]: https://github.com/huggingface/tokenizers/pull/707
 [#693]: https://github.com/huggingface/tokenizers/pull/693
 [#686]: https://github.com/huggingface/tokenizers/pull/686

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -7,12 +7,12 @@ dir_guard=@mkdir -p $(@D)
 # Format source code automatically
 style:
 	python stub.py
-	black --line-length 100 --target-version py35 examples py_src/tokenizers tests
+	black --line-length 100 --target-version py36 examples py_src/tokenizers tests
 
 # Check the source code is formatted correctly
 check-style:
 	python stub.py --check
-	black --check --line-length 100 --target-version py35 examples py_src/tokenizers tests
+	black --check --line-length 100 --target-version py36 examples py_src/tokenizers tests
 
 TESTS_RESOURCES = $(DATA_DIR)/small.txt $(DATA_DIR)/roberta.json
 

--- a/bindings/python/build-wheels.sh
+++ b/bindings/python/build-wheels.sh
@@ -20,5 +20,5 @@ done
 rm dist/*-linux_*
 
 # Upload wheels
-# /opt/python/cp37-cp37m/bin/pip install -U awscli
-# /opt/python/cp37-cp37m/bin/python -m awscli s3 sync --exact-timestamps ./dist "s3://tokenizers-releases/python/$DIST_DIR"
+/opt/python/cp37-cp37m/bin/pip install -U awscli
+/opt/python/cp37-cp37m/bin/python -m awscli s3 sync --exact-timestamps ./dist "s3://tokenizers-releases/python/$DIST_DIR"

--- a/bindings/python/build-wheels.sh
+++ b/bindings/python/build-wheels.sh
@@ -4,7 +4,7 @@ set -ex
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 export PATH="$HOME/.cargo/bin:$PATH"
 
-for PYBIN in /opt/python/{cp35-cp35m,cp36-cp36m,cp37-cp37m,cp38-cp38,cp39-cp39}/bin; do
+for PYBIN in /opt/python/{cp36-cp36m,cp37-cp37m,cp38-cp38,cp39-cp39}/bin; do
     export PYTHON_SYS_EXECUTABLE="$PYBIN/python"
 
     "${PYBIN}/pip" install -U setuptools-rust==0.11.3
@@ -20,5 +20,5 @@ done
 rm dist/*-linux_*
 
 # Upload wheels
-/opt/python/cp37-cp37m/bin/pip install -U awscli
-/opt/python/cp37-cp37m/bin/python -m awscli s3 sync --exact-timestamps ./dist "s3://tokenizers-releases/python/$DIST_DIR"
+# /opt/python/cp37-cp37m/bin/pip install -U awscli
+# /opt/python/cp37-cp37m/bin/python -m awscli s3 sync --exact-timestamps ./dist "s3://tokenizers-releases/python/$DIST_DIR"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -3,5 +3,5 @@ requires = ["setuptools", "wheel", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py35']
+target-version = ['py36']
 line-length = 100

--- a/bindings/python/stub.py
+++ b/bindings/python/stub.py
@@ -122,7 +122,7 @@ def py_file(module, origin):
 
 def do_black(content, is_pyi):
     mode = black.Mode(
-        target_versions={black.TargetVersion.PY35},
+        target_versions={black.TargetVersion.PY36},
         line_length=100,
         is_pyi=is_pyi,
         string_normalization=True,


### PR DESCRIPTION
The manylinux image we use to build wheels for Linux removed support for python 3.5, so we remove it too.