### PR TITLE
fix: change var name from `vocab` to `vocab_file`

### DIFF
--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -54,8 +54,8 @@ impl WordLevelBuilder {
 
     /// Set the input files.
     #[must_use]
-    pub fn files(mut self, files: String) -> Self {
-        self.config.files = Some(files);
+    pub fn files(mut self, vocab_file: String) -> Self {
+        self.config.files = Some(vocab_file);
         self
     }
 

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -54,8 +54,8 @@ impl WordLevelBuilder {
 
     /// Set the input files.
     #[must_use]
-    pub fn files(mut self, vocab: String) -> Self {
-        self.config.files = Some(vocab);
+    pub fn files(mut self, files: String) -> Self {
+        self.config.files = Some(files);
         self
     }
 


### PR DESCRIPTION
This is just a minor suggestion. 

There are two `vocab`s in `/tokenizers/src/models/wordlevel/mod.rs` with two different type and meaning:

- The vocab related file
https://github.com/huggingface/tokenizers/blob/09069717e94e1a22010d340bb947d7e49ef2baa9/tokenizers/src/models/wordlevel/mod.rs#L57-L60

- The vocab hashmap(truly)
https://github.com/huggingface/tokenizers/blob/09069717e94e1a22010d340bb947d7e49ef2baa9/tokenizers/src/models/wordlevel/mod.rs#L64-L67

Therefore, change the parameter name from `vocab` to `vocab_file` should help to avoid misunderstanding.
