### PR TITLE
Bump cached-path from 0.5 to 0.6

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -59,7 +59,7 @@ derive_builder = "0.9"
 spm_precompiled = "0.1"
 dirs = "3.0"
 reqwest = { version = "0.11", optional = true }
-cached-path = { version = "0.5", optional = true }
+cached-path = { version = "0.6", optional = true }
 aho-corasick = "0.7"
 paste = "1.0.6"
 macro_rules_attribute = "0.1.2"


### PR DESCRIPTION
This updates the minor version of `cached-path` from `0.5` to `0.6`.