### PR TITLE
Update Cargo.toml rust edition

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Anthony MOI <m.anthony.moi@gmail.com>", "Nicolas Patry <patry.nicolas@protonmail.com>"]
-edition = "2018"
+edition = "2021"
 name = "tokenizers"
 version = "0.13.3"
 homepage = "https://github.com/huggingface/tokenizers"


### PR DESCRIPTION
### What this PR does
In Cargo.toml, bump edition into "2021"
### How this PR was tested 
```
cargo test
cargo test --release
```
all tests pass.
### What issues might block
`cargo --edition` shows this message :
although it does not seem to be a big issue
```
When building the following dependencies, the given features will no longer be used:

  libc v0.2.142 (as host dependency) removed features: extra_traits
  serde v1.0.160 removed features: alloc
  syn v1.0.109 (as host dependency) removed features: visit
  tokio v1.28.0 removed features: windows-sys
```
### What is the goal of this PR
- keep this codebase up to date with rust toolchains
- allow eaiser updates and modifications to dependencies (rust 2018 has a new dependency resolver)