### PR TITLE
Parallelize (pretokenization)

### DIFF
--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -1131,7 +1131,7 @@ where
                 let pre_tokenized = self.do_pre_tokenize(normalized)?;
                 Ok(pre_tokenized
                     .get_splits(OffsetReferential::Original, OffsetType::Byte)
-                    .into_iter()
+                    .into_maybe_par_iter()
                     .map(|(s, _, _)| s.to_owned())
                     .collect())
             },


### PR DESCRIPTION
This commit parallelizes the process when an iterator is used to feed the tokenizer.
This would help in case of : long sequence being passed into tokenizer trainer even after pretokenization.

https://huggingface.co/docs/tokenizers/training_from_memory

This commit alone seems benign since map operates on each string slice without any concern for it's offsets.
Passes all tests.

more important are these parts within tokenizer/mod.rs but they might be much more difficult or involved.
```
let normalized = self.do_normalize(seq.as_ref())?;
let pre_tokenized = self.do_pre_tokenize(normalized)?;
```

I hope to look into low hanging fruit in the individual normalizers and pretokenizers and add them all up into this PR.

If there are suggestions for more deeper architectural changes feel free to point them out.