### PR TITLE
Improve truncation_side

### DIFF
--- a/bindings/node/native/src/encoding.rs
+++ b/bindings/node/native/src/encoding.rs
@@ -4,7 +4,7 @@ use crate::extraction::*;
 use crate::tokenizer::PaddingParams;
 use neon::prelude::*;
 
-use tk::utils::truncation::TruncateDirection;
+use tk::utils::truncation::TruncationDirection;
 
 /// Encoding
 pub struct Encoding {
@@ -349,8 +349,8 @@ declare_types! {
             let direction = cx.extract_opt::<String>(2)?.unwrap_or_else(|| String::from("right"));
 
             let tdir = match direction.as_str() {
-                "left" => TruncateDirection::Left,
-                "right" => TruncateDirection::Right,
+                "left" => TruncationDirection::Left,
+                "right" => TruncationDirection::Right,
                 _ => panic!("Invalid truncation direction value : {}", direction),
             };
 

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::*;
 use pyo3::{PyObjectProtocol, PySequenceProtocol};
 use tk::tokenizer::{Offsets, PaddingDirection};
-use tk::utils::truncation::TruncateDirection;
+use tk::utils::truncation::TruncationDirection;
 use tokenizers as tk;
 
 use crate::error::{deprecation_warning, PyError};
@@ -448,8 +448,8 @@ impl PyEncoding {
     #[text_signature = "(self, max_length, stride=0, direction='right')"]
     fn truncate(&mut self, max_length: usize, stride: usize, direction: &str) {
         let tdir = match direction {
-            "left" => TruncateDirection::Left,
-            "right" => TruncateDirection::Right,
+            "left" => TruncationDirection::Left,
+            "right" => TruncationDirection::Right,
             _ => panic!("Invalid truncation direction value : {}", direction),
         };
 

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -731,6 +731,7 @@ impl PyTokenizer {
             dict.set_item("max_length", params.max_length)?;
             dict.set_item("stride", params.stride)?;
             dict.set_item("strategy", params.strategy.as_ref())?;
+            dict.set_item("direction", params.direction.as_ref())?;
 
             Ok(Some(dict))
         })

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -10,7 +10,7 @@ use pyo3::PyObjectProtocol;
 use tk::models::bpe::BPE;
 use tk::tokenizer::{
     Model, PaddingDirection, PaddingParams, PaddingStrategy, PostProcessor, TokenizerImpl,
-    TruncationParams, TruncationStrategy,
+    TruncationDirection,, TruncationParams, TruncationStrategy, 
 };
 use tk::utils::iter::ResultShunt;
 use tokenizers as tk;
@@ -661,7 +661,7 @@ impl PyTokenizer {
     ///         The strategy used to truncation. Can be one of ``longest_first``, ``only_first`` or
     ///         ``only_second``.
     #[args(kwargs = "**")]
-    #[text_signature = "(self, max_length, stride=0, strategy='longest_first')"]
+    #[text_signature = "(self, max_length, stride=0, strategy='longest_first', direction='right')"]
     fn enable_truncation(&mut self, max_length: usize, kwargs: Option<&PyDict>) -> PyResult<()> {
         let mut params = TruncationParams {
             max_length,
@@ -686,6 +686,19 @@ impl PyTokenizer {
                             ))
                             .into_pyerr::<exceptions::PyValueError>()),
                         }?
+                    }
+                    "direction" => {
+                        let value: &str = value.extract()?;
+                        params.direction = match value {
+                            "left" => Ok(TruncationDirection::Left),
+                            "right" => Ok(TruncationDirection::Right),
+                            other => Err(PyError(format!(
+                                "Unknown `direction`: `{}`. Use \
+                                 one of `left` or `right`",
+                                other
+                            ))
+                            .into_pyerr::<exceptions::PyValueError>()),
+                        }?;
                     }
                     _ => println!("Ignored unknown kwarg option {}", key),
                 }

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -10,7 +10,7 @@ use pyo3::PyObjectProtocol;
 use tk::models::bpe::BPE;
 use tk::tokenizer::{
     Model, PaddingDirection, PaddingParams, PaddingStrategy, PostProcessor, TokenizerImpl,
-    TruncationDirection,, TruncationParams, TruncationStrategy, 
+    TruncationDirection, TruncationParams, TruncationStrategy, 
 };
 use tk::utils::iter::ResultShunt;
 use tokenizers as tk;

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::mem;
 
-pub enum TruncateDirection {
+pub enum TruncationDirection {
     Left,
     Right,
 }
@@ -72,9 +72,9 @@ pub fn truncate_encodings(
     params: &TruncationParams,
 ) -> Result<(Encoding, Option<Encoding>)> {
     if params.max_length == 0 {
-        encoding.truncate(0, params.stride, TruncateDirection::Right);
+        encoding.truncate(0, params.stride, TruncationDirection::Right);
         if let Some(other_encoding) = pair_encoding.as_mut() {
-            other_encoding.truncate(0, params.stride, TruncateDirection::Right);
+            other_encoding.truncate(0, params.stride, TruncationDirection::Right);
         }
         return Ok((encoding, pair_encoding));
     }
@@ -134,13 +134,13 @@ pub fn truncate_encodings(
                 if swap {
                     mem::swap(&mut n1, &mut n2);
                 }
-                encoding.truncate(n1, params.stride, TruncateDirection::Right);
-                other_encoding.truncate(n2, params.stride, TruncateDirection::Right);
+                encoding.truncate(n1, params.stride, TruncationDirection::Right);
+                other_encoding.truncate(n2, params.stride, TruncationDirection::Right);
             } else {
                 encoding.truncate(
                     total_length - to_remove,
                     params.stride,
-                    TruncateDirection::Right,
+                    TruncationDirection::Right,
                 );
             }
         }
@@ -158,7 +158,7 @@ pub fn truncate_encodings(
                 target.truncate(
                     target_len - to_remove,
                     params.stride,
-                    TruncateDirection::Right,
+                    TruncationDirection::Right,
                 );
             } else {
                 return Err(Box::new(TruncationError::SequenceTooShort));


### PR DESCRIPTION
This PR:

- adds the "direction" parameter to `enable_truncation`, as this is required for it to be used in Transformers. 
- renames `TruncateDirection` to `TruncationDirection` everywhere (to be consistent with `PaddingDirection`, sorry bit of nitpicking here)

To do:

- [ ] add tests to [test_tokenizer.py](https://github.com/huggingface/tokenizers/blob/master/bindings/python/tests/bindings/test_tokenizer.py) for testing padding/truncation on the right/left