### PR TITLE
implement a simple max_sentencepiece_length into BPE

### DIFF
--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -502,6 +502,18 @@ impl BpeTrainer {
                 }
             }
             let new_token = format!("{}{}", part_a, part_b);
+        
+            // implement sentencepiece-like merge.
+            // if this code were to be merged, integrate a way in the python bindings to communicate this variable
+            // default should be 0/None to maintain previous behavior. 16 is the spm default.
+            let max_merge_length = 16;
+
+            if max_merge_length == 0 {
+                // if max_merge_length is default(==0) skip this part
+            } else if new_token.len() > max_merge_length {
+                // if potential merge length > max_merge_length, skip the merge.
+                continue; 
+            }
 
             // Insert new token if it does not already exist
             let new_token_id = word_to_id


### PR DESCRIPTION
Add a way for the BPE trainer to behave like the unigram trainer where tokens longer than a certain lenght(default 16 in SPM) to be skipped. this is implemented in unigram trainer but in a different way.

If this code were to be actually integrated some works to be done

1. Documentation describing the behavior and how it should be set. 
2. Set default==0 so it doesnt act unless set
3. provide ways in the python binding for the user to set max token length