### PR TITLE
fix: usage of `node12 which is deprecated` in CI

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -14,17 +14,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
       - name: Install dependencies
         run: pip install sphinx sphinx_rtd_theme setuptools-rust
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Build tokenizers
         working-directory: ./bindings/python

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 


### PR DESCRIPTION
fixes #1658.