### PR TITLE
Enable fancy regex

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -17,7 +17,6 @@ env_logger = "0.11"
 pyo3 = { version = "0.21" }
 numpy = "0.21"
 ndarray = "0.15"
-onig = { version = "6.4", default-features = false }
 itertools = "0.12"
 
 [dependencies.tokenizers]

--- a/bindings/python/src/utils/regex.rs
+++ b/bindings/python/src/utils/regex.rs
@@ -1,11 +1,11 @@
-use onig::Regex;
 use pyo3::exceptions;
 use pyo3::prelude::*;
+use tk::utils::SysRegex;
 
 /// Instantiate a new Regex with the given pattern
 #[pyclass(module = "tokenizers", name = "Regex")]
 pub struct PyRegex {
-    pub inner: Regex,
+    pub inner: SysRegex,
     pub pattern: String,
 }
 
@@ -15,8 +15,8 @@ impl PyRegex {
     #[pyo3(text_signature = "(self, pattern)")]
     fn new(s: &str) -> PyResult<Self> {
         Ok(Self {
-            inner: Regex::new(s)
-                .map_err(|e| exceptions::PyException::new_err(e.description().to_owned()))?,
+            inner: SysRegex::new(s)
+                .map_err(|e| exceptions::PyException::new_err(e.to_string().to_owned()))?,
             pattern: s.to_owned(),
         })
     }

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -460,13 +460,13 @@ impl BPE {
     }
 
     fn tokenize_with_cache(&self, sequence: &str) -> Result<Vec<Token>> {
-        if let Some(ref hit) = self.cache.as_ref().and_then(|c| c.get(sequence)) {
-            return Ok(self.word_to_tokens(hit).collect());
-        }
         if self.ignore_merges {
             if let Some(id) = self.vocab.get(sequence) {
                 return Ok(vec![Token::new(*id, sequence.to_string().clone(), (0, 0))]);
             }
+        }
+        if let Some(ref hit) = self.cache.as_ref().and_then(|c| c.get(sequence)) {
+            return Ok(self.word_to_tokens(hit).collect());
         }
         let word = self.merge_word(sequence)?;
         let ret = self.word_to_tokens(&word).collect();


### PR DESCRIPTION
`tokenizers` enable the use of 2 regex engines.
The main supported one is `onig`, the other one is unstable and used by `unstable_wasm` and it's `fancy_regex` (onig being C cannot be compiled as is. on wasm targets).

This PR fixes the code so that it leverages `tokenizers` regexes instead of `onig` directly in the python bindings, which allows swapping one for the other.

Unfortunately `FancyRegex` is slower.