### PR TITLE
Make AddedVocabulary more versatile

### DIFF
--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -198,13 +198,18 @@ impl AddedVocabulary {
         self.added_tokens_map
             .get(token)
             .copied()
+            // In order to prevent id collisions added ids start
+            // where model ids end
+            .map(|id| id + (model.get_vocab_size() as u32))
             .or_else(|| model.token_to_id(token))
     }
 
     /// Get the token matching the given id if it exists
     pub fn id_to_token(&self, id: u32, model: &impl Model) -> Option<String> {
         self.added_tokens_map_r
-            .get(&id)
+            // In order to prevent id collisions added ids start
+            // where model ids end
+            .get(&((model.get_vocab_size() as u32) + id))
             .map(|t| t.content.clone())
             .or_else(|| model.id_to_token(id))
     }
@@ -249,7 +254,7 @@ impl AddedVocabulary {
                 ignored += 1;
                 id
             } else {
-                let new_id = (model.get_vocab_size() + self.added_tokens_map.len()) as u32;
+                let new_id = self.added_tokens_map.len() as u32;
                 self.added_tokens_map.insert(token.content.clone(), new_id);
 
                 if !self.special_tokens_set.contains(&token.content) {

--- a/tokenizers/tests/added_tokens.rs
+++ b/tokenizers/tests/added_tokens.rs
@@ -1,7 +1,10 @@
 mod common;
 
+use tokenizers::models::TrainerWrapper;
+use tokenizers::models::wordlevel::WordLevelTrainerBuilder;
 use common::*;
-use tokenizers::tokenizer::AddedToken;
+use tokenizers::models::wordlevel::WordLevel;
+use tokenizers::{Tokenizer, AddedToken};
 
 #[test]
 fn add_tokens() {
@@ -26,6 +29,24 @@ fn add_tokens() {
     );
     assert_eq!(tokenizer.token_to_id("hello"), Some(2));
     assert_eq!(tokenizer.token_to_id("world"), Some(3));
+}
+
+#[test]
+fn add_tokens_with_model_change() {
+    let mut tokenizer = Tokenizer::new(WordLevel::default());
+    let mut trainer: TrainerWrapper = WordLevelTrainerBuilder::default()
+        .show_progress(false)
+        .build().unwrap().into();
+
+    tokenizer.add_tokens(&[AddedToken::from("hello", true)]);
+
+    tokenizer.train(&mut trainer, ["new"].iter()).unwrap();
+
+    tokenizer.add_tokens(&[AddedToken::from("world", true)]);
+
+    assert_eq!(tokenizer.token_to_id("new"), Some(0));
+    assert_eq!(tokenizer.token_to_id("hello"), Some(1));
+    assert_eq!(tokenizer.token_to_id("world"), Some(2));
 }
 
 #[test]


### PR DESCRIPTION
By ensuring addedvocabulary ids start where model ids end collisions are avoided.

Fixes #523 