### PR TITLE
Expose `Encoding` attributes via the buffer protocol interface

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
 libc = "0.2"
 env_logger = "0.11"
-pyo3 = { version = "0.24.2", features = ["abi3", "abi3-py39", "py-clone"] }
+pyo3 = { version = "0.24.2", features = ["py-clone"] }
 numpy = "0.24"
 ndarray = "0.16"
 itertools = "0.12"

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -97,6 +97,20 @@ class Encoding:
         """
         pass
 
+    @property
+    def attention_mask_buffer(self):
+        """
+        The attention mask as a buffer.
+
+        This indicates to the LM which tokens should be attended to, and which should not.
+        This is especially important when batching sequences, where we need to applying
+        padding.
+
+        Returns
+           :obj:`Buffer`: The attention mask
+        """
+        pass
+
     def char_to_token(self, char_pos, sequence_index=0):
         """
         Get the token that contains the char at the given position in the input sequence.
@@ -140,6 +154,19 @@ class Encoding:
         """
         pass
 
+    @property
+    def ids_buffer(self):
+        """
+        The generated IDs as a buffer.
+
+        The IDs are the main input to a Language Model. They are the token indices,
+        the numerical representations that a LM understands.
+
+        Returns
+           :obj:`Buffer`: The buffer of IDs
+        """
+        pass
+
     @staticmethod
     def merge(encodings, growing_offsets=True):
         """
@@ -177,6 +204,19 @@ class Encoding:
 
         Returns:
             A :obj:`List` of :obj:`Tuple[int, int]`: The list of offsets
+        """
+        pass
+
+    @property
+    def offsets_buffer(self):
+        """
+        The generated type IDs as a buffer.
+
+        Generally used for tasks like sequence classification or question answering,
+        these tokens let the LM know which input sequence corresponds to each tokens.
+
+        Returns
+           :obj:`Buffer`: The buffer of type IDs
         """
         pass
 
@@ -249,6 +289,18 @@ class Encoding:
 
         Returns:
             :obj:`List[int]`: The special tokens mask
+        """
+        pass
+
+    @property
+    def special_tokens_mask_buffer(self):
+        """
+        The special token mask as a buffer.
+
+        This indicates which tokens are special tokens, and which are not.
+
+        Returns
+           :obj:`Buffer`: The special tokens mask
         """
         pass
 
@@ -343,6 +395,19 @@ class Encoding:
 
         Returns:
             :obj:`List[int]`: The list of type ids
+        """
+        pass
+
+    @property
+    def type_ids_buffer(self):
+        """
+        The generated type IDs as a buffer.
+
+        Generally used for tasks like sequence classification or question answering,
+        these tokens let the LM know which input sequence corresponds to each tokens.
+
+        Returns
+           :obj:`Buffer`: The buffer of type IDs
         """
         pass
 

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -592,6 +592,16 @@ class TestTokenizer:
         tokenizer.pre_tokenizer = None
         assert tokenizer.pre_tokenizer == None
 
+    def test_encode_buffer_protocol(self):
+        tokenizer = Tokenizer(BPE())
+        tokenizer.add_tokens(["my", "name", "is", "john"])
+        output = tokenizer.encode("my name is john")
+        assert output.ids == memoryview(output.ids_buffer).tolist()
+        assert output.type_ids == memoryview(output.type_ids_buffer).tolist()
+        assert output.attention_mask == memoryview(output.attention_mask_buffer).tolist()
+        assert output.offsets == [tuple(offset) for offset in memoryview(output.offsets_buffer).tolist()]
+        assert output.special_tokens_mask == memoryview(output.special_tokens_mask_buffer).tolist()
+
 
 class TestTokenizerRepr:
     def test_repr(self):


### PR DESCRIPTION
This PR enables access to the underlying buffers of an `Encoding` object via the [buffer protocol interface](https://docs.python.org/3/c-api/buffer.html), allowing for efficient conversion from Rust to Python for types that support that interface (e.g., NumPy, PyTorch, PyArrow).

This can save >20% of time when tokenizing datasets (with longer sequences) based on [my benchmarks](https://gist.github.com/mariosasko/80a4424f4c6627ed7c10f22d43880b2d).
