### PR TITLE
Wrap rustdoc html entity in code block

### DIFF
--- a/tokenizers/src/decoders/ctc.rs
+++ b/tokenizers/src/decoders/ctc.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 pub struct CTC {
     /// The pad token used by CTC to delimit a new token.
     pub pad_token: String,
-    /// The word delimiter token. It will be replaced by a <space>
+    /// The word delimiter token. It will be replaced by a `<space>`.
     pub word_delimiter_token: String,
     /// Whether to cleanup some tokenization artifacts.
     /// Mainly spaces before punctuation, and some abbreviated english forms.


### PR DESCRIPTION
This prevents a warning when running the linter about opened code block not having a closing block.