### PR TITLE
Update Cargo.toml

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -46,16 +46,16 @@ harness = false
 lazy_static = "1.4"
 rand = "0.8"
 onig = { version = "6.0", default-features = false, optional = true }
-regex = "1.3"
-regex-syntax = "0.6"
-rayon = "1.3"
+regex = "1.8"
+regex-syntax = "0.7"
+rayon = "1.7"
 rayon-cond = "0.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 clap = { version = "4.0", features=["derive"], optional = true }
 unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
-unicode-segmentation = "1.6"
+unicode-segmentation = "1.10"
 indicatif = {version = "0.15", optional = true}
 itertools = "0.9"
 log = "0.4"


### PR DESCRIPTION
The only really relevant updates for me are 
```
unicode-segmentation = "1.10"
regex = "1.8"
```

This is because the current dependency version unicode-segmentation 1.6 supports unicode 12
while 1.10 supports unicode 15 with a lot of CJK relevant changes in the meantime.

However, I did just added several ones that i thought were crucial.

anyway not that relevant in the first place since it seems due to dependencies updated versions were already used.
(most recent versions were already being used)

`cargo update` yield the following
Updating regex v1.8.1 -> v1.8.3
Updating regex-syntax v0.7.1 -> v0.7.2

```
cargo test, bench
python setup.py install
```
all passes on my end.
