### PR TITLE
fix unigram.rs test_sample()

### DIFF
--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -68,7 +68,7 @@ fn test_train_unigram_from_file() {
 #[cfg(not(debug_assertions))]
 #[test]
 fn test_sample() {
-    let mut lattice = Lattice::from("ABC", 0, 1, 2);
+    let mut lattice = Lattice::from("ABC", 0, 2);
     lattice.insert(0, 1, 1.0, 3); // A
     lattice.insert(1, 1, 1.2, 4); // B
     lattice.insert(2, 1, 1.5, 5); // C


### PR DESCRIPTION
https://github.com/huggingface/tokenizers/blob/87230bb59b2a70b6c361943d1394f42218b0040b/tokenizers/tests/unigram.rs#LL71C1-L71C53

When running cargo test --release, the above line causes an error.

referring to https://github.com/huggingface/tokenizers/blob/87230bb59b2a70b6c361943d1394f42218b0040b/tokenizers/src/models/unigram/lattice.rs#L138

It seems that lattice::from should only take 3 arguments. If i had to guess, it should be Lattice::from("ABC", 0, 2); 

This change makes cargo test --release pass without error.