### PR TITLE
Efficient Replace normalizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,5 @@ print(output.tokens)
 # ["Hello", ",", "y", "'", "all", "!", "How", "are", "you", "[UNK]", "?"]
 ```
 
-Check the [python documentation](https://huggingface.co/docs/tokenizers/index) or the
-
-[python quicktour](https://huggingface.co/docs/tokenizers/python/latest/quicktour.html) to learn
-more!
+Check the [documentation](https://huggingface.co/docs/tokenizers/index)
+or the [quicktour](https://huggingface.co/docs/tokenizers/quicktour) to learn more!

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -672,8 +672,6 @@ impl NormalizedString {
         Ok(())
     }
 
-
-
     /// Clear the normalized part of the string
     pub fn clear(&mut self) -> usize {
         let len = self.len();

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -663,7 +663,7 @@ impl NormalizedString {
                 }
             });
 
-        // Copy the part remaining part of the input
+        // Copy the remaining part of the input
         new_normalized.push_str(&self.normalized[last_end..]);
         new_alignments.extend(&self.alignments[last_end..]);
 

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -5,19 +5,6 @@ use unicode_normalization_alignments::UnicodeNormalization;
 
 use serde::{Deserialize, Serialize};
 
-/// Add or Substract a signed isize on a usize. Makes sure of avoiding
-/// any substraction overflow, flooring at 0.
-macro_rules! apply_signed {
-    ($origin: expr, $signed: expr) => {
-        if $signed.is_positive() {
-            $origin += $signed as usize;
-        } else {
-            let (result, overflow) = $origin.overflowing_sub(-($signed) as usize);
-            $origin = if overflow { 0 } else { result };
-        }
-    };
-}
-
 /// The possible offsets referential
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OffsetReferential {

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -567,9 +567,6 @@ impl NormalizedString {
 
     /// Replace anything that matches the pattern with the given content.
     pub fn replace<P: Pattern>(&mut self, pattern: P, content: &str) -> Result<()> {
-        let mut num_matches = 0;
-        let start = std::time::Instant::now();
-        let mut time_spent_in = std::time::Duration::new(0, 0);
         let mut new_normalized = String::with_capacity(self.normalized.len()); // Initially allocate for the input size
         let mut new_alignments: Vec<(usize, usize)> = Vec::with_capacity(self.alignments.len());
         let mut last_end = 0; // Keep track of the last end position
@@ -579,14 +576,10 @@ impl NormalizedString {
             .into_iter()
             .for_each(|((start, end), is_match)| {
                 if is_match {
-                    num_matches += 1;
                     let range = start..end;
-                    //apply_signed!(range.start, offset);
-                    //apply_signed!(range.end, offset);
 
                     let mut new_len = 0;
                     let removed_chars = self.normalized[range.clone()].chars().count();
-                    let this_start = std::time::Instant::now();
 
                     /* The following code is equivalent to this call, but computationally much more efficient
                     self.transform_range(
@@ -620,7 +613,6 @@ impl NormalizedString {
                         (c, 1)
                     });
                     let mut offset = (initial_removed + n_range.start) as isize;
-                    //let mut alignments = Vec::with_capacity(n_range.len());
                     let normalized = dest
                         .into_iter()
                         .map(|(c, changes): (char, i32)| {
@@ -666,17 +658,7 @@ impl NormalizedString {
                         })
                         .collect::<String>();
 
-                    //self.alignments.splice(n_range.clone(), alignments);
                     new_normalized.push_str(&normalized);
-                    /*unsafe {
-                        self.normalized
-                            .as_mut_vec()
-                            .splice(n_range, normalized.bytes());
-                    }*/
-                    time_spent_in += this_start.elapsed();
-
-                    let old_len = end - start;
-                    offset += new_len as isize - old_len as isize;
                     last_end = end;
                 }
             });
@@ -685,11 +667,8 @@ impl NormalizedString {
         new_normalized.push_str(&self.normalized[last_end..]);
         new_alignments.extend(&self.alignments[last_end..]);
 
-        self.normalized = new_normalized; //std::mem::take(&mut new_normalized);
+        self.normalized = new_normalized;
         self.alignments = new_alignments;
-
-        println!("Replaced {} matches in {:?}", num_matches, start.elapsed());
-        println!("Time spent in transform: {:?}", time_spent_in);
         Ok(())
     }
 


### PR DESCRIPTION
The existing Replace normalizer, used for example in the Llama and Mistral tokenizers, is implemented very inefficiently.
This results in normalization taking orders of magnitude longer than it should, making it very time consuming to tokenize long sequences. I've seen a few issues that probably refer to this, for example https://github.com/huggingface/transformers/issues/25873.

This PR replaces the existing implementation -- which seems to scale quadratically with sequence length and number of matches -- with an implementation that scales linearly, while (hopefully) retaining the exact same semantics.
In my benchmarks with real long-sequence data, tokenizing with the Llama tokenizer is more than two orders of magnitude faster.