### PR TITLE
Update unigram/trainer.rs

### DIFF
--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -204,6 +204,9 @@ impl UnigramTrainer {
         let c_sentence_boundary = '\0';
         let k_sentence_boundary = '\0'.to_string();
         for (string, n) in sentences {
+            if string.is_empty() {
+                continue;
+            }
             flat_string.push_str(string);
             // XXX
             // Comment suggests we add sentence boundary, but it seems to be missing from actual
@@ -215,6 +218,7 @@ impl UnigramTrainer {
                 }
             }
         }
+        flat_string.shrink_to_fit();
         #[cfg(feature = "esaxx_fast")]
         let suffix = esaxx_rs::suffix(&flat_string).unwrap();
         #[cfg(not(feature = "esaxx_fast"))]


### PR DESCRIPTION
implement skip for empty sentences.
This is implementing the following line:
https://github.com/google/sentencepiece/blob/master/src/trainer_interface.cc#L373

This might seem superfluous and of limited applicability, but it actually serves as a baseline for further changes.

More specifically the --max_sentence_length [option](https://github.com/google/sentencepiece/blob/master/doc/options.md) in [spm](https://github.com/google/sentencepiece/blob/f2219b53e24ff5deee4cacdc2d0ca3074e529a07/src/trainer_interface.cc#L375)


### What this PR does as is
while constructing the flat_string to send to the suffix array function, skip any empty sentences. 
After it is done, shrink the flat_string, which was created with_capacity to a conservative high number not accounting for empty strings.
My review of the codebase reveals no specific preprocessing in any other area of the codebase that addresses this.
This will bring huggingface unigram a bit closer to the original implementation.

### What I hope to achieve with this PR going forward 
I would actually like to implement the --max_sentence_length option which limits each sentence to a maximum of 4192 bytes (seems arbitrary or even a typo for 4096 but that's what the original spm default).
The rationale for this limitation is also delineated in spm source comments :

From sentencepiece/src/sentencepiece_model.proto
>   // The maximum sentence length in byte. The sentences with the length
>   // larger than `max_sentence_length` is simply ignored.
>   // Longer input tends to bring the following risks:
>   //  * Overflow during EM training (unigram language model only)
>   //  * Performance drop because of O(n log n) cost in BPE.

This PR alone will not tangible change tokenizer behavior or results except for maybe providing marginal performance gains when there are a lot of empty inputs.

If the max_sentence_length option is also implemented it would bring some tangible benefits but it would also change behavior so defaults etc must be closely considered.

These changes are applicable to BPE too.