### PR TITLE
Fixing bad deserialization following inclusion of a default for `Punctuation`.

### DIFF
--- a/bindings/node/native/Cargo.lock
+++ b/bindings/node/native/Cargo.lock
@@ -1668,7 +1668,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokenizers"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aho-corasick",
  "cached-path",

--- a/tokenizers/src/pre_tokenizers/bert.rs
+++ b/tokenizers/src/pre_tokenizers/bert.rs
@@ -6,6 +6,7 @@ fn is_bert_punc(x: char) -> bool {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct BertPreTokenizer;
 impl_serde_unit_struct!(BertVisitor, BertPreTokenizer);
 

--- a/tokenizers/src/pre_tokenizers/bert.rs
+++ b/tokenizers/src/pre_tokenizers/bert.rs
@@ -5,8 +5,7 @@ fn is_bert_punc(x: char) -> bool {
     char::is_ascii_punctuation(&x) || x.is_punctuation()
 }
 
-#[derive(Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct BertPreTokenizer;
 impl_serde_unit_struct!(BertVisitor, BertPreTokenizer);
 

--- a/tokenizers/src/pre_tokenizers/delimiter.rs
+++ b/tokenizers/src/pre_tokenizers/delimiter.rs
@@ -1,12 +1,34 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, PartialEq)]
 #[serde(tag = "type")]
 #[non_exhaustive]
 pub struct CharDelimiterSplit {
     pub delimiter: char,
+}
+
+impl<'de> Deserialize<'de> for CharDelimiterSplit {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        enum Type {
+            CharDelimiterSplit,
+        }
+
+        #[derive(Deserialize)]
+        pub struct CharDelimiterSplitHelper {
+            #[serde(rename = "type")]
+            _type: Type,
+            delimiter: char,
+        }
+
+        let helper = CharDelimiterSplitHelper::deserialize(deserializer)?;
+        Ok(CharDelimiterSplit::new(helper.delimiter))
+    }
 }
 
 impl CharDelimiterSplit {

--- a/tokenizers/src/pre_tokenizers/delimiter.rs
+++ b/tokenizers/src/pre_tokenizers/delimiter.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
 #[serde(tag = "type")]
 #[non_exhaustive]
 pub struct CharDelimiterSplit {

--- a/tokenizers/src/pre_tokenizers/delimiter.rs
+++ b/tokenizers/src/pre_tokenizers/delimiter.rs
@@ -2,8 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]
 #[non_exhaustive]
 pub struct CharDelimiterSplit {

--- a/tokenizers/src/pre_tokenizers/digits.rs
+++ b/tokenizers/src/pre_tokenizers/digits.rs
@@ -2,8 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 /// Pre tokenizes the numbers into single tokens. If individual_digits is set
 /// to true, then all digits are splitted into individual tokens.
 #[serde(tag = "type")]

--- a/tokenizers/src/pre_tokenizers/digits.rs
+++ b/tokenizers/src/pre_tokenizers/digits.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 /// Pre tokenizes the numbers into single tokens. If individual_digits is set
 /// to true, then all digits are splitted into individual tokens.
 #[serde(tag = "type")]

--- a/tokenizers/src/pre_tokenizers/digits.rs
+++ b/tokenizers/src/pre_tokenizers/digits.rs
@@ -1,14 +1,36 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Clone, Debug, PartialEq)]
 /// Pre tokenizes the numbers into single tokens. If individual_digits is set
 /// to true, then all digits are splitted into individual tokens.
 #[serde(tag = "type")]
 #[non_exhaustive]
 pub struct Digits {
     pub individual_digits: bool,
+}
+
+impl<'de> Deserialize<'de> for Digits {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        enum Type {
+            Digits,
+        }
+
+        #[derive(Deserialize)]
+        pub struct DigitsHelper {
+            #[serde(rename = "type")]
+            _type: Type,
+            individual_digits: bool,
+        }
+
+        let helper = DigitsHelper::deserialize(deserializer)?;
+        Ok(Digits::new(helper.individual_digits))
+    }
 }
 
 impl Digits {

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -109,6 +109,12 @@ mod tests {
             serde_json::from_str::<Metaspace>(metaspace_s).unwrap(),
             metaspace
         );
+
+        let metaspace_parsed: Metaspace = serde_json::from_str(
+            r#"{"type":"Metaspace","replacement":"_","add_prefix_space":true}"#,
+        )
+        .unwrap();
+        assert_eq!(metaspace_parsed, metaspace);
     }
 
     #[test]

--- a/tokenizers/src/pre_tokenizers/mod.rs
+++ b/tokenizers/src/pre_tokenizers/mod.rs
@@ -23,8 +23,7 @@ use crate::pre_tokenizers::unicode_scripts::UnicodeScripts;
 use crate::pre_tokenizers::whitespace::{Whitespace, WhitespaceSplit};
 use crate::{PreTokenizedString, PreTokenizer};
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum PreTokenizerWrapper {
     BertPreTokenizer(BertPreTokenizer),
@@ -77,6 +76,26 @@ mod tests {
     #[test]
     fn test_deserialize() {
         let pre_tokenizer: PreTokenizerWrapper = serde_json::from_str(r#"{"type":"Sequence","pretokenizers":[{"type":"WhitespaceSplit"},{"type":"Metaspace","replacement":"▁","str_rep":"▁","add_prefix_space":true}]}"#).unwrap();
+
+        assert_eq!(
+            pre_tokenizer,
+            PreTokenizerWrapper::Sequence(Sequence::new(vec![
+                PreTokenizerWrapper::WhitespaceSplit(WhitespaceSplit {}),
+                PreTokenizerWrapper::Metaspace(Metaspace::new('▁', true))
+            ]))
+        );
+
+        let pre_tokenizer: PreTokenizerWrapper = serde_json::from_str(
+            r#"{"type":"Metaspace","replacement":"▁","add_prefix_space":true}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            pre_tokenizer,
+            PreTokenizerWrapper::Metaspace(Metaspace::new('▁', true))
+        );
+
+        let pre_tokenizer: PreTokenizerWrapper = serde_json::from_str(r#"{"type":"Sequence","pretokenizers":[{"type":"WhitespaceSplit"},{"type":"Metaspace","replacement":"▁","add_prefix_space":true}]}"#).unwrap();
 
         assert_eq!(
             pre_tokenizer,

--- a/tokenizers/src/pre_tokenizers/mod.rs
+++ b/tokenizers/src/pre_tokenizers/mod.rs
@@ -23,7 +23,8 @@ use crate::pre_tokenizers::unicode_scripts::UnicodeScripts;
 use crate::pre_tokenizers::whitespace::{Whitespace, WhitespaceSplit};
 use crate::{PreTokenizedString, PreTokenizer};
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 #[serde(untagged)]
 pub enum PreTokenizerWrapper {
     BertPreTokenizer(BertPreTokenizer),
@@ -68,3 +69,31 @@ impl_enum_from!(Metaspace, PreTokenizerWrapper, Metaspace);
 impl_enum_from!(WhitespaceSplit, PreTokenizerWrapper, WhitespaceSplit);
 impl_enum_from!(Digits, PreTokenizerWrapper, Digits);
 impl_enum_from!(UnicodeScripts, PreTokenizerWrapper, UnicodeScripts);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize() {
+        let pre_tokenizer: PreTokenizerWrapper = serde_json::from_str(r#"{"type":"Sequence","pretokenizers":[{"type":"WhitespaceSplit"},{"type":"Metaspace","replacement":"▁","str_rep":"▁","add_prefix_space":true}]}"#).unwrap();
+
+        assert_eq!(
+            pre_tokenizer,
+            PreTokenizerWrapper::Sequence(Sequence::new(vec![
+                PreTokenizerWrapper::WhitespaceSplit(WhitespaceSplit {}),
+                PreTokenizerWrapper::Metaspace(Metaspace::new('▁', true))
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_deserialize_whitespace_split() {
+        let pre_tokenizer: PreTokenizerWrapper =
+            serde_json::from_str(r#"{"type":"WhitespaceSplit"}"#).unwrap();
+        assert_eq!(
+            pre_tokenizer,
+            PreTokenizerWrapper::WhitespaceSplit(WhitespaceSplit {})
+        );
+    }
+}

--- a/tokenizers/src/pre_tokenizers/punctuation.rs
+++ b/tokenizers/src/pre_tokenizers/punctuation.rs
@@ -9,6 +9,7 @@ fn is_punc(x: char) -> bool {
 
 #[derive(Serialize, Copy, Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
+#[serde(tag = "type")]
 pub struct Punctuation {
     behavior: SplitDelimiterBehavior,
 }

--- a/tokenizers/src/pre_tokenizers/punctuation.rs
+++ b/tokenizers/src/pre_tokenizers/punctuation.rs
@@ -7,8 +7,7 @@ fn is_punc(x: char) -> bool {
     char::is_ascii_punctuation(&x) || x.is_punctuation()
 }
 
-#[derive(Serialize, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Serialize, Copy, Clone, Debug, PartialEq)]
 #[serde(tag = "type")]
 pub struct Punctuation {
     behavior: SplitDelimiterBehavior,

--- a/tokenizers/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/src/pre_tokenizers/sequence.rs
@@ -1,11 +1,33 @@
 use crate::pre_tokenizers::PreTokenizerWrapper;
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 #[serde(tag = "type")]
 pub struct Sequence {
     pretokenizers: Vec<PreTokenizerWrapper>,
+}
+
+impl<'de> Deserialize<'de> for Sequence {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        enum Type {
+            Sequence,
+        }
+
+        #[derive(Deserialize)]
+        pub struct SequenceHelper {
+            #[serde(rename = "type")]
+            _type: Type,
+            pretokenizers: Vec<PreTokenizerWrapper>,
+        }
+
+        let helper = SequenceHelper::deserialize(deserializer)?;
+        Ok(Sequence::new(helper.pretokenizers))
+    }
 }
 
 impl Sequence {

--- a/tokenizers/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/src/pre_tokenizers/sequence.rs
@@ -3,6 +3,7 @@ use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 #[serde(tag = "type")]
 pub struct Sequence {
     pretokenizers: Vec<PreTokenizerWrapper>,

--- a/tokenizers/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/src/pre_tokenizers/sequence.rs
@@ -2,8 +2,7 @@ use crate::pre_tokenizers::PreTokenizerWrapper;
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub struct Sequence {
     pretokenizers: Vec<PreTokenizerWrapper>,

--- a/tokenizers/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
+++ b/tokenizers/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
@@ -1,8 +1,7 @@
 use crate::pre_tokenizers::unicode_scripts::scripts::{get_script, Script};
 use crate::tokenizer::{normalizer::Range, PreTokenizedString, PreTokenizer, Result};
 
-#[derive(Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct UnicodeScripts;
 impl_serde_unit_struct!(UnicodeScriptsVisitor, UnicodeScripts);
 

--- a/tokenizers/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
+++ b/tokenizers/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
@@ -2,6 +2,7 @@ use crate::pre_tokenizers::unicode_scripts::scripts::{get_script, Script};
 use crate::tokenizer::{normalizer::Range, PreTokenizedString, PreTokenizer, Result};
 
 #[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct UnicodeScripts;
 impl_serde_unit_struct!(UnicodeScriptsVisitor, UnicodeScripts);
 

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -4,8 +4,7 @@ use crate::tokenizer::{
     pattern::Invert, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior,
 };
 
-#[derive(Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Whitespace;
 impl_serde_unit_struct!(WhitespaceVisitor, Whitespace);
 
@@ -28,8 +27,7 @@ impl PreTokenizer for Whitespace {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct WhitespaceSplit;
 impl_serde_unit_struct!(WhitespaceSplitVisitor, WhitespaceSplit);
 

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -5,6 +5,7 @@ use crate::tokenizer::{
 };
 
 #[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Whitespace;
 impl_serde_unit_struct!(WhitespaceVisitor, Whitespace);
 
@@ -28,6 +29,7 @@ impl PreTokenizer for Whitespace {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct WhitespaceSplit;
 impl_serde_unit_struct!(WhitespaceSplitVisitor, WhitespaceSplit);
 

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -403,7 +403,8 @@ impl Tokenizer {
     }
     pub fn from_file<P: AsRef<Path>>(file: P) -> Result<Self> {
         let content = read_to_string(file)?;
-        Ok(serde_json::from_str(&content)?)
+        let tokenizer = serde_json::from_str(&content)?;
+        Ok(tokenizer)
     }
     #[cfg(feature = "http")]
     pub fn from_pretrained<S: AsRef<str>>(
@@ -1131,7 +1132,8 @@ where
     /// Instantiate a new Tokenizer from the given file
     pub fn from_file<P: AsRef<Path>>(file: P) -> Result<Self> {
         let content = read_to_string(file)?;
-        Ok(serde_json::from_str(&content)?)
+        let tokenizer = serde_json::from_str(&content)?;
+        Ok(tokenizer)
     }
 }
 


### PR DESCRIPTION
Deserialization is a bit basic, and ignore `type` field.

IIRC, it's because we didn't always add it, and so old `tokenizers` might still have `pre_tokenizers` without any `type` field in them being serialized.

However https://github.com/huggingface/tokenizers/pull/882 introduced a pretty bad bug, since it allowed `Punctuation` to work without any data. Since it's based **Before** `WhitespaceSplit`, then all `WhitespaceSplit` would be deserialized as `Punctuation`.

In order to avoid that, there are 2 options:

- Change the order in the `PretokenizerWrapper` enum, but that seems quite brittle
- Force the presence of `type` in *some* pretokenizers.

I went for the second version to avoid further hacks like ordering of the enum, which is brittle and we're bound to forget about it later.

In order to make sure we don't break old tokenizers that would be using `Punctuation`, I am making a full sweep on the hub to see how things get loaded