### PR TITLE
tokenizer.save has the wrong arguments compared to documentation

### DIFF
--- a/bindings/node/native/Cargo.lock
+++ b/bindings/node/native/Cargo.lock
@@ -1136,6 +1136,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1179,10 @@ checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "proc_macros"
+version = "0.1.0"
 
 [[package]]
 name = "quote"
@@ -1668,7 +1678,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokenizers"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "aho-corasick",
  "cached-path",
@@ -1681,6 +1691,8 @@ dependencies = [
  "lazy_static",
  "log",
  "onig",
+ "paste",
+ "proc_macros",
  "rand 0.7.3",
  "rayon",
  "rayon-cond",

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1159,6 +1159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
 name = "paste-impl"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1219,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc_macros"
+version = "0.1.0"
+
+[[package]]
 name = "pyo3"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,7 +1233,7 @@ dependencies = [
  "inventory",
  "libc",
  "parking_lot",
- "paste",
+ "paste 0.1.18",
  "pyo3cls",
  "unindent",
 ]
@@ -1743,7 +1753,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokenizers"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "aho-corasick",
  "cached-path",
@@ -1756,6 +1766,8 @@ dependencies = [
  "lazy_static",
  "log",
  "onig",
+ "paste 1.0.6",
+ "proc_macros",
  "rand 0.7.3",
  "rayon",
  "rayon-cond",

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -1012,7 +1012,7 @@ class Tokenizer:
         The `optional` :class:`~tokenizers.pre_tokenizers.PreTokenizer` in use by the Tokenizer
         """
         pass
-    def save(self, path: str, pretty=True):
+    def save(self, path, pretty=True):
         """
         Save the :class:`~tokenizers.Tokenizer` to the file at the given path.
 
@@ -1036,7 +1036,7 @@ class Tokenizer:
             :obj:`str`: A string representing the serialized Tokenizer
         """
         pass
-    def token_to_id(self, token:str):
+    def token_to_id(self, token):
         """
         Convert the given token to its corresponding id if it exists
 

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -1012,7 +1012,7 @@ class Tokenizer:
         The `optional` :class:`~tokenizers.pre_tokenizers.PreTokenizer` in use by the Tokenizer
         """
         pass
-    def save(self, pretty=True):
+    def save(self, path: str, pretty=True):
         """
         Save the :class:`~tokenizers.Tokenizer` to the file at the given path.
 
@@ -1036,7 +1036,7 @@ class Tokenizer:
             :obj:`str`: A string representing the serialized Tokenizer
         """
         pass
-    def token_to_id(self, token):
+    def token_to_id(self, token:str):
         """
         Convert the given token to its corresponding id if it exists
 

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -604,7 +604,7 @@ impl PyTokenizer {
     ///     pretty (:obj:`bool`, defaults to :obj:`True`):
     ///         Whether the JSON file should be pretty formatted.
     #[args(pretty = true)]
-    #[text_signature = "(self, pretty=True)"]
+    #[text_signature = "(self, path, pretty=True)"]
     fn save(&self, path: &str, pretty: bool) -> PyResult<()> {
         ToPyResult(self.tokenizer.save(path, pretty)).into()
     }


### PR DESCRIPTION
Unless I'm wrong, `tokenizer.save` should accept a `path:str` as argument.