### PR TITLE
Preventing yelling on empty OrderedVocab (triggered by pickle.dumps).

### DIFF
--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -34,8 +34,8 @@ impl<'a> Serialize for OrderedVocabIter<'a> {
         S: Serializer,
     {
         // There could be holes so max + 1 is more correct than vocab_r.len()
-        let max = self.vocab_r.iter().map(|(key, _)| key).max().unwrap_or(&0) + 1;
-        let iter = (0..max).filter_map(|i| {
+        if let Some(max) = self.vocab_r.iter().map(|(key, _)| key).max() {
+            let iter = (0..*max + 1).filter_map(|i| {
             if let Some(token) = self.vocab_r.get(&i){
                 Some((token, i))
             }else{
@@ -44,7 +44,10 @@ impl<'a> Serialize for OrderedVocabIter<'a> {
                 None
             }
         });
-        serializer.collect_map(iter)
+            serializer.collect_map(iter)
+        } else {
+            serializer.collect_map(std::iter::empty::<(&str, u32)>())
+        }
     }
 }
 


### PR DESCRIPTION
Original issue was triggered by:

```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("bigscience/tokenizer", use_auth_token=True)
import pickle
pickle.dumps(tokenizer)
```
Yells `The OrderedVocab you are attempting to save contains a hole for index 0, your vocabulary could be corrupted !`

The crux of the issue is that pickle needs to serialize a default Model (empty) to do the pickling ???!!
Original confused comment.
https://github.com/huggingface/tokenizers/blob/master/bindings/python/src/models.rs#L95

Anyway, the core issue, is that the recent modifications would actually yell if `vocab_r` was empty, which is incorrect `(0 + 1)`.

This modification should make both use cases work, and still yell appropriately on holes.