### PR TITLE
Upgrade macro_rules_attribute to 0.1.2

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -58,7 +58,7 @@ reqwest = { version = "0.11", optional = true }
 cached-path = { version = "0.5", optional = true }
 aho-corasick = "0.7"
 paste = "1.0.6"
-macro_rules_attribute = "0.0.2"
+macro_rules_attribute = "0.1.2"
 thiserror = "1.0.30"
 fancy-regex = { version = "0.10", optional = true}
 getrandom = { version = "0.2.6" }


### PR DESCRIPTION
# Changes
I've upgraded `macro_rules_attribute` to 0.1.2 so that `cargo build` can generate static libraries for more platforms.

# Motivation
The change solves the following error when building a static library of `tokenizer`

Rust version: rustc 1.62.1 (e092d0b6b 2022-07-16)

```
....
   Compiling macro_rules_attribute v0.0.2
error[E0432]: unresolved imports `proc_macro::macro_rules_attribute`, `proc_macro::macro_rules_derive`
 --> /Users/paco/.cargo/registry/src/github.com-1ecc6299db9ec823/macro_rules_attribute-0.0.2/src/lib.rs:8:5
  |
8 |     macro_rules_attribute,
  |     ^^^^^^^^^^^^^^^^^^^^^ no `macro_rules_attribute` in the root
9 |     macro_rules_derive,
  |     ^^^^^^^^^^^^^^^^^^ no `macro_rules_derive` in the root

For more information about this error, try `rustc --explain E0432`.
error: could not compile `macro_rules_attribute` due to previous error
warning: build failed, waiting for other jobs to finish...
```