### PR TITLE
Tiny improvement

### DIFF
--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -460,13 +460,13 @@ impl BPE {
     }
 
     fn tokenize_with_cache(&self, sequence: &str) -> Result<Vec<Token>> {
-        if let Some(ref hit) = self.cache.as_ref().and_then(|c| c.get(sequence)) {
-            return Ok(self.word_to_tokens(hit).collect());
-        }
         if self.ignore_merges {
             if let Some(id) = self.vocab.get(sequence) {
                 return Ok(vec![Token::new(*id, sequence.to_string().clone(), (0, 0))]);
             }
+        }
+        if let Some(ref hit) = self.cache.as_ref().and_then(|c| c.get(sequence)) {
+            return Ok(self.word_to_tokens(hit).collect());
         }
         let word = self.merge_word(sequence)?;
         let ret = self.word_to_tokens(&word).collect();


### PR DESCRIPTION
Rational is as follows, before we used to hash the sequence, fail to find in cache, then lookup in vocab, hit and return.
This `ignore_merges` doesn't insert in cache (it's already in the vocab so no need to duplicate the data), we can put it beforehand limiting the amount of cache reads.

Before:
```
==============
num_threads: 8, data size: 24.04 MB, documents: 10000 Avg Length: 1659
tiktoken 	61.73 MB  / s
huggingface 	23.32 MB / s
==============
num_threads: 8, data size: 1.11 MB, documents: 10000 Avg Length: 116
tiktoken 	6.65 MB  / s
huggingface 	20.20 MB / s
```

After: 
```
==============
num_threads: 8, data size: 24.04 MB, documents: 10000 Avg Length: 1659
tiktoken 	59.51 MB  / s
huggingface 	25.36 MB / s
==============
num_threads: 8, data size: 1.11 MB, documents: 10000 Avg Length: 116
tiktoken 	7.48 MB  / s
huggingface 	20.93 MB / s
```

