### PR TITLE
Add FxHash and ShortStringOptimization.

### DIFF
--- a/bindings/node/src/models.rs
+++ b/bindings/node/src/models.rs
@@ -4,7 +4,7 @@ use crate::trainers::Trainer;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use tokenizers as tk;
@@ -95,7 +95,7 @@ impl tk::Model for Model {
     self.model.as_ref()?.read().unwrap().id_to_token(id)
   }
 
-  fn get_vocab(&self) -> HashMap<String, u32> {
+  fn get_vocab(&self) -> FxHashMap<String, u32> {
     self
       .model
       .as_ref()

--- a/bindings/node/src/tokenizer.rs
+++ b/bindings/node/src/tokenizer.rs
@@ -6,7 +6,7 @@ use crate::pre_tokenizers::PreTokenizer;
 use crate::processors::Processor;
 use crate::tasks::tokenizer::{DecodeBatchTask, DecodeTask, EncodeBatchTask, EncodeTask};
 use crate::trainers::Trainer;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use tokenizers::Model as ModelTrait;
 
 use napi::bindgen_prelude::*;
@@ -433,7 +433,7 @@ impl Tokenizer {
   }
 
   #[napi]
-  pub fn get_vocab(&self, with_added_tokens: Option<bool>) -> HashMap<String, u32> {
+  pub fn get_vocab(&self, with_added_tokens: Option<bool>) -> FxHashMap<String, u32> {
     let with_added_tokens = with_added_tokens.unwrap_or(true);
     self.tokenizer.read().unwrap().get_vocab(with_added_tokens)
   }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -19,6 +19,7 @@ numpy = "0.23"
 ndarray = "0.16"
 itertools = "0.12"
 rustc-hash = "2.1.1"
+compact_str = { version = "0.8.1", features = ["serde"] }
 
 [dependencies.tokenizers]
 path = "../../tokenizers"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -18,6 +18,7 @@ pyo3 = { version = "0.23", features = ["abi3", "abi3-py39", "py-clone"] }
 numpy = "0.23"
 ndarray = "0.16"
 itertools = "0.12"
+rustc-hash = "2.1.1"
 
 [dependencies.tokenizers]
 path = "../../tokenizers"

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, RwLock};
 use crate::pre_tokenizers::from_string;
 use crate::tokenizer::PyTokenizer;
 use crate::utils::PyPattern;
+use compact_str::ToCompactString;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
@@ -91,7 +92,10 @@ impl PyDecoder {
 }
 
 impl Decoder for PyDecoder {
-    fn decode_chain(&self, tokens: Vec<String>) -> tk::Result<Vec<String>> {
+    fn decode_chain<T: ToCompactString>(
+        &self,
+        tokens: Vec<T>,
+    ) -> tk::Result<Vec<impl ToCompactString>> {
         self.decoder.decode_chain(tokens)
     }
 }
@@ -139,7 +143,12 @@ impl PyDecoder {
     ///     :obj:`str`: The decoded string
     #[pyo3(text_signature = "(self, tokens)")]
     fn decode(&self, tokens: Vec<String>) -> PyResult<String> {
-        ToPyResult(self.decoder.decode(tokens)).into()
+        ToPyResult(
+            self.decoder
+                .decode(tokens)
+                .map(|t| t.to_compact_string().to_string()),
+        )
+        .into()
     }
 
     fn __repr__(&self) -> PyResult<String> {
@@ -235,12 +244,12 @@ pub struct PyWordPieceDec {}
 impl PyWordPieceDec {
     #[getter]
     fn get_prefix(self_: PyRef<Self>) -> String {
-        getter!(self_, WordPiece, prefix.clone())
+        getter!(self_, WordPiece, prefix.clone().to_string())
     }
 
     #[setter]
     fn set_prefix(self_: PyRef<Self>, prefix: String) {
-        setter!(self_, WordPiece, prefix, prefix);
+        setter!(self_, WordPiece, prefix, prefix.to_compact_string());
     }
 
     #[getter]
@@ -256,7 +265,10 @@ impl PyWordPieceDec {
     #[new]
     #[pyo3(signature = (prefix = String::from("##"), cleanup = true), text_signature = "(self, prefix=\"##\", cleanup=True)")]
     fn new(prefix: String, cleanup: bool) -> (Self, PyDecoder) {
-        (PyWordPieceDec {}, WordPiece::new(prefix, cleanup).into())
+        (
+            PyWordPieceDec {},
+            WordPiece::new(prefix.to_compact_string(), cleanup).into(),
+        )
     }
 }
 
@@ -526,22 +538,33 @@ impl CustomDecoder {
 }
 
 impl Decoder for CustomDecoder {
-    fn decode(&self, tokens: Vec<String>) -> tk::Result<String> {
+    fn decode<T: ToCompactString>(&self, tokens: Vec<T>) -> tk::Result<impl ToCompactString> {
+        let tokens: Vec<String> = tokens
+            .into_iter()
+            .map(|t| t.to_compact_string().to_string())
+            .collect();
         Python::with_gil(|py| {
             let decoded = self
                 .inner
                 .call_method(py, "decode", (tokens,), None)?
-                .extract(py)?;
+                .extract::<String>(py)?;
             Ok(decoded)
         })
     }
 
-    fn decode_chain(&self, tokens: Vec<String>) -> tk::Result<Vec<String>> {
+    fn decode_chain<T: ToCompactString>(
+        &self,
+        tokens: Vec<T>,
+    ) -> tk::Result<Vec<impl ToCompactString>> {
+        let tokens: Vec<String> = tokens
+            .into_iter()
+            .map(|t| t.to_compact_string().to_string())
+            .collect();
         Python::with_gil(|py| {
             let decoded = self
                 .inner
                 .call_method(py, "decode_chain", (tokens,), None)?
-                .extract(py)?;
+                .extract::<Vec<String>>(py)?;
             Ok(decoded)
         })
     }
@@ -595,10 +618,21 @@ where
 }
 
 impl Decoder for PyDecoderWrapper {
-    fn decode_chain(&self, tokens: Vec<String>) -> tk::Result<Vec<String>> {
+    fn decode_chain<T: ToCompactString>(
+        &self,
+        tokens: Vec<T>,
+    ) -> tk::Result<Vec<impl ToCompactString>> {
         match self {
-            PyDecoderWrapper::Wrapped(inner) => inner.read().unwrap().decode_chain(tokens),
-            PyDecoderWrapper::Custom(inner) => inner.read().unwrap().decode_chain(tokens),
+            PyDecoderWrapper::Wrapped(inner) => inner
+                .read()
+                .unwrap()
+                .decode_chain(tokens)
+                .map(|v| v.into_iter().map(|t| t.to_compact_string()).collect()),
+            PyDecoderWrapper::Custom(inner) => inner
+                .read()
+                .unwrap()
+                .decode_chain(tokens)
+                .map(|v| v.into_iter().map(|t| t.to_compact_string()).collect()),
         }
     }
 }
@@ -663,14 +697,17 @@ impl PyDecodeStream {
 
     #[pyo3(signature = (tokenizer, id), text_signature = "(self, tokenizer, id)")]
     fn step(&mut self, tokenizer: &PyTokenizer, id: u32) -> PyResult<Option<String>> {
-        ToPyResult(tk::tokenizer::step_decode_stream(
-            &tokenizer.tokenizer,
-            id,
-            self.skip_special_tokens,
-            &mut self.ids,
-            &mut self.prefix,
-            &mut self.prefix_index,
-        ))
+        ToPyResult(
+            tk::tokenizer::step_decode_stream(
+                &tokenizer.tokenizer,
+                id,
+                self.skip_special_tokens,
+                &mut self.ids,
+                &mut self.prefix.to_compact_string(),
+                &mut self.prefix_index,
+            )
+            .map(|o| o.map(|s| s.to_string())),
+        )
         .into()
     }
 }

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -127,7 +127,11 @@ impl PyEncoding {
     ///     :obj:`List[str]`: The list of tokens
     #[getter]
     fn get_tokens(&self) -> Vec<String> {
-        self.encoding.get_tokens().to_vec()
+        self.encoding
+            .get_tokens()
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect()
     }
 
     /// The generated word indices.

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -1,3 +1,4 @@
+use compact_str::{CompactString, ToCompactString};
 use rustc_hash::FxHashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
@@ -8,7 +9,7 @@ use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
 use serde::{Deserialize, Serialize};
-use tk::models::bpe::{BpeBuilder, Merges, Vocab, BPE};
+use tk::models::bpe::{BpeBuilder, BPE};
 use tk::models::unigram::Unigram;
 use tk::models::wordlevel::WordLevel;
 use tk::models::wordpiece::{WordPiece, WordPieceBuilder};
@@ -17,6 +18,9 @@ use tk::{Model, Token};
 use tokenizers as tk;
 
 use super::error::{deprecation_warning, ToPyResult};
+
+pub type Vocab = FxHashMap<String, u32>;
+pub type Merges = Vec<(String, String)>;
 
 /// Base class for all models
 ///
@@ -66,11 +70,15 @@ impl Model for PyModel {
         self.model.read().unwrap().token_to_id(token)
     }
 
-    fn id_to_token(&self, id: u32) -> Option<String> {
-        self.model.read().unwrap().id_to_token(id)
+    fn id_to_token(&self, id: u32) -> Option<CompactString> {
+        self.model
+            .read()
+            .unwrap()
+            .id_to_token(id)
+            .map(|t| t.to_compact_string())
     }
 
-    fn get_vocab(&self) -> FxHashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<CompactString, u32> {
         self.model.read().unwrap().get_vocab()
     }
 
@@ -175,7 +183,7 @@ impl PyModel {
     ///     :obj:`str`: The token associated to the ID
     #[pyo3(text_signature = "(self, id)")]
     fn id_to_token(&self, id: u32) -> Option<String> {
-        self.model.read().unwrap().id_to_token(id)
+        self.model.read().unwrap().id_to_token(id).map(|t| t.into())
     }
 
     /// Save the current model
@@ -297,14 +305,19 @@ impl PyBPE {
                         }
                     }
                     "unk_token" => {
-                        if let Some(unk) = value.extract()? {
-                            builder = builder.unk_token(unk);
+                        if let Some(unk) = value.extract::<Option<String>>()? {
+                            builder = builder.unk_token(unk.to_compact_string());
                         }
                     }
                     "continuing_subword_prefix" => {
-                        builder = builder.continuing_subword_prefix(value.extract()?)
+                        builder = builder.continuing_subword_prefix(
+                            value.extract::<String>()?.to_compact_string(),
+                        )
                     }
-                    "end_of_word_suffix" => builder = builder.end_of_word_suffix(value.extract()?),
+                    "end_of_word_suffix" => {
+                        builder = builder
+                            .end_of_word_suffix(value.extract::<String>()?.to_compact_string())
+                    }
                     "fuse_unk" => builder = builder.fuse_unk(value.extract()?),
                     "byte_fallback" => builder = builder.byte_fallback(value.extract()?),
                     "ignore_merges" => builder = builder.ignore_merges(value.extract()?),
@@ -345,15 +358,63 @@ macro_rules! setter {
     }};
 }
 
-#[derive(FromPyObject)]
 enum PyVocab {
     Vocab(Vocab),
     Filename(String),
 }
-#[derive(FromPyObject)]
+impl<'py> FromPyObject<'py> for PyVocab {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if let Ok(dict) = ob.downcast::<PyDict>() {
+            let mut vocab: Vocab = FxHashMap::default();
+            for (key, value) in dict.iter() {
+                let key_str = key.extract::<String>()?;
+                let value_u32 = value.extract::<u32>()?;
+                vocab.insert(key_str, value_u32);
+            }
+            Ok(PyVocab::Vocab(vocab))
+        } else if let Ok(s) = ob.extract::<String>() {
+            Ok(PyVocab::Filename(s))
+        } else {
+            Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                "Expected a dictionary (str -> u32) or a string for PyVocab",
+            ))
+        }
+    }
+}
 enum PyMerges {
     Merges(Merges),
     Filename(String),
+}
+impl<'py> FromPyObject<'py> for PyMerges {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if let Ok(list) = ob.downcast::<PyList>() {
+            let mut merges: Merges = Vec::new();
+            for item in list.iter() {
+                if let Ok(tup) = item.downcast::<PyTuple>() {
+                    if tup.len() == 2 {
+                        let first = tup.get_item(0)?.extract::<String>()?;
+                        let second = tup.get_item(1)?.extract::<String>()?;
+                        merges.push((first, second))
+                    } else {
+                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                            "Expected tuples of length 2 for Merges variant",
+                        ));
+                    }
+                } else {
+                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                        "Expected a list of tuples (CompactString, CompactString) for Merges variant",
+                    ));
+                }
+            }
+            Ok(PyMerges::Merges(merges))
+        } else if let Ok(s) = ob.downcast::<PyString>() {
+            Ok(PyMerges::Filename(s.to_string()))
+        } else {
+            Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                "Expected list of tuples or a string for Merges",
+            ))
+        }
+    }
 }
 
 #[pymethods]
@@ -370,17 +431,22 @@ impl PyBPE {
 
     #[getter]
     fn get_unk_token(self_: PyRef<Self>) -> Option<String> {
-        getter!(self_, BPE, unk_token.clone())
+        getter!(self_, BPE, unk_token.clone()).map(|t| t.into())
     }
 
     #[setter]
     fn set_unk_token(self_: PyRef<Self>, unk_token: Option<String>) {
-        setter!(self_, BPE, unk_token, unk_token);
+        setter!(
+            self_,
+            BPE,
+            unk_token,
+            unk_token.map(|t| t.to_compact_string())
+        );
     }
 
     #[getter]
     fn get_continuing_subword_prefix(self_: PyRef<Self>) -> Option<String> {
-        getter!(self_, BPE, continuing_subword_prefix.clone())
+        getter!(self_, BPE, continuing_subword_prefix.clone()).map(|t| t.into())
     }
 
     #[setter]
@@ -392,18 +458,23 @@ impl PyBPE {
             self_,
             BPE,
             continuing_subword_prefix,
-            continuing_subword_prefix
+            continuing_subword_prefix.map(|t| t.to_compact_string())
         );
     }
 
     #[getter]
     fn get_end_of_word_suffix(self_: PyRef<Self>) -> Option<String> {
-        getter!(self_, BPE, end_of_word_suffix.clone())
+        getter!(self_, BPE, end_of_word_suffix.clone()).map(|t| t.into())
     }
 
     #[setter]
     fn set_end_of_word_suffix(self_: PyRef<Self>, end_of_word_suffix: Option<String>) {
-        setter!(self_, BPE, end_of_word_suffix, end_of_word_suffix);
+        setter!(
+            self_,
+            BPE,
+            end_of_word_suffix,
+            end_of_word_suffix.map(|t| t.to_compact_string())
+        );
     }
 
     #[getter]
@@ -454,6 +525,14 @@ impl PyBPE {
         if let (Some(vocab), Some(merges)) = (vocab, merges) {
             match (vocab, merges) {
                 (PyVocab::Vocab(vocab), PyMerges::Merges(merges)) => {
+                    let vocab = vocab
+                        .into_iter()
+                        .map(|(k, v)| (k.to_compact_string(), v))
+                        .collect();
+                    let merges = merges
+                        .into_iter()
+                        .map(|(k, v)| (k.to_compact_string(), v.to_compact_string()))
+                        .collect();
                     builder = builder.vocab_and_merges(vocab, merges);
                 }
                 (PyVocab::Filename(vocab_filename), PyMerges::Filename(merges_filename)) => {
@@ -495,12 +574,23 @@ impl PyBPE {
     #[staticmethod]
     #[pyo3(text_signature = "(self, vocab, merges)")]
     fn read_file(vocab: &str, merges: &str) -> PyResult<(Vocab, Merges)> {
-        BPE::read_file(vocab, merges).map_err(|e| {
-            exceptions::PyException::new_err(format!(
-                "Error while reading vocab & merges files: {}",
-                e
-            ))
-        })
+        BPE::read_file(vocab, merges)
+            .map(|(vocab, merges)| {
+                (
+                    vocab.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+                    merges
+                        .into_iter()
+                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                        .collect(),
+                )
+            })
+            .map_err(|e| {
+                exceptions::PyException::new_err(format!(
+                    "Error while reading vocab & merges files: {}",
+                    e
+                ))
+            })
+            .into()
     }
 
     /// Instantiate a BPE model from the given files.
@@ -540,8 +630,15 @@ impl PyBPE {
             py,
             PyBPE::new(
                 py,
-                Some(PyVocab::Vocab(vocab)),
-                Some(PyMerges::Merges(merges)),
+                Some(PyVocab::Vocab(
+                    vocab.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+                )),
+                Some(PyMerges::Merges(
+                    merges
+                        .into_iter()
+                        .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
+                        .collect(),
+                )),
                 kwargs,
             )?,
         )
@@ -596,13 +693,15 @@ impl PyWordPiece {
                 let key: String = key.extract()?;
                 match key.as_ref() {
                     "unk_token" => {
-                        builder = builder.unk_token(val.extract()?);
+                        builder = builder.unk_token(val.extract::<String>()?.to_compact_string());
                     }
                     "max_input_chars_per_word" => {
                         builder = builder.max_input_chars_per_word(val.extract()?);
                     }
                     "continuing_subword_prefix" => {
-                        builder = builder.continuing_subword_prefix(val.extract()?);
+                        builder = builder.continuing_subword_prefix(
+                            val.extract::<String>()?.to_compact_string(),
+                        );
                     }
                     _ => println!("Ignored unknown kwargs option {}", key),
                 }
@@ -623,17 +722,17 @@ impl PyWordPiece {
 impl PyWordPiece {
     #[getter]
     fn get_unk_token(self_: PyRef<Self>) -> String {
-        getter!(self_, WordPiece, unk_token.clone())
+        getter!(self_, WordPiece, unk_token.clone()).into()
     }
 
     #[setter]
     fn set_unk_token(self_: PyRef<Self>, unk_token: String) {
-        setter!(self_, WordPiece, unk_token, unk_token);
+        setter!(self_, WordPiece, unk_token, unk_token.to_compact_string());
     }
 
     #[getter]
     fn get_continuing_subword_prefix(self_: PyRef<Self>) -> String {
-        getter!(self_, WordPiece, continuing_subword_prefix.clone())
+        getter!(self_, WordPiece, continuing_subword_prefix.clone()).into()
     }
 
     #[setter]
@@ -642,7 +741,7 @@ impl PyWordPiece {
             self_,
             WordPiece,
             continuing_subword_prefix,
-            continuing_subword_prefix
+            continuing_subword_prefix.to_compact_string()
         );
     }
 
@@ -668,6 +767,10 @@ impl PyWordPiece {
         if let Some(vocab) = vocab {
             match vocab {
                 PyVocab::Vocab(vocab) => {
+                    let vocab = vocab
+                        .into_iter()
+                        .map(|(k, v)| (k.to_compact_string(), v))
+                        .collect();
                     builder = builder.vocab(vocab);
                 }
                 PyVocab::Filename(vocab_filename) => {
@@ -676,7 +779,7 @@ impl PyWordPiece {
                         "0.9.0",
                         "WordPiece.__init__ will not create from files anymore, try `WordPiece.from_file` instead",
                     )?;
-                    builder = builder.files(vocab_filename.to_string());
+                    builder = builder.files(vocab_filename.to_compact_string());
                 }
             }
         }
@@ -700,9 +803,14 @@ impl PyWordPiece {
     #[staticmethod]
     #[pyo3(text_signature = "(vocab)")]
     fn read_file(vocab: &str) -> PyResult<Vocab> {
-        WordPiece::read_file(vocab).map_err(|e| {
-            exceptions::PyException::new_err(format!("Error while reading WordPiece file: {}", e))
-        })
+        WordPiece::read_file(vocab)
+            .map(|vocab| vocab.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+            .map_err(|e| {
+                exceptions::PyException::new_err(format!(
+                    "Error while reading WordPiece file: {}",
+                    e
+                ))
+            })
     }
 
     /// Instantiate a WordPiece model from the given file
@@ -736,7 +844,13 @@ impl PyWordPiece {
         })?;
         Py::new(
             py,
-            PyWordPiece::new(py, Some(PyVocab::Vocab(vocab)), kwargs)?,
+            PyWordPiece::new(
+                py,
+                Some(PyVocab::Vocab(
+                    vocab.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+                )),
+                kwargs,
+            )?,
         )
     }
 }
@@ -758,12 +872,12 @@ pub struct PyWordLevel {}
 impl PyWordLevel {
     #[getter]
     fn get_unk_token(self_: PyRef<Self>) -> String {
-        getter!(self_, WordLevel, unk_token.clone())
+        getter!(self_, WordLevel, unk_token.clone()).into()
     }
 
     #[setter]
     fn set_unk_token(self_: PyRef<Self>, unk_token: String) {
-        setter!(self_, WordLevel, unk_token, unk_token);
+        setter!(self_, WordLevel, unk_token, unk_token.to_compact_string());
     }
 
     #[new]
@@ -778,6 +892,10 @@ impl PyWordLevel {
         if let Some(vocab) = vocab {
             match vocab {
                 PyVocab::Vocab(vocab) => {
+                    let vocab = vocab
+                        .into_iter()
+                        .map(|(k, v)| (k.to_compact_string(), v))
+                        .collect();
                     builder = builder.vocab(vocab);
                 }
                 PyVocab::Filename(vocab_filename) => {
@@ -787,12 +905,12 @@ impl PyWordLevel {
                         "WordLevel.__init__ will not create from files anymore, \
                             try `WordLevel.from_file` instead",
                     )?;
-                    builder = builder.files(vocab_filename.to_string());
+                    builder = builder.files(vocab_filename.to_compact_string());
                 }
             };
         }
         if let Some(unk_token) = unk_token {
-            builder = builder.unk_token(unk_token);
+            builder = builder.unk_token(unk_token.to_compact_string());
         }
 
         Ok((
@@ -819,9 +937,14 @@ impl PyWordLevel {
     #[staticmethod]
     #[pyo3(text_signature = "(vocab)")]
     fn read_file(vocab: &str) -> PyResult<Vocab> {
-        WordLevel::read_file(vocab).map_err(|e| {
-            exceptions::PyException::new_err(format!("Error while reading WordLevel file: {}", e))
-        })
+        WordLevel::read_file(vocab)
+            .map(|vocab| vocab.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+            .map_err(|e| {
+                exceptions::PyException::new_err(format!(
+                    "Error while reading WordLevel file: {}",
+                    e
+                ))
+            })
     }
 
     /// Instantiate a WordLevel model from the given file
@@ -855,7 +978,13 @@ impl PyWordLevel {
         })?;
         Py::new(
             py,
-            PyWordLevel::new(py, Some(PyVocab::Vocab(vocab)), unk_token)?,
+            PyWordLevel::new(
+                py,
+                Some(PyVocab::Vocab(
+                    vocab.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+                )),
+                unk_token,
+            )?,
         )
     }
 }
@@ -879,6 +1008,10 @@ impl PyUnigram {
     ) -> PyResult<(Self, PyModel)> {
         match (vocab, unk_id, byte_fallback) {
             (Some(vocab), unk_id, byte_fallback) => {
+                let vocab = vocab
+                    .into_iter()
+                    .map(|(t, s)| (t.to_compact_string(), s))
+                    .collect();
                 let model =
                     Unigram::from(vocab, unk_id, byte_fallback.unwrap_or(false)).map_err(|e| {
                         exceptions::PyException::new_err(format!(

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
@@ -70,7 +70,7 @@ impl Model for PyModel {
         self.model.read().unwrap().id_to_token(id)
     }
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         self.model.read().unwrap().get_vocab()
     }
 

--- a/bindings/python/src/token.rs
+++ b/bindings/python/src/token.rs
@@ -1,3 +1,4 @@
+use compact_str::ToCompactString;
 use pyo3::prelude::*;
 use tk::Token;
 
@@ -22,7 +23,7 @@ impl PyToken {
     #[new]
     #[pyo3(text_signature = None)]
     fn new(id: u32, value: String, offsets: (usize, usize)) -> PyToken {
-        Token::new(id, value, offsets).into()
+        Token::new(id, value.to_compact_string(), offsets).into()
     }
 
     #[getter]

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
-use std::collections::{hash_map::DefaultHasher, HashMap};
+use std::collections::hash_map::DefaultHasher;
+use rustc_hash::FxHashMap;
 use std::hash::{Hash, Hasher};
 
 use numpy::{npyffi, PyArray1, PyArrayMethods};
@@ -675,7 +676,7 @@ impl PyTokenizer {
     ///     :obj:`Dict[str, int]`: The vocabulary
     #[pyo3(signature = (with_added_tokens = true))]
     #[pyo3(text_signature = "(self, with_added_tokens=True)")]
-    fn get_vocab(&self, with_added_tokens: bool) -> HashMap<String, u32> {
+    fn get_vocab(&self, with_added_tokens: bool) -> FxHashMap<String, u32> {
         self.tokenizer.get_vocab(with_added_tokens)
     }
 

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -2,6 +2,8 @@ use std::sync::{Arc, RwLock};
 
 use crate::models::PyModel;
 use crate::tokenizer::PyAddedToken;
+use compact_str::CompactString;
+use compact_str::ToCompactString;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
@@ -105,7 +107,7 @@ impl Trainer for PyTrainer {
     where
         I: Iterator<Item = S> + Send,
         S: AsRef<str> + Send,
-        F: Fn(&str) -> tk::Result<Vec<String>> + Sync,
+        F: Fn(&str) -> tk::Result<Vec<CompactString>> + Sync,
     {
         self.trainer.write().unwrap().feed(iterator, process)
     }
@@ -295,22 +297,40 @@ impl PyBpeTrainer {
 
     #[getter]
     fn get_continuing_subword_prefix(self_: PyRef<Self>) -> Option<String> {
-        getter!(self_, BpeTrainer, continuing_subword_prefix.clone())
+        getter!(
+            self_,
+            BpeTrainer,
+            continuing_subword_prefix.clone().map(|s| s.to_string())
+        )
     }
 
     #[setter]
     fn set_continuing_subword_prefix(self_: PyRef<Self>, prefix: Option<String>) {
-        setter!(self_, BpeTrainer, continuing_subword_prefix, prefix);
+        setter!(
+            self_,
+            BpeTrainer,
+            continuing_subword_prefix,
+            prefix.map(|s| s.to_compact_string())
+        );
     }
 
     #[getter]
     fn get_end_of_word_suffix(self_: PyRef<Self>) -> Option<String> {
-        getter!(self_, BpeTrainer, end_of_word_suffix.clone())
+        getter!(
+            self_,
+            BpeTrainer,
+            end_of_word_suffix.clone().map(|s| s.to_string())
+        )
     }
 
     #[setter]
     fn set_end_of_word_suffix(self_: PyRef<Self>, suffix: Option<String>) {
-        setter!(self_, BpeTrainer, end_of_word_suffix, suffix);
+        setter!(
+            self_,
+            BpeTrainer,
+            end_of_word_suffix,
+            suffix.map(|s| s.to_compact_string())
+        );
     }
 
     #[new]
@@ -357,9 +377,13 @@ impl PyBpeTrainer {
                         );
                     }
                     "continuing_subword_prefix" => {
-                        builder = builder.continuing_subword_prefix(val.extract()?)
+                        builder = builder
+                            .continuing_subword_prefix(val.extract::<String>()?.to_compact_string())
                     }
-                    "end_of_word_suffix" => builder = builder.end_of_word_suffix(val.extract()?),
+                    "end_of_word_suffix" => {
+                        builder =
+                            builder.end_of_word_suffix(val.extract::<String>()?.to_compact_string())
+                    }
                     _ => println!("Ignored unknown kwargs option {}", key),
                 };
             }
@@ -499,22 +523,30 @@ impl PyWordPieceTrainer {
 
     #[getter]
     fn get_continuing_subword_prefix(self_: PyRef<Self>) -> Option<String> {
-        getter!(self_, WordPieceTrainer, continuing_subword_prefix().clone())
+        getter!(
+            self_,
+            WordPieceTrainer,
+            continuing_subword_prefix().clone().map(|s| s.to_string())
+        )
     }
 
     #[setter]
     fn set_continuing_subword_prefix(self_: PyRef<Self>, prefix: Option<String>) {
-        setter!(self_, WordPieceTrainer, @set_continuing_subword_prefix, prefix);
+        setter!(self_, WordPieceTrainer, @set_continuing_subword_prefix, prefix.map(|s| s.to_compact_string()));
     }
 
     #[getter]
     fn get_end_of_word_suffix(self_: PyRef<Self>) -> Option<String> {
-        getter!(self_, WordPieceTrainer, end_of_word_suffix().clone())
+        getter!(
+            self_,
+            WordPieceTrainer,
+            end_of_word_suffix().clone().map(|s| s.to_string())
+        )
     }
 
     #[setter]
     fn set_end_of_word_suffix(self_: PyRef<Self>, suffix: Option<String>) {
-        setter!(self_, WordPieceTrainer, @set_end_of_word_suffix, suffix);
+        setter!(self_, WordPieceTrainer, @set_end_of_word_suffix, suffix.map(|s| s.to_compact_string()));
     }
 
     #[new]
@@ -563,9 +595,13 @@ impl PyWordPieceTrainer {
                         );
                     }
                     "continuing_subword_prefix" => {
-                        builder = builder.continuing_subword_prefix(val.extract()?)
+                        builder = builder
+                            .continuing_subword_prefix(val.extract::<String>()?.to_compact_string())
                     }
-                    "end_of_word_suffix" => builder = builder.end_of_word_suffix(val.extract()?),
+                    "end_of_word_suffix" => {
+                        builder =
+                            builder.end_of_word_suffix(val.extract::<String>()?.to_compact_string())
+                    }
                     _ => println!("Ignored unknown kwargs option {}", key),
                 };
             }
@@ -840,7 +876,10 @@ impl PyUnigramTrainer {
                     "show_progress" => builder.show_progress(val.extract()?),
                     "n_sub_iterations" => builder.n_sub_iterations(val.extract()?),
                     "shrinking_factor" => builder.shrinking_factor(val.extract()?),
-                    "unk_token" => builder.unk_token(val.extract()?),
+                    "unk_token" => builder.unk_token(
+                        val.extract::<Option<String>>()?
+                            .map(|s| s.to_compact_string()),
+                    ),
                     "max_piece_length" => builder.max_piece_length(val.extract()?),
                     "seed_size" => builder.seed_size(val.extract()?),
                     "initial_alphabet" => {

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -68,6 +68,8 @@ fancy-regex = { version = "0.14", optional = true}
 getrandom = { version = "0.2.10" }
 esaxx-rs = { version = "0.1.10", default-features = false, features=[]}
 monostate = "0.1.12"
+flexstr = { version = "0.9.2", features = ["serde", "fast_format"] }
+rustc-hash = "2.1.1"
 
 [features]
 default = ["progressbar", "onig", "esaxx_fast"]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-authors = ["Anthony MOI <m.anthony.moi@gmail.com>", "Nicolas Patry <patry.nicolas@protonmail.com>"]
+authors = [
+    "Anthony MOI <m.anthony.moi@gmail.com>",
+    "Nicolas Patry <patry.nicolas@protonmail.com>",
+]
 edition = "2018"
 name = "tokenizers"
 version = "0.21.0-dev.0"
@@ -13,7 +16,14 @@ description = """
 Provides an implementation of today's most used tokenizers,
 with a focus on performances and versatility.
 """
-exclude = [ "rust-toolchain", "target/*", "Cargo.lock", "benches/*.txt", "benches/*.json", "data/*" ]
+exclude = [
+    "rust-toolchain",
+    "target/*",
+    "Cargo.lock",
+    "benches/*.txt",
+    "benches/*.json",
+    "data/*",
+]
 
 [lib]
 name = "tokenizers"
@@ -49,12 +59,12 @@ regex = "1.10"
 regex-syntax = "0.8"
 rayon = "1.10"
 rayon-cond = "0.3"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 unicode-segmentation = "1.11"
-indicatif = {version = "0.17", optional = true}
+indicatif = { version = "0.17", optional = true }
 itertools = "0.13"
 log = "0.4"
 derive_builder = "0.20"
@@ -64,12 +74,12 @@ aho-corasick = "1.1"
 paste = "1.0.14"
 macro_rules_attribute = "0.2.0"
 thiserror = "2"
-fancy-regex = { version = "0.14", optional = true}
+fancy-regex = { version = "0.14", optional = true }
 getrandom = { version = "0.2.10" }
-esaxx-rs = { version = "0.1.10", default-features = false, features=[]}
+esaxx-rs = { version = "0.1.10", default-features = false, features = [] }
 monostate = "0.1.12"
-flexstr = { version = "0.9.2", features = ["serde", "fast_format"] }
 rustc-hash = "2.1.1"
+compact_str = { version = "0.8.1", features = ["serde"] }
 
 [features]
 default = ["progressbar", "onig", "esaxx_fast"]
@@ -91,4 +101,3 @@ lto = "fat"
 [[example]]
 name = "encode_batch"
 required-features = ["http"]
-

--- a/tokenizers/benches/bert_benchmark.rs
+++ b/tokenizers/benches/bert_benchmark.rs
@@ -38,8 +38,8 @@ fn create_bert_tokenizer(wp: WordPiece) -> BertTokenizer {
     tokenizer.with_normalizer(Some(BertNormalizer::default()));
     tokenizer.with_decoder(Some(decoders::wordpiece::WordPiece::default()));
     tokenizer.with_post_processor(Some(BertProcessing::new(
-        ("[SEP]".to_string(), sep_id),
-        ("[CLS]".to_string(), cls_id),
+        ("[SEP]".into(), sep_id),
+        ("[CLS]".into(), cls_id),
     )));
     tokenizer
 }

--- a/tokenizers/benches/unigram_benchmark.rs
+++ b/tokenizers/benches/unigram_benchmark.rs
@@ -25,10 +25,7 @@ pub fn bench_train(c: &mut Criterion) {
         *word_counts.entry(word).or_insert(0) += 1;
     });
 
-    let sentences: Vec<_> = word_counts
-        .iter()
-        .map(|(s, i)| (s.to_owned(), *i))
-        .collect();
+    let sentences: Vec<_> = word_counts.iter().map(|(s, i)| (s.into(), *i)).collect();
 
     c.bench_function("Unigram Train vocabulary (small)", |b| {
         b.iter_custom(|iters| {
@@ -53,10 +50,7 @@ pub fn bench_train(c: &mut Criterion) {
         *word_counts.entry(word).or_insert(0) += 1;
     });
 
-    let sentences: Vec<_> = word_counts
-        .iter()
-        .map(|(s, i)| (s.to_owned(), *i))
-        .collect();
+    let sentences: Vec<_> = word_counts.iter().map(|(s, i)| (s.into(), *i)).collect();
 
     c.bench_function("Unigram Train vocabulary (medium)", |b| {
         b.iter_custom(|iters| {

--- a/tokenizers/src/decoders/bpe.rs
+++ b/tokenizers/src/decoders/bpe.rs
@@ -28,15 +28,18 @@ impl Decoder for BPEDecoder {
     fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
-    ) -> Result<Vec<CompactString>> {
+    ) -> Result<Vec<impl ToCompactString>> {
         let n = tokens.len() - 1;
         Ok(tokens
             .into_iter()
             .enumerate()
             .map(|(i, token)| {
                 let replacement = if i == n { "" } else { " " };
-                token.to_compact_string().replace(&self.suffix, replacement).into()
+                token
+                    .to_compact_string()
+                    .replace(&self.suffix, replacement)
+                    .to_compact_string()
             })
-            .collect())
+            .collect::<Vec<CompactString>>())
     }
 }

--- a/tokenizers/src/decoders/bpe.rs
+++ b/tokenizers/src/decoders/bpe.rs
@@ -1,6 +1,6 @@
 use crate::tokenizer::{Decoder, Result};
 
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Clone, Debug, Serialize)]
@@ -25,7 +25,7 @@ impl Default for BPEDecoder {
 }
 
 impl Decoder for BPEDecoder {
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+    fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
     ) -> Result<Vec<CompactString>> {
@@ -35,7 +35,7 @@ impl Decoder for BPEDecoder {
             .enumerate()
             .map(|(i, token)| {
                 let replacement = if i == n { "" } else { " " };
-                token.into().replace(&self.suffix, replacement).into()
+                token.to_compact_string().replace(&self.suffix, replacement).into()
             })
             .collect())
     }

--- a/tokenizers/src/decoders/bpe.rs
+++ b/tokenizers/src/decoders/bpe.rs
@@ -1,5 +1,6 @@
 use crate::tokenizer::{Decoder, Result};
 
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Clone, Debug, Serialize)]
@@ -24,14 +25,14 @@ impl Default for BPEDecoder {
 }
 
 impl Decoder for BPEDecoder {
-    fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
+    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
         let n = tokens.len() - 1;
         Ok(tokens
             .into_iter()
             .enumerate()
             .map(|(i, token)| {
                 let replacement = if i == n { "" } else { " " };
-                token.replace(&self.suffix, replacement)
+                token.replace(&self.suffix, replacement).into()
             })
             .collect())
     }

--- a/tokenizers/src/decoders/bpe.rs
+++ b/tokenizers/src/decoders/bpe.rs
@@ -25,14 +25,17 @@ impl Default for BPEDecoder {
 }
 
 impl Decoder for BPEDecoder {
-    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
+    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+        &self,
+        tokens: Vec<T>,
+    ) -> Result<Vec<CompactString>> {
         let n = tokens.len() - 1;
         Ok(tokens
             .into_iter()
             .enumerate()
             .map(|(i, token)| {
                 let replacement = if i == n { "" } else { " " };
-                token.replace(&self.suffix, replacement).into()
+                token.into().replace(&self.suffix, replacement).into()
             })
             .collect())
     }

--- a/tokenizers/src/decoders/byte_fallback.rs
+++ b/tokenizers/src/decoders/byte_fallback.rs
@@ -1,5 +1,5 @@
 use crate::tokenizer::{Decoder, Result};
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use monostate::MustBe;
 
 use serde::{Deserialize, Serialize};
@@ -23,7 +23,7 @@ impl ByteFallback {
 }
 
 impl Decoder for ByteFallback {
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+    fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
     ) -> Result<Vec<CompactString>> {
@@ -31,7 +31,7 @@ impl Decoder for ByteFallback {
         let mut previous_byte_tokens: Vec<u8> = vec![];
 
         for token in tokens {
-            let token: CompactString = token.into();
+            let token: CompactString = token.to_compact_string();
             let bytes = if token.len() == 6 && token.starts_with("<0x") && token.ends_with('>') {
                 if let Ok(byte) = u8::from_str_radix(&token[3..5], 16) {
                     Some(byte)

--- a/tokenizers/src/decoders/byte_fallback.rs
+++ b/tokenizers/src/decoders/byte_fallback.rs
@@ -26,7 +26,7 @@ impl Decoder for ByteFallback {
     fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
-    ) -> Result<Vec<CompactString>> {
+    ) -> Result<Vec<impl ToCompactString>> {
         let mut new_tokens: Vec<CompactString> = vec![];
         let mut previous_byte_tokens: Vec<u8> = vec![];
 
@@ -81,18 +81,38 @@ mod tests {
         let res = decoder
             .decode_chain(vec!["Hey".to_owned(), "friend!".to_owned()])
             .unwrap();
-        assert_eq!(res, vec!["Hey".to_owned(), "friend!".to_owned()]);
+        assert_eq!(
+            res.into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
+            vec!["Hey".to_owned(), "friend!".to_owned()]
+        );
 
         let res = decoder.decode_chain(vec!["<0x61>".to_owned()]).unwrap();
-        assert_eq!(res, vec!["a".to_owned()]);
+        assert_eq!(
+            res.into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
+            vec!["a".to_owned()]
+        );
 
         let res = decoder.decode_chain(vec!["<0xE5>".to_owned()]).unwrap();
-        assert_eq!(res, vec!["�"]);
+        assert_eq!(
+            res.into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
+            vec!["�"]
+        );
 
         let res = decoder
             .decode_chain(vec!["<0xE5>".to_owned(), "<0x8f>".to_owned()])
             .unwrap();
-        assert_eq!(res, vec!["�".to_owned(), "�".to_owned()]);
+        assert_eq!(
+            res.into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
+            vec!["�".to_owned(), "�".to_owned()]
+        );
 
         // 叫
         let res = decoder
@@ -102,7 +122,12 @@ mod tests {
                 "<0xab>".to_owned(),
             ])
             .unwrap();
-        assert_eq!(res, vec!["叫"]);
+        assert_eq!(
+            res.into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
+            vec!["叫"]
+        );
 
         let res = decoder
             .decode_chain(vec![
@@ -112,7 +137,12 @@ mod tests {
                 "a".to_owned(),
             ])
             .unwrap();
-        assert_eq!(res, vec!["叫".to_owned(), "a".to_owned()]);
+        assert_eq!(
+            res.into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
+            vec!["叫".to_owned(), "a".to_owned()]
+        );
 
         let res = decoder
             .decode_chain(vec![
@@ -121,6 +151,11 @@ mod tests {
                 "a".to_owned(),
             ])
             .unwrap();
-        assert_eq!(res, vec!["�".to_owned(), "�".to_owned(), "a".to_owned()]);
+        assert_eq!(
+            res.into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
+            vec!["�".to_owned(), "�".to_owned(), "a".to_owned()]
+        );
     }
 }

--- a/tokenizers/src/decoders/byte_fallback.rs
+++ b/tokenizers/src/decoders/byte_fallback.rs
@@ -1,4 +1,5 @@
 use crate::tokenizer::{Decoder, Result};
+use compact_str::CompactString;
 use monostate::MustBe;
 
 use serde::{Deserialize, Serialize};
@@ -22,8 +23,8 @@ impl ByteFallback {
 }
 
 impl Decoder for ByteFallback {
-    fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
-        let mut new_tokens: Vec<String> = vec![];
+    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
+        let mut new_tokens: Vec<CompactString> = vec![];
         let mut previous_byte_tokens: Vec<u8> = vec![];
 
         for token in tokens {
@@ -40,7 +41,7 @@ impl Decoder for ByteFallback {
                 previous_byte_tokens.push(bytes);
             } else {
                 if !previous_byte_tokens.is_empty() {
-                    if let Ok(string) = String::from_utf8(previous_byte_tokens.clone()) {
+                    if let Ok(string) = CompactString::from_utf8(previous_byte_tokens.clone()) {
                         new_tokens.push(string);
                     } else {
                         for _ in 0..previous_byte_tokens.len() {
@@ -53,7 +54,7 @@ impl Decoder for ByteFallback {
             }
         }
         if !previous_byte_tokens.is_empty() {
-            if let Ok(string) = String::from_utf8(previous_byte_tokens.clone()) {
+            if let Ok(string) = CompactString::from_utf8(previous_byte_tokens.clone()) {
                 new_tokens.push(string);
             } else {
                 for _ in 0..previous_byte_tokens.len() {

--- a/tokenizers/src/decoders/ctc.rs
+++ b/tokenizers/src/decoders/ctc.rs
@@ -43,9 +43,13 @@ impl Default for CTC {
 }
 
 impl Decoder for CTC {
-    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
+    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+        &self,
+        tokens: Vec<T>,
+    ) -> Result<Vec<CompactString>> {
         Ok(tokens
             .into_iter()
+            .map(|token| token.into())
             .dedup()
             .filter_map(|token| {
                 let mut replaced: CompactString = token.replace(&self.pad_token, "").into();

--- a/tokenizers/src/decoders/ctc.rs
+++ b/tokenizers/src/decoders/ctc.rs
@@ -1,7 +1,7 @@
 use crate::decoders::wordpiece;
 use crate::tokenizer::{Decoder, Result};
 
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
@@ -43,13 +43,13 @@ impl Default for CTC {
 }
 
 impl Decoder for CTC {
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+    fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
     ) -> Result<Vec<CompactString>> {
         Ok(tokens
             .into_iter()
-            .map(|token| token.into())
+            .map(|token| token.to_compact_string())
             .dedup()
             .filter_map(|token| {
                 let mut replaced: CompactString = token.replace(&self.pad_token, "").into();

--- a/tokenizers/src/decoders/ctc.rs
+++ b/tokenizers/src/decoders/ctc.rs
@@ -46,7 +46,7 @@ impl Decoder for CTC {
     fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
-    ) -> Result<Vec<CompactString>> {
+    ) -> Result<Vec<impl ToCompactString>> {
         Ok(tokens
             .into_iter()
             .map(|token| token.to_compact_string())
@@ -70,9 +70,10 @@ impl Decoder for CTC {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::utils::compact_string::to_compact_strings;
     use compact_str::ToCompactString;
 
-    use super::*;
     #[test]
     fn handmade_sample() {
         let ctc_decoder = CTC::default();
@@ -81,7 +82,10 @@ mod tests {
             .map(|s| s.to_compact_string())
             .collect();
         assert_eq!(
-            ctc_decoder.decode_chain(id_to_string_result).unwrap(),
+            ctc_decoder
+                .decode_chain(id_to_string_result)
+                .map(to_compact_strings)
+                .unwrap(),
             vec!["h", "e", "l", "l", "o"]
         );
     }
@@ -93,7 +97,10 @@ mod tests {
             .map(|s| s.to_compact_string())
             .collect();
         assert_eq!(
-            ctc_decoder.decode_chain(id_to_string_result).unwrap(),
+            ctc_decoder
+                .decode_chain(id_to_string_result)
+                .map(to_compact_strings)
+                .unwrap(),
             vec!["h", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d"]
         );
     }
@@ -102,7 +109,10 @@ mod tests {
         let ctc_decoder = CTC::default();
         let id_to_string_result = "<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> A | | <pad> M <pad> <pad> <pad> <pad> A <pad> <pad> N <pad> <pad> <pad> | | | <pad> <pad> <pad> <pad> S <pad> <pad> <pad> A I <pad> D D | | T T <pad> O <pad> | | T H E E | | | <pad> U U <pad> N N <pad> I <pad> <pad> V <pad> <pad> <pad> E R R <pad> <pad> <pad> S E E | | <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> S S <pad> <pad> <pad> <pad> I <pad> R R <pad> <pad> | | | <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> I <pad> <pad> <pad> | <pad> <pad> <pad> E X <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> I <pad> S <pad> <pad> T <pad> <pad> | | <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>".split(' ').map(|s| s.to_compact_string()).collect();
         assert_eq!(
-            ctc_decoder.decode_chain(id_to_string_result).unwrap(),
+            ctc_decoder
+                .decode_chain(id_to_string_result)
+                .map(to_compact_strings)
+                .unwrap(),
             vec![
                 "A", " ", "M", "A", "N", " ", "S", "A", "I", "D", " ", "T", "O", " ", "T", "H",
                 "E", " ", "U", "N", "I", "V", "E", "R", "S", "E", " ", "S", "I", "R", " ", "I",
@@ -115,7 +125,10 @@ mod tests {
         let ctc_decoder = CTC::default();
         let id_to_string_result = "<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> H <pad> I <pad> S S | | <pad> <pad> <pad> I N <pad> <pad> S <pad> T T <pad> <pad> A N C C T <pad> | | | | | <pad> <pad> <pad> <pad> P <pad> <pad> <pad> <pad> A <pad> <pad> N N N <pad> <pad> I <pad> C <pad> <pad> | | <pad> W <pad> <pad> A S <pad> | | <pad> <pad> <pad> F <pad> <pad> O L <pad> <pad> L L O O W E E D | | <pad> B <pad> <pad> <pad> Y <pad> | | | A | | <pad> S S S <pad> M M <pad> <pad> <pad> A L L <pad> <pad> <pad> <pad> L <pad> | | | <pad> <pad> <pad> <pad> S H H <pad> <pad> <pad> <pad> A R R <pad> <pad> P <pad> <pad> | <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> B <pad> <pad> L L <pad> <pad> <pad> <pad> <pad> O W W <pad> <pad> | | | <pad> <pad> <pad> <pad> <pad> <pad> <pad> H <pad> <pad> <pad> <pad> <pad> <pad> <pad> I G H H | | <pad> <pad> O N <pad> | | H <pad> I S S | | <pad> <pad> C H H <pad> <pad> <pad> E <pad> S S <pad> T T <pad> <pad> | | | <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>".split(' ').map(|s| s.to_compact_string()).collect();
         assert_eq!(
-            ctc_decoder.decode_chain(id_to_string_result).unwrap(),
+            ctc_decoder
+                .decode_chain(id_to_string_result)
+                .map(to_compact_strings)
+                .unwrap(),
             vec![
                 "H", "I", "S", " ", "I", "N", "S", "T", "A", "N", "C", "T", " ", "P", "A", "N",
                 "I", "C", " ", "W", "A", "S", " ", "F", "O", "L", "L", "O", "W", "E", "D", " ",

--- a/tokenizers/src/decoders/fuse.rs
+++ b/tokenizers/src/decoders/fuse.rs
@@ -1,4 +1,5 @@
 use crate::tokenizer::{Decoder, Result};
+use compact_str::CompactString;
 use monostate::MustBe;
 use serde::{Deserialize, Serialize};
 
@@ -22,8 +23,8 @@ impl Fuse {
 }
 
 impl Decoder for Fuse {
-    fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
-        let new_string = tokens.join("");
+    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
+        let new_string: CompactString = tokens.join("").into();
         Ok(vec![new_string])
     }
 }

--- a/tokenizers/src/decoders/fuse.rs
+++ b/tokenizers/src/decoders/fuse.rs
@@ -26,7 +26,7 @@ impl Decoder for Fuse {
     fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
-    ) -> Result<Vec<CompactString>> {
+    ) -> Result<Vec<impl ToCompactString>> {
         let new_string: CompactString = tokens
             .into_iter()
             .map(|token| token.to_compact_string())
@@ -47,6 +47,11 @@ mod tests {
         let res = decoder
             .decode_chain(vec!["Hey".to_owned(), " friend!".to_owned()])
             .unwrap();
-        assert_eq!(res, vec!["Hey friend!"]);
+        assert_eq!(
+            res.into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
+            vec!["Hey friend!"]
+        );
     }
 }

--- a/tokenizers/src/decoders/fuse.rs
+++ b/tokenizers/src/decoders/fuse.rs
@@ -23,8 +23,16 @@ impl Fuse {
 }
 
 impl Decoder for Fuse {
-    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
-        let new_string: CompactString = tokens.join("").into();
+    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+        &self,
+        tokens: Vec<T>,
+    ) -> Result<Vec<CompactString>> {
+        let new_string: CompactString = tokens
+            .into_iter()
+            .map(|token| token.into())
+            .collect::<Vec<_>>()
+            .join("")
+            .into();
         Ok(vec![new_string])
     }
 }
@@ -37,7 +45,7 @@ mod tests {
     fn decode() {
         let decoder = Fuse::new();
         let res = decoder
-            .decode_chain(vec!["Hey".into(), " friend!".into()])
+            .decode_chain(vec!["Hey".to_owned(), " friend!".to_owned()])
             .unwrap();
         assert_eq!(res, vec!["Hey friend!"]);
     }

--- a/tokenizers/src/decoders/fuse.rs
+++ b/tokenizers/src/decoders/fuse.rs
@@ -1,5 +1,5 @@
 use crate::tokenizer::{Decoder, Result};
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use monostate::MustBe;
 use serde::{Deserialize, Serialize};
 
@@ -23,13 +23,13 @@ impl Fuse {
 }
 
 impl Decoder for Fuse {
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+    fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
     ) -> Result<Vec<CompactString>> {
         let new_string: CompactString = tokens
             .into_iter()
-            .map(|token| token.into())
+            .map(|token| token.to_compact_string())
             .collect::<Vec<_>>()
             .join("")
             .into();

--- a/tokenizers/src/decoders/mod.rs
+++ b/tokenizers/src/decoders/mod.rs
@@ -151,7 +151,10 @@ impl<'de> Deserialize<'de> for DecoderWrapper {
 }
 
 impl Decoder for DecoderWrapper {
-    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
+    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+        &self,
+        tokens: Vec<T>,
+    ) -> Result<Vec<CompactString>> {
         match self {
             Self::BPE(bpe) => bpe.decode_chain(tokens),
             Self::ByteLevel(bl) => bl.decode_chain(tokens),

--- a/tokenizers/src/decoders/mod.rs
+++ b/tokenizers/src/decoders/mod.rs
@@ -10,7 +10,7 @@ pub mod wordpiece;
 pub use super::pre_tokenizers::byte_level;
 pub use super::pre_tokenizers::metaspace;
 
-use compact_str::{CompactString, ToCompactString};
+use compact_str::ToCompactString;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::decoders::bpe::BPEDecoder;
@@ -23,6 +23,7 @@ use crate::decoders::wordpiece::WordPiece;
 use crate::normalizers::replace::Replace;
 use crate::pre_tokenizers::byte_level::ByteLevel;
 use crate::pre_tokenizers::metaspace::Metaspace;
+use crate::utils::compact_string::to_compact_strings;
 use crate::{Decoder, Result};
 
 #[derive(Serialize, Clone, Debug)]
@@ -154,18 +155,18 @@ impl Decoder for DecoderWrapper {
     fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
-    ) -> Result<Vec<CompactString>> {
+    ) -> Result<Vec<impl ToCompactString>> {
         match self {
-            Self::BPE(bpe) => bpe.decode_chain(tokens),
-            Self::ByteLevel(bl) => bl.decode_chain(tokens),
-            Self::Metaspace(ms) => ms.decode_chain(tokens),
-            Self::WordPiece(wp) => wp.decode_chain(tokens),
-            Self::CTC(ctc) => ctc.decode_chain(tokens),
-            Self::Sequence(seq) => seq.decode_chain(tokens),
-            Self::Replace(seq) => seq.decode_chain(tokens),
-            Self::ByteFallback(bf) => bf.decode_chain(tokens),
-            Self::Strip(bf) => bf.decode_chain(tokens),
-            Self::Fuse(bf) => bf.decode_chain(tokens),
+            Self::BPE(bpe) => bpe.decode_chain(tokens).map(to_compact_strings),
+            Self::ByteLevel(bl) => bl.decode_chain(tokens).map(to_compact_strings),
+            Self::Metaspace(ms) => ms.decode_chain(tokens).map(to_compact_strings),
+            Self::WordPiece(wp) => wp.decode_chain(tokens).map(to_compact_strings),
+            Self::CTC(ctc) => ctc.decode_chain(tokens).map(to_compact_strings),
+            Self::Sequence(seq) => seq.decode_chain(tokens).map(to_compact_strings),
+            Self::Replace(seq) => seq.decode_chain(tokens).map(to_compact_strings),
+            Self::ByteFallback(bf) => bf.decode_chain(tokens).map(to_compact_strings),
+            Self::Strip(bf) => bf.decode_chain(tokens).map(to_compact_strings),
+            Self::Fuse(bf) => bf.decode_chain(tokens).map(to_compact_strings),
         }
     }
 }

--- a/tokenizers/src/decoders/mod.rs
+++ b/tokenizers/src/decoders/mod.rs
@@ -10,6 +10,7 @@ pub mod wordpiece;
 pub use super::pre_tokenizers::byte_level;
 pub use super::pre_tokenizers::metaspace;
 
+use compact_str::CompactString;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::decoders::bpe::BPEDecoder;
@@ -150,7 +151,7 @@ impl<'de> Deserialize<'de> for DecoderWrapper {
 }
 
 impl Decoder for DecoderWrapper {
-    fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
+    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
         match self {
             Self::BPE(bpe) => bpe.decode_chain(tokens),
             Self::ByteLevel(bl) => bl.decode_chain(tokens),

--- a/tokenizers/src/decoders/mod.rs
+++ b/tokenizers/src/decoders/mod.rs
@@ -10,7 +10,7 @@ pub mod wordpiece;
 pub use super::pre_tokenizers::byte_level;
 pub use super::pre_tokenizers::metaspace;
 
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::decoders::bpe::BPEDecoder;
@@ -151,7 +151,7 @@ impl<'de> Deserialize<'de> for DecoderWrapper {
 }
 
 impl Decoder for DecoderWrapper {
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+    fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
     ) -> Result<Vec<CompactString>> {

--- a/tokenizers/src/decoders/sequence.rs
+++ b/tokenizers/src/decoders/sequence.rs
@@ -1,6 +1,7 @@
 use crate::decoders::DecoderWrapper;
 use crate::tokenizer::{Decoder, Result};
 use crate::utils::macro_rules_attribute;
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
@@ -24,7 +25,7 @@ impl Sequence {
 }
 
 impl Decoder for Sequence {
-    fn decode_chain(&self, mut tokens: Vec<String>) -> Result<Vec<String>> {
+    fn decode_chain(&self, mut tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
         for decoder in &self.decoders {
             tokens = decoder.decode_chain(tokens)?;
         }
@@ -34,6 +35,8 @@ impl Decoder for Sequence {
 
 #[cfg(test)]
 mod tests {
+    use compact_str::ToCompactString;
+
     use super::*;
     use crate::decoders::ctc::CTC;
     use crate::pre_tokenizers::metaspace::Metaspace;
@@ -45,9 +48,9 @@ mod tests {
             DecoderWrapper::Metaspace(Metaspace::default()),
         ];
         let decoder = Sequence::new(decoders);
-        let tokens: Vec<String> = vec!["▁", "▁", "H", "H", "i", "i", "▁", "y", "o", "u"]
+        let tokens: Vec<CompactString> = vec!["▁", "▁", "H", "H", "i", "i", "▁", "y", "o", "u"]
             .into_iter()
-            .map(|s| s.to_string())
+            .map(|s| s.to_compact_string())
             .collect();
         let out_tokens = decoder.decode(tokens).unwrap();
         assert_eq!(out_tokens, "Hi you");

--- a/tokenizers/src/decoders/sequence.rs
+++ b/tokenizers/src/decoders/sequence.rs
@@ -1,7 +1,7 @@
 use crate::decoders::DecoderWrapper;
 use crate::tokenizer::{Decoder, Result};
 use crate::utils::macro_rules_attribute;
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
@@ -25,18 +25,15 @@ impl Sequence {
 }
 
 impl Decoder for Sequence {
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+    fn decode_chain<T: ToCompactString>(
         &self,
-        mut tokens: Vec<T>,
+        tokens: Vec<T>,
     ) -> Result<Vec<CompactString>> {
+        let mut current_tokens = tokens.into_iter().map(|t| t.to_compact_string()).collect();
         for decoder in &self.decoders {
-            tokens = decoder
-                .decode_chain(tokens)?
-                .into_iter()
-                .map(|token| token.to_string().into())
-                .collect();
+            current_tokens = decoder.decode_chain(current_tokens)?;
         }
-        Ok(tokens.into_iter().map(|token| token.into()).collect())
+        Ok(current_tokens)
     }
 }
 

--- a/tokenizers/src/decoders/strip.rs
+++ b/tokenizers/src/decoders/strip.rs
@@ -29,7 +29,7 @@ impl Decoder for Strip {
     fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
-    ) -> Result<Vec<CompactString>> {
+    ) -> Result<Vec<impl ToCompactString>> {
         Ok(tokens
             .into_iter()
             .map(|token| {
@@ -77,12 +77,22 @@ mod tests {
                 "HHH".to_owned(),
             ])
             .unwrap();
-        assert_eq!(res, vec!["ey", " friend!", "HH"]);
+        assert_eq!(
+            res.into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
+            vec!["ey", " friend!", "HH"]
+        );
 
         let decoder = Strip::new('y', 0, 1);
         let res = decoder
             .decode_chain(vec!["Hey".to_owned(), " friend!".to_owned()])
             .unwrap();
-        assert_eq!(res, vec!["He", " friend!"]);
+        assert_eq!(
+            res.into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
+            vec!["He", " friend!"]
+        );
     }
 }

--- a/tokenizers/src/decoders/strip.rs
+++ b/tokenizers/src/decoders/strip.rs
@@ -1,5 +1,6 @@
 use crate::tokenizer::{Decoder, Result};
 
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Clone, Debug, Serialize, Default)]
@@ -25,7 +26,7 @@ impl Strip {
 }
 
 impl Decoder for Strip {
-    fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
+    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
         Ok(tokens
             .into_iter()
             .map(|token| {
@@ -52,7 +53,7 @@ impl Decoder for Strip {
                     }
                 }
 
-                let new_token: String = chars[start_cut..stop_cut].iter().collect();
+                let new_token: CompactString = chars[start_cut..stop_cut].iter().collect();
                 new_token
             })
             .collect())

--- a/tokenizers/src/decoders/strip.rs
+++ b/tokenizers/src/decoders/strip.rs
@@ -1,6 +1,6 @@
 use crate::tokenizer::{Decoder, Result};
 
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Clone, Debug, Serialize, Default)]
@@ -26,14 +26,14 @@ impl Strip {
 }
 
 impl Decoder for Strip {
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+    fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
     ) -> Result<Vec<CompactString>> {
         Ok(tokens
             .into_iter()
             .map(|token| {
-                let chars: Vec<char> = token.into().chars().collect();
+                let chars: Vec<char> = token.to_compact_string().chars().collect();
 
                 let mut start_cut = 0;
                 for (i, &c) in chars.iter().enumerate().take(self.start) {

--- a/tokenizers/src/decoders/strip.rs
+++ b/tokenizers/src/decoders/strip.rs
@@ -26,11 +26,14 @@ impl Strip {
 }
 
 impl Decoder for Strip {
-    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
+    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+        &self,
+        tokens: Vec<T>,
+    ) -> Result<Vec<CompactString>> {
         Ok(tokens
             .into_iter()
             .map(|token| {
-                let chars: Vec<char> = token.chars().collect();
+                let chars: Vec<char> = token.into().chars().collect();
 
                 let mut start_cut = 0;
                 for (i, &c) in chars.iter().enumerate().take(self.start) {
@@ -68,13 +71,17 @@ mod tests {
     fn decode() {
         let decoder = Strip::new('H', 1, 0);
         let res = decoder
-            .decode_chain(vec!["Hey".into(), " friend!".into(), "HHH".into()])
+            .decode_chain(vec![
+                "Hey".to_owned(),
+                " friend!".to_owned(),
+                "HHH".to_owned(),
+            ])
             .unwrap();
         assert_eq!(res, vec!["ey", " friend!", "HH"]);
 
         let decoder = Strip::new('y', 0, 1);
         let res = decoder
-            .decode_chain(vec!["Hey".into(), " friend!".into()])
+            .decode_chain(vec!["Hey".to_owned(), " friend!".to_owned()])
             .unwrap();
         assert_eq!(res, vec!["He", " friend!"]);
     }

--- a/tokenizers/src/decoders/wordpiece.rs
+++ b/tokenizers/src/decoders/wordpiece.rs
@@ -50,7 +50,7 @@ impl Decoder for WordPiece {
     fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
-    ) -> Result<Vec<CompactString>> {
+    ) -> Result<Vec<impl ToCompactString>> {
         tokens
             .into_iter()
             .map(|t| t.to_compact_string())
@@ -66,7 +66,7 @@ impl Decoder for WordPiece {
                 if self.cleanup {
                     token = cleanup(token);
                 }
-                Ok(token.clone().into())
+                Ok(token)
             })
             .collect::<Result<Vec<CompactString>>>()
     }
@@ -90,7 +90,8 @@ mod tests {
                     "No".to_owned(),
                     "##guera".to_owned()
                 ])
-                .unwrap(),
+                .unwrap()
+                .to_compact_string(),
             "##uelo Araújo Noguera"
         );
     }

--- a/tokenizers/src/models/bpe/mod.rs
+++ b/tokenizers/src/models/bpe/mod.rs
@@ -1,5 +1,6 @@
 //! [Byte Pair Encoding](https://www.aclweb.org/anthology/P16-1162/) model.
 use std::{iter, mem};
+use compact_str::CompactString;
 
 mod model;
 mod serialization;
@@ -26,10 +27,10 @@ pub enum Error {
     BadMerges(usize),
     /// If a token found in merges, is not in the vocab
     #[error("Token `{0}` out of vocabulary")]
-    MergeTokenOutOfVocabulary(String),
+    MergeTokenOutOfVocabulary(CompactString),
     /// If the provided unk token is out of vocabulary
     #[error("Unk token `{0}` not found in the vocabulary")]
-    UnkTokenOutOfVocabulary(String),
+    UnkTokenOutOfVocabulary(CompactString),
     /// Dropout not between 0 and 1.
     #[error("Dropout should be between 0 and 1, inclusive")]
     InvalidDropout,

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -5,16 +5,16 @@ use crate::utils::iter::ResultShunt;
 use serde_json::Value;
 use std::borrow::Cow;
 use std::{
-    collections::HashMap,
     fs::File,
     io::prelude::*,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
 };
+use rustc_hash::FxHashMap;
 
-pub type Vocab = HashMap<String, u32>;
-type VocabR = HashMap<u32, String>;
-pub type MergeMap = HashMap<Pair, (u32, u32)>;
+pub type Vocab = FxHashMap<String, u32>;
+type VocabR = FxHashMap<u32, String>;
+pub type MergeMap = FxHashMap<Pair, (u32, u32)>;
 pub type Merges = Vec<(String, String)>;
 
 struct Config {
@@ -41,7 +41,7 @@ impl Default for BpeBuilder {
         Self {
             config: Config {
                 files: None,
-                vocab: HashMap::new(),
+                vocab: FxHashMap::default(),
                 merges: vec![],
                 cache_capacity: DEFAULT_CACHE_CAPACITY,
                 dropout: None,
@@ -324,7 +324,7 @@ impl BPE {
         let mut buffer = String::new();
         vocab_file.read_to_string(&mut buffer)?;
         let json: Value = serde_json::from_str(&buffer)?;
-        let mut vocab = HashMap::new();
+        let mut vocab = FxHashMap::default();
         match json {
             Value::Object(m) => {
                 for (token, id) in m {
@@ -493,7 +493,7 @@ impl BPE {
 impl Model for BPE {
     type Trainer = BpeTrainer;
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         self.vocab.clone()
     }
 

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -4,7 +4,7 @@ use serde::{
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 impl Serialize for BPE {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -80,7 +80,7 @@ impl<'de> Visitor<'de> for BPEVisitor {
         V: MapAccess<'de>,
     {
         let mut builder = BpeBuilder::new();
-        let mut vocab: Option<HashMap<String, u32>> = None;
+        let mut vocab: Option<FxHashMap<String, u32>> = None;
 
         #[derive(Debug, Deserialize)]
         #[serde(untagged)]

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -1,10 +1,11 @@
 use super::{super::OrderedVocabIter, convert_merges_to_hashmap, BpeBuilder, Pair, BPE};
+use compact_str::CompactString;
+use rustc_hash::FxHashMap;
 use serde::{
     de::{Error, MapAccess, Visitor},
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use rustc_hash::FxHashMap;
 
 impl Serialize for BPE {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -80,13 +81,13 @@ impl<'de> Visitor<'de> for BPEVisitor {
         V: MapAccess<'de>,
     {
         let mut builder = BpeBuilder::new();
-        let mut vocab: Option<FxHashMap<String, u32>> = None;
+        let mut vocab: Option<FxHashMap<CompactString, u32>> = None;
 
         #[derive(Debug, Deserialize)]
         #[serde(untagged)]
         enum MergeType {
-            Tuple(Vec<(String, String)>),
-            Legacy(Vec<String>),
+            Tuple(Vec<(CompactString, CompactString)>),
+            Legacy(Vec<CompactString>),
         }
         let mut merges: Option<MergeType> = None;
         while let Some(key) = map.next_key::<String>()? {
@@ -172,8 +173,8 @@ mod test {
         .cloned()
         .collect();
         let bpe = BpeBuilder::default()
-            .vocab_and_merges(vocab, vec![("a".to_string(), "b".to_string())])
-            .unk_token("<unk>".to_string())
+            .vocab_and_merges(vocab, vec![("a".into(), "b".into())])
+            .unk_token("<unk>".into())
             .ignore_merges(true)
             .build()
             .unwrap();
@@ -201,8 +202,8 @@ mod test {
         .cloned()
         .collect();
         let bpe = BpeBuilder::default()
-            .vocab_and_merges(vocab, vec![("a".to_string(), "b c d".to_string())])
-            .unk_token("<unk>".to_string())
+            .vocab_and_merges(vocab, vec![("a".into(), "b c d".into())])
+            .unk_token("<unk>".into())
             .ignore_merges(true)
             .build()
             .unwrap();
@@ -223,7 +224,7 @@ mod test {
             .collect();
         let mut bpe = BpeBuilder::default()
             .vocab_and_merges(vocab, vec![])
-            .unk_token("<unk>".to_string())
+            .unk_token("<unk>".into())
             .ignore_merges(true)
             .build()
             .unwrap();

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -163,13 +163,14 @@ impl BpeTrainerBuilder {
 /// # Examples
 ///
 /// ```
+/// use compact_str::ToCompactString;
 /// use tokenizers::tokenizer::Trainer;
 /// use tokenizers::models::bpe::{BPE, BpeTrainer};
 ///
 /// let sequences = vec![ "Hello", "World" ];
 ///
 /// let mut trainer = BpeTrainer::default();
-/// trainer.feed(sequences.iter(), |s| Ok(vec![s.to_owned()]));
+/// let  _ = trainer.feed(sequences.iter(), |s| Ok(vec![s.to_compact_string()]));
 ///
 /// let mut model = BPE::default();
 /// let special_tokens = trainer.train(&mut model).unwrap();

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -6,13 +6,14 @@ use crate::tokenizer::{AddedToken, Result, Trainer};
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::BinaryHeap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 #[derive(Debug, Eq)]
 struct Merge {
     pair: Pair,
     count: u64,
-    pos: HashSet<usize>,
+    pos: FxHashSet<usize>,
 }
 impl PartialEq for Merge {
     fn eq(&self, other: &Self) -> bool {
@@ -41,7 +42,7 @@ struct Config {
     show_progress: bool,
     special_tokens: Vec<AddedToken>,
     limit_alphabet: Option<usize>,
-    initial_alphabet: HashSet<char>,
+    initial_alphabet: FxHashSet<char>,
     continuing_subword_prefix: Option<String>,
     end_of_word_suffix: Option<String>,
     max_token_length: Option<usize>,
@@ -62,7 +63,7 @@ impl Default for BpeTrainerBuilder {
                 show_progress: true,
                 special_tokens: vec![],
                 limit_alphabet: None,
-                initial_alphabet: HashSet::new(),
+                initial_alphabet: FxHashSet::default(),
                 continuing_subword_prefix: None,
                 end_of_word_suffix: None,
                 max_token_length: None,
@@ -114,7 +115,7 @@ impl BpeTrainerBuilder {
 
     /// Set the initial alphabet
     #[must_use]
-    pub fn initial_alphabet(mut self, alphabet: HashSet<char>) -> Self {
+    pub fn initial_alphabet(mut self, alphabet: FxHashSet<char>) -> Self {
         self.config.initial_alphabet = alphabet;
         self
     }
@@ -151,7 +152,7 @@ impl BpeTrainerBuilder {
             continuing_subword_prefix: self.config.continuing_subword_prefix,
             end_of_word_suffix: self.config.end_of_word_suffix,
             max_token_length: self.config.max_token_length,
-            words: HashMap::new(),
+            words: FxHashMap::default(),
         }
     }
 }
@@ -187,7 +188,7 @@ pub struct BpeTrainer {
     pub limit_alphabet: Option<usize>,
     /// The initial alphabet we want absolutely to include. This allows to cover
     /// some characters that are not necessarily in the training set
-    pub initial_alphabet: HashSet<char>,
+    pub initial_alphabet: FxHashSet<char>,
     /// An optional prefix to use on any subword that exist only behind another one
     pub continuing_subword_prefix: Option<String>,
     /// An optional suffix to caracterize and end-of-word subword
@@ -195,7 +196,7 @@ pub struct BpeTrainer {
     /// An optional parameter to limit the max length of any single token
     pub max_token_length: Option<usize>,
 
-    words: HashMap<String, u64>,
+    words: FxHashMap<String, u64>,
 }
 
 impl Default for BpeTrainer {
@@ -251,7 +252,7 @@ impl BpeTrainer {
     }
 
     /// Add the provided special tokens to the initial vocabulary
-    fn add_special_tokens(&self, w2id: &mut HashMap<String, u32>, id2w: &mut Vec<String>) {
+    fn add_special_tokens(&self, w2id: &mut FxHashMap<String, u32>, id2w: &mut Vec<String>) {
         for token in &self.special_tokens {
             if !w2id.contains_key(&token.content) {
                 id2w.push(token.content.to_owned());
@@ -263,12 +264,12 @@ impl BpeTrainer {
     /// Compute the initial alphabet and limit it if relevant
     fn compute_alphabet(
         &self,
-        wc: &HashMap<String, u64>,
-        w2id: &mut HashMap<String, u32>,
+        wc: &FxHashMap<String, u64>,
+        w2id: &mut FxHashMap<String, u32>,
         id2w: &mut Vec<String>,
     ) {
         // Compute the alphabet from seen words
-        let mut alphabet: HashMap<char, usize> = HashMap::new();
+        let mut alphabet: FxHashMap<char, usize> = FxHashMap::default();
         for (word, count) in wc {
             for c in word.chars() {
                 alphabet
@@ -322,8 +323,8 @@ impl BpeTrainer {
     /// Tokenize words and add subwords to the vocabulary when relevant
     fn tokenize_words(
         &self,
-        wc: &HashMap<String, u64>,
-        w2id: &mut HashMap<String, u32>,
+        wc: &FxHashMap<String, u64>,
+        w2id: &mut FxHashMap<String, u32>,
         id2w: &mut Vec<String>,
         p: &Option<ProgressBar>,
     ) -> (Vec<Word>, Vec<u64>) {
@@ -375,13 +376,13 @@ impl BpeTrainer {
         words: &[Word],
         counts: &[u64],
         p: &Option<ProgressBar>,
-    ) -> (HashMap<Pair, i32>, HashMap<Pair, HashSet<usize>>) {
+    ) -> (FxHashMap<Pair, i32>, FxHashMap<Pair, FxHashSet<usize>>) {
         words
             .maybe_par_iter()
             .enumerate()
             .map(|(i, word)| {
-                let mut pair_counts = HashMap::new();
-                let mut where_to_update: HashMap<Pair, HashSet<usize>> = HashMap::new();
+                let mut pair_counts = FxHashMap::default();
+                let mut where_to_update: FxHashMap<Pair, FxHashSet<usize>> = FxHashMap::default();
 
                 for window in word.get_chars().windows(2) {
                     let cur_pair: Pair = (window[0], window[1]);
@@ -399,7 +400,7 @@ impl BpeTrainer {
                             h.insert(i);
                         })
                         .or_insert_with(|| {
-                            let mut h = HashSet::new();
+                            let mut h = FxHashSet::default();
                             h.insert(i);
                             h
                         });
@@ -413,7 +414,7 @@ impl BpeTrainer {
                 (pair_counts, where_to_update)
             })
             .reduce(
-                || (HashMap::new(), HashMap::new()),
+                || (FxHashMap::default(), FxHashMap::default()),
                 |(mut pair_counts, mut where_to_update), (pc, wtu)| {
                     for (k, v) in pc {
                         pair_counts.entry(k).and_modify(|c| *c += v).or_insert(v);
@@ -431,10 +432,10 @@ impl BpeTrainer {
 
     pub fn do_train(
         &self,
-        word_counts: &HashMap<String, u64>,
+        word_counts: &FxHashMap<String, u64>,
         model: &mut BPE,
     ) -> Result<Vec<AddedToken>> {
-        let mut word_to_id: HashMap<String, u32> = HashMap::with_capacity(self.vocab_size);
+        let mut word_to_id: FxHashMap<String, u32> = FxHashMap::with_capacity_and_hasher(self.vocab_size, Default::default());
         let mut id_to_word: Vec<String> = Vec::with_capacity(self.vocab_size);
         let max_token_length: usize = self.max_token_length.unwrap_or(usize::MAX);
 
@@ -532,7 +533,7 @@ impl BpeTrainer {
             // Merge the new pair in every words
             // Safety: This is just a type assertion, the code below may no longer be safe
             // if the type of `pos` changes
-            let pos: &HashSet<usize> = &top.pos;
+            let pos: &FxHashSet<usize> = &top.pos;
 
             let words_len = words.len();
             struct WordPtr(*mut Word);
@@ -577,7 +578,7 @@ impl BpeTrainer {
                             h.insert(iw);
                         })
                         .or_insert_with(|| {
-                            let mut h = HashSet::new();
+                            let mut h = FxHashSet::default();
                             h.insert(iw);
                             h
                         });
@@ -647,18 +648,18 @@ impl Trainer for BpeTrainer {
         S: AsRef<str> + Send,
         F: Fn(&str) -> Result<Vec<String>> + Sync,
     {
-        let words: Result<HashMap<String, u64>> = iterator
+        let words: Result<FxHashMap<String, u64>> = iterator
             .maybe_par_bridge()
             .map(|sequence| {
                 let words = process(sequence.as_ref())?;
-                let mut map = HashMap::new();
+                let mut map = FxHashMap::default();
                 for word in words {
                     map.entry(word).and_modify(|c| *c += 1).or_insert(1);
                 }
                 Ok(map)
             })
             .reduce(
-                || Ok(HashMap::new()),
+                || Ok(FxHashMap::default()),
                 |acc, ws| {
                     let mut acc = acc?;
                     for (k, v) in ws? {
@@ -676,11 +677,11 @@ impl Trainer for BpeTrainer {
 #[cfg(test)]
 mod tests {
     use super::{BpeTrainer, Pair, BPE};
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
 
     #[test]
     fn test_train() {
-        let word_counts: HashMap<String, u64> = [
+        let word_counts: FxHashMap<String, u64> = [
             ("roses".into(), 1),
             ("are".into(), 2),
             ("red".into(), 1),
@@ -705,7 +706,7 @@ mod tests {
 
         // Vocab should contain all of the characters from the `word_counts` mapping
         // as well as three merges: 're', 'are', and 'is'.
-        let expected_vocab: HashMap<String, u32> = [
+        let expected_vocab: FxHashMap<String, u32> = [
             ("-".into(), 0),
             ("2".into(), 1),
             ("B".into(), 2),
@@ -741,7 +742,7 @@ mod tests {
         // where 'rank' determines the order in which this merge will be applied during
         // tokenization, and 'id' is the vocab id of the symbol resulting from merging
         // the pair of symbols in the corresponding key.
-        let expected_merges: HashMap<Pair, (u32, u32)> = [
+        let expected_merges: FxHashMap<Pair, (u32, u32)> = [
             ((17, 11), (0, 22)), // 'r' + 'e'  -> 're'
             ((8, 22), (1, 23)),  // 'a' + 're' -> 'are'
             ((13, 18), (2, 24)), // 'i' + 's'  -> 'is'
@@ -759,7 +760,7 @@ mod tests {
          */
 
         let max_token_length = 16;
-        let long_word_counts: HashMap<String, u64> = [
+        let long_word_counts: FxHashMap<String, u64> = [
             ("singlelongtokenwithoutcasechange", 2),
             ("singleLongTokenWithCamelCaseChange", 2),
             ("Longsingletokenwithpunctu@t!onwithin", 2),
@@ -799,7 +800,7 @@ mod tests {
         // directly compares tokens with known expected values.
         // maybe unstable depending on specific settings or changes.
          */
-        let long_word_counts: HashMap<String, u64> = [
+        let long_word_counts: FxHashMap<String, u64> = [
             ("sin", 2),
             ("Sin", 2),
             ("Lon", 2),
@@ -823,8 +824,8 @@ mod tests {
             .build();
         let mut model = BPE::default();
         trainer.do_train(&long_word_counts, &mut model).unwrap();
-        let trained_vocab: HashMap<String, u32> = model.get_vocab();
-        let expected_vocab: HashMap<String, u32> = [
+        let trained_vocab: FxHashMap<String, u32> = model.get_vocab();
+        let expected_vocab: FxHashMap<String, u32> = [
             ("短", 12),
             ("n", 6),
             ("i", 5),

--- a/tokenizers/src/models/bpe/word.rs
+++ b/tokenizers/src/models/bpe/word.rs
@@ -1,7 +1,8 @@
 use super::Pair;
 use rand::{thread_rng, Rng};
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
+use rustc_hash::FxHashMap;
 
 #[derive(Debug, Eq)]
 struct Merge {
@@ -158,7 +159,7 @@ impl Word {
         changes
     }
 
-    pub(super) fn merge_all(&mut self, merges: &HashMap<Pair, (u32, u32)>, dropout: Option<f32>) {
+    pub(super) fn merge_all(&mut self, merges: &FxHashMap<Pair, (u32, u32)>, dropout: Option<f32>) {
         let mut queue = BinaryHeap::with_capacity(self.symbols.len());
         let mut skip = Vec::with_capacity(queue.len());
 

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -5,7 +5,7 @@ pub mod unigram;
 pub mod wordlevel;
 pub mod wordpiece;
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -19,11 +19,11 @@ use crate::{AddedToken, Model, Result, Token, Trainer};
 /// Wraps a vocab mapping (ID -> token) to a struct that will be serialized in order
 /// of token ID, smallest to largest.
 struct OrderedVocabIter<'a> {
-    vocab_r: &'a HashMap<u32, String>,
+    vocab_r: &'a FxHashMap<u32, String>,
 }
 
 impl<'a> OrderedVocabIter<'a> {
-    fn new(vocab_r: &'a HashMap<u32, String>) -> Self {
+    fn new(vocab_r: &'a FxHashMap<u32, String>) -> Self {
         Self { vocab_r }
     }
 }
@@ -170,7 +170,7 @@ impl Model for ModelWrapper {
         }
     }
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         match self {
             Self::WordLevel(t) => t.get_vocab(),
             Self::WordPiece(t) => t.get_vocab(),
@@ -301,8 +301,12 @@ mod tests {
 
     #[test]
     fn incomplete_ordered_vocab() {
-        let vocab_r: HashMap<u32, String> =
-            HashMap::from([(0, "Hi".to_string()), (2, "There".to_string())]);
+        let vocab_r: FxHashMap<u32, String> = {
+            let mut tmp = FxHashMap::default();
+            tmp.insert(0, "Hi".to_string());
+            tmp.insert(2, "There".to_string());
+            tmp
+        };
 
         let ordered = OrderedVocabIter::new(&vocab_r);
 

--- a/tokenizers/src/models/unigram/lattice.rs
+++ b/tokenizers/src/models/unigram/lattice.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use rand::distributions::WeightedIndex;
 use rand::prelude::*;
 use std::cell::RefCell;
@@ -223,11 +224,11 @@ impl<'a> Lattice<'a> {
         results
     }
 
-    pub fn piece(&self, node: &Node) -> String {
-        self.sentence[node.pos..node.pos + node.length].to_owned()
+    pub fn piece(&self, node: &Node) -> CompactString {
+        self.sentence[node.pos..node.pos + node.length].into()
     }
 
-    pub fn tokens(&mut self) -> Vec<String> {
+    pub fn tokens(&mut self) -> Vec<CompactString> {
         self.viterbi()
             .iter()
             .map(|node| self.piece(&node.borrow()))
@@ -296,7 +297,7 @@ impl<'a> Lattice<'a> {
         }
     }
 
-    pub fn nbest_tokens(&mut self, n: usize) -> Vec<Vec<String>> {
+    pub fn nbest_tokens(&mut self, n: usize) -> Vec<Vec<CompactString>> {
         self.nbest(n)
             .iter()
             .map(|v| v.iter().map(|node| self.piece(&node.borrow())).collect())
@@ -422,7 +423,7 @@ impl<'a> Lattice<'a> {
         results
     }
 
-    pub fn sample_token(&self, theta: f64) -> Vec<String> {
+    pub fn sample_token(&self, theta: f64) -> Vec<CompactString> {
         self.sample(theta)
             .iter()
             .map(|node| self.piece(&node.borrow()))

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -6,19 +6,20 @@ use super::{
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 
+use compact_str::{format_compact, CompactString};
+use rustc_hash::FxHashMap;
 use std::convert::TryInto;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
-use rustc_hash::FxHashMap;
 
-type TokenMap = FxHashMap<String, u32>;
-type Vocab = Vec<(String, f64)>;
+type TokenMap = FxHashMap<CompactString, u32>;
+type Vocab = Vec<(CompactString, f64)>;
 
 /// A `Unigram` model to encode sentences.
 pub struct Unigram {
     token_to_ids: TokenMap,
     pub(crate) vocab: Vocab,
-    cache: Cache<String, Vec<String>>,
+    cache: Cache<CompactString, Vec<CompactString>>,
     trie: Trie<u8>,
     pub min_score: f64,
     pub(super) unk_id: Option<usize>,
@@ -80,7 +81,7 @@ pub enum UnigramError {
 
 impl Default for Unigram {
     fn default() -> Self {
-        let vocab = vec![("<unk>".to_string(), 0.0)];
+        let vocab = vec![("<unk>".into(), 0.0)];
         Self::from(vocab, Some(0), false).unwrap()
     }
 }
@@ -93,7 +94,7 @@ impl Unigram {
     /// For now `Unigram` *requires* at least `unk` because we might find a never seen char.
     /// Further versions might allow that part to be hidden.
     pub fn from(
-        vocab: Vec<(String, f64)>,
+        vocab: Vec<(CompactString, f64)>,
         unk_id: Option<usize>,
         byte_fallback: bool,
     ) -> Result<Self> {
@@ -114,7 +115,7 @@ impl Unigram {
 
         let mut min_score = f64::INFINITY;
         for (id, (token, score)) in vocab.iter().enumerate() {
-            token_to_ids.insert(token.to_string(), id as u32);
+            token_to_ids.insert(token.clone(), id as u32);
             let bytes: Vec<u8> = token.bytes().collect();
             builder.push(&bytes);
             if score < &min_score {
@@ -177,7 +178,7 @@ impl Unigram {
                 .common_prefix_search(lattice.sentence.bytes().skip(begin_pos))
             {
                 let n = bytes.len();
-                let tok = String::from_utf8(bytes).unwrap();
+                let tok = CompactString::from_utf8(bytes).unwrap();
                 let id = *self.token_to_ids.get(&tok).unwrap();
 
                 let item = &self.vocab[id as usize];
@@ -204,21 +205,21 @@ impl Unigram {
     /// use tokenizers::models::unigram::Unigram;
     ///
     /// let pieces = vec![
-    ///     ("<unk>".to_string(), 0.0),
-    ///     ("a".to_string(), 0.0),
-    ///     ("b".to_string(), 0.0),
-    ///     ("c".to_string(), 0.0),
-    ///     ("d".to_string(), 0.0),
-    ///     ("cd".to_string(), 1.0),
-    ///     ("ab".to_string(), 2.0),
-    ///     ("abc".to_string(), 5.0),
-    ///     ("abcd".to_string(), 10.0),
+    ///     ("<unk>".into(), 0.0),
+    ///     ("a".into(), 0.0),
+    ///     ("b".into(), 0.0),
+    ///     ("c".into(), 0.0),
+    ///     ("d".into(), 0.0),
+    ///     ("cd".into(), 1.0),
+    ///     ("ab".into(), 2.0),
+    ///     ("abc".into(), 5.0),
+    ///     ("abcd".into(), 10.0),
     /// ];
     /// let model = Unigram::from(pieces, Some(0), false).unwrap();
     /// let result = model.encode("abcdacdxx").unwrap();
     /// assert_eq!(result, vec!["abcd", "a", "cd", "xx"]);
     /// ```
-    pub fn encode(&self, sentence: &str) -> Result<Vec<String>> {
+    pub fn encode(&self, sentence: &str) -> Result<Vec<CompactString>> {
         if sentence.is_empty() {
             return Ok(vec![]);
         }
@@ -231,13 +232,13 @@ impl Unigram {
                 self.encode_unoptimized(sentence)?
             };
             if sentence.len() < MAX_LENGTH {
-                self.cache.set(sentence.to_owned(), result.clone());
+                self.cache.set(sentence.into(), result.clone());
             }
             Ok(result)
         }
     }
 
-    fn encode_optimized(&self, sentence: &str) -> Result<Vec<String>> {
+    fn encode_optimized(&self, sentence: &str) -> Result<Vec<CompactString>> {
         // https://github.com/google/sentencepiece/blob/d48247191a6d50e469ed1a4a36e877befffd1851/src/unigram_model.cc#L600
         #[derive(Debug, Clone)]
         struct BestPathNode {
@@ -272,7 +273,7 @@ impl Unigram {
                 .common_prefix_search(sentence.bytes().skip(starts_at))
             {
                 let key_pos = starts_at + tok_bytes.len();
-                let token: String = String::from_utf8(tok_bytes).unwrap();
+                let token: CompactString = CompactString::from_utf8(tok_bytes).unwrap();
                 let target_node = &mut best_path_ends_at[key_pos];
                 let length = key_pos - starts_at;
                 let id = self.token_to_ids.get(&token).unwrap();
@@ -303,7 +304,7 @@ impl Unigram {
             starts_at += mblen
         }
         let mut ends_at = size;
-        let mut results: Vec<String> = vec![];
+        let mut results: Vec<CompactString> = vec![];
         let mut token = vec![];
         while ends_at > 0 {
             let node = &best_path_ends_at[ends_at];
@@ -313,34 +314,34 @@ impl Unigram {
                 && node.id == self.unk_id.ok_or(UnigramError::MissingUnkId)?
             {
                 token.push(
-                    String::from_utf8(sentence[starts_at..ends_at].as_bytes().to_vec()).unwrap(),
+                    CompactString::from_utf8(sentence[starts_at..ends_at].as_bytes()).unwrap(),
                 );
             } else {
                 if !token.is_empty() {
                     token.reverse();
-                    results.push(token.concat());
+                    results.push(token.concat().into());
                     token = vec![];
                 }
                 results.push(
-                    String::from_utf8(sentence[starts_at..ends_at].as_bytes().to_vec()).unwrap(),
+                    CompactString::from_utf8(sentence[starts_at..ends_at].as_bytes()).unwrap(),
                 );
             }
             ends_at = starts_at;
         }
         if !token.is_empty() {
             token.reverse();
-            results.push(token.concat());
+            results.push(token.concat().into());
         }
         results.reverse();
         Ok(results)
     }
 
-    fn encode_unoptimized(&self, sentence: &str) -> Result<Vec<String>> {
+    fn encode_unoptimized(&self, sentence: &str) -> Result<Vec<CompactString>> {
         let mut lattice = Lattice::from(sentence, self.bos_id, self.eos_id);
         self.populate_nodes(&mut lattice);
         if self.fuse_unk {
             let mut results = vec![];
-            let mut token = String::new();
+            let mut token = CompactString::default();
             for node in lattice.viterbi().iter() {
                 let item = lattice.piece(&node.borrow());
                 if node.borrow().id == self.unk_id.ok_or(UnigramError::MissingUnkId)? {
@@ -348,9 +349,9 @@ impl Unigram {
                 } else {
                     if !token.is_empty() {
                         results.push(token);
-                        token = String::new();
+                        token = CompactString::default();
                     }
-                    results.push(item.to_string());
+                    results.push(item);
                 }
             }
             if !token.is_empty() {
@@ -398,7 +399,7 @@ pub struct UnigramIterator<'a> {
 }
 
 impl<'a> Iterator for UnigramIterator<'a> {
-    type Item = &'a (String, f64);
+    type Item = &'a (CompactString, f64);
 
     fn next(&mut self) -> Option<Self::Item> {
         let i = self.i;
@@ -415,7 +416,7 @@ impl<'a> Iterator for UnigramIterator<'a> {
 impl Model for Unigram {
     type Trainer = UnigramTrainer;
 
-    fn get_vocab(&self) -> FxHashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<CompactString, u32> {
         self.token_to_ids.clone()
     }
 
@@ -437,7 +438,7 @@ impl Model for Unigram {
                         let byte_tokens: Option<Vec<_>> = string
                             .bytes()
                             .map(|byte| -> Option<Token> {
-                                let byte_string = format!("<0x{byte:02X}>");
+                                let byte_string = format_compact!("<0x{byte:02X}>");
                                 let id = self.token_to_ids.get(&byte_string);
                                 id.map(|id| Token::new(*id, byte_string, (offset, offset + len)))
                             })
@@ -463,7 +464,7 @@ impl Model for Unigram {
         self.token_to_ids.get(token).copied()
     }
 
-    fn id_to_token(&self, id: u32) -> Option<String> {
+    fn id_to_token(&self, id: u32) -> Option<CompactString> {
         self.vocab.get(id as usize).map(|item| item.0.clone())
     }
 
@@ -491,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_populate_nodes_unk() {
-        let pieces = vec![("<unk>".to_string(), 0.0)];
+        let pieces = vec![("<unk>".into(), 0.0)];
         let model = Unigram::from(pieces, Some(0), false).unwrap();
 
         let mut lattice = Lattice::from("abc", model.bos_id, model.eos_id);
@@ -511,11 +512,11 @@ mod tests {
     #[test]
     fn test_populate_nodes() {
         let pieces = vec![
-            ("<unk>".to_string(), 0.0),
-            ("a".to_string(), 0.1),
-            ("b".to_string(), 0.2),
-            ("ab".to_string(), 0.3),
-            ("bc".to_string(), 0.4),
+            ("<unk>".into(), 0.0),
+            ("a".into(), 0.1),
+            ("b".into(), 0.2),
+            ("ab".into(), 0.3),
+            ("bc".into(), 0.4),
         ];
         let model = Unigram::from(pieces, Some(0), false).unwrap();
 
@@ -543,15 +544,15 @@ mod tests {
     #[test]
     fn test_encode() {
         let sentencepieces = vec![
-            ("<unk>".to_string(), 0.0),
-            ("a".to_string(), 0.0),
-            ("b".to_string(), 0.0),
-            ("c".to_string(), 0.0),
-            ("d".to_string(), 0.0),
-            ("cd".to_string(), 1.0),
-            ("ab".to_string(), 2.0),
-            ("abc".to_string(), 5.0),
-            ("abcd".to_string(), 10.0),
+            ("<unk>".into(), 0.0),
+            ("a".into(), 0.0),
+            ("b".into(), 0.0),
+            ("c".into(), 0.0),
+            ("d".into(), 0.0),
+            ("cd".into(), 1.0),
+            ("ab".into(), 2.0),
+            ("abc".into(), 5.0),
+            ("abcd".into(), 10.0),
         ];
 
         let model = Unigram::from(sentencepieces, Some(0), false).unwrap();
@@ -562,18 +563,18 @@ mod tests {
     #[test]
     fn test_encode2() {
         let sentencepieces = vec![
-            ("<unk>".to_string(), 0.0),
-            ("ab".to_string(), 0.0),
-            ("cd".to_string(), -0.1),
-            ("abc".to_string(), -0.2),
-            ("a".to_string(), -0.3),
-            ("b".to_string(), -0.4),
-            ("c".to_string(), -0.5),
-            ("ABC".to_string(), -0.5),
-            ("abcdabcd".to_string(), 20.0), // User defined just max the scores.
-            ("q".to_string(), 20.5),
-            ("r".to_string(), 20.5),
-            ("qr".to_string(), -0.5),
+            ("<unk>".into(), 0.0),
+            ("ab".into(), 0.0),
+            ("cd".into(), -0.1),
+            ("abc".into(), -0.2),
+            ("a".into(), -0.3),
+            ("b".into(), -0.4),
+            ("c".into(), -0.5),
+            ("ABC".into(), -0.5),
+            ("abcdabcd".into(), 20.0), // User defined just max the scores.
+            ("q".into(), 20.5),
+            ("r".into(), 20.5),
+            ("qr".into(), -0.5),
         ];
 
         let mut model = Unigram::from(sentencepieces, Some(0), false).unwrap();
@@ -619,9 +620,9 @@ mod tests {
         // In [97]: processor.encode_as_pieces("⅐⅛⅑ ")
         // Out[97]: ['▁', '<0xE2>', '<0x85>', '<0x90>', '⅛', '<0xE2>', '<0x85>', '<0x91>', '▁']
         let sentencepieces = vec![
-            ("<unk>".to_string(), 0.0),
-            ("<0xC3>".to_string(), -0.01),
-            ("<0xA9>".to_string(), -0.03),
+            ("<unk>".into(), 0.0),
+            ("<0xC3>".into(), -0.01),
+            ("<0xA9>".into(), -0.03),
         ];
         let unigram = Unigram::from(sentencepieces, Some(0), true).unwrap();
         let tokens: Vec<Token> = unigram.tokenize("é").unwrap();
@@ -630,12 +631,12 @@ mod tests {
             [
                 Token {
                     id: 1,
-                    value: "<0xC3>".to_string(),
+                    value: "<0xC3>".into(),
                     offsets: (0, 2)
                 },
                 Token {
                     id: 2,
-                    value: "<0xA9>".to_string(),
+                    value: "<0xA9>".into(),
                     offsets: (0, 2)
                 }
             ]

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -6,12 +6,12 @@ use super::{
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 
-use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
+use rustc_hash::FxHashMap;
 
-type TokenMap = HashMap<String, u32>;
+type TokenMap = FxHashMap<String, u32>;
 type Vocab = Vec<(String, f64)>;
 
 /// A `Unigram` model to encode sentences.
@@ -98,7 +98,7 @@ impl Unigram {
         byte_fallback: bool,
     ) -> Result<Self> {
         let n = vocab.len();
-        let mut token_to_ids: TokenMap = HashMap::new();
+        let mut token_to_ids: TokenMap = FxHashMap::default();
         let mut builder = TrieBuilder::default();
 
         if let Some(unk_id) = unk_id {
@@ -415,7 +415,7 @@ impl<'a> Iterator for UnigramIterator<'a> {
 impl Model for Unigram {
     type Trainer = UnigramTrainer;
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         self.token_to_ids.clone()
     }
 

--- a/tokenizers/src/models/unigram/serialization.rs
+++ b/tokenizers/src/models/unigram/serialization.rs
@@ -1,4 +1,5 @@
 use super::model::Unigram;
+use compact_str::CompactString;
 use serde::{
     de::{Error, MapAccess, Visitor},
     ser::SerializeStruct,
@@ -46,10 +47,10 @@ impl<'de> Visitor<'de> for UnigramVisitor {
     where
         V: MapAccess<'de>,
     {
-        let mut vocab: Option<Vec<(String, f64)>> = None;
+        let mut vocab: Option<Vec<(CompactString, f64)>> = None;
         let mut unk_id: Option<usize> = None;
         let mut byte_fallback: bool = false;
-        while let Some(key) = map.next_key::<String>()? {
+        while let Some(key) = map.next_key::<CompactString>()? {
             match key.as_ref() {
                 "unk_id" => {
                     unk_id = map.next_value()?;
@@ -82,7 +83,7 @@ mod test {
 
     #[test]
     fn test_serialization() {
-        let vocab = vec![("<unk>".to_string(), 0.0), ("a".to_string(), -0.5)];
+        let vocab = vec![("<unk>".into(), 0.0), ("a".into(), -0.5)];
         let model = Unigram::from(vocab, Some(0), false).unwrap();
 
         let data = serde_json::to_string(&model).unwrap();
@@ -93,7 +94,7 @@ mod test {
 
     #[test]
     fn test_serialization_unk_id_not_zero() {
-        let vocab = vec![("a".to_string(), -0.5), ("<unk>".to_string(), 0.0)];
+        let vocab = vec![("a".into(), -0.5), ("<unk>".into(), 0.0)];
         let model = Unigram::from(vocab, Some(1), false).unwrap();
 
         let data = serde_json::to_string(&model).unwrap();
@@ -104,7 +105,7 @@ mod test {
 
     #[test]
     fn test_serialization_no_unk_id() {
-        let vocab = vec![("a".to_string(), -0.5)];
+        let vocab = vec![("a".into(), -0.5)];
         let model = Unigram::from(vocab, None, false).unwrap();
 
         let data = serde_json::to_string(&model).unwrap();

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -1,7 +1,7 @@
 use super::OrderedVocabIter;
 use crate::tokenizer::{Model, Result, Token};
 use serde_json::Value;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
@@ -12,7 +12,7 @@ mod trainer;
 // Re-export
 pub use trainer::*;
 
-type Vocab = HashMap<String, u32>;
+type Vocab = FxHashMap<String, u32>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -24,7 +24,7 @@ pub enum Error {
 
 struct Config {
     files: Option<String>,
-    vocab: HashMap<String, u32>,
+    vocab: FxHashMap<String, u32>,
     unk_token: String,
 }
 
@@ -39,7 +39,7 @@ impl Default for WordLevelBuilder {
         Self {
             config: Config {
                 files: None,
-                vocab: HashMap::new(),
+                vocab: FxHashMap::default(),
                 unk_token: String::from("<unk>"),
             },
         }
@@ -61,7 +61,7 @@ impl WordLevelBuilder {
 
     /// Set the vocab (token -> ID) mapping.
     #[must_use]
-    pub fn vocab(mut self, vocab: HashMap<String, u32>) -> Self {
+    pub fn vocab(mut self, vocab: FxHashMap<String, u32>) -> Self {
         self.config.vocab = vocab;
         self
     }
@@ -96,8 +96,8 @@ impl WordLevelBuilder {
 
 #[derive(PartialEq, Clone, Eq)]
 pub struct WordLevel {
-    vocab: HashMap<String, u32>,
-    vocab_r: HashMap<u32, String>,
+    vocab: FxHashMap<String, u32>,
+    vocab_r: FxHashMap<u32, String>,
     pub unk_token: String,
 }
 
@@ -119,7 +119,7 @@ impl WordLevel {
         let vocab_file = File::open(vocab_path)?;
         let mut vocab_file = BufReader::new(vocab_file);
         let mut buffer = String::new();
-        let mut vocab = HashMap::new();
+        let mut vocab = FxHashMap::default();
 
         vocab_file.read_to_string(&mut buffer)?;
         let json: Value = serde_json::from_str(&buffer)?;
@@ -148,8 +148,8 @@ impl WordLevel {
 impl Default for WordLevel {
     fn default() -> Self {
         Self {
-            vocab: HashMap::new(),
-            vocab_r: HashMap::new(),
+            vocab: FxHashMap::default(),
+            vocab_r: FxHashMap::default(),
             unk_token: String::from("<unk>"),
         }
     }
@@ -184,7 +184,7 @@ impl Model for WordLevel {
         self.vocab_r.get(&id).cloned()
     }
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         self.vocab.clone()
     }
 

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -1,7 +1,8 @@
 use super::OrderedVocabIter;
 use crate::tokenizer::{Model, Result, Token};
-use serde_json::Value;
+use compact_str::CompactString;
 use rustc_hash::FxHashMap;
+use serde_json::Value;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
@@ -12,7 +13,7 @@ mod trainer;
 // Re-export
 pub use trainer::*;
 
-type Vocab = FxHashMap<String, u32>;
+type Vocab = FxHashMap<CompactString, u32>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -23,9 +24,9 @@ pub enum Error {
 }
 
 struct Config {
-    files: Option<String>,
-    vocab: FxHashMap<String, u32>,
-    unk_token: String,
+    files: Option<CompactString>,
+    vocab: FxHashMap<CompactString, u32>,
+    unk_token: CompactString,
 }
 
 /// A `WordLevelBuilder` can be used to create a `WordLevel`
@@ -40,7 +41,7 @@ impl Default for WordLevelBuilder {
             config: Config {
                 files: None,
                 vocab: FxHashMap::default(),
-                unk_token: String::from("<unk>"),
+                unk_token: CompactString::from("<unk>"),
             },
         }
     }
@@ -54,21 +55,21 @@ impl WordLevelBuilder {
 
     /// Set the input files.
     #[must_use]
-    pub fn files(mut self, vocab: String) -> Self {
+    pub fn files(mut self, vocab: CompactString) -> Self {
         self.config.files = Some(vocab);
         self
     }
 
     /// Set the vocab (token -> ID) mapping.
     #[must_use]
-    pub fn vocab(mut self, vocab: FxHashMap<String, u32>) -> Self {
+    pub fn vocab(mut self, vocab: FxHashMap<CompactString, u32>) -> Self {
         self.config.vocab = vocab;
         self
     }
 
     /// The the `UNK` token for the vocab.
     #[must_use]
-    pub fn unk_token(mut self, unk_token: String) -> Self {
+    pub fn unk_token(mut self, unk_token: CompactString) -> Self {
         self.config.unk_token = unk_token;
         self
     }
@@ -96,9 +97,9 @@ impl WordLevelBuilder {
 
 #[derive(PartialEq, Clone, Eq)]
 pub struct WordLevel {
-    vocab: FxHashMap<String, u32>,
-    vocab_r: FxHashMap<u32, String>,
-    pub unk_token: String,
+    vocab: FxHashMap<CompactString, u32>,
+    vocab_r: FxHashMap<u32, CompactString>,
+    pub unk_token: CompactString,
 }
 
 impl std::fmt::Debug for WordLevel {
@@ -129,7 +130,7 @@ impl WordLevel {
                 for (token, id) in m {
                     if let Value::Number(id) = id {
                         let id = id.as_u64().ok_or(Error::BadVocabulary)? as u32;
-                        vocab.insert(token, id);
+                        vocab.insert(token.into(), id);
                     }
                 }
             }
@@ -139,7 +140,7 @@ impl WordLevel {
     }
 
     /// Initialize a WordLevel model from vocab and merges file.
-    pub fn from_file(vocab_path: &str, unk_token: String) -> Result<WordLevel> {
+    pub fn from_file(vocab_path: &str, unk_token: CompactString) -> Result<WordLevel> {
         let vocab = WordLevel::read_file(vocab_path)?;
         Self::builder().vocab(vocab).unk_token(unk_token).build()
     }
@@ -150,7 +151,7 @@ impl Default for WordLevel {
         Self {
             vocab: FxHashMap::default(),
             vocab_r: FxHashMap::default(),
-            unk_token: String::from("<unk>"),
+            unk_token: CompactString::from("<unk>"),
         }
     }
 }
@@ -162,7 +163,7 @@ impl Model for WordLevel {
         if let Some(&id) = self.vocab.get(token) {
             Ok(vec![Token {
                 id,
-                value: token.to_owned(),
+                value: token.into(),
                 offsets: (0, token.len()),
             }])
         } else if let Some(&unk_id) = self.vocab.get(&self.unk_token) {
@@ -180,11 +181,11 @@ impl Model for WordLevel {
         self.vocab.get(token).copied()
     }
 
-    fn id_to_token(&self, id: u32) -> Option<String> {
+    fn id_to_token(&self, id: u32) -> Option<CompactString> {
         self.vocab_r.get(&id).cloned()
     }
 
-    fn get_vocab(&self) -> FxHashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<CompactString, u32> {
         self.vocab.clone()
     }
 
@@ -217,6 +218,8 @@ impl Model for WordLevel {
 
 #[cfg(test)]
 mod tests {
+    use compact_str::ToCompactString;
+
     use super::*;
 
     #[test]
@@ -227,7 +230,7 @@ mod tests {
             .collect();
         let wordlevel = WordLevelBuilder::default()
             .vocab(vocab)
-            .unk_token("<unk>".to_string())
+            .unk_token("<unk>".to_compact_string())
             .build()
             .unwrap();
         let tokens = wordlevel.tokenize("c").unwrap();

--- a/tokenizers/src/models/wordlevel/serialization.rs
+++ b/tokenizers/src/models/wordlevel/serialization.rs
@@ -83,6 +83,8 @@ impl<'de> Visitor<'de> for WordLevelVisitor {
 
 #[cfg(test)]
 mod tests {
+    use compact_str::ToCompactString;
+
     use crate::models::wordlevel::{Vocab, WordLevel, WordLevelBuilder};
 
     #[test]
@@ -102,7 +104,7 @@ mod tests {
             .collect();
         let wordlevel = WordLevelBuilder::default()
             .vocab(vocab)
-            .unk_token("<unk>".to_string())
+            .unk_token("<unk>".to_compact_string())
             .build()
             .unwrap();
         let wl_s = r#"{"type":"WordLevel","vocab":{"<unk>":0,"b":2},"unk_token":"<unk>"}"#;

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -3,7 +3,7 @@ use crate::utils::parallelism::*;
 use crate::{AddedToken, Result, Trainer};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Builder, Serialize, Deserialize)]
@@ -22,7 +22,7 @@ pub struct WordLevelTrainer {
     pub special_tokens: Vec<AddedToken>,
 
     #[builder(default, private)]
-    words: HashMap<String, u64>,
+    words: FxHashMap<String, u64>,
 }
 
 impl Default for WordLevelTrainer {
@@ -38,7 +38,7 @@ impl WordLevelTrainer {
 
     fn do_train(
         &self,
-        word_counts: &HashMap<String, u64>,
+        word_counts: &FxHashMap<String, u64>,
         model: &mut WordLevel,
     ) -> Result<Vec<AddedToken>> {
         let mut ordered_counts = word_counts.iter().collect::<Vec<_>>();
@@ -100,18 +100,18 @@ impl Trainer for WordLevelTrainer {
         S: AsRef<str> + Send,
         F: Fn(&str) -> Result<Vec<String>> + Sync,
     {
-        let words: Result<HashMap<String, u64>> = iterator
+        let words: Result<FxHashMap<String, u64>> = iterator
             .maybe_par_bridge()
             .map(|sequence| {
                 let words = process(sequence.as_ref())?;
-                let mut map = HashMap::new();
+                let mut map = FxHashMap::default();
                 for word in words {
                     map.entry(word).and_modify(|c| *c += 1).or_insert(1);
                 }
                 Ok(map)
             })
             .reduce(
-                || Ok(HashMap::new()),
+                || Ok(FxHashMap::default()),
                 |acc, ws| {
                     let mut acc = acc?;
                     for (k, v) in ws? {
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_train() {
-        let word_counts: HashMap<String, u64> = [
+        let word_counts: FxHashMap<String, u64> = [
             ("the".into(), 25),
             ("roses".into(), 22),
             ("are".into(), 24),
@@ -151,7 +151,7 @@ mod tests {
 
         let mut model = WordLevel::default();
         trainer.do_train(&word_counts, &mut model).unwrap();
-        let expected_vocab: HashMap<String, u32> = [
+        let expected_vocab: FxHashMap<String, u32> = [
             ("the".into(), 0),
             ("are".into(), 1),
             ("roses".into(), 2),
@@ -167,7 +167,7 @@ mod tests {
         trainer.min_frequency = 15;
         let mut model = WordLevel::default();
         trainer.do_train(&word_counts, &mut model).unwrap();
-        let expected_vocab: HashMap<String, u32> = [
+        let expected_vocab: FxHashMap<String, u32> = [
             ("the".into(), 0),
             ("are".into(), 1),
             ("roses".into(), 2),

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -5,12 +5,12 @@ use crate::models::bpe::BPE;
 use crate::tokenizer::{Model, Result, Token};
 use std::{
     borrow::Cow,
-    collections::HashMap,
     fs::File,
     io::prelude::*,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
 };
+use rustc_hash::FxHashMap;
 
 mod serialization;
 mod trainer;
@@ -22,8 +22,8 @@ pub enum Error {
     MissingUnkToken,
 }
 
-type Vocab = HashMap<String, u32>;
-type VocabR = HashMap<u32, String>;
+type Vocab = FxHashMap<String, u32>;
+type VocabR = FxHashMap<u32, String>;
 
 struct Config {
     files: Option<String>,
@@ -43,7 +43,7 @@ impl Default for WordPieceBuilder {
         Self {
             config: Config {
                 files: None,
-                vocab: HashMap::new(),
+                vocab: FxHashMap::default(),
                 unk_token: String::from("[UNK]"),
                 continuing_subword_prefix: String::from("##"),
                 max_input_chars_per_word: 100,
@@ -142,8 +142,8 @@ impl std::fmt::Debug for WordPiece {
 impl Default for WordPiece {
     fn default() -> Self {
         Self {
-            vocab: HashMap::new(),
-            vocab_r: HashMap::new(),
+            vocab: FxHashMap::default(),
+            vocab_r: FxHashMap::default(),
             unk_token: String::from("[UNK]"),
             continuing_subword_prefix: String::from("##"),
             max_input_chars_per_word: 100,
@@ -162,7 +162,7 @@ impl WordPiece {
         let file = File::open(vocab)?;
         let file = BufReader::new(file);
 
-        let mut vocab = HashMap::new();
+        let mut vocab = FxHashMap::default();
         for (index, line) in file.lines().enumerate() {
             let line = line?;
             vocab.insert(line.trim_end().to_owned(), index as u32);
@@ -192,7 +192,7 @@ impl WordPiece {
 impl Model for WordPiece {
     type Trainer = WordPieceTrainer;
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         self.vocab.clone()
     }
 

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -1,8 +1,9 @@
 use super::WordPiece;
 use crate::models::bpe::{BpeTrainer, BpeTrainerBuilder, BPE};
 use crate::tokenizer::{AddedToken, Result, Trainer};
-use serde::{Deserialize, Serialize};
+use compact_str::CompactString;
 use rustc_hash::FxHashSet;
+use serde::{Deserialize, Serialize};
 
 /// A `WordPieceTrainerBuilder` can be used to create a `WordPieceTrainer` with a custom
 /// configuration.
@@ -68,14 +69,14 @@ impl WordPieceTrainerBuilder {
 
     /// Set the continuing_subword_prefix
     #[must_use]
-    pub fn continuing_subword_prefix(mut self, prefix: String) -> Self {
+    pub fn continuing_subword_prefix(mut self, prefix: CompactString) -> Self {
         self.bpe_trainer_builder = self.bpe_trainer_builder.continuing_subword_prefix(prefix);
         self
     }
 
     /// Set the end_of_word_suffix
     #[must_use]
-    pub fn end_of_word_suffix(mut self, suffix: String) -> Self {
+    pub fn end_of_word_suffix(mut self, suffix: CompactString) -> Self {
         self.bpe_trainer_builder = self.bpe_trainer_builder.end_of_word_suffix(suffix);
         self
     }
@@ -142,19 +143,19 @@ impl WordPieceTrainer {
         self.bpe_trainer.initial_alphabet = alphabet;
     }
 
-    pub fn continuing_subword_prefix(&self) -> &Option<String> {
+    pub fn continuing_subword_prefix(&self) -> &Option<CompactString> {
         &self.bpe_trainer.continuing_subword_prefix
     }
 
-    pub fn set_continuing_subword_prefix(&mut self, prefix: Option<String>) {
+    pub fn set_continuing_subword_prefix(&mut self, prefix: Option<CompactString>) {
         self.bpe_trainer.continuing_subword_prefix = prefix;
     }
 
-    pub fn end_of_word_suffix(&self) -> &Option<String> {
+    pub fn end_of_word_suffix(&self) -> &Option<CompactString> {
         &self.bpe_trainer.end_of_word_suffix
     }
 
-    pub fn set_end_of_word_suffix(&mut self, suffix: Option<String>) {
+    pub fn set_end_of_word_suffix(&mut self, suffix: Option<CompactString>) {
         self.bpe_trainer.end_of_word_suffix = suffix;
     }
 
@@ -192,7 +193,7 @@ impl Trainer for WordPieceTrainer {
     where
         I: Iterator<Item = S> + Send,
         S: AsRef<str> + Send,
-        F: Fn(&str) -> Result<Vec<String>> + Sync,
+        F: Fn(&str) -> Result<Vec<CompactString>> + Sync,
     {
         self.bpe_trainer.feed(iterator, process)
     }

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -2,7 +2,7 @@ use super::WordPiece;
 use crate::models::bpe::{BpeTrainer, BpeTrainerBuilder, BPE};
 use crate::tokenizer::{AddedToken, Result, Trainer};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 /// A `WordPieceTrainerBuilder` can be used to create a `WordPieceTrainer` with a custom
 /// configuration.
@@ -61,7 +61,7 @@ impl WordPieceTrainerBuilder {
 
     /// Set the initial alphabet
     #[must_use]
-    pub fn initial_alphabet(mut self, alphabet: HashSet<char>) -> Self {
+    pub fn initial_alphabet(mut self, alphabet: FxHashSet<char>) -> Self {
         self.bpe_trainer_builder = self.bpe_trainer_builder.initial_alphabet(alphabet);
         self
     }
@@ -134,11 +134,11 @@ impl WordPieceTrainer {
         self.bpe_trainer.limit_alphabet = limit;
     }
 
-    pub fn initial_alphabet(&self) -> &HashSet<char> {
+    pub fn initial_alphabet(&self) -> &FxHashSet<char> {
         &self.bpe_trainer.initial_alphabet
     }
 
-    pub fn set_initial_alphabet(&mut self, alphabet: HashSet<char>) {
+    pub fn set_initial_alphabet(&mut self, alphabet: FxHashSet<char>) {
         self.bpe_trainer.initial_alphabet = alphabet;
     }
 

--- a/tokenizers/src/normalizers/replace.rs
+++ b/tokenizers/src/normalizers/replace.rs
@@ -2,7 +2,7 @@ use crate::tokenizer::pattern::Pattern;
 use crate::tokenizer::Decoder;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::SysRegex;
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use serde::{Deserialize, Serialize};
 
 /// Represents the different patterns that `Replace` can use
@@ -87,14 +87,14 @@ impl Normalizer for Replace {
 }
 
 impl Decoder for Replace {
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+    fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
     ) -> Result<Vec<CompactString>> {
         tokens
             .into_iter()
             .map(|token| -> Result<CompactString> {
-                let token = Into::<CompactString>::into(token);
+                let token = token.to_compact_string();
                 let mut new_token = CompactString::from("");
 
                 for ((start, stop), is_match) in (&self.regex).find_matches(token.as_str())? {

--- a/tokenizers/src/normalizers/replace.rs
+++ b/tokenizers/src/normalizers/replace.rs
@@ -87,13 +87,17 @@ impl Normalizer for Replace {
 }
 
 impl Decoder for Replace {
-    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
+    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+        &self,
+        tokens: Vec<T>,
+    ) -> Result<Vec<CompactString>> {
         tokens
             .into_iter()
             .map(|token| -> Result<CompactString> {
+                let token = Into::<CompactString>::into(token);
                 let mut new_token = CompactString::from("");
 
-                for ((start, stop), is_match) in (&self.regex).find_matches(&token)? {
+                for ((start, stop), is_match) in (&self.regex).find_matches(token.as_str())? {
                     if is_match {
                         new_token.push_str(&self.content);
                     } else {
@@ -150,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_replace_decode() {
-        let original = vec!["hello".into(), "_hello".into()];
+        let original = vec!["hello".to_owned(), "_hello".to_owned()];
         let replace = Replace::new("_", " ").unwrap();
         assert_eq!(
             replace.decode_chain(original).unwrap(),

--- a/tokenizers/src/normalizers/replace.rs
+++ b/tokenizers/src/normalizers/replace.rs
@@ -90,7 +90,7 @@ impl Decoder for Replace {
     fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
-    ) -> Result<Vec<CompactString>> {
+    ) -> Result<Vec<impl ToCompactString>> {
         tokens
             .into_iter()
             .map(|token| -> Result<CompactString> {
@@ -157,7 +157,12 @@ mod tests {
         let original = vec!["hello".to_owned(), "_hello".to_owned()];
         let replace = Replace::new("_", " ").unwrap();
         assert_eq!(
-            replace.decode_chain(original).unwrap(),
+            replace
+                .decode_chain(original)
+                .unwrap()
+                .into_iter()
+                .map(|t| t.to_compact_string())
+                .collect::<Vec<_>>(),
             vec!["hello", " hello"]
         );
     }

--- a/tokenizers/src/normalizers/replace.rs
+++ b/tokenizers/src/normalizers/replace.rs
@@ -2,6 +2,7 @@ use crate::tokenizer::pattern::Pattern;
 use crate::tokenizer::Decoder;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::SysRegex;
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
 /// Represents the different patterns that `Replace` can use
@@ -86,11 +87,11 @@ impl Normalizer for Replace {
 }
 
 impl Decoder for Replace {
-    fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
+    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
         tokens
             .into_iter()
-            .map(|token| -> Result<String> {
-                let mut new_token = "".to_string();
+            .map(|token| -> Result<CompactString> {
+                let mut new_token = CompactString::from("");
 
                 for ((start, stop), is_match) in (&self.regex).find_matches(&token)? {
                     if is_match {
@@ -149,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_replace_decode() {
-        let original = vec!["hello".to_string(), "_hello".to_string()];
+        let original = vec!["hello".into(), "_hello".into()];
         let replace = Replace::new("_", " ").unwrap();
         assert_eq!(
             replace.decode_chain(original).unwrap(),

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -158,10 +158,14 @@ impl PreTokenizer for ByteLevel {
 /// the fact that single token decoded might be a byte not representable as
 /// as String.
 impl Decoder for ByteLevel {
-    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
+    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+        &self,
+        tokens: Vec<T>,
+    ) -> Result<Vec<CompactString>> {
         let toks = tokens
             .into_iter()
             .flat_map(|t| {
+                let t: CompactString = t.into();
                 t.chars()
                     .try_fold(vec![], |mut acc, c| {
                         CHAR_BYTES.get(&c).map(|b| {
@@ -300,7 +304,7 @@ mod tests {
                     ]
                     .into_iter()
                     .map(|s| s.into())
-                    .collect::<Vec<_>>()
+                    .collect::<Vec<CompactString>>()
                 )
                 .unwrap(),
             vec!["Hello my friend, how is your day going?"]
@@ -354,7 +358,7 @@ mod tests {
                 .get_splits(OffsetReferential::Original, OffsetType::Byte)
                 .iter()
                 .flat_map(|(s, _, _)| s.split("").map(|t| t.into()))
-                .collect::<Vec<_>>();
+                .collect::<Vec<CompactString>>();
             assert_eq!(
                 sample,
                 bytelevel.decode_chain(separated_tokens).unwrap().join("")
@@ -561,12 +565,12 @@ mod tests {
         assert_eq!(
             byte_level
                 .decode_chain(vec![
-                    "Hello".into(),
-                    "Ġthere".into(),
-                    "Ġdear".into(),
-                    "Ġfriend!".into(),
-                    "Ġ".into(),
-                    "[PA D]".into()
+                    "Hello".to_owned(),
+                    "Ġthere".to_owned(),
+                    "Ġdear".to_owned(),
+                    "Ġfriend!".to_owned(),
+                    "Ġ".to_owned(),
+                    "[PA D]".to_owned()
                 ])
                 .unwrap(),
             vec!["Hello there dear friend! [PA D]"]

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::utils::SysRegex;
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
 use crate::tokenizer::{
@@ -157,7 +158,7 @@ impl PreTokenizer for ByteLevel {
 /// the fact that single token decoded might be a byte not representable as
 /// as String.
 impl Decoder for ByteLevel {
-    fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
+    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
         let toks = tokens
             .into_iter()
             .flat_map(|t| {
@@ -171,7 +172,7 @@ impl Decoder for ByteLevel {
                     .unwrap_or_else(|| t.as_bytes().to_vec())
             })
             .collect::<Vec<u8>>();
-        Ok(vec![String::from_utf8_lossy(&toks).to_string()])
+        Ok(vec![String::from_utf8_lossy(&toks).into()])
     }
 }
 
@@ -299,7 +300,7 @@ mod tests {
                     ]
                     .into_iter()
                     .map(|s| s.into())
-                    .collect::<Vec<String>>()
+                    .collect::<Vec<_>>()
                 )
                 .unwrap(),
             vec!["Hello my friend, how is your day going?"]

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::utils::SysRegex;
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use serde::{Deserialize, Serialize};
 
 use crate::tokenizer::{
@@ -158,14 +158,14 @@ impl PreTokenizer for ByteLevel {
 /// the fact that single token decoded might be a byte not representable as
 /// as String.
 impl Decoder for ByteLevel {
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+    fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
     ) -> Result<Vec<CompactString>> {
         let toks = tokens
             .into_iter()
             .flat_map(|t| {
-                let t: CompactString = t.into();
+                let t: CompactString = t.to_compact_string();
                 t.chars()
                     .try_fold(vec![], |mut acc, c| {
                         CHAR_BYTES.get(&c).map(|b| {
@@ -302,9 +302,9 @@ mod tests {
                         "Hello", "Ġmy", "Ġfriend", ",", "Ġhow", "Ġis", "Ġyour", "Ġday", "Ġgoing",
                         "?"
                     ]
-                    .into_iter()
-                    .map(|s| s.into())
-                    .collect::<Vec<CompactString>>()
+                        .into_iter()
+                        .map(|s| s.into())
+                        .collect::<Vec<CompactString>>()
                 )
                 .unwrap(),
             vec!["Hello my friend, how is your day going?"]
@@ -583,20 +583,20 @@ mod tests {
         let byte_level: ByteLevel = serde_json::from_str(
             r#"{"type": "ByteLevel", "add_prefix_space": true, "trim_offsets": false}"#,
         )
-        .unwrap();
+            .unwrap();
         assert!(byte_level.use_regex);
 
         // Loading works, new future BC test.
         let byte_level: ByteLevel = serde_json::from_str(
             r#"{"type": "ByteLevel", "add_prefix_space": true, "trim_offsets": false, "use_regex": true}"#,
         )
-        .unwrap();
+            .unwrap();
         assert!(byte_level.use_regex);
 
         let byte_level: ByteLevel = serde_json::from_str(
             r#"{"type": "ByteLevel", "add_prefix_space": true, "trim_offsets": false, "use_regex": false}"#,
         )
-        .unwrap();
+            .unwrap();
         assert!(!byte_level.use_regex);
     }
 }

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -1,5 +1,5 @@
 use crate::tokenizer::{Decoder, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use serde::{de, Deserialize, Deserializer, Serialize};
 
 /// Enum representing options for the metaspace prepending scheme.
@@ -149,16 +149,13 @@ impl PreTokenizer for Metaspace {
 }
 
 impl Decoder for Metaspace {
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
-        &self,
-        tokens: Vec<T>,
-    ) -> Result<Vec<CompactString>> {
+    fn decode_chain<T: ToCompactString>(&self, tokens: Vec<T>) -> Result<Vec<CompactString>> {
         Ok(tokens
-            .iter()
+            .into_iter()
             .enumerate()
             .map(|(i, token)| {
-                let tmp_token = Into::<CompactString>::into(token.clone());
-                tmp_token
+                token
+                    .to_compact_string()
                     .chars()
                     .flat_map(|c| {
                         if c == self.replacement {
@@ -209,7 +206,7 @@ mod tests {
         let metaspace_parsed: Metaspace = serde_json::from_str(
             r#"{"type":"Metaspace","replacement":"_","add_prefix_space":true}"#,
         )
-        .unwrap();
+            .unwrap();
         assert_eq!(metaspace_parsed, metaspace);
     }
 

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -149,12 +149,16 @@ impl PreTokenizer for Metaspace {
 }
 
 impl Decoder for Metaspace {
-    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
+    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+        &self,
+        tokens: Vec<T>,
+    ) -> Result<Vec<CompactString>> {
         Ok(tokens
             .iter()
             .enumerate()
             .map(|(i, token)| {
-                token
+                let tmp_token = Into::<CompactString>::into(token.clone());
+                tmp_token
                     .chars()
                     .flat_map(|c| {
                         if c == self.replacement {
@@ -358,13 +362,13 @@ mod tests {
     fn decode() {
         let decoder = Metaspace::new('▁', PrependScheme::Always, true);
         let res = decoder
-            .decode_chain(vec!["▁Hey".into(), "▁friend!".into()])
+            .decode_chain(vec!["▁Hey".to_owned(), "▁friend!".to_owned()])
             .unwrap();
         assert_eq!(res, vec!["Hey", " friend!"]);
 
         let decoder = Metaspace::new('▁', PrependScheme::Never, true);
         let res = decoder
-            .decode_chain(vec!["▁Hey".into(), "▁friend!".into()])
+            .decode_chain(vec!["▁Hey".to_owned(), "▁friend!".to_owned()])
             .unwrap();
         assert_eq!(res, vec![" Hey", " friend!"]);
     }

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -1,4 +1,5 @@
 use crate::tokenizer::{Decoder, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
+use compact_str::CompactString;
 use serde::{de, Deserialize, Deserializer, Serialize};
 
 /// Enum representing options for the metaspace prepending scheme.
@@ -148,7 +149,7 @@ impl PreTokenizer for Metaspace {
 }
 
 impl Decoder for Metaspace {
-    fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
+    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>> {
         Ok(tokens
             .iter()
             .enumerate()
@@ -166,7 +167,7 @@ impl Decoder for Metaspace {
                             Some(c)
                         }
                     })
-                    .collect::<String>()
+                    .collect()
             })
             .collect())
     }

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -1,4 +1,5 @@
 use crate::tokenizer::{Encoding, PostProcessor, Result};
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::iter::FromIterator;
@@ -6,8 +7,8 @@ use std::iter::FromIterator;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub struct BertProcessing {
-    pub sep: (String, u32),
-    pub cls: (String, u32),
+    pub sep: (CompactString, u32),
+    pub cls: (CompactString, u32),
 }
 
 impl Default for BertProcessing {
@@ -20,15 +21,15 @@ impl Default for BertProcessing {
 }
 
 impl BertProcessing {
-    pub fn new(sep: (String, u32), cls: (String, u32)) -> Self {
+    pub fn new(sep: (CompactString, u32), cls: (CompactString, u32)) -> Self {
         Self { sep, cls }
     }
 
-    pub fn get_sep_copy(&self) -> (String, u32) {
+    pub fn get_sep_copy(&self) -> (CompactString, u32) {
         (self.sep.0.clone(), self.sep.1)
     }
 
-    pub fn get_cls_copy(&self) -> (String, u32) {
+    pub fn get_cls_copy(&self) -> (CompactString, u32) {
         (self.cls.0.clone(), self.cls.1)
     }
 }

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -1,5 +1,6 @@
 use crate::processors::byte_level::process_offsets;
 use crate::tokenizer::{Encoding, PostProcessor, Result};
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::iter::FromIterator;
@@ -7,8 +8,8 @@ use std::iter::FromIterator;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub struct RobertaProcessing {
-    pub sep: (String, u32),
-    pub cls: (String, u32),
+    pub sep: (CompactString, u32),
+    pub cls: (CompactString, u32),
     pub trim_offsets: bool,
     pub add_prefix_space: bool,
 }
@@ -25,7 +26,7 @@ impl Default for RobertaProcessing {
 }
 
 impl RobertaProcessing {
-    pub fn new(sep: (String, u32), cls: (String, u32)) -> Self {
+    pub fn new(sep: (CompactString, u32), cls: (CompactString, u32)) -> Self {
         Self {
             sep,
             cls,
@@ -45,11 +46,11 @@ impl RobertaProcessing {
         self
     }
 
-    pub fn get_sep_copy(&self) -> (String, u32) {
+    pub fn get_sep_copy(&self) -> (CompactString, u32) {
         (self.sep.0.clone(), self.sep.1)
     }
 
-    pub fn get_cls_copy(&self) -> (String, u32) {
+    pub fn get_cls_copy(&self) -> (CompactString, u32) {
         (self.cls.0.clone(), self.cls.1)
     }
 }

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -4,7 +4,7 @@ use super::{
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 use regex::Regex;
 use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Represent a token added by the user on top of the existing Model vocabulary.
 /// AddedToken can be configured to specify the behavior they should have in various situations
@@ -142,10 +142,10 @@ fn space_rightmost_at_start(sentence: &str) -> usize {
 pub struct AddedVocabulary {
     /// Contains the mapping from String (token content) to ID. This map contains both special
     /// tokens and classic added tokens that were added to the this vocabulary.
-    added_tokens_map: HashMap<String, u32>,
+    added_tokens_map: FxHashMap<String, u32>,
     /// Contains the mapping from ID to AddedToken for all the added tokens, both special
     /// and classic.
-    added_tokens_map_r: HashMap<u32, AddedToken>,
+    added_tokens_map_r: FxHashMap<u32, AddedToken>,
 
     /// Contains only the classic AddedToken, in the specific order the user gave them.
     added_tokens: Vec<AddedToken>,
@@ -154,7 +154,7 @@ pub struct AddedVocabulary {
 
     /// A Set, containing all the special token for easy access while decoding. This let's
     /// us remove them easily with an O(1) complexity.
-    special_tokens_set: HashSet<String>,
+    special_tokens_set: FxHashSet<String>,
 
     /// A RegexSet containing all the non-normalized patterns used to split on AddedTokens
     split_trie: MatchingSet,
@@ -176,11 +176,11 @@ impl AddedVocabulary {
             .build::<_, &&[u8]>([])
             .expect("The normalized trie should build correctly");
         Self {
-            added_tokens_map: HashMap::new(),
-            added_tokens_map_r: HashMap::new(),
+            added_tokens_map: FxHashMap::default(),
+            added_tokens_map_r: FxHashMap::default(),
             added_tokens: vec![],
             special_tokens: vec![],
-            special_tokens_set: HashSet::new(),
+            special_tokens_set: FxHashSet::default(),
             split_trie: (trie, vec![]),
             split_normalized_trie: (normalized_trie, vec![]),
             encode_special_tokens: false,
@@ -198,12 +198,12 @@ impl AddedVocabulary {
     }
 
     /// Get the additional vocabulary
-    pub fn get_vocab(&self) -> &HashMap<String, u32> {
+    pub fn get_vocab(&self) -> &FxHashMap<String, u32> {
         &self.added_tokens_map
     }
 
     /// Get the additional vocabulary with the AddedTokens
-    pub fn get_added_tokens_decoder(&self) -> &HashMap<u32, AddedToken> {
+    pub fn get_added_tokens_decoder(&self) -> &FxHashMap<u32, AddedToken> {
         &self.added_tokens_map_r
     }
 
@@ -551,15 +551,15 @@ mod tests {
 
     #[derive(Serialize, Deserialize)]
     struct ModelMock {
-        vocab: HashMap<String, u32>,
-        vocab_r: HashMap<u32, String>,
+        vocab: FxHashMap<String, u32>,
+        vocab_r: FxHashMap<u32, String>,
     }
     impl ModelMock {
         pub fn new<I>(iter: I) -> Self
         where
             I: IntoIterator<Item = &'static (&'static str, u32)>,
         {
-            let vocab: HashMap<String, u32> = iter
+            let vocab: FxHashMap<String, u32> = iter
                 .into_iter()
                 .map(|&(tok, id)| (tok.to_string(), id))
                 .collect();
@@ -619,7 +619,7 @@ mod tests {
         fn id_to_token(&self, id: u32) -> Option<String> {
             self.vocab_r.get(&id).cloned()
         }
-        fn get_vocab(&self) -> HashMap<String, u32> {
+        fn get_vocab(&self) -> FxHashMap<String, u32> {
             self.vocab.clone()
         }
         fn get_vocab_size(&self) -> usize {
@@ -716,11 +716,13 @@ mod tests {
         assert!(vocab.is_special_token("test"));
         assert_eq!(
             *vocab.get_added_tokens_decoder(),
-            HashMap::from([
-                (0, AddedToken::from("test", true)),
-                (2, AddedToken::from("added_token_1", true)),
-                (3, AddedToken::from("added_token_2", true)),
-            ])
+            {
+                let mut map = FxHashMap::default();
+                map.insert(0, AddedToken::from("test", true));
+                map.insert(2, AddedToken::from("added_token_1", true));
+                map.insert(3, AddedToken::from("added_token_2", true));
+                map
+            }
         );
         assert!(vocab.added_tokens_map.contains_key("test"));
         assert!(vocab.added_tokens_map_r.contains_key(&0));

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -10,12 +10,12 @@
 //!     ...).
 
 use std::{
-    collections::HashMap,
     fs::{read_to_string, File},
     io::{prelude::*, BufReader},
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };
+use rustc_hash::FxHashMap;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -77,7 +77,7 @@ pub trait Model {
     /// Find the string token associated to an ID
     fn id_to_token(&self, id: u32) -> Option<String>;
     /// Retrieve the entire vocabulary mapping (token -> ID)
-    fn get_vocab(&self) -> HashMap<String, u32>;
+    fn get_vocab(&self) -> FxHashMap<String, u32>;
     /// Retrieve the size of the vocabulary
     fn get_vocab_size(&self) -> usize;
     /// Save the current `Model` in the given folder, using the given `prefix` for the various
@@ -658,7 +658,7 @@ where
     }
 
     /// Get the vocabulary
-    pub fn get_vocab(&self, with_added_tokens: bool) -> HashMap<String, u32> {
+    pub fn get_vocab(&self, with_added_tokens: bool) -> FxHashMap<String, u32> {
         let mut final_vocab = self.model.get_vocab();
 
         if with_added_tokens {
@@ -675,7 +675,7 @@ where
     }
 
     /// Get the added tokens decoder
-    pub fn get_added_tokens_decoder(&self) -> HashMap<u32, AddedToken> {
+    pub fn get_added_tokens_decoder(&self) -> FxHashMap<u32, AddedToken> {
         self.added_vocabulary.get_added_tokens_decoder().clone()
     }
 

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -929,18 +929,19 @@ where
 /// Example:
 ///
 /// ```
-/// # #[cfg(not(target_os = "windows"))]
+/// # use compact_str::ToCompactString;
+/// #[cfg(not(target_os = "windows"))]
 /// # {
 /// use tokenizers::Tokenizer;
 /// let tokenizer = Tokenizer::from_file("data/roberta.json").unwrap();
 ///
 /// let mut decode_stream = tokenizer.decode_stream(false);
-/// assert_eq!(decode_stream.step(713).unwrap(), Some("This".to_string()));
-/// assert_eq!(decode_stream.step(16).unwrap(), Some(" is".to_string()));
-/// assert_eq!(decode_stream.step(41).unwrap(), Some(" an".to_string()));
+/// assert_eq!(decode_stream.step(713).unwrap(), Some("This".to_compact_string()));
+/// assert_eq!(decode_stream.step(16).unwrap(), Some(" is".to_compact_string()));
+/// assert_eq!(decode_stream.step(41).unwrap(), Some(" an".to_compact_string()));
 /// assert_eq!(
 ///     decode_stream.step(1246).unwrap(),
-///     Some(" example".to_string())
+///     Some(" example".to_compact_string())
 /// );
 /// # }
 /// ```
@@ -951,14 +952,15 @@ where
 /// a valid chunk.
 /// ```
 /// use tokenizers::{Tokenizer, TokenizerBuilder, models::bpe::BPE, decoders::byte_fallback::ByteFallback, pre_tokenizers::byte_level::ByteLevel, normalizers::unicode::NFC};
-/// use std::collections::HashMap;
 /// use std::iter::FromIterator;
+/// use compact_str::{CompactString, ToCompactString};
+/// use rustc_hash::FxHashMap;
 ///
-/// let vocab = HashMap::from_iter([
-///     ("<0x20>".to_string(), 0),
-///     ("<0xC3>".to_string(), 1),
-///     ("<0xA9>".to_string(), 2),
-///     (" This".to_string(), 3),
+/// let vocab: FxHashMap<CompactString, u32> = FxHashMap::from_iter([
+///     ("<0x20>".into(), 0),
+///     ("<0xC3>".into(), 1),
+///     ("<0xA9>".into(), 2),
+///     (" This".into(), 3),
 /// ]);
 /// let merges = vec![];
 /// let bpe = BPE::builder()
@@ -976,11 +978,11 @@ where
 ///
 /// let mut decode_stream = tokenizer.decode_stream(false);
 /// // Single byte_fallback is valid utf-8
-/// assert_eq!(decode_stream.step(0).unwrap(), Some(" ".to_string()));
+/// assert_eq!(decode_stream.step(0).unwrap(), Some(" ".to_compact_string()));
 /// // Invalid utf-8
 /// assert_eq!(decode_stream.step(1).unwrap(), None);
 /// // Valid utf-8 again, this corresponds to both tokens: [1, 2]
-/// assert_eq!(decode_stream.step(2).unwrap(), Some("é".to_string()));
+/// assert_eq!(decode_stream.step(2).unwrap(), Some("é".to_compact_string()));
 /// ```
 ///
 /// To see how [`DecodeStream`] is necessary, let's show how using raw [`TokenizerImpl::decode`] would
@@ -988,11 +990,12 @@ where
 ///
 /// ```
 /// use tokenizers::{Tokenizer, TokenizerBuilder, models::bpe::BPE, pre_tokenizers::{byte_level::ByteLevel, metaspace::Metaspace}, normalizers::unicode::NFC};
-/// use std::collections::HashMap;
 /// use std::iter::FromIterator;
+/// use compact_str::{CompactString, ToCompactString};
+/// use rustc_hash::FxHashMap;
 ///
-/// let vocab = HashMap::from_iter([
-///     ("▁This".to_string(), 0),
+/// let vocab: FxHashMap<CompactString, u32> = FxHashMap::from_iter([
+///     ("▁This".into(), 0),
 /// ]);
 /// let merges = vec![];
 /// let bpe = BPE::builder()
@@ -1016,8 +1019,8 @@ where
 ///
 /// // Using a stream fixes it by keeping the necessary state.
 /// let mut decode_stream = tokenizer.decode_stream(false);
-/// assert_eq!(decode_stream.step(0).unwrap(), Some("This".to_string()));
-/// assert_eq!(decode_stream.step(0).unwrap(), Some(" This".to_string()));
+/// assert_eq!(decode_stream.step(0).unwrap(), Some("This".to_compact_string()));
+/// assert_eq!(decode_stream.step(0).unwrap(), Some(" This".to_compact_string()));
 /// ```
 pub struct DecodeStream<'tok, M, N, PT, PP, D> {
     /// A reference to the tokenizer

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -9,7 +9,7 @@
 //!   - [`PostProcessor`](trait.PostProcessor.html): Takes care of the processing after tokenization (like truncating, padding,
 //!     ...).
 
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use rustc_hash::FxHashMap;
 use std::{
     fs::{read_to_string, File},
@@ -152,14 +152,14 @@ pub enum ProcessorError {
 
 /// A `Decoder` changes the raw tokens into its more readable form.
 pub trait Decoder {
-    fn decode<T: Into<CompactString> + From<String> + Clone>(
+    fn decode<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
     ) -> Result<CompactString> {
-        let results = self.decode_chain(tokens.into_iter().map(|x| x.into()).collect())?;
+        let results: Vec<CompactString> = self.decode_chain(tokens.into_iter().map(|x| x.to_compact_string()).collect())?;
         Ok(results.join("").into())
     }
-    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+    fn decode_chain<T: ToCompactString>(
         &self,
         tokens: Vec<T>,
     ) -> Result<Vec<CompactString>>;

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -152,11 +152,17 @@ pub enum ProcessorError {
 
 /// A `Decoder` changes the raw tokens into its more readable form.
 pub trait Decoder {
-    fn decode(&self, tokens: Vec<CompactString>) -> Result<CompactString> {
-        let results = self.decode_chain(tokens)?;
+    fn decode<T: Into<CompactString> + From<String> + Clone>(
+        &self,
+        tokens: Vec<T>,
+    ) -> Result<CompactString> {
+        let results = self.decode_chain(tokens.into_iter().map(|x| x.into()).collect())?;
         Ok(results.join("").into())
     }
-    fn decode_chain(&self, tokens: Vec<CompactString>) -> Result<Vec<CompactString>>;
+    fn decode_chain<T: Into<CompactString> + From<String> + Clone>(
+        &self,
+        tokens: Vec<T>,
+    ) -> Result<Vec<CompactString>>;
 }
 
 /// A `Trainer` has the responsibility to train a model. We feed it with lines/sentences

--- a/tokenizers/src/tokenizer/pre_tokenizer.rs
+++ b/tokenizers/src/tokenizer/pre_tokenizer.rs
@@ -1,3 +1,5 @@
+use compact_str::CompactString;
+
 use crate::{
     normalizer::Range, Encoding, NormalizedString, OffsetReferential, Offsets, Result, Token,
 };
@@ -154,7 +156,7 @@ impl PreTokenizedString {
                         .flat_map(|split| {
                             split.tokens.unwrap().into_iter().map(|token| {
                                 // Replace this with the actual fields you need for the Encoding type
-                                (token.id, String::with_capacity(0), (0, 0), None, 0)
+                                (token.id, CompactString::with_capacity(0), (0, 0), None, 0)
                             })
                         })
                         .collect();

--- a/tokenizers/src/utils/compact_string.rs
+++ b/tokenizers/src/utils/compact_string.rs
@@ -1,0 +1,22 @@
+use compact_str::{CompactString, ToCompactString};
+
+pub fn to_compact_strings_option(
+    input_options: Option<impl ToCompactString>,
+) -> Option<CompactString> {
+    input_options.map(|s| s.to_compact_string())
+}
+
+pub fn to_compact_strings_result<E>(
+    input_results: Result<impl ToCompactString, E>,
+) -> Result<CompactString, E> {
+    input_results.map(|s| s.to_compact_string())
+}
+
+pub fn to_compact_strings<T: ToCompactString, C: IntoIterator<Item = T>>(
+    input_strings: C,
+) -> Vec<CompactString> {
+    input_strings
+        .into_iter()
+        .map(|s| s.to_compact_string())
+        .collect()
+}

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -11,6 +11,7 @@ mod onig;
 #[cfg(not(feature = "unstable_wasm"))]
 pub use crate::utils::onig::SysRegex;
 
+pub mod compact_string;
 pub mod iter;
 pub mod padding;
 pub mod parallelism;

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -168,6 +168,8 @@ pub fn truncate_encodings(
 
 #[cfg(test)]
 mod tests {
+    use compact_str::CompactString;
+
     use super::*;
     use crate::tokenizer::Encoding;
     use std::collections::HashMap;
@@ -190,7 +192,7 @@ mod tests {
         Encoding::new(
             vec![1, 2],
             vec![0, 0],
-            vec![String::from("a"), String::from("b")],
+            vec![CompactString::from("a"), CompactString::from("b")],
             vec![Some(0), Some(1)],
             vec![(0, 1), (1, 2)],
             vec![0, 0],
@@ -205,10 +207,10 @@ mod tests {
             vec![3, 4, 5, 6],
             vec![0, 0, 0, 0],
             vec![
-                String::from("d"),
-                String::from("e"),
-                String::from("f"),
-                String::from("g"),
+                CompactString::from("d"),
+                CompactString::from("e"),
+                CompactString::from("f"),
+                CompactString::from("g"),
             ],
             vec![Some(0), Some(1), Some(2), Some(3)],
             vec![(0, 1), (1, 2), (2, 3), (3, 4)],
@@ -224,14 +226,14 @@ mod tests {
             vec![7, 8, 9, 10, 11, 12, 13, 14],
             vec![0, 0, 0, 0, 0, 0, 0, 0],
             vec![
-                String::from("h"),
-                String::from("i"),
-                String::from("j"),
-                String::from("k"),
-                String::from("l"),
-                String::from("m"),
-                String::from("n"),
-                String::from("o"),
+                CompactString::from("h"),
+                CompactString::from("i"),
+                CompactString::from("j"),
+                CompactString::from("k"),
+                CompactString::from("l"),
+                CompactString::from("m"),
+                CompactString::from("n"),
+                CompactString::from("o"),
             ],
             vec![
                 Some(0),

--- a/tokenizers/tests/common/mod.rs
+++ b/tokenizers/tests/common/mod.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use tokenizers::decoders::wordpiece::WordPiece as WordPieceDecoder;
 use tokenizers::models::bpe::BPE;
 use tokenizers::models::wordpiece::WordPiece;
@@ -49,8 +50,8 @@ pub fn get_bert() -> Tokenizer {
         .with_pre_tokenizer(Some(BertPreTokenizer))
         .with_decoder(Some(WordPieceDecoder::default()))
         .with_post_processor(Some(BertProcessing::new(
-            (String::from("[SEP]"), sep),
-            (String::from("[CLS]"), cls),
+            (CompactString::from("[SEP]"), sep),
+            (CompactString::from("[CLS]"), cls),
         )));
 
     tokenizer

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -67,35 +67,29 @@ fn streaming_tokenizer() {
     let tokenizer = Tokenizer::from_file("data/roberta.json").unwrap();
 
     let mut decode_stream = tokenizer.decode_stream(false);
-    assert_eq!(decode_stream.step(713).unwrap(), Some("This".to_string()));
-    assert_eq!(decode_stream.step(16).unwrap(), Some(" is".to_string()));
-    assert_eq!(decode_stream.step(41).unwrap(), Some(" an".to_string()));
-    assert_eq!(
-        decode_stream.step(1246).unwrap(),
-        Some(" example".to_string())
-    );
+    assert_eq!(decode_stream.step(713).unwrap(), Some("This".into()));
+    assert_eq!(decode_stream.step(16).unwrap(), Some(" is".into()));
+    assert_eq!(decode_stream.step(41).unwrap(), Some(" an".into()));
+    assert_eq!(decode_stream.step(1246).unwrap(), Some(" example".into()));
 
     let tokenizer = Tokenizer::from_file("data/albert-base-v1-tokenizer.json").unwrap();
     let encoded = tokenizer.encode("This is an example", false).unwrap();
     assert_eq!(encoded.get_ids(), &[48, 25, 40, 823]);
     let mut decode_stream = tokenizer.decode_stream(false);
     // No space anymore
-    assert_eq!(decode_stream.step(25).unwrap(), Some("is".to_string()));
+    assert_eq!(decode_stream.step(25).unwrap(), Some("is".into()));
     let mut decode_stream = tokenizer.decode_stream(false);
-    assert_eq!(decode_stream.step(48).unwrap(), Some("this".to_string()));
-    assert_eq!(decode_stream.step(25).unwrap(), Some(" is".to_string()));
-    assert_eq!(decode_stream.step(40).unwrap(), Some(" an".to_string()));
-    assert_eq!(
-        decode_stream.step(823).unwrap(),
-        Some(" example".to_string())
-    );
+    assert_eq!(decode_stream.step(48).unwrap(), Some("this".into()));
+    assert_eq!(decode_stream.step(25).unwrap(), Some(" is".into()));
+    assert_eq!(decode_stream.step(40).unwrap(), Some(" an".into()));
+    assert_eq!(decode_stream.step(823).unwrap(), Some(" example".into()));
 
     // None example
     let vocab = HashMap::from_iter([
-        ("<0x20>".to_string(), 0),
-        ("<0xC3>".to_string(), 1),
-        ("<0xA9>".to_string(), 2),
-        (" This".to_string(), 3),
+        ("<0x20>".into(), 0),
+        ("<0xC3>".into(), 1),
+        ("<0xA9>".into(), 2),
+        (" This".into(), 3),
     ]);
     let merges = vec![];
     let bpe = BPE::builder()
@@ -115,9 +109,9 @@ fn streaming_tokenizer() {
         .build()
         .unwrap();
     let mut decode_stream = tokenizer.decode_stream(false);
-    assert_eq!(decode_stream.step(0).unwrap(), Some(" ".to_string()));
+    assert_eq!(decode_stream.step(0).unwrap(), Some(" ".into()));
     assert_eq!(decode_stream.step(1).unwrap(), None);
-    assert_eq!(decode_stream.step(2).unwrap(), Some("é".to_string()));
+    assert_eq!(decode_stream.step(2).unwrap(), Some("é".into()));
     assert_eq!(decode_stream.step(2).unwrap(), None);
 }
 
@@ -133,12 +127,7 @@ fn quicktour_slow_train() -> tokenizers::Result<()> {
         PreTokenizerWrapper,
         PostProcessorWrapper,
         DecoderWrapper,
-    > = TokenizerImpl::new(
-        BPE::builder()
-            .unk_token("[UNK]".to_string())
-            .build()
-            .unwrap(),
-    );
+    > = TokenizerImpl::new(BPE::builder().unk_token("[UNK]".into()).build().unwrap());
     // END quicktour_init_tokenizer
     // START quicktour_init_trainer
     use tokenizers::models::bpe::BpeTrainer;
@@ -429,7 +418,7 @@ fn train_pipeline_bert() -> tokenizers::Result<()> {
 
     let mut bert_tokenizer = Tokenizer::new(
         WordPiece::builder()
-            .unk_token("[UNK]".to_string())
+            .unk_token("[UNK]".into())
             .build()
             .unwrap(),
     );

--- a/tokenizers/tests/stream.rs
+++ b/tokenizers/tests/stream.rs
@@ -1,3 +1,4 @@
+use compact_str::ToCompactString;
 use tokenizers::{
     normalizers,
     pre_tokenizers::split::{Split, SplitPattern},
@@ -29,8 +30,11 @@ fn test_decoding_with_added_bpe() {
         ["Hey", "!", "Ġhow", "Ġi", "s", "Ġthi", "s", "Ġtoken", ":", "Ġ", "嗎"]
     );
 
-    let decoded = tokenizer.decode(encoded.get_ids(), false);
-    assert_eq!(decoded.unwrap(), "Hey! how is this token: 嗎");
+    let decoded = tokenizer
+        .decode(encoded.get_ids(), false)
+        .unwrap()
+        .to_compact_string();
+    assert_eq!(decoded, "Hey! how is this token: 嗎");
 
     tokenizer.add_tokens(&[AddedToken::from("д", false).normalized(true)]);
     let encoded = tokenizer
@@ -44,8 +48,11 @@ fn test_decoding_with_added_bpe() {
         encoded.get_tokens(),
         ["Hey", "!", "Ġhow", "Ġi", "s", "Ġthi", "s", "Ġtoken", ":", "Ġ", "Ð´"]
     );
-    let decoded = tokenizer.decode(encoded.get_ids(), false);
-    assert_eq!(decoded.unwrap(), "Hey! how is this token: д")
+    let decoded = tokenizer
+        .decode(encoded.get_ids(), false)
+        .unwrap()
+        .to_compact_string();
+    assert_eq!(decoded, "Hey! how is this token: д")
 }
 
 #[test]

--- a/tokenizers/tests/stream.rs
+++ b/tokenizers/tests/stream.rs
@@ -54,25 +54,25 @@ fn test_decode_stream_step_no_panic() {
 
     // "A B C D E F G H I J"
     let mut decode_stream = tokenizer.decode_stream(false);
-    assert_eq!(decode_stream.step(32).unwrap(), Some("A".to_string()));
-    assert_eq!(decode_stream.step(426).unwrap(), Some(" B".to_string()));
-    assert_eq!(decode_stream.step(356).unwrap(), Some(" C".to_string()));
-    assert_eq!(decode_stream.step(423).unwrap(), Some(" D".to_string()));
-    assert_eq!(decode_stream.step(469).unwrap(), Some(" E".to_string()));
-    assert_eq!(decode_stream.step(435).unwrap(), Some(" F".to_string()));
-    assert_eq!(decode_stream.step(480).unwrap(), Some(" G".to_string()));
-    assert_eq!(decode_stream.step(473).unwrap(), Some(" H".to_string()));
-    assert_eq!(decode_stream.step(358).unwrap(), Some(" I".to_string()));
-    assert_eq!(decode_stream.step(622).unwrap(), Some(" J".to_string()));
+    assert_eq!(decode_stream.step(32).unwrap(), Some("A".into()));
+    assert_eq!(decode_stream.step(426).unwrap(), Some(" B".into()));
+    assert_eq!(decode_stream.step(356).unwrap(), Some(" C".into()));
+    assert_eq!(decode_stream.step(423).unwrap(), Some(" D".into()));
+    assert_eq!(decode_stream.step(469).unwrap(), Some(" E".into()));
+    assert_eq!(decode_stream.step(435).unwrap(), Some(" F".into()));
+    assert_eq!(decode_stream.step(480).unwrap(), Some(" G".into()));
+    assert_eq!(decode_stream.step(473).unwrap(), Some(" H".into()));
+    assert_eq!(decode_stream.step(358).unwrap(), Some(" I".into()));
+    assert_eq!(decode_stream.step(622).unwrap(), Some(" J".into()));
     // for (i, &token) in output_tokens.iter().enumerate() {}
 
     // "삥뽕빵" (Korean words composed of 2-3 tokens: [80690, 98], [167, 121, 243], and [102457, 113])
     let mut decode_stream = tokenizer.decode_stream(false);
     assert_eq!(decode_stream.step(80690).unwrap(), None);
-    assert_eq!(decode_stream.step(98).unwrap(), Some("삥".to_string()));
+    assert_eq!(decode_stream.step(98).unwrap(), Some("삥".into()));
     assert_eq!(decode_stream.step(167).unwrap(), None);
     assert_eq!(decode_stream.step(121).unwrap(), None);
-    assert_eq!(decode_stream.step(243).unwrap(), Some("뽕".to_string()));
+    assert_eq!(decode_stream.step(243).unwrap(), Some("뽕".into()));
     assert_eq!(decode_stream.step(102457).unwrap(), None);
-    assert_eq!(decode_stream.step(113).unwrap(), Some("빵".to_string()));
+    assert_eq!(decode_stream.step(113).unwrap(), Some("빵".into()));
 }

--- a/tokenizers/tests/training.rs
+++ b/tokenizers/tests/training.rs
@@ -14,7 +14,7 @@ fn bpe_values_after_training() {
     >::default()
     .with_model(
         BPE::builder()
-            .unk_token("[UNK]".to_string())
+            .unk_token("[UNK]".into())
             .dropout(0.1)
             .build()
             .unwrap(),
@@ -23,10 +23,10 @@ fn bpe_values_after_training() {
     .unwrap();
     let mut trainer = tokenizer.get_model().get_trainer();
     tokenizer
-        .train_from_files(&mut trainer, vec!["./data/small.txt".to_string()])
+        .train_from_files(&mut trainer, vec!["./data/small.txt".into()])
         .unwrap();
     assert_eq!(tokenizer.get_model().dropout, Some(0.1));
-    assert_eq!(tokenizer.get_model().unk_token, Some("[UNK]".to_string()));
+    assert_eq!(tokenizer.get_model().unk_token, Some("[UNK]".into()));
 }
 
 #[test]
@@ -40,8 +40,8 @@ fn bpe_continuing_subword_prefix_error() {
     >::default()
     .with_model(
         BPE::builder()
-            .unk_token("[UNK]".to_string())
-            .continuing_subword_prefix("##".to_string())
+            .unk_token("[UNK]".into())
+            .continuing_subword_prefix("##".into())
             .build()
             .unwrap(),
     )

--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -57,10 +57,7 @@ fn test_train_unigram_from_file() {
         .unwrap();
     let mut model = Unigram::default();
 
-    let sentences: Vec<_> = word_counts
-        .iter()
-        .map(|(s, i)| (s.to_owned(), *i))
-        .collect();
+    let sentences: Vec<_> = word_counts.iter().map(|(s, i)| (s.into(), *i)).collect();
     trainer.do_train(sentences, &mut model).unwrap();
     assert_eq!(model.get_vocab_size(), 719);
 }


### PR DESCRIPTION
This PR contains performance optimizations (spreadsheet of benchmark comparisons linked below). The two main optimizations are:

- Switching to FxHash instead of standard library default hasher. This is provided by the `rustc_hash` crate, which the compiler uses internally.

- Switch from `String` to `CompactString`, provided by the `compact_str` crate, which has short-string-optimization for up to 24 bytes, which many tokens can fit inside of.

# Progress:
This PR is not fully complete. At this point in time, the following tasks have been completed:
- [X] Convert base crate.
  - Tests are passing, and benchmarks were run (linked below).
- [X] Convert Python bindings.
  - The same tests that pass on HEAD are passing on this branch. There seems to be 2 failing tests on HEAD, but this branch fails the exact same tests, and in the same manner (i.e. same output).
- [ ] Convert Node bindings.
- [ ] Cleanup.

# Benchmarks:
The benchmarks are at the following link: [Tokenizer Benchmarks](https://docs.google.com/spreadsheets/d/14_nPSj6sZVBaJ8zLbCp-gekYOC8fYUZDjB5a3uOA0TU/edit?usp=sharing). All benchmarks were run on a Macbook Pro with the M2 Pro chip and 16GB memory.

Additionally, the `BPE Train vocabulary (huge)` benchmark is one that I added (not committed, as that would warrant its own PR). This benchmark is using the dataset: [One Billion Word Challenge](https://www.statmt.org/lm-benchmark/), which clocks in at 4.15GB.