### PR TITLE
Fix word level tokenizer determinism

### DIFF
--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -1,6 +1,7 @@
 use super::WordLevel;
 use crate::utils::parallelism::*;
 use crate::{AddedToken, Result, Trainer};
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
 #[non_exhaustive]
@@ -43,12 +44,12 @@ impl WordLevelTrainer {
 
         //sort the word counts first by inverse counts and then by word, in order
         //to keep the sorting deterministic in case of equal counts
-        let cmp = |l: &(&String, &u32), r: &(&String, &u32)| -> std::cmp::Ordering {
-            let count_comp: std::cmp::Ordering = l.1.cmp(&r.1);
-            if count_comp != Equal {
+        let cmp = |l: &(&String, &u32), r: &(&String, &u32)| -> Ordering {
+            let count_comp: Ordering = l.1.cmp(r.1);
+            if count_comp != Ordering::Equal {
                 return count_comp.reverse();
             }
-            return l.0.cmp(&r.0);
+            l.0.cmp(r.0)
         };
 
         ordered_counts.sort_by(cmp);

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -40,7 +40,19 @@ impl WordLevelTrainer {
         model: &mut WordLevel,
     ) -> Result<Vec<AddedToken>> {
         let mut ordered_counts = word_counts.iter().collect::<Vec<_>>();
-        ordered_counts.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+
+        //sort the word counts first by inverse counts and then by word, in order
+        //to keep the sorting deterministic in case of equal counts
+        let cmp = |l: &(&String, &u32), r: &(&String, &u32)| -> std::cmp::Ordering {
+            let count_comp: std::cmp::Ordering = l.1.cmp(&r.1);
+            if count_comp != Equal {
+                return count_comp.reverse()
+            }
+            return l.0.cmp(&r.0);
+        };
+
+        ordered_counts.sort_by(cmp);
+
         let word_level = WordLevel::builder()
             .vocab(
                 self.special_tokens

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -46,7 +46,7 @@ impl WordLevelTrainer {
         let cmp = |l: &(&String, &u32), r: &(&String, &u32)| -> std::cmp::Ordering {
             let count_comp: std::cmp::Ordering = l.1.cmp(&r.1);
             if count_comp != Equal {
-                return count_comp.reverse()
+                return count_comp.reverse();
             }
             return l.0.cmp(&r.0);
         };


### PR DESCRIPTION
Fixes #717 
If two word level tokens have the same counts, their order is determined by the token itself alphabetically. This allows for determinism in the resulting tokenizer.

I have tested the code only in the online playground of rust ([here](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=14e462cded705bd9f8d590624004e88b)), as setting up everything on my system would take too much time. I thus didn't run any tests.

Thanks for taking a look at this. :)