### PR TITLE
Feature gate http-deps

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -58,7 +58,7 @@ reqwest = { version = "0.11", optional = true }
 cached-path = { version = "0.5", optional = true }
 
 [features]
-default = ["progressbar", "http", "cached-path"]
+default = ["progressbar", "http"]
 progressbar = ["indicatif"]
 http = ["reqwest", "cached-path"]
 

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -54,12 +54,13 @@ esaxx-rs = "0.1"
 derive_builder = "0.9"
 spm_precompiled = "0.1"
 dirs = "3.0"
-reqwest = "0.11"
-cached-path = "0.5"
+reqwest = { version = "0.11", optional = true }
+cached-path = { version = "0.5", optional = true }
 
 [features]
-default = ["progressbar"]
+default = ["progressbar", "http", "cached-path"]
 progressbar = ["indicatif"]
+http = ["reqwest", "cached-path"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -38,11 +38,13 @@ The various steps of the pipeline are:
 use tokenizers::tokenizer::{Result, Tokenizer};
 
 fn main() -> Result<()> {
-    let tokenizer = Tokenizer::from_pretrained("bert-base-cased", None)?;
+    # #[cfg(feature = "http")]
+    # {
+        let tokenizer = Tokenizer::from_pretrained("bert-base-cased", None)?;
 
-    let encoding = tokenizer.encode("Hey there!", false)?;
-    println!("{:?}", encoding.get_tokens());
-
+        let encoding = tokenizer.encode("Hey there!", false)?;
+        println!("{:?}", encoding.get_tokens());
+    # }
     Ok(())
 }
 ```

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -26,11 +26,13 @@
 //! use tokenizers::tokenizer::{Result, Tokenizer};
 //!
 //! fn main() -> Result<()> {
-//!     let tokenizer = Tokenizer::from_pretrained("bert-base-cased", None)?;
+//!     #[cfg(feature = "http")]
+//!     {
+//!         let tokenizer = Tokenizer::from_pretrained("bert-base-cased", None)?;
 //!
-//!     let encoding = tokenizer.encode("Hey there!", false)?;
-//!     println!("{:?}", encoding.get_tokens());
-//!
+//!         let encoding = tokenizer.encode("Hey there!", false)?;
+//!         println!("{:?}", encoding.get_tokens());
+//!     }
 //!     Ok(())
 //! }
 //! ```
@@ -145,4 +147,5 @@ pub use tokenizer::*;
 pub use utils::parallelism;
 
 // Re-export for from_pretrained
+#[cfg(feature = "http")]
 pub use utils::from_pretrained::FromPretrainedParameters;

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -26,13 +26,13 @@
 //! use tokenizers::tokenizer::{Result, Tokenizer};
 //!
 //! fn main() -> Result<()> {
-//!     #[cfg(feature = "http")]
-//!     {
+//!     # #[cfg(feature = "http")]
+//!     # {
 //!         let tokenizer = Tokenizer::from_pretrained("bert-base-cased", None)?;
 //!
 //!         let encoding = tokenizer.encode("Hey there!", false)?;
 //!         println!("{:?}", encoding.get_tokens());
-//!     }
+//!     # }
 //!     Ok(())
 //! }
 //! ```

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -22,7 +22,6 @@ use std::{
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::utils::from_pretrained::{from_pretrained, FromPretrainedParameters};
 use crate::utils::iter::ResultShunt;
 use crate::utils::parallelism::*;
 use crate::utils::progress::{ProgressBar, ProgressStyle};
@@ -397,11 +396,12 @@ impl Tokenizer {
         let content = read_to_string(file)?;
         Ok(serde_json::from_str(&content)?)
     }
+    #[cfg(feature = "http")]
     pub fn from_pretrained<S: AsRef<str>>(
         identifier: S,
-        params: Option<FromPretrainedParameters>,
+        params: Option<crate::utils::from_pretrained::FromPretrainedParameters>,
     ) -> Result<Self> {
-        let tokenizer_file = from_pretrained(identifier, params)?;
+        let tokenizer_file = crate::utils::from_pretrained::from_pretrained(identifier, params)?;
         Tokenizer::from_file(tokenizer_file)
     }
 }
@@ -1134,13 +1134,14 @@ where
     PP: DeserializeOwned + PostProcessor,
     D: DeserializeOwned + Decoder,
 {
+    #[cfg(feature = "http")]
     /// Instantiate a new Tokenizer from a file hosted on the Hugging Face Hub.
     /// It expects the `identifier` of a model that includes a `tokenizer.json` file.
     pub fn from_pretrained<S: AsRef<str>>(
         identifier: S,
-        params: Option<FromPretrainedParameters>,
+        params: Option<crate::utils::from_pretrained::FromPretrainedParameters>,
     ) -> Result<Self> {
-        let tokenizer_file = from_pretrained(identifier, params)?;
+        let tokenizer_file = crate::utils::from_pretrained::from_pretrained(identifier, params)?;
         TokenizerImpl::from_file(tokenizer_file)
     }
 }

--- a/tokenizers/src/utils/from_pretrained.rs
+++ b/tokenizers/src/utils/from_pretrained.rs
@@ -110,7 +110,7 @@ pub fn from_pretrained<S: AsRef<str>>(
     if let Some(ref token) = params.auth_token {
         headers.insert(
             "Authorization",
-            reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token))?,
+            header::HeaderValue::from_str(&format!("Bearer {}", token))?,
         );
     }
     let client_builder = Client::builder()

--- a/tokenizers/src/utils/from_pretrained.rs
+++ b/tokenizers/src/utils/from_pretrained.rs
@@ -1,7 +1,6 @@
 use crate::Result;
 use cached_path::CacheBuilder;
 use itertools::Itertools;
-use reqwest::{blocking::Client, header};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -96,6 +95,7 @@ impl Default for FromPretrainedParameters {
     }
 }
 
+#[cfg(feature = "http")]
 /// Downloads and cache the identified tokenizer if it exists on
 /// the Hugging Face Hub, and returns a local path to the file
 pub fn from_pretrained<S: AsRef<str>>(
@@ -106,14 +106,14 @@ pub fn from_pretrained<S: AsRef<str>>(
     let cache_dir = ensure_cache_dir()?;
 
     // Build a custom HTTP Client using our user-agent and custom headers
-    let mut headers = header::HeaderMap::new();
+    let mut headers = reqwest::header::HeaderMap::new();
     if let Some(ref token) = params.auth_token {
         headers.insert(
             "Authorization",
-            header::HeaderValue::from_str(&format!("Bearer {}", token))?,
+            reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token))?,
         );
     }
-    let client_builder = Client::builder()
+    let client_builder = reqwest::blocking::Client::builder()
         .user_agent(user_agent(params.user_agent))
         .default_headers(headers);
 

--- a/tokenizers/src/utils/from_pretrained.rs
+++ b/tokenizers/src/utils/from_pretrained.rs
@@ -1,6 +1,7 @@
 use crate::Result;
 use cached_path::CacheBuilder;
 use itertools::Itertools;
+use reqwest::{blocking::Client, header};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -95,7 +96,6 @@ impl Default for FromPretrainedParameters {
     }
 }
 
-#[cfg(feature = "http")]
 /// Downloads and cache the identified tokenizer if it exists on
 /// the Hugging Face Hub, and returns a local path to the file
 pub fn from_pretrained<S: AsRef<str>>(
@@ -106,14 +106,14 @@ pub fn from_pretrained<S: AsRef<str>>(
     let cache_dir = ensure_cache_dir()?;
 
     // Build a custom HTTP Client using our user-agent and custom headers
-    let mut headers = reqwest::header::HeaderMap::new();
+    let mut headers = header::HeaderMap::new();
     if let Some(ref token) = params.auth_token {
         headers.insert(
             "Authorization",
             reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token))?,
         );
     }
-    let client_builder = reqwest::blocking::Client::builder()
+    let client_builder = Client::builder()
         .user_agent(user_agent(params.user_agent))
         .default_headers(headers);
 

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod cache;
+#[cfg(feature = "http")]
 pub(crate) mod from_pretrained;
 pub mod iter;
 pub mod padding;

--- a/tokenizers/tests/from_pretrained.rs
+++ b/tokenizers/tests/from_pretrained.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "http")]
 use tokenizers::{FromPretrainedParameters, Result, Tokenizer};
 
 #[test]


### PR DESCRIPTION
Make pulling in reqwest and cached-path optional, reducing the dependency footprint from 235 to 117 with a 20% release build time reduction (in very primitive timing on my specific machine). 

Useful for providing some additional safety if running on production servers where dynamically downloading external files are prohibited.