### PR TITLE
add Zenodo DOI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
     <a href="https://pepy.tech/project/tokenizers">
         <img src="https://pepy.tech/badge/tokenizers/week" />
     </a>
+    <a href="https://doi.org/10.5281/zenodo.4784271">
+        <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4784271.svg" alt="DOI">
+    </a>
 </p>
 
 Provides an implementation of today's most used tokenizers, with a focus on performance and


### PR DESCRIPTION
Proposal to add the Zenodo DOI Badge in the README.

The DOI used here corresponds to the Concept DOI (versus the Version DOIs), which represents the concept of the software package and all the versions of the given software package. 

Currently, the Concept DOI links to the landing page for the latest version of our package. Note that in the future Zenodo plans to change this to create a landing page specifically representing the concept behind the record and all its versions.