### PR TITLE
Bump spm_precompiled to 0.1.3

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -53,7 +53,7 @@ indicatif = {version = "0.17", optional = true}
 itertools = "0.12"
 log = "0.4"
 derive_builder = "0.20"
-spm_precompiled = "0.1"
+spm_precompiled = "0.1.3"
 hf-hub = { version = "0.3.2", optional = true }
 aho-corasick = "1.1"
 paste = "1.0.14"


### PR DESCRIPTION
As it stands now using spm_precompiled < 0.1.3 will result in the build of tokenizers failing.
While by default cargo will pick the newest available version for all dependencies, if a user has not run `cargo update` in a while they can still have older versions in their lock file.

This error can be reproduced by running `rustup run nightly cargo update -Zminimal-versions && cargo --locked check`, creating a lock file with minimal versions of all dependencies allowed by Cargo.toml.

It may also be a good idea to add such a check to the CI, if you think this would be a valuable addition, let me know, and I'll be happy to do it.