### PR TITLE
add LlamaConverter

### DIFF
--- a/bindings/python/scripts/convert.py
+++ b/bindings/python/scripts/convert.py
@@ -328,6 +328,17 @@ class T5Converter(SpmConverter):
         )
 
 
+class LlamaConverter(SpmConverter):
+    def normalizer(self, proto):
+        return Sequence([])
+
+    def post_processor(self, tokenizer):
+        return TemplateProcessing(
+            single=["<s>", "$0"],
+            special_tokens=[("<s>", self.original_tokenizer.bos_token_id)],
+        )
+
+
 CONVERTERS = {
     "AlbertTokenizer": AlbertConverter,
     "CamembertTokenizer": CamembertConverter,


### PR DESCRIPTION
This adds a converter for the LLaMA SentencePiece tokenizer. 

The SentencePiece model provided by Meta errors when loading in using `SpmConverter` because `proto.normalizer_spec.precompiled_charsmap` is actually an empty string. However, since it's simply an identity normalization, skipping this step of `SpmConverter` is sufficient. 

LLaMA uses a BOS token but no EOS token, so a simple `TemplateProcessing` is used to prepend the BOS token itself. The BOS token has no text mapping, so the id is read directly from `original_tokenizer`.