### PR TITLE
Added support for building an `AddedVocabulary` based on a pre-existing `AddedVocabulary`.

### DIFF
--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -1046,6 +1046,17 @@ class Tokenizer:
                 Whether the JSON file should be pretty formatted.
         """
         pass
+    def set_added_tokens_decoder(self, added_tokens_decoder, encode_special_tokens=False):
+        """
+        Sets the underlying added tokens vocabulary
+
+        Args:
+            added_tokens_decoder (:obj:`Dict[int, AddedToken]`):
+                Map from added token ID to :obj:`AddedToken`.
+            encode_special_tokens (:obj:`bool`, defaults to :obj:`False`):
+                Whether or not special tokens should be split when encoding. This is equivalent to ignoring them.
+        """
+        pass
     def to_str(self, pretty=False):
         """
         Gets a serialized string representing this :class:`~tokenizers.Tokenizer`.

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -668,7 +668,7 @@ impl PyTokenizer {
     /// Args:
     ///     added_tokens_decoder (:obj:`Dict[int, AddedToken]`):
     ///         Map from added token ID to :obj:`AddedToken`.
-    ///     encode_special_tokens (:obj:`bool`, defaults to :onj:`False`):
+    ///     encode_special_tokens (:obj:`bool`, defaults to :obj:`False`):
     ///         Whether or not special tokens should be split when encoding. This is equivalent to ignoring them.
     #[pyo3(signature = (added_tokens_decoder, encode_special_tokens = false))]
     #[pyo3(text_signature = "(self, added_tokens_decoder, encode_special_tokens=False)")]

--- a/tokenizers/src/decoders/sequence.rs
+++ b/tokenizers/src/decoders/sequence.rs
@@ -13,6 +13,14 @@ impl Sequence {
     pub fn new(decoders: Vec<DecoderWrapper>) -> Self {
         Self { decoders }
     }
+
+    pub fn get_decoders(&self) -> &[DecoderWrapper] {
+        &self.decoders
+    }
+
+    pub fn get_decoders_mut(&mut self) -> &mut [DecoderWrapper] {
+        &mut self.decoders
+    }
 }
 
 impl Decoder for Sequence {

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -139,7 +139,7 @@ fn space_rightmost_at_start(sentence: &str) -> usize {
 /// exist as required.
 ///
 #[derive(Clone, Debug)]
-pub(super) struct AddedVocabulary {
+pub struct AddedVocabulary {
     /// Contains the mapping from String (token content) to ID. This map contains both special
     /// tokens and classic added tokens that were added to the this vocabulary.
     added_tokens_map: HashMap<String, u32>,
@@ -190,6 +190,11 @@ impl AddedVocabulary {
     #[allow(dead_code)] // Suppress the "method is never used" warning
     pub fn len(&self) -> usize {
         self.added_tokens_map.len()
+    }
+
+    /// Whether or not this vocabulary is empty
+    pub fn is_empty(&self) -> bool {
+        self.added_tokens_map.is_empty()
     }
 
     /// Get the additional vocabulary
@@ -484,6 +489,12 @@ impl AddedVocabulary {
         // "I read a " "[DAY]", "book monday" -> "i read a " "[day]", "book monday"
 
         pretokenized
+    }
+}
+
+impl Default for AddedVocabulary {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -198,7 +198,7 @@ impl AddedVocabulary {
     ) -> Self {
         let mut vocabulary = AddedVocabulary::new();
         vocabulary.encode_special_tokens = encode_special_tokens;
-        
+
         // Handle special tokens (if any).
         for token in tokens.values() {
             if token.special
@@ -209,19 +209,25 @@ impl AddedVocabulary {
                 vocabulary.special_tokens_set.insert(token.content.clone());
             }
         }
-        
+
         for (token_id, token) in tokens {
-            if token.content.is_empty() || vocabulary.added_tokens_map_r.values().any(|val| *val == token)
+            if token.content.is_empty()
+                || vocabulary
+                    .added_tokens_map_r
+                    .values()
+                    .any(|val| *val == token)
             {
                 continue;
             }
 
-            vocabulary.added_tokens_map
+            vocabulary
+                .added_tokens_map
                 .entry(token.content.clone())
                 .and_modify(|old_id| *old_id = token_id)
                 .or_insert_with(|| token_id);
 
-            vocabulary.added_tokens_map_r
+            vocabulary
+                .added_tokens_map_r
                 .entry(token_id)
                 .and_modify(|t| *t = token.clone())
                 .or_insert_with(|| token.clone());

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -384,6 +384,12 @@ where
         self
     }
 
+    /// Set the added vocabulary.
+    pub fn with_added_vocabulary(mut self, added_vocabulary: AddedVocabulary) -> Self {
+        self.added_vocabulary = added_vocabulary;
+        self
+    }
+
     /// Set the trunaction parameters.
     #[must_use]
     pub fn with_truncation(mut self, trunc: Option<TruncationParams>) -> Self {
@@ -596,6 +602,17 @@ where
     /// Get the model
     pub fn get_model(&self) -> &M {
         &self.model
+    }
+
+    /// Set the added vocabulary.
+    pub fn with_added_vocabulary(&mut self, added_vocabulary: AddedVocabulary) -> &mut Self {
+        self.added_vocabulary = added_vocabulary.into();
+        self
+    }
+
+    /// Get the added vocabulary
+    pub fn get_added_vocabulary(&self) -> &AddedVocabulary {
+        &self.added_vocabulary
     }
 
     /// Set the truncation parameters

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -606,7 +606,7 @@ where
 
     /// Set the added vocabulary.
     pub fn with_added_vocabulary(&mut self, added_vocabulary: AddedVocabulary) -> &mut Self {
-        self.added_vocabulary = added_vocabulary.into();
+        self.added_vocabulary = added_vocabulary;
         self
     }
 


### PR DESCRIPTION
(This PR is stacked on top of #1443 and so currently shows the changes for both PRs together)

The changes introduced in this PR are necessary if one wants to maintain the token IDs of the pre-existing `AddedVocabulary` and more importantly, they are necessary if one wants to build a fast tokenizer correctly based on a Python tokenizer.

Consider for example the [Yi tokenizer](https://huggingface.co/01-ai/Yi-6B-Chat/blob/main/tokenizer_config.json). If one tries to load a fast tokenizer for Yi, then you will end up with token IDs 64000 and 64001 for the BOS and EOS tokens, respectively. That's because that tokenizer uses custom BOS and EOS tokens but assigns them known/pre-existing IDs via the `added_tokens_decoder` field. These IDs end up getting ignored when building the fast tokenizer due to the code block starting [here](https://github.com/huggingface/transformers/blob/e547458c43dfdbbb8f6a7757237e234c44e20a8f/src/transformers/tokenization_utils_fast.py#L162). This is also evident from the recommendation of the Yi model authors to set `use_fast=False` as shown [here](https://huggingface.co/01-ai/Yi-34B-Chat#perform-inference-with-yi-chat-model).

That's at least partially because this library does not support building tokenizers using a pre-existing `AddedVocabulary`. This PR adds support for that. I plan to follow up with a PR in the `transformers` library after this PR is merged, updating that code block.