### PR TITLE
Fix typo in Split docstrings

### DIFF
--- a/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
@@ -422,10 +422,10 @@ class Split(PreTokenizer):
     Args:
         pattern (:obj:`str` or :class:`~tokenizers.Regex`):
             A pattern used to split the string. Usually a string or a regex built with `tokenizers.Regex`.
-            If you want to use a regex pattern, it has to be wrapped around a `tokenizer.Regex`,
+            If you want to use a regex pattern, it has to be wrapped around a `tokenizers.Regex`,
             otherwise we consider is as a string pattern. For example `pattern="|"`
             means you want to split on `|` (imagine a csv file for example), while
-            `patter=tokenizer.Regex("1|2")` means you split on either '1' or '2'.
+            `pattern=tokenizers.Regex("1|2")` means you split on either '1' or '2'.
         behavior (:class:`~tokenizers.SplitDelimiterBehavior`):
             The behavior to use when splitting.
             Choices: "removed", "isolated", "merged_with_previous", "merged_with_next",

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -335,10 +335,10 @@ impl PyWhitespaceSplit {
 /// Args:
 ///     pattern (:obj:`str` or :class:`~tokenizers.Regex`):
 ///         A pattern used to split the string. Usually a string or a regex built with `tokenizers.Regex`.
-///         If you want to use a regex pattern, it has to be wrapped around a `tokenizer.Regex`,
+///         If you want to use a regex pattern, it has to be wrapped around a `tokenizers.Regex`,
 ///         otherwise we consider is as a string pattern. For example `pattern="|"`
 ///         means you want to split on `|` (imagine a csv file for example), while
-///         `patter=tokenizer.Regex("1|2")` means you split on either '1' or '2'.
+///         `pattern=tokenizers.Regex("1|2")` means you split on either '1' or '2'.
 ///     behavior (:class:`~tokenizers.SplitDelimiterBehavior`):
 ///         The behavior to use when splitting.
 ///         Choices: "removed", "isolated", "merged_with_previous", "merged_with_next",


### PR DESCRIPTION
fixed errors in the docstrings:
- `tokenizer.Regex` doesn't exist
- the arg name is pattern