### PR TITLE
remove enforcement of non special when adding tokens

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: -D warnings -f ./bindings/python/Cargo.lock
+          args: -D warnings --ignore RUSTSEC-2024-0335 -f ./bindings/python/Cargo.lock
 
       - name: Install
         working-directory: ./bindings/python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -95,6 +95,9 @@ jobs:
           command: clippy
           args: --manifest-path ./bindings/python/Cargo.toml --all-targets --all-features -- -D warnings
 
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
       - name: Run Audit
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: -D warnings --ignore RUSTSEC-2024-0335 -f ./bindings/python/Cargo.lock
+          args: -D warnings -f ./bindings/python/Cargo.lock --ignore RUSTSEC-2024-0335
 
       - name: Install
         working-directory: ./bindings/python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: -D warnings -f ./bindings/python/Cargo.lock --ignore RUSTSEC-2024-0335
+          args: -D warnings -f ./bindings/python/Cargo.lock
 
       - name: Install
         working-directory: ./bindings/python

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,9 @@ jobs:
           command: test
           args: --verbose --manifest-path ./tokenizers/Cargo.toml --doc
 
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
       - name: Run Audit
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: -D warnings -f ./tokenizers/Cargo.lock
+          args: -D --ignore RUSTSEC-2024-0335 warnings -f ./tokenizers/Cargo.lock
 
       # Verify that Readme.md is up to date.
       - name: Make sure, Readme generated from lib.rs matches actual Readme

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: -D --ignore RUSTSEC-2024-0335 warnings -f ./tokenizers/Cargo.lock
+          args: -D warnings -f ./tokenizers/Cargo.lock --ignore RUSTSEC-2024-0335
 
       # Verify that Readme.md is up to date.
       - name: Make sure, Readme generated from lib.rs matches actual Readme

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: -D warnings -f ./tokenizers/Cargo.lock --ignore RUSTSEC-2024-0335
+          args: -D warnings -f ./tokenizers/Cargo.lock
 
       # Verify that Readme.md is up to date.
       - name: Make sure, Readme generated from lib.rs matches actual Readme

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -19,6 +19,7 @@ numpy = "0.21"
 ndarray = "0.15"
 onig = { version = "6.4", default-features = false }
 itertools = "0.12"
+cargo-audit = "0.20.0"
 
 [dependencies.tokenizers]
 path = "../../tokenizers"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -19,7 +19,6 @@ numpy = "0.21"
 ndarray = "0.15"
 onig = { version = "6.4", default-features = false }
 itertools = "0.12"
-cargo-audit = "0.20.0"
 
 [dependencies.tokenizers]
 path = "../../tokenizers"

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1151,7 +1151,7 @@ impl PyTokenizer {
             .map(|token| {
                 if let Ok(content) = token.extract::<String>() {
                     Ok(PyAddedToken::from(content, Some(false)).get_token())
-                } else if let Ok(mut token) = token.extract::<PyRefMut<PyAddedToken>>() {
+                } else if let Ok(token) = token.extract::<PyRefMut<PyAddedToken>>() {
                     Ok(token.get_token())
                 } else {
                     Err(exceptions::PyTypeError::new_err(

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1152,7 +1152,6 @@ impl PyTokenizer {
                 if let Ok(content) = token.extract::<String>() {
                     Ok(PyAddedToken::from(content, Some(false)).get_token())
                 } else if let Ok(mut token) = token.extract::<PyRefMut<PyAddedToken>>() {
-                    token.special = false;
                     Ok(token.get_token())
                 } else {
                     Err(exceptions::PyTypeError::new_err(

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -535,3 +535,15 @@ class TestTokenizer:
             "▁▁▁▁▁▁",
             "▁.",
         ]
+
+    def test_decode_special(self):
+        tokenizer = Tokenizer(BPE())
+        tokenizer.add_tokens([AddedToken("my",special=True), AddedToken("name",special=False), "is", "john", "pair"])
+
+        # Can decode single sequences
+        output = tokenizer.decode([0, 1, 2, 3],skip_special_tokens=False)
+        assert output == "my name is john"
+
+        output = tokenizer.decode([0, 1, 2, 3], skip_special_tokens=True)
+        assert output == "name is john"
+        assert tokenizer.get_added_tokens_decoder()[1] == AddedToken("my",special=False)

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -538,12 +538,12 @@ class TestTokenizer:
 
     def test_decode_special(self):
         tokenizer = Tokenizer(BPE())
-        tokenizer.add_tokens([AddedToken("my",special=True), AddedToken("name",special=False), "is", "john", "pair"])
+        tokenizer.add_tokens([AddedToken("my", special=True), AddedToken("name", special=False), "is", "john", "pair"])
 
         # Can decode single sequences
-        output = tokenizer.decode([0, 1, 2, 3],skip_special_tokens=False)
+        output = tokenizer.decode([0, 1, 2, 3], skip_special_tokens=False)
         assert output == "my name is john"
 
         output = tokenizer.decode([0, 1, 2, 3], skip_special_tokens=True)
         assert output == "name is john"
-        assert tokenizer.get_added_tokens_decoder()[0] == AddedToken("my",special=True)
+        assert tokenizer.get_added_tokens_decoder()[0] == AddedToken("my", special=True)

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -546,4 +546,4 @@ class TestTokenizer:
 
         output = tokenizer.decode([0, 1, 2, 3], skip_special_tokens=True)
         assert output == "name is john"
-        assert tokenizer.get_added_tokens_decoder()[1] == AddedToken("my",special=False)
+        assert tokenizer.get_added_tokens_decoder()[0] == AddedToken("my",special=True)


### PR DESCRIPTION
Fix the issue that prevented us from adding special and non special tokens using a single call to `add_tokens`. 
Very important because calling this multiple times adds a huge slowdown (regex re-compilation).

```python 
>>> from transformers import AutoTokenizer, AddedToken
>>> tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3-8B")
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.

>>> tokenizer._tokenizer.add_tokens([AddedToken("<me-and-you>", special=True, normalized=False)])
1

>>> tokenizer._tokenizer.decode([128256], skip_special_tokens=True)
''
```
before it would output `'<me-and-you>'`. and the token was always special when added.
This will allow us to do the following cleanup: https://github.com/huggingface/transformers/blob/main/src/transformers/tokenization_utils_fast.py#L169-L192 

```diff 
-        encoder = list(self.added_tokens_encoder.keys()) + [str(token) f
-        # if some of the special tokens are strings, we check if we don'
-        tokens_to_add += [
-            token for token in self.all_special_tokens_extended if token
-        ]
-        if len(tokens_to_add) > 0:
-            # super hack: if a token.special is set, tokenizer ignores i
-            # Accumulate added tokens into batches of special/non-specia
-            # individual tokens would repeatedly rebuild a trie, which c
-            is_last_special = None
-            tokens = []
-            special_tokens = self.all_special_tokens
-            for token in tokens_to_add:
-                is_special = (
-                    (token.special or str(token) in special_tokens)
-                    if isinstance(token, AddedToken)
-                    else str(token) in special_tokens
-                )
-                if is_last_special is None or is_last_special == is_spec
-                    tokens.append(token)
-                else:
-                    self._add_tokens(tokens, special_tokens=is_last_spec
-                    tokens = [token]
-                is_last_special = is_special
-            if tokens:
-                self._add_tokens(tokens, special_tokens=is_last_special)
+ self._add_tokens(tokens_to_add)
```

this issue comes from https://github.com/huggingface/tokenizers/commit/c02d4e2202314cfc4e23bce16f7991261f4b2c93 which was introduced in v0.8