### PR TITLE
Switch to FXHash

### DIFF
--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi        = "2"
 napi-derive = "2"
+rustc-hash = "2.1.1"
 serde       = { version = "1.0.163", features = ["derive"] }
 tokenizers  = { path = "../../tokenizers/" }
 

--- a/bindings/node/src/models.rs
+++ b/bindings/node/src/models.rs
@@ -3,8 +3,8 @@ use crate::tasks::models::{BPEFromFilesTask, WordLevelFromFilesTask, WordPieceFr
 use crate::trainers::Trainer;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use tokenizers as tk;
@@ -95,7 +95,7 @@ impl tk::Model for Model {
     self.model.as_ref()?.read().unwrap().id_to_token(id)
   }
 
-  fn get_vocab(&self) -> HashMap<String, u32> {
+  fn get_vocab(&self) -> FxHashMap<String, u32> {
     self
       .model
       .as_ref()

--- a/bindings/node/src/tokenizer.rs
+++ b/bindings/node/src/tokenizer.rs
@@ -6,7 +6,7 @@ use crate::pre_tokenizers::PreTokenizer;
 use crate::processors::Processor;
 use crate::tasks::tokenizer::{DecodeBatchTask, DecodeTask, EncodeBatchTask, EncodeTask};
 use crate::trainers::Trainer;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use tokenizers::Model as ModelTrait;
 
 use napi::bindgen_prelude::*;
@@ -433,7 +433,7 @@ impl Tokenizer {
   }
 
   #[napi]
-  pub fn get_vocab(&self, with_added_tokens: Option<bool>) -> HashMap<String, u32> {
+  pub fn get_vocab(&self, with_added_tokens: Option<bool>) -> FxHashMap<String, u32> {
     let with_added_tokens = with_added_tokens.unwrap_or(true);
     self.tokenizer.read().unwrap().get_vocab(with_added_tokens)
   }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -18,6 +18,7 @@ pyo3 = { version = "0.23", features = ["abi3", "abi3-py39", "py-clone"] }
 numpy = "0.23"
 ndarray = "0.16"
 itertools = "0.12"
+rustc-hash = "2.1.1"
 
 [dependencies.tokenizers]
 path = "../../tokenizers"

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
@@ -70,7 +70,7 @@ impl Model for PyModel {
         self.model.read().unwrap().id_to_token(id)
     }
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         self.model.read().unwrap().get_vocab()
     }
 

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1,5 +1,5 @@
+use rustc_hash::{FxHashMap, FxHasher};
 use serde::Serialize;
-use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
 
 use numpy::{npyffi, PyArray1, PyArrayMethods};
@@ -255,7 +255,7 @@ impl PyAddedToken {
     }
 
     fn __hash__(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = FxHasher::default();
         self.get_token().hash(&mut hasher);
         hasher.finish()
     }
@@ -675,7 +675,7 @@ impl PyTokenizer {
     ///     :obj:`Dict[str, int]`: The vocabulary
     #[pyo3(signature = (with_added_tokens = true))]
     #[pyo3(text_signature = "(self, with_added_tokens=True)")]
-    fn get_vocab(&self, with_added_tokens: bool) -> HashMap<String, u32> {
+    fn get_vocab(&self, with_added_tokens: bool) -> FxHashMap<String, u32> {
         self.tokenizer.get_vocab(with_added_tokens)
     }
 

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -67,6 +67,7 @@ fancy-regex = { version = "0.14", optional = true}
 getrandom = { version = "0.2.10" }
 esaxx-rs = { version = "0.1.10", default-features = false, features=[]}
 monostate = "0.1.12"
+rustc-hash = "2.1.1"
 
 [features]
 default = ["progressbar", "onig", "esaxx_fast"]

--- a/tokenizers/benches/unigram_benchmark.rs
+++ b/tokenizers/benches/unigram_benchmark.rs
@@ -2,7 +2,7 @@
 extern crate criterion;
 
 use criterion::Criterion;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fs::read_to_string;
 use std::time::{Duration, Instant};
 use tokenizers::models::unigram::Unigram;
@@ -18,7 +18,7 @@ pub fn bench_train(c: &mut Criterion) {
     let mut model = Unigram::default();
 
     let content = read_to_string("data/small.txt").unwrap();
-    let mut word_counts = HashMap::new();
+    let mut word_counts = FxHashMap::default();
     content.split_whitespace().for_each(|word| {
         // This is important for the test of char vs u8
         let word = format!("▁{word}");
@@ -46,7 +46,7 @@ pub fn bench_train(c: &mut Criterion) {
     let content = read_to_string("data/big.txt").unwrap();
     // creating `medium` data, which is the first 25% of `data/big.txt`
     let content = String::from(&content[..(content.len() as f64 * 0.25) as usize]);
-    let mut word_counts = HashMap::new();
+    let mut word_counts = FxHashMap::default();
     content.split_whitespace().for_each(|word| {
         // This is important for the test of char vs u8
         let word = format!("▁{word}");

--- a/tokenizers/benches/unigram_benchmark.rs
+++ b/tokenizers/benches/unigram_benchmark.rs
@@ -2,7 +2,7 @@
 extern crate criterion;
 
 use criterion::Criterion;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use std::fs::read_to_string;
 use std::time::{Duration, Instant};
 use tokenizers::models::unigram::Unigram;
@@ -18,7 +18,7 @@ pub fn bench_train(c: &mut Criterion) {
     let mut model = Unigram::default();
 
     let content = read_to_string("data/small.txt").unwrap();
-    let mut word_counts = FxHashMap::default();
+    let mut word_counts = HashMap::new();
     content.split_whitespace().for_each(|word| {
         // This is important for the test of char vs u8
         let word = format!("▁{word}");
@@ -46,7 +46,7 @@ pub fn bench_train(c: &mut Criterion) {
     let content = read_to_string("data/big.txt").unwrap();
     // creating `medium` data, which is the first 25% of `data/big.txt`
     let content = String::from(&content[..(content.len() as f64 * 0.25) as usize]);
-    let mut word_counts = FxHashMap::default();
+    let mut word_counts = HashMap::new();
     content.split_whitespace().for_each(|word| {
         // This is important for the test of char vs u8
         let word = format!("▁{word}");

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -540,7 +540,7 @@ impl Model for BPE {
             .iter()
             .collect();
         let mut vocab_file = File::create(&vocab_path)?;
-        let order_vocab_iter = OrderedVocabIter::new(self.vocab_r.clone());
+        let order_vocab_iter = OrderedVocabIter::new(&self.vocab_r);
         let serialized = serde_json::to_string(&order_vocab_iter)?;
         vocab_file.write_all(serialized.as_bytes())?;
 
@@ -594,7 +594,7 @@ mod tests {
         .iter()
         .cloned()
         .collect();
-        let order_vocab_iter = OrderedVocabIter::new(vocab_r.clone());
+        let order_vocab_iter = OrderedVocabIter::new(&vocab_r);
         let serialized = serde_json::to_string(&order_vocab_iter).unwrap();
         assert_eq!(serialized, "{\"a\":0,\"b\":1,\"c\":2,\"ab\":3}");
     }

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -2,19 +2,19 @@ use super::{super::OrderedVocabIter, trainer::BpeTrainer, Error, Pair, Word};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
+use rustc_hash::FxHashMap;
 use serde_json::Value;
 use std::borrow::Cow;
 use std::{
-    collections::HashMap,
     fs::File,
     io::prelude::*,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
 };
 
-pub type Vocab = HashMap<String, u32>;
-type VocabR = HashMap<u32, String>;
-pub type MergeMap = HashMap<Pair, (u32, u32)>;
+pub type Vocab = FxHashMap<String, u32>;
+type VocabR = FxHashMap<u32, String>;
+pub type MergeMap = FxHashMap<Pair, (u32, u32)>;
 pub type Merges = Vec<(String, String)>;
 
 struct Config {
@@ -41,7 +41,7 @@ impl Default for BpeBuilder {
         Self {
             config: Config {
                 files: None,
-                vocab: HashMap::new(),
+                vocab: FxHashMap::default(),
                 merges: vec![],
                 cache_capacity: DEFAULT_CACHE_CAPACITY,
                 dropout: None,
@@ -324,7 +324,7 @@ impl BPE {
         let mut buffer = String::new();
         vocab_file.read_to_string(&mut buffer)?;
         let json: Value = serde_json::from_str(&buffer)?;
-        let mut vocab = HashMap::new();
+        let mut vocab = FxHashMap::default();
         match json {
             Value::Object(m) => {
                 for (token, id) in m {
@@ -493,7 +493,7 @@ impl BPE {
 impl Model for BPE {
     type Trainer = BpeTrainer;
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         self.vocab.clone()
     }
 

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -34,7 +34,7 @@ impl Serialize for BPE {
             .into_iter()
             .map(|(pair, _)| (self.vocab_r[&pair.0].clone(), self.vocab_r[&pair.1].clone()))
             .collect::<Vec<_>>();
-        let ordered_vocab = OrderedVocabIter::new(&self.vocab_r);
+        let ordered_vocab = OrderedVocabIter::new(self.vocab_r.clone());
 
         model.serialize_field("vocab", &ordered_vocab)?;
         model.serialize_field("merges", &merges)?;

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -1,10 +1,10 @@
 use super::{super::OrderedVocabIter, convert_merges_to_hashmap, BpeBuilder, Pair, BPE};
+use rustc_hash::FxHashMap;
 use serde::{
     de::{Error, MapAccess, Visitor},
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::collections::HashMap;
 
 impl Serialize for BPE {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -80,7 +80,7 @@ impl<'de> Visitor<'de> for BPEVisitor {
         V: MapAccess<'de>,
     {
         let mut builder = BpeBuilder::new();
-        let mut vocab: Option<HashMap<String, u32>> = None;
+        let mut vocab: Option<FxHashMap<String, u32>> = None;
 
         #[derive(Debug, Deserialize)]
         #[serde(untagged)]

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -34,7 +34,7 @@ impl Serialize for BPE {
             .into_iter()
             .map(|(pair, _)| (self.vocab_r[&pair.0].clone(), self.vocab_r[&pair.1].clone()))
             .collect::<Vec<_>>();
-        let ordered_vocab = OrderedVocabIter::new(self.vocab_r.clone());
+        let ordered_vocab = OrderedVocabIter::new(&self.vocab_r);
 
         model.serialize_field("vocab", &ordered_vocab)?;
         model.serialize_field("merges", &merges)?;

--- a/tokenizers/src/models/bpe/word.rs
+++ b/tokenizers/src/models/bpe/word.rs
@@ -1,7 +1,8 @@
 use super::Pair;
 use rand::{thread_rng, Rng};
+use rustc_hash::FxHashMap;
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
 
 #[derive(Debug, Eq)]
 struct Merge {
@@ -158,7 +159,7 @@ impl Word {
         changes
     }
 
-    pub(super) fn merge_all(&mut self, merges: &HashMap<Pair, (u32, u32)>, dropout: Option<f32>) {
+    pub(super) fn merge_all(&mut self, merges: &FxHashMap<Pair, (u32, u32)>, dropout: Option<f32>) {
         let mut queue = BinaryHeap::with_capacity(self.symbols.len());
         let mut skip = Vec::with_capacity(queue.len());
 

--- a/tokenizers/src/models/bpe/word.rs
+++ b/tokenizers/src/models/bpe/word.rs
@@ -1,8 +1,8 @@
 use super::Pair;
 use rand::{thread_rng, Rng};
-use rustc_hash::FxHashMap;
 use std::cmp::Ordering;
-use std::collections::BinaryHeap;
+use std::collections::{BinaryHeap, HashMap};
+use std::hash::BuildHasher;
 
 #[derive(Debug, Eq)]
 struct Merge {
@@ -159,7 +159,11 @@ impl Word {
         changes
     }
 
-    pub(super) fn merge_all(&mut self, merges: &FxHashMap<Pair, (u32, u32)>, dropout: Option<f32>) {
+    pub(super) fn merge_all<S: BuildHasher>(
+        &mut self,
+        merges: &HashMap<Pair, (u32, u32), S>,
+        dropout: Option<f32>,
+    ) {
         let mut queue = BinaryHeap::with_capacity(self.symbols.len());
         let mut skip = Vec::with_capacity(queue.len());
 

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -5,7 +5,7 @@ pub mod unigram;
 pub mod wordlevel;
 pub mod wordpiece;
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -19,11 +19,11 @@ use crate::{AddedToken, Model, Result, Token, Trainer};
 /// Wraps a vocab mapping (ID -> token) to a struct that will be serialized in order
 /// of token ID, smallest to largest.
 struct OrderedVocabIter<'a> {
-    vocab_r: &'a HashMap<u32, String>,
+    vocab_r: &'a FxHashMap<u32, String>,
 }
 
 impl<'a> OrderedVocabIter<'a> {
-    fn new(vocab_r: &'a HashMap<u32, String>) -> Self {
+    fn new(vocab_r: &'a FxHashMap<u32, String>) -> Self {
         Self { vocab_r }
     }
 }
@@ -170,7 +170,7 @@ impl Model for ModelWrapper {
         }
     }
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         match self {
             Self::WordLevel(t) => t.get_vocab(),
             Self::WordPiece(t) => t.get_vocab(),
@@ -287,6 +287,8 @@ impl_enum_from!(WordLevelTrainer, TrainerWrapper, WordLevelTrainer);
 
 #[cfg(test)]
 mod tests {
+    use std::iter::FromIterator;
+
     use super::*;
     use crate::models::bpe::{BpeBuilder, Vocab};
 
@@ -301,8 +303,8 @@ mod tests {
 
     #[test]
     fn incomplete_ordered_vocab() {
-        let vocab_r: HashMap<u32, String> =
-            HashMap::from([(0, "Hi".to_string()), (2, "There".to_string())]);
+        let vocab_r: FxHashMap<u32, String> =
+            FxHashMap::from_iter([(0, "Hi".to_string()), (2, "There".to_string())]);
 
         let ordered = OrderedVocabIter::new(&vocab_r);
 

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -6,12 +6,12 @@ use super::{
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::convert::TryInto;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
-type TokenMap = HashMap<String, u32>;
+type TokenMap = FxHashMap<String, u32>;
 type Vocab = Vec<(String, f64)>;
 
 /// A `Unigram` model to encode sentences.
@@ -98,7 +98,7 @@ impl Unigram {
         byte_fallback: bool,
     ) -> Result<Self> {
         let n = vocab.len();
-        let mut token_to_ids: TokenMap = HashMap::new();
+        let mut token_to_ids: TokenMap = FxHashMap::default();
         let mut builder = TrieBuilder::default();
 
         if let Some(unk_id) = unk_id {
@@ -415,7 +415,7 @@ impl<'a> Iterator for UnigramIterator<'a> {
 impl Model for Unigram {
     type Trainer = UnigramTrainer;
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         self.token_to_ids.clone()
     }
 

--- a/tokenizers/src/models/unigram/trie.rs
+++ b/tokenizers/src/models/unigram/trie.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::hash::Hash;
 
 #[derive(Default)]
@@ -78,14 +78,14 @@ impl<Label> Default for Trie<Label> {
 #[derive(Clone)]
 pub struct Node<Label> {
     is_leaf: bool,
-    children: HashMap<Label, Node<Label>>,
+    children: FxHashMap<Label, Node<Label>>,
 }
 
 impl<Label> Default for Node<Label> {
     fn default() -> Self {
         Self {
             is_leaf: false,
-            children: HashMap::new(),
+            children: FxHashMap::default(),
         }
     }
 }

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -206,7 +206,7 @@ impl Model for WordLevel {
             .iter()
             .collect();
         let mut vocab_file = File::create(&vocab_path)?;
-        let order_vocab_iter = OrderedVocabIter::new(self.vocab_r.clone());
+        let order_vocab_iter = OrderedVocabIter::new(&self.vocab_r);
         let serialized = serde_json::to_string(&order_vocab_iter)?;
         vocab_file.write_all(serialized.as_bytes())?;
 

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -1,7 +1,7 @@
 use super::OrderedVocabIter;
 use crate::tokenizer::{Model, Result, Token};
+use rustc_hash::FxHashMap;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
@@ -12,7 +12,7 @@ mod trainer;
 // Re-export
 pub use trainer::*;
 
-type Vocab = HashMap<String, u32>;
+type Vocab = FxHashMap<String, u32>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -24,7 +24,7 @@ pub enum Error {
 
 struct Config {
     files: Option<String>,
-    vocab: HashMap<String, u32>,
+    vocab: FxHashMap<String, u32>,
     unk_token: String,
 }
 
@@ -39,7 +39,7 @@ impl Default for WordLevelBuilder {
         Self {
             config: Config {
                 files: None,
-                vocab: HashMap::new(),
+                vocab: FxHashMap::default(),
                 unk_token: String::from("<unk>"),
             },
         }
@@ -61,7 +61,7 @@ impl WordLevelBuilder {
 
     /// Set the vocab (token -> ID) mapping.
     #[must_use]
-    pub fn vocab(mut self, vocab: HashMap<String, u32>) -> Self {
+    pub fn vocab(mut self, vocab: FxHashMap<String, u32>) -> Self {
         self.config.vocab = vocab;
         self
     }
@@ -96,8 +96,8 @@ impl WordLevelBuilder {
 
 #[derive(PartialEq, Clone, Eq)]
 pub struct WordLevel {
-    vocab: HashMap<String, u32>,
-    vocab_r: HashMap<u32, String>,
+    vocab: FxHashMap<String, u32>,
+    vocab_r: FxHashMap<u32, String>,
     pub unk_token: String,
 }
 
@@ -119,7 +119,7 @@ impl WordLevel {
         let vocab_file = File::open(vocab_path)?;
         let mut vocab_file = BufReader::new(vocab_file);
         let mut buffer = String::new();
-        let mut vocab = HashMap::new();
+        let mut vocab = FxHashMap::default();
 
         vocab_file.read_to_string(&mut buffer)?;
         let json: Value = serde_json::from_str(&buffer)?;
@@ -148,8 +148,8 @@ impl WordLevel {
 impl Default for WordLevel {
     fn default() -> Self {
         Self {
-            vocab: HashMap::new(),
-            vocab_r: HashMap::new(),
+            vocab: FxHashMap::default(),
+            vocab_r: FxHashMap::default(),
             unk_token: String::from("<unk>"),
         }
     }
@@ -184,7 +184,7 @@ impl Model for WordLevel {
         self.vocab_r.get(&id).cloned()
     }
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         self.vocab.clone()
     }
 

--- a/tokenizers/src/models/wordlevel/serialization.rs
+++ b/tokenizers/src/models/wordlevel/serialization.rs
@@ -1,10 +1,10 @@
 use super::{super::OrderedVocabIter, WordLevel, WordLevelBuilder};
+use rustc_hash::FxHashSet;
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::collections::HashSet;
 
 impl Serialize for WordLevel {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -52,7 +52,7 @@ impl<'de> Visitor<'de> for WordLevelVisitor {
             "vocab",
         ]
         .into_iter()
-        .collect::<HashSet<_>>();
+        .collect::<FxHashSet<_>>();
         while let Some(key) = map.next_key::<String>()? {
             match key.as_ref() {
                 "vocab" => builder = builder.vocab(map.next_value()?),

--- a/tokenizers/src/models/wordlevel/serialization.rs
+++ b/tokenizers/src/models/wordlevel/serialization.rs
@@ -12,7 +12,7 @@ impl Serialize for WordLevel {
         S: Serializer,
     {
         let mut model = serializer.serialize_struct("WordLevel", 3)?;
-        let ordered_vocab = OrderedVocabIter::new(self.vocab_r.clone());
+        let ordered_vocab = OrderedVocabIter::new(&self.vocab_r);
         model.serialize_field("type", "WordLevel")?;
         model.serialize_field("vocab", &ordered_vocab)?;
         model.serialize_field("unk_token", &self.unk_token)?;

--- a/tokenizers/src/models/wordlevel/serialization.rs
+++ b/tokenizers/src/models/wordlevel/serialization.rs
@@ -12,7 +12,7 @@ impl Serialize for WordLevel {
         S: Serializer,
     {
         let mut model = serializer.serialize_struct("WordLevel", 3)?;
-        let ordered_vocab = OrderedVocabIter::new(&self.vocab_r);
+        let ordered_vocab = OrderedVocabIter::new(self.vocab_r.clone());
         model.serialize_field("type", "WordLevel")?;
         model.serialize_field("vocab", &ordered_vocab)?;
         model.serialize_field("unk_token", &self.unk_token)?;
@@ -55,7 +55,7 @@ impl<'de> Visitor<'de> for WordLevelVisitor {
         .collect::<FxHashSet<_>>();
         while let Some(key) = map.next_key::<String>()? {
             match key.as_ref() {
-                "vocab" => builder = builder.vocab(map.next_value()?),
+                "vocab" => builder = builder.vocab::<rustc_hash::FxBuildHasher>(map.next_value()?),
                 "unk_token" => builder = builder.unk_token(map.next_value()?),
                 "type" => match map.next_value()? {
                     "WordLevel" => {}

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -1,9 +1,9 @@
 use super::WordLevel;
 use crate::utils::parallelism::*;
 use crate::{AddedToken, Result, Trainer};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::collections::HashMap;
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Builder, Serialize, Deserialize)]
@@ -22,7 +22,7 @@ pub struct WordLevelTrainer {
     pub special_tokens: Vec<AddedToken>,
 
     #[builder(default, private)]
-    words: HashMap<String, u64>,
+    words: FxHashMap<String, u64>,
 }
 
 impl Default for WordLevelTrainer {
@@ -38,7 +38,7 @@ impl WordLevelTrainer {
 
     fn do_train(
         &self,
-        word_counts: &HashMap<String, u64>,
+        word_counts: &FxHashMap<String, u64>,
         model: &mut WordLevel,
     ) -> Result<Vec<AddedToken>> {
         let mut ordered_counts = word_counts.iter().collect::<Vec<_>>();
@@ -100,18 +100,18 @@ impl Trainer for WordLevelTrainer {
         S: AsRef<str> + Send,
         F: Fn(&str) -> Result<Vec<String>> + Sync,
     {
-        let words: Result<HashMap<String, u64>> = iterator
+        let words: Result<FxHashMap<String, u64>> = iterator
             .maybe_par_bridge()
             .map(|sequence| {
                 let words = process(sequence.as_ref())?;
-                let mut map = HashMap::new();
+                let mut map = FxHashMap::default();
                 for word in words {
                     map.entry(word).and_modify(|c| *c += 1).or_insert(1);
                 }
                 Ok(map)
             })
             .reduce(
-                || Ok(HashMap::new()),
+                || Ok(FxHashMap::default()),
                 |acc, ws| {
                     let mut acc = acc?;
                     for (k, v) in ws? {
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_train() {
-        let word_counts: HashMap<String, u64> = [
+        let word_counts: FxHashMap<String, u64> = [
             ("the".into(), 25),
             ("roses".into(), 22),
             ("are".into(), 24),
@@ -151,7 +151,7 @@ mod tests {
 
         let mut model = WordLevel::default();
         trainer.do_train(&word_counts, &mut model).unwrap();
-        let expected_vocab: HashMap<String, u32> = [
+        let expected_vocab: FxHashMap<String, u32> = [
             ("the".into(), 0),
             ("are".into(), 1),
             ("roses".into(), 2),
@@ -167,7 +167,7 @@ mod tests {
         trainer.min_frequency = 15;
         let mut model = WordLevel::default();
         trainer.do_train(&word_counts, &mut model).unwrap();
-        let expected_vocab: HashMap<String, u32> = [
+        let expected_vocab: FxHashMap<String, u32> = [
             ("the".into(), 0),
             ("are".into(), 1),
             ("roses".into(), 2),

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -3,9 +3,9 @@
 
 use crate::models::bpe::BPE;
 use crate::tokenizer::{Model, Result, Token};
+use rustc_hash::FxHashMap;
 use std::{
     borrow::Cow,
-    collections::HashMap,
     fs::File,
     io::prelude::*,
     io::{BufRead, BufReader},
@@ -22,8 +22,8 @@ pub enum Error {
     MissingUnkToken,
 }
 
-type Vocab = HashMap<String, u32>;
-type VocabR = HashMap<u32, String>;
+type Vocab = FxHashMap<String, u32>;
+type VocabR = FxHashMap<u32, String>;
 
 struct Config {
     files: Option<String>,
@@ -43,7 +43,7 @@ impl Default for WordPieceBuilder {
         Self {
             config: Config {
                 files: None,
-                vocab: HashMap::new(),
+                vocab: FxHashMap::default(),
                 unk_token: String::from("[UNK]"),
                 continuing_subword_prefix: String::from("##"),
                 max_input_chars_per_word: 100,
@@ -142,8 +142,8 @@ impl std::fmt::Debug for WordPiece {
 impl Default for WordPiece {
     fn default() -> Self {
         Self {
-            vocab: HashMap::new(),
-            vocab_r: HashMap::new(),
+            vocab: FxHashMap::default(),
+            vocab_r: FxHashMap::default(),
             unk_token: String::from("[UNK]"),
             continuing_subword_prefix: String::from("##"),
             max_input_chars_per_word: 100,
@@ -162,7 +162,7 @@ impl WordPiece {
         let file = File::open(vocab)?;
         let file = BufReader::new(file);
 
-        let mut vocab = HashMap::new();
+        let mut vocab = FxHashMap::default();
         for (index, line) in file.lines().enumerate() {
             let line = line?;
             vocab.insert(line.trim_end().to_owned(), index as u32);
@@ -192,7 +192,7 @@ impl WordPiece {
 impl Model for WordPiece {
     type Trainer = WordPieceTrainer;
 
-    fn get_vocab(&self) -> HashMap<String, u32> {
+    fn get_vocab(&self) -> FxHashMap<String, u32> {
         self.vocab.clone()
     }
 

--- a/tokenizers/src/models/wordpiece/serialization.rs
+++ b/tokenizers/src/models/wordpiece/serialization.rs
@@ -20,7 +20,7 @@ impl Serialize for WordPiece {
         model.serialize_field("max_input_chars_per_word", &self.max_input_chars_per_word)?;
 
         // Then large ones
-        let ordered_vocab = OrderedVocabIter::new(&self.vocab_r);
+        let ordered_vocab = OrderedVocabIter::new(self.vocab_r.clone());
         model.serialize_field("vocab", &ordered_vocab)?;
 
         model.end()

--- a/tokenizers/src/models/wordpiece/serialization.rs
+++ b/tokenizers/src/models/wordpiece/serialization.rs
@@ -20,7 +20,7 @@ impl Serialize for WordPiece {
         model.serialize_field("max_input_chars_per_word", &self.max_input_chars_per_word)?;
 
         // Then large ones
-        let ordered_vocab = OrderedVocabIter::new(self.vocab_r.clone());
+        let ordered_vocab = OrderedVocabIter::new(&self.vocab_r);
         model.serialize_field("vocab", &ordered_vocab)?;
 
         model.end()

--- a/tokenizers/src/models/wordpiece/serialization.rs
+++ b/tokenizers/src/models/wordpiece/serialization.rs
@@ -1,10 +1,10 @@
 use super::{super::OrderedVocabIter, WordPiece, WordPieceBuilder};
+use rustc_hash::FxHashSet;
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::collections::HashSet;
 
 impl Serialize for WordPiece {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -67,7 +67,7 @@ impl<'de> Visitor<'de> for WordPieceVisitor {
             "vocab",
         ]
         .into_iter()
-        .collect::<HashSet<_>>();
+        .collect::<FxHashSet<_>>();
 
         while let Some(key) = map.next_key::<String>()? {
             match key.as_ref() {

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -1,3 +1,7 @@
+use std::collections::HashSet;
+use std::hash::BuildHasher;
+use std::iter::FromIterator;
+
 use super::WordPiece;
 use crate::models::bpe::{BpeTrainer, BpeTrainerBuilder, BPE};
 use crate::tokenizer::{AddedToken, Result, Trainer};
@@ -61,7 +65,7 @@ impl WordPieceTrainerBuilder {
 
     /// Set the initial alphabet
     #[must_use]
-    pub fn initial_alphabet(mut self, alphabet: FxHashSet<char>) -> Self {
+    pub fn initial_alphabet<S: BuildHasher>(mut self, alphabet: HashSet<char, S>) -> Self {
         self.bpe_trainer_builder = self.bpe_trainer_builder.initial_alphabet(alphabet);
         self
     }
@@ -138,8 +142,8 @@ impl WordPieceTrainer {
         &self.bpe_trainer.initial_alphabet
     }
 
-    pub fn set_initial_alphabet(&mut self, alphabet: FxHashSet<char>) {
-        self.bpe_trainer.initial_alphabet = alphabet;
+    pub fn set_initial_alphabet<S: BuildHasher>(&mut self, alphabet: HashSet<char, S>) {
+        self.bpe_trainer.initial_alphabet = FxHashSet::from_iter(alphabet);
     }
 
     pub fn continuing_subword_prefix(&self) -> &Option<String> {

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -1,8 +1,8 @@
 use super::WordPiece;
 use crate::models::bpe::{BpeTrainer, BpeTrainerBuilder, BPE};
 use crate::tokenizer::{AddedToken, Result, Trainer};
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// A `WordPieceTrainerBuilder` can be used to create a `WordPieceTrainer` with a custom
 /// configuration.
@@ -61,7 +61,7 @@ impl WordPieceTrainerBuilder {
 
     /// Set the initial alphabet
     #[must_use]
-    pub fn initial_alphabet(mut self, alphabet: HashSet<char>) -> Self {
+    pub fn initial_alphabet(mut self, alphabet: FxHashSet<char>) -> Self {
         self.bpe_trainer_builder = self.bpe_trainer_builder.initial_alphabet(alphabet);
         self
     }
@@ -134,11 +134,11 @@ impl WordPieceTrainer {
         self.bpe_trainer.limit_alphabet = limit;
     }
 
-    pub fn initial_alphabet(&self) -> &HashSet<char> {
+    pub fn initial_alphabet(&self) -> &FxHashSet<char> {
         &self.bpe_trainer.initial_alphabet
     }
 
-    pub fn set_initial_alphabet(&mut self, alphabet: HashSet<char>) {
+    pub fn set_initial_alphabet(&mut self, alphabet: FxHashSet<char>) {
         self.bpe_trainer.initial_alphabet = alphabet;
     }
 

--- a/tokenizers/src/normalizers/byte_level.rs
+++ b/tokenizers/src/normalizers/byte_level.rs
@@ -1,14 +1,15 @@
 use crate::processors::byte_level::bytes_char;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
-use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use std::sync::LazyLock;
 
 #[derive(Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct ByteLevel;
 
-static BYTES_CHAR: LazyLock<HashMap<u8, char>> = LazyLock::new(bytes_char);
+static BYTES_CHAR: LazyLock<FxHashMap<u8, char>> = LazyLock::new(bytes_char);
 
 impl Default for ByteLevel {
     fn default() -> Self {
@@ -21,7 +22,7 @@ impl ByteLevel {
         Self {}
     }
 
-    pub fn alphabet() -> HashSet<char> {
+    pub fn alphabet() -> FxHashSet<char> {
         BYTES_CHAR.values().copied().collect()
     }
 }

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -244,7 +244,7 @@ mod tests {
         Decoder, Encoding, OffsetReferential, OffsetType, PostProcessor, PreTokenizedString,
         PreTokenizer,
     };
-    use std::iter::FromIterator;
+    use std::collections::HashMap;
 
     #[test]
     fn pre_tokenization() {
@@ -451,7 +451,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            FxHashMap::default(),
+            HashMap::new(),
         );
         process_offsets(&mut encoding, true);
         assert_eq!(
@@ -465,7 +465,7 @@ mod tests {
                 vec![],
                 vec![],
                 vec![],
-                FxHashMap::default(),
+                HashMap::new(),
             )
         );
     }
@@ -487,7 +487,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            FxHashMap::default(),
+            HashMap::new(),
         );
         let expected = Encoding::new(
             vec![0; 5],
@@ -504,7 +504,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            FxHashMap::from_iter(vec![(0, 0..5)]),
+            HashMap::from([(0, 0..5)]),
         );
 
         let bytelevel = ByteLevel::default().trim_offsets(true);
@@ -544,7 +544,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            FxHashMap::from_iter(vec![(0, 0..5), (1, 5..10)]),
+            HashMap::from([(0, 0..5), (1, 5..10)]),
         );
         assert_eq!(
             pair_expected,

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use std::sync::LazyLock;
 
 use crate::utils::SysRegex;
@@ -12,7 +13,7 @@ use crate::utils::macro_rules_attribute;
 
 /// Converts bytes to unicode characters.
 /// See https://github.com/openai/gpt-2/blob/master/src/encoder.py#L9
-pub(crate) fn bytes_char() -> HashMap<u8, char> {
+pub(crate) fn bytes_char() -> FxHashMap<u8, char> {
     let mut bs: Vec<u8> = vec![];
     bs.extend(b'!'..=b'~');
     bs.extend(b'\xA1'..=b'\xAC');
@@ -44,8 +45,8 @@ static RE: LazyLock<SysRegex> = LazyLock::new(|| {
     SysRegex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+")
         .unwrap()
 });
-static BYTES_CHAR: LazyLock<HashMap<u8, char>> = LazyLock::new(bytes_char);
-static CHAR_BYTES: LazyLock<HashMap<char, u8>> =
+static BYTES_CHAR: LazyLock<FxHashMap<u8, char>> = LazyLock::new(bytes_char);
+static CHAR_BYTES: LazyLock<FxHashMap<char, u8>> =
     LazyLock::new(|| bytes_char().into_iter().map(|(c, b)| (b, c)).collect());
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -90,7 +91,7 @@ impl ByteLevel {
         }
     }
 
-    pub fn alphabet() -> HashSet<char> {
+    pub fn alphabet() -> FxHashSet<char> {
         BYTES_CHAR.values().copied().collect()
     }
 
@@ -450,7 +451,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            HashMap::new(),
+            FxHashMap::default(),
         );
         process_offsets(&mut encoding, true);
         assert_eq!(
@@ -464,7 +465,7 @@ mod tests {
                 vec![],
                 vec![],
                 vec![],
-                HashMap::new(),
+                FxHashMap::default(),
             )
         );
     }
@@ -486,7 +487,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            HashMap::new(),
+            FxHashMap::default(),
         );
         let expected = Encoding::new(
             vec![0; 5],
@@ -503,7 +504,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            HashMap::from_iter(vec![(0, 0..5)]),
+            FxHashMap::from_iter(vec![(0, 0..5)]),
         );
 
         let bytelevel = ByteLevel::default().trim_offsets(true);
@@ -543,7 +544,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            HashMap::from_iter(vec![(0, 0..5), (1, 5..10)]),
+            FxHashMap::from_iter(vec![(0, 0..5), (1, 5..10)]),
         );
         assert_eq!(
             pair_expected,

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -1,6 +1,6 @@
 use crate::tokenizer::{Encoding, PostProcessor, Result};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::iter::FromIterator;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -78,7 +78,7 @@ impl PostProcessor for BertProcessing {
 
                     // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't contain
                     // the special tokens.
-                    let sequence_ranges = HashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
+                    let sequence_ranges = FxHashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
                     Encoding::new(
                         ids,
                         type_ids,
@@ -111,7 +111,7 @@ impl PostProcessor for BertProcessing {
                                 // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't
                                 // contain the special tokens.
                                 let sequence_ranges =
-                                    HashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
+                                    FxHashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
                                 Encoding::new(
                                     ids,
                                     type_ids,
@@ -139,7 +139,8 @@ impl PostProcessor for BertProcessing {
 
                     // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't contain
                     // the special tokens.
-                    let pair_sequence_ranges = HashMap::from_iter(vec![(1, 0..pair_ids.len() - 1)]);
+                    let pair_sequence_ranges =
+                        FxHashMap::from_iter(vec![(1, 0..pair_ids.len() - 1)]);
                     Encoding::new(
                         pair_ids,
                         pair_type_ids,
@@ -165,7 +166,7 @@ impl PostProcessor for BertProcessing {
                                 // For compatibility with `TemplateProcessing`, the sequence_ranges
                                 // shouldn't contain the special tokens.
                                 let pair_sequence_ranges =
-                                    HashMap::from_iter(vec![(1, 0..pair_ids.len() - 1)]);
+                                    FxHashMap::from_iter(vec![(1, 0..pair_ids.len() - 1)]);
                                 Encoding::new(
                                     pair_ids,
                                     pair_type_ids,
@@ -236,7 +237,7 @@ mod tests {
                 vec![1, 0, 0, 1],
                 vec![1, 1, 1, 1],
                 vec![],
-                HashMap::from_iter(vec![(0, 1..3)]),
+                FxHashMap::from_iter(vec![(0, 1..3)]),
             )
         );
         assert_eq!(single_encoding.token_to_sequence(2), Some(0));
@@ -262,7 +263,7 @@ mod tests {
                 vec![1, 0, 0, 1, 0, 1],
                 vec![1, 1, 1, 1, 1, 1],
                 vec![],
-                HashMap::from_iter(vec![(0, 1..3), (1, 4..5)]),
+                FxHashMap::from_iter(vec![(0, 1..3), (1, 4..5)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(2), Some(0));
@@ -283,7 +284,7 @@ mod tests {
                 vec![0, 0, 0],
                 vec![1, 1, 1],
                 vec![],
-                HashMap::from_iter(vec![(0, 0..2), (1, 2..3)]),
+                FxHashMap::from_iter(vec![(0, 0..2), (1, 2..3)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(0), Some(0));

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -192,6 +192,8 @@ impl PostProcessor for BertProcessing {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
 
     #[test]
@@ -237,7 +239,7 @@ mod tests {
                 vec![1, 0, 0, 1],
                 vec![1, 1, 1, 1],
                 vec![],
-                FxHashMap::from_iter(vec![(0, 1..3)]),
+                HashMap::from([(0, 1..3)]),
             )
         );
         assert_eq!(single_encoding.token_to_sequence(2), Some(0));
@@ -263,7 +265,7 @@ mod tests {
                 vec![1, 0, 0, 1, 0, 1],
                 vec![1, 1, 1, 1, 1, 1],
                 vec![],
-                FxHashMap::from_iter(vec![(0, 1..3), (1, 4..5)]),
+                HashMap::from([(0, 1..3), (1, 4..5)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(2), Some(0));
@@ -284,7 +286,7 @@ mod tests {
                 vec![0, 0, 0],
                 vec![1, 1, 1],
                 vec![],
-                FxHashMap::from_iter(vec![(0, 0..2), (1, 2..3)]),
+                HashMap::from([(0, 0..2), (1, 2..3)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(0), Some(0));

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -1,7 +1,7 @@
 use crate::processors::byte_level::process_offsets;
 use crate::tokenizer::{Encoding, PostProcessor, Result};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::iter::FromIterator;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -108,7 +108,7 @@ impl PostProcessor for RobertaProcessing {
 
                     // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't contain
                     // the special tokens.
-                    let sequence_ranges = HashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
+                    let sequence_ranges = FxHashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
                     Encoding::new(
                         ids,
                         type_ids,
@@ -141,7 +141,7 @@ impl PostProcessor for RobertaProcessing {
                                 // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't
                                 // contain the special tokens.
                                 let sequence_ranges =
-                                    HashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
+                                    FxHashMap::from_iter(vec![(0, 1..ids.len() - 1)]);
                                 Encoding::new(
                                     ids,
                                     type_ids,
@@ -174,7 +174,8 @@ impl PostProcessor for RobertaProcessing {
 
                     // For compatibility with `TemplateProcessing`, the sequence_ranges shouldn't contain
                     // the special tokens.
-                    let pair_sequence_ranges = HashMap::from_iter(vec![(1, 1..pair_ids.len() - 1)]);
+                    let pair_sequence_ranges =
+                        FxHashMap::from_iter(vec![(1, 1..pair_ids.len() - 1)]);
                     Encoding::new(
                         pair_ids,
                         pair_type_ids,
@@ -208,7 +209,7 @@ impl PostProcessor for RobertaProcessing {
                                 // For compatibility with `TemplateProcessing`, the sequence_ranges
                                 // shouldn't contain the special tokens.
                                 let pair_sequence_ranges =
-                                    HashMap::from_iter(vec![(1, 1..pair_ids.len() - 1)]);
+                                    FxHashMap::from_iter(vec![(1, 1..pair_ids.len() - 1)]);
                                 Encoding::new(
                                     pair_ids,
                                     pair_type_ids,
@@ -281,7 +282,7 @@ mod tests {
                 vec![1, 0, 0, 1],
                 vec![1, 1, 1, 1],
                 vec![],
-                HashMap::from_iter(vec![(0, 1..3)]),
+                FxHashMap::from_iter(vec![(0, 1..3)]),
             )
         );
         assert_eq!(single_encoding.token_to_sequence(2), Some(0));
@@ -308,7 +309,7 @@ mod tests {
                 vec![1, 0, 0, 1, 1, 0, 1],
                 vec![1, 1, 1, 1, 1, 1, 1],
                 vec![],
-                HashMap::from_iter(vec![(0, 1..3), (1, 5..6)]),
+                FxHashMap::from_iter(vec![(0, 1..3), (1, 5..6)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(2), Some(0));
@@ -330,7 +331,7 @@ mod tests {
                 vec![0, 0, 0],
                 vec![1, 1, 1],
                 vec![],
-                HashMap::from_iter(vec![(0, 0..2), (1, 2..3)]),
+                FxHashMap::from_iter(vec![(0, 0..2), (1, 2..3)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(0), Some(0));

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -235,6 +235,8 @@ impl PostProcessor for RobertaProcessing {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
 
     #[test]
@@ -282,7 +284,7 @@ mod tests {
                 vec![1, 0, 0, 1],
                 vec![1, 1, 1, 1],
                 vec![],
-                FxHashMap::from_iter(vec![(0, 1..3)]),
+                HashMap::from([(0, 1..3)]),
             )
         );
         assert_eq!(single_encoding.token_to_sequence(2), Some(0));
@@ -309,7 +311,7 @@ mod tests {
                 vec![1, 0, 0, 1, 1, 0, 1],
                 vec![1, 1, 1, 1, 1, 1, 1],
                 vec![],
-                FxHashMap::from_iter(vec![(0, 1..3), (1, 5..6)]),
+                HashMap::from([(0, 1..3), (1, 5..6)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(2), Some(0));
@@ -331,7 +333,7 @@ mod tests {
                 vec![0, 0, 0],
                 vec![1, 1, 1],
                 vec![],
-                FxHashMap::from_iter(vec![(0, 0..2), (1, 2..3)]),
+                HashMap::from([(0, 0..2), (1, 2..3)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(0), Some(0));

--- a/tokenizers/src/processors/sequence.rs
+++ b/tokenizers/src/processors/sequence.rs
@@ -73,7 +73,7 @@ mod tests {
     use super::*;
     use crate::processors::{ByteLevel, PostProcessorWrapper};
     use crate::tokenizer::{Encoding, PostProcessor};
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
     use std::iter::FromIterator;
 
     #[test]
@@ -93,7 +93,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            HashMap::new(),
+            FxHashMap::default(),
         );
 
         let bytelevel = ByteLevel::default().trim_offsets(true);
@@ -113,7 +113,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            HashMap::from_iter(vec![(0, 0..5)]),
+            FxHashMap::from_iter(vec![(0, 0..5)]),
         );
 
         assert_eq!(
@@ -156,7 +156,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            HashMap::from_iter(vec![(0, 0..5), (1, 5..10)]),
+            FxHashMap::from_iter(vec![(0, 0..5), (1, 5..10)]),
         );
         assert_eq!(
             pair_expected,

--- a/tokenizers/src/processors/sequence.rs
+++ b/tokenizers/src/processors/sequence.rs
@@ -73,8 +73,7 @@ mod tests {
     use super::*;
     use crate::processors::{ByteLevel, PostProcessorWrapper};
     use crate::tokenizer::{Encoding, PostProcessor};
-    use rustc_hash::FxHashMap;
-    use std::iter::FromIterator;
+    use std::collections::HashMap;
 
     #[test]
     fn process_chain() {
@@ -93,7 +92,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            FxHashMap::default(),
+            HashMap::new(),
         );
 
         let bytelevel = ByteLevel::default().trim_offsets(true);
@@ -113,7 +112,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            FxHashMap::from_iter(vec![(0, 0..5)]),
+            HashMap::from([(0, 0..5)]),
         );
 
         assert_eq!(
@@ -156,7 +155,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            FxHashMap::from_iter(vec![(0, 0..5), (1, 5..10)]),
+            HashMap::from([(0, 0..5), (1, 5..10)]),
         );
         assert_eq!(
             pair_expected,

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -58,8 +58,9 @@
 //!
 use crate::{Encoding, PostProcessor, Result};
 use itertools::Itertools;
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::result::Result as StdResult;
 
@@ -293,7 +294,7 @@ impl TryFrom<&str> for Template {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, Eq)]
 #[serde(transparent)]
 pub struct Tokens(
-    #[serde(serialize_with = "crate::utils::ordered_map")] pub HashMap<String, SpecialToken>,
+    #[serde(serialize_with = "crate::utils::ordered_map")] pub FxHashMap<String, SpecialToken>,
 );
 
 impl<T: Into<SpecialToken>> From<Vec<T>> for Tokens {
@@ -309,8 +310,8 @@ impl<T: Into<SpecialToken>> From<Vec<T>> for Tokens {
     }
 }
 
-impl From<HashMap<String, SpecialToken>> for Tokens {
-    fn from(v: HashMap<String, SpecialToken>) -> Self {
+impl From<FxHashMap<String, SpecialToken>> for Tokens {
+    fn from(v: FxHashMap<String, SpecialToken>) -> Self {
         Self(v)
     }
 }
@@ -502,7 +503,7 @@ impl TemplateProcessingBuilder {
         };
 
         let empty = [];
-        let missing: HashSet<&str> = self
+        let missing: FxHashSet<&str> = self
             .single
             .as_ref()
             .map_or(empty.iter(), |s| s.0.iter())
@@ -511,7 +512,7 @@ impl TemplateProcessingBuilder {
                 Piece::Sequence { .. } => None,
                 Piece::SpecialToken { id, .. } => check(id.as_ref()),
             })
-            .collect::<HashSet<_>>();
+            .collect::<FxHashSet<_>>();
 
         if missing.is_empty() {
             Ok(())
@@ -578,7 +579,7 @@ impl TemplateProcessing {
                                 // overflowing
                                 vec![],
                                 // sequence_range
-                                HashMap::new(),
+                                FxHashMap::default(),
                             );
                             Some(encoding)
                         } else {
@@ -917,7 +918,7 @@ mod tests {
                 vec![1, 0, 0, 1],
                 vec![1, 1, 1, 1],
                 vec![],
-                HashMap::from_iter(vec![(0, 1..3)]),
+                FxHashMap::from_iter(vec![(0, 1..3)]),
             )
         );
         assert_eq!(single_encoding.token_to_sequence(2), Some(0));
@@ -941,7 +942,7 @@ mod tests {
                 vec![1, 0, 0, 1, 0, 1],
                 vec![1, 1, 1, 1, 1, 1],
                 vec![],
-                HashMap::from_iter(vec![(0, 1..3), (1, 4..5)]),
+                FxHashMap::from_iter(vec![(0, 1..3), (1, 4..5)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(2), Some(0));
@@ -1003,9 +1004,9 @@ mod tests {
                     vec![1, 0, 1],
                     vec![1, 1, 1],
                     vec![],
-                    HashMap::from_iter(vec![(0, 1..2)]),
+                    FxHashMap::from_iter(vec![(0, 1..2)]),
                 )],
-                HashMap::from_iter(vec![(0, 1..3)]),
+                FxHashMap::from_iter(vec![(0, 1..3)]),
             )
         );
         assert_eq!(single_encoding.token_to_sequence(2), Some(0));
@@ -1061,9 +1062,9 @@ mod tests {
                             vec![1, 0, 1, 0, 1],
                             vec![1, 1, 1, 1, 1],
                             vec![],
-                            HashMap::from_iter(vec![(0, 1..2), (1, 3..4)]),
+                            FxHashMap::from_iter(vec![(0, 1..2), (1, 3..4)]),
                         ),],
-                        HashMap::from_iter(vec![(1, 3..5), (0, 1..2)]),
+                        FxHashMap::from_iter(vec![(1, 3..5), (0, 1..2)]),
                     ),
                     Encoding::new(
                         vec![1, 13, 0, 17, 0],
@@ -1080,7 +1081,7 @@ mod tests {
                         vec![1, 0, 1, 0, 1],
                         vec![1, 1, 1, 1, 1],
                         vec![],
-                        HashMap::from_iter(vec![(0, 1..2), (1, 3..4)]),
+                        FxHashMap::from_iter(vec![(0, 1..2), (1, 3..4)]),
                     ),
                     Encoding::new(
                         vec![1, 12, 14, 0, 17, 0],
@@ -1112,12 +1113,12 @@ mod tests {
                             vec![1, 0, 1, 0, 1],
                             vec![1, 1, 1, 1, 1],
                             vec![],
-                            HashMap::from_iter(vec![(0, 1..2), (1, 3..4)]),
+                            FxHashMap::from_iter(vec![(0, 1..2), (1, 3..4)]),
                         ),],
-                        HashMap::from_iter(vec![(0, 1..3), (1, 4..5)]),
+                        FxHashMap::from_iter(vec![(0, 1..3), (1, 4..5)]),
                     )
                 ],
-                HashMap::from_iter(vec![(0, 1..3), (1, 4..6)]),
+                FxHashMap::from_iter(vec![(0, 1..3), (1, 4..6)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(2), Some(0));

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -61,7 +61,10 @@ use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
+use std::hash::BuildHasher;
+use std::iter::FromIterator;
 use std::result::Result as StdResult;
 
 /// Represents any sequences received as input of the PostProcessor
@@ -310,9 +313,9 @@ impl<T: Into<SpecialToken>> From<Vec<T>> for Tokens {
     }
 }
 
-impl From<FxHashMap<String, SpecialToken>> for Tokens {
-    fn from(v: FxHashMap<String, SpecialToken>) -> Self {
-        Self(v)
+impl<S: BuildHasher> From<HashMap<String, SpecialToken, S>> for Tokens {
+    fn from(v: HashMap<String, SpecialToken, S>) -> Self {
+        Self(FxHashMap::from_iter(v))
     }
 }
 
@@ -689,8 +692,8 @@ impl PostProcessor for TemplateProcessing {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::convert::TryInto;
-    use std::iter::FromIterator;
 
     #[test]
     fn piece_serde() {
@@ -918,7 +921,7 @@ mod tests {
                 vec![1, 0, 0, 1],
                 vec![1, 1, 1, 1],
                 vec![],
-                FxHashMap::from_iter(vec![(0, 1..3)]),
+                HashMap::from([(0, 1..3)]),
             )
         );
         assert_eq!(single_encoding.token_to_sequence(2), Some(0));
@@ -942,7 +945,7 @@ mod tests {
                 vec![1, 0, 0, 1, 0, 1],
                 vec![1, 1, 1, 1, 1, 1],
                 vec![],
-                FxHashMap::from_iter(vec![(0, 1..3), (1, 4..5)]),
+                HashMap::from([(0, 1..3), (1, 4..5)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(2), Some(0));
@@ -1004,9 +1007,9 @@ mod tests {
                     vec![1, 0, 1],
                     vec![1, 1, 1],
                     vec![],
-                    FxHashMap::from_iter(vec![(0, 1..2)]),
+                    HashMap::from([(0, 1..2)]),
                 )],
-                FxHashMap::from_iter(vec![(0, 1..3)]),
+                HashMap::from([(0, 1..3)]),
             )
         );
         assert_eq!(single_encoding.token_to_sequence(2), Some(0));
@@ -1062,9 +1065,9 @@ mod tests {
                             vec![1, 0, 1, 0, 1],
                             vec![1, 1, 1, 1, 1],
                             vec![],
-                            FxHashMap::from_iter(vec![(0, 1..2), (1, 3..4)]),
+                            HashMap::from([(0, 1..2), (1, 3..4)]),
                         ),],
-                        FxHashMap::from_iter(vec![(1, 3..5), (0, 1..2)]),
+                        HashMap::from([(1, 3..5), (0, 1..2)]),
                     ),
                     Encoding::new(
                         vec![1, 13, 0, 17, 0],
@@ -1081,7 +1084,7 @@ mod tests {
                         vec![1, 0, 1, 0, 1],
                         vec![1, 1, 1, 1, 1],
                         vec![],
-                        FxHashMap::from_iter(vec![(0, 1..2), (1, 3..4)]),
+                        HashMap::from([(0, 1..2), (1, 3..4)]),
                     ),
                     Encoding::new(
                         vec![1, 12, 14, 0, 17, 0],
@@ -1113,12 +1116,12 @@ mod tests {
                             vec![1, 0, 1, 0, 1],
                             vec![1, 1, 1, 1, 1],
                             vec![],
-                            FxHashMap::from_iter(vec![(0, 1..2), (1, 3..4)]),
+                            HashMap::from([(0, 1..2), (1, 3..4)]),
                         ),],
-                        FxHashMap::from_iter(vec![(0, 1..3), (1, 4..5)]),
+                        HashMap::from([(0, 1..3), (1, 4..5)]),
                     )
                 ],
-                FxHashMap::from_iter(vec![(0, 1..3), (1, 4..6)]),
+                HashMap::from([(0, 1..3), (1, 4..6)]),
             )
         );
         assert_eq!(pair_encoding.token_to_sequence(2), Some(0));

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -3,8 +3,9 @@ use super::{
 };
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 use regex::Regex;
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
-use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 /// Represent a token added by the user on top of the existing Model vocabulary.
@@ -141,10 +142,10 @@ fn space_rightmost_at_start(sentence: &str) -> usize {
 pub struct AddedVocabulary {
     /// Contains the mapping from String (token content) to ID. This map contains both special
     /// tokens and classic added tokens that were added to the this vocabulary.
-    added_tokens_map: HashMap<String, u32>,
+    added_tokens_map: FxHashMap<String, u32>,
     /// Contains the mapping from ID to AddedToken for all the added tokens, both special
     /// and classic.
-    added_tokens_map_r: HashMap<u32, AddedToken>,
+    added_tokens_map_r: FxHashMap<u32, AddedToken>,
 
     /// Contains only the classic AddedToken, in the specific order the user gave them.
     added_tokens: Vec<AddedToken>,
@@ -153,7 +154,7 @@ pub struct AddedVocabulary {
 
     /// A Set, containing all the special token for easy access while decoding. This let's
     /// us remove them easily with an O(1) complexity.
-    special_tokens_set: HashSet<String>,
+    special_tokens_set: FxHashSet<String>,
 
     /// A RegexSet containing all the non-normalized patterns used to split on AddedTokens
     split_trie: MatchingSet,
@@ -175,11 +176,11 @@ impl AddedVocabulary {
             .build::<_, &&[u8]>([])
             .expect("The normalized trie should build correctly");
         Self {
-            added_tokens_map: HashMap::new(),
-            added_tokens_map_r: HashMap::new(),
+            added_tokens_map: FxHashMap::default(),
+            added_tokens_map_r: FxHashMap::default(),
             added_tokens: vec![],
             special_tokens: vec![],
-            special_tokens_set: HashSet::new(),
+            special_tokens_set: FxHashSet::default(),
             split_trie: (trie, vec![]),
             split_normalized_trie: (normalized_trie, vec![]),
             encode_special_tokens: false,
@@ -197,12 +198,12 @@ impl AddedVocabulary {
     }
 
     /// Get the additional vocabulary
-    pub fn get_vocab(&self) -> &HashMap<String, u32> {
+    pub fn get_vocab(&self) -> &FxHashMap<String, u32> {
         &self.added_tokens_map
     }
 
     /// Get the additional vocabulary with the AddedTokens
-    pub fn get_added_tokens_decoder(&self) -> &HashMap<u32, AddedToken> {
+    pub fn get_added_tokens_decoder(&self) -> &FxHashMap<u32, AddedToken> {
         &self.added_tokens_map_r
     }
 
@@ -546,19 +547,20 @@ mod tests {
     use crate::normalizers::utils::Lowercase;
     use crate::normalizers::NormalizerWrapper;
     use crate::{OffsetReferential, OffsetType, Result, Token, Trainer};
+    use std::iter::FromIterator;
     use std::path::{Path, PathBuf};
 
     #[derive(Serialize, Deserialize)]
     struct ModelMock {
-        vocab: HashMap<String, u32>,
-        vocab_r: HashMap<u32, String>,
+        vocab: FxHashMap<String, u32>,
+        vocab_r: FxHashMap<u32, String>,
     }
     impl ModelMock {
         pub fn new<I>(iter: I) -> Self
         where
             I: IntoIterator<Item = &'static (&'static str, u32)>,
         {
-            let vocab: HashMap<String, u32> = iter
+            let vocab: FxHashMap<String, u32> = iter
                 .into_iter()
                 .map(|&(tok, id)| (tok.to_string(), id))
                 .collect();
@@ -618,7 +620,7 @@ mod tests {
         fn id_to_token(&self, id: u32) -> Option<String> {
             self.vocab_r.get(&id).cloned()
         }
-        fn get_vocab(&self) -> HashMap<String, u32> {
+        fn get_vocab(&self) -> FxHashMap<String, u32> {
             self.vocab.clone()
         }
         fn get_vocab_size(&self) -> usize {
@@ -715,7 +717,7 @@ mod tests {
         assert!(vocab.is_special_token("test"));
         assert_eq!(
             *vocab.get_added_tokens_decoder(),
-            HashMap::from([
+            FxHashMap::from_iter([
                 (0, AddedToken::from("test", true)),
                 (2, AddedToken::from("added_token_1", true)),
                 (3, AddedToken::from("added_token_2", true)),

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -2,8 +2,8 @@ use crate::parallelism::*;
 use crate::tokenizer::{Offsets, Token};
 use crate::utils::padding::PaddingDirection;
 use crate::utils::truncation::TruncationDirection;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::ops::Range;
 
 /// Represents the output of a `Tokenizer`.
@@ -27,7 +27,7 @@ pub struct Encoding {
     overflowing: Vec<Encoding>,
     /// Ranges of tokens covered by each sequence. If this is empty we consider
     /// there is only one sequence in this Encoding, and that it covers the entire range.
-    sequence_ranges: HashMap<usize, Range<usize>>,
+    sequence_ranges: FxHashMap<usize, Range<usize>>,
 }
 impl Encoding {
     #[allow(clippy::too_many_arguments)]
@@ -40,7 +40,7 @@ impl Encoding {
         special_tokens_mask: Vec<u32>,
         attention_mask: Vec<u32>,
         overflowing: Vec<Self>,
-        sequence_ranges: HashMap<usize, Range<usize>>,
+        sequence_ranges: FxHashMap<usize, Range<usize>>,
     ) -> Self {
         Self {
             ids,
@@ -65,7 +65,7 @@ impl Encoding {
             special_tokens_mask: Vec::with_capacity(len),
             attention_mask: Vec::with_capacity(len),
             overflowing: vec![],
-            sequence_ranges: HashMap::new(),
+            sequence_ranges: FxHashMap::default(),
         }
     }
 
@@ -94,7 +94,7 @@ impl Encoding {
             attention_mask: vec![1; length],
             special_tokens_mask: vec![0; length],
             overflowing: vec![],
-            sequence_ranges: HashMap::new(),
+            sequence_ranges: FxHashMap::default(),
         }
     }
 
@@ -363,7 +363,7 @@ impl Encoding {
             special_tokens_mask: self.special_tokens_mask[start..stop].to_vec(),
             attention_mask: self.attention_mask[start..stop].to_vec(),
             overflowing: vec![],
-            sequence_ranges: HashMap::new(),
+            sequence_ranges: FxHashMap::default(),
         };
 
         loop {
@@ -381,7 +381,7 @@ impl Encoding {
                 special_tokens_mask: self.special_tokens_mask[start..stop].to_vec(),
                 attention_mask: self.attention_mask[start..stop].to_vec(),
                 overflowing: vec![],
-                sequence_ranges: HashMap::new(),
+                sequence_ranges: FxHashMap::default(),
             });
         }
         *self = new_encoding;
@@ -563,8 +563,9 @@ impl std::iter::FromIterator<(u32, String, (usize, usize), Option<u32>, u32)> fo
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::iter::FromIterator;
+
+    use super::*;
 
     #[test]
     fn merge_encodings() {
@@ -837,7 +838,7 @@ mod tests {
                 Some(2),
                 Some(3),
             ],
-            sequence_ranges: HashMap::from_iter(vec![(0, 0..7), (1, 7..11)]),
+            sequence_ranges: FxHashMap::from_iter(vec![(0, 0..7), (1, 7..11)]),
             ..Default::default()
         };
         assert_eq!(encoding.word_to_tokens(0, 0), Some((0, 2)));
@@ -890,7 +891,7 @@ mod tests {
             offsets: vec![(0, 6)],
             special_tokens_mask: vec![0],
             attention_mask: vec![1],
-            sequence_ranges: HashMap::from([(0, 0..1)]),
+            sequence_ranges: FxHashMap::from_iter([(0, 0..1)]),
             ..Default::default()
         };
         let target_length = 2;
@@ -904,6 +905,6 @@ mod tests {
             pad_token,
             PaddingDirection::Left,
         );
-        assert_eq!(a.sequence_ranges, HashMap::from([(0, 1..2)]));
+        assert_eq!(a.sequence_ranges, FxHashMap::from_iter([(0, 1..2)]));
     }
 }

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -4,6 +4,9 @@ use crate::utils::padding::PaddingDirection;
 use crate::utils::truncation::TruncationDirection;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+use std::iter::FromIterator;
 use std::ops::Range;
 
 /// Represents the output of a `Tokenizer`.
@@ -31,7 +34,7 @@ pub struct Encoding {
 }
 impl Encoding {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new<S: BuildHasher>(
         ids: Vec<u32>,
         type_ids: Vec<u32>,
         tokens: Vec<String>,
@@ -40,7 +43,7 @@ impl Encoding {
         special_tokens_mask: Vec<u32>,
         attention_mask: Vec<u32>,
         overflowing: Vec<Self>,
-        sequence_ranges: FxHashMap<usize, Range<usize>>,
+        sequence_ranges: HashMap<usize, Range<usize>, S>,
     ) -> Self {
         Self {
             ids,
@@ -51,7 +54,7 @@ impl Encoding {
             special_tokens_mask,
             attention_mask,
             overflowing,
-            sequence_ranges,
+            sequence_ranges: FxHashMap::from_iter(sequence_ranges),
         }
     }
 
@@ -838,7 +841,7 @@ mod tests {
                 Some(2),
                 Some(3),
             ],
-            sequence_ranges: FxHashMap::from_iter(vec![(0, 0..7), (1, 7..11)]),
+            sequence_ranges: HashMap::from_iter(vec![(0, 0..7), (1, 7..11)]),
             ..Default::default()
         };
         assert_eq!(encoding.word_to_tokens(0, 0), Some((0, 2)));
@@ -891,7 +894,7 @@ mod tests {
             offsets: vec![(0, 6)],
             special_tokens_mask: vec![0],
             attention_mask: vec![1],
-            sequence_ranges: FxHashMap::from_iter([(0, 0..1)]),
+            sequence_ranges: HashMap::from_iter([(0, 0..1)]),
             ..Default::default()
         };
         let target_length = 2;
@@ -905,6 +908,6 @@ mod tests {
             pad_token,
             PaddingDirection::Left,
         );
-        assert_eq!(a.sequence_ranges, FxHashMap::from_iter([(0, 1..2)]));
+        assert_eq!(a.sequence_ranges, HashMap::from_iter([(0, 1..2)]));
     }
 }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -944,10 +944,10 @@ where
 /// a valid chunk.
 /// ```
 /// use tokenizers::{Tokenizer, TokenizerBuilder, models::bpe::BPE, decoders::byte_fallback::ByteFallback, pre_tokenizers::byte_level::ByteLevel, normalizers::unicode::NFC};
-/// use rustc_hash::FxHashMap;
+/// use std::collections::HashMap;
 /// use std::iter::FromIterator;
 ///
-/// let vocab = FxHashMap::from_iter([
+/// let vocab = HashMap::from([
 ///     ("<0x20>".to_string(), 0),
 ///     ("<0xC3>".to_string(), 1),
 ///     ("<0xA9>".to_string(), 2),
@@ -981,10 +981,10 @@ where
 ///
 /// ```
 /// use tokenizers::{Tokenizer, TokenizerBuilder, models::bpe::BPE, pre_tokenizers::{byte_level::ByteLevel, metaspace::Metaspace}, normalizers::unicode::NFC};
-/// use rustc_hash::FxHashMap;
+/// use std::collections::HashMap;
 /// use std::iter::FromIterator;
 ///
-/// let vocab = FxHashMap::from_iter([
+/// let vocab = HashMap::from([
 ///     ("▁This".to_string(), 0),
 /// ]);
 /// let merges = vec![];

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -9,8 +9,8 @@
 //!   - [`PostProcessor`](trait.PostProcessor.html): Takes care of the processing after tokenization (like truncating, padding,
 //!     ...).
 
+use rustc_hash::FxHashMap;
 use std::{
-    collections::HashMap,
     fs::{read_to_string, File},
     io::{prelude::*, BufReader},
     ops::{Deref, DerefMut},
@@ -77,7 +77,7 @@ pub trait Model {
     /// Find the string token associated to an ID
     fn id_to_token(&self, id: u32) -> Option<String>;
     /// Retrieve the entire vocabulary mapping (token -> ID)
-    fn get_vocab(&self) -> HashMap<String, u32>;
+    fn get_vocab(&self) -> FxHashMap<String, u32>;
     /// Retrieve the size of the vocabulary
     fn get_vocab_size(&self) -> usize;
     /// Save the current `Model` in the given folder, using the given `prefix` for the various
@@ -658,7 +658,7 @@ where
     }
 
     /// Get the vocabulary
-    pub fn get_vocab(&self, with_added_tokens: bool) -> HashMap<String, u32> {
+    pub fn get_vocab(&self, with_added_tokens: bool) -> FxHashMap<String, u32> {
         let mut final_vocab = self.model.get_vocab();
 
         if with_added_tokens {
@@ -675,7 +675,7 @@ where
     }
 
     /// Get the added tokens decoder
-    pub fn get_added_tokens_decoder(&self) -> HashMap<u32, AddedToken> {
+    pub fn get_added_tokens_decoder(&self) -> FxHashMap<u32, AddedToken> {
         self.added_vocabulary.get_added_tokens_decoder().clone()
     }
 
@@ -944,10 +944,10 @@ where
 /// a valid chunk.
 /// ```
 /// use tokenizers::{Tokenizer, TokenizerBuilder, models::bpe::BPE, decoders::byte_fallback::ByteFallback, pre_tokenizers::byte_level::ByteLevel, normalizers::unicode::NFC};
-/// use std::collections::HashMap;
+/// use rustc_hash::FxHashMap;
 /// use std::iter::FromIterator;
 ///
-/// let vocab = HashMap::from_iter([
+/// let vocab = FxHashMap::from_iter([
 ///     ("<0x20>".to_string(), 0),
 ///     ("<0xC3>".to_string(), 1),
 ///     ("<0xA9>".to_string(), 2),
@@ -981,10 +981,10 @@ where
 ///
 /// ```
 /// use tokenizers::{Tokenizer, TokenizerBuilder, models::bpe::BPE, pre_tokenizers::{byte_level::ByteLevel, metaspace::Metaspace}, normalizers::unicode::NFC};
-/// use std::collections::HashMap;
+/// use rustc_hash::FxHashMap;
 /// use std::iter::FromIterator;
 ///
-/// let vocab = HashMap::from_iter([
+/// let vocab = FxHashMap::from_iter([
 ///     ("▁This".to_string(), 0),
 /// ]);
 /// let merges = vec![];

--- a/tokenizers/src/tokenizer/pre_tokenizer.rs
+++ b/tokenizers/src/tokenizer/pre_tokenizer.rs
@@ -1,7 +1,7 @@
 use crate::{
     normalizer::Range, Encoding, NormalizedString, OffsetReferential, Offsets, Result, Token,
 };
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 /// Various possible types of offsets
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -265,7 +265,7 @@ impl From<String> for PreTokenizedString {
 }
 
 struct BytesToCharOffsetConverter {
-    map: HashMap<usize, usize>,
+    map: FxHashMap<usize, usize>,
 }
 
 impl BytesToCharOffsetConverter {

--- a/tokenizers/src/utils/cache.rs
+++ b/tokenizers/src/utils/cache.rs
@@ -1,5 +1,5 @@
+use rustc_hash::FxHashMap;
 use std::borrow::Borrow;
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::RwLock;
 
@@ -19,7 +19,7 @@ where
     K: Eq + Hash + Clone,
     V: Clone,
 {
-    map: RwLock<HashMap<K, V>>,
+    map: RwLock<FxHashMap<K, V>>,
     pub capacity: usize,
 }
 
@@ -51,7 +51,10 @@ where
 {
     /// Create new `Cache` with the given capacity.
     pub(crate) fn new(capacity: usize) -> Self {
-        let map = RwLock::new(HashMap::with_capacity(capacity));
+        let map = RwLock::new(FxHashMap::with_capacity_and_hasher(
+            capacity,
+            Default::default(),
+        ));
         Cache { map, capacity }
     }
 

--- a/tokenizers/src/utils/from_pretrained.rs
+++ b/tokenizers/src/utils/from_pretrained.rs
@@ -1,13 +1,13 @@
 use crate::Result;
 use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::PathBuf;
 
 /// Defines the additional parameters available for the `from_pretrained` function
 #[derive(Debug, Clone)]
 pub struct FromPretrainedParameters {
     pub revision: String,
-    pub user_agent: HashMap<String, String>,
+    pub user_agent: FxHashMap<String, String>,
     pub token: Option<String>,
 }
 
@@ -15,7 +15,7 @@ impl Default for FromPretrainedParameters {
     fn default() -> Self {
         Self {
             revision: "main".into(),
-            user_agent: HashMap::new(),
+            user_agent: FxHashMap::default(),
             token: None,
         }
     }

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -17,11 +17,12 @@ pub mod parallelism;
 pub(crate) mod progress;
 pub mod truncation;
 
+use rustc_hash::FxHashMap;
 use serde::{Serialize, Serializer};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 pub(crate) fn ordered_map<S, K, V>(
-    value: &HashMap<K, V>,
+    value: &FxHashMap<K, V>,
     serializer: S,
 ) -> std::result::Result<S::Ok, S::Error>
 where

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -17,18 +17,21 @@ pub mod parallelism;
 pub(crate) mod progress;
 pub mod truncation;
 
-use rustc_hash::FxHashMap;
 use serde::{Serialize, Serializer};
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, HashMap},
+    hash::BuildHasher,
+};
 
-pub(crate) fn ordered_map<S, K, V>(
-    value: &FxHashMap<K, V>,
+pub(crate) fn ordered_map<S, K, V, H>(
+    value: &HashMap<K, V, H>,
     serializer: S,
 ) -> std::result::Result<S::Ok, S::Error>
 where
     S: Serializer,
     K: Serialize + std::cmp::Ord,
     V: Serialize,
+    H: BuildHasher,
 {
     let ordered: BTreeMap<_, _> = value.iter().collect();
     ordered.serialize(serializer)

--- a/tokenizers/src/utils/padding.rs
+++ b/tokenizers/src/utils/padding.rs
@@ -82,9 +82,10 @@ pub fn pad_encodings(encodings: &mut [Encoding], params: &PaddingParams) -> Resu
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::tokenizer::Encoding;
-    use rustc_hash::FxHashMap;
 
     #[test]
     fn pad_to_multiple() {
@@ -99,7 +100,7 @@ mod tests {
                     vec![],
                     vec![],
                     vec![],
-                    FxHashMap::default(),
+                    HashMap::new(),
                 ),
                 Encoding::new(
                     vec![0, 1, 2],
@@ -110,7 +111,7 @@ mod tests {
                     vec![],
                     vec![],
                     vec![],
-                    FxHashMap::default(),
+                    HashMap::new(),
                 ),
             ]
         }

--- a/tokenizers/src/utils/padding.rs
+++ b/tokenizers/src/utils/padding.rs
@@ -84,7 +84,7 @@ pub fn pad_encodings(encodings: &mut [Encoding], params: &PaddingParams) -> Resu
 mod tests {
     use super::*;
     use crate::tokenizer::Encoding;
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
 
     #[test]
     fn pad_to_multiple() {
@@ -99,7 +99,7 @@ mod tests {
                     vec![],
                     vec![],
                     vec![],
-                    HashMap::new(),
+                    FxHashMap::default(),
                 ),
                 Encoding::new(
                     vec![0, 1, 2],
@@ -110,7 +110,7 @@ mod tests {
                     vec![],
                     vec![],
                     vec![],
-                    HashMap::new(),
+                    FxHashMap::default(),
                 ),
             ]
         }

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -170,7 +170,7 @@ pub fn truncate_encodings(
 mod tests {
     use super::*;
     use crate::tokenizer::Encoding;
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
 
     fn get_empty() -> Encoding {
         Encoding::new(
@@ -182,7 +182,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            HashMap::new(),
+            FxHashMap::default(),
         )
     }
 
@@ -196,7 +196,7 @@ mod tests {
             vec![0, 0],
             vec![1, 1],
             vec![],
-            HashMap::new(),
+            FxHashMap::default(),
         )
     }
 
@@ -215,7 +215,7 @@ mod tests {
             vec![0, 0, 0, 0],
             vec![1, 1, 1, 1],
             vec![],
-            HashMap::new(),
+            FxHashMap::default(),
         )
     }
 
@@ -256,7 +256,7 @@ mod tests {
             vec![0, 0, 0, 0, 0, 0, 0, 0],
             vec![1, 1, 1, 1, 1, 1, 1, 1],
             vec![],
-            HashMap::new(),
+            FxHashMap::default(),
         )
     }
 

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -168,9 +168,10 @@ pub fn truncate_encodings(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::tokenizer::Encoding;
-    use rustc_hash::FxHashMap;
 
     fn get_empty() -> Encoding {
         Encoding::new(
@@ -182,7 +183,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
-            FxHashMap::default(),
+            HashMap::new(),
         )
     }
 
@@ -196,7 +197,7 @@ mod tests {
             vec![0, 0],
             vec![1, 1],
             vec![],
-            FxHashMap::default(),
+            HashMap::new(),
         )
     }
 
@@ -215,7 +216,7 @@ mod tests {
             vec![0, 0, 0, 0],
             vec![1, 1, 1, 1],
             vec![],
-            FxHashMap::default(),
+            HashMap::new(),
         )
     }
 
@@ -256,7 +257,7 @@ mod tests {
             vec![0, 0, 0, 0, 0, 0, 0, 0],
             vec![1, 1, 1, 1, 1, 1, 1, 1],
             vec![],
-            FxHashMap::default(),
+            HashMap::new(),
         )
     }
 

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -1,5 +1,4 @@
-use rustc_hash::FxHashMap;
-use std::iter::FromIterator;
+use std::collections::HashMap;
 
 use tokenizers::decoders::byte_fallback::ByteFallback;
 use tokenizers::models::bpe::{BpeTrainerBuilder, BPE};
@@ -91,7 +90,7 @@ fn streaming_tokenizer() {
     );
 
     // None example
-    let vocab = FxHashMap::from_iter([
+    let vocab = HashMap::from([
         ("<0x20>".to_string(), 0),
         ("<0xC3>".to_string(), 1),
         ("<0xA9>".to_string(), 2),

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::iter::FromIterator;
 
 use tokenizers::decoders::byte_fallback::ByteFallback;
@@ -91,7 +91,7 @@ fn streaming_tokenizer() {
     );
 
     // None example
-    let vocab = HashMap::from_iter([
+    let vocab = FxHashMap::from_iter([
         ("<0x20>".to_string(), 0),
         ("<0xC3>".to_string(), 1),
         ("<0xA9>".to_string(), 2),

--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -1,6 +1,6 @@
 #[cfg(not(debug_assertions))]
 use assert_approx_eq::assert_approx_eq;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fs::read_to_string;
 use std::path::Path;
 #[cfg(not(debug_assertions))]
@@ -41,7 +41,7 @@ fn test_unigram_from_file() {
 #[test]
 fn test_train_unigram_from_file() {
     let content = read_to_string("data/small.txt").unwrap();
-    let mut word_counts = HashMap::new();
+    let mut word_counts = FxHashMap::default();
     content.split_whitespace().for_each(|word| {
         // This is important for the test of char vs u8
         let word = format!("▁{word}");

--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -1,6 +1,6 @@
 #[cfg(not(debug_assertions))]
 use assert_approx_eq::assert_approx_eq;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use std::fs::read_to_string;
 use std::path::Path;
 #[cfg(not(debug_assertions))]
@@ -41,7 +41,7 @@ fn test_unigram_from_file() {
 #[test]
 fn test_train_unigram_from_file() {
     let content = read_to_string("data/small.txt").unwrap();
-    let mut word_counts = FxHashMap::default();
+    let mut word_counts = HashMap::new();
     content.split_whitespace().for_each(|word| {
         // This is important for the test of char vs u8
         let word = format!("▁{word}");


### PR DESCRIPTION
Split PR #1733 into two separate PRs, as per @McPatate 's suggestion. This PR contains the changes for adding FXHash.

The benchmarks (from `cargo bench`) are in [cargo_bench.txt](https://github.com/user-attachments/files/19333143/cargo_bench.txt). Some performance gains, but not as large as the short-string optimization.

Note: The changes in this PR are slightly different than the ones from the other PR. I refactored some things to make this change mostly invisible to the user (this only applies to the Rust library; the Python and Node users shouldn't feel any difference). The only exposure these changes have to a library user are the return types for the "getters". For the setters (and other functionality), you can provide a `std::collections::HashMap` and it will convert to a `rustc_hash::FxHashMap` (and the same for HashSet) internally.

I'll work on the PR for the short-string optimization after this PR has been reviewed. I think that would be easier, as changes here would impact the other.