### PR TITLE
Give error when initializing tokenizer with too high stride

### DIFF
--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -712,8 +712,9 @@ impl PyTokenizer {
             }
         }
 
-        self.tokenizer.with_truncation(Some(params));
-
+        if let Err(error_message) = self.tokenizer.with_truncation(Some(params)) {
+            return Err(PyError(error_message.to_string()).into_pyerr::<exceptions::PyValueError>());
+        }
         Ok(())
     }
 

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -721,7 +721,7 @@ impl PyTokenizer {
     /// Disable truncation
     #[pyo3(text_signature = "(self)")]
     fn no_truncation(&mut self) {
-        self.tokenizer.with_truncation(None);
+        let _ = self.tokenizer.with_truncation(None);
     }
 
     /// Get the currently set truncation parameters

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -37,19 +37,19 @@ impl<'a> Serialize for OrderedVocabIter<'a> {
         let mut holes = vec![];
         let result = if let Some(max) = self.vocab_r.iter().map(|(key, _)| key).max() {
             let iter = (0..*max + 1).filter_map(|i| {
-            if let Some(token) = self.vocab_r.get(&i){
-                Some((token, i))
-            }else{
-                holes.push(i);
-                None
-            }
+                if let Some(token) = self.vocab_r.get(&i) {
+                    Some((token, i))
+                } else {
+                    holes.push(i);
+                    None
+                }
             });
             serializer.collect_map(iter)
         } else {
             serializer.collect_map(std::iter::empty::<(&str, u32)>())
         };
 
-        if !holes.is_empty(){
+        if !holes.is_empty() {
             warn!("The OrderedVocab you are attempting to save contains holes for indices {:?}, your vocabulary could be corrupted !", holes);
             println!("The OrderedVocab you are attempting to save contains holes for indices {:?}, your vocabulary could be corrupted !", holes);
         }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -902,11 +902,7 @@ where
         // 1. First we truncate if needed
         let (encoding, pair_encoding) = {
             if let Some(trunc) = &self.truncation {
-                let n_added_tokens = if let Some(processor) = &self.post_processor {
-                    processor.added_tokens(pair_encoding.is_some())
-                } else {
-                    0
-                };
+                let n_added_tokens = self.get_n_added_tokens(pair_encoding.is_some());
 
                 if add_special_tokens && n_added_tokens > 0 {
                     let params = TruncationParams {
@@ -949,6 +945,14 @@ where
         };
 
         Ok(final_encoding)
+    }
+
+    fn get_n_added_tokens(&self, is_pair: bool) -> usize {
+        if let Some(processor) = &self.post_processor {
+            processor.added_tokens(is_pair)
+        } else {
+            0
+        }
     }
 }
 

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -497,6 +497,10 @@ impl DerefMut for Tokenizer {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+#[error("{0}")]
+pub struct TruncationParamError(String);
+
 /// A `Tokenizer` is capable of encoding/decoding any text.
 #[derive(Clone, Debug)]
 pub struct TokenizerImpl<M, N, PT, PP, D> {
@@ -595,9 +599,21 @@ where
     }
 
     /// Set the truncation parameters
-    pub fn with_truncation(&mut self, trunc: Option<TruncationParams>) -> &mut Self {
+    ///
+    /// Fails if `stride` is too high relative to `max_length` and `post_processor.added_tokens()`
+    pub fn with_truncation(&mut self, trunc: Option<TruncationParams>) -> Result<&mut Self> {
+        if let Some(trunc_params) = &trunc {
+            let n_added_tokens = self.get_n_added_tokens(false);
+            let effective_max_length = trunc_params.max_length - n_added_tokens;
+            if effective_max_length <= trunc_params.stride {
+                return Err(Box::new(TruncationParamError(format!(
+                    "tokenizer stride set to {}, which is greater than or equal to its effective max length of {} (= {} original max length - {} added special tokens), ",
+                    trunc_params.stride, effective_max_length, trunc_params.max_length, n_added_tokens
+                ))));
+            }
+        }
         self.truncation = trunc;
-        self
+        Ok(self)
     }
 
     /// Get the currently set truncation parameters


### PR DESCRIPTION
Related to #1269. Implements improvements requested [here](https://github.com/huggingface/tokenizers/pull/1275#pullrequestreview-1474362381).

Enabling truncation with bad parameters (specifically `stride` and `max_length`) on a tokenizer now gives an error (in the form of a proper Python exception, explaining the relation of added special tokens and max length to stride).

Note that I didn't remove the original `assert!()` for a few reasons:

1. I assumed that the number of added special tokens is always lowest when `is_pair = false`. I'm not sure if this is true/a justified assumption
2. I have not implemented any error output for the Node bindings. I haven't even looked at them yet, but I imagine they will enable truncation with bad params and ignore the `Err` output of the function. It might be nice to implement that functionality as part of this PR.