### PR TITLE
Use sentencepiece's protobuf module instead of the local protobuf file

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
@@ -147,16 +147,29 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
 
     @staticmethod
     def from_spm(filename: str):
+        # Because sentencepiece_model_pb2 requires protobuf,
+        # check whether protobuf is installed beforehand.
         try:
-            import sys
-
-            sys.path.append(".")
-
-            import sentencepiece_model_pb2 as model
-        except Exception:
+            import google.protobuf
+        except ModuleNotFoundError as e:
             raise Exception(
-                "You don't seem to have the required protobuf file, in order to use this function you need to run `pip install protobuf` and `wget https://raw.githubusercontent.com/google/sentencepiece/master/python/src/sentencepiece/sentencepiece_model_pb2.py` for us to be able to read the intrinsics of your spm_file. `pip install sentencepiece` is not required."
+                "You need to run `pip install protobuf for us to be able to read the intrinsics of your spm_file."
             )
+
+        try:
+            import sentencepiece.sentencepiece_model_pb2 as model
+        except ModuleNotFoundError as e:
+            if 'sentencepiece' in str(e):
+                # If sentencepiece is not installed, you need the required protobuf file
+                # in the current directory.
+                try:
+                    import sys
+                    sys.path.append(".")
+                    import sentencepiece_model_pb2 as model
+                except Exception:
+                    raise Exception(
+                        "You don't seem to have the required protobuf file, in order to use this function you need to run `wget https://raw.githubusercontent.com/google/sentencepiece/master/python/src/sentencepiece/sentencepiece_model_pb2.py` for us to be able to read the intrinsics of your spm_file. Otherwise you need to `pip install sentencepiece`."
+                    )
 
         m = model.ModelProto()
         m.ParseFromString(open(filename, "rb").read())


### PR DESCRIPTION
Thanks for the great work.

When I load a unigram tokenizer of SentencePiece by `SentencePieceUnigramTokenizer.from_spm()`, it requires `sentencepiece_model_pb2.py` in the current directory. If `sentencepiece` is already installed, I think importing `sentencepiece_model_pb2` from `sentencepiece` instead of downloading this file is easy and useful.

So, I modified `SentencePieceUnigramTokenizer.from_spm()` in order to import `sentencepiece_model_pb2` from `sentencepiece` if `sentencepiece` is installed. This PR first tries to import `sentencepiece.sentencepiece_model_pb2` and then tries to import `sentencepiece_model_pb2` in the current directory

By this PR, the exception changes depend on whether `protobuf` and `sentencepiece` are installed.

If `protobuf` is not installed
```
Exception: You need to run `pip install protobuf for us to be able to read the intrinsics of your spm_file.
```

If `sentencepiece` is not installed and `sentencepiece_model_pb2.py` does not exist in the current directory.
```
Exception: You don't seem to have the required protobuf file, in order to use this function you need to run `wget https://raw.githubusercontent.com/google/sentencepiece/master/python/src/sentencepiece/sentencepiece_model_pb2.py` for us to be able to read the intrinsics of your spm_file. Otherwise you need to `pip install sentencepiece`.
```