### PR TITLE
 fix: remove useless token

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -18,5 +18,4 @@ jobs:
       package_path: tokenizers/bindings/python/
       install_rust: true
     secrets:
-      token: ${{ secrets.HUGGINGFACE_PUSH }}
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}


### PR DESCRIPTION
This token is not used by your action.
Secret is removed from the repository.