### PR TITLE
Fix type notation of merges in BPE Python binding

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
@@ -16,7 +16,7 @@ class ByteLevelBPETokenizer(BaseTokenizer):
     def __init__(
         self,
         vocab: Optional[Union[str, Dict[str, int]]] = None,
-        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]] = None,
+        merges: Optional[Union[str, List[Tuple[str, str]]]] = None,
         add_prefix_space: bool = False,
         lowercase: bool = False,
         dropout: Optional[float] = None,

--- a/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
@@ -25,7 +25,7 @@ class CharBPETokenizer(BaseTokenizer):
     def __init__(
         self,
         vocab: Optional[Union[str, Dict[str, int]]] = None,
-        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]] = None,
+        merges: Optional[Union[str, List[Tuple[str, str]]]] = None,
         unk_token: Union[str, AddedToken] = "<unk>",
         suffix: str = "</w>",
         dropout: Optional[float] = None,

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -16,7 +16,7 @@ class SentencePieceBPETokenizer(BaseTokenizer):
     def __init__(
         self,
         vocab: Optional[Union[str, Dict[str, int]]] = None,
-        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]] = None,
+        merges: Optional[Union[str, List[Tuple[str, str]]]] = None,
         unk_token: Union[str, AddedToken] = "<unk>",
         replacement: str = "▁",
         add_prefix_space: bool = True,


### PR DESCRIPTION
Heya, this change is to correct type notations of `merges` in Python binding of BPE as the [counterpart in Rust implementation](https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/models/bpe/model.rs#L18) expects a file name string or `Vec<(String, String)>` instead of a mapping from a tuple of integers to another.