### PR TITLE
Fixing roberta type id (everything is zero).

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokenizers"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aho-corasick",
  "cached-path",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "tokenizers-python"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "env_logger",
  "itertools 0.9.0",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0", features = [ "rc", "derive" ]}
 serde_json = "1.0"
 libc = "0.2"
 env_logger = "0.7.1"
-pyo3 = { version = "0.16.2", features = ["extension-module"] }
+pyo3 = { version = "0.16.2" }
 numpy = "0.16.2"
 ndarray = "0.13"
 onig = { version = "6.0", default-features = false }
@@ -28,5 +28,6 @@ path = "../../tokenizers"
 tempfile = "3.1"
 
 [features]
+default = ["pyo3/extension-module"]
 test = ["pyo3/auto-initialize"]
 

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -20,7 +20,7 @@ TESTS_RESOURCES = $(DATA_DIR)/small.txt $(DATA_DIR)/roberta.json
 test: $(TESTS_RESOURCES)
 	pip install pytest requests setuptools_rust numpy pyarrow datasets
 	python -m pytest -s -v tests
-	cargo test --features test
+	cargo test --no-default-features --features test
 
 $(DATA_DIR)/big.txt :
 	$(dir_guard)

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -146,7 +146,7 @@ impl PostProcessor for RobertaProcessing {
                     )
                 } else {
                     let pair_ids = [&[self.sep.1], encoding.get_ids(), &[self.sep.1]].concat();
-                    let pair_type_ids = vec![1; encoding.get_ids().len() + 2];
+                    let pair_type_ids = vec![0; encoding.get_ids().len() + 2];
                     let pair_tokens = [
                         &[self.sep.0.clone()],
                         encoding.get_tokens(),
@@ -280,7 +280,7 @@ mod tests {
             pair_encoding,
             Encoding::new(
                 vec![0, 12, 14, 2, 2, 15, 2],
-                vec![0, 0, 0, 0, 1, 1, 1],
+                vec![0, 0, 0, 0, 0, 0, 0],
                 vec![
                     "<s>".into(),
                     "Hello".into(),
@@ -310,7 +310,7 @@ mod tests {
             pair_encoding,
             Encoding::new(
                 vec![12, 14, 15],
-                vec![0, 0, 1],
+                vec![0, 0, 0],
                 vec!["Hello".into(), "there".into(), "pair".into(),],
                 vec![None, None, None],
                 vec![(0, 5), (6, 11), (0, 4)],

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -70,6 +70,11 @@ impl PostProcessor for RobertaProcessing {
             }
         }
 
+        // Roberta is weird, and every encoding is type_id=0.
+        encodings
+            .iter_mut()
+            .for_each(|encoding| encoding.set_type_ids(vec![0; encoding.len()]));
+
         if !add_special_tokens {
             return Ok(encodings);
         }
@@ -110,7 +115,7 @@ impl PostProcessor for RobertaProcessing {
                             .map(|encoding| {
                                 let ids =
                                     [&[self.cls.1], encoding.get_ids(), &[self.sep.1]].concat();
-                                let type_ids = [&[0], encoding.get_type_ids(), &[0]].concat();
+                                let type_ids = vec![0; encoding.get_ids().len() + 2];
                                 let tokens = [
                                     &[self.cls.0.clone()],
                                     encoding.get_tokens(),
@@ -176,7 +181,7 @@ impl PostProcessor for RobertaProcessing {
                             .map(|encoding| {
                                 let pair_ids =
                                     [&[self.sep.1], encoding.get_ids(), &[self.sep.1]].concat();
-                                let pair_type_ids = vec![1; encoding.get_ids().len() + 2];
+                                let pair_type_ids = vec![0; encoding.get_ids().len() + 2];
                                 let pair_tokens = [
                                     &[self.sep.0.clone()],
                                     encoding.get_tokens(),


### PR DESCRIPTION
The original Roberta `type_ids` actually gives out `0` for every part:

https://github.com/huggingface/tokenizers/blob/python-v0.12.1/tokenizers/src/processors/roberta.rs#L117

This broke 1 integration test in `transformers`.

```py
from transformers import AutoTokenizer, LayoutLMForQuestionAnswering
from datasets import load_dataset
import torch

tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)
model = LayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa", revision="1e3ebac")

dataset = load_dataset("nielsr/funsd", split="train")
example = dataset[0]
question = "what's his name?"
words = example["words"]
boxes = example["bboxes"]

encoding = tokenizer(
    question.split(), words, is_split_into_words=True, return_token_type_ids=True, return_tensors="pt"
)
print(encoding["input_ids"])
print(encoding.sequence_ids(0))
bbox = []
for i, s, w in zip(encoding.input_ids[0], encoding.sequence_ids(0), encoding.word_ids(0)):
    if s == 1:
        bbox.append(boxes[w])
    elif i == tokenizer.sep_token_id:
        bbox.append([1000] * 4)
    else:
        bbox.append([0] * 4)
encoding["bbox"] = torch.tensor([bbox])

word_ids = encoding.word_ids(0)
outputs = model(**encoding)
loss = outputs.loss
start_scores = outputs.start_logits
end_scores = outputs.end_logits
start, end = word_ids[start_scores.argmax(-1)], word_ids[end_scores.argmax(-1)]
data = " ".join(words[start : end + 1])
print(repr(data))
```