### PR TITLE
feat: support custom regexes for GPT pre-tokenizer

### DIFF
--- a/tokenizers/src/processors/sequence.rs
+++ b/tokenizers/src/processors/sequence.rs
@@ -64,7 +64,7 @@ mod tests {
         );
 
         let bytelevel = ByteLevel::default().trim_offsets(true);
-        let sequence = Sequence::new(vec![PostProcessorWrapper::ByteLevel(bytelevel)]);
+        let sequence = Sequence::new(vec![PostProcessorWrapper::ByteLevel(bytelevel.clone())]);
         let expected = Encoding::new(
             vec![0; 5],
             vec![0; 5],

--- a/tokenizers/tests/serialization.rs
+++ b/tokenizers/tests/serialization.rs
@@ -173,7 +173,7 @@ fn decoders() {
     let byte_level_ser = serde_json::to_string(&byte_level).unwrap();
     assert_eq!(
         byte_level_ser,
-        r#"{"type":"ByteLevel","add_prefix_space":true,"trim_offsets":true,"use_regex":true}"#
+        r#"{"type":"ByteLevel","add_prefix_space":true,"trim_offsets":true,"use_regex":true,"custom_regex":null}"#
     );
     serde_json::from_str::<ByteLevel>(&byte_level_ser).unwrap();
     let byte_level_wrapper: DecoderWrapper = serde_json::from_str(&byte_level_ser).unwrap();


### PR DESCRIPTION
In order to properly support GPT3.5/GPT4 models which changed the regex compared to GPT2

Existing tokenizer files are not affected. New tokenizer files can be created that copy the new regex from the tiktoken sources.

I'm new to Rust, so the code probably doesn't look very idiomatic. Happy to adjust it.