### PR TITLE
Fix ApiBuilder in from_pretrained to use env variables

### DIFF
--- a/tokenizers/src/utils/from_pretrained.rs
+++ b/tokenizers/src/utils/from_pretrained.rs
@@ -59,7 +59,7 @@ pub fn from_pretrained<S: AsRef<str>>(
         .into());
     }
 
-    let mut builder = ApiBuilder::new();
+    let mut builder = ApiBuilder::from_env();
     if let Some(token) = params.token {
         builder = builder.with_token(Some(token));
     }


### PR DESCRIPTION
## Bug

Using `Tokenizer::from_pretrained` does not download the tokenizer into the `HF_HOME` folder.
Instead it will download it in the user home cache directory.

## Fix

Use env variable to load the ApiBuilder so it will read `HF_HOME` variable. 
Currently they are ignored and the default cache location is used `$HOME/.cache/huggingface`