### PR TITLE
Fix wordlevel encode `<unk>`

### DIFF
--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -229,7 +229,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_unk() {
+    fn test_tokenize_unk() {
         let vocab: Vocab = [("<unk>".into(), 0), ("a".into(), 1), ("b".into(), 2)]
             .iter()
             .cloned()


### PR DESCRIPTION
Closes #746

#746 is a bug? If not, please feel free to ignore this PR

let's say
```
# Tokenizer-Model
tokenizer = Tokenizer(WordLevel(unk_token="<unk>"))
with vocab = {"<unk>": 0, "a": 1, "b": 1}

# Pre-tokenizer
tokenizer.pre_tokenizer = Whitespace()
```

, then the expected behaviour for `tkns = tokenizer.encode("a b c")` should be 
```
tkns.tokens == ['a', 'b', '<unk>']
```

however, what actually gets produced is a buggy result
```
tkns.tokens == ['a', 'b', 'c']
```

and this PR fixes this bug

