### PR TITLE
Improve error for truncation with too high stride

### DIFF
--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -316,7 +316,7 @@ impl Encoding {
             return;
         }
 
-        assert!(stride < max_len);
+        assert!(stride < max_len, "`stride` must be strictly less than `max_len={}` (note that `max_len` may be shorter than the max length of the original model, as it subtracts the number of special characters", max_len);
 
         // When truncating, we lose the `sequence_ranges` information.
         self.sequence_ranges.clear();


### PR DESCRIPTION
Fixes #1269

@ArthurZucker I took the liberty of opening this PR. Let me know if this is a good format for the error message.

I ran tested that the message propagated through to the Python binding and also ran `make all-checks`; I'm not sure if there are any other pre-commit checks to run.