### PR TITLE
Python - add doctype to length in implementations spm unigram

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
@@ -101,6 +101,9 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
                 A list of special tokens the model should know of.
             unk_token (:obj:`str`, `optional`):
                 The unknown token to be used by the model.
+            length (:obj:`int`, `optional`):
+                The total number of sequences in the iterator. This is used to
+                provide meaningful progress tracking
         """
 
         trainer = trainers.UnigramTrainer(


### PR DESCRIPTION
Did not notice the doctype in #937 