### PR TITLE
Added ability to inspect a 'Sequence' pre-tokenizer.

### DIFF
--- a/tokenizers/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/src/pre_tokenizers/sequence.rs
@@ -6,27 +6,27 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct Sequence {
-    pre_tokenizers: Vec<PreTokenizerWrapper>,
+    pretokenizers: Vec<PreTokenizerWrapper>,
 }
 
 impl Sequence {
-    pub fn new(pre_tokenizers: Vec<PreTokenizerWrapper>) -> Self {
-        Self { pre_tokenizers }
+    pub fn new(pretokenizers: Vec<PreTokenizerWrapper>) -> Self {
+        Self { pretokenizers }
     }
 
     pub fn get_pre_tokenizers(&self) -> &[PreTokenizerWrapper] {
-        &self.pre_tokenizers
+        &self.pretokenizers
     }
 
     pub fn get_pre_tokenizers_mut(&mut self) -> &mut [PreTokenizerWrapper] {
-        &mut self.pre_tokenizers
+        &mut self.pretokenizers
     }
 }
 
 impl PreTokenizer for Sequence {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
-        for pre_tokenizer in &self.pre_tokenizers {
-            pre_tokenizer.pre_tokenize(pretokenized)?;
+        for pretokenizer in &self.pretokenizers {
+            pretokenizer.pre_tokenize(pretokenized)?;
         }
         Ok(())
     }

--- a/tokenizers/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/src/pre_tokenizers/sequence.rs
@@ -6,19 +6,27 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct Sequence {
-    pretokenizers: Vec<PreTokenizerWrapper>,
+    pre_tokenizers: Vec<PreTokenizerWrapper>,
 }
 
 impl Sequence {
     pub fn new(pretokenizers: Vec<PreTokenizerWrapper>) -> Self {
-        Self { pretokenizers }
+        Self { pre_tokenizers: pretokenizers }
+    }
+
+    pub fn get_pre_tokenizers(&self) -> &[PreTokenizerWrapper] {
+        &self.pre_tokenizers
+    }
+
+    pub fn get_pre_tokenizers_mut(&mut self) -> &mut [PreTokenizerWrapper] {
+        &mut self.pre_tokenizers
     }
 }
 
 impl PreTokenizer for Sequence {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
-        for pretokenizer in &self.pretokenizers {
-            pretokenizer.pre_tokenize(pretokenized)?;
+        for pre_tokenizer in &self.pre_tokenizers {
+            pre_tokenizer.pre_tokenize(pretokenized)?;
         }
         Ok(())
     }

--- a/tokenizers/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/src/pre_tokenizers/sequence.rs
@@ -10,8 +10,8 @@ pub struct Sequence {
 }
 
 impl Sequence {
-    pub fn new(pretokenizers: Vec<PreTokenizerWrapper>) -> Self {
-        Self { pre_tokenizers: pretokenizers }
+    pub fn new(pre_tokenizers: Vec<PreTokenizerWrapper>) -> Self {
+        Self { pre_tokenizers }
     }
 
     pub fn get_pre_tokenizers(&self) -> &[PreTokenizerWrapper] {

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -401,7 +401,7 @@ where
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Tokenizer(
-    pub TokenizerImpl<
+    pub  TokenizerImpl<
         ModelWrapper,
         NormalizerWrapper,
         PreTokenizerWrapper,

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -401,7 +401,7 @@ where
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Tokenizer(
-    TokenizerImpl<
+    pub TokenizerImpl<
         ModelWrapper,
         NormalizerWrapper,
         PreTokenizerWrapper,

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -401,7 +401,7 @@ where
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Tokenizer(
-    pub  TokenizerImpl<
+    TokenizerImpl<
         ModelWrapper,
         NormalizerWrapper,
         PreTokenizerWrapper,


### PR DESCRIPTION
I ran into this while attempting to create a modified copy of a `Tokenizer` instance after it has been created.