### PR TITLE
in serialization.rs, the supplementary tokens are now added "in batch…

### DIFF
--- a/tokenizers/examples/serialization.rs
+++ b/tokenizers/examples/serialization.rs
@@ -2,13 +2,15 @@ use tokenizers::models::wordpiece::WordPiece;
 use tokenizers::{AddedToken, Tokenizer};
 
 fn main() {
+    let start = std::time::Instant::now();
     let mut tokenizer = Tokenizer::new(WordPiece::default());
 
-    let tokens: Vec<_> = (0..4000)
+    let tokens: Vec<_> = (0..120_000)
         .map(|i| AddedToken::from(format!("[SPECIAL_{}]", i), false))
         .collect();
     tokenizer.add_tokens(&tokens);
     tokenizer.save("_tok.json", false).unwrap();
+    println!("Save took {:?}", start.elapsed());
     let start = std::time::Instant::now();
     let _tok = Tokenizer::from_file("_tok.json").unwrap();
     println!("Took {:?}", start.elapsed());

--- a/tokenizers/src/tokenizer/serialization.rs
+++ b/tokenizers/src/tokenizer/serialization.rs
@@ -150,34 +150,17 @@ where
             .build()
             .map_err(|e| V::Error::custom(e.to_string()))?;
 
+        let mut regular_tokens = vec![];
+        let mut special_tokens = vec![];
         // We take care of deserializing the added_tokens (instead of `AddedVocabulary` directly
         // because it let us check that associated IDs are still good, and warn the user otherwise
-        tokenizer.add_special_tokens(
-            tokens
-                .iter()
-                .filter(|added_token_with_id| added_token_with_id.special)
-                .map(|added_token_with_id| added_token_with_id.token.clone())
-                .collect::<Vec<_>>()
-                .as_slice(),
-        );
-        tokenizer.add_tokens(
-            tokens
-                .iter()
-                .filter(|added_token_with_id| !added_token_with_id.special)
-                .map(|added_token_with_id| added_token_with_id.token.clone())
-                .collect::<Vec<_>>()
-                .as_slice(),
-        );
-
         for token in tokens {
-            let tk = token.token.content.clone();
-
             // Warn the user if the id is different than expected
-            let received_id = tokenizer.token_to_id(&tk);
+            let received_id = tokenizer.token_to_id(&token.token.content);
             if received_id != Some(token.id) {
                 warn!(
                     "Warning: Token '{}' was expected to have ID '{}' but was given ID '{}'",
-                    tk,
+                    token.token.content,
                     token.id,
                     if let Some(rid) = received_id {
                         rid.to_string()
@@ -186,7 +169,15 @@ where
                     }
                 );
             }
+
+            if token.special {
+                special_tokens.push(token.token);
+            } else {
+                regular_tokens.push(token.token);
+            }
         }
+        tokenizer.add_special_tokens(&special_tokens[..]);
+        tokenizer.add_tokens(&regular_tokens[..]);
 
         Ok(tokenizer)
     }

--- a/tokenizers/src/tokenizer/serialization.rs
+++ b/tokenizers/src/tokenizer/serialization.rs
@@ -152,17 +152,21 @@ where
 
         // We take care of deserializing the added_tokens (instead of `AddedVocabulary` directly
         // because it let us check that associated IDs are still good, and warn the user otherwise
-        tokenizer.add_special_tokens(tokens.iter().
-            filter(|added_token_with_id| added_token_with_id.special).
-            map(|added_token_with_id| added_token_with_id.token.clone()).
-            collect::<Vec<_>>().
-            as_slice()
+        tokenizer.add_special_tokens(
+            tokens
+                .iter()
+                .filter(|added_token_with_id| added_token_with_id.special)
+                .map(|added_token_with_id| added_token_with_id.token.clone())
+                .collect::<Vec<_>>()
+                .as_slice(),
         );
-        tokenizer.add_tokens(tokens.iter().
-            filter(|added_token_with_id| !added_token_with_id.special).
-            map(|added_token_with_id| added_token_with_id.token.clone()).
-            collect::<Vec<_>>().
-            as_slice()
+        tokenizer.add_tokens(
+            tokens
+                .iter()
+                .filter(|added_token_with_id| !added_token_with_id.special)
+                .map(|added_token_with_id| added_token_with_id.token.clone())
+                .collect::<Vec<_>>()
+                .as_slice(),
         );
 
         for token in tokens {

--- a/tokenizers/src/tokenizer/serialization.rs
+++ b/tokenizers/src/tokenizer/serialization.rs
@@ -152,13 +152,22 @@ where
 
         // We take care of deserializing the added_tokens (instead of `AddedVocabulary` directly
         // because it let us check that associated IDs are still good, and warn the user otherwise
+        tokenizer.add_special_tokens(tokens.iter().
+            filter(|added_token_with_id| added_token_with_id.special).
+            map(|added_token_with_id| added_token_with_id.token.clone()).
+            collect::<Vec<_>>().
+            as_slice()
+        );
+        tokenizer.add_tokens(tokens.iter().
+            filter(|added_token_with_id| !added_token_with_id.special).
+            map(|added_token_with_id| added_token_with_id.token.clone()).
+            collect::<Vec<_>>().
+            as_slice()
+        );
+
         for token in tokens {
             let tk = token.token.content.clone();
-            if token.special {
-                tokenizer.add_special_tokens(&[token.token]);
-            } else {
-                tokenizer.add_tokens(&[token.token]);
-            }
+
             // Warn the user if the id is different than expected
             let received_id = tokenizer.token_to_id(&tk);
             if received_id != Some(token.id) {


### PR DESCRIPTION
…" to the tokenizer vocabulary, so that the tokenizer trie is built just once (Fix #914)

Building the trie is a very expensive operation: previously this operation was carried out for every and each token, so that, for large vocabularies, the overall loading time of the vocabulary resulted unacceptable.