### PR TITLE
Enable `dropout = 0.0` as an equivalent to `none` in BPE

### DIFF
--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -73,6 +73,7 @@ class TestBPE:
         model = BPE(dropout=0.0)
         assert model.dropout == 0.0
 
+
 class TestWordPiece:
     def test_instantiate(self, bert_files):
         assert isinstance(WordPiece(), Model)

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -73,7 +73,6 @@ class TestBPE:
         model = BPE(dropout=0.0)
         assert model.dropout == 0.0
 
-
 class TestWordPiece:
     def test_instantiate(self, bert_files):
         assert isinstance(WordPiece(), Model)

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -69,6 +69,9 @@ class TestBPE:
         model.byte_fallback = True
         assert model.byte_fallback == True
 
+    def test_dropout_zero(self):
+        model = BPE(dropout=0.0)
+        assert model.dropout == 0.0
 
 class TestWordPiece:
     def test_instantiate(self, bert_files):

--- a/tokenizers/src/models/bpe/mod.rs
+++ b/tokenizers/src/models/bpe/mod.rs
@@ -31,7 +31,7 @@ pub enum Error {
     #[error("Unk token `{0}` not found in the vocabulary")]
     UnkTokenOutOfVocabulary(String),
     /// Dropout not between 0 and 1.
-    #[error("Dropout should be between 0 and 1")]
+    #[error("Dropout should be between 0 and 1, inclusive")]
     InvalidDropout,
 }
 

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -136,7 +136,7 @@ impl BpeBuilder {
     pub fn build(mut self) -> Result<BPE> {
         // Validate dropout.
         if let Some(p) = self.config.dropout {
-            if p < 0.0 || p > 1.0 {
+            if !(0.0..=1.0).contains(&p) {
                 return Err(Error::InvalidDropout.into());
             }
         }

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -136,7 +136,7 @@ impl BpeBuilder {
     pub fn build(mut self) -> Result<BPE> {
         // Validate dropout.
         if let Some(p) = self.config.dropout {
-            if p <= 0.0 || p > 1.0 {
+            if p < 0.0 || p > 1.0 {
                 return Err(Error::InvalidDropout.into());
             }
         }
@@ -214,7 +214,7 @@ pub struct BPE {
     pub(crate) merges: MergeMap,
     /// Contains the cache for optimizing the encoding step.
     cache: Option<Cache<String, Word>>,
-    /// Dropout probability for merges. 0 = no dropout is the default. At 1.0, tokenization will
+    /// Dropout probability for merges. 0.0 = no dropout is the default. At 1.0, tokenization will
     /// perform no merges, so the result will just be characters.
     pub dropout: Option<f32>,
     /// The unknown token to be used when we encounter an unknown char
@@ -493,7 +493,7 @@ impl Model for BPE {
             return Ok(vec![]);
         }
 
-        if self.dropout.is_none() {
+        if self.dropout.is_none() || self.dropout == Some(0.0) {
             self.tokenize_with_cache(sequence)
         } else {
             let word = self.merge_word(sequence)?;
@@ -685,6 +685,11 @@ mod tests {
         let tokens = bpe.tokenize("unrelated").unwrap();
         assert_eq!(tokens, vec![Token::new(15u32, "unrelated".into(), (0, 9))]);
 
+        // With dropout = 0.0 (equivalent to dropout == none)
+        bpe.dropout = Some(0.0);
+        let tokens = bpe.tokenize("unrelated").unwrap();
+        assert_eq!(tokens, vec![Token::new(15u32, "unrelated".into(), (0, 9))]);
+
         // Now set dropout to 1.0. Result should be no merges performed.
         bpe.dropout = Some(1.0);
         let tokens = bpe.tokenize("unrelated").unwrap();
@@ -737,6 +742,13 @@ mod tests {
         assert_eq!(bpe.vocab.get("b").unwrap(), &1u32);
         assert_eq!(bpe.vocab.get("c").unwrap(), &2u32);
         assert_eq!(bpe.vocab.get("ab").unwrap(), &3u32);
+    }
+
+    #[test]
+    // Ensure BPEBuilder with dropout = 0.0 doesn't error
+    fn test_bpe_with_dropout_0() {
+        let bpe = BPE::builder().dropout(0.0).build().unwrap();
+        assert_eq!(bpe.dropout, Some(0.0));
     }
 
     #[test]

--- a/tokenizers/tests/serialization.rs
+++ b/tokenizers/tests/serialization.rs
@@ -237,7 +237,7 @@ fn bpe_with_dropout_serde() {
     let de = serde_json::from_str(&ser).unwrap();
     assert_eq!(bpe, de);
 
-    // set dropout to 0.0 (which is analagous to None) and reserialize
+    // set dropout to 0.0 (which is analogous to None) and reserialize
     bpe.dropout = Some(0.0);
     let ser = serde_json::to_string(&bpe).unwrap();
     let de = serde_json::from_str(&ser).unwrap();

--- a/tokenizers/tests/serialization.rs
+++ b/tokenizers/tests/serialization.rs
@@ -230,6 +230,21 @@ fn tokenizer() {
 }
 
 #[test]
+fn bpe_with_dropout_serde() {
+    let mut bpe = BPE::default();
+    bpe.dropout = Some(0.1);
+    let ser = serde_json::to_string(&bpe).unwrap();
+    let de = serde_json::from_str(&ser).unwrap();
+    assert_eq!(bpe, de);
+
+    // set dropout to 0.0 (which is analagous to None) and reserialize
+    bpe.dropout = Some(0.0);
+    let ser = serde_json::to_string(&bpe).unwrap();
+    let de = serde_json::from_str(&ser).unwrap();
+    assert_eq!(bpe, de);
+}
+
+#[test]
 fn test_deserialize_long_file() {
     let _tokenizer = Tokenizer::from_file("data/albert-base-v1-tokenizer.json").unwrap();
 }


### PR DESCRIPTION
This is related to the discussion in #1541.

This PR allows for `0.0` to be used as the dropout value in BPE models with equivalent functionality to `none`. Previously, the docs and implementation were inconsistent:
- the docs said 0.0 to 1.0 were acceptable values for dropout and that the default was 0
    - the default was actually `none`
- it was possible to set dropout to 0.0 once the model was built (and it would work the same as if it was `none`)
    - however, in this case caching was disabled
    - on a small benchmark, i measured a 50% increase in encoding time with dropout = 0.0 compared to none (this discrepancy goes away after this PR is applied)
- serialization worked, but deserialization failed, since there was a check that `dropout \in (0.0, 1.0]`
- initializing a python BPE model with dropout 0.0 failed (e.g. `BPE(dropout = 0.0)`)

This simply allows for `0.0` to be an acceptable value during initialization and enables caching when tokenizing if `dropout == 0.0`.

E.g., now the following works

```python
>>> from tokenizers import Tokenizer, models
>>> tokenizer = Tokenizer(models.BPE(dropout = 0.0))
>>> s = tokenizer.to_str()
>>> s
'{"version":"1.0","truncation":null,"padding":null,"added_tokens":[],"normalizer":null,"pre_tokenizer":null,"post_processor":null,"decoder":null,"model":{"type":"BPE","dropout":0.0,"unk_token":null,"continuing_subword_prefix":null,"end_of_word_suffix":null,"fuse_unk":false,"byte_fallback":false,"ignore_merges":false,"vocab":{},"merges":[]}}'
>>> deserialized = Tokenizer.from_str(s)
>>> deserialized.model.dropout
0.0
```

whereas before it errored.

-----------------------------

As future work, I think that dropout should be made non-optional, with the default being 0.0. This would remove the checks for `dropout.is_none()`, etc, but keep the functionality the same. However, I guess this would be a breaking change (since then all tokenizers serialized before this change would be invalid?).