### PR TITLE
Upgrade onig, to get it compiling with GCC 15

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -43,7 +43,7 @@ harness = false
 
 [dependencies]
 rand = "0.8"
-onig = { version = "6.4", default-features = false, optional = true }
+onig = { version = "6.5.1", default-features = false, optional = true }
 regex = "1.10"
 regex-syntax = "0.8"
 rayon = "1.10"


### PR DESCRIPTION
Distributions are starting to ship with GCC 15, which won't build `onig`. We can upgrade `onig` to an unreleased version, which fixes the issue. We should make a mental note to upgrade to a stable point release, when one is available (although at the moment, the onig repository is archived, so I'm not sure when that will happen).