### PR TITLE
Derive clone for TrainerWrapper

### DIFF
--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -140,7 +140,7 @@ impl Model for ModelWrapper {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub enum TrainerWrapper {
     BpeTrainer(BpeTrainer),
     WordPieceTrainer(WordPieceTrainer),

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -88,7 +88,7 @@ impl WordPieceTrainerBuilder {
 }
 
 /// Trains a `WordPiece` model.
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Default, Clone, Deserialize, Serialize)]
 pub struct WordPieceTrainer {
     bpe_trainer: BpeTrainer,
 }


### PR DESCRIPTION
Derives `Clone` for `WordPieceTrainer` to match other trainers, and also for `TrainerWrapper` for convenience.