### PR TITLE
Use `thiserror` crate for Errors

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -59,6 +59,7 @@ cached-path = { version = "0.5", optional = true }
 aho-corasick = "0.7"
 paste = "1.0.6"
 macro_rules_attribute = "0.0.2"
+thiserror = "1.0.30"
 
 [features]
 default = ["progressbar", "http"]

--- a/tokenizers/src/models/bpe/mod.rs
+++ b/tokenizers/src/models/bpe/mod.rs
@@ -13,10 +13,18 @@ type Pair = (u32, u32);
 pub enum Error {
     /// An error encountered while reading files mainly.
     #[error("IoError: {0}")]
-    Io(#[from] #[source] std::io::Error),
+    Io(
+        #[from]
+        #[source]
+        std::io::Error,
+    ),
     /// An error forwarded from Serde, while parsing JSON
     #[error("JsonError: {0}")]
-    JsonError(#[from] #[source] serde_json::Error),
+    JsonError(
+        #[from]
+        #[source]
+        serde_json::Error,
+    ),
     /// When the vocab.json file is in the wrong format
     #[error("Bad vocabulary json file")]
     BadVocabulary,

--- a/tokenizers/src/models/bpe/mod.rs
+++ b/tokenizers/src/models/bpe/mod.rs
@@ -13,18 +13,10 @@ type Pair = (u32, u32);
 pub enum Error {
     /// An error encountered while reading files mainly.
     #[error("IoError: {0}")]
-    Io(
-        #[from]
-        #[source]
-        std::io::Error,
-    ),
+    Io(#[from] std::io::Error),
     /// An error forwarded from Serde, while parsing JSON
     #[error("JsonError: {0}")]
-    JsonError(
-        #[from]
-        #[source]
-        serde_json::Error,
-    ),
+    JsonError(#[from] serde_json::Error),
     /// When the vocab.json file is in the wrong format
     #[error("Bad vocabulary json file")]
     BadVocabulary,

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -65,30 +65,15 @@ impl std::fmt::Debug for Unigram {
 
 static K_UNK_PENALTY: f64 = 10.0;
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum UnigramError {
+    #[error("The vocabulary is empty but at least <unk> is needed")]
     EmptyVocabulary,
+    #[error("The `unk_id` is larger than vocabulary size")]
     UnkIdNotInVocabulary,
+    #[error("Encountered an unknown token but `unk_id` is missing")]
     MissingUnkId,
 }
-
-impl std::fmt::Display for UnigramError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::EmptyVocabulary => {
-                write!(f, "The vocabulary is empty but at least <unk> is needed")
-            }
-            Self::UnkIdNotInVocabulary => {
-                write!(f, "The `unk_id` is larger than vocabulary size")
-            }
-            Self::MissingUnkId => {
-                write!(f, "Encountered an unknown token but `unk_id` is missing")
-            }
-        }
-    }
-}
-
-impl std::error::Error for UnigramError {}
 
 impl Default for Unigram {
     fn default() -> Self {

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -2,7 +2,6 @@ use super::OrderedVocabIter;
 use crate::tokenizer::{Model, Result, Token};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fmt;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
@@ -15,23 +14,12 @@ pub use trainer::*;
 
 type Vocab = HashMap<String, u32>;
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("WordLevel error: Missing [UNK] token from the vocabulary")]
     MissingUnkToken,
+    #[error("Bad vocabulary json file")]
     BadVocabulary,
-}
-impl std::error::Error for Error {}
-
-impl fmt::Display for Error {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::MissingUnkToken => write!(
-                fmt,
-                "WordLevel error: Missing [UNK] token from the vocabulary"
-            ),
-            Self::BadVocabulary => write!(fmt, "Bad vocabulary json file"),
-        }
-    }
 }
 
 struct Config {

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -6,7 +6,6 @@ use crate::tokenizer::{Model, Result, Token};
 use std::{
     borrow::Cow,
     collections::HashMap,
-    fmt,
     fs::File,
     io::prelude::*,
     io::{BufRead, BufReader},
@@ -17,21 +16,10 @@ mod serialization;
 mod trainer;
 pub use trainer::*;
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("WordPiece error: Missing [UNK] token from the vocabulary")]
     MissingUnkToken,
-}
-impl std::error::Error for Error {}
-
-impl fmt::Display for Error {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::MissingUnkToken => write!(
-                fmt,
-                "WordPiece error: Missing [UNK] token from the vocabulary"
-            ),
-        }
-    }
 }
 
 type Vocab = HashMap<String, u32>;

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -11,7 +11,6 @@
 
 use std::{
     collections::HashMap,
-    fmt,
     fs::{read_to_string, File},
     io::prelude::*,
     io::BufReader,
@@ -240,16 +239,9 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
+#[error("{0}")]
 pub struct BuilderError(String);
-
-impl std::error::Error for BuilderError {}
-
-impl fmt::Display for BuilderError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 /// Builder for Tokenizer structs.
 ///

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -43,7 +43,7 @@ impl Default for TruncationParams {
     }
 }
 
-#[derive(thiserror::Error,Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum TruncationError {
     /// We are supposed to truncate the pair sequence, but it has not been provided.
     #[error("Truncation error: Second sequence not provided")]

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -43,29 +43,15 @@ impl Default for TruncationParams {
     }
 }
 
-#[derive(Debug)]
+#[derive(thiserror::Error,Debug)]
 pub enum TruncationError {
     /// We are supposed to truncate the pair sequence, but it has not been provided.
+    #[error("Truncation error: Second sequence not provided")]
     SecondSequenceNotProvided,
     /// We cannot truncate the target sequence enough to respect the provided max length.
+    #[error("Truncation error: Sequence to truncate too short to respect the provided max_length")]
     SequenceTooShort,
 }
-
-impl std::fmt::Display for TruncationError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use TruncationError::*;
-        match self {
-            SecondSequenceNotProvided => {
-                write!(fmt, "Truncation error: Second sequence not provided")
-            }
-            SequenceTooShort => write!(
-                fmt,
-                "Truncation error: Sequence to truncate too short to respect the provided max_length"
-            ),
-        }
-    }
-}
-impl std::error::Error for TruncationError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum TruncationStrategy {


### PR DESCRIPTION
# TLDR: use [thiserror crate](https://github.com/dtolnay/thiserror) for Errors

Pros: derive macro for [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html) & [std::fmt::Display](https://doc.rust-lang.org/std/fmt/trait.Display.html) traits while still being readable

Cons: a new dependency

@Narsil , I'll let you decide whether this PR is necessary. If not, I'll just close it 😊