### PR TITLE
don't update added tokens map if token already in vocab

### DIFF
--- a/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
@@ -411,7 +411,7 @@ class Split(PreTokenizer):
 
     Args:
         pattern (:obj:`str` or :class:`~tokenizers.Regex`):
-            A pattern used to split the string. Usually a string or a a regex built with `tokenizers.Regex`
+            A pattern used to split the string. Usually a string or a regex built with `tokenizers.Regex`
 
         behavior (:class:`~tokenizers.SplitDelimiterBehavior`):
             The behavior to use when splitting.

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -325,7 +325,7 @@ impl PyWhitespaceSplit {
 ///
 /// Args:
 ///     pattern (:obj:`str` or :class:`~tokenizers.Regex`):
-///         A pattern used to split the string. Usually a string or a a regex built with `tokenizers.Regex`
+///         A pattern used to split the string. Usually a string or a regex built with `tokenizers.Regex`
 ///
 ///     behavior (:class:`~tokenizers.SplitDelimiterBehavior`):
 ///         The behavior to use when splitting.

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -748,11 +748,11 @@ mod tests {
             ("singleLongTokenWithCamelCaseChange", 2),
             ("Longsingletokenwithpunctu@t!onwithin", 2),
             ("Anotherlongsingletokenwithnumberw1th1n", 2),
-            ("짧은한글문자열짧은한", 2),             // korean 10 char
+            ("짧은한글문자열짧은한", 2), // korean 10 char
             ("긴한글문자열긴한글문자열긴한글문", 2), // korean 16 char
-            ("短字符串短字符串短字", 2),             //simplified chinese 10 char
+            ("短字符串短字符串短字", 2), //simplified chinese 10 char
             ("长字符串长字符串长字符串长字符串", 2), // simp. chinese 16 char
-            ("短い文字列短い文字列", 2),             // japanese 10 char
+            ("短い文字列短い文字列", 2), // japanese 10 char
             ("長い文字列長い文字列長い文字列長", 2), // japanese 16 char
             ("so", 2),
             ("GPT-2", 2),

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -250,12 +250,10 @@ impl AddedVocabulary {
             } else {
                 let new_id = (model.get_vocab_size() + self.added_tokens_map.len()) as u32;
                 self.added_tokens_map.insert(token.content.clone(), new_id);
-
+                self.added_tokens_map_r.insert(new_id, token.clone());
                 if !self.special_tokens_set.contains(&token.content) {
                     self.added_tokens.push(token.clone());
                 }
-                // Update the current revert operation
-                self.added_tokens_map_r.insert(new_id, token.clone());
             };
         }
 

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -249,9 +249,8 @@ impl AddedVocabulary {
                 continue;
             }
 
-            let id = if let Some(id) = self.token_to_id(&token.content, model) {
+            if let Some(_id) = self.token_to_id(&token.content, model) {
                 ignored += 1;
-                id
             } else {
                 let new_id = (model.get_vocab_size() + self.added_tokens_map.len()) as u32;
                 self.added_tokens_map.insert(token.content.clone(), new_id);
@@ -259,15 +258,11 @@ impl AddedVocabulary {
                 if !self.special_tokens_set.contains(&token.content) {
                     self.added_tokens.push(token.clone());
                 }
-
-                new_id
+                // Update the current revert operation
+                self.added_tokens_map_r.insert(new_id, token.clone());
             };
 
-            // Update the current revert operation
-            self.added_tokens_map_r
-                .entry(id)
-                .and_modify(|t| *t = token.clone())
-                .or_insert_with(|| token.clone());
+
         }
 
         self.refresh_added_tokens(model, normalizer);

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -244,7 +244,7 @@ impl AddedVocabulary {
         // Then we delegate to `add_tokens`, that will take care of refreshing added tokens too.
         let mut ignored = 0;
         for token in tokens {
-            if token.content.is_empty() ||  self.token_to_id(&token.content, model).is_some() {
+            if token.content.is_empty() || self.token_to_id(&token.content, model).is_some() {
                 ignored += 1;
                 continue;
             } else {

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -244,13 +244,9 @@ impl AddedVocabulary {
         // Then we delegate to `add_tokens`, that will take care of refreshing added tokens too.
         let mut ignored = 0;
         for token in tokens {
-            if token.content.is_empty() {
+            if token.content.is_empty() ||  self.token_to_id(&token.content, model).is_some() {
                 ignored += 1;
                 continue;
-            }
-
-            if let Some(_id) = self.token_to_id(&token.content, model) {
-                ignored += 1;
             } else {
                 let new_id = (model.get_vocab_size() + self.added_tokens_map.len()) as u32;
                 self.added_tokens_map.insert(token.content.clone(), new_id);
@@ -261,8 +257,6 @@ impl AddedVocabulary {
                 // Update the current revert operation
                 self.added_tokens_map_r.insert(new_id, token.clone());
             };
-
-
         }
 
         self.refresh_added_tokens(model, normalizer);


### PR DESCRIPTION
# Issue : 
When tokens are added using `add_token`, if they were already part of the vocab, they are not completely ignored.:
- the `added_tokens_map_r` is update, but the `added_tokens` is not 
- this induces bugs, where changing `single_word` will result in a different behaviour after adding the token again. 
- erros do propagate to `transformers` : adding a token that already exists ( let's say `eos_token`) will not update the `trie` but it will update the `added_tokens_map_r`. 

A potential improvement here could be to add the feature `update_added_token` to update a token that was already added. 

Missing feature in fast that could help debug slow and vice-versa: 
- `.get_special_tokens()` to return the equivalent `added_special_tokens` of slow. 
- `.get_added_tokens()` to return the equivalent `added_tokens` of slow
- `.get_added_tokens_map()` to return the equivalent `added_tokens_encoder` of slow
- `.get_added_vocab` which would return the entire vocab
This fixes the issue when an added token is updated if it was already part of the vocab 