### PR TITLE
Modify processor trait

### DIFF
--- a/bindings/node/native/Cargo.lock
+++ b/bindings/node/native/Cargo.lock
@@ -847,18 +847,19 @@ dependencies = [
 
 [[package]]
 name = "macro_rules_attribute"
-version = "0.0.2"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641c64af6cd80b81cf9c2f2f6ee382b1050c71ce63e20800499971a4a4195005"
+checksum = "258c86475e1616d6f2d8f5227cfaabd3dae1f6d5388b9597df8a199d4497aba7"
 dependencies = [
  "macro_rules_attribute-proc_macro",
+ "paste",
 ]
 
 [[package]]
 name = "macro_rules_attribute-proc_macro"
-version = "0.0.2"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb246ada5a8c47b8b6e90c9f9a0f84f294939cdf558f1bc8d17fbb30f9706598"
+checksum = "f26a8d2502d5aa4d411ef494ba7470eb299f05725179ce3b5de77aa01a9ffdea"
 
 [[package]]
 name = "matches"
@@ -1182,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
 
 [[package]]
 name = "percent-encoding"

--- a/bindings/node/native/src/processors.rs
+++ b/bindings/node/native/src/processors.rs
@@ -22,16 +22,15 @@ impl tk::PostProcessor for Processor {
             .added_tokens(is_pair)
     }
 
-    fn process(
+    fn process_encodings(
         &self,
-        encoding: Encoding,
-        pair_encoding: Option<Encoding>,
+        encodings: Vec<Encoding>,
         add_special_tokens: bool,
-    ) -> tk::Result<Encoding> {
+    ) -> tk::Result<Vec<Encoding>> {
         self.processor
             .as_ref()
             .ok_or("Uninitialized PostProcessor")?
-            .process(encoding, pair_encoding, add_special_tokens)
+            .process_encodings(encodings, add_special_tokens)
     }
 }
 

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -836,18 +836,19 @@ dependencies = [
 
 [[package]]
 name = "macro_rules_attribute"
-version = "0.0.2"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641c64af6cd80b81cf9c2f2f6ee382b1050c71ce63e20800499971a4a4195005"
+checksum = "258c86475e1616d6f2d8f5227cfaabd3dae1f6d5388b9597df8a199d4497aba7"
 dependencies = [
  "macro_rules_attribute-proc_macro",
+ "paste",
 ]
 
 [[package]]
 name = "macro_rules_attribute-proc_macro"
-version = "0.0.2"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb246ada5a8c47b8b6e90c9f9a0f84f294939cdf558f1bc8d17fbb30f9706598"
+checksum = "f26a8d2502d5aa4d411ef494ba7470eb299f05725179ce3b5de77aa01a9ffdea"
 
 [[package]]
 name = "matches"
@@ -1154,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
 
 [[package]]
 name = "percent-encoding"

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,5 +1,7 @@
 #![warn(clippy::all)]
 #![allow(clippy::upper_case_acronyms)]
+// Many false positives with pyo3 it seems &str, and &PyAny get flagged
+#![allow(clippy::borrow_deref_ref)]
 
 extern crate tokenizers as tk;
 

--- a/bindings/python/src/processors.rs
+++ b/bindings/python/src/processors.rs
@@ -59,14 +59,13 @@ impl PostProcessor for PyPostProcessor {
         self.processor.added_tokens(is_pair)
     }
 
-    fn process(
+    fn process_encodings(
         &self,
-        encoding: Encoding,
-        pair_encoding: Option<Encoding>,
+        encodings: Vec<Encoding>,
         add_special_tokens: bool,
-    ) -> tk::Result<Encoding> {
+    ) -> tk::Result<Vec<Encoding>> {
         self.processor
-            .process(encoding, pair_encoding, add_special_tokens)
+            .process_encodings(encodings, add_special_tokens)
     }
 }
 

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -164,7 +164,7 @@ impl BpeTrainerBuilder {
 /// let special_tokens = trainer.train(&mut model).unwrap();
 /// ```
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq)]
 pub struct BpeTrainer {
     /// The minimum frequency a pair must have to produce a merge operation
     pub min_frequency: u32,

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -94,7 +94,7 @@ impl WordLevelBuilder {
     }
 }
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Eq)]
 pub struct WordLevel {
     vocab: HashMap<String, u32>,
     vocab_r: HashMap<u32, String>,

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -119,7 +119,7 @@ impl WordPieceBuilder {
 /// A
 /// [WordPiece](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/37842.pdf)
 /// model.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct WordPiece {
     vocab: Vocab,
     vocab_r: VocabR,

--- a/tokenizers/src/normalizers/replace.rs
+++ b/tokenizers/src/normalizers/replace.rs
@@ -3,7 +3,7 @@ use crate::utils::SysRegex;
 use serde::{Deserialize, Serialize};
 
 /// Represents the different patterns that `Replace` can use
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq)]
 pub enum ReplacePattern {
     String(String),
     Regex(String),

--- a/tokenizers/src/pre_tokenizers/bert.rs
+++ b/tokenizers/src/pre_tokenizers/bert.rs
@@ -6,7 +6,7 @@ fn is_bert_punc(x: char) -> bool {
     char::is_ascii_punctuation(&x) || x.is_punctuation()
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct BertPreTokenizer;
 

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -42,7 +42,7 @@ lazy_static! {
         bytes_char().into_iter().map(|(c, b)| (b, c)).collect();
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// Provides all the necessary steps to handle the BPE tokenization at the byte-level. Takes care
 /// of all the required processing steps to transform a UTF-8 string as needed before and after the
 /// BPE model does its job.

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -174,20 +174,13 @@ impl PostProcessor for ByteLevel {
         0
     }
 
-    fn process(
+    fn process_encodings(
         &self,
-        mut encoding: Encoding,
-        mut pair_encoding: Option<Encoding>,
+        mut encodings: Vec<Encoding>,
         add_special_tokens: bool,
-    ) -> Result<Encoding> {
+    ) -> Result<Vec<Encoding>> {
         if self.trim_offsets {
-            process_offsets(&mut encoding, self.add_prefix_space);
-            encoding
-                .get_overflowing_mut()
-                .iter_mut()
-                .for_each(|encoding| process_offsets(encoding, self.add_prefix_space));
-
-            if let Some(encoding) = pair_encoding.as_mut() {
+            for encoding in encodings.iter_mut() {
                 process_offsets(encoding, self.add_prefix_space);
                 encoding
                     .get_overflowing_mut()
@@ -195,8 +188,7 @@ impl PostProcessor for ByteLevel {
                     .for_each(|encoding| process_offsets(encoding, self.add_prefix_space));
             }
         }
-
-        <dyn PostProcessor>::default_process(encoding, pair_encoding, add_special_tokens)
+        <dyn PostProcessor>::default_process(encodings, add_special_tokens)
     }
 }
 

--- a/tokenizers/src/pre_tokenizers/delimiter.rs
+++ b/tokenizers/src/pre_tokenizers/delimiter.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use crate::utils::macro_rules_attribute;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct CharDelimiterSplit {

--- a/tokenizers/src/pre_tokenizers/digits.rs
+++ b/tokenizers/src/pre_tokenizers/digits.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use crate::utils::macro_rules_attribute;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 /// Pre tokenizes the numbers into single tokens. If individual_digits is set
 /// to true, then all digits are splitted into individual tokens.
 #[non_exhaustive]

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::tokenizer::{Decoder, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Eq)]
 /// Replaces all the whitespaces by the provided meta character and then
 /// splits on this character
 #[serde(tag = "type")]

--- a/tokenizers/src/pre_tokenizers/punctuation.rs
+++ b/tokenizers/src/pre_tokenizers/punctuation.rs
@@ -8,7 +8,7 @@ fn is_punc(x: char) -> bool {
     char::is_ascii_punctuation(&x) || x.is_punctuation()
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct Punctuation {
     #[serde(default = "default_split")]

--- a/tokenizers/src/pre_tokenizers/split.rs
+++ b/tokenizers/src/pre_tokenizers/split.rs
@@ -6,7 +6,7 @@ use crate::tokenizer::{
 };
 
 /// Represents the different patterns that `Split` can use
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq)]
 pub enum SplitPattern {
     String(String),
     Regex(String),

--- a/tokenizers/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
+++ b/tokenizers/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
@@ -2,7 +2,7 @@ use crate::pre_tokenizers::unicode_scripts::scripts::{get_script, Script};
 use crate::tokenizer::{normalizer::Range, PreTokenizedString, PreTokenizer, Result};
 use crate::utils::macro_rules_attribute;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct UnicodeScripts;
 

--- a/tokenizers/src/pre_tokenizers/unicode_scripts/scripts.rs
+++ b/tokenizers/src/pre_tokenizers/unicode_scripts/scripts.rs
@@ -2,7 +2,7 @@
 // Unicode scripts : https://gist.github.com/Narsil/07556f26dc84a6baeff4d499e68d3cd2
 // Rust adaptation : https://gist.github.com/Narsil/1df9fbbf5296a8d4d62de55dcb2fe700
 
-#[derive(PartialEq, Debug, Clone, Copy)]
+#[derive(PartialEq, Debug, Clone, Copy, Eq)]
 pub enum Script {
     Any,
     Adlam,

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -5,7 +5,7 @@ use crate::tokenizer::{
 };
 use crate::utils::macro_rules_attribute;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct Whitespace;
 
@@ -28,7 +28,7 @@ impl PreTokenizer for Whitespace {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct WhitespaceSplit;
 

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -1,4 +1,4 @@
-use crate::tokenizer::{Encoding, PostProcessor, Result};
+use crate::tokenizer::{Encoding, PostProcessor, ProcessorError, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::iter::FromIterator;
@@ -25,6 +25,12 @@ impl BertProcessing {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum BertProcessorError {
+    #[error("encodings vector length must be either 1 or 2")]
+    InvalidEncodingsVecLength,
+}
+
 impl PostProcessor for BertProcessing {
     fn added_tokens(&self, is_pair: bool) -> usize {
         if is_pair {
@@ -34,19 +40,33 @@ impl PostProcessor for BertProcessing {
         }
     }
 
-    fn process(
+    fn process_encodings(
         &self,
-        mut encoding: Encoding,
-        pair_encoding: Option<Encoding>,
+        mut encodings: Vec<Encoding>,
         add_special_tokens: bool,
-    ) -> Result<Encoding> {
+    ) -> Result<Vec<Encoding>> {
         if !add_special_tokens {
-            return <dyn PostProcessor>::default_process(
-                encoding,
-                pair_encoding,
-                add_special_tokens,
-            );
+            return Ok(encodings);
         }
+
+        let (mut encoding, pair_encoding): (Encoding, Option<Encoding>) = match encodings.len() {
+            1 => (
+                encodings
+                    .pop()
+                    .ok_or(ProcessorError::InvalidEncodingsVecLength)?,
+                None,
+            ),
+            2 => {
+                let pair = encodings
+                    .pop()
+                    .ok_or(ProcessorError::InvalidEncodingsVecLength)?;
+                let encoding = encodings
+                    .pop()
+                    .ok_or(ProcessorError::InvalidEncodingsVecLength)?;
+                (encoding, Some(pair))
+            }
+            _ => return Err(Box::new(ProcessorError::InvalidEncodingsVecLength)),
+        };
 
         let ids = [&[self.cls.1], encoding.get_ids(), &[self.sep.1]].concat();
         let type_ids = [&[0], encoding.get_type_ids(), &[0]].concat();
@@ -166,7 +186,7 @@ impl PostProcessor for BertProcessing {
             new_encoding.merge_with(new_pair_encoding, false);
         }
 
-        Ok(new_encoding)
+        Ok(vec![new_encoding])
     }
 }
 

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::iter::FromIterator;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub struct BertProcessing {
     sep: (String, u32),

--- a/tokenizers/src/processors/mod.rs
+++ b/tokenizers/src/processors/mod.rs
@@ -13,7 +13,7 @@ use crate::processors::roberta::RobertaProcessing;
 use crate::processors::template::TemplateProcessing;
 use crate::{Encoding, PostProcessor, Result};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
 #[serde(untagged)]
 pub enum PostProcessorWrapper {
     // Roberta must be before Bert for deserialization (serde does not validate tags)

--- a/tokenizers/src/processors/mod.rs
+++ b/tokenizers/src/processors/mod.rs
@@ -33,19 +33,16 @@ impl PostProcessor for PostProcessorWrapper {
         }
     }
 
-    fn process(
+    fn process_encodings(
         &self,
-        encoding: Encoding,
-        pair_encoding: Option<Encoding>,
+        encodings: Vec<Encoding>,
         add_special_tokens: bool,
-    ) -> Result<Encoding> {
+    ) -> Result<Vec<Encoding>> {
         match self {
-            Self::Bert(bert) => bert.process(encoding, pair_encoding, add_special_tokens),
-            Self::ByteLevel(bl) => bl.process(encoding, pair_encoding, add_special_tokens),
-            Self::Roberta(roberta) => roberta.process(encoding, pair_encoding, add_special_tokens),
-            Self::Template(template) => {
-                template.process(encoding, pair_encoding, add_special_tokens)
-            }
+            Self::Bert(bert) => bert.process_encodings(encodings, add_special_tokens),
+            Self::ByteLevel(bl) => bl.process_encodings(encodings, add_special_tokens),
+            Self::Roberta(roberta) => roberta.process_encodings(encodings, add_special_tokens),
+            Self::Template(template) => template.process_encodings(encodings, add_special_tokens),
         }
     }
 }

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::iter::FromIterator;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub struct RobertaProcessing {
     sep: (String, u32),

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -63,7 +63,7 @@ use std::convert::{TryFrom, TryInto};
 use std::result::Result as StdResult;
 
 /// Represents both sequences received as input of the PostProcessor
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq)]
 pub enum Sequence {
     /// This is the first sequence, the one that is always specified
     A,
@@ -91,7 +91,7 @@ pub enum Sequence {
 ///
 /// [`SpecialToken`]: struct.SpecialToken.html
 ///
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq)]
 pub enum Piece {
     Sequence { id: Sequence, type_id: u32 },
     SpecialToken { id: String, type_id: u32 },
@@ -188,7 +188,7 @@ impl TryFrom<&str> for Piece {
 ///     vec!["A".into(), "complex".into(), "special".into(), "token".into(), ":".into()]
 /// ).unwrap();
 /// ```
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq)]
 pub struct SpecialToken {
     /// A unique id used to identify this SpecialToken in the template
     id: String,
@@ -249,7 +249,7 @@ impl SpecialToken {
 ///
 /// [`Piece`]: enum.Piece.html
 ///
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq)]
 #[serde(transparent)]
 pub struct Template(Vec<Piece>);
 
@@ -289,7 +289,7 @@ impl TryFrom<&str> for Template {
 /// from a HashMap or a Vec<[`SpecialToken`]>.
 ///
 /// [`SpecialToken`]: struct.SpecialToken.html
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, Eq)]
 #[serde(transparent)]
 pub struct Tokens(
     #[serde(serialize_with = "crate::utils::ordered_map")] pub HashMap<String, SpecialToken>,
@@ -332,7 +332,7 @@ impl From<HashMap<String, SpecialToken>> for Tokens {
 ///     .unwrap();
 /// ```
 ///
-#[derive(Debug, Clone, PartialEq, Builder, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Builder, Serialize, Deserialize, Eq)]
 #[serde(tag = "type", from = "TemplateProcessingDeserializer")]
 #[builder(build_fn(validate = "Self::validate"))]
 pub struct TemplateProcessing {

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -99,24 +99,48 @@ pub trait PostProcessor {
         encoding: Encoding,
         pair_encoding: Option<Encoding>,
         add_special_tokens: bool,
-    ) -> Result<Encoding>;
+    ) -> Result<Encoding> {
+        let encodings = if let Some(pair_encoding) = pair_encoding {
+            vec![encoding, pair_encoding]
+        } else {
+            vec![encoding]
+        };
+
+        let encodings = self.process_encodings(encodings, add_special_tokens)?;
+
+        Ok(Encoding::merge(encodings, false))
+    }
+
+    /// Process any amount of encodings and returns a series of encoding (might merge them)
+    fn process_encodings(
+        &self,
+        encodings: Vec<Encoding>,
+        add_special_tokens: bool,
+    ) -> Result<Vec<Encoding>>;
 }
 impl dyn PostProcessor {
     pub fn default_process(
-        mut encoding: Encoding,
-        pair_encoding: Option<Encoding>,
+        encodings: Vec<Encoding>,
         _add_special_tokens: bool,
-    ) -> Result<Encoding> {
-        match pair_encoding {
-            None => Ok(encoding),
-            Some(mut pair) => {
-                encoding.set_sequence_id(0);
-                pair.set_sequence_id(1);
-                encoding.merge_with(pair, false);
-                Ok(encoding)
+    ) -> Result<Vec<Encoding>> {
+        match encodings.len() {
+            1 => Ok(encodings),
+            _ => {
+                let mut final_encoding = Encoding::default();
+                for (i, mut encoding) in encodings.into_iter().enumerate() {
+                    encoding.set_sequence_id(i);
+                    final_encoding.merge_with(encoding, false);
+                }
+                Ok(vec![final_encoding])
             }
         }
     }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ProcessorError {
+    #[error("encodings vector length must be either 1 or 2")]
+    InvalidEncodingsVecLength,
 }
 
 /// A `Decoder` changes the raw tokens into its more readable form.
@@ -895,7 +919,17 @@ where
         let final_encoding = if let Some(processor) = &self.post_processor {
             processor.process(encoding, pair_encoding, add_special_tokens)?
         } else {
-            <dyn PostProcessor>::default_process(encoding, pair_encoding, add_special_tokens)?
+            let encodings = if let Some(pair_encoding) = pair_encoding {
+                vec![encoding, pair_encoding]
+            } else {
+                vec![encoding]
+            };
+            let mut encodings =
+                <dyn PostProcessor>::default_process(encodings, add_special_tokens)?;
+            if encodings.len() != 1 {
+                panic!("We haven't reduced the encodings like we should have");
+            }
+            encodings.pop().unwrap()
         };
 
         // 3. Then we pad if needed

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -146,7 +146,7 @@ pub trait Trainer {
         F: Fn(&str) -> Result<Vec<String>> + Sync;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Token {
     pub id: u32,
     pub value: String,

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -19,7 +19,7 @@ macro_rules! apply_signed {
 }
 
 /// The possible offsets referential
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OffsetReferential {
     Original,
     Normalized,
@@ -27,7 +27,7 @@ pub enum OffsetReferential {
 
 /// Represents a Range usable by the NormalizedString to index its content.
 /// A Range can use indices relative to either the `Original` or the `Normalized` string
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Range<T: RangeBounds<usize> + Clone> {
     Original(T),
     Normalized(T),
@@ -91,7 +91,7 @@ where
 ///  - MergedWithPrevious => `[ "the-", "final-", "-", "countdown" ]`
 ///  - MergedWithNext => `[ "the", "-final", "-", "-countdown" ]`
 ///  - Contiguous => `[ "the", "-", "final", "--", "countdown" ]`
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Eq)]
 pub enum SplitDelimiterBehavior {
     Removed,
     Isolated,
@@ -108,7 +108,7 @@ pub enum SplitDelimiterBehavior {
 /// It is possible to retrieve a part of the original string, by indexing it with
 /// offsets from the normalized one, and the other way around too. It is also
 /// possible to convert offsets from one referential to the other one easily.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedString {
     /// The original version of the string, before any modification
     original: String,

--- a/tokenizers/src/tokenizer/pre_tokenizer.rs
+++ b/tokenizers/src/tokenizer/pre_tokenizer.rs
@@ -4,7 +4,7 @@ use crate::{
 use std::collections::HashMap;
 
 /// Various possible types of offsets
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OffsetType {
     Byte,
     Char,
@@ -15,7 +15,7 @@ pub enum OffsetType {
 /// This Split contains the underlying `NormalizedString` as well as its offsets
 /// in the original string. These offsets are in the `original` referential.
 /// It also contains any `Token` associated to the current split
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Split {
     /// The underlying `NormalizedString`. Each SubString is represented by a `NormalizedString`
     /// and in the end we might be carrying a lot of SubString representing various parts of the
@@ -49,7 +49,7 @@ impl From<(NormalizedString, Option<Vec<Token>>)> for Split {
 /// Once everything has been normalized and tokenized, the `PreTokenizedString` is able
 /// to build an `Encoding` with all the relevant offsets and word ids, relative to the
 /// original string.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreTokenizedString {
     original: String,
     splits: Vec<Split>,

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::mem;
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Eq)]
 pub enum TruncationDirection {
     Left,
     Right,
@@ -53,7 +53,7 @@ pub enum TruncationError {
     SequenceTooShort,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Eq)]
 pub enum TruncationStrategy {
     LongestFirst,
     OnlyFirst,


### PR DESCRIPTION
This actually changes implementation (so real risk of  backward regression).

The idea is that the processors should not (as much as possible), fuse the encodings themselves, everything should be taken care of by `Encoding::merge(encodings)` instead. So they only need to create the encodings and modify them accordingly.


Benchmark is unclear: 


```python
WordPiece BERT encode   time:   [25.492 us 26.008 us 26.442 us]
                        change: [+9.6881% +12.165% +14.652%] (p = 0.00 < 0.05) 

    Performance has regressed.
----
WordPiece BERT encode batch
                        time:   [10.383 ms 10.615 ms 10.816 ms]
                        change: [-0.3604% +3.1938% +6.4601%] (p = 0.07 > 0.05)

   No change in performance detected.

----
BPE GPT2 encode         time:   [15.162 us 15.399 us 15.644 us]
                        change: [-5.9290% -3.5010% -1.0007%] (p = 0.01 < 0.05)

     Performance has improved.**
----
BPE GPT2 encode batch   time:   [9.1476 ms 9.3622 ms 9.6480 ms]                            
                        change: [+7.9795% +10.891% +13.714%] (p = 0.00 < 0.05)

Performance has regressed.
----
BPE GPT2 encode, no cache
                        time:   [27.387 us 28.347 us 29.280 us]
                        change: [+1.1100% +3.9995% +6.8846%] (p = 0.01 < 0.05)

   Performance has regressed.
----
BPE GPT2 encode batch, no cache
                        time:   [12.613 ms 12.986 ms 13.459 ms]
                        change: [-3.6782% -0.7142% +2.6011%] (p = 0.68 > 0.05)

    No change in performance detected.
```

BPE GPT2 doesn't use PostProcessor and seem both improved and worse ?? 
WordPiece Bert seems roughly slower (it uses `BertProcessing` which has been modified).

It's not entirely clear why it's slower, will try and do some simple modifications to recover perf but not too much.
