### PR TITLE
Update outdated dependencies and feature-gate CLI

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -24,6 +24,7 @@ bench = false
 name = "cli"
 path = "src/cli.rs"
 bench = false
+required-features = ["cli"]
 
 [[bench]]
 name = "bpe_benchmark"
@@ -43,7 +44,7 @@ rayon = "1.3"
 rayon-cond = "0.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
-clap = "3.1.6"
+clap = { version = "3.1.6", optional = true }
 unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 unicode-segmentation = "1.6"
@@ -62,9 +63,10 @@ macro_rules_attribute = "0.0.2"
 thiserror = "1.0.30"
 
 [features]
-default = ["progressbar", "http"]
+default = ["progressbar", "http", "cli"]
 progressbar = ["indicatif"]
 http = ["reqwest", "cached-path"]
+cli = ["clap"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -24,7 +24,6 @@ bench = false
 name = "cli"
 path = "src/cli.rs"
 bench = false
-required-features = ["cli"]
 
 [[bench]]
 name = "bpe_benchmark"
@@ -44,7 +43,7 @@ rayon = "1.3"
 rayon-cond = "0.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
-clap = { version = "3.1.6", optional = true }
+clap = { version = "3.1.6"}
 unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 unicode-segmentation = "1.6"
@@ -63,10 +62,9 @@ macro_rules_attribute = "0.0.2"
 thiserror = "1.0.30"
 
 [features]
-default = ["progressbar", "http", "cli"]
+default = ["progressbar", "http"]
 progressbar = ["indicatif"]
 http = ["reqwest", "cached-path", "dirs"]
-cli = ["clap"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -49,7 +49,7 @@ unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 unicode-segmentation = "1.6"
 indicatif = {version = "0.15", optional = true}
-itertools = "0.9"
+itertools = "0.10.3"
 log = "0.4"
 esaxx-rs = "0.1"
 derive_builder = "0.9"

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -54,7 +54,7 @@ log = "0.4"
 esaxx-rs = "0.1"
 derive_builder = "0.9"
 spm_precompiled = "0.1"
-dirs = "3.0"
+dirs = { version = "3.0", optional = true }
 reqwest = { version = "0.11", optional = true }
 cached-path = { version = "0.5", optional = true }
 aho-corasick = "0.7"
@@ -65,7 +65,7 @@ thiserror = "1.0.30"
 [features]
 default = ["progressbar", "http", "cli"]
 progressbar = ["indicatif"]
-http = ["reqwest", "cached-path"]
+http = ["reqwest", "cached-path", "dirs"]
 cli = ["clap"]
 
 [dev-dependencies]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -35,7 +35,7 @@ harness = false
 
 [dependencies]
 lazy_static = "1.4"
-rand = "0.7"
+rand = "0.8.5"
 onig = { version = "6.0", default-features = false }
 regex = "1.3"
 regex-syntax = "0.6"
@@ -43,7 +43,7 @@ rayon = "1.3"
 rayon-cond = "0.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
-clap = "2.33"
+clap = "3.1.6"
 unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 unicode-segmentation = "1.6"

--- a/tokenizers/src/cli.rs
+++ b/tokenizers/src/cli.rs
@@ -82,6 +82,6 @@ fn main() -> Result<()> {
 
     match matches.subcommand() {
         Some(("shell", matches)) => shell(matches),
-        _ => panic!("Unknown subcommand")
+        _ => panic!("Unknown subcommand"),
     }
 }

--- a/tokenizers/src/cli.rs
+++ b/tokenizers/src/cli.rs
@@ -2,7 +2,7 @@
 //! This is the CLI binary for the Tokenizers project
 //!
 
-use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use clap::{Arg, ArgMatches, Command};
 use std::io::{self, BufRead, Write};
 use tokenizers::models::bpe::BPE;
 use tokenizers::pre_tokenizers::byte_level::ByteLevel;
@@ -55,33 +55,33 @@ fn shell(matches: &ArgMatches) -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let matches = App::new("tokenizers")
+    let matches = Command::new("tokenizers")
         .version("0.0.1")
         .author("Anthony M. <anthony@huggingface.co>")
         .about("Generate custom Tokenizers or use existing ones")
-        .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
-            SubCommand::with_name("shell")
+            Command::new("shell")
                 .about("Interactively test a tokenizer")
                 .arg(
-                    Arg::with_name("vocab")
+                    Arg::new("vocab")
                         .long("vocab")
                         .value_name("VOCAB_FILE")
                         .help("Path to the vocab.json file")
                         .required(true),
                 )
                 .arg(
-                    Arg::with_name("merges")
+                    Arg::new("merges")
                         .long("merges")
                         .value_name("MERGES_FILE")
                         .help("Path to the merges.txt file")
                         .required(true),
-                ),
+                )
+                .arg_required_else_help(true),
         )
         .get_matches();
 
     match matches.subcommand() {
-        ("shell", matches) => shell(matches.unwrap()),
-        (subcommand, _) => panic!("Unknown subcommand {}", subcommand),
+        Some(("shell", matches)) => shell(matches),
+        _ => panic!("Unknown subcommand")
     }
 }


### PR DESCRIPTION
Making the library a bit more up to date with common dependencies.
Unsure whether special testing is required for the cli.

Added a feature-gate to cli but kept it as default. This allows someone only using the library who doesn't wish to use the binary at all to opt out using `default-features = false`

Also put dirs behind the feature gate http, as it's only used hogether with cached_path in the from_pretrained-flow