### PR TITLE
Update all GH Actions with dependency on actions/checkout

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Python
         uses: actions/setup-python@v1

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/python-release-conda.yml
+++ b/.github/workflows/python-release-conda.yml
@@ -18,7 +18,7 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/python-release-extra.yml
+++ b/.github/workflows/python-release-extra.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Create wheels for manylinux2014 - PowerPC
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Upgrade libssl
         run: sudo apt-get install -y libssl-dev

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -20,7 +20,7 @@ jobs:
     container: quay.io/pypa/manylinux2014_x86_64
     steps:
       # v1 is required when using manylinux2010
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: yum install -y openssl-devel

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,7 +19,7 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Install Rust Stable
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
This PR upgrades `actions/checkout` from v[1,2]… to v3 to notably improve performance (retrieve only the commit being checked-out)

See: 

- v2.0 : https://github.com/actions/checkout/releases/tag/v2.0.0
- v3.0 : https://github.com/actions/checkout/releases/tag/v3.0.0