### PR TITLE
Update derive_builder to 0.10 in cargo.toml

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -51,7 +51,7 @@ unicode-segmentation = "1.6"
 indicatif = {version = "0.15", optional = true}
 itertools = "0.9"
 log = "0.4"
-derive_builder = "0.9"
+derive_builder = "0.10"
 spm_precompiled = "0.1"
 dirs = "3.0"
 reqwest = { version = "0.11", optional = true }


### PR DESCRIPTION
Update derive_builder to 0.10 in cargo.toml. 
Related to issue #1029 