### PR TITLE
Derive `Clone` on `Tokenizer`, add `Encoding.into_tokens()` method

### DIFF
--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -126,6 +126,10 @@ impl Encoding {
         &self.tokens[..]
     }
 
+    pub fn into_tokens(self) -> Vec<String> {
+        self.tokens
+    }
+
     pub fn get_word_ids(&self) -> &[Option<u32>] {
         &self.words
     }

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -126,10 +126,6 @@ impl Encoding {
         &self.tokens[..]
     }
 
-    pub fn into_tokens(self) -> Vec<String> {
-        self.tokens
-    }
-
     pub fn get_word_ids(&self) -> &[Option<u32>] {
         &self.words
     }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -399,7 +399,7 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Tokenizer(
     TokenizerImpl<
         ModelWrapper,


### PR DESCRIPTION
Hey team,

For the [What's In My Big Data? (WIMBD)](https://arxiv.org/abs/2310.20707) project I found that we needed a couple additional features in the Rust library here. Currently we're depending on my fork of tokenizers but I was hoping we could get this merged and released so I can publish our `wimbd` crate.

The changes proposed are:
- Deriving the `Clone` trait for the `Tokenizer` struct. This proved super useful so we don't need to re-instantiate the same tokenizer over and over when we run worker jobs in threads.
- Adding an `.into_tokens() -> Vec<String>` method on the `Encoding` class so we can easily get an owned `Vec` of the raw tokens without having to create a new one.