### PR TITLE
Use LTO for release and benchmark builds

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -81,3 +81,6 @@ unstable_wasm = ["fancy-regex", "getrandom/js"]
 criterion = "0.4"
 tempfile = "3.1"
 assert_approx_eq = "1.1"
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
Enable LTO optimizations for the release and benchmark build. 10-40% improvement based on the benchmark.

```
     Running benches\bert_benchmark.rs (target\release\deps\bert_benchmark-ab50c2abceb48f78.exe)
Benchmarking WordPiece BERT encode
Benchmarking WordPiece BERT encode: Warming up for 3.0000 s
Benchmarking WordPiece BERT encode: Collecting 20 samples in estimated 5.0023 s (225540 iterations)
Benchmarking WordPiece BERT encode: Analyzing
WordPiece BERT encode   time:   [22.069 µs 22.256 µs 22.429 µs]
                        change: [-43.858% -42.120% -40.433%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 20 measurements (15.00%)
  2 (10.00%) low mild
  1 (5.00%) high mild
slope  [22.069 µs 22.429 µs] R^2            [0.9891008 0.9894425]
mean   [21.775 µs 22.403 µs] std. dev.      [430.10 ns 945.35 ns]
median [21.931 µs 22.388 µs] med. abs. dev. [246.80 ns 912.87 ns]

Benchmarking WordPiece BERT encode batch
Benchmarking WordPiece BERT encode batch: Warming up for 3.0000 s
Benchmarking WordPiece BERT encode batch: Collecting 20 samples in estimated 5.4444 s (840 iterations)
Benchmarking WordPiece BERT encode batch: Analyzing
WordPiece BERT encode batch
                        time:   [6.1949 ms 6.2125 ms 6.2402 ms]
                        change: [-28.127% -26.776% -25.463%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 20 measurements (15.00%)
  2 (10.00%) high mild
  1 (5.00%) high severe
slope  [6.1949 ms 6.2402 ms] R^2            [0.9959444 0.9955571]
mean   [6.2414 ms 6.4360 ms] std. dev.      [113.95 µs 293.98 µs]
median [6.2016 ms 6.2940 ms] med. abs. dev. [15.562 µs 183.86 µs]

Benchmarking WordPiece Train vocabulary (small)
Benchmarking WordPiece Train vocabulary (small): Warming up for 3.0000 s
Benchmarking WordPiece Train vocabulary (small): Collecting 10 samples in estimated 5.6061 s (220 iterations)
Benchmarking WordPiece Train vocabulary (small): Analyzing
WordPiece Train vocabulary (small)
                        time:   [24.715 ms 24.796 ms 24.895 ms]
                        change: [-12.294% -10.375% -8.0660%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  2 (20.00%) high severe
slope  [24.715 ms 24.895 ms] R^2            [0.9984030 0.9983044]
mean   [24.750 ms 25.747 ms] std. dev.      [109.27 µs 1.3037 ms]
median [24.733 ms 25.417 ms] med. abs. dev. [27.664 µs 799.35 µs]

Benchmarking WordPiece Train vocabulary (big)
Benchmarking WordPiece Train vocabulary (big): Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.5s.
Benchmarking WordPiece Train vocabulary (big): Collecting 10 samples in estimated 7.5241 s (10 iterations)
Benchmarking WordPiece Train vocabulary (big): Analyzing
WordPiece Train vocabulary (big)
                        time:   [735.46 ms 740.17 ms 745.19 ms]
                        change: [-14.705% -13.977% -13.265%] (p = 0.00 < 0.05)
                        Performance has improved.
mean   [735.46 ms 745.19 ms] std. dev.      [3.6400 ms 11.235 ms]
median [736.12 ms 745.50 ms] med. abs. dev. [115.27 µs 14.248 ms]

     Running benches\bpe_benchmark.rs (target\release\deps\bpe_benchmark-0baeb34903957df4.exe)
Benchmarking BPE GPT2 encode
Benchmarking BPE GPT2 encode: Warming up for 3.0000 s
Benchmarking BPE GPT2 encode: Collecting 20 samples in estimated 5.0031 s (316050 iterations)
Benchmarking BPE GPT2 encode: Analyzing
BPE GPT2 encode         time:   [15.879 µs 16.016 µs 16.156 µs]
                        change: [-31.938% -30.681% -29.497%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild
slope  [15.879 µs 16.156 µs] R^2            [0.9909072 0.9908037]
mean   [15.683 µs 16.020 µs] std. dev.      [274.07 ns 483.27 ns]
median [15.695 µs 15.978 µs] med. abs. dev. [98.141 ns 702.20 ns]

Benchmarking BPE GPT2 encode batch
Benchmarking BPE GPT2 encode batch: Warming up for 3.0000 s
Benchmarking BPE GPT2 encode batch: Collecting 20 samples in estimated 5.7377 s (1050 iterations)
Benchmarking BPE GPT2 encode batch: Analyzing
BPE GPT2 encode batch   time:   [5.3231 ms 5.3427 ms 5.3663 ms]
                        change: [-25.950% -23.600% -21.823%] (p = 0.00 < 0.05)
                        Performance has improved.
slope  [5.3231 ms 5.3663 ms] R^2            [0.9975463 0.9973584]
mean   [5.3491 ms 5.4014 ms] std. dev.      [42.972 µs 75.008 µs]
median [5.3360 ms 5.4085 ms] med. abs. dev. [27.864 µs 102.34 µs]

Benchmarking BPE GPT2 encode, no cache
Benchmarking BPE GPT2 encode, no cache: Warming up for 3.0000 s
Benchmarking BPE GPT2 encode, no cache: Collecting 20 samples in estimated 5.0001 s (221760 iterations)
Benchmarking BPE GPT2 encode, no cache: Analyzing
BPE GPT2 encode, no cache
                        time:   [22.562 µs 22.644 µs 22.737 µs]
                        change: [-27.449% -26.762% -26.135%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild
slope  [22.562 µs 22.737 µs] R^2            [0.9973428 0.9972119]
mean   [22.559 µs 22.835 µs] std. dev.      [191.55 ns 429.07 ns]
median [22.511 µs 22.826 µs] med. abs. dev. [95.696 ns 429.56 ns]

Benchmarking BPE GPT2 encode batch, no cache
Benchmarking BPE GPT2 encode batch, no cache: Warming up for 3.0000 s
Benchmarking BPE GPT2 encode batch, no cache: Collecting 20 samples in estimated 5.7360 s (840 iterations)
Benchmarking BPE GPT2 encode batch, no cache: Analyzing
BPE GPT2 encode batch, no cache
                        time:   [6.7050 ms 6.7393 ms 6.7865 ms]
                        change: [-23.129% -22.631% -21.980%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high severe
slope  [6.7050 ms 6.7865 ms] R^2            [0.9940111 0.9932740]
mean   [6.7040 ms 6.7821 ms] std. dev.      [38.806 µs 140.88 µs]
median [6.6827 ms 6.7528 ms] med. abs. dev. [30.385 µs 89.564 µs]

Benchmarking BPE Train vocabulary (small)
Benchmarking BPE Train vocabulary (small): Warming up for 3.0000 s
Benchmarking BPE Train vocabulary (small): Collecting 10 samples in estimated 6.1949 s (275 iterations)
Benchmarking BPE Train vocabulary (small): Analyzing
BPE Train vocabulary (small)
                        time:   [22.302 ms 22.338 ms 22.378 ms]
                        change: [-15.050% -13.810% -12.611%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
slope  [22.302 ms 22.378 ms] R^2            [0.9998033 0.9997897]
mean   [22.282 ms 22.453 ms] std. dev.      [59.854 µs 193.35 µs]
median [22.276 ms 22.453 ms] med. abs. dev. [14.122 µs 248.66 µs]

Benchmarking BPE Train vocabulary (big)
Benchmarking BPE Train vocabulary (big): Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.4s.
Benchmarking BPE Train vocabulary (big): Collecting 10 samples in estimated 7.4178 s (10 iterations)
Benchmarking BPE Train vocabulary (big): Analyzing
BPE Train vocabulary (big)
                        time:   [730.65 ms 733.34 ms 737.08 ms]
                        change: [-16.088% -15.030% -14.086%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
mean   [730.65 ms 737.08 ms] std. dev.      [1.5432 ms 8.3653 ms]
median [729.93 ms 733.79 ms] med. abs. dev. [311.94 µs 6.2676 ms]

     Running benches\layout_benchmark.rs (target\release\deps\layout_benchmark-554038beabf945e0.exe)
Benchmarking TemplateProcessing single encode
Benchmarking TemplateProcessing single encode: Warming up for 3.0000 s
Benchmarking TemplateProcessing single encode: Collecting 20 samples in estimated 5.0005 s (2082150 iterations)
TemplateProcessing single encode
                        time:   [1.5679 µs 1.5796 µs 1.5950 µs]
                        change: [-21.510% -18.579% -15.576%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 20 measurements (10.00%)
  1 (5.00%) high mild
  1 (5.00%) high severe
slope  [1.5679 µs 1.5950 µs] R^2            [0.9882793 0.9869073]
mean   [1.5884 µs 1.6636 µs] std. dev.      [31.021 ns 129.12 ns]
median [1.5749 µs 1.6191 µs] med. abs. dev. [19.097 ns 73.304 ns]

Benchmarking TemplateProcessing pair encode
Benchmarking TemplateProcessing pair encode: Warming up for 3.0000 s
Benchmarking TemplateProcessing pair encode: Collecting 20 samples in estimated 5.0003 s (1114470 iterations)
Benchmarking TemplateProcessing pair encode: Analyzing
TemplateProcessing pair encode
                        time:   [3.1489 µs 3.1679 µs 3.2012 µs]
                        change: [-31.820% -27.564% -22.455%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 20 measurements (10.00%)
  1 (5.00%) high mild
  1 (5.00%) high severe
slope  [3.1489 µs 3.2012 µs] R^2            [0.9818992 0.9794425]
mean   [3.2179 µs 3.4932 µs] std. dev.      [104.61 ns 502.42 ns]
median [3.1554 µs 3.2941 µs] med. abs. dev. [40.175 ns 229.46 ns]
```