### PR TITLE
Switch git dependencies in Cargo.toml back to regular versions

### DIFF
--- a/bindings/node/native/Cargo.lock
+++ b/bindings/node/native/Cargo.lock
@@ -706,7 +706,8 @@ dependencies = [
 [[package]]
 name = "rayon-cond"
 version = "0.1.0"
-source = "git+https://github.com/n1t0/rayon-cond#c56e4f1ded0fcb92eac70e0533703bba3ca2983f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1259362c9065e5ea39a789ef40b1e3fd934c94beb7b5ab3ac6629d3b5e7cb7"
 dependencies = [
  "either",
  "itertools 0.8.2",

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -475,15 +475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8a15b776d9dfaecd44b03c5828c2199cddff5247215858aac14624f8d6b741"
-dependencies = [
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,21 +495,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac06db03ec2f46ee0ecdca1a1c34a99c0d188a0d83439b84bf0cb4b386e4ab09"
 dependencies = [
- "matrixmultiply 0.2.4",
- "num-complex 0.2.4",
- "num-integer",
- "num-traits",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e854964160a323e65baa19a0b1a027f76d590faba01f05c0cbc3187221a8c9"
-dependencies = [
- "matrixmultiply 0.3.1",
- "num-complex 0.4.0",
+ "matrixmultiply",
+ "num-complex",
  "num-integer",
  "num-traits",
  "rawpointer",
@@ -544,15 +522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
-dependencies = [
  "num-traits",
 ]
 
@@ -593,13 +562,14 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "numpy"
-version = "0.11.0"
-source = "git+https://github.com/pyo3/rust-numpy/?rev=e331befa27fede78d4662edf08fa0508db39be01#e331befa27fede78d4662edf08fa0508db39be01"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd9e8e652becf4ba6c11803945f8bf463c23f482f704bb33f70ae9d22482d10"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "ndarray 0.15.3",
- "num-complex 0.2.4",
+ "ndarray",
+ "num-complex",
  "num-traits",
  "pyo3",
 ]
@@ -858,7 +828,8 @@ dependencies = [
 [[package]]
 name = "rayon-cond"
 version = "0.1.0"
-source = "git+https://github.com/n1t0/rayon-cond#c56e4f1ded0fcb92eac70e0533703bba3ca2983f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1259362c9065e5ea39a789ef40b1e3fd934c94beb7b5ab3ac6629d3b5e7cb7"
 dependencies = [
  "either",
  "itertools 0.8.2",
@@ -1083,7 +1054,7 @@ dependencies = [
  "env_logger",
  "itertools 0.9.0",
  "libc",
- "ndarray 0.13.1",
+ "ndarray",
  "numpy",
  "onig",
  "pyo3",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1.0"
 libc = "0.2"
 env_logger = "0.7.1"
 pyo3 = "0.12"
-numpy = { git = "https://github.com/pyo3/rust-numpy/", rev = "e331befa27fede78d4662edf08fa0508db39be01" }
+numpy = "0.12"
 ndarray = "0.13"
 onig = { version = "6.0", default-features = false }
 itertools = "0.9"

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -40,7 +40,7 @@ onig = { version = "6.0", default-features = false }
 regex = "1.3"
 regex-syntax = "0.6"
 rayon = "1.3"
-rayon-cond = { version = "*", git = "https://github.com/n1t0/rayon-cond" }
+rayon-cond = "0.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 clap = "2.33"


### PR DESCRIPTION
rayon-cond turned out to be a rustc bug that has been fixed for a while
(see cuviper/rayon-cond#2), so we can revert the git dependency.

numpy has released the commit in question as part of 0.12.