### PR TITLE
Implement `from_bytes` and `read_bytes` Methods in WordPiece Tokenizer for WebAssembly Compatibility

### DIFF
--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -182,9 +182,10 @@ impl WordPiece {
 
         Ok(vocab)
     }
-    pub fn from_bytes(vocab: &[u8]) -> Result<WordPieceBuilder> {
-        let vocab = WordPiece::read_bytes(vocab)?;
-        Ok(WordPiece::builder().vocab(vocab))
+
+    pub fn from_bytes<P: AsRef<[u8]>>(bytes: P) -> Result<Self> {
+        let tokenizer = serde_json::from_slice(bytes.as_ref())?;
+        Ok(tokenizer)
     }
 
     /// Initialize a `WordPiece` model from a vocab mapping file.

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -171,6 +171,22 @@ impl WordPiece {
         Ok(vocab)
     }
 
+    pub fn read_bytes(vocab: &[u8]) -> Result<Vocab> {
+        let file = BufReader::new(vocab);
+
+        let mut vocab = HashMap::new();
+        for (index, line) in file.lines().enumerate() {
+            let line = line?;
+            vocab.insert(line.trim_end().to_owned(), index as u32);
+        }
+
+        Ok(vocab)
+    }
+    pub fn from_bytes(vocab: &[u8]) -> Result<WordPieceBuilder> {
+        let vocab = WordPiece::read_bytes(vocab)?;
+        Ok(WordPiece::builder().vocab(vocab))
+    }
+
     /// Initialize a `WordPiece` model from a vocab mapping file.
     pub fn from_file(vocab: &str) -> WordPieceBuilder {
         WordPiece::builder().files(vocab.to_owned())


### PR DESCRIPTION
**Description:**  

This Pull Request introduces the implementation of `from_bytes` and `read_bytes` methods within the WordPiece tokenizer. These methods were added to improve integration with WebAssembly (Wasm). As model downloading is managed on the JavaScript side in a Wasm target environment, methods compatible with `u8` types facilitates the transfer of a `Uint8Array` from JavaScript to Rust.

