### PR TITLE
Add rustls-tls feature

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -59,7 +59,7 @@ itertools = "0.13"
 log = "0.4"
 derive_builder = "0.20"
 spm_precompiled = "0.1.3"
-hf-hub = { version = "0.3.2", optional = true }
+hf-hub = { version = "0.4.1", features = ["ureq"], default-features = false, optional = true }
 aho-corasick = "1.1"
 paste = "1.0.14"
 macro_rules_attribute = "0.2.0"
@@ -75,6 +75,7 @@ esaxx_fast = ["esaxx-rs/cpp"]
 progressbar = ["indicatif"]
 http = ["hf-hub"]
 unstable_wasm = ["fancy-regex", "getrandom/js"]
+rustls-tls = ["hf-hub?/rustls-tls"]
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
Allow opting out of `openssl` in favor of [rustls ](https://github.com/rustls/rustls) via  `features = ["http", "rustls-tls"]`.

`Tokenizers` with `features = ["http"]` depends on `hf-hub`:

```
[[package]]
name = "tokenizers"
version = "0.21.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
checksum = "9ecededfed68a69bc657e486510089e255e53c3d38cc7d4d59c8742668ca2cae"
dependencies = [
 "aho-corasick",
 "derive_builder",
 "esaxx-rs",
 "getrandom 0.2.15",
 "hf-hub 0.3.2",
...
]
```

And default features of `hf-hub`  bring `openssl` with it via `native-tls`:
```
[[package]]
name = "hf-hub"
version = "0.3.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
checksum = "2b780635574b3d92f036890d8373433d6f9fc7abb320ee42a5c25897fc8ed732"
dependencies = [
 "dirs",
 "indicatif",
 "log",
 "native-tls",
 "rand",
 "serde",
 "serde_json",
 "thiserror 1.0.69",
 "ureq",
]
```

However, `hf-hub` provides a way out of `openssl` via `rustls-tls` feature: https://github.com/huggingface/hf-hub/blob/v0.4.1/Cargo.toml#L47

This change will allow to use `tokenizers` without `openssl` with `features = ["http", "rustls-tls"]`.