### PR TITLE
Update the builder to use earlier windows version (2022) is not understood.

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -7,8 +7,8 @@ env:
 
 on:
   push:
-    # tags:
-    #   - node-v*
+    tags:
+      - node-v*
 
 jobs:
   rust_publish:
@@ -79,38 +79,38 @@ jobs:
           pip install awscli
           aws s3 sync --exact-timestamps --exclude "*" --include "*.tar.gz" --acl public-read ./bin-package "s3://tokenizers-releases/node/$(node -p -e 'require("./package.json").version')"
 
-          # npm_publish:
-          #   name: Build and publish JS lib
-          #   needs: rust_publish
-          #   runs-on: ubuntu-latest
-          #   steps:
-          #     - name: Checkout repository
-          #       uses: actions/checkout@v1
+  npm_publish:
+    name: Build and publish JS lib
+    needs: rust_publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
 
-          #     - name: Install Node 12.x
-          #       uses: actions/setup-node@v1
-          #       with:
-          #         registry-url: https://registry.npmjs.org
-          #         node-version: 12.x
+      - name: Install Node 12.x
+        uses: actions/setup-node@v1
+        with:
+          registry-url: https://registry.npmjs.org
+          node-version: 12.x
 
-          #     - name: Get NPM cache directory
-          #       id: npm-cache
-          #       run: |
-          #         echo "::set-output name=dir::$(npm config get cache)"
-          #     - name: Cache NPM cache
-          #       uses: actions/cache@v1
-          #       with:
-          #         path: ${{ steps.npm-cache.outputs.dir }}
-          #         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          #         restore-keys: |
-          #           ${{ runner.os }}-node-
+      - name: Get NPM cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - name: Cache NPM cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
-          #     - name: Install npm dependencies
-          #       working-directory: ./bindings/node
-          #       run: npm ci --ignore-scripts
+      - name: Install npm dependencies
+        working-directory: ./bindings/node
+        run: npm ci --ignore-scripts
 
-          #     - name: Build and publish on NPM
-          #       working-directory: ./bindings/node
-          #       run: node build.js --npm-publish
-          #       env:
-          #         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Build and publish on NPM
+        working-directory: ./bindings/node
+        run: node build.js --npm-publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -20,7 +20,7 @@ jobs:
         node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
         exclude:
           # Exclude node 15 for windows
-          - os: windows-latest
+          - os: windows-2019
             node-version: 15.x
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -7,8 +7,8 @@ env:
 
 on:
   push:
-    tags:
-      - node-v*
+    # tags:
+    #   - node-v*
 
 jobs:
   rust_publish:
@@ -16,7 +16,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.11
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-2019, macos-latest, ubuntu-latest]
         node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
         exclude:
           # Exclude node 15 for windows
@@ -79,38 +79,38 @@ jobs:
           pip install awscli
           aws s3 sync --exact-timestamps --exclude "*" --include "*.tar.gz" --acl public-read ./bin-package "s3://tokenizers-releases/node/$(node -p -e 'require("./package.json").version')"
 
-  npm_publish:
-    name: Build and publish JS lib
-    needs: rust_publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v1
+          # npm_publish:
+          #   name: Build and publish JS lib
+          #   needs: rust_publish
+          #   runs-on: ubuntu-latest
+          #   steps:
+          #     - name: Checkout repository
+          #       uses: actions/checkout@v1
 
-      - name: Install Node 12.x
-        uses: actions/setup-node@v1
-        with:
-          registry-url: https://registry.npmjs.org
-          node-version: 12.x
+          #     - name: Install Node 12.x
+          #       uses: actions/setup-node@v1
+          #       with:
+          #         registry-url: https://registry.npmjs.org
+          #         node-version: 12.x
 
-      - name: Get NPM cache directory
-        id: npm-cache
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
-      - name: Cache NPM cache
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.npm-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          #     - name: Get NPM cache directory
+          #       id: npm-cache
+          #       run: |
+          #         echo "::set-output name=dir::$(npm config get cache)"
+          #     - name: Cache NPM cache
+          #       uses: actions/cache@v1
+          #       with:
+          #         path: ${{ steps.npm-cache.outputs.dir }}
+          #         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          #         restore-keys: |
+          #           ${{ runner.os }}-node-
 
-      - name: Install npm dependencies
-        working-directory: ./bindings/node
-        run: npm ci --ignore-scripts
+          #     - name: Install npm dependencies
+          #       working-directory: ./bindings/node
+          #       run: npm ci --ignore-scripts
 
-      - name: Build and publish on NPM
-        working-directory: ./bindings/node
-        run: node build.js --npm-publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          #     - name: Build and publish on NPM
+          #       working-directory: ./bindings/node
+          #       run: node build.js --npm-publish
+          #       env:
+          #         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Error on `windows-latest` is 

```
  gyp verb find VS msvs_version not set from command line or npm config
  gyp verb find VS VCINSTALLDIR not set, not running in VS Command Prompt
  gyp verb find VS unknown version "undefined" found at "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
  gyp verb find VS could not find a version of Visual Studio 2017 or newer to use
  gyp verb find VS looking for Visual Studio 2015
  gyp verb find VS - not found
  gyp verb find VS not looking for VS2013 as it is only supported up to Node.js 8
  gyp ERR! find VS 
```

I took the short route and simply use `windows-2019` to build this, which ships with MSVC 2019 instead of 2022 and works.

The cleaner fix would be to rewrite the node bindings to newer neon bindings in order to support node 16+ (and probably newer MSVC too).

https://github.com/huggingface/tokenizers/issues/911