### PR TITLE
[BREAKING CHANGE] Ignore added_tokens (both special and not) in the decoder

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -63,6 +63,12 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
 
+      - name: Install audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-audit
+
       - name: Install Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,12 @@ jobs:
           command: install
           args: cargo-readme
 
+      - name: Install audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-audit
+
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -216,11 +216,18 @@ impl AddedVocabulary {
     }
 
     /// Get the token matching the given id if it exists
+    #[deprecated(since="0.19.0", note="please use `added_vocabulary.simple_id_to_token(id).or_else(|| model.id_to_token(id)` instead")]
     pub fn id_to_token(&self, id: u32, model: &impl Model) -> Option<String> {
         self.added_tokens_map_r
             .get(&id)
             .map(|t| t.content.clone())
             .or_else(|| model.id_to_token(id))
+    }
+
+    pub fn simple_id_to_token(&self, id: u32) -> Option<String> {
+        self.added_tokens_map_r
+            .get(&id)
+            .map(|t| t.content.clone())
     }
 
     //

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -216,7 +216,10 @@ impl AddedVocabulary {
     }
 
     /// Get the token matching the given id if it exists
-    #[deprecated(since="0.19.0", note="please use `added_vocabulary.simple_id_to_token(id).or_else(|| model.id_to_token(id)` instead")]
+    #[deprecated(
+        since = "0.19.0",
+        note = "please use `added_vocabulary.simple_id_to_token(id).or_else(|| model.id_to_token(id)` instead"
+    )]
     pub fn id_to_token(&self, id: u32, model: &impl Model) -> Option<String> {
         self.added_tokens_map_r
             .get(&id)
@@ -225,9 +228,7 @@ impl AddedVocabulary {
     }
 
     pub fn simple_id_to_token(&self, id: u32) -> Option<String> {
-        self.added_tokens_map_r
-            .get(&id)
-            .map(|t| t.content.clone())
+        self.added_tokens_map_r.get(&id).map(|t| t.content.clone())
     }
 
     //

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -860,7 +860,7 @@ where
                     chunks.join(" ")
                 };
                 result.push_str(&text_chunk);
-                if !result.is_empty() {
+                if !result.is_empty() && self.decoder.is_none() {
                     result.push(' ');
                 }
                 result.push_str(&added_token);

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -699,7 +699,9 @@ where
 
     /// Converts an id to the corresponding token.
     pub fn id_to_token(&self, id: u32) -> Option<String> {
-        self.added_vocabulary.simple_id_to_token(id).or_else(|| self.model.id_to_token(id))
+        self.added_vocabulary
+            .simple_id_to_token(id)
+            .or_else(|| self.model.id_to_token(id))
     }
 
     /// set the added bocab's splitting scheme
@@ -847,31 +849,31 @@ where
     pub fn decode(&self, ids: &[u32], skip_special_tokens: bool) -> Result<String> {
         let mut result = String::with_capacity(ids.len());
         let mut chunks = Vec::with_capacity(ids.len());
-        for id in ids{
-            if let Some(added_token) = self.added_vocabulary.simple_id_to_token(*id){
-                if skip_special_tokens{
+        for id in ids {
+            if let Some(added_token) = self.added_vocabulary.simple_id_to_token(*id) {
+                if skip_special_tokens {
                     if self.added_vocabulary.is_special_token(&added_token) {
-                        continue
+                        continue;
                     }
                 }
-                let text_chunk = if let Some(decoder) = &self.decoder{
+                let text_chunk = if let Some(decoder) = &self.decoder {
                     decoder.decode(chunks.clone())?
-                }else{
+                } else {
                     chunks.join(" ")
                 };
                 result.push_str(&text_chunk);
                 result.push_str(&added_token);
                 chunks.clear();
-            }else{
-                if let Some(token) = self.model.id_to_token(*id){
+            } else {
+                if let Some(token) = self.model.id_to_token(*id) {
                     chunks.push(token);
                 }
                 // Ignore unmapped ids.
             }
         }
-        let text_chunk = if let Some(decoder) = &self.decoder{
+        let text_chunk = if let Some(decoder) = &self.decoder {
             decoder.decode(chunks.clone())?
-        }else{
+        } else {
             chunks.join(" ")
         };
         result.push_str(&text_chunk);

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -860,7 +860,7 @@ where
                     chunks.join(" ")
                 };
                 result.push_str(&text_chunk);
-                if !result.is_empty(){
+                if !result.is_empty() {
                     result.push_str(" ");
                 }
                 result.push_str(&added_token);

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -851,10 +851,8 @@ where
         let mut chunks = Vec::with_capacity(ids.len());
         for id in ids {
             if let Some(added_token) = self.added_vocabulary.simple_id_to_token(*id) {
-                if skip_special_tokens {
-                    if self.added_vocabulary.is_special_token(&added_token) {
-                        continue;
-                    }
+                if skip_special_tokens && self.added_vocabulary.is_special_token(&added_token) {
+                    continue;
                 }
                 let text_chunk = if let Some(decoder) = &self.decoder {
                     decoder.decode(chunks.clone())?
@@ -864,11 +862,8 @@ where
                 result.push_str(&text_chunk);
                 result.push_str(&added_token);
                 chunks.clear();
-            } else {
-                if let Some(token) = self.model.id_to_token(*id) {
-                    chunks.push(token);
-                }
-                // Ignore unmapped ids.
+            } else if let Some(token) = self.model.id_to_token(*id) {
+                chunks.push(token);
             }
         }
         let text_chunk = if let Some(decoder) = &self.decoder {

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -861,7 +861,7 @@ where
                 };
                 result.push_str(&text_chunk);
                 if !result.is_empty() {
-                    result.push_str(" ");
+                    result.push(' ');
                 }
                 result.push_str(&added_token);
                 chunks.clear();

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -860,6 +860,9 @@ where
                     chunks.join(" ")
                 };
                 result.push_str(&text_chunk);
+                if !result.is_empty(){
+                    result.push_str(" ");
+                }
                 result.push_str(&added_token);
                 chunks.clear();
             } else if let Some(token) = self.model.id_to_token(*id) {


### PR DESCRIPTION
Causes issues with `ByteLevel` messing up some `AddedTokens` with some
utf-8 range used in the bytelevel mapping.

This commit tests the extend of the damage of ignoring the decoder for
those tokens.