### PR TITLE
make sure we don't warn on empty tokens

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -75,6 +75,8 @@ unstable_wasm = ["fancy-regex", "getrandom/js"]
 criterion = "0.5"
 tempfile = "3.10"
 assert_approx_eq = "1.1"
+tracing-test = "0.2"
+tracing = "0.1"
 
 [profile.release]
 lto = "fat"

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -75,8 +75,8 @@ unstable_wasm = ["fancy-regex", "getrandom/js"]
 criterion = "0.5"
 tempfile = "3.10"
 assert_approx_eq = "1.1"
-tracing-test = "0.2"
 tracing = "0.1"
+tracing-subscriber = "0.3.18"
 
 [profile.release]
 lto = "fat"

--- a/tokenizers/src/tokenizer/serialization.rs
+++ b/tokenizers/src/tokenizer/serialization.rs
@@ -177,7 +177,7 @@ where
 mod tests {
     use crate::tokenizer::Tokenizer;
     use std::str::FromStr;
-    use tracing_test::traced_test;
+    use tracing_subscriber::fmt;
 
     #[test]
     fn test_deserialization_serialization_invariant() {
@@ -234,10 +234,13 @@ mod tests {
     }
 
     #[cfg(feature = "http")]
-    #[traced_test]
     #[test]
     fn test_from_pretrained() {
+        fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_target(false)
+            .init();
         let _ = Tokenizer::from_pretrained("Qwen/Qwen2-7B-Instruct", None);
-        assert!(!logs_contain("WARN"), "Warning: Token '");
+        warn!("This should be the first warning");
     }
 }


### PR DESCRIPTION
When activating warnings, there was an issue with added tokens that are not part of the vocab. I am pretty sure that the main point about added tokens is that they don't have to be in the vocab, so fixing this. 