### PR TITLE
fix documentation regarding regex 

### DIFF
--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -494,7 +494,7 @@ class NormalizedString:
 
         Args:
             pattern: Pattern:
-                A pattern used to split the string. Usually a string or a Regex
+                A pattern used to split the string. Usually a string or a regex built with tokenizers.Regex
 
             behavior: SplitDelimiterBehavior:
                 The behavior to use when splitting.

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -494,7 +494,7 @@ class NormalizedString:
 
         Args:
             pattern: Pattern:
-                A pattern used to split the string. Usually a string or a a regex built with tokenizers.Regex
+                A pattern used to split the string. Usually a string or a a regex built with `tokenizers.Regex`
 
             behavior: SplitDelimiterBehavior:
                 The behavior to use when splitting.

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -472,7 +472,7 @@ class NormalizedString:
 
         Args:
             pattern: Pattern:
-                A pattern used to match the string. Usually a string or a Regex
+                A pattern used to match the string. Usually a string or a a regex built with tokenizers.Regex
 
             content: str:
                 The content to be used as replacement
@@ -494,7 +494,7 @@ class NormalizedString:
 
         Args:
             pattern: Pattern:
-                A pattern used to split the string. Usually a string or a Regex
+                A pattern used to split the string. Usually a string or a a regex built with tokenizers.Regex
 
             behavior: SplitDelimiterBehavior:
                 The behavior to use when splitting.

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -494,7 +494,7 @@ class NormalizedString:
 
         Args:
             pattern: Pattern:
-                A pattern used to split the string. Usually a string or a a regex built with `tokenizers.Regex`
+                A pattern used to split the string. Usually a string or a a regex built with tokenizers.Regex
 
             behavior: SplitDelimiterBehavior:
                 The behavior to use when splitting.

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -472,7 +472,7 @@ class NormalizedString:
 
         Args:
             pattern: Pattern:
-                A pattern used to match the string. Usually a string or a a regex built with `tokenizers.Regex`
+                A pattern used to match the string. Usually a string or a a regex built with tokenizers.Regex
 
             content: str:
                 The content to be used as replacement

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -472,7 +472,7 @@ class NormalizedString:
 
         Args:
             pattern: Pattern:
-                A pattern used to match the string. Usually a string or a a regex built with tokenizers.Regex
+                A pattern used to match the string. Usually a string or a Regex
 
             content: str:
                 The content to be used as replacement
@@ -494,7 +494,7 @@ class NormalizedString:
 
         Args:
             pattern: Pattern:
-                A pattern used to split the string. Usually a string or a a regex built with tokenizers.Regex
+                A pattern used to split the string. Usually a string or a Regex
 
             behavior: SplitDelimiterBehavior:
                 The behavior to use when splitting.

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -472,7 +472,7 @@ class NormalizedString:
 
         Args:
             pattern: Pattern:
-                A pattern used to match the string. Usually a string or a a regex built with tokenizers.Regex
+                A pattern used to match the string. Usually a string or a a regex built with `tokenizers.Regex`
 
             content: str:
                 The content to be used as replacement

--- a/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
@@ -411,7 +411,7 @@ class Split(PreTokenizer):
 
     Args:
         pattern (:obj:`str` or :class:`~tokenizers.Regex`):
-            A pattern used to split the string. Usually a string or a Regex
+            A pattern used to split the string. Usually a string or a a regex built with tokenizers.Regex
 
         behavior (:class:`~tokenizers.SplitDelimiterBehavior`):
             The behavior to use when splitting.

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -325,7 +325,7 @@ impl PyWhitespaceSplit {
 ///
 /// Args:
 ///     pattern (:obj:`str` or :class:`~tokenizers.Regex`):
-///         A pattern used to split the string. Usually a string or a Regex
+///         A pattern used to split the string. Usually a string or a a regex built with tokenizers.Regex
 ///
 ///     behavior (:class:`~tokenizers.SplitDelimiterBehavior`):
 ///         The behavior to use when splitting.

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -325,7 +325,7 @@ impl PyWhitespaceSplit {
 ///
 /// Args:
 ///     pattern (:obj:`str` or :class:`~tokenizers.Regex`):
-///         A pattern used to split the string. Usually a string or a a regex built with tokenizers.Regex
+///         A pattern used to split the string. Usually a string or a a regex built with `tokenizers.Regex`
 ///
 ///     behavior (:class:`~tokenizers.SplitDelimiterBehavior`):
 ///         The behavior to use when splitting.

--- a/bindings/python/src/utils/normalization.rs
+++ b/bindings/python/src/utils/normalization.rs
@@ -318,7 +318,7 @@ impl PyNormalizedString {
     ///
     /// Args:
     ///     pattern: Pattern:
-    ///         A pattern used to split the string. Usually a string or a regex built with tokenizers.Regex
+    ///         A pattern used to split the string. Usually a string or a regex built with `tokenizers.Regex`
     ///
     ///     behavior: SplitDelimiterBehavior:
     ///         The behavior to use when splitting.

--- a/bindings/python/src/utils/normalization.rs
+++ b/bindings/python/src/utils/normalization.rs
@@ -318,7 +318,7 @@ impl PyNormalizedString {
     ///
     /// Args:
     ///     pattern: Pattern:
-    ///         A pattern used to split the string. Usually a string or a Regex
+    ///         A pattern used to split the string. Usually a string or a regex built with tokenizers.Regex
     ///
     ///     behavior: SplitDelimiterBehavior:
     ///         The behavior to use when splitting.


### PR DESCRIPTION
Split() in pre_tokenizers.rs and normalizations take a regex that is required to be built with a tokenizer specific regex module. Clarify this in the documentation.

This is not a full fix since it does not describe how to build with tokenizer.Regex

However, I feel like that should be its own documentation. In the meantime, this change atleast exposes the fact that such procedure is necessary, and hopefully people would be aware of it.

Addresses #1261