### PR TITLE
Expand documentation of UnigramTrainer

### DIFF
--- a/bindings/python/py_src/tokenizers/trainers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/trainers/__init__.pyi
@@ -86,7 +86,6 @@ class UnigramTrainer(Trainer):
         n_sub_iterations (:obj:`int`):
             The number of iterations of the EM algorithm to perform before
             pruning the vocabulary.
-
     """
 
     def __init__(

--- a/bindings/python/py_src/tokenizers/trainers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/trainers/__init__.pyi
@@ -72,9 +72,33 @@ class UnigramTrainer(Trainer):
             if not seen in the training dataset.
             If the strings contain more than one character, only the first one
             is kept.
+        
+        shrinking_factor (:obj:`float`):
+            The shrinking factor used at each step of the training to prune the
+            vocabulary.
+        
+        unk_token (:obj:`str`):
+            The token used for out-of-vocabulary tokens.
+        
+        max_piece_length (:obj:`int`):
+            The maximum length of a given token.
+        
+        n_sub_iterations (:obj:`int`):
+            The number of iterations of the EM algorithm to perform before
+            pruning the vocabulary.
+
     """
 
-    def __init__(self, vocab_size=8000, show_progress=True, special_tokens=[]):
+    def __init__(
+        self,
+        vocab_size=8000,
+        show_progress=True,
+        special_tokens=[],
+        shrinking_factor=0.75,
+        unk_token=None,
+        max_piece_length=16,
+        n_sub_iterations=2
+    ):
         pass
 
 class WordLevelTrainer(Trainer):

--- a/bindings/python/py_src/tokenizers/trainers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/trainers/__init__.pyi
@@ -72,17 +72,17 @@ class UnigramTrainer(Trainer):
             if not seen in the training dataset.
             If the strings contain more than one character, only the first one
             is kept.
-        
+
         shrinking_factor (:obj:`float`):
             The shrinking factor used at each step of the training to prune the
             vocabulary.
-        
+
         unk_token (:obj:`str`):
             The token used for out-of-vocabulary tokens.
-        
+
         max_piece_length (:obj:`int`):
             The maximum length of a given token.
-        
+
         n_sub_iterations (:obj:`int`):
             The number of iterations of the EM algorithm to perform before
             pruning the vocabulary.
@@ -96,7 +96,7 @@ class UnigramTrainer(Trainer):
         shrinking_factor=0.75,
         unk_token=None,
         max_piece_length=16,
-        n_sub_iterations=2
+        n_sub_iterations=2,
     ):
         pass
 

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -684,7 +684,7 @@ impl PyWordLevelTrainer {
 ///         The number of iterations of the EM algorithm to perform before
 ///         pruning the vocabulary.
 #[pyclass(extends=PyTrainer, module = "tokenizers.trainers", name=UnigramTrainer)]
-#[text_signature = "(self, vocab_size=8000, show_progress=True, special_tokens= [])"]
+#[text_signature = "(self, vocab_size=8000, show_progress=True, special_tokens=[], shrinking_factor=0.75, unk_token=None, max_piece_length=16, n_sub_iterations=2)"]
 pub struct PyUnigramTrainer {}
 #[pymethods]
 impl PyUnigramTrainer {

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -669,6 +669,20 @@ impl PyWordLevelTrainer {
 ///         if not seen in the training dataset.
 ///         If the strings contain more than one character, only the first one
 ///         is kept.
+///
+///     shrinking_factor (:obj:`float`):
+///         The shrinking factor used at each step of the training to prune the
+///         vocabulary.
+///
+///     unk_token (:obj:`str`):
+///         The token used for out-of-vocabulary tokens.
+///
+///     max_piece_length (:obj:`int`):
+///         The maximum length of a given token.
+///
+///     n_sub_iterations (:obj:`int`):
+///         The number of iterations of the EM algorithm to perform before
+///         pruning the vocabulary.
 #[pyclass(extends=PyTrainer, module = "tokenizers.trainers", name=UnigramTrainer)]
 #[text_signature = "(self, vocab_size=8000, show_progress=True, special_tokens= [])"]
 pub struct PyUnigramTrainer {}


### PR DESCRIPTION
Currently the documentation of the [UnigramTrainer](https://huggingface.co/docs/tokenizers/python/latest/api/reference.html#tokenizers.trainers.UnigramTrainer) does not contain all the options you can set, and the auto-complete in an IDE does not show them either.

This PR fixes that.