### PR TITLE
Fix truncation length assertion

### DIFF
--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -605,7 +605,7 @@ where
         if let Some(trunc_params) = &trunc {
             let n_added_tokens = self.get_n_added_tokens(false);
             let effective_max_length = trunc_params.max_length - n_added_tokens;
-            if effective_max_length < trunc_params.stride {
+            if effective_max_length <= trunc_params.stride {
                 return Err(Box::new(TruncationParamError(format!(
                     "tokenizer stride set to {}, which is greater than or equal to its effective max length of {} (= {} original max length - {} added special tokens), ",
                     trunc_params.stride, effective_max_length, trunc_params.max_length, n_added_tokens


### PR DESCRIPTION
Fixes #1326 

I haven't seen any explanation from @Narsil why [the line in question](https://github.com/huggingface/tokenizers/blob/9a93c50c25c1e0b73a85584f327113bcbef5ac80/tokenizers/src/tokenizer/mod.rs#L608) was changed, so I just went ahead and made this PR reversing it.

I've tested my version of this locally and can confirm that there are no longer two different errors at different places for slightly different invalid stride values:

```python
from tokenizers import Tokenizer

tokenizer = Tokenizer.from_pretrained('bert-base-cased')
tokenizer.enable_truncation(max_length=10, stride=9)  # This line still fails (as it should)
print(tokenizer.encode("This piece of text is at least ten tokens long. In fact, it is likely many more than that."))

tokenizer = Tokenizer.from_pretrained('bert-base-cased')
tokenizer.enable_truncation(max_length=10, stride=8)  # Now this line (correctly) fails too
print(tokenizer.encode("This piece of text is at least ten tokens long. In fact, it is likely many more than that."))
```