### PR TITLE
fix python3.10 build

### DIFF
--- a/bindings/python/build-wheels.sh
+++ b/bindings/python/build-wheels.sh
@@ -4,7 +4,7 @@ set -ex
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 export PATH="$HOME/.cargo/bin:$PATH"
 
-for PYBIN in /opt/python/{cp36-cp36m,cp37-cp37m,cp38-cp38,cp39-cp39}/bin; do
+for PYBIN in /opt/python/{cp36-cp36m,cp37-cp37m,cp38-cp38,cp39-cp39,cp310-cp310}/bin; do
     export PYTHON_SYS_EXECUTABLE="$PYBIN/python"
 
     "${PYBIN}/pip" install -U setuptools-rust==0.11.3


### PR DESCRIPTION
since https://github.com/huggingface/tokenizers/pull/877 we have python3.10 wheels  for macOS but not linux