### PR TITLE
Update Cargo.toml for bindings

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -9,16 +9,16 @@ name = "tokenizers"
 crate-type = ["cdylib"]
 
 [dependencies]
-rayon = "1.3"
+rayon = "1.7"
 serde = { version = "1.0", features = [ "rc", "derive" ]}
 serde_json = "1.0"
 libc = "0.2"
-env_logger = "0.7.1"
-pyo3 = "0.18.1"
-numpy = "0.18.0"
+env_logger = "0.10"
+pyo3 = "0.19"
+numpy = "0.19"
 ndarray = "0.13"
-onig = { version = "6.0", default-features = false }
-itertools = "0.9"
+onig = { version = "6.4", default-features = false }
+itertools = "0.10"
 
 [dependencies.tokenizers]
 version = "*"
@@ -26,7 +26,10 @@ path = "../../tokenizers"
 
 [dev-dependencies]
 tempfile = "3.1"
-pyo3 = { version = "0.18.1", features = ["auto-initialize"] }
+pyo3 = { version = "0.19", features = ["auto-initialize"] }
 
 [features]
 default = ["pyo3/extension-module"]
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
besides updating dependencies, I added
```
[profile.release]
lto = "fat"
```
ran
`cargo test`
`cargo test --release`
in the tokenizers

and from bindings
`python3 setup.py test`

all passes.

1. seems like theres deprecation warnings starting to creep up from pyo3
2. it seems like the rust edition for the bindings are 2021. the main code is 2018.  would this be a problem? should we bump the main code to 2021 too? (refer to #1245 )
3.  im not sure if lto option is redundant for the bindings but I added it anyway.