### PR TITLE
Fixing issue with ConvBert not being able to save because of of holes in the vocab.

### DIFF
--- a/bindings/node/native/Cargo.lock
+++ b/bindings/node/native/Cargo.lock
@@ -1743,6 +1743,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
+ "thiserror",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1719,18 +1719,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1788,6 +1788,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
+ "thiserror",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",

--- a/tokenizers/src/models/wordlevel/serialization.rs
+++ b/tokenizers/src/models/wordlevel/serialization.rs
@@ -83,7 +83,7 @@ impl<'de> Visitor<'de> for WordLevelVisitor {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::models::wordlevel::{Vocab, WordLevel, WordLevelBuilder};
 
     #[test]
     fn serde() {
@@ -92,6 +92,22 @@ mod tests {
 
         assert_eq!(serde_json::to_string(&wl).unwrap(), wl_s);
         assert_eq!(serde_json::from_str::<WordLevel>(wl_s).unwrap(), wl);
+    }
+
+    #[test]
+    fn incomplete_vocab() {
+        let vocab: Vocab = [("<unk>".into(), 0), ("b".into(), 2)]
+            .iter()
+            .cloned()
+            .collect();
+        let wordlevel = WordLevelBuilder::default()
+            .vocab(vocab)
+            .unk_token("<unk>".to_string())
+            .build()
+            .unwrap();
+        let wl_s = r#"{"type":"WordLevel","vocab":{"<unk>":0,"b":2},"unk_token":"<unk>"}"#;
+        assert_eq!(serde_json::to_string(&wordlevel).unwrap(), wl_s);
+        assert_eq!(serde_json::from_str::<WordLevel>(wl_s).unwrap(), wordlevel);
     }
 
     #[test]


### PR DESCRIPTION
Original issue:

```python
from transformers import AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained("YituTech/conv-bert-base")
tokenizer.save_pretrained("test-tok")
# or alternatively the line that causes the issue:
# tokenizer.backend_tokenizer.save("tokenizer.json")
```

Core of the issue is that the original `vocab.txt` contains duplicates (https://huggingface.co/YituTech/conv-bert-base/raw/main/vocab.txt look towards the end), meaning this code https://github.com/huggingface/transformers/blob/master/src/transformers/models/bert/tokenization_bert.py#L97 would created holes in the vocab (there's not check that `token` doesn't already exist).

The crust of the proposed fix, is to mimick slow tokenizers behavior, which is yelling that something bad is ocurring but continue saving the vocab without crashing. 