### PR TITLE
Add 3.13t CI using pytest-run-parallel

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -52,6 +52,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        python: ["3.13", "3.13t"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -72,7 +73,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: ${{ matrix.python }}
           architecture: "x64"
 
 
@@ -116,7 +117,7 @@ jobs:
           python -m venv .env
           source .env/bin/activate
           pip install -U pip
-          pip install pytest requests setuptools_rust numpy pyarrow datasets
+          pip install pytest requests setuptools_rust numpy pyarrow datasets pytest-run-parallel
           pip install -e .[dev]
 
       - name: Check style

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -127,7 +127,15 @@ jobs:
           make check-style
 
       - name: Run tests
+        if: ${{ !endsWith(matrix.python, 't') }}
         working-directory: ./bindings/python
         run: |
           source .env/bin/activate
           make test
+
+      - name: Run tests (free-threaded)
+        if: ${{ endsWith(matrix.python, 't') }}
+        working-directory: ./bindings/python
+        run: |
+          source .env/bin/activate
+          make nogil-test

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -21,8 +21,13 @@ TESTS_RESOURCES = $(DATA_DIR)/small.txt $(DATA_DIR)/roberta.json
 
 # Launch the test suite
 test: $(TESTS_RESOURCES)
+	pip install pytest requests setuptools_rust numpy pyarrow datasets
+	python -m pytest -s -v tests
+	cargo test --no-default-features
+
+nogil-test: $(TESTS_RESOURCES)
 	pip install pytest requests setuptools_rust numpy pyarrow datasets pytest-run-parallel
-	python -m pytest -s -v tests --parallel-threads=4
+	PYTHON_GIL=0 python -m pytest -s -v tests --parallel-threads=4
 	cargo test --no-default-features
 
 $(DATA_DIR)/big.txt :

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -21,8 +21,8 @@ TESTS_RESOURCES = $(DATA_DIR)/small.txt $(DATA_DIR)/roberta.json
 
 # Launch the test suite
 test: $(TESTS_RESOURCES)
-	pip install pytest requests setuptools_rust numpy pyarrow datasets
-	python -m pytest -s -v tests
+	pip install pytest requests setuptools_rust numpy pyarrow datasets pytest-run-parallel
+	python -m pytest -s -v tests --parallel-threads=4
 	cargo test --no-default-features
 
 $(DATA_DIR)/big.txt :

--- a/bindings/python/conftest.py
+++ b/bindings/python/conftest.py
@@ -1,13 +1,25 @@
 import pytest
 
 
+try:
+    import pytest_run_parallel  # noqa:F401
+    PARALLEL_RUN_AVAILABLE = True
+except ImportError:
+    PARALLEL_RUN_AVAILABLE = False
+
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
-
+    # Don't warn for `pytest-run-parallel` markers if they're not available
+    breakpoint()
+    if not PARALLEL_RUN_AVAILABLE:
+        config.addinivalue_line(
+            "markers",
+            "thread_unsafe: mark the test function as single-threaded",
+        )
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runslow"):

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -1,3 +1,5 @@
+use std::sync::Mutex;
+
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
@@ -11,12 +13,14 @@ use crate::error::{deprecation_warning, PyError};
 #[pyclass(dict, module = "tokenizers", name = "Encoding")]
 #[repr(transparent)]
 pub struct PyEncoding {
-    pub encoding: tk::tokenizer::Encoding,
+    pub encoding: Mutex<tk::tokenizer::Encoding>,
 }
 
 impl From<tk::tokenizer::Encoding> for PyEncoding {
     fn from(v: tk::tokenizer::Encoding) -> Self {
-        Self { encoding: v }
+        Self {
+            encoding: Mutex::new(v),
+        }
     }
 }
 
@@ -26,7 +30,7 @@ impl PyEncoding {
     #[pyo3(text_signature = None)]
     fn new() -> Self {
         Self {
-            encoding: tk::tokenizer::Encoding::default(),
+            encoding: Mutex::new(tk::tokenizer::Encoding::default()),
         }
     }
 
@@ -59,12 +63,12 @@ impl PyEncoding {
         Ok(format!(
             "Encoding(num_tokens={}, attributes=[ids, type_ids, tokens, offsets, \
              attention_mask, special_tokens_mask, overflowing])",
-            self.encoding.get_ids().len()
+            self.encoding.lock().unwrap().get_ids().len()
         ))
     }
 
     fn __len__(&self) -> PyResult<usize> {
-        Ok(self.encoding.len())
+        Ok(self.encoding.lock().unwrap().len())
     }
 
     /// Merge the list of encodings into one final :class:`~tokenizers.Encoding`
@@ -83,7 +87,9 @@ impl PyEncoding {
     #[pyo3(text_signature = "(encodings, growing_offsets=True)")]
     fn merge(encodings: Vec<PyRef<PyEncoding>>, growing_offsets: bool) -> PyEncoding {
         tk::tokenizer::Encoding::merge(
-            encodings.into_iter().map(|e| e.encoding.clone()),
+            encodings
+                .into_iter()
+                .map(|e| e.encoding.lock().unwrap().clone()),
             growing_offsets,
         )
         .into()
@@ -95,7 +101,7 @@ impl PyEncoding {
     ///     :obj:`int`: The number of sequences in this :class:`~tokenizers.Encoding`
     #[getter]
     fn get_n_sequences(&self) -> usize {
-        self.encoding.n_sequences()
+        self.encoding.lock().unwrap().n_sequences()
     }
 
     /// Set the given sequence index
@@ -104,7 +110,7 @@ impl PyEncoding {
     /// :class:`~tokenizers.Encoding`.
     #[pyo3(text_signature = "(self, sequence_id)")]
     fn set_sequence_id(&mut self, sequence_id: usize) {
-        self.encoding.set_sequence_id(sequence_id);
+        self.encoding.lock().unwrap().set_sequence_id(sequence_id);
     }
 
     /// The generated IDs
@@ -116,7 +122,7 @@ impl PyEncoding {
     ///     :obj:`List[int]`: The list of IDs
     #[getter]
     fn get_ids(&self) -> Vec<u32> {
-        self.encoding.get_ids().to_vec()
+        self.encoding.lock().unwrap().get_ids().to_vec()
     }
 
     /// The generated tokens
@@ -127,7 +133,7 @@ impl PyEncoding {
     ///     :obj:`List[str]`: The list of tokens
     #[getter]
     fn get_tokens(&self) -> Vec<String> {
-        self.encoding.get_tokens().to_vec()
+        self.encoding.lock().unwrap().get_tokens().to_vec()
     }
 
     /// The generated word indices.
@@ -170,7 +176,7 @@ impl PyEncoding {
     ///     A :obj:`List` of :obj:`Optional[int]`: A list of optional word index.
     #[getter]
     fn get_word_ids(&self) -> Vec<Option<u32>> {
-        self.encoding.get_word_ids().to_vec()
+        self.encoding.lock().unwrap().get_word_ids().to_vec()
     }
 
     /// The generated sequence indices.
@@ -183,7 +189,7 @@ impl PyEncoding {
     ///     A :obj:`List` of :obj:`Optional[int]`: A list of optional sequence index.
     #[getter]
     fn get_sequence_ids(&self) -> Vec<Option<usize>> {
-        self.encoding.get_sequence_ids()
+        self.encoding.lock().unwrap().get_sequence_ids()
     }
 
     /// The generated type IDs
@@ -195,7 +201,7 @@ impl PyEncoding {
     ///     :obj:`List[int]`: The list of type ids
     #[getter]
     fn get_type_ids(&self) -> Vec<u32> {
-        self.encoding.get_type_ids().to_vec()
+        self.encoding.lock().unwrap().get_type_ids().to_vec()
     }
 
     /// The offsets associated to each token
@@ -207,7 +213,7 @@ impl PyEncoding {
     ///     A :obj:`List` of :obj:`Tuple[int, int]`: The list of offsets
     #[getter]
     fn get_offsets(&self) -> Vec<(usize, usize)> {
-        self.encoding.get_offsets().to_vec()
+        self.encoding.lock().unwrap().get_offsets().to_vec()
     }
 
     /// The special token mask
@@ -218,7 +224,11 @@ impl PyEncoding {
     ///     :obj:`List[int]`: The special tokens mask
     #[getter]
     fn get_special_tokens_mask(&self) -> Vec<u32> {
-        self.encoding.get_special_tokens_mask().to_vec()
+        self.encoding
+            .lock()
+            .unwrap()
+            .get_special_tokens_mask()
+            .to_vec()
     }
 
     /// The attention mask
@@ -231,7 +241,7 @@ impl PyEncoding {
     ///    :obj:`List[int]`: The attention mask
     #[getter]
     fn get_attention_mask(&self) -> Vec<u32> {
-        self.encoding.get_attention_mask().to_vec()
+        self.encoding.lock().unwrap().get_attention_mask().to_vec()
     }
 
     /// A :obj:`List` of overflowing :class:`~tokenizers.Encoding`
@@ -246,6 +256,8 @@ impl PyEncoding {
     #[getter]
     fn get_overflowing(&self) -> Vec<PyEncoding> {
         self.encoding
+            .lock()
+            .unwrap()
             .get_overflowing()
             .clone()
             .into_iter()
@@ -267,7 +279,10 @@ impl PyEncoding {
     #[pyo3(signature = (word_index, sequence_index = 0))]
     #[pyo3(text_signature = "(self, word_index, sequence_index=0)")]
     fn word_to_tokens(&self, word_index: u32, sequence_index: usize) -> Option<(usize, usize)> {
-        self.encoding.word_to_tokens(word_index, sequence_index)
+        self.encoding
+            .lock()
+            .unwrap()
+            .word_to_tokens(word_index, sequence_index)
     }
 
     /// Get the offsets of the word at the given index in one of the input sequences.
@@ -283,7 +298,10 @@ impl PyEncoding {
     #[pyo3(signature = (word_index, sequence_index = 0))]
     #[pyo3(text_signature = "(self, word_index, sequence_index=0)")]
     fn word_to_chars(&self, word_index: u32, sequence_index: usize) -> Option<Offsets> {
-        self.encoding.word_to_chars(word_index, sequence_index)
+        self.encoding
+            .lock()
+            .unwrap()
+            .word_to_chars(word_index, sequence_index)
     }
 
     /// Get the index of the sequence represented by the given token.
@@ -299,7 +317,7 @@ impl PyEncoding {
     ///     :obj:`int`: The sequence id of the given token
     #[pyo3(text_signature = "(self, token_index)")]
     fn token_to_sequence(&self, token_index: usize) -> Option<usize> {
-        self.encoding.token_to_sequence(token_index)
+        self.encoding.lock().unwrap().token_to_sequence(token_index)
     }
 
     /// Get the offsets of the token at the given index.
@@ -316,7 +334,7 @@ impl PyEncoding {
     ///     :obj:`Tuple[int, int]`: The token offsets :obj:`(first, last + 1)`
     #[pyo3(text_signature = "(self, token_index)")]
     fn token_to_chars(&self, token_index: usize) -> Option<Offsets> {
-        let (_, offsets) = self.encoding.token_to_chars(token_index)?;
+        let (_, offsets) = self.encoding.lock().unwrap().token_to_chars(token_index)?;
         Some(offsets)
     }
 
@@ -334,7 +352,7 @@ impl PyEncoding {
     ///     :obj:`int`: The index of the word in the relevant input sequence.
     #[pyo3(text_signature = "(self, token_index)")]
     fn token_to_word(&self, token_index: usize) -> Option<u32> {
-        let (_, word_idx) = self.encoding.token_to_word(token_index)?;
+        let (_, word_idx) = self.encoding.lock().unwrap().token_to_word(token_index)?;
         Some(word_idx)
     }
 
@@ -351,7 +369,10 @@ impl PyEncoding {
     #[pyo3(signature = (char_pos, sequence_index = 0))]
     #[pyo3(text_signature = "(self, char_pos, sequence_index=0)")]
     fn char_to_token(&self, char_pos: usize, sequence_index: usize) -> Option<usize> {
-        self.encoding.char_to_token(char_pos, sequence_index)
+        self.encoding
+            .lock()
+            .unwrap()
+            .char_to_token(char_pos, sequence_index)
     }
 
     /// Get the word that contains the char at the given position in the input sequence.
@@ -367,7 +388,10 @@ impl PyEncoding {
     #[pyo3(signature = (char_pos, sequence_index = 0))]
     #[pyo3(text_signature = "(self, char_pos, sequence_index=0)")]
     fn char_to_word(&self, char_pos: usize, sequence_index: usize) -> Option<u32> {
-        self.encoding.char_to_word(char_pos, sequence_index)
+        self.encoding
+            .lock()
+            .unwrap()
+            .char_to_word(char_pos, sequence_index)
     }
 
     /// Pad the :class:`~tokenizers.Encoding` at the given length
@@ -422,6 +446,8 @@ impl PyEncoding {
             }
         }
         self.encoding
+            .lock()
+            .unwrap()
             .pad(length, pad_id, pad_type_id, &pad_token, direction);
         Ok(())
     }
@@ -453,7 +479,10 @@ impl PyEncoding {
             .into_pyerr::<exceptions::PyValueError>()),
         }?;
 
-        self.encoding.truncate(max_length, stride, tdir);
+        self.encoding
+            .lock()
+            .unwrap()
+            .truncate(max_length, stride, tdir);
         Ok(())
     }
 }

--- a/bindings/python/src/processors.rs
+++ b/bindings/python/src/processors.rs
@@ -171,8 +171,8 @@ impl PyPostProcessor {
         add_special_tokens: bool,
     ) -> PyResult<PyEncoding> {
         let final_encoding = ToPyResult(self.processor.process(
-            encoding.encoding.clone(),
-            pair.map(|e| e.encoding.clone()),
+            encoding.encoding.lock().unwrap().clone(),
+            pair.map(|e| e.encoding.lock().unwrap().clone()),
             add_special_tokens,
         ))
         .into_py()?;

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1402,8 +1402,8 @@ impl PyTokenizer {
         ToPyResult(
             self.tokenizer
                 .post_process(
-                    encoding.encoding.clone(),
-                    pair.map(|p| p.encoding.clone()),
+                    encoding.encoding.lock().unwrap().clone(),
+                    pair.map(|p| p.encoding.lock().unwrap().clone()),
                     add_special_tokens,
                 )
                 .map(|e| e.into()),

--- a/bindings/python/tests/bindings/test_encoding.py
+++ b/bindings/python/tests/bindings/test_encoding.py
@@ -108,12 +108,14 @@ class TestEncoding:
         assert pair.char_to_word(2, 1) == None
         assert pair.char_to_word(3, 1) == 1
 
+    @pytest.mark.thread_unsafe(reason="mutable operation on fixture that is shared between threads")
     def test_truncation(self, encodings):
         single, _ = encodings
         single.truncate(2, 1, "right")
         assert single.tokens == ["[CLS]", "i"]
         assert single.overflowing[0].tokens == ["i", "love"]
 
+    @pytest.mark.thread_unsafe(reason="mutable operation on fixture that is shared between threads")
     def test_invalid_truncate_direction(self, encodings):
         single, _ = encodings
         with pytest.raises(ValueError) as excinfo:

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -446,6 +446,7 @@ class TestTokenizer:
         output = tokenizer.post_process(encoding, pair_encoding)
         assert output.tokens == ["my", "pair", "[PAD]", "[PAD]"]
 
+    @pytest.mark.thread_unsafe(reason="mutates os.environ")
     def test_multiprocessing_with_parallelism(self):
         tokenizer = Tokenizer(BPE())
         multiprocessing_with_parallelism(tokenizer, False)

--- a/bindings/python/tests/bindings/test_trainers.py
+++ b/bindings/python/tests/bindings/test_trainers.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import pickle
+import uuid
 
 import pytest
 
@@ -150,14 +151,15 @@ class TestWordLevelTrainer:
 
 
 class TestUnigram:
-    def test_train(self, train_files):
+    def test_train(self, tmp_path, train_files):
         tokenizer = SentencePieceUnigramTokenizer()
         tokenizer.train(train_files["small"], show_progress=False)
 
-        filename = "tests/data/unigram_trained.json"
-        tokenizer.save(filename)
+        filename = f"tests/data/unigram_trained{uuid.uuid4()}.json"
+        tokenizer.save(str(filename))
         os.remove(filename)
 
+    @pytest.mark.thread_unsafe(reason="mutates os.environ")
     def test_train_parallelism_with_custom_pretokenizer(self, train_files):
         class GoodCustomPretok:
             def split(self, n, normalized):
@@ -183,7 +185,7 @@ class TestUnigram:
         assert isinstance(pickle.loads(pickle.dumps(trainers.UnigramTrainer())), trainers.UnigramTrainer)
 
     def test_train_with_special_tokens(self):
-        filename = "tests/data/dummy-unigram-special_tokens-train.txt"
+        filename = f"tests/data/dummy-unigram-special_tokens-train{uuid.uuid4()}.txt"
         with open(filename, "w") as f:
             f.write(
                 """
@@ -297,7 +299,7 @@ class TestUnigram:
         )
         tokenizer.train(files=[train_files["big"]], trainer=trainer)
 
-        tokenizer_json = os.path.join(DATA_PATH, "tokenizer.json")
+        tokenizer_json = os.path.join(DATA_PATH, f"tokenizer{uuid.uuid4()}.json")
         tokenizer.save(tokenizer_json)
 
         tokenizer.from_file(tokenizer_json)

--- a/bindings/python/tests/implementations/test_bert_wordpiece.py
+++ b/bindings/python/tests/implementations/test_bert_wordpiece.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tokenizers import BertWordPieceTokenizer
 
 from ..utils import bert_files, data_dir, multiprocessing_with_parallelism
@@ -39,6 +41,7 @@ class TestBertWordPieceTokenizer:
         assert output.offsets == [(0, 2), (3, 7), (8, 10), (11, 15), (0, 4)]
         assert output.type_ids == [0, 0, 0, 0, 1]
 
+    @pytest.mark.thread_unsafe(reason="mutates os.environ")
     def test_multiprocessing_with_parallelism(self, bert_files):
         tokenizer = BertWordPieceTokenizer.from_file(bert_files["vocab"])
         multiprocessing_with_parallelism(tokenizer, False)

--- a/bindings/python/tests/implementations/test_byte_level_bpe.py
+++ b/bindings/python/tests/implementations/test_byte_level_bpe.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tokenizers import ByteLevelBPETokenizer
 
 from ..utils import data_dir, multiprocessing_with_parallelism, roberta_files
@@ -84,6 +86,7 @@ class TestByteLevelBPE:
             "Ġdog",
         ]
 
+    @pytest.mark.thread_unsafe(reason="mutates OS.environ")
     def test_multiprocessing_with_parallelism(self, roberta_files):
         tokenizer = ByteLevelBPETokenizer.from_file(roberta_files["vocab"], roberta_files["merges"])
         multiprocessing_with_parallelism(tokenizer, False)

--- a/bindings/python/tests/implementations/test_char_bpe.py
+++ b/bindings/python/tests/implementations/test_char_bpe.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tokenizers import CharBPETokenizer
 
 from ..utils import data_dir, multiprocessing_with_parallelism, openai_files
@@ -44,6 +46,7 @@ class TestCharBPETokenizer:
         decoded = tokenizer.decode(tokenizer.encode("my name is john").ids)
         assert decoded == "my name is john"
 
+    @pytest.mark.thread_unsafe(reason="mutates os.environ")
     def test_multiprocessing_with_parallelism(self, openai_files):
         tokenizer = CharBPETokenizer.from_file(openai_files["vocab"], openai_files["merges"])
         multiprocessing_with_parallelism(tokenizer, False)

--- a/bindings/python/tests/implementations/test_sentencepiece.py
+++ b/bindings/python/tests/implementations/test_sentencepiece.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from tokenizers import SentencePieceBPETokenizer, SentencePieceUnigramTokenizer
@@ -14,9 +16,10 @@ class TestSentencePieceBPE:
 
 
 class TestSentencePieceUnigram:
-    def test_train(self, tmpdir):
-        p = tmpdir.mkdir("tmpdir").join("file.txt")
-        p.write("A first sentence\nAnother sentence\nAnd a last one")
+    def test_train(self, tmp_path_factory):
+        p = tmp_path_factory.mktemp("tmpdir") / "file.txt"
+        with open(p, "w") as f:
+            f.write("A first sentence\nAnother sentence\nAnd a last one")
 
         tokenizer = SentencePieceUnigramTokenizer()
         tokenizer.train(files=str(p), show_progress=False)
@@ -28,9 +31,10 @@ class TestSentencePieceUnigram:
             _ = tokenizer.encode("A sentence 🤗")
         assert str(excinfo.value) == "Encountered an unknown token but `unk_id` is missing"
 
-    def test_train_with_unk_token(self, tmpdir):
-        p = tmpdir.mkdir("tmpdir").join("file.txt")
-        p.write("A first sentence\nAnother sentence\nAnd a last one")
+    def test_train_with_unk_token(self, tmp_path_factory):
+        p = tmp_path_factory.mktemp("tmpdir") / "file.txt"
+        with open(p, "w") as f:
+            f.write("A first sentence\nAnother sentence\nAnd a last one")
 
         tokenizer = SentencePieceUnigramTokenizer()
         tokenizer.train(files=str(p), show_progress=False, special_tokens=["<unk>"], unk_token="<unk>")


### PR DESCRIPTION
This PR updates the tests to be runnable in a thread pool under pytest-run-parallel. It then makes use of pytest-run-parallel to do multithreaded testing on the free-threaded build in CI.

The updates to the tests are mostly to avoid sharing filesystem paths between test runners. I also marked all the multiprocessing tests as thread-unsafe because they rely on `fork` and they rely on mutating `os.environ`.

To avoid running into runtime borrow-checker errors, I wrapped the internal state of the `PyEncoder` pyclass in a `Mutex`. I don't think it's possible for any panics to happen while mutexes are locked that weren't already possible and in all cases I think it's correct to immediately propagate panics with `unlock()` rather than trying to handle poisoned mutexes.