### PR TITLE
Rename modeled `token_to_id`

### DIFF
--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -199,7 +199,7 @@ impl AddedVocabulary {
     }
 
     /// Get the id matching one of our token if it exists
-    pub fn token_to_id(&self, token: &str, model: &impl Model) -> Option<u32> {
+    pub fn token_to_id_model(&self, token: &str, model: &impl Model) -> Option<u32> {
         self.added_tokens_map
             .get(token)
             .copied()
@@ -256,7 +256,7 @@ impl AddedVocabulary {
                 continue;
             }
             // If a token is already part of the vocabulary, we mark it as added
-            let new_id = if let Some(new_id) = self.token_to_id(&token.content, model) {
+            let new_id = if let Some(new_id) = self.token_to_id_model(&token.content, model) {
                 new_id
             } else {
                 self.added_tokens_map.values().cloned().max().map_or(
@@ -307,7 +307,7 @@ impl AddedVocabulary {
             .map(|token| {
                 (
                     token,
-                    self.token_to_id(&token.content, model)
+                    self.token_to_id_model(&token.content, model)
                         .expect("Missing additional token"),
                 )
             })

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -677,7 +677,7 @@ where
 
     /// Converts a token in the corresponding id.
     pub fn token_to_id(&self, token: &str) -> Option<u32> {
-        self.added_vocabulary.token_to_id(token, &self.model)
+        self.added_vocabulary.token_to_id_model(token, &self.model)
     }
 
     /// Converts an id to the corresponding token.


### PR DESCRIPTION
Currently, there are two different public `token_to_id` methods.

One can be found in `tokenizers/src/tokenizer/added_vocabulary.rs`
as part of the `AddedVocabulary` struct

another is found in `tokenizers/src/tokenizer/mod.rs`
as part of `TokenizerImpl` struct

This causes issues with type inference especially with 
https://github.com/huggingface/tokenizers/blob/c718c53bb95884752badfbb27920396bb2df1518/tokenizers/src/tokenizer/added_vocabulary.rs#L259

where `rust-analyzer` complains of [E0107](https://doc.rust-lang.org/stable/error_codes/E0107.html)

Since it technically builds its not a real error, and the compiler itself eventually finds out the correct version to use, I think renaming one of the functions would be the best option.

Changing visibility might help the problem go away, but 
https://github.com/huggingface/tokenizers/blob/c718c53bb95884752badfbb27920396bb2df1518/tokenizers/src/tokenizer/added_vocabulary.rs#L202
```
    pub fn token_to_id(&self, token: &str, model: &impl Model) -> Option<u32> {
        self.added_tokens_map
            .get(token)
            .copied()
            .or_else(|| model.token_to_id(token))
    }
```
will still remain ambiguous in such cases.

I think multiple approaches  including more informative fn names could be helpful as well
(since `AddedVocabulary` 's `token_to_id` is used only there change it's version into `addedvocab_token_to_id`?)

