### PR TITLE
Update added tokens

### DIFF
--- a/bindings/python/py_src/tokenizers/__init__.py
+++ b/bindings/python/py_src/tokenizers/__init__.py
@@ -89,7 +89,6 @@ from .tokenizers import (
     pre_tokenizers,
     processors,
     trainers,
-    __version__,
 )
 from .implementations import (
     BertWordPieceTokenizer,

--- a/bindings/python/py_src/tokenizers/__init__.py
+++ b/bindings/python/py_src/tokenizers/__init__.py
@@ -89,6 +89,7 @@ from .tokenizers import (
     pre_tokenizers,
     processors,
     trainers,
+    __version__,
 )
 from .implementations import (
     BertWordPieceTokenizer,

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -899,6 +899,14 @@ class Tokenizer:
             :class:`~tokenizers.Tokenizer`: The new tokenizer
         """
         pass
+    def get_added_tokens_decoder(self):
+        """
+        Get the underlying vocabulary
+
+        Returns:
+            :obj:`Dict[int, AddedToken]`: The vocabulary
+        """
+        pass
     def get_vocab(self, with_added_tokens=True):
         """
         Get the underlying vocabulary

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -28,13 +28,14 @@ class AddedToken:
         normalized (:obj:`bool`, defaults to :obj:`True` with :meth:`~tokenizers.Tokenizer.add_tokens` and :obj:`False` with :meth:`~tokenizers.Tokenizer.add_special_tokens`):
             Defines whether this token should match against the normalized version of the input
             text. For example, with the added token ``"yesterday"``, and a normalizer in charge of
-            lowercasing the text, the token could be extracted from the input ``"I saw a lion
-            Yesterday"``. 
+            lowercasing the text, the token could be extract from the input ``"I saw a lion
+            Yesterday"``.
         special (:obj:`bool`, defaults to :obj:`False` with :meth:`~tokenizers.Tokenizer.add_tokens` and :obj:`False` with :meth:`~tokenizers.Tokenizer.add_special_tokens`):
             Defines whether this token should be skipped when decoding.
+
     """
 
-    def __init__(self, content, single_word=False, lstrip=False, rstrip=False, normalized=True):
+    def __init__(self, content, single_word=False, lstrip=False, rstrip=False, normalized=True, special=False):
         pass
     @property
     def content(self):
@@ -65,7 +66,7 @@ class AddedToken:
         """
         Get the value of the :obj:`single_word` option
         """
-    pass
+        pass
     @property
     def special(self):
         """

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -28,9 +28,10 @@ class AddedToken:
         normalized (:obj:`bool`, defaults to :obj:`True` with :meth:`~tokenizers.Tokenizer.add_tokens` and :obj:`False` with :meth:`~tokenizers.Tokenizer.add_special_tokens`):
             Defines whether this token should match against the normalized version of the input
             text. For example, with the added token ``"yesterday"``, and a normalizer in charge of
-            lowercasing the text, the token could be extract from the input ``"I saw a lion
-            Yesterday"``.
-
+            lowercasing the text, the token could be extracted from the input ``"I saw a lion
+            Yesterday"``. 
+        special (:obj:`bool`, defaults to :obj:`False` with :meth:`~tokenizers.Tokenizer.add_tokens` and :obj:`False` with :meth:`~tokenizers.Tokenizer.add_special_tokens`):
+            Defines whether this token should be skipped when decoding.
     """
 
     def __init__(self, content, single_word=False, lstrip=False, rstrip=False, normalized=True):
@@ -63,6 +64,12 @@ class AddedToken:
     def single_word(self):
         """
         Get the value of the :obj:`single_word` option
+        """
+    pass
+    @property
+    def special(self):
+        """
+        Get the value of the :obj:`special` option
         """
         pass
 

--- a/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
@@ -42,6 +42,14 @@ class BaseTokenizer:
         """
         return self._tokenizer.get_vocab(with_added_tokens=with_added_tokens)
 
+    def get_added_tokens_decoder(self) -> Dict[int, AddedToken]:
+        """Returns the added reverse vocabulary
+
+        Returns:
+            The added vocabulary mapping ints to AddedTokens
+        """
+        return self._tokenizer.get_added_tokens_decoder()
+
     def get_vocab_size(self, with_added_tokens: bool = True) -> int:
         """Return the size of vocabulary, with or without added tokens.
 

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -119,7 +119,7 @@ impl From<tk::AddedToken> for PyAddedToken {
             lstrip: Some(token.lstrip),
             rstrip: Some(token.rstrip),
             normalized: Some(token.normalized),
-            special: Some(token.special),
+            special: token.special,
         }
     }
 }
@@ -127,7 +127,7 @@ impl From<tk::AddedToken> for PyAddedToken {
 #[pymethods]
 impl PyAddedToken {
     #[new]
-    #[pyo3(signature = (content=None, **kwargs), text_signature = "(self, content, single_word=False, lstrip=False, rstrip=False, normalized=True)")]
+    #[pyo3(signature = (content=None, **kwargs), text_signature = "(self, content, single_word=False, lstrip=False, rstrip=False, normalized=True, special=False)")]
     fn __new__(content: Option<&str>, kwargs: Option<&PyDict>) -> PyResult<Self> {
         let mut token = PyAddedToken::from(content.unwrap_or(""), None);
 
@@ -139,7 +139,7 @@ impl PyAddedToken {
                     "lstrip" => token.lstrip = Some(value.extract()?),
                     "rstrip" => token.rstrip = Some(value.extract()?),
                     "normalized" => token.normalized = Some(value.extract()?),
-                    "special" => token.special = Some(value.extract()?),
+                    "special" => token.special = value.extract()?,
                     _ => println!("Ignored unknown kwarg option {}", key),
                 }
             }
@@ -163,7 +163,7 @@ impl PyAddedToken {
                         "lstrip" => self.lstrip = Some(value.extract()?),
                         "rstrip" => self.rstrip = Some(value.extract()?),
                         "normalized" => self.normalized = Some(value.extract()?),
-                        "special" => self.special = Some(value.extract()?),
+                        "special" => self.special = value.extract()?,
                         _ => {}
                     }
                 }

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -663,15 +663,18 @@ impl PyTokenizer {
     }
 
     /// Get the underlying vocabulary
-    /// 
+    ///
     /// Returns:
     ///     :obj:`Dict[int, AddedToken]`: The vocabulary
     #[pyo3(signature = ())]
     #[pyo3(text_signature = "(self)")]
     fn get_added_tokens_decoder(&self) -> HashMap<u32, PyAddedToken> {
-        self.tokenizer.get_added_tokens_decoder().into_iter().map(|(key, value)| (key, value.into())).collect()
+        self.tokenizer
+            .get_added_tokens_decoder()
+            .into_iter()
+            .map(|(key, value)| (key, value.into()))
+            .collect()
     }
-
 
     /// Get the size of the underlying vocabulary
     ///

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -75,7 +75,7 @@ impl PyAddedToken {
             single_word: None,
             lstrip: None,
             rstrip: None,
-            normalized: Some(!special.unwrap_or(true)),
+            normalized: None,
         }
     }
 

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -25,6 +25,7 @@ use super::pre_tokenizers::PyPreTokenizer;
 use super::trainers::PyTrainer;
 use crate::processors::PyPostProcessor;
 use crate::utils::{MaybeSizedIterator, PyBufferedIterator};
+use std::collections::BTreeMap;
 
 /// Represents a token that can be be added to a :class:`~tokenizers.Tokenizer`.
 /// It can have special options that defines the way it should behave.
@@ -668,12 +669,14 @@ impl PyTokenizer {
     ///     :obj:`Dict[int, AddedToken]`: The vocabulary
     #[pyo3(signature = ())]
     #[pyo3(text_signature = "(self)")]
-    fn get_added_tokens_decoder(&self) -> HashMap<u32, PyAddedToken> {
-        self.tokenizer
-            .get_added_tokens_decoder()
-            .into_iter()
-            .map(|(key, value)| (key, value.into()))
-            .collect()
+    fn get_added_tokens_decoder(&self) -> BTreeMap<u32, PyAddedToken> {
+        let mut sorted_map = BTreeMap::new();
+
+        for (key, value) in self.tokenizer.get_added_tokens_decoder() {
+            sorted_map.insert(key, value.into());
+        }
+
+        sorted_map
     }
 
     /// Get the size of the underlying vocabulary

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -75,7 +75,7 @@ impl PyAddedToken {
             single_word: None,
             lstrip: None,
             rstrip: None,
-            normalized: None,
+            normalized: Some(!special.unwrap_or(true)),
         }
     }
 

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -662,6 +662,17 @@ impl PyTokenizer {
         self.tokenizer.get_vocab(with_added_tokens)
     }
 
+    /// Get the underlying vocabulary
+    /// 
+    /// Returns:
+    ///     :obj:`Dict[int, AddedToken]`: The vocabulary
+    #[pyo3(signature = ())]
+    #[pyo3(text_signature = "(self)")]
+    fn get_added_tokens_decoder(&self) -> HashMap<u32, PyAddedToken> {
+        self.tokenizer.get_added_tokens_decoder().into_iter().map(|(key, value)| (key, value.into())).collect()
+    }
+
+
     /// Get the size of the underlying vocabulary
     ///
     /// Args:

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -216,6 +216,12 @@ impl PyAddedToken {
         self.get_token().special
     }
 
+    /// Set the value of the :obj:`special` option
+    #[setter]
+    fn set_special(&mut self, special: bool) {
+        self.special = special;
+    }
+
     fn __str__(&self) -> PyResult<&str> {
         Ok(&self.content)
     }

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -55,6 +55,8 @@ use crate::utils::{MaybeSizedIterator, PyBufferedIterator};
 ///         text. For example, with the added token ``"yesterday"``, and a normalizer in charge of
 ///         lowercasing the text, the token could be extract from the input ``"I saw a lion
 ///         Yesterday"``.
+///     special (:obj:`bool`, defaults to :obj:`False` with :meth:`~tokenizers.Tokenizer.add_tokens` and :obj:`False` with :meth:`~tokenizers.Tokenizer.add_special_tokens`):
+///         Defines whether this token should be skipped when decoding.
 ///
 #[pyclass(dict, module = "tokenizers", name = "AddedToken")]
 pub struct PyAddedToken {
@@ -177,6 +179,12 @@ impl PyAddedToken {
     #[getter]
     fn get_content(&self) -> &str {
         &self.content
+    }
+
+    /// Set the content of this :obj:`AddedToken`
+    #[setter]
+    fn set_content(&self, content: String){
+        self.get_token().content = content
     }
 
     /// Get the value of the :obj:`rstrip` option

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -183,8 +183,8 @@ impl PyAddedToken {
 
     /// Set the content of this :obj:`AddedToken`
     #[setter]
-    fn set_content(&self, content: String){
-        self.get_token().content = content
+    fn set_content(&mut self, content: String) {
+        self.content = content.into();
     }
 
     /// Get the value of the :obj:`rstrip` option

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -184,7 +184,7 @@ impl PyAddedToken {
     /// Set the content of this :obj:`AddedToken`
     #[setter]
     fn set_content(&mut self, content: String) {
-        self.content = content.into();
+        self.content = content;
     }
 
     /// Get the value of the :obj:`rstrip` option

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -226,7 +226,7 @@ impl PyBpeTrainer {
                     if let Ok(content) = token.extract::<String>() {
                         Ok(tk::tokenizer::AddedToken::from(content, true))
                     } else if let Ok(mut token) = token.extract::<PyRefMut<PyAddedToken>>() {
-                        token.special = true;
+                        token.special = false;
                         Ok(token.get_token())
                     } else {
                         Err(exceptions::PyTypeError::new_err(

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -226,7 +226,7 @@ impl PyBpeTrainer {
                     if let Ok(content) = token.extract::<String>() {
                         Ok(tk::tokenizer::AddedToken::from(content, true))
                     } else if let Ok(mut token) = token.extract::<PyRefMut<PyAddedToken>>() {
-                        token.is_special_token = true;
+                        token.special = true;
                         Ok(token.get_token())
                     } else {
                         Err(exceptions::PyTypeError::new_err(
@@ -319,7 +319,7 @@ impl PyBpeTrainer {
                                     } else if let Ok(mut token) =
                                         token.extract::<PyRefMut<PyAddedToken>>()
                                     {
-                                        token.is_special_token = true;
+                                        token.special = true;
                                         Ok(token.get_token())
                                     } else {
                                         Err(exceptions::PyTypeError::new_err(
@@ -440,7 +440,7 @@ impl PyWordPieceTrainer {
                     if let Ok(content) = token.extract::<String>() {
                         Ok(tk::tokenizer::AddedToken::from(content, true))
                     } else if let Ok(mut token) = token.extract::<PyRefMut<PyAddedToken>>() {
-                        token.is_special_token = true;
+                        token.special = true;
                         Ok(token.get_token())
                     } else {
                         Err(exceptions::PyTypeError::new_err(
@@ -526,7 +526,7 @@ impl PyWordPieceTrainer {
                                     } else if let Ok(mut token) =
                                         token.extract::<PyRefMut<PyAddedToken>>()
                                     {
-                                        token.is_special_token = true;
+                                        token.special = true;
                                         Ok(token.get_token())
                                     } else {
                                         Err(exceptions::PyTypeError::new_err(
@@ -632,7 +632,7 @@ impl PyWordLevelTrainer {
                     if let Ok(content) = token.extract::<String>() {
                         Ok(tk::tokenizer::AddedToken::from(content, true))
                     } else if let Ok(mut token) = token.extract::<PyRefMut<PyAddedToken>>() {
-                        token.is_special_token = true;
+                        token.special = true;
                         Ok(token.get_token())
                     } else {
                         Err(exceptions::PyTypeError::new_err(
@@ -673,7 +673,7 @@ impl PyWordLevelTrainer {
                                     } else if let Ok(mut token) =
                                         token.extract::<PyRefMut<PyAddedToken>>()
                                     {
-                                        token.is_special_token = true;
+                                        token.special = true;
                                         Ok(token.get_token())
                                     } else {
                                         Err(exceptions::PyTypeError::new_err(
@@ -778,7 +778,7 @@ impl PyUnigramTrainer {
                     if let Ok(content) = token.extract::<String>() {
                         Ok(tk::tokenizer::AddedToken::from(content, true))
                     } else if let Ok(mut token) = token.extract::<PyRefMut<PyAddedToken>>() {
-                        token.is_special_token = true;
+                        token.special = true;
                         Ok(token.get_token())
                     } else {
                         Err(exceptions::PyTypeError::new_err(
@@ -846,7 +846,7 @@ impl PyUnigramTrainer {
                                 } else if let Ok(mut token) =
                                     token.extract::<PyRefMut<PyAddedToken>>()
                                 {
-                                    token.is_special_token = true;
+                                    token.special = true;
                                     Ok(token.get_token())
                                 } else {
                                     Err(exceptions::PyTypeError::new_err(

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -226,7 +226,7 @@ impl PyBpeTrainer {
                     if let Ok(content) = token.extract::<String>() {
                         Ok(tk::tokenizer::AddedToken::from(content, true))
                     } else if let Ok(mut token) = token.extract::<PyRefMut<PyAddedToken>>() {
-                        token.special = false;
+                        token.special = true;
                         Ok(token.get_token())
                     } else {
                         Err(exceptions::PyTypeError::new_err(

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -373,10 +373,16 @@ class TestTokenizer:
         # Can retrieve vocab without added tokens
         vocab = tokenizer.get_vocab(with_added_tokens=False)
         assert vocab == {}
-        
+
         # Can retrieve added token decoder
         vocab = tokenizer.get_added_tokens_decoder()
-        assert vocab == {0: AddedToken("my", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),1: AddedToken("name", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),2: AddedToken("is", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),3: AddedToken("john", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),4: AddedToken("pair", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False)}
+        assert vocab == {
+            0: AddedToken("my", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),
+            1: AddedToken("name", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),
+            2: AddedToken("is", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),
+            3: AddedToken("john", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),
+            4: AddedToken("pair", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),
+        }
 
     def test_get_vocab_size(self):
         tokenizer = Tokenizer(BPE())

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -16,6 +16,7 @@ from ..utils import bert_files, data_dir, multiprocessing_with_parallelism, robe
 class TestAddedToken:
     def test_instantiate_with_content_only(self):
         added_token = AddedToken("<mask>")
+        added_token.content = "<MASK>"
         assert type(added_token) == AddedToken
         assert str(added_token) == "<mask>"
         assert (

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -17,7 +17,10 @@ class TestAddedToken:
     def test_instantiate_with_content_only(self):
         added_token = AddedToken("<mask>")
         added_token.content = "<MASK>"
+        assert added_token.content == "<MASK>"
         assert type(added_token) == AddedToken
+        added_token.content = added_token.content.lower()
+        
         assert str(added_token) == "<mask>"
         assert (
             repr(added_token) == 'AddedToken("<mask>", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False)'

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -24,7 +24,7 @@ class TestAddedToken:
         assert added_token.special == False
         added_token.special = True
         assert added_token.special == True
-
+        added_token.special = False
         assert str(added_token) == "<mask>"
         assert (
             repr(added_token)

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -20,7 +20,7 @@ class TestAddedToken:
         assert added_token.content == "<MASK>"
         assert type(added_token) == AddedToken
         added_token.content = added_token.content.lower()
-        
+
         assert added_token.special == False
         added_token.special = True
         assert added_token.special == True

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -20,6 +20,10 @@ class TestAddedToken:
         assert added_token.content == "<MASK>"
         assert type(added_token) == AddedToken
         added_token.content = added_token.content.lower()
+        
+        assert added_token.special == False
+        added_token.special = True
+        assert added_token.special == True
 
         assert str(added_token) == "<mask>"
         assert (

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -20,10 +20,11 @@ class TestAddedToken:
         assert added_token.content == "<MASK>"
         assert type(added_token) == AddedToken
         added_token.content = added_token.content.lower()
-        
+
         assert str(added_token) == "<mask>"
         assert (
-            repr(added_token) == 'AddedToken("<mask>", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False)'
+            repr(added_token)
+            == 'AddedToken("<mask>", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False)'
         )
         assert added_token.rstrip == False
         assert added_token.lstrip == False

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -19,7 +19,7 @@ class TestAddedToken:
         assert type(added_token) == AddedToken
         assert str(added_token) == "<mask>"
         assert (
-            repr(added_token) == 'AddedToken("<mask>", rstrip=False, lstrip=False, single_word=False, normalized=True)'
+            repr(added_token) == 'AddedToken("<mask>", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False)'
         )
         assert added_token.rstrip == False
         assert added_token.lstrip == False

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -373,6 +373,10 @@ class TestTokenizer:
         # Can retrieve vocab without added tokens
         vocab = tokenizer.get_vocab(with_added_tokens=False)
         assert vocab == {}
+        
+        # Can retrieve added token decoder
+        vocab = tokenizer.get_added_tokens_decoder()
+        assert vocab == {0: AddedToken("my", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),1: AddedToken("name", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),2: AddedToken("is", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),3: AddedToken("john", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),4: AddedToken("pair", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False)}
 
     def test_get_vocab_size(self):
         tokenizer = Tokenizer(BPE())

--- a/bindings/python/tests/bindings/test_trainers.py
+++ b/bindings/python/tests/bindings/test_trainers.py
@@ -34,8 +34,8 @@ class TestBpeTrainer:
         assert trainer.min_frequency == 12
         assert trainer.show_progress == False
         assert trainer.special_tokens == [
-            AddedToken("1"),
-            AddedToken("2"),
+            AddedToken("1", special = True),
+            AddedToken("2", special = True),
         ]
         assert trainer.limit_alphabet == 13
         assert sorted(trainer.initial_alphabet) == ["a", "b", "c"]
@@ -91,8 +91,8 @@ class TestWordPieceTrainer:
         assert trainer.min_frequency == 12
         assert trainer.show_progress == False
         assert trainer.special_tokens == [
-            AddedToken("1"),
-            AddedToken("2"),
+            AddedToken("1", special = True),
+            AddedToken("2", special = True),
         ]
         assert trainer.limit_alphabet == 13
         assert sorted(trainer.initial_alphabet) == ["a", "b", "c"]
@@ -131,8 +131,8 @@ class TestWordLevelTrainer:
         assert trainer.min_frequency == 12
         assert trainer.show_progress == False
         assert trainer.special_tokens == [
-            AddedToken("1"),
-            AddedToken("2"),
+            AddedToken("1", special = True),
+            AddedToken("2", special = True),
         ]
 
         # Modify these
@@ -272,8 +272,8 @@ class TestUnigram:
         assert trainer.vocab_size == 12345
         assert trainer.show_progress == False
         assert trainer.special_tokens == [
-            AddedToken("1", normalized=False),
-            AddedToken("2", lstrip=True, normalized=False),
+            AddedToken("1", normalized=False, special = True),
+            AddedToken("2", lstrip=True, normalized=False, special = True),
         ]
         assert sorted(trainer.initial_alphabet) == ["a", "b", "c"]
 

--- a/bindings/python/tests/bindings/test_trainers.py
+++ b/bindings/python/tests/bindings/test_trainers.py
@@ -34,8 +34,8 @@ class TestBpeTrainer:
         assert trainer.min_frequency == 12
         assert trainer.show_progress == False
         assert trainer.special_tokens == [
-            AddedToken("1", special = True),
-            AddedToken("2", special = True),
+            AddedToken("1", special=True),
+            AddedToken("2", special=True),
         ]
         assert trainer.limit_alphabet == 13
         assert sorted(trainer.initial_alphabet) == ["a", "b", "c"]
@@ -91,8 +91,8 @@ class TestWordPieceTrainer:
         assert trainer.min_frequency == 12
         assert trainer.show_progress == False
         assert trainer.special_tokens == [
-            AddedToken("1", special = True),
-            AddedToken("2", special = True),
+            AddedToken("1", special=True),
+            AddedToken("2", special=True),
         ]
         assert trainer.limit_alphabet == 13
         assert sorted(trainer.initial_alphabet) == ["a", "b", "c"]
@@ -131,8 +131,8 @@ class TestWordLevelTrainer:
         assert trainer.min_frequency == 12
         assert trainer.show_progress == False
         assert trainer.special_tokens == [
-            AddedToken("1", special = True),
-            AddedToken("2", special = True),
+            AddedToken("1", special=True),
+            AddedToken("2", special=True),
         ]
 
         # Modify these
@@ -272,8 +272,8 @@ class TestUnigram:
         assert trainer.vocab_size == 12345
         assert trainer.show_progress == False
         assert trainer.special_tokens == [
-            AddedToken("1", normalized=False, special = True),
-            AddedToken("2", lstrip=True, normalized=False, special = True),
+            AddedToken("1", normalized=False, special=True),
+            AddedToken("2", lstrip=True, normalized=False, special=True),
         ]
         assert sorted(trainer.initial_alphabet) == ["a", "b", "c"]
 

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -678,6 +678,10 @@ mod tests {
         let mut token: AddedToken = AddedToken::from("Hey", false);
         token.content = "hey".to_string();
         assert_eq!(token.content, "hey"); // Token was already there
+
+        token.special = true;
+        assert_eq!(token.special, true); // Token was already there
+
     }
 
     #[test]

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -607,7 +607,7 @@ mod tests {
         assert_eq!(vocab.add_tokens(&[added_token.clone()], &model, normalizer),1);
         assert_eq!(vocab.len(), 3);
 
-        assert_eq!(vocab.get_vocab_r()[&1], added_token);
+        assert_eq!(vocab.get_vocab_r()[&0], added_token);
     }
 
     #[test]
@@ -652,8 +652,8 @@ mod tests {
             (3,AddedToken::from("added_token_2", true)),
             (0,AddedToken::from("test", true)),
         ]));
-
-        assert!(!vocab.added_tokens_map.contains_key("test"));
+        assert!(vocab.added_tokens_map.contains_key("test"));
+        assert!(vocab.added_tokens_map_r.contains_key(&0));
     }
 
     #[test]

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -609,7 +609,7 @@ mod tests {
         );
         assert_eq!(vocab.len(), 3);
 
-        assert_eq!(vocab.get_vocab_r()[&0], added_token);
+        assert_eq!(vocab.get_added_tokens_decoder()[&0], added_token);
     }
 
     #[test]
@@ -650,7 +650,7 @@ mod tests {
         assert_eq!(vocab.len(), 3); // New token was added
         assert!(vocab.is_special_token("test"));
         assert_eq!(
-            *vocab.get_vocab_r(),
+            *vocab.get_added_tokens_decoder(),
             HashMap::from([
                 (0, AddedToken::from("test", true)),
                 (2, AddedToken::from("added_token_1", true)),

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -675,10 +675,9 @@ mod tests {
         assert_eq!(vocab.get_vocab()["another_two"], 4); // Token idx not changed
 
         // Just checking that we can set the content of the string in rust
-        let mut token:AddedToken = AddedToken::from("Hey", false);
+        let mut token: AddedToken = AddedToken::from("Hey", false);
         token.content = "hey".to_string();
         assert_eq!(token.content, "hey"); // Token was already there
-
     }
 
     #[test]

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -650,7 +650,7 @@ mod tests {
         assert_eq!(*vocab.get_vocab_r(), HashMap::from([
             (2,AddedToken::from("added_token_1", true)),
             (3,AddedToken::from("added_token_2", true)),
-            (4,AddedToken::from("test", true)),
+            (0,AddedToken::from("test", true)),
         ]));
 
         assert!(!vocab.added_tokens_map.contains_key("test"));

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -180,8 +180,8 @@ impl AddedVocabulary {
             split_normalized_trie: (normalized_trie, vec![]),
         }
     }
-
     /// Size of the additional vocabulary
+    #[allow(dead_code)] // Suppress the "method is never used" warning
     pub fn len(&self) -> usize {
         self.added_tokens_map.len()
     }
@@ -585,7 +585,9 @@ mod tests {
             ),
             1
         );
-        assert_eq!(vocab.len(), 1);
+
+        let vocab_len: usize = vocab.len();
+        assert_eq!(vocab_len, 1);
 
         // Does not add multiple time the same token
         assert_eq!(
@@ -685,7 +687,7 @@ mod tests {
         assert_eq!(token.content, "hey"); // Token was already there
 
         token.special = true;
-        assert_eq!(token.special, true); // Token was already there
+        assert!(token.special); // Token was already there
     }
 
     #[test]
@@ -820,6 +822,8 @@ mod tests {
         let model = ModelMock::new(&[]);
         let mut vocab = AddedVocabulary::new();
         let normalizer = Lowercase;
+
+        assert_eq!(vocab.len(), 0);
 
         vocab.add_tokens(
             &[AddedToken::from("<mask>", false).single_word(true)],

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -192,7 +192,7 @@ impl AddedVocabulary {
     }
 
     /// Get the additional vocabulary with the AddedTokens
-    pub fn get_vocab_r(&self) -> &HashMap<u32, AddedToken> {
+    pub fn get_added_tokens_decoder(&self) -> &HashMap<u32, AddedToken> {
         &self.added_tokens_map_r
     }
 
@@ -260,7 +260,7 @@ impl AddedVocabulary {
                 self.added_tokens_map.values().cloned().max().map_or(
                     model.get_vocab_size() as u32,
                     |max| {
-                        if max >= (model.get_vocab_size() as u32) || model.get_vocab_size() == 0 {
+                        if (max >= model.get_vocab_size() as u32) || model.get_vocab_size() == 0 {
                             max + 1
                         } else {
                             model.get_vocab_size() as u32

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -673,6 +673,12 @@ mod tests {
         );
         assert_eq!(vocab.len(), 5); // Token was already there
         assert_eq!(vocab.get_vocab()["another_two"], 4); // Token idx not changed
+
+        // Just checking that we can set the content of the string in rust
+        let mut token:AddedToken = AddedToken::from("Hey", false);
+        token.content = "hey".to_string();
+        assert_eq!(token.content, "hey"); // Token was already there
+
     }
 
     #[test]

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -93,7 +93,12 @@ impl std::hash::Hash for AddedToken {
 }
 impl std::cmp::PartialEq for AddedToken {
     fn eq(&self, other: &Self) -> bool {
-        self.content == other.content && self.special == other.special && self.lstrip == other.lstrip && self.rstrip == other.rstrip && self.normalized == other.normalized && self.single_word == other.single_word
+        self.content == other.content
+            && self.special == other.special
+            && self.lstrip == other.lstrip
+            && self.rstrip == other.rstrip
+            && self.normalized == other.normalized
+            && self.single_word == other.single_word
     }
 }
 impl std::cmp::Eq for AddedToken {}
@@ -673,7 +678,10 @@ mod tests {
         assert_eq!(vocab.get_vocab()["another_two"], 4); // New token was added, but the index is not the length of the vocab
 
         // Let's add an already added token again
-        assert_eq!(vocab.add_special_tokens(&[AddedToken::from("another_two", true)], &model, normalizer), 1);
+        assert_eq!(
+            vocab.add_special_tokens(&[AddedToken::from("another_two", true)], &model, normalizer),
+            1
+        );
         assert_eq!(vocab.len(), 5); // Token was already there
         assert_eq!(vocab.get_vocab()["another_two"], 4); // Token idx not changed
     }

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 /// like:
 ///   - Whether they should only match single words
 ///   - Whether to include any whitespace on its left or right
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AddedToken {
     /// The content of the added token
     pub content: String,
@@ -91,17 +91,6 @@ impl std::hash::Hash for AddedToken {
         self.content.hash(state);
     }
 }
-impl std::cmp::PartialEq for AddedToken {
-    fn eq(&self, other: &Self) -> bool {
-        self.content == other.content
-            && self.special == other.special
-            && self.lstrip == other.lstrip
-            && self.rstrip == other.rstrip
-            && self.normalized == other.normalized
-            && self.single_word == other.single_word
-    }
-}
-impl std::cmp::Eq for AddedToken {}
 
 type MatchingSet = (AhoCorasick, Vec<u32>);
 

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -261,7 +261,7 @@ impl AddedVocabulary {
                     .values()
                     .cloned()
                     .max()
-                    .map_or(model.get_vocab_size() as u32, |max| max.clone() + 1)
+                    .map_or(model.get_vocab_size() as u32, |max| max + 1)
             };
             // Make sure we modify the previous entry
             self.added_tokens_map

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -259,7 +259,7 @@ impl AddedVocabulary {
                 ignored += 1;
                 continue;
             }
-            
+
             // If a token is already part of the vocabulary, we mark it as added
             let id = if let Some(id) = self.token_to_id(&token.content, model) {
                 id
@@ -267,14 +267,16 @@ impl AddedVocabulary {
                 let new_id = (model.get_vocab_size() + self.added_tokens_map.len()) as u32;
                 new_id
             };
-            
-            if self.added_tokens_map_r.values().any(| val| val == token){
+
+            if self.added_tokens_map_r.values().any(|val| val == token) {
                 // We only ignore if the AddedToken is already part of the added_tokens_map_r
-                ignored +=1;
-            }
-            else{
+                ignored += 1;
+            } else {
                 // Make sure we modify the previous entry
-                self.added_tokens_map.entry(token.content.clone()).and_modify(|old_id| *old_id = id).or_insert_with(||id);
+                self.added_tokens_map
+                    .entry(token.content.clone())
+                    .and_modify(|old_id| *old_id = id)
+                    .or_insert_with(|| id);
                 if !self.special_tokens_set.contains(&token.content) {
                     self.added_tokens.push(token.clone());
                 }
@@ -284,7 +286,6 @@ impl AddedVocabulary {
                     .and_modify(|t| *t = token.clone())
                     .or_insert_with(|| token.clone());
             }
-
         }
 
         self.refresh_added_tokens(model, normalizer);
@@ -603,8 +604,11 @@ mod tests {
         assert_eq!(vocab.len(), 2);
 
         // Also adds tokens already covered by the model
-        let added_token= AddedToken::from("test", false);
-        assert_eq!(vocab.add_tokens(&[added_token.clone()], &model, normalizer),1);
+        let added_token = AddedToken::from("test", false);
+        assert_eq!(
+            vocab.add_tokens(&[added_token.clone()], &model, normalizer),
+            1
+        );
         assert_eq!(vocab.len(), 3);
 
         assert_eq!(vocab.get_vocab_r()[&0], added_token);
@@ -647,11 +651,14 @@ mod tests {
         );
         assert_eq!(vocab.len(), 3); // New token was added
         assert!(vocab.is_special_token("test"));
-        assert_eq!(*vocab.get_vocab_r(), HashMap::from([
-            (2,AddedToken::from("added_token_1", true)),
-            (3,AddedToken::from("added_token_2", true)),
-            (0,AddedToken::from("test", true)),
-        ]));
+        assert_eq!(
+            *vocab.get_vocab_r(),
+            HashMap::from([
+                (2, AddedToken::from("added_token_1", true)),
+                (3, AddedToken::from("added_token_2", true)),
+                (0, AddedToken::from("test", true)),
+            ])
+        );
         assert!(vocab.added_tokens_map.contains_key("test"));
         assert!(vocab.added_tokens_map_r.contains_key(&0));
     }

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -257,11 +257,16 @@ impl AddedVocabulary {
             let new_id = if let Some(new_id) = self.token_to_id(&token.content, model) {
                 new_id
             } else {
-                self.added_tokens_map
-                    .values()
-                    .cloned()
-                    .max()
-                    .map_or(model.get_vocab_size() as u32, |max| max + 1)
+                self.added_tokens_map.values().cloned().max().map_or(
+                    model.get_vocab_size() as u32,
+                    |max| {
+                        if max >= (model.get_vocab_size() as u32) || model.get_vocab_size() == 0 {
+                            max + 1
+                        } else {
+                            model.get_vocab_size() as u32
+                        }
+                    },
+                )
             };
             // Make sure we modify the previous entry
             self.added_tokens_map
@@ -681,7 +686,6 @@ mod tests {
 
         token.special = true;
         assert_eq!(token.special, true); // Token was already there
-
     }
 
     #[test]

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -264,7 +264,7 @@ impl AddedVocabulary {
             let id = if let Some(id) = self.token_to_id(&token.content, model) {
                 id
             } else {
-                let new_id = (model.get_vocab_size() + self.added_tokens_map.len()) as u32;
+                let new_id = (model.get_vocab_size() + cmp::max(self.added_tokens_map_r.keys(),0)) as u32;
                 new_id
             };
 

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -85,8 +85,7 @@ impl Default for AddedToken {
         }
     }
 }
-// We only want to hash on the content. AddedToken cannot be added multiple times with different
-// options
+// AddedTokens can be updated if value changed
 impl std::hash::Hash for AddedToken {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.content.hash(state);
@@ -94,7 +93,7 @@ impl std::hash::Hash for AddedToken {
 }
 impl std::cmp::PartialEq for AddedToken {
     fn eq(&self, other: &Self) -> bool {
-        self.content == other.content
+        self.content == other.content && self.special == other.special && self.lstrip == other.lstrip && self.rstrip == other.rstrip && self.normalized == other.normalized && self.single_word == other.single_word
     }
 }
 impl std::cmp::Eq for AddedToken {}
@@ -665,13 +664,18 @@ mod tests {
         vocab.add_tokens(
             &[
                 AddedToken::from("tost", true),
-                AddedToken::from("another_two", true),
+                AddedToken::from("another_two", false),
             ],
             &model,
             normalizer,
         );
         assert_eq!(vocab.len(), 5); // New token was added
         assert_eq!(vocab.get_vocab()["another_two"], 4); // New token was added, but the index is not the length of the vocab
+
+        // Let's add an already added token again
+        assert_eq!(vocab.add_special_tokens(&[AddedToken::from("another_two", true)], &model, normalizer), 1);
+        assert_eq!(vocab.len(), 5); // Token was already there
+        assert_eq!(vocab.get_vocab()["another_two"], 4); // Token idx not changed
     }
 
     #[test]

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -668,12 +668,11 @@ where
     pub fn get_vocab_size(&self, with_added_tokens: bool) -> usize {
         // TODO ArthurZ THIS IS WRONG! We need to measure the length of the `set` because
         // now some tokens can be both in the added_tokens_encoder and in the vocab
-        self.model.get_vocab_size()
-            + if with_added_tokens {
-                self.added_vocabulary.len()
-            } else {
-                0
-            }
+        if with_added_tokens {
+            self.get_vocab(with_added_tokens).len()
+        } else {
+            self.model.get_vocab_size()
+        }
     }
 
     /// Converts a token in the corresponding id.

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -669,7 +669,7 @@ where
         // TODO ArthurZ THIS IS WRONG! We need to measure the length of the `set` because
         // now some tokens can be both in the added_tokens_encoder and in the vocab
         if with_added_tokens {
-            self.get_vocab(with_added_tokens).len()
+            self.get_vocab(true).len()
         } else {
             self.model.get_vocab_size()
         }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -659,11 +659,9 @@ where
         final_vocab
     }
 
-    /// Get the added vocabulary only
-
     /// Get the added tokens decoder
-    pub fn get_added_tokens_decoder(&self) -> &HashMap<u32, AddedToken> {
-        self.added_vocabulary.get_vocab_r()
+    pub fn get_added_tokens_decoder(&self) -> HashMap<u32, AddedToken> {
+        self.added_vocabulary.get_added_tokens_decoder().clone()
     }
 
     /// Get the size of the vocabulary

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -660,8 +660,8 @@ where
     }
 
     /// Get the added vocabulary only
-    
-    /// Get the added tokens decoder 
+
+    /// Get the added tokens decoder
     pub fn get_added_tokens_decoder(&self) -> &HashMap<u32, AddedToken> {
         self.added_vocabulary.get_vocab_r()
     }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -659,8 +659,17 @@ where
         final_vocab
     }
 
+    /// Get the added vocabulary only
+    
+    /// Get the added tokens decoder 
+    pub fn get_added_tokens_decoder(&self) -> &HashMap<u32, AddedToken> {
+        self.added_vocabulary.get_vocab_r()
+    }
+
     /// Get the size of the vocabulary
     pub fn get_vocab_size(&self, with_added_tokens: bool) -> usize {
+        // TODO ArthurZ THIS IS WRONG! We need to measure the length of the `set` because
+        // now some tokens can be both in the added_tokens_encoder and in the vocab
         self.model.get_vocab_size()
             + if with_added_tokens {
                 self.added_vocabulary.len()


### PR DESCRIPTION
# What does this PR do?
Fixes #1334 and refactors the `AddedVocabulary`. Previously the when a token was already part of the vocabuary it was not added to the `added_tokens_map` but still added to `added_tokens_map_r` which is not consistent. Now it is added in both even if it already existed. 

Here is a small snippet of what is now possible in python

```python
>>> from tokenizers import AddedToken, Tokenizer
>>> token = AddedToken("HEY")
>>> tokenizer = Tokenizer.from_pretrained("gpt2")
>>> tokenizer.get_added_tokens_decoder()

>>> tokenizer.add_tokens([token])
1
>>> token.special = False
>>> tokenizer.add_tokens([token])
1 
>>> tokenizer.get_vocab_size()
50258
>>> content = tokenizer.decode([4])
'%'
>>> tokenizer.add_tokens([AddedToken('%')])
1
>>> tokenizer.get_added_tokens_decoder()
{4: AddedToken("%", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False),
 50256: AddedToken("<|endoftext|>", rstrip=False, lstrip=False, single_word=False, normalized=True, special=True),
 50257: AddedToken("HEY", rstrip=False, lstrip=False, single_word=False, normalized=True, special=False)}
>>> tokenizer.get_vocab_size()
50258
```
