### PR TITLE
Fix type notation of merges in BPE Python binding

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
@@ -16,7 +16,7 @@ class ByteLevelBPETokenizer(BaseTokenizer):
     def __init__(
         self,
         vocab: Optional[Union[str, Dict[str, int]]] = None,
-        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]] = None,
+        merges: Optional[Union[str, List[Tuple[str, str]]]] = None,
         add_prefix_space: bool = False,
         lowercase: bool = False,
         dropout: Optional[float] = None,

--- a/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
@@ -25,7 +25,7 @@ class CharBPETokenizer(BaseTokenizer):
     def __init__(
         self,
         vocab: Optional[Union[str, Dict[str, int]]] = None,
-        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]] = None,
+        merges: Optional[Union[str, List[Tuple[str, str]]]] = None,
         unk_token: Union[str, AddedToken] = "<unk>",
         suffix: str = "</w>",
         dropout: Optional[float] = None,

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py
@@ -16,7 +16,7 @@ class SentencePieceBPETokenizer(BaseTokenizer):
     def __init__(
         self,
         vocab: Optional[Union[str, Dict[str, int]]] = None,
-        merges: Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]] = None,
+        merges: Optional[Union[str, List[Tuple[str, str]]]] = None,
         unk_token: Union[str, AddedToken] = "<unk>",
         replacement: str = "▁",
         add_prefix_space: bool = True,


### PR DESCRIPTION
Hi, this change is to correct type notations of merges in Python binding of BPE as the [counterpart in Rust implementation](https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/models/bpe/model.rs#L18) expects a file name string or Vec<(String, String)> instead of a mapping from a tuple of integers to another.

Taking the Python [SentencePieceBPETokenizer](https://github.com/huggingface/tokenizers/blob/f0c48bd89a442819b39605ca117ecabd293bfdd7/bindings/python/py_src/tokenizers/implementations/sentencepiece_bpe.py#L26-L29) class as an example, the `merges` annotated as `Optional[Union[str, Dict[Tuple[int, int], Tuple[int, int]]]]` is only used to initialize the [`BPE`](https://github.com/huggingface/tokenizers/blob/f0c48bd89a442819b39605ca117ecabd293bfdd7/bindings/python/py_src/tokenizers/models/__init__.pyi#L82) class:
```python
if vocab is not None and merges is not None:
        tokenizer = Tokenizer(BPE(vocab, merges, dropout=dropout, unk_token=unk_token, fuse_unk=fuse_unk))
``` 
where the `BPE` class is generated from the Rust implementation mentioned in the original post.

`BPE` class also [contains below comment](https://github.com/huggingface/tokenizers/blob/f0c48bd89a442819b39605ca117ecabd293bfdd7/bindings/python/py_src/tokenizers/models/__init__.pyi#L90):
```python
class BPE(Model):
    """
    An implementation of the BPE (Byte-Pair Encoding) algorithm

    Args:
        vocab (:obj:`Dict[str, int]`, `optional`):
            A dictionary of string keys and their ids :obj:`{"am": 0,...}`

        merges (:obj:`List[Tuple[str, str]]`, `optional`):
            A list of pairs of tokens (:obj:`Tuple[str, str]`) :obj:`[("a", "b"),...]`
```
This comment also gives a different type annotation for `merges`.

I encountered an issue initializing `SentencePieceBPETokenizer` with the given type annotation, but succeeded following the type annotation given in the comment of `BPE` class.

The type annotation of `merges` being `Dict[Tuple[int, int], Tuple[int, int]]]]` should actually be for [`MergesMap`](https://github.com/huggingface/tokenizers/blob/f0c48b/tokenizers/src/models/bpe/model.rs#L17C10-L17C18) in Rust, as an alias of `HashMap<Pair, (u32, u32)>`, which is built internally in Rust from `merges`.



Note that this is a second PR with the same change as [PR#1685](https://github.com/huggingface/tokenizers/pull/1685), which got closed with replies to questions from an reviewer that got ignored.