### PR TITLE
Add `unk_token` argument in UnigramTrainer documentation

### DIFF
--- a/bindings/python/py_src/tokenizers/trainers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/trainers/__init__.pyi
@@ -72,9 +72,12 @@ class UnigramTrainer(Trainer):
             if not seen in the training dataset.
             If the strings contain more than one character, only the first one
             is kept.
+
+        unk_token (:obj:`str`, `optional`):
+            The unknown token to be used by the model.
     """
 
-    def __init__(self, vocab_size=8000, show_progress=True, special_tokens=[]):
+    def __init__(self, vocab_size=8000, show_progress=True, special_tokens=[], unk_token=None):
         pass
 
 class WordLevelTrainer(Trainer):

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -669,8 +669,11 @@ impl PyWordLevelTrainer {
 ///         if not seen in the training dataset.
 ///         If the strings contain more than one character, only the first one
 ///         is kept.
+///
+///     unk_token (:obj:`str`, `optional`):
+///         The unknown token to be used by the model.
 #[pyclass(extends=PyTrainer, module = "tokenizers.trainers", name=UnigramTrainer)]
-#[text_signature = "(self, vocab_size=8000, show_progress=True, special_tokens= [])"]
+#[text_signature = "(self, vocab_size=8000, show_progress=True, special_tokens= [], unk_token=None)"]
 pub struct PyUnigramTrainer {}
 #[pymethods]
 impl PyUnigramTrainer {


### PR DESCRIPTION
# What does this PR do?

This PR proposes to add the `unk_token` argument to the python documentation of `UnigramTrainer`. This addition is especially motivated by [this issue](https://github.com/huggingface/transformers/issues/12756) on the :hugs: transformers repo.

## Additional details

To add this part to the documentation, I manually modified the file `bindings/python/src/trainers.rs` and then run the command `python stub.py` to automatically modify the `bindings/python/py_src/tokenizers/trainers/__init__.pyi` file.

I have tested the change locally, here is a screen of the modified part of the documentation
![image](https://user-images.githubusercontent.com/55560583/127126514-7b894a1f-1601-4b97-af0f-6436c98c7d3d.png)


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. I would love to hear your opinion @n1t0 and @Narsil. :smile: 