### PR TITLE
Feature gate CLI and clap dependency

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -24,6 +24,7 @@ bench = false
 name = "cli"
 path = "src/cli.rs"
 bench = false
+required-features = ["cli"]
 
 [[bench]]
 name = "bpe_benchmark"
@@ -43,7 +44,7 @@ rayon = "1.3"
 rayon-cond = "0.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
-clap = "2.33"
+clap = { version = "2.33", optional = true }
 unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 unicode-segmentation = "1.6"
@@ -62,9 +63,10 @@ macro_rules_attribute = "0.0.2"
 thiserror = "1.0.30"
 
 [features]
-default = ["progressbar", "http"]
+default = ["progressbar", "http", "cli"]
 progressbar = ["indicatif"]
 http = ["reqwest", "cached-path"]
+cli = ["clap"]
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Move CLI behind a feature so that users dependent on the lib don't pull in the clap dependency tree.
Split from https://github.com/huggingface/tokenizers/pull/958