### PR TITLE
Add `from_bytes` approach for creating tokenizers

### DIFF
--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -402,6 +402,10 @@ impl Tokenizer {
         let tokenizer = serde_json::from_str(&content)?;
         Ok(tokenizer)
     }
+    pub fn from_bytes<P: AsRef<[u8]>>(bytes: P) -> Result<Self> {
+        let tokenizer = serde_json::from_slice(bytes.as_ref())?;
+        Ok(tokenizer)
+    }
     #[cfg(feature = "http")]
     pub fn from_pretrained<S: AsRef<str>>(
         identifier: S,
@@ -1129,6 +1133,21 @@ where
     pub fn from_file<P: AsRef<Path>>(file: P) -> Result<Self> {
         let content = read_to_string(file)?;
         let tokenizer = serde_json::from_str(&content)?;
+        Ok(tokenizer)
+    }
+}
+
+impl<M, N, PT, PP, D> TokenizerImpl<M, N, PT, PP, D>
+where
+    M: DeserializeOwned + Model,
+    N: DeserializeOwned + Normalizer,
+    PT: DeserializeOwned + PreTokenizer,
+    PP: DeserializeOwned + PostProcessor,
+    D: DeserializeOwned + Decoder,
+{
+    /// Instantiate a new Tokenizer from bytes
+    pub fn from_bytes<P: AsRef<[u8]>>(bytes: P) -> Result<Self> {
+        let tokenizer = serde_json::from_slice(bytes.as_ref())?;
         Ok(tokenizer)
     }
 }


### PR DESCRIPTION
This PR fixes #1013.
Tokenizer can be created from bytes in memory using added `Tokenizers::from_bytes`.

Signed-off-by: HaoboGu <haobogu@outlook.com>