### PR TITLE
Load tokenizer via String

### DIFF
--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -406,9 +406,8 @@ impl Tokenizer {
         let tokenizer = serde_json::from_str(&content)?;
         Ok(tokenizer)
     }
-    pub fn from_string(content: String) -> Result<Self> {
-        let tokenizer = serde_json::from_str(&content)?;
-        Ok(tokenizer)
+    pub fn from_string(content: &str) -> Result<Self> {
+        serde_json::from_str(content)
     }
     #[cfg(feature = "http")]
     pub fn from_pretrained<S: AsRef<str>>(

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -407,7 +407,8 @@ impl Tokenizer {
         Ok(tokenizer)
     }
     pub fn from_string(content: &str) -> Result<Self> {
-        serde_json::from_str(content)
+        let tokenizer = serde_json::from_str(content)?;
+        Ok(tokenizer)
     }
     #[cfg(feature = "http")]
     pub fn from_pretrained<S: AsRef<str>>(

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -406,6 +406,10 @@ impl Tokenizer {
         let tokenizer = serde_json::from_str(&content)?;
         Ok(tokenizer)
     }
+    pub fn from_string(content: String) -> Result<Self> {
+        let tokenizer = serde_json::from_str(&content)?;
+        Ok(tokenizer)
+    }
     #[cfg(feature = "http")]
     pub fn from_pretrained<S: AsRef<str>>(
         identifier: S,

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -61,7 +61,7 @@ fn load_tokenizer() {
 #[test]
 fn load_tokenizer_from_string() {
     let tokenizer_content = std::fs::read_to_string("data/roberta.json").unwrap();
-    let tokenizer = Tokenizer::from_string(tokenizer_content).unwrap();
+    let tokenizer = Tokenizer::from_string(tokenizer_content.as_str()).unwrap();
 
     let example = "This is an example";
     let ids = vec![713, 16, 41, 1246];

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -59,6 +59,24 @@ fn load_tokenizer() {
 }
 
 #[test]
+fn load_tokenizer_from_string() {
+    let tokenizer_content = std::fs::read_to_string("data/roberta.json").unwrap();
+    let tokenizer = Tokenizer::from_string(tokenizer_content).unwrap();
+
+    let example = "This is an example";
+    let ids = vec![713, 16, 41, 1246];
+    let tokens = vec!["This", "Ġis", "Ġan", "Ġexample"];
+
+    let encodings = tokenizer.encode(example, false).unwrap();
+
+    assert_eq!(encodings.get_ids(), ids);
+    assert_eq!(encodings.get_tokens(), tokens);
+
+    let decoded = tokenizer.decode(ids, false).unwrap();
+    assert_eq!(decoded, example);
+}
+
+#[test]
 #[ignore]
 fn quicktour_slow_train() -> tokenizers::Result<()> {
     // START quicktour_init_tokenizer


### PR DESCRIPTION
Being able to load a tokenizer via a string can allow enable loading tokenizers in use cases such as loading a string asset from an App Asset bundle or streaming over network. In these cases we do not have a file path to resolve and/or prefer not to save a file to a temporary location.

I added a test for this but couldn't get the test to pass in my local environment because I cannot find the "data/roberta.json" file.