### PR TITLE
Update __init__.pyi: fix 525: SyntaxWarning: invalid escape sequence '\w'

### DIFF
--- a/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/pre_tokenizers/__init__.pyi
@@ -522,7 +522,7 @@ class UnicodeScripts(PreTokenizer):
         pass
 
 class Whitespace(PreTokenizer):
-    """
+    r"""
     This pre-tokenizer simply splits using the following regex: `\w+|[^\w\s]+`
     """
     def __init__(self):


### PR DESCRIPTION
Using a raw string.