### PR TITLE
Make `onig` crate non-optional

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -39,7 +39,7 @@ harness = false
 [dependencies]
 lazy_static = "1.4"
 rand = "0.8"
-onig = { version = "6.4", default-features = false, optional = true }
+onig = { version = "6.4", default-features = false }
 regex = "1.10"
 regex-syntax = "0.8"
 rayon = "1.10"
@@ -65,11 +65,13 @@ esaxx-rs = { version = "0.1.10", default-features = false, features=[]}
 monostate = "0.1.12"
 
 [features]
-default = ["progressbar", "onig", "esaxx_fast"]
+default = ["progressbar", "esaxx_fast"]
 esaxx_fast = ["esaxx-rs/cpp"]
 progressbar = ["indicatif"]
 http = ["hf-hub"]
 unstable_wasm = ["fancy-regex", "getrandom/js"]
+# Dummy placeholder for backwards compatibility
+onig = []
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
This PR allows the Rust crate to be used without default features. 

I ran into trouble trying to add this crate to a project without its default features. Looks like the `onig` crate has become a non-optional dependency of this crate as this crate will not compile without it. To reflect this, I made `onig` a required dependency and added a placeholder feature for backwards compatibility.

If adding multiple regex backends like #1510 is desired, this PR should be reworked to detect multiple enabled regex backends and no enabled regex backends and throw a compile error.