### PR TITLE
Fix panic in DecodeStream::step due to incorrect index usage

### DIFF
--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -1106,7 +1106,7 @@ where
         }
         let new_text = &string[prefix.len()..].to_string();
         let new_prefix_index = ids.len() - *prefix_index;
-        *ids = ids.drain(*read_index..).collect();
+        *ids = ids.drain(*prefix_index..).collect();
         *prefix = tokenizer.decode(ids, skip_special_tokens)?;
         *read_index = *prefix_index;
         *prefix_index = new_prefix_index;

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -1616,4 +1616,23 @@ mod test {
         let decoded = tokenizer.decode(encoded.get_ids(), false);
         assert_eq!(decoded.unwrap(), "Hey! how is this token: д")
     }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn test_decode_stream_step_no_panic() {
+        use std::panic;
+
+        use crate::Tokenizer;
+
+        let tokenizer =
+            Tokenizer::from_pretrained("meta-llama/Meta-Llama-3-8B", None).unwrap();
+        let mut decode_stream = tokenizer.decode_stream(false);
+
+        // "A B C D E F G H I J"
+        let output_tokens = vec![32, 426, 356, 423, 469, 435, 480, 473, 358, 622];
+        for token in output_tokens {
+            let result = panic::catch_unwind(panic::AssertUnwindSafe(|| decode_stream.step(token)));
+            assert!(result.is_ok());
+        }
+    }
 }


### PR DESCRIPTION
When calling `DecodeStream::step` multiple times, it eventually panics with attempt to subtract with overflow in the following lines of code:

https://github.com/huggingface/tokenizers/blob/24d29f498d890638279b0d51e899b6020571719d/tokenizers/src/tokenizer/mod.rs#L1108-L1109

The panic can be easily reproduced, and I have added a test case to demonstrate the issue.

Upon inspecting the code, I found that the shrinking of the token buffer references `read_index` instead of `prefix_index`. This PR corrects the issue by using the correct index.

However, this change makes `read_index` unused, so I am not entirely certain if it aligns with the intended logic of the original implementation. Please let me know if further adjustments or clarifications are needed, or if there is additional context regarding the intended use of `read_index`.