### PR TITLE
add a clear_cache function!

### DIFF
--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -537,8 +537,8 @@ impl PyBPE {
 
     fn clear_cache(self_: PyRef<Self>){
         let super_ = self_.as_ref();
-        let model = super_.model.read().unwrap();
-        if let ModelWrapper::BPE(ref mo) = *model {
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::Unigram(ref mut mo) = *model {
             mo.clear_cache()
         } else {
             unreachable!()
@@ -867,6 +867,16 @@ impl PyUnigram {
                 "`vocab` and `unk_id` must be both specified",
             )),
         }
+    }
+
+    fn clear_cache(self_: PyRef<Self>){
+        let super_ = self_.as_ref();
+        let mut model = super_.model.write().unwrap();
+        if let ModelWrapper::Unigram(ref mut mo) = *model {
+            mo.clear_cache()
+        } else {
+            unreachable!()
+        };
     }
 }
 

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -538,7 +538,7 @@ impl PyBPE {
     fn clear_cache(self_: PyRef<Self>){
         let super_ = self_.as_ref();
         let mut model = super_.model.write().unwrap();
-        if let ModelWrapper::Unigram(ref mut mo) = *model {
+        if let ModelWrapper::BPE(ref mut mo) = *model {
             mo.clear_cache()
         } else {
             unreachable!()

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -534,6 +534,16 @@ impl PyBPE {
             )?,
         )
     }
+
+    fn clear_cache(self_: PyRef<Self>){
+        let super_ = self_.as_ref();
+        let model = super_.model.read().unwrap();
+        if let ModelWrapper::BPE(ref mo) = *model {
+            mo.clear_cache()
+        } else {
+            unreachable!()
+        };
+    }
 }
 
 /// An implementation of the WordPiece algorithm

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -68,6 +68,7 @@ fancy-regex = { version = "0.13", optional = true}
 getrandom = { version = "0.2.10" }
 esaxx-rs = { version = "0.1.10", default-features = false, features=[]}
 monostate = "0.1.12"
+sysinfo = "0.32.0"
 
 [features]
 default = ["progressbar", "onig", "esaxx_fast"]

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -154,10 +154,7 @@ impl BpeBuilder {
             .iter()
             .map(|(key, val)| (*val, key.to_owned()))
             .collect();
-        let cache = match self.config.cache_capacity {
-            0 => None,
-            capacity => Some(Cache::new(false)),
-        };
+        let cache =Some(Cache::new(self.config.cache_capacity));
 
         let vocab = self.config.vocab;
         let prefix_len = if let Some(prefix) = &self.config.continuing_subword_prefix {

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -156,7 +156,7 @@ impl BpeBuilder {
             .collect();
         let cache = match self.config.cache_capacity {
             0 => None,
-            capacity => Some(Cache::new(capacity)),
+            capacity => Some(Cache::new(false)),
         };
 
         let vocab = self.config.vocab;

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -377,6 +377,10 @@ impl Unigram {
         let string = read_to_string(path)?;
         Ok(serde_json::from_str(&string)?)
     }
+
+    pub fn clear_cache(&mut self){
+        self.cache.clear();
+    }
 }
 
 /// Iterator to iterate of vocabulary of the model, and their relative score.

--- a/tokenizers/src/utils/cache.rs
+++ b/tokenizers/src/utils/cache.rs
@@ -56,8 +56,6 @@ where
         } else{
             use_default_capacity
         };
-        let h_format = capacity / (1024 * 1024 * 1024);
-        println!("Using capacity {h_format} (nb of elements)");
         let map = RwLock::new(HashMap::with_capacity(capacity));
         Cache { map, capacity }
     }
@@ -138,13 +136,9 @@ fn default_cache_capacity<K, V>() -> usize {
     // Get the sizes of the key and value types in bytes
     let key_size = mem::size_of::<K>();
     let value_size = mem::size_of::<V>();
-    println!("{key_size}bytes, {value_size}bytes");
     let entry_size = key_size + value_size;
 
-    // Total available memory in bytes (from KB to bytes)
     let available_memory_bytes = ((total_memory as f64* 0.90) as usize / 64) * entry_size ;
-    let h_format = available_memory_bytes/ (1024 * 1024 * 1024);
-    println!("Available memory: {h_format}GB");
     return available_memory_bytes /entry_size
 }
 

--- a/tokenizers/src/utils/cache.rs
+++ b/tokenizers/src/utils/cache.rs
@@ -2,8 +2,12 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::RwLock;
-use sysinfo::{System};
+use sysinfo::System;
 use std::mem;
+
+
+/// The default capacity for a `BPE`'s internal cache.
+pub static DEFAULT_CACHE_CAPACITY: usize = 10000;
 
 /// Provides a simple multithread cache to speed up BPE tokenization that will try to read values
 /// concurrently but won't block if another thread is writing.
@@ -36,7 +40,7 @@ where
     V: Clone,
 {
     fn default() -> Self {
-        Self::new(false)
+        Self::new(0)
     }
 }
 
@@ -46,11 +50,11 @@ where
     V: Clone,
 {
     /// Create new `Cache` with the given capacity.
-    pub(crate) fn new(use_default_capacity: bool) -> Self {
-        let capacity = if use_default_capacity{
-            DEFAULT_CACHE_CAPACITY
-        } else{
+    pub(crate) fn new(use_default_capacity: usize) -> Self {
+        let capacity = if use_default_capacity == 0{
             default_cache_capacity::<K, V>()
+        } else{
+            use_default_capacity
         };
         let h_format = capacity / (1024 * 1024 * 1024);
         println!("Using capacity {h_format} (nb of elements)");
@@ -60,7 +64,7 @@ where
 
     /// Create a fresh `Cache` with the same configuration.
     pub(crate) fn fresh(&self) -> Self {
-        Self::new(false)
+        Self::new(0)
     }
 
     /// Clear the cache.
@@ -144,5 +148,3 @@ fn default_cache_capacity<K, V>() -> usize {
     return available_memory_bytes /entry_size
 }
 
-/// The default capacity for a `BPE`'s internal cache.
-pub static DEFAULT_CACHE_CAPACITY: usize = 10_000;


### PR DESCRIPTION
Fixes #1539 

Tried the provided script with this:
```python
In [4]: from transformers import AutoTokenizer
   ...: import gc
   ...: 
   ...: tokenizer = AutoTokenizer.from_pretrained("TinyLlama/TinyLlama-1.1B-Chat-v1.0", use_fast=True)
   ...: refresh_every = 100
   ...: 
   ...: for i in range(100000):
   ...:   s = f'{i} {i} ' * 10000
   ...:   tokenizer.encode(s)
   ...:   gc.collect()
   ...:   if i % 100 == 0:
   ...:     print(i)
   ...:   if i % refresh_every == 0:
   ...:     tokenizer._tokenizer.model.clear_cache()
```
and had no "leaks"