### PR TITLE
Add safety comments

### DIFF
--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -532,7 +532,7 @@ impl BpeTrainer {
             // Merge the new pair in every words
             // Safety: This is just a type assertion, the code below may no longer be safe
             // if the type of `pos` changes
-            let ref pos: HashSet<usize> = top.pos;
+            let pos: &HashSet<usize> = &top.pos;
 
             let words_len = words.len();
             struct WordPtr(*mut Word);

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -534,7 +534,6 @@ impl BpeTrainer {
             // if the type of `pos` changes
             let ref pos: HashSet<usize> = top.pos;
 
-
             let words_len = words.len();
             struct WordPtr(*mut Word);
             // Safety: We do not actually use this for concurrent access to the same memory,

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -28,6 +28,9 @@ pub(crate) fn bytes_char() -> HashMap<u8, char> {
         }
     }
 
+    // Safety: cs contains all values from bs (between 0 and 255),
+    // and some values of value 2⁸ + n, where n is between 0 and 255. This is between 255 and 512.
+    // Both ranges are valid UTF-32 values (which is fully saturated until 0xD000)
     bs.into_iter()
         .zip(cs)
         .map(|(f, t)| (f, unsafe { std::char::from_u32_unchecked(t) }))


### PR DESCRIPTION
I recently performed safety review on 0.19. Besides finding the already-fixed https://github.com/huggingface/tokenizers/issues/1491, I also found that these cases of unsafety were a bit hard to disentangle, and documented them further.