### PR TITLE
Optimize GPT-2 regex as logic for improved performance

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -69,6 +69,6 @@ http = ["reqwest", "cached-path"]
 cli = ["clap"]
 
 [dev-dependencies]
-criterion = { version = "0.3", features = ["html_reports"]}
+criterion = "0.3"
 tempfile = "3.1"
 assert_approx_eq = "1.1"

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -69,6 +69,6 @@ http = ["reqwest", "cached-path"]
 cli = ["clap"]
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = { version = "0.3", features = ["html_reports"]}
 tempfile = "3.1"
 assert_approx_eq = "1.1"

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -10,19 +10,33 @@ use std::path::Path;
 use criterion::Criterion;
 use tokenizers::models::bpe::{BpeTrainerBuilder, BPE};
 use tokenizers::models::TrainerWrapper;
-use tokenizers::pre_tokenizers::byte_level::ByteLevel;
+use tokenizers::pre_tokenizers::byte_level::{ByteLevel, OptimizedByteRegex};
 use tokenizers::pre_tokenizers::whitespace::Whitespace;
 use tokenizers::tokenizer::{AddedToken, EncodeInput};
-use tokenizers::Tokenizer;
+use tokenizers::{PreTokenizerWrapper, Tokenizer};
 
 use common::{iter_bench_encode, iter_bench_encode_batch, iter_bench_train};
 use std::ops::Deref;
+use tokenizers::pre_tokenizers::sequence::Sequence;
 
 static BATCH_SIZE: usize = 1_000;
 
 fn create_gpt2_tokenizer(bpe: BPE) -> Tokenizer {
     let mut tokenizer = Tokenizer::new(bpe);
     tokenizer.with_pre_tokenizer(ByteLevel::default());
+    tokenizer.with_decoder(ByteLevel::default());
+    tokenizer.add_tokens(&[AddedToken::from("ing", false).single_word(false)]);
+    tokenizer.add_special_tokens(&[AddedToken::from("[ENT]", true).single_word(true)]);
+    tokenizer
+}
+
+fn create_optimized_gpt2_tokenizer(bpe: BPE) -> Tokenizer {
+    let mut tokenizer = Tokenizer::new(bpe);
+    let byte_level = ByteLevel::default().use_regex(false).add_prefix_space(false); 
+    tokenizer.with_pre_tokenizer(Sequence::new(vec![
+        PreTokenizerWrapper::OptimizedByteRegex(OptimizedByteRegex::default()),
+        PreTokenizerWrapper::ByteLevel(byte_level),
+    ]));
     tokenizer.with_decoder(ByteLevel::default());
     tokenizer.add_tokens(&[AddedToken::from("ing", false).single_word(false)]);
     tokenizer.add_special_tokens(&[AddedToken::from("[ENT]", true).single_word(true)]);
@@ -68,6 +82,45 @@ fn bench_gpt2(c: &mut Criterion) {
     });
 }
 
+fn bench_optimized_gpt2(c: &mut Criterion) {
+    let bpe = BPE::from_file("data/gpt2-vocab.json", "data/gpt2-merges.txt")
+        .build()
+        .unwrap();
+    let tokenizer = create_optimized_gpt2_tokenizer(bpe);
+    let mut lines: Vec<EncodeInput> = vec![];
+    let mut batches: Vec<Vec<EncodeInput>> = vec![vec![]];
+    for line in BufReader::new(File::open(Path::new("data/big.txt")).unwrap()).lines() {
+        let line: EncodeInput = line.unwrap().into();
+        lines.push(line.clone());
+        if batches.last().unwrap().len() >= BATCH_SIZE {
+            batches.push(vec![]);
+        }
+        batches.last_mut().unwrap().push(line);
+    }
+
+    c.bench_function("BPE GPT2 Optimized encode", |b| {
+        b.iter_custom(|iters| iter_bench_encode(iters, tokenizer.deref(), &lines))
+    });
+
+    c.bench_function("BPE GPT2 Optimized encode batch", |b| {
+        b.iter_custom(|iters| iter_bench_encode_batch(iters, tokenizer.deref(), &batches))
+    });
+
+    let bpe = BPE::from_file("data/gpt2-vocab.json", "data/gpt2-merges.txt")
+        .cache_capacity(0)
+        .build()
+        .unwrap();
+    let tokenizer = create_optimized_gpt2_tokenizer(bpe);
+
+    c.bench_function("BPE GPT2 Optimized encode, no cache", |b| {
+        b.iter_custom(|iters| iter_bench_encode(iters, &tokenizer, &lines))
+    });
+
+    c.bench_function("BPE GPT2 Optimized encode batch, no cache", |b| {
+        b.iter_custom(|iters| iter_bench_encode_batch(iters, &tokenizer, &batches))
+    });
+}
+
 fn bench_train(c: &mut Criterion) {
     let mut trainer: TrainerWrapper = BpeTrainerBuilder::default()
         .show_progress(false)
@@ -106,8 +159,13 @@ criterion_group! {
     targets = bench_gpt2
 }
 criterion_group! {
+    name = benches_optimized;
+    config = Criterion::default().sample_size(20);
+    targets = bench_optimized_gpt2
+}
+criterion_group! {
     name = benches_train;
     config = Criterion::default().sample_size(10);
     targets = bench_train
 }
-criterion_main!(benches, benches_train);
+criterion_main!(benches, benches_optimized, benches_train);

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -13,10 +13,10 @@ use tokenizers::models::TrainerWrapper;
 use tokenizers::pre_tokenizers::byte_level::ByteLevel;
 use tokenizers::pre_tokenizers::whitespace::Whitespace;
 use tokenizers::tokenizer::{AddedToken, EncodeInput};
-use tokenizers::{NormalizedString, SplitDelimiterBehavior, Tokenizer};
+use tokenizers::Tokenizer;
 
 use common::{iter_bench_encode, iter_bench_encode_batch, iter_bench_train};
-use std::time::Duration;
+use std::ops::Deref;
 
 static BATCH_SIZE: usize = 1_000;
 

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -10,13 +10,16 @@ use std::path::Path;
 use criterion::Criterion;
 use tokenizers::models::bpe::{BpeTrainerBuilder, BPE};
 use tokenizers::models::TrainerWrapper;
-use tokenizers::pre_tokenizers::byte_level::ByteLevel;
+use tokenizers::pre_tokenizers::byte_level::{gpt2_regex_optimized, ByteLevel};
 use tokenizers::pre_tokenizers::whitespace::Whitespace;
 use tokenizers::tokenizer::{AddedToken, EncodeInput};
-use tokenizers::Tokenizer;
+use tokenizers::{NormalizedString, SplitDelimiterBehavior, Tokenizer};
 
 use common::{iter_bench_encode, iter_bench_encode_batch, iter_bench_train};
+use lazy_static::lazy_static;
+use onig::Regex;
 use std::ops::Deref;
+use std::time::Duration;
 
 static BATCH_SIZE: usize = 1_000;
 
@@ -100,6 +103,45 @@ fn bench_train(c: &mut Criterion) {
     });
 }
 
+lazy_static! {
+    static ref RE: Regex =
+        Regex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+")
+            .unwrap();
+}
+
+fn bench_gpt_regex(c: &mut Criterion) {
+    let re_ref: &Regex = &RE;
+    let mut lines: Vec<NormalizedString> = vec![];
+    for line in BufReader::new(File::open(Path::new("data/big.txt")).unwrap()).lines() {
+        let input = line.unwrap();
+        lines.push(NormalizedString::from(input.trim().clone()));
+    }
+    c.bench_function("BPE split REGEX", |b| {
+        b.iter(|| {
+            for normalized in &lines {
+                normalized
+                    .split(re_ref, SplitDelimiterBehavior::Isolated)
+                    .unwrap();
+            }
+        })
+    });
+}
+
+fn bench_gpt_logic(c: &mut Criterion) {
+    let mut lines: Vec<NormalizedString> = vec![];
+    for line in BufReader::new(File::open(Path::new("data/big.txt")).unwrap()).lines() {
+        let input = line.unwrap();
+        lines.push(NormalizedString::from(input.trim().clone()));
+    }
+    c.bench_function("BPE split Logic", |b| {
+        b.iter(|| {
+            for normalized in &lines {
+                gpt2_regex_optimized(&normalized).unwrap();
+            }
+        })
+    });
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(20);
@@ -110,4 +152,14 @@ criterion_group! {
     config = Criterion::default().sample_size(10);
     targets = bench_train
 }
-criterion_main!(benches, benches_train);
+criterion_group! {
+    name = benches_regex;
+    config = Criterion::default().sample_size(100).warm_up_time(Duration::from_secs(10));
+    targets = bench_gpt_regex
+}
+criterion_group! {
+    name = benches_regex_logic;
+    config = Criterion::default().sample_size(100).warm_up_time(Duration::from_secs(10));
+    targets = bench_gpt_logic
+}
+criterion_main!(benches, benches_train, benches_regex, benches_regex_logic);

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -227,23 +227,21 @@ impl OptimizedByteRegex {
                     CharKind::WHITESPACE => {
                         if c != ' ' {
                             offset_end += c.len_utf8();
-                        } else {
-                            if let Some(next_c) = chars.next() {
-                                if next_c.is_whitespace() {
-                                    offset_end += c.len_utf8();
-                                    char_queue.push_back(next_c);
-                                } else {
-                                    offsets.push((offset_start, offset_end));
-                                    offset_start = offset_end;
-                                    offset_end += c.len_utf8();
-                                    char_queue.push_back(next_c);
-                                    prev_char_kind = NONE(true);
-                                }
-                            } else {
+                        } else if let Some(next_c) = chars.next() {
+                            if next_c.is_whitespace() {
                                 offset_end += c.len_utf8();
+                                char_queue.push_back(next_c);
+                            } else {
                                 offsets.push((offset_start, offset_end));
                                 offset_start = offset_end;
+                                offset_end += c.len_utf8();
+                                char_queue.push_back(next_c);
+                                prev_char_kind = NONE(true);
                             }
+                        } else {
+                            offset_end += c.len_utf8();
+                            offsets.push((offset_start, offset_end));
+                            offset_start = offset_end;
                         }
                     }
                     CharKind::NONE(prefix_space) => {

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -154,7 +154,7 @@ impl From<&char> for CharKind {
 ///  - Maybe a space followed by numbers
 ///  - Maybe a space followed by more whitespace
 ///  - Maybe a space followed by anything other than numbers, letters, and whitespace
-pub fn gpt2_regex_optimized(input: &NormalizedString) -> Result<Vec<NormalizedString>> {
+fn gpt2_regex_optimized(input: &NormalizedString) -> Result<Vec<NormalizedString>> {
     let mut offset_start = 0usize;
     let mut offset_end = 0usize;
     let mut prev_char_kind: CharKind = CharKind::NONE(false);

--- a/tokenizers/src/pre_tokenizers/mod.rs
+++ b/tokenizers/src/pre_tokenizers/mod.rs
@@ -12,7 +12,7 @@ pub mod whitespace;
 use serde::{Deserialize, Serialize};
 
 use crate::pre_tokenizers::bert::BertPreTokenizer;
-use crate::pre_tokenizers::byte_level::ByteLevel;
+use crate::pre_tokenizers::byte_level::{ByteLevel, OptimizedByteRegex};
 use crate::pre_tokenizers::delimiter::CharDelimiterSplit;
 use crate::pre_tokenizers::digits::Digits;
 use crate::pre_tokenizers::metaspace::Metaspace;
@@ -28,6 +28,7 @@ use crate::{PreTokenizedString, PreTokenizer};
 pub enum PreTokenizerWrapper {
     BertPreTokenizer(BertPreTokenizer),
     ByteLevel(ByteLevel),
+    OptimizedByteRegex(OptimizedByteRegex),
     Delimiter(CharDelimiterSplit),
     Metaspace(Metaspace),
     Whitespace(Whitespace),
@@ -44,6 +45,7 @@ impl PreTokenizer for PreTokenizerWrapper {
         match self {
             Self::BertPreTokenizer(bpt) => bpt.pre_tokenize(normalized),
             Self::ByteLevel(bpt) => bpt.pre_tokenize(normalized),
+            Self::OptimizedByteRegex(bpt) => bpt.pre_tokenize(normalized),
             Self::Delimiter(dpt) => dpt.pre_tokenize(normalized),
             Self::Metaspace(mspt) => mspt.pre_tokenize(normalized),
             Self::Whitespace(wspt) => wspt.pre_tokenize(normalized),
@@ -59,6 +61,7 @@ impl PreTokenizer for PreTokenizerWrapper {
 
 impl_enum_from!(BertPreTokenizer, PreTokenizerWrapper, BertPreTokenizer);
 impl_enum_from!(ByteLevel, PreTokenizerWrapper, ByteLevel);
+impl_enum_from!(OptimizedByteRegex, PreTokenizerWrapper, OptimizedByteRegex);
 impl_enum_from!(CharDelimiterSplit, PreTokenizerWrapper, Delimiter);
 impl_enum_from!(Whitespace, PreTokenizerWrapper, Whitespace);
 impl_enum_from!(Punctuation, PreTokenizerWrapper, Punctuation);

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -1,6 +1,7 @@
 use crate::pattern::Pattern;
 use crate::{Offsets, Result};
 use std::ops::{Bound, RangeBounds};
+use std::str::Chars;
 use unicode_normalization_alignments::UnicodeNormalization;
 
 use serde::{Deserialize, Serialize};
@@ -702,6 +703,10 @@ impl NormalizedString {
                 }
             })
             .collect())
+    }
+
+    pub fn chars(&self) -> Chars {
+        self.normalized.chars()
     }
 
     /// Remove any leading space(s) of the normalized string


### PR DESCRIPTION
The regex used by the BPE pre-tokenizer has fairly simple logic. The tokens are split along: letters, numbers, whitespace, symbols. Each possibly being prefixed with a `' '` and with special handling for specific apostrophe scenarios. 

Transforming this into logic instead of REGEX improves performance. Here are benchmarks (for the split function only):

Ran with 10s warmup over 100 samples of the `big.txt` data set.
```
BPE split REGEX         time:   [1.1157 s 1.1181 s 1.1207 s]

BPE split Logic         time:   [640.42 ms 645.15 ms 650.22 ms]
```

Here are some benchmarks for the overall GPT2 process (I include only the improvements, the previous run was the REGEX split)

```
BPE GPT2 encode         time:   [29.143 us 29.432 us 29.861 us]
                        change: [-12.354% -10.057% -7.6869%] (p = 0.00 < 0.05)
                        Performance has improved.

BPE GPT2 encode batch   time:   [8.8120 ms 9.0704 ms 9.3106 ms]
                        change: [-7.4765% -5.5234% -3.6632%] (p = 0.00 < 0.05)
                        Performance has improved.

BPE GPT2 encode, no cache
                        time:   [35.395 us 35.681 us 36.070 us]
                        change: [-14.634% -13.082% -11.349%] (p = 0.00 < 0.05)
                        Performance has improved.

BPE GPT2 encode batch, no cache
                        time:   [10.708 ms 10.824 ms 10.952 ms]
                        change: [-10.197% -7.7006% -5.4115%] (p = 0.00 < 0.05)
                        Performance has improved.
```

All the benchmarks were ran on my local machine:

```
MacBook Pro (16-inch, 2019)
2.4 GHz 8-Core Intel Core i9
64 GB 2667 MHz DDR4
Intel UHD Graphics 630 1536 MB
```
