### PR TITLE
[FIX] In SentencePieceBPETokenizer, when Vocab or merges is None, unk_token cannot be used.

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -25,10 +25,8 @@ class SentencePieceBPETokenizer(BaseTokenizer):
     ):
         if vocab is not None and merges is not None:
             tokenizer = Tokenizer(BPE(vocab, merges, dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))
-        elif unk_token is not None:
-            tokenizer = Tokenizer(BPE(dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))
         else:
-            tokenizer = Tokenizer(BPE())
+            tokenizer = Tokenizer(BPE(dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))
 
         if tokenizer.token_to_id(str(unk_token)) is not None:
             tokenizer.add_special_tokens([str(unk_token)])

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -25,8 +25,10 @@ class SentencePieceBPETokenizer(BaseTokenizer):
     ):
         if vocab is not None and merges is not None:
             tokenizer = Tokenizer(BPE(vocab, merges, dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))
-        else:
+        elif unk_token is not None:
             tokenizer = Tokenizer(BPE(dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))
+        else:
+            tokenizer = Tokenizer(BPE())
 
         if tokenizer.token_to_id(str(unk_token)) is not None:
             tokenizer.add_special_tokens([str(unk_token)])

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -26,7 +26,7 @@ class SentencePieceBPETokenizer(BaseTokenizer):
         if vocab is not None and merges is not None:
             tokenizer = Tokenizer(BPE(vocab, merges, dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))
         else:
-            tokenizer = Tokenizer(BPE())
+            tokenizer = Tokenizer(BPE(dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))
 
         if tokenizer.token_to_id(str(unk_token)) is not None:
             tokenizer.add_special_tokens([str(unk_token)])


### PR DESCRIPTION
## Q&A
```
if tokenizer.token_to_id(str(unk_token)) is not None:
            tokenizer.add_special_tokens([str(unk_token)])
```
In the above situation I want to use the [unk_token] but the SentencePieceBPETokenizer doesn't allow me to use it in this scenario.

## before

sentencepiece_bpe.py
```
if vocab is not None and merges is not None:
            tokenizer = Tokenizer(
                BPE(vocab, merges, dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk)
            )
        else:
            tokenizer = Tokenizer(BPE())

```

main,py
```
from tokenizers import SentencePieceBPETokenizer

SentencePiece_tokenizer = SentencePieceBPETokenizer(
    add_prefix_space=False,
    unk_token="[UNK]",
    fuse_unk=True,
)

SentencePiece_tokenizer.train(
    files = './vocab-2.txt',
    vocab_size = 100,
    min_frequency = 1,
    special_tokens = ["[PAD]", "[BOS]", "[EOS]", "[UNK]", "[SEP]", "[CLS]", "[MASK]"],
)

line = "축구를 😀 😃 😄 사랑해 😀 😃 😄"
pieces = SentencePiece_tokenizer.encode(line)
print("SentencePieceBPETokenizer", pieces.tokens, SentencePiece_tokenizer.decode(pieces.ids))

output: 

SentencePieceBPETokenizer ['축구', '를', '▁', '▁', '▁', '▁사랑', '해', '▁', '▁', '▁'] 축구를    사랑해

SentencePiece_tokenizer.to_str()["model"]:{"type":"BPE","dropout":null,"unk_token":null,"continuing_subword_prefix":null,"end_of_word_suffix":null,"fuse_unk":false,"vocab":{"[PAD]":0,"[BOS]":1,"[EOS]":2,"[UNK]":3,"[SEP]":4,"[CLS]":5,"[MASK]":6,"\\n":7,"▁":8,"가":9,"구":10,"국":11,"기":12,"나":13,"내":14,"너":15,"네":16,"는":17,"랑":18,"를":19,"사":20,"삽":21,"술":22,"아":23,"않":24,"야":25,"은":26,"을":27,"지":28,"질":29,"축":30,"하":31,"한":32,"해":33,"▁사":34,"▁사랑":35,"▁하":36,"▁는":37,"▁해":38,"▁해\\n":39,"▁가":40,"▁아":41,"▁않":42,"▁을":43,"▁지":44,"▁아\\n":45,"▁나":46,"▁너":47,"▁를":48,"▁은":49,"기술":50,"삽질":51,"야구":52,"축구":53,"한국":54,"▁너\\n":55},"merges":["▁ 사","▁사 랑","▁ 하","▁ 는","▁ 해","▁해 \\n","▁ 가","▁ 아","▁ 않","▁ 을","▁ 지","▁아 \\n","▁ 나","▁ 너","▁ 를","▁ 은","기 술","삽 질","야 구","축 구","한 국","▁너 \\n"]}

```

## after

sentencepiece_bpe.py
```
if vocab is not None and merges is not None:
            tokenizer = Tokenizer(
                BPE(vocab, merges, dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk)
            )
        else:
            tokenizer = Tokenizer(BPE(dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))

```

main,py
```
from tokenizers import SentencePieceBPETokenizer

SentencePiece_tokenizer = SentencePieceBPETokenizer(
    add_prefix_space=False,
    unk_token="[UNK]",
    fuse_unk=True,
)

SentencePiece_tokenizer.train(
    files = './vocab-2.txt',
    vocab_size = 100,
    min_frequency = 1,
    special_tokens = ["[PAD]", "[BOS]", "[EOS]", "[UNK]", "[SEP]", "[CLS]", "[MASK]"],
)

line = "축구를 😀 😃 😄 사랑해 😀 😃 😄"
pieces = SentencePiece_tokenizer.encode(line)
print("SentencePieceBPETokenizer", pieces.tokens, SentencePiece_tokenizer.decode(pieces.ids))

output: 

SentencePieceBPETokenizer ['축구', '를', '▁', '[UNK]', '▁', '[UNK]', '▁', '[UNK]', '▁사랑', '해', '▁', '[UNK]', '▁', '[UNK]', '▁', '[UNK]'] 축구를    사랑해 

SentencePiece_tokenizer.to_str()["model"]:{"type":"BPE","dropout":null,"unk_token":"[UNK]","continuing_subword_prefix":null,"end_of_word_suffix":null,"fuse_unk":true,"vocab":{"[PAD]":0,"[BOS]":1,"[EOS]":2,"[UNK]":3,"[SEP]":4,"[CLS]":5,"[MASK]":6,"\\n":7,"▁":8,"가":9,"구":10,"국":11,"기":12,"나":13,"내":14,"너":15,"네":16,"는":17,"랑":18,"를":19,"사":20,"삽":21,"술":22,"아":23,"않":24,"야":25,"은":26,"을":27,"지":28,"질":29,"축":30,"하":31,"한":32,"해":33,"▁사":34,"▁사랑":35,"▁하":36,"▁는":37,"▁해":38,"▁해\\n":39,"▁가":40,"▁아":41,"▁않":42,"▁을":43,"▁지":44,"▁아\\n":45,"▁나":46,"▁너":47,"▁를":48,"▁은":49,"기술":50,"삽질":51,"야구":52,"축구":53,"한국":54,"▁너\\n":55},"merges":["▁ 사","▁사 랑","▁ 하","▁ 는","▁ 해","▁해 \\n","▁ 가","▁ 아","▁ 않","▁ 을","▁ 지","▁아 \\n","▁ 나","▁ 너","▁ 를","▁ 은","기 술","삽 질","야 구","축 구","한 국","▁너 \\n"]}

```

