### PR TITLE
Adding pretty print of tokenizer

### DIFF
--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -28,7 +28,7 @@ use super::error::ToPyResult;
 /// This class is not supposed to be instantiated directly. Instead, any implementation of
 /// a Decoder will return an instance of this class when instantiated.
 #[pyclass(dict, module = "tokenizers.decoders", name = "Decoder", subclass)]
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct PyDecoder {
     #[serde(flatten)]
     pub(crate) decoder: PyDecoderWrapper,
@@ -478,7 +478,7 @@ impl PySequenceDecoder {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct CustomDecoder {
     inner: PyObject,
 }
@@ -531,7 +531,7 @@ impl<'de> Deserialize<'de> for CustomDecoder {
     }
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(untagged)]
 pub(crate) enum PyDecoderWrapper {
     Custom(Arc<RwLock<CustomDecoder>>),

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -25,7 +25,7 @@ use super::error::{deprecation_warning, ToPyResult};
 ///
 /// This class cannot be constructed directly. Please use one of the concrete models.
 #[pyclass(module = "tokenizers.models", name = "Model", subclass)]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PyModel {
     #[serde(flatten)]
     pub model: Arc<RwLock<ModelWrapper>>,

--- a/bindings/python/src/normalizers.rs
+++ b/bindings/python/src/normalizers.rs
@@ -43,7 +43,7 @@ impl PyNormalizedStringMut<'_> {
 /// This class is not supposed to be instantiated directly. Instead, any implementation of a
 /// Normalizer will return an instance of this class when instantiated.
 #[pyclass(dict, module = "tokenizers.normalizers", name = "Normalizer", subclass)]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PyNormalizer {
     #[serde(flatten)]
     pub(crate) normalizer: PyNormalizerTypeWrapper,

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -34,7 +34,7 @@ use super::utils::*;
     name = "PreTokenizer",
     subclass
 )]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PyPreTokenizer {
     #[serde(flatten)]
     pub(crate) pretok: PyPreTokenizerTypeWrapper,
@@ -587,7 +587,7 @@ impl PyUnicodeScripts {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct CustomPreTokenizer {
     inner: PyObject,
 }
@@ -631,7 +631,7 @@ impl<'de> Deserialize<'de> for CustomPreTokenizer {
     }
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(untagged)]
 pub(crate) enum PyPreTokenizerWrapper {
     Custom(CustomPreTokenizer),
@@ -650,7 +650,7 @@ impl Serialize for PyPreTokenizerWrapper {
     }
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(untagged)]
 pub(crate) enum PyPreTokenizerTypeWrapper {
     Sequence(Vec<Arc<RwLock<PyPreTokenizerWrapper>>>),

--- a/bindings/python/src/processors.rs
+++ b/bindings/python/src/processors.rs
@@ -27,7 +27,7 @@ use tokenizers as tk;
     name = "PostProcessor",
     subclass
 )]
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct PyPostProcessor {
     #[serde(flatten)]
     pub processor: Arc<PostProcessorWrapper>,

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1410,6 +1410,14 @@ impl PyTokenizer {
     fn set_decoder(&mut self, decoder: PyRef<PyDecoder>) {
         self.tokenizer.with_decoder(decoder.clone());
     }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(format!("{:#?}", &self.tokenizer))
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("{:#?}", &self.tokenizer))
+    }
 }
 
 #[cfg(test)]

--- a/tokenizers/rust-toolchain
+++ b/tokenizers/rust-toolchain
@@ -1,1 +1,3 @@
-stable
+[toolchain]
+channel = "1.78"
+components = ["rustfmt", "clippy"]

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -523,7 +523,7 @@ impl BpeTrainer {
                 .get(&new_token)
                 .copied()
                 .unwrap_or(id_to_word.len() as u32);
-            if word_to_id.get(&new_token).is_none() {
+            if !word_to_id.contains_key(&new_token) {
                 id_to_word.push(new_token.clone());
                 word_to_id.insert(new_token.clone(), new_token_id);
             }

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -180,10 +180,10 @@ impl WordPiece {
     pub fn from_bpe(bpe: &BPE) -> Self {
         let mut wp = Self::builder().vocab(bpe.get_vocab()).build().unwrap();
         if let Some(unk) = bpe.get_unk_token() {
-            wp.unk_token = unk.to_owned();
+            unk.clone_into(&mut wp.unk_token);
         }
         if let Some(prefix) = bpe.get_continuing_subword_prefix() {
-            wp.continuing_subword_prefix = prefix.to_owned();
+            prefix.clone_into(&mut wp.continuing_subword_prefix);
         }
         wp
     }


### PR DESCRIPTION
Adding a default implementation for `__str__` and `__repr__` for Tokenizer.

## Test it out

### Before

```python
>>> from tokenizers import Tokenizer, decoders, models, normalizers, pre_tokenizers, processors
>>> from tokenizers.implementations import BaseTokenizer
>>> toki = Tokenizer(models.BPE())
>>> print(toki)
<tokenizers.Tokenizer object at 0x7d687d32bc30>
```

### After

```python
>>> from tokenizers import Tokenizer, decoders, models, normalizers, pre_tokenizers, processors
>>> from tokenizers.implementations import BaseTokenizer
>>> toki = Tokenizer(models.BPE())
>>> print(toki)
TokenizerImpl {
    normalizer: None,
    pre_tokenizer: None,
    model: PyModel {
        model: RwLock {
            data: BPE(
                BPE {
                    dropout: None,
                    unk_token: None,
                    continuing_subword_prefix: None,
                    end_of_word_suffix: None,
                    fuse_unk: false,
                    byte_fallback: false,
                    vocab: 0,
                    merges: 0,
                    ignore_merges: false,
                },
            ),
            poisoned: false,
            ..
        },
    },
    post_processor: None,
    decoder: None,
    added_vocabulary: AddedVocabulary {
        added_tokens_map: {},
        added_tokens_map_r: {},
        added_tokens: [],
        special_tokens: [],
        special_tokens_set: {},
        split_trie: (
            AhoCorasick(
                dfa::DFA(
                D 000000: \x00 => 0
                F 000001:
                 >000002: \x00 => 2
                  000003: \x00 => 0
                match kind: LeftmostLongest
                prefilter: false
                state length: 4
                pattern length: 0
                shortest pattern length: 18446744073709551615
                longest pattern length: 0
                alphabet length: 1
                stride: 1
                byte classes: ByteClasses(0 => [0-255])
                memory usage: 16
                )
                ,
            ),
            [],
        ),
        split_normalized_trie: (
            AhoCorasick(
                dfa::DFA(
                D 000000: \x00 => 0
                F 000001:
                 >000002: \x00 => 2
                  000003: \x00 => 0
                match kind: LeftmostLongest
                prefilter: false
                state length: 4
                pattern length: 0
                shortest pattern length: 18446744073709551615
                longest pattern length: 0
                alphabet length: 1
                stride: 1
                byte classes: ByteClasses(0 => [0-255])
                memory usage: 16
                )
                ,
            ),
            [],
        ),
        encode_special_tokens: false,
    },
    truncation: None,
    padding: None,
}
```

Hope this helps :) 

Open for any critics and the representation or implementation

Inspired by https://github.com/dora-rs/dora/pull/503 