### PR TITLE
Allow `huggingface_hub<1.0`

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = [
     'license',
     'readme',
 ]
-dependencies = ["huggingface_hub>=0.16.4,<0.19"]
+dependencies = ["huggingface_hub>=0.16.4,<1.0"]
 
 [project.urls]
 Homepage = 'https://github.com/huggingface/tokenizers'


### PR DESCRIPTION
Follow-up PR after https://github.com/huggingface/tokenizers/pull/1383 and especially https://github.com/huggingface/tokenizers/pull/1383#issuecomment-1794980028. I still believe that we should not block `huggingface_hub` from introducing breaking changes. However for the most used and less prone to change APIs (like the upload/download ones), I'm more than fine to consider them as "fixed until at least v1.0".

I've looked into `tokenizers` implementation and given that it uses only `hf_hub_download`, let's set `huggingface_hub<1.0` as dependency. This will reduce the friction for users wanting to install the latest `huggingface_hub` version. If at any point `tokenizers` starts to use other methods, let's reassess and chose a solution described in https://github.com/huggingface/tokenizers/pull/1383#issuecomment-1794980028. In the meantime, I think we should merge this PR.


(also related: once merged and released you should be able to delete https://github.com/huggingface/tokenizers/pull/1377 @clefourrier)