### PR TITLE
Fix Strip decoder doc comment

### DIFF
--- a/tokenizers/src/decoders/strip.rs
+++ b/tokenizers/src/decoders/strip.rs
@@ -3,9 +3,8 @@ use crate::tokenizer::{Decoder, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Clone, Debug, Serialize, Default)]
-/// Strip is a simple trick which converts tokens looking like `<0x61>`
-/// to pure bytes, and attempts to make them into a string. If the tokens
-/// cannot be decoded you will get � instead for each inconvertable byte token
+// Strip removes prefixes and suffixes (of length at most start/stop,
+// respectively) which consist solely of the given character.
 #[serde(tag = "type")]
 #[non_exhaustive]
 pub struct Strip {

--- a/tokenizers/src/decoders/strip.rs
+++ b/tokenizers/src/decoders/strip.rs
@@ -34,7 +34,6 @@ impl Decoder for Strip {
                 for (i, &c) in chars.iter().enumerate().take(self.start) {
                     if c == self.content {
                         start_cut = i + 1;
-                        continue;
                     } else {
                         break;
                     }
@@ -45,7 +44,6 @@ impl Decoder for Strip {
                     let index = chars.len() - i - 1;
                     if chars[index] == self.content {
                         stop_cut = index;
-                        continue;
                     } else {
                         break;
                     }


### PR DESCRIPTION
The old comment was copied over from the `ByteFallback` decoder