### PR TITLE
Update dependency versions to fix NoGIL Python package install

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -14,8 +14,8 @@ serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
 libc = "0.2"
 env_logger = "0.11"
-pyo3 = { version = "0.23", features = ["abi3", "abi3-py39", "py-clone"] }
-numpy = "0.23"
+pyo3 = { version = "0.24", features = ["abi3", "abi3-py39", "py-clone"] }
+numpy = "0.24"
 ndarray = "0.16"
 itertools = "0.12"
 
@@ -24,7 +24,7 @@ path = "../../tokenizers"
 
 [dev-dependencies]
 tempfile = "3.10"
-pyo3 = { version = "0.23", features = ["auto-initialize"] }
+pyo3 = { version = "0.24", features = ["auto-initialize"] }
 
 [features]
 defaut = ["pyo3/extension-module"]


### PR DESCRIPTION
Resolves https://github.com/huggingface/tokenizers/issues/1749.

Updates `pyo3` and `numpy` dependency versions to fix build failures when building with a free-threaded build of Python.