### PR TITLE
Unsound call of `set_var`

### DIFF
--- a/bindings/python/src/normalizers.rs
+++ b/bindings/python/src/normalizers.rs
@@ -553,7 +553,7 @@ impl tk::tokenizer::Normalizer for CustomNormalizer {
         Python::with_gil(|py| {
             let normalized = PyNormalizedStringRefMut::new(normalized);
             let py_normalized = self.inner.bind(py);
-            py_normalized.call_method("normalize", (normalized.get(),), None)?;
+            py_normalized.call_method("normalize", (normalized.get().clone(),), None)?;
             Ok(())
         })
     }

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -634,7 +634,7 @@ impl tk::tokenizer::PreTokenizer for CustomPreTokenizer {
         Python::with_gil(|py| {
             let pretok = PyPreTokenizedStringRefMut::new(sentence);
             let py_pretok = self.inner.bind(py);
-            py_pretok.call_method("pre_tokenize", (pretok.get(),), None)?;
+            py_pretok.call_method("pre_tokenize", (pretok.get().clone(),), None)?;
             Ok(())
         })
     }

--- a/bindings/python/src/utils/mod.rs
+++ b/bindings/python/src/utils/mod.rs
@@ -18,11 +18,11 @@ pub trait DestroyPtr {
     fn destroy(&mut self);
 }
 
-pub struct RefMutGuard<'r, T: DestroyPtr + Clone> {
+pub struct RefMutGuard<'r, T: DestroyPtr> {
     content: T,
     r: PhantomData<&'r mut T>,
 }
-impl<T: DestroyPtr + Clone> RefMutGuard<'_, T> {
+impl<T: DestroyPtr> RefMutGuard<'_, T> {
     pub fn new(content: T) -> Self {
         Self {
             content,
@@ -30,12 +30,12 @@ impl<T: DestroyPtr + Clone> RefMutGuard<'_, T> {
         }
     }
 
-    pub fn get(&self) -> T {
-        self.content.clone()
+    pub fn get(&self) -> &T {
+        &self.content
     }
 }
 
-impl<T: DestroyPtr + Clone> Drop for RefMutGuard<'_, T> {
+impl<T: DestroyPtr> Drop for RefMutGuard<'_, T> {
     fn drop(&mut self) {
         self.content.destroy()
     }

--- a/bindings/python/src/utils/normalization.rs
+++ b/bindings/python/src/utils/normalization.rs
@@ -396,7 +396,7 @@ impl DestroyPtr for PyNormalizedStringRefMut {
 }
 
 impl PyNormalizedStringRefMut {
-    pub fn new(normalized: &mut NormalizedString) -> RefMutGuard<Self> {
+    pub fn new(normalized: &mut NormalizedString) -> RefMutGuard<'_, Self> {
         RefMutGuard::new(Self {
             inner: RefMutContainer::new(normalized),
         })

--- a/bindings/python/src/utils/pretokenization.rs
+++ b/bindings/python/src/utils/pretokenization.rs
@@ -39,7 +39,7 @@ fn normalize(pretok: &mut PreTokenizedString, func: &Bound<'_, PyAny>) -> PyResu
     } else {
         ToPyResult(pretok.normalize(|normalized| {
             let norm = PyNormalizedStringRefMut::new(normalized);
-            func.call((norm.get(),), None)?;
+            func.call((norm.get().clone(),), None)?;
             Ok(())
         }))
         .into()

--- a/bindings/python/src/utils/pretokenization.rs
+++ b/bindings/python/src/utils/pretokenization.rs
@@ -272,7 +272,7 @@ impl DestroyPtr for PyPreTokenizedStringRefMut {
 }
 
 impl PyPreTokenizedStringRefMut {
-    pub fn new(pretok: &mut tk::PreTokenizedString) -> RefMutGuard<Self> {
+    pub fn new(pretok: &mut tk::PreTokenizedString) -> RefMutGuard<'_, Self> {
         // SAFETY: This is safe because we return a RefMutGuard here.
         // The compiler will make sure the &mut stays valid as necessary.
         RefMutGuard::new(Self {


### PR DESCRIPTION
There have been multiple attempts to communicate that the pattern `&mut *(&T as *const T as *mut T)` is not sound, as in #1485 .

~~This is the most straightforward modification of the code that passes `cargo miri`.~~ See #1651 for the fix.
To detect the unsoundness, the parallelism must be turned off under miri, otherwise it falls over because of some unrelated issue in `crossbeam-epoch`:
```
MIRIFLAGS='-Zmiri-env-set=TOKENIZERS_PARALLELISM=false' cargo +nightly miri test bpe::trainer::tests::test_train
```

There ~~are two soundness issues~~is one soundness issue fix and one code cleanup in this PR.

The ~~first~~ soundness issue ~~is transforming & to &mut, the second~~ is hidden by the fact that std until recently had a safe `env::set_var` function. This was a breaking change and is as of now an unsafe function to call.
Lastly, some elided lifetimes were making it quite hard to see whether the use of `RefMutContainer` as mentioned in #1612 was sound. It does not seem to be unsound.