### PR TITLE
Allow to build without onig or fancy-regex

### DIFF
--- a/tokenizers/src/normalizers/replace.rs
+++ b/tokenizers/src/normalizers/replace.rs
@@ -1,5 +1,8 @@
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
+#[cfg(any(feature = "onig", feature = "unstable-wasm"))]
 use crate::utils::SysRegex;
+#[cfg(not(any(feature = "onig", feature = "unstable-wasm")))]
+use regex::Regex as SysRegex;
 use serde::{Deserialize, Serialize};
 
 /// Represents the different patterns that `Replace` can use

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
+#[cfg(any(feature = "onig", feature = "unstable-wasm"))]
 use crate::utils::SysRegex;
+#[cfg(not(any(feature = "onig", feature = "unstable-wasm")))]
+use regex::Regex as SysRegex;
 use serde::{Deserialize, Serialize};
 
 use crate::tokenizer::{

--- a/tokenizers/src/pre_tokenizers/split.rs
+++ b/tokenizers/src/pre_tokenizers/split.rs
@@ -1,4 +1,7 @@
+#[cfg(any(feature = "onig", feature = "unstable-wasm"))]
 use crate::utils::SysRegex;
+#[cfg(not(any(feature = "onig", feature = "unstable-wasm")))]
+use regex::Regex as SysRegex;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::tokenizer::{

--- a/tokenizers/src/tokenizer/pattern.rs
+++ b/tokenizers/src/tokenizer/pattern.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "onig", feature = "unstable-wasm"))]
 use crate::utils::SysRegex;
 use crate::{Offsets, Result};
 use regex::Regex;
@@ -60,6 +61,7 @@ impl Pattern for &Regex {
     }
 }
 
+#[cfg(any(feature = "onig", feature = "unstable-wasm"))]
 impl Pattern for &SysRegex {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
         if inside.is_empty() {
@@ -205,6 +207,7 @@ mod tests {
         do_test!("aaa", &is_whitespace => vec![((0, 3), false)]);
     }
 
+    #[cfg(any(features = "onig", features = "unstable-wasm"))]
     #[test]
     fn sys_regex() {
         let is_whitespace = SysRegex::new(r"\s+").unwrap();

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -6,9 +6,9 @@ pub(crate) mod from_pretrained;
 mod fancy;
 #[cfg(feature = "unstable_wasm")]
 pub use fancy::SysRegex;
-#[cfg(not(feature = "unstable_wasm"))]
+#[cfg(all(feature = "onig", not(feature = "unstable_wasm")))]
 mod onig;
-#[cfg(not(feature = "unstable_wasm"))]
+#[cfg(all(feature = "onig", not(feature = "unstable_wasm")))]
 pub use crate::utils::onig::SysRegex;
 
 pub mod iter;


### PR DESCRIPTION
Not all tokenizers need the advanced features of either oniguruma or fancy-regex. Unfortunately, as things are now, tokenizers does not build unless either the "onig" or the "unstable-wasm" feature is enabled.

So this PR allows tokenizers to be built with plain regex, reducing both build time and size overhead.