### PR TITLE
Fixing `special_tokens_mask`.

### DIFF
--- a/bindings/node/native/Cargo.lock
+++ b/bindings/node/native/Cargo.lock
@@ -1136,6 +1136,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1179,10 @@ checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "proc_macros"
+version = "0.1.0"
 
 [[package]]
 name = "quote"
@@ -1668,7 +1678,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokenizers"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "aho-corasick",
  "cached-path",
@@ -1681,6 +1691,8 @@ dependencies = [
  "lazy_static",
  "log",
  "onig",
+ "paste",
+ "proc_macros",
  "rand 0.7.3",
  "rayon",
  "rayon-cond",

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1159,6 +1159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
 name = "paste-impl"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1219,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc_macros"
+version = "0.1.0"
+
+[[package]]
 name = "pyo3"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,7 +1233,7 @@ dependencies = [
  "inventory",
  "libc",
  "parking_lot",
- "paste",
+ "paste 0.1.18",
  "pyo3cls",
  "unindent",
 ]
@@ -1743,7 +1753,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokenizers"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "aho-corasick",
  "cached-path",
@@ -1756,6 +1766,8 @@ dependencies = [
  "lazy_static",
  "log",
  "onig",
+ "paste 1.0.6",
+ "proc_macros",
  "rand 0.7.3",
  "rayon",
  "rayon-cond",

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -95,7 +95,7 @@ impl PostProcessor for RobertaProcessing {
         .concat();
         let words = [&[None], encoding.get_word_ids(), &[None]].concat();
         let offsets = [&[(0, 0)], encoding.get_offsets(), &[(0, 0)]].concat();
-        let special_tokens = [&[1u32], &vec![0; encoding.get_ids().len()][..], &[1]].concat();
+        let special_tokens = [&[1u32], encoding.get_special_tokens_mask(), &[1]].concat();
         let attention_mask = vec![1; ids.len()];
 
         // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't contain

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -644,7 +644,7 @@ where
                 .added_vocabulary
                 .extract_and_normalize(self.normalizer.as_ref(), subseq);
             let pre_tokenized = self.do_pre_tokenize(normalized)?;
-            let subseq_encoding = self.do_tokenize(
+            let mut subseq_encoding = self.do_tokenize(
                 pre_tokenized,
                 type_id,
                 if is_pre_tokenized {
@@ -654,6 +654,7 @@ where
                 },
                 offsets_type,
             )?;
+            subseq_encoding.update_special_tokens_mask(&self.added_vocabulary);
 
             Ok(subseq_encoding)
         };


### PR DESCRIPTION
Fixes #790.

- Roberta didn't use `Encoding.get_special_tokens_mask`. This is
  obviously a bug.
- AddedVocabulary, didn't propagate the special status of tokens to
  their encoding.

It seems very dangerous to change this behavior.

`added_tokens` and `added_special_tokens` are very peculiar, and I expect users to use them in probably every possible way, and they expect no change on that end (all changes are probably going to be silent, which makes this even worse). 