### PR TITLE
revise type specification

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
@@ -16,7 +16,7 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
 
     def __init__(
         self,
-        vocab: Optional[str] = None,
+        vocab: Optional[List[Tuple[str, float]]] = None,
         replacement: str = "▁",
         add_prefix_space: bool = True,
     ):


### PR DESCRIPTION
The type of the arg `vocab` is defined as `Option[str]` in `SentencePieceUnigramTokenizer.__init()__` but `List[Tuple[str, float]]` in `Unigram`

https://github.com/huggingface/tokenizers/blob/v0.13.4-rc2/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py#L19
https://github.com/huggingface/tokenizers/blob/v0.13.4-rc2/bindings/python/py_src/tokenizers/models/__init__.pyi#L245

This inconsistency is very confusing to users.