### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -49,8 +49,9 @@ jobs:
 
       - name: Get NPM cache directory
         id: npm-cache
+        shell: bash
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - name: Cache NPM cache
         uses: actions/cache@v1
         with:
@@ -100,8 +101,9 @@ jobs:
 
       - name: Get NPM cache directory
         id: npm-cache
+        shell: bash
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - name: Cache NPM cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Get NPM cache directory
         id: npm-cache
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - name: Cache NPM cache
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
## Description

Resolve  #1247

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: |
  echo "::set-output name=dir::$(npm config get cache)"
```

**TO-BE**

```yml
run: |
  echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
```