### PR TITLE
WIP: ByteLevel without regex.

### DIFF
--- a/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
@@ -102,7 +102,7 @@ class ByteLevel(PreTokenizer):
             lets us treat `hello` exactly like `say hello`.
     """
 
-    def __init__(self, add_prefix_space=True, trim_offsets=True, regex_type="original"):
+    def __init__(self, add_prefix_space=True, regex_type="original"):
         pass
     @staticmethod
     def alphabet():

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -230,7 +230,7 @@ macro_rules! setter {
 ///         Whether to add a space to the first word if there isn't already one. This
 ///         lets us treat `hello` exactly like `say hello`.
 #[pyclass(extends=PyPreTokenizer, module = "tokenizers.pre_tokenizers", name=ByteLevel)]
-#[text_signature = "(self, add_prefix_space=True, trim_offsets=True, regex_type=\"original\")"]
+#[text_signature = "(self, add_prefix_space=True, regex_type=\"original\")"]
 pub struct PyByteLevel {}
 #[pymethods]
 impl PyByteLevel {
@@ -258,7 +258,7 @@ impl PyByteLevel {
                 // .regex_type(regex_type) # TODO: use enum
                 .regex_type(match regex_type {
                     "original" => RegexType::ORIGINAL,
-                    "whitespace" => RegexType::WHITESPACE,
+                    "no_regex" => RegexType::NO_REGEX,
                     _ => unimplemented!(), // TODO: throw errors
                 })
                 .into(),

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -255,10 +255,9 @@ impl PyByteLevel {
             PyByteLevel {},
             ByteLevel::default()
                 .add_prefix_space(add_prefix_space)
-                // .regex_type(regex_type) # TODO: use enum
                 .regex_type(match regex_type {
                     "original" => RegexType::ORIGINAL,
-                    "no_regex" => RegexType::NO_REGEX,
+                    "no_regex" => RegexType::NOREGEX,
                     _ => unimplemented!(), // TODO: throw errors
                 })
                 .into(),

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -33,10 +33,9 @@ fn bytes_char() -> HashMap<u8, char> {
 }
 
 lazy_static! {
-    static ref ORIGINAL_RE: Regex =
+    static ref RE: Regex =
         Regex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+")
             .unwrap();
-    static ref WHITESPACE_RE: Regex = Regex::new(r" ?[^ ]+").unwrap();
     static ref BYTES_CHAR: HashMap<u8, char> = bytes_char();
     static ref CHAR_BYTES: HashMap<char, u8> =
         bytes_char().into_iter().map(|(c, b)| (b, c)).collect();
@@ -46,7 +45,6 @@ lazy_static! {
 #[serde(rename_all = "lowercase")]
 pub enum RegexType {
     ORIGINAL,
-    WHITESPACE,
     NO_REGEX,
 }
 
@@ -115,8 +113,7 @@ impl ByteLevel {
 
     pub fn regex(&self) -> Option<&Regex> {
         match self.regex_type {
-            RegexType::ORIGINAL => Some(&ORIGINAL_RE),
-            RegexType::WHITESPACE => Some(&WHITESPACE_RE),
+            RegexType::ORIGINAL => Some(&RE),
             RegexType::NO_REGEX => None,
         }
     }
@@ -557,9 +554,9 @@ mod tests {
 
         // Loading works, new future BC test.
         let byte_level: ByteLevel = serde_json::from_str(
-            r#"{"type": "ByteLevel", "add_prefix_space": true, "trim_offsets": false, "regex_type": "whitespace"}"#,
+            r#"{"type": "ByteLevel", "add_prefix_space": true, "trim_offsets": false, "regex_type": "no_regex"}"#,
         )
         .unwrap();
-        assert_eq!(byte_level.regex_type, RegexType::WHITESPACE);
+        assert_eq!(byte_level.regex_type, RegexType::NO_REGEX);
     }
 }

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -45,7 +45,7 @@ lazy_static! {
 #[serde(rename_all = "lowercase")]
 pub enum RegexType {
     ORIGINAL,
-    NO_REGEX,
+    NOREGEX,
 }
 
 impl Default for RegexType {
@@ -114,7 +114,7 @@ impl ByteLevel {
     pub fn regex(&self) -> Option<&Regex> {
         match self.regex_type {
             RegexType::ORIGINAL => Some(&RE),
-            RegexType::NO_REGEX => None,
+            RegexType::NOREGEX => None,
         }
     }
 }
@@ -131,7 +131,7 @@ impl PreTokenizer for ByteLevel {
                 }
                 normalized.split(re_ref, SplitDelimiterBehavior::Isolated)
             })?;
-        }
+        };
         pretokenized.normalize(|normalized| {
             let s = normalized.get();
             let mut transformations: Vec<(char, isize)> = Vec::with_capacity(s.len());

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -130,9 +130,9 @@ impl PreTokenizer for ByteLevel {
                 normalized.prepend(" ");
             }
             if let Some(re_ref) = regex {
-                return normalized.split(re_ref, SplitDelimiterBehavior::Isolated);
+                normalized.split(re_ref, SplitDelimiterBehavior::Isolated)
             } else {
-                return Ok(vec![normalized]);
+                Ok(vec![normalized])
             }
         })?;
         pretokenized.normalize(|normalized| {

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -124,14 +124,17 @@ impl ByteLevel {
 // TODO: Give the ability to modify this regex
 impl PreTokenizer for ByteLevel {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
-        if let Some(re_ref) = self.regex() {
-            pretokenized.split(|_, mut normalized| {
-                if self.add_prefix_space && !normalized.get().starts_with(' ') {
-                    normalized.prepend(" ");
-                }
-                normalized.split(re_ref, SplitDelimiterBehavior::Isolated)
-            })?;
-        };
+        let regex: Option<&Regex> = self.regex();
+        pretokenized.split(|_, mut normalized| {
+            if self.add_prefix_space && !normalized.get().starts_with(' ') {
+                normalized.prepend(" ");
+            }
+            if let Some(re_ref) = regex {
+                return normalized.split(re_ref, SplitDelimiterBehavior::Isolated);
+            } else {
+                return Ok(vec![normalized]);
+            }
+        })?;
         pretokenized.normalize(|normalized| {
             let s = normalized.get();
             let mut transformations: Vec<(char, isize)> = Vec::with_capacity(s.len());

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -557,6 +557,6 @@ mod tests {
             r#"{"type": "ByteLevel", "add_prefix_space": true, "trim_offsets": false, "regex_type": "no_regex"}"#,
         )
         .unwrap();
-        assert_eq!(byte_level.regex_type, RegexType::NO_REGEX);
+        assert_eq!(byte_level.regex_type, RegexType::NOREGEX);
     }
 }

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -554,7 +554,7 @@ mod tests {
 
         // Loading works, new future BC test.
         let byte_level: ByteLevel = serde_json::from_str(
-            r#"{"type": "ByteLevel", "add_prefix_space": true, "trim_offsets": false, "regex_type": "no_regex"}"#,
+            r#"{"type": "ByteLevel", "add_prefix_space": true, "trim_offsets": false, "regex_type": "noregex"}"#,
         )
         .unwrap();
         assert_eq!(byte_level.regex_type, RegexType::NOREGEX);


### PR DESCRIPTION
We can use Split to customise specific regex split strategies.

@Narsil sicne you initially suggested having no regex in the ByteLevel.

Test:
```python
>>> from tokenizers import pre_tokenizers, Regex
>>> pre_tokenizer_0 = pre_tokenizers.Sequence([pre_tokenizers.Split(Regex(" "), "isolated"), pre_tokenizers.ByteLevel(regex_type="no_regex")])
>>> pre_tokenizer_1 = pre_tokenizers.Sequence([pre_tokenizers.Split(Regex(","), "isolated"), pre_tokenizers.ByteLevel(regex_type="no_regex")])
>>> text = "Hello, Morning to you! Today, this will be a good day!"
>>> pre_tokenizer_0.pre_tokenize_str(text)
[('Hello,', (0, 6)), ('Ġ', (6, 7)), ('Morning', (7, 14)), ('Ġ', (14, 15)), ('to', (15, 17)), ('Ġ', (17, 18)), ('you!', (18, 22)), ('Ġ', (22, 23)), ('Today,', (23, 29)), ('Ġ', (29, 30)), ('this', (30, 34)), ('Ġ', (34, 35)), ('will', (35, 39)), ('Ġ', (39, 40)), ('be', (40, 42)), ('Ġ', (42, 43)), ('a', (43, 44)), ('Ġ', (44, 45)), ('good', (45, 49)), ('Ġ', (49, 50)), ('day!', (50, 54))]
>>> pre_tokenizer_1.pre_tokenize_str(text)
[('Hello', (0, 5)), (',', (5, 6)), ('ĠMorningĠtoĠyou!ĠToday', (6, 28)), (',', (28, 29)), ('ĠthisĠwillĠbeĠaĠgoodĠday!', (29, 54))]
```

cc @SaulLu 
