### PR TITLE
`.dev0` suffix in python version

### DIFF
--- a/bindings/python/py_src/tokenizers/__init__.py
+++ b/bindings/python/py_src/tokenizers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.1"
+__version__ = "0.12.1.dev0"
 
 from typing import Tuple, Union, Tuple, List
 from enum import Enum

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -8,7 +8,7 @@ extras["dev"] = extras["testing"]
 
 setup(
     name="tokenizers",
-    version="0.12.1",
+    version="0.12.1.dev0",
     description="Fast and Customizable Tokenizers",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
See more details [here](https://huggingface.slack.com/archives/C02GLJ5S0E9/p1650559719632929)

`RELEASE.md` already has necessary update info:
https://github.com/huggingface/tokenizers/blob/4a9da798e2893b6d142100fe1a2735e232021ff9/RELEASE.md#L50-L51

cc: @julien-c @LysandreJik  @sgugger @Pierrci 