### PR TITLE
Fix features blending into a paragraph

### DIFF
--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -122,10 +122,12 @@
 //!   **_Please note this behavior may evolve in the future_**
 //!
 //! # Features
-//! **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
+//!
+//! - **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
 //!   compilation for certain targets is not supported by the [termios](https://crates.io/crates/termios)
 //!   dependency of the [indicatif](https://crates.io/crates/indicatif) progress bar.
-//! **http**: This feature enables downloading the tokenizer via HTTP. It is disabled by default.
+//! 
+//! - **http**: This feature enables downloading the tokenizer via HTTP. It is disabled by default.
 //!   With this feature enabled, `Tokenizer::from_pretrained` becomes accessible.
 
 #[macro_use]


### PR DESCRIPTION
i was wondering why the main example didn't work, required the "http" feature, but i had glanced at the features list and just seen "progressbar" and didn't notice the "http" feature existed because it began at the end of a line here

this minor docs change puts these features in an unordered list with newlines between them

![image](https://github.com/user-attachments/assets/cc13921e-c34a-471a-a4e0-7c3fa388ffd7)
