### PR TITLE
Tokenizer: Add native async bindings, via py03-async-runtimes.

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -15,6 +15,9 @@ serde_json = "1.0"
 libc = "0.2"
 env_logger = "0.11"
 pyo3 = { version = "0.25", features = ["abi3", "abi3-py39", "py-clone"] }
+pyo3-async-runtimes = { version = "0.25", features = ["tokio-runtime"] }
+tokio = { version = "1.47.1", features = ["rt", "rt-multi-thread", "macros", "signal"] }
+once_cell = "1.19.0"
 numpy = "0.25"
 ndarray = "0.16"
 itertools = "0.14"

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -929,6 +929,56 @@ class Tokenizer:
 
         """
         pass
+    
+    async def async_encode_batch(self, input, is_pretokenized=False, add_special_tokens=True):
+        """
+        Asynchronously encode the given batch of inputs. This method can be used to
+        encode multiple sequences in parallel.
+
+        Args:
+            input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
+                A list of single sequences or pair sequences to encode. Each sequence
+                can be either raw text or pre-tokenized, according to the ``is_pretokenized``
+                argument:
+
+                - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
+                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
+
+            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+                Whether the input is already pre-tokenized
+
+            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+                Whether to add the special tokens
+
+        Returns:
+            A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
+        """
+        pass
+    
+    async def async_encode_batch_fast(self, input, is_pretokenized=False, add_special_tokens=True):
+        """
+        Asynchronously encode the given batch of inputs. This method is faster than
+        `async_encode_batch` because it doesn't keep track of offsets, they will be all zeros.
+
+        Args:
+            input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
+                A list of single sequences or pair sequences to encode. Each sequence
+                can be either raw text or pre-tokenized, according to the ``is_pretokenized``
+                argument:
+
+                - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
+                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
+
+            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+                Whether the input is already pre-tokenized
+
+            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+                Whether to add the special tokens
+
+        Returns:
+            A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
+        """
+        pass
 
     @property
     def encode_special_tokens(self):

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -725,6 +725,130 @@ class Tokenizer:
         """
         pass
 
+    def async_decode_batch(self, sequences, skip_special_tokens=True):
+        """
+        Decode a batch of ids back to their corresponding string
+
+        Args:
+            sequences (:obj:`List` of :obj:`List[int]`):
+                The batch of sequences we want to decode
+
+            skip_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+                Whether the special tokens should be removed from the decoded strings
+
+        Returns:
+            :obj:`List[str]`: A list of decoded strings
+        """
+        pass
+
+    def async_encode(self, sequence, pair=None, is_pretokenized=False, add_special_tokens=True):
+        """
+        Asynchronously encode the given input with character offsets.
+
+        This is an async version of encode that can be awaited in async Python code.
+
+        Example:
+            Here are some examples of the inputs that are accepted::
+
+                await async_encode("A single sequence")
+
+        Args:
+            sequence (:obj:`~tokenizers.InputSequence`):
+                The main input sequence we want to encode. This sequence can be either raw
+                text or pre-tokenized, according to the ``is_pretokenized`` argument:
+
+                - If ``is_pretokenized=False``: :class:`~tokenizers.TextInputSequence`
+                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedInputSequence`
+
+            pair (:obj:`~tokenizers.InputSequence`, `optional`):
+                An optional input sequence. The expected format is the same that for ``sequence``.
+
+            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+                Whether the input is already pre-tokenized
+
+            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+                Whether to add the special tokens
+
+        Returns:
+            :class:`~tokenizers.Encoding`: The encoded result
+
+        """
+        pass
+
+    def async_encode_batch(self, input, is_pretokenized=False, add_special_tokens=True):
+        """
+        Asynchronously encode the given batch of inputs with character offsets.
+
+        This is an async version of encode_batch that can be awaited in async Python code.
+
+        Example:
+            Here are some examples of the inputs that are accepted::
+
+                await async_encode_batch([
+                    "A single sequence",
+                    ("A tuple with a sequence", "And its pair"),
+                    [ "A", "pre", "tokenized", "sequence" ],
+                    ([ "A", "pre", "tokenized", "sequence" ], "And its pair")
+                ])
+
+        Args:
+            input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
+                A list of single sequences or pair sequences to encode. Each sequence
+                can be either raw text or pre-tokenized, according to the ``is_pretokenized``
+                argument:
+
+                - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
+                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
+
+            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+                Whether the input is already pre-tokenized
+
+            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+                Whether to add the special tokens
+
+        Returns:
+            A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
+
+        """
+        pass
+
+    def async_encode_batch_fast(self, input, is_pretokenized=False, add_special_tokens=True):
+        """
+        Asynchronously encode the given batch of inputs without tracking character offsets.
+
+        This is an async version of encode_batch_fast that can be awaited in async Python code.
+
+        Example:
+            Here are some examples of the inputs that are accepted::
+
+                await async_encode_batch_fast([
+                    "A single sequence",
+                    ("A tuple with a sequence", "And its pair"),
+                    [ "A", "pre", "tokenized", "sequence" ],
+                    ([ "A", "pre", "tokenized", "sequence" ], "And its pair")
+                ])
+
+        Args:
+            input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
+                A list of single sequences or pair sequences to encode. Each sequence
+                can be either raw text or pre-tokenized, according to the ``is_pretokenized``
+                argument:
+
+                - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
+                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
+
+            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+                Whether the input is already pre-tokenized
+
+            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+                Whether to add the special tokens
+
+        Returns:
+            A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
+
+        """
+        pass
+
     def decode(self, ids, skip_special_tokens=True):
         """
         Decode the given list of ids back to a string
@@ -927,56 +1051,6 @@ class Tokenizer:
         Returns:
             A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
 
-        """
-        pass
-    
-    async def async_encode_batch(self, input, is_pretokenized=False, add_special_tokens=True):
-        """
-        Asynchronously encode the given batch of inputs. This method can be used to
-        encode multiple sequences in parallel.
-
-        Args:
-            input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
-                A list of single sequences or pair sequences to encode. Each sequence
-                can be either raw text or pre-tokenized, according to the ``is_pretokenized``
-                argument:
-
-                - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
-                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
-
-            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
-                Whether the input is already pre-tokenized
-
-            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
-                Whether to add the special tokens
-
-        Returns:
-            A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
-        """
-        pass
-    
-    async def async_encode_batch_fast(self, input, is_pretokenized=False, add_special_tokens=True):
-        """
-        Asynchronously encode the given batch of inputs. This method is faster than
-        `async_encode_batch` because it doesn't keep track of offsets, they will be all zeros.
-
-        Args:
-            input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
-                A list of single sequences or pair sequences to encode. Each sequence
-                can be either raw text or pre-tokenized, according to the ``is_pretokenized``
-                argument:
-
-                - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
-                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
-
-            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
-                Whether the input is already pre-tokenized
-
-            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
-                Whether to add the special tokens
-
-        Returns:
-            A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
         """
         pass
 

--- a/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
@@ -258,6 +258,51 @@ class BaseTokenizer:
             raise ValueError("encode_batch: `inputs` can't be `None`")
 
         return self._tokenizer.encode_batch(inputs, is_pretokenized, add_special_tokens)
+    
+    async def async_encode_batch(
+        self,
+        inputs: List[EncodeInput],
+        is_pretokenized: bool = False,
+        add_special_tokens: bool = True,
+    ) -> List[Encoding]:
+        """Asynchronously encode a batch (tracks character offsets).
+
+        Args:
+            inputs: A list of single or pair sequences to encode.
+            is_pretokenized: Whether inputs are already pre-tokenized.
+            add_special_tokens: Whether to add special tokens.
+
+        Returns:
+            A list of Encoding.
+        """
+        if inputs is None:
+            raise ValueError("async_encode_batch: `inputs` can't be `None`")
+        # Exposed by the Rust bindings via pyo3_async_runtimes::tokio::future_into_py
+        return await self._tokenizer.async_encode_batch(
+            inputs, is_pretokenized, add_special_tokens
+        )
+
+    async def async_encode_batch_fast(
+        self,
+        inputs: List[EncodeInput],
+        is_pretokenized: bool = False,
+        add_special_tokens: bool = True,
+    ) -> List[Encoding]:
+        """Asynchronously encode a batch (no character offsets, faster).
+
+        Args:
+            inputs: A list of single or pair sequences to encode.
+            is_pretokenized: Whether inputs are already pre-tokenized.
+            add_special_tokens: Whether to add special tokens.
+
+        Returns:
+            A list of Encoding.
+        """
+        if inputs is None:
+            raise ValueError("async_encode_batch_fast: `inputs` can't be `None`")
+        return await self._tokenizer.async_encode_batch_fast(
+            inputs, is_pretokenized, add_special_tokens
+        )
 
     def decode(self, ids: List[int], skip_special_tokens: Optional[bool] = True) -> str:
         """Decode the given list of ids to a string sequence

--- a/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
@@ -258,7 +258,7 @@ class BaseTokenizer:
             raise ValueError("encode_batch: `inputs` can't be `None`")
 
         return self._tokenizer.encode_batch(inputs, is_pretokenized, add_special_tokens)
-    
+
     async def async_encode_batch(
         self,
         inputs: List[EncodeInput],
@@ -278,9 +278,7 @@ class BaseTokenizer:
         if inputs is None:
             raise ValueError("async_encode_batch: `inputs` can't be `None`")
         # Exposed by the Rust bindings via pyo3_async_runtimes::tokio::future_into_py
-        return await self._tokenizer.async_encode_batch(
-            inputs, is_pretokenized, add_special_tokens
-        )
+        return await self._tokenizer.async_encode_batch(inputs, is_pretokenized, add_special_tokens)
 
     async def async_encode_batch_fast(
         self,
@@ -300,9 +298,7 @@ class BaseTokenizer:
         """
         if inputs is None:
             raise ValueError("async_encode_batch_fast: `inputs` can't be `None`")
-        return await self._tokenizer.async_encode_batch_fast(
-            inputs, is_pretokenized, add_special_tokens
-        )
+        return await self._tokenizer.async_encode_batch_fast(inputs, is_pretokenized, add_special_tokens)
 
     def decode(self, ids: List[int], skip_special_tokens: Optional[bool] = True) -> str:
         """Decode the given list of ids to a string sequence

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -31,7 +31,7 @@ Source = "https://github.com/huggingface/tokenizers"
 
 
 [project.optional-dependencies]
-testing = ["pytest", "requests", "numpy", "datasets", "black==22.3", "ruff"]
+testing = ["pytest", "pytest-asyncio", "requests", "numpy", "datasets", "black==22.3", "ruff"]
 docs = ["sphinx", "sphinx_rtd_theme", "setuptools_rust"]
 dev = ["tokenizers[testing]"]
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -5,6 +5,19 @@
 
 extern crate tokenizers as tk;
 
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+// We create a global runtime that will be initialized once when first needed
+// This ensures we always have a runtime available for tokio::task::spawn_blocking
+static TOKIO_RUNTIME: Lazy<Arc<Runtime>> = Lazy::new(|| {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create global Tokio runtime");
+    Arc::new(rt)
+});
 mod decoders;
 mod encoding;
 mod error;

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -8,6 +8,7 @@ use pyo3::exceptions;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::*;
+use pyo3::IntoPyObject;
 use tk::models::bpe::BPE;
 use tk::tokenizer::{
     Model, PaddingDirection, PaddingParams, PaddingStrategy, PostProcessor, TokenizerImpl,
@@ -478,6 +479,83 @@ impl PyTokenizer {
 
     fn from_model(model: PyModel) -> Self {
         PyTokenizer::new(TokenizerImpl::new(model))
+    }
+
+    // Extract a pretokenized sequence into an owned Vec<String>
+    fn extract_pretok_seq(ob: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
+        if let Ok(seq) = ob.extract::<PyArrayUnicode>() {
+            return Ok(seq.0);
+        }
+        if let Ok(seq) = ob.extract::<PyArrayStr>() {
+            return Ok(seq.0);
+        }
+        if let Ok(list) = ob.downcast::<PyList>() {
+            return list.extract::<Vec<String>>();
+        }
+        if let Ok(tup) = ob.downcast::<PyTuple>() {
+            return tup.extract::<Vec<String>>();
+        }
+        Err(exceptions::PyTypeError::new_err(
+            "PreTokenizedInputSequence must be List[str] | Tuple[str] | np.ndarray[U] | np.ndarray[object[str]]",
+        ))
+    }
+
+    // Convert Python inputs into fully-owned EncodeInput<'static>
+    fn build_owned_encode_inputs(
+        items: &[Bound<'_, PyAny>],
+        is_pretokenized: bool,
+    ) -> PyResult<Vec<tk::EncodeInput<'static>>> {
+        let mut out = Vec::with_capacity(items.len());
+
+        for it in items {
+            if is_pretokenized {
+                // Pair?
+                if let Ok(tup) = it.downcast::<PyTuple>() {
+                    if tup.len() == 2 {
+                        let a = Self::extract_pretok_seq(&tup.get_item(0)?)?;
+                        let b = Self::extract_pretok_seq(&tup.get_item(1)?)?;
+                        out.push(tk::EncodeInput::Dual(a.into(), b.into()));
+                        continue;
+                    }
+                }
+                if let Ok(lst) = it.downcast::<PyList>() {
+                    if lst.len() == 2 {
+                        let a = Self::extract_pretok_seq(&lst.get_item(0)?)?;
+                        let b = Self::extract_pretok_seq(&lst.get_item(1)?)?;
+                        out.push(tk::EncodeInput::Dual(a.into(), b.into()));
+                        continue;
+                    }
+                }
+                // Single pretokenized
+                let a = Self::extract_pretok_seq(it)?;
+                out.push(tk::EncodeInput::Single(a.into()));
+            } else {
+                // Raw text: pair?
+                if let Ok(tup) = it.downcast::<PyTuple>() {
+                    if tup.len() == 2 {
+                        let a: String = tup.get_item(0)?.extract()?;
+                        let b: String = tup.get_item(1)?.extract()?;
+                        out.push(tk::EncodeInput::Dual(a.into(), b.into()));
+                        continue;
+                    }
+                }
+                if let Ok(lst) = it.downcast::<PyList>() {
+                    if lst.len() == 2
+                        && lst.get_item(0)?.downcast::<PyString>().is_ok()
+                        && lst.get_item(1)?.downcast::<PyString>().is_ok()
+                    {
+                        let a: String = lst.get_item(0)?.extract()?;
+                        let b: String = lst.get_item(1)?.extract()?;
+                        out.push(tk::EncodeInput::Dual(a.into(), b.into()));
+                        continue;
+                    }
+                }
+                // Single raw text
+                let s: String = it.extract()?;
+                out.push(tk::EncodeInput::Single(s.into()));
+            }
+        }
+        Ok(out)
     }
 }
 
@@ -1053,6 +1131,78 @@ impl PyTokenizer {
             .into()
         })
     }
+    /// Asynchronously encode the given batch of inputs with character offsets.
+    ///
+    /// This is an async version of encode_batch that can be awaited in async Python code.
+    ///
+    /// Example:
+    ///     Here are some examples of the inputs that are accepted::
+    ///
+    ///         await async_encode_batch([
+    ///             "A single sequence",
+    ///             ("A tuple with a sequence", "And its pair"),
+    ///             [ "A", "pre", "tokenized", "sequence" ],
+    ///             ([ "A", "pre", "tokenized", "sequence" ], "And its pair")
+    ///         ])
+    ///
+    /// Args:
+    ///     input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
+    ///         A list of single sequences or pair sequences to encode. Each sequence
+    ///         can be either raw text or pre-tokenized, according to the ``is_pretokenized``
+    ///         argument:
+    ///
+    ///         - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
+    ///         - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
+    ///
+    ///     is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+    ///         Whether the input is already pre-tokenized
+    ///
+    ///     add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+    ///         Whether to add the special tokens
+    ///
+    /// Returns:
+    ///     A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
+    ///
+    #[pyo3(name = "async_encode_batch", signature = (input, is_pretokenized = false, add_special_tokens = true))]
+    #[pyo3(text_signature = "(self, input, is_pretokenized=False, add_special_tokens=True)")]
+    fn async_encode_batch<'py>(
+        &self,
+        py: Python<'py>,
+        input: Vec<Bound<'_, PyAny>>,
+        is_pretokenized: bool,
+        add_special_tokens: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        // Fully own the inputs before leaving the GIL/thread
+        let owned_items = Self::build_owned_encode_inputs(&input, is_pretokenized)?;
+
+        let tokenizer = self.tokenizer.clone();
+        let rt = crate::TOKIO_RUNTIME.clone();
+
+        let fut = py.allow_threads(|| async move {
+            let result = rt
+                .spawn_blocking(move || {
+                    tokenizer
+                        .encode_batch_char_offsets(owned_items, add_special_tokens)
+                        .map(|encs| encs.into_iter().map(PyEncoding::from).collect::<Vec<_>>())
+                })
+                .await
+                .unwrap();
+
+            // Convert to a Python object directly rather than going through ToPyResult
+            match result {
+                Ok(encodings) => Python::with_gil(|py| {
+                    let obj: PyObject = encodings
+                        .into_pyobject(py)? // Vec<PyEncoding> -> Bound<'py, PyList>
+                        .into_any() // Bound<'py, PyAny>
+                        .unbind(); // Py<PyAny> a.k.a. PyObject (owned)
+                    Ok(obj)
+                }),
+                Err(e) => Err(exceptions::PyException::new_err(e.to_string())),
+            }
+        });
+
+        pyo3_async_runtimes::tokio::future_into_py(py, fut)
+    }
 
     /// Encode the given batch of inputs. This method is faster than `encode_batch`
     /// because it doesn't keep track of offsets, they will be all zeros.
@@ -1113,6 +1263,77 @@ impl PyTokenizer {
         })
     }
 
+    /// Asynchronously encode the given batch of inputs without tracking character offsets.
+    ///
+    /// This is an async version of encode_batch_fast that can be awaited in async Python code.
+    ///
+    /// Example:
+    ///     Here are some examples of the inputs that are accepted::
+    ///
+    ///         await async_encode_batch_fast([
+    ///             "A single sequence",
+    ///             ("A tuple with a sequence", "And its pair"),
+    ///             [ "A", "pre", "tokenized", "sequence" ],
+    ///             ([ "A", "pre", "tokenized", "sequence" ], "And its pair")
+    ///         ])
+    ///
+    /// Args:
+    ///     input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
+    ///         A list of single sequences or pair sequences to encode. Each sequence
+    ///         can be either raw text or pre-tokenized, according to the ``is_pretokenized``
+    ///         argument:
+    ///
+    ///         - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
+    ///         - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
+    ///
+    ///     is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+    ///         Whether the input is already pre-tokenized
+    ///
+    ///     add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+    ///         Whether to add the special tokens
+    ///
+    /// Returns:
+    ///     A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
+    ///
+    #[pyo3(name = "async_encode_batch_fast", signature = (input, is_pretokenized = false, add_special_tokens = true))]
+    #[pyo3(text_signature = "(self, input, is_pretokenized=False, add_special_tokens=True)")]
+    fn async_encode_batch_fast<'py>(
+        &self,
+        py: Python<'py>,
+        input: Vec<Bound<'_, PyAny>>,
+        is_pretokenized: bool,
+        add_special_tokens: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let owned_items = Self::build_owned_encode_inputs(&input, is_pretokenized)?;
+
+        let tokenizer = self.tokenizer.clone();
+        let rt = crate::TOKIO_RUNTIME.clone();
+        let fut = py.allow_threads(|| async move {
+            let result = rt
+                .spawn_blocking(move || {
+                    tokenizer
+                        .encode_batch_fast(owned_items, add_special_tokens)
+                        .map(|encs| encs.into_iter().map(PyEncoding::from).collect::<Vec<_>>())
+                })
+                .await
+                .unwrap();
+
+            // Convert to a Python object directly rather than going through ToPyResult
+            match result {
+                Ok(encodings) => Python::with_gil(|py| {
+                    let obj: PyObject = encodings
+                        .into_pyobject(py)? // Vec<PyEncoding> -> Bound<'py, PyList>
+                        .into_any() // Bound<'py, PyAny>
+                        .unbind(); // Py<PyAny> a.k.a. PyObject (owned)
+                    Ok(obj)
+                }),
+                Err(e) => Err(exceptions::PyException::new_err(e.to_string())),
+            }
+        });
+
+        pyo3_async_runtimes::tokio::future_into_py(py, fut)
+    }
+
     /// Decode the given list of ids back to a string
     ///
     /// This is used to decode anything coming back from a Language Model
@@ -1155,6 +1376,52 @@ impl PyTokenizer {
             let slices = sequences.iter().map(|v| &v[..]).collect::<Vec<&[u32]>>();
             ToPyResult(self.tokenizer.decode_batch(&slices, skip_special_tokens)).into()
         })
+    }
+
+    /// Decode a batch of ids back to their corresponding string
+    ///
+    /// Args:
+    ///     sequences (:obj:`List` of :obj:`List[int]`):
+    ///         The batch of sequences we want to decode
+    ///
+    ///     skip_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+    ///         Whether the special tokens should be removed from the decoded strings
+    ///
+    /// Returns:
+    ///     :obj:`List[str]`: A list of decoded strings
+    #[pyo3(name = "async_decode_batch", signature = (sequences, skip_special_tokens = true))]
+    #[pyo3(text_signature = "(self, sequences, skip_special_tokens=True)")]
+    fn async_decode_batch<'py>(
+        &self,
+        py: Python<'py>,
+        sequences: Vec<Vec<u32>>,
+        skip_special_tokens: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let tokenizer = self.tokenizer.clone();
+        let rt = crate::TOKIO_RUNTIME.clone();
+
+        let fut = py.allow_threads(|| async move {
+            let result = rt
+                .spawn_blocking(move || {
+                    let slices = sequences.iter().map(|v| &v[..]).collect::<Vec<&[u32]>>();
+                    tokenizer.decode_batch(&slices, skip_special_tokens)
+                })
+                .await
+                .unwrap();
+
+            match result {
+                Ok(decoded_strings) => Python::with_gil(|py| {
+                    let obj: PyObject = decoded_strings
+                        .into_pyobject(py)? // Vec<String> -> Bound<'py, PyList>
+                        .into_any() // Bound<'py, PyAny>
+                        .unbind(); // Py<PyAny> a.k.a. PyObject (owned)
+                    Ok(obj)
+                }),
+                Err(e) => Err(exceptions::PyException::new_err(e.to_string())),
+            }
+        });
+
+        pyo3_async_runtimes::tokio::future_into_py(py, fut)
     }
 
     /// Convert the given token to its corresponding id if it exists

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -625,7 +625,7 @@ class TestAsyncTokenizer:
 
     def setup_method(self):
         """Setup a basic tokenizer before each test."""
-        self.tokenizer = Tokenizer.from_pretrained("openai/gpt-oss-20b")
+        self.tokenizer = Tokenizer.from_pretrained("hf-internal-testing/gpt-oss-20b")
 
     async def _compare_sync_async(self, input_data, is_pretokenized=False, add_special_tokens=True):
         """Helper to compare sync and async results for both normal and fast encoding."""

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -842,7 +842,7 @@ class TestAsyncTokenizer:
             await asyncio.gather(*[encode_sync_with_executor(i) for i in range(2048)])
             await asyncio.gather(*[encode_async(i) for i in range(2048)])
 
-            for n_tasks in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]:
+            for n_tasks in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]:
                 # Measure sync performance with pre-initialized executor
                 # Warm up
                 await asyncio.gather(*[encode_sync_with_executor(i) for i in range(10)])

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -973,8 +973,3 @@ class TestAsyncTokenizer:
         finally:
             # Make sure we shut down the executor properly
             executor.shutdown(wait=False)
-
-        # assert async_time < sync_time, ("Async processing was faster than sync processing")
-        # assert any(a < s for a, s in zip(results_async, results_sync)), (
-        #     "Async processing was faster than sync processing"
-        # )

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -975,6 +975,6 @@ class TestAsyncTokenizer:
             executor.shutdown(wait=False)
 
         # assert async_time < sync_time, ("Async processing was faster than sync processing")
-        assert any(a < s for a, s in zip(results_async, results_sync)), (
-            "Async processing was faster than sync processing"
-        )
+        # assert any(a < s for a, s in zip(results_async, results_sync)), (
+        #     "Async processing was faster than sync processing"
+        # )

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -2,7 +2,7 @@ import pickle
 import concurrent.futures
 import pytest
 import numpy as np
-import asyncio 
+import asyncio
 from tokenizers import AddedToken, Encoding, Tokenizer
 from tokenizers.implementations import BertWordPieceTokenizer
 from tokenizers.models import BPE, Model, Unigram
@@ -622,18 +622,17 @@ class TestTokenizerRepr:
 
 class TestAsyncTokenizer:
     """Tests for async methods of the Tokenizer class."""
-    
+
     def setup_method(self):
         """Setup a basic tokenizer before each test."""
-        self.tokenizer = Tokenizer(BPE())
-        self.tokenizer.add_tokens(["my", "name", "is", "john", "pair", "longer"])
-    
+        self.tokenizer = Tokenizer.from_pretrained("openai/gpt-oss-20b")
+
     async def _compare_sync_async(self, input_data, is_pretokenized=False, add_special_tokens=True):
         """Helper to compare sync and async results for both normal and fast encoding."""
         # Normal encoding
         sync_result = self.tokenizer.encode_batch(input_data, is_pretokenized, add_special_tokens)
         async_result = await self.tokenizer.async_encode_batch(input_data, is_pretokenized, add_special_tokens)
-        
+
         assert len(sync_result) == len(async_result)
         for s, a in zip(sync_result, async_result):
             assert s.tokens == a.tokens
@@ -642,11 +641,13 @@ class TestAsyncTokenizer:
             assert s.attention_mask == a.attention_mask
             assert s.special_tokens_mask == a.special_tokens_mask
             assert s.type_ids == a.type_ids
-        
+
         # Fast encoding
         sync_fast_result = self.tokenizer.encode_batch_fast(input_data, is_pretokenized, add_special_tokens)
-        async_fast_result = await self.tokenizer.async_encode_batch_fast(input_data, is_pretokenized, add_special_tokens)
-        
+        async_fast_result = await self.tokenizer.async_encode_batch_fast(
+            input_data, is_pretokenized, add_special_tokens
+        )
+
         assert len(sync_fast_result) == len(async_fast_result)
         for s, a in zip(sync_fast_result, async_fast_result):
             assert s.tokens == a.tokens
@@ -654,19 +655,28 @@ class TestAsyncTokenizer:
             assert s.attention_mask == a.attention_mask
             assert s.special_tokens_mask == a.special_tokens_mask
             assert s.type_ids == a.type_ids
-    
+
     @pytest.mark.asyncio
     async def test_basic_encoding(self):
         """Test basic encoding functionality."""
         # Single sequences
         await self._compare_sync_async(["my name is john", "my pair"])
-        
+
         # Pair sequences
         await self._compare_sync_async([("my name", "is john"), ("my", "pair")])
-        
+
         # Empty batch
         await self._compare_sync_async([])
 
+    @pytest.mark.asyncio
+    async def test_encode(self):
+        out = await self.tokenizer.async_encode("my name is john", "my pair")
+        no_async_out = self.tokenizer.encode("my name is john", "my pair")
+        assert out.ids == no_async_out.ids
+
+        out = await self.tokenizer.async_encode("my name is john")
+        no_async_out = self.tokenizer.encode("my name is john")
+        assert out.ids == no_async_out.ids
 
     @pytest.mark.asyncio
     async def test_with_special_tokens(self):
@@ -676,14 +686,14 @@ class TestAsyncTokenizer:
             single=["[CLS]", "$0", "[SEP]"],
             pair=["[CLS]", "$A", "[SEP]", "$B", "[SEP]"],
             special_tokens=[
-                ("[CLS]", self.tokenizer.token_to_id("[CLS]")), 
-                ("[SEP]", self.tokenizer.token_to_id("[SEP]"))
+                ("[CLS]", self.tokenizer.token_to_id("[CLS]")),
+                ("[SEP]", self.tokenizer.token_to_id("[SEP]")),
             ],
         )
-        
+
         # With special tokens
         await self._compare_sync_async(["my name is john", "my pair"], add_special_tokens=True)
-        
+
         # Without special tokens
         await self._compare_sync_async(["my name is john", "my pair"], add_special_tokens=False)
 
@@ -692,10 +702,10 @@ class TestAsyncTokenizer:
         """Test with truncation and padding enabled."""
         self.tokenizer.enable_truncation(2)
         self.tokenizer.enable_padding(length=4)
-        
+
         # Single sequences
         await self._compare_sync_async(["my name is john", "pair longer"])
-        
+
         # Pair sequences
         await self._compare_sync_async([("my name", "is john"), ("pair", "longer")])
 
@@ -704,13 +714,13 @@ class TestAsyncTokenizer:
         """Test with various input formats."""
         # Lists
         await self._compare_sync_async(["my name", "is john"])
-        
+
         # Tuples
         await self._compare_sync_async(("my name", "is john"))
-        
+
         # Numpy arrays
         # await self._compare_sync_async(np.array(["my name", "is john"]))
-        
+
         # Mixed pairs
         await self._compare_sync_async([("my name", "is john"), ["my", "pair"]])
 
@@ -720,14 +730,14 @@ class TestAsyncTokenizer:
         # Invalid input type for single item
         with pytest.raises(TypeError):
             await self.tokenizer.async_encode_batch(123)
-            
+
         with pytest.raises(TypeError):
             self.tokenizer.encode_batch(123)
-        
+
         # Invalid pre-tokenized input
         with pytest.raises(TypeError):
             await self.tokenizer.async_encode_batch("my name", is_pretokenized=True)
-            
+
         with pytest.raises(TypeError):
             self.tokenizer.encode_batch("my name", is_pretokenized=True)
 
@@ -736,21 +746,21 @@ class TestAsyncTokenizer:
         """Test concurrent encoding operations."""
         # Create some significant workload
         large_batch = ["my name is john " * 50] * 20
-        
+
         # Run multiple encoding operations concurrently
         tasks = [
             self.tokenizer.async_encode_batch(large_batch),
             self.tokenizer.async_encode_batch_fast(large_batch),
             self.tokenizer.async_encode_batch(large_batch),
         ]
-        
+
         # They should all complete successfully
         results = await asyncio.gather(*tasks)
-        
+
         # Verify results
         assert len(results) == 3
         assert all(len(result) == 20 for result in results)
-        
+
     @pytest.mark.asyncio
     async def test_decode(self):
         tokenizer = Tokenizer(BPE())
@@ -759,10 +769,10 @@ class TestAsyncTokenizer:
         # Can decode single sequences
         output = tokenizer.decode([0, 1, 2, 3])
         assert output == "my name is john"
-        
+
         output = tokenizer.decode_batch([[0, 1, 2, 3], [4]])
         assert output == ["my name is john", "pair"]
-        
+
         output = await tokenizer.async_decode_batch([[0, 1, 2, 3], [4]])
         assert output == ["my name is john", "pair"]
 
@@ -770,11 +780,11 @@ class TestAsyncTokenizer:
     async def test_large_batch(self):
         """Test encoding a large batch of sequences."""
         large_batch = ["my name is john"] * 1000
-        
+
         # Encode large batch both ways
         async_result = await self.tokenizer.async_encode_batch_fast(large_batch)
         sync_result = self.tokenizer.encode_batch_fast(large_batch)
-        
+
         # Results should be identical
         assert len(async_result) == len(sync_result)
         assert all(a.tokens == s.tokens for a, s in zip(async_result[:10], sync_result[:10]))
@@ -785,7 +795,7 @@ class TestAsyncTokenizer:
         # Single numpy array
         input_array = np.array(["my name", "is john", "pair longer"])
         await self._compare_sync_async(input_array)
-        
+
         # Pre-tokenized numpy array
         pretok_array = np.array([["my", "name"], ["is", "john"]], dtype=object)
         await self._compare_sync_async(pretok_array, is_pretokenized=True)
@@ -801,38 +811,37 @@ class TestAsyncTokenizer:
     async def test_performance_comparison(self):
         """Compare performance between sync and async methods (informational)."""
         # Create a large batch for performance comparison
-        large_batch = ["short text"]
+        large_batch = [
+            "short text",
+            "Sometimes it helps to have a better idea",
+            "More short",
+            "Let's not delve into that habbit sir",
+            "I believe we can get to",
+            "I am going to do it. I have made up my mind. These are the first few words of the new… the best … the Longest Text In The Entire History Of The Known Universe! This Has To Have Over 35,000 words the beat the current world record set by that person who made that flaming chicken handbooky thingy. I might just be saying random things the whole time I type in this so you might get confused a lot. I just discovered something terrible. autocorrect is on!! no!!! this has to be crazy, so I will have to break all the English language rules and the basic knowledge of the average human being. I am not an average human being, however I am special. no no no, not THAT kind of special ;). Why do people send that wink face! it always gives me nightmares! it can make a completely normal sentence creepy. imagine you are going to a friend’s house, so you text this: [ see you soon 🙂 ] seems normal, right? But what is you add the word semi to that colon? (Is that right? or is it the other way around) what is you add a lorry to that briquettes? (Semi-truck to that coal-on) anyway, back to the point: [ see you soon 😉 ]THAT IS JUST SO CREEPY! is that really your friend, or is it a creepy stalker watching your every move? Or even worse, is it your friend who is a creepy stalker? maybe you thought it was your friend, but it was actually your fri end (let me explain: you are happily in McDonalds, getting fat while eating yummy food and some random dude walks up and blots out the sun (he looks like a regular here) you can’t see anything else than him, so you can’t try to avoid eye contact. he finishes eating his cheeseburger (more like horseburgher(I learned that word from the merchant of Venice(which is a good play(if you can understand it(I can cause I got a special book with all the words in readable English written on the side of the page(which is kinda funny because Shakespeare was supposed to be a good poet but no-one can understand him(and he’s racist in act 2 scene1 of the play too))))))) and sits down beside you , like you are old pals (you’ve never met him before but he looks like he could be in some weird cult) he clears his throat and asks you a very personal question. “can i have some French fries?” (I don’t know why there called French fries when I’ve never seen a French person eat fries! all they eat it is stuff like baguettes and crêpes and rats named ratty-two-ee which is a really fun game on the PlayStation 2) And you think {bubbly cloud thinking bubble} “Hahahahahhahahahahahahahaha!!!!!!!!!!!! Hehheheheheh…..heeeheehe..hehe… sigh. I remember that i was just about to eat one of my fries when I noticed something mushy and moist and [insert gross color like green or brown] on the end of one of my fries! now I can give it to this NERD!! ” (yes he is a nerd because all he does all day is watch the extended editions of the hobbit, lord of the rings and star wars and eat fat cakes (what the heck is a fat cake? I think it might be like a Twinkie or something)and twinkies(wow so is doesn’t really matter which is which because he eats both(i may have just done that so I didn’t have to Google what a fat cake is (right now I am typing on my iPhone 3gs anyway, which has a broken antenna so i can’t get internet anyway (it’s actually a really funny story that i’ll tell you sometime)))and sit in his man cave with his friend named Joe (an ACTUAL friend, not a fri end)and all Joe does is watch sports like football with bob and all bob does is gamble ferociously (don’t ask(it means he buys all those bags of chips that say “win a free monkey or something if you find a banana in your bag*”(if there is a little star it means there is fine print so I always check the back of the package) *flips over the package* okay, it says: “one of our workers accidentally threw a banana in the packing machine and we don’t want to get sued so we did this promotion thing” cool. Oh wow, this is salt and vinegar! my favourite! i hate cheese and onion.))and that’s pretty much his life, he lives in Jamaica with Naruto and his friends) so you give him that gross fri end he throws up all over you and me and the worker behind the counter who was still making an onion, and THAT is the story of the fri end, not a friend who somehow remembered your name and your phone number / email so he could text you saying he would come to your house soon. *finally takes a breath after typing a few hundred words about fri-ends* so what now? i know, i know, you think i ramble too much and use too many brackets (i don’t) but now i am going to talk about my amAZEing day. first i woke up, ate choco pops for breakfast even tho i always hate it when people say that cause i get jealous and super hungry. then i… umm… yea! that was my day. you know that other person i mentioned before? that flaming chicken person? WELL. i will steal something from that person but do it better. i will… drum roll please … badabadabadabadabadabadabummmmmmmmmmmchshchshchshchshbadabadboumboumpoopoopichypichypichypowpow-crash! *a drum roll was just playing in the background* that drumroll was so long i forget what i was talking about. *scrolls up to see what he was writing about* oh yea! i will make my own FLAMING CHICKEN HANDBOOK! what things do i like? instead of flaming it could be rainbow, instead of chicken it could be fluffysheep and instead of handbook it could be handbook (not very creative, i know) but the total complete name is now to rainbow fluffysheep handbook! to make life easier for you guys, instead of taking random rules out of book willy nilly, i will take them out using my favourite numbers! so, section 5040 of the rainbow fluffysheep handbook states that the king of all oddly coloured farm animals (thats me!) is allowed to tell you any part out of this book randomly or if it is his one of his favorite numbers! 5040 is a great number because it is divisible by 60 integers which i don’t know. i’m tired. it is 10:41 and i am getting sleepy… hey hey hey! an intruder! remember that from pokepals rulers of time and darkness or something like that! with piplup and sunflora and chimchar! whaoh piplup is really hard to write on a tiny qwerty keyboard! try it! i realised that asdf is actually written in order on the qwerty keyboard! (just in case you didn’t know, asdf is an amazing short video clips cartoony thing on youtube i first learned bout on flipnote hatena, which is now shut down 😦 ) what if one day they get rid of the qwerty keyboard completely! i will type it out for you just in case one day they get rid of it.",
+        ]
         results_sync = []
         results_async = []
-        
+
         # Pre-initialize a thread pool executor with a reasonable number of workers
         # This avoids the overhead of creating the pool for each task
-        
 
         try:
-            executor = concurrent.futures.ThreadPoolExecutor(
-                max_workers=2048
-            )
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=2048)
             loop = asyncio.get_running_loop()
 
             async def encode_sync_with_executor(_):
                 # Use the pre-initialized executor
-                return await loop.run_in_executor(
-                    executor, 
-                    lambda: self.tokenizer.encode_batch_fast(large_batch)
-                )
-                
+                return await loop.run_in_executor(executor, lambda: self.tokenizer.encode_batch_fast(large_batch))
+
             async def encode_to_thread_sync(_):
-                return await asyncio.to_thread(
-                    self.tokenizer.encode_batch_fast, large_batch
-                )
-            
+                return await asyncio.to_thread(self.tokenizer.encode_batch_fast, large_batch)
+
             async def encode_async(_):
                 return await self.tokenizer.async_encode_batch_fast(large_batch)
-            
+
             await asyncio.gather(*[encode_sync_with_executor(i) for i in range(2048)])
             await asyncio.gather(*[encode_async(i) for i in range(2048)])
-            
+
             for n_tasks in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]:
                 # Measure sync performance with pre-initialized executor
                 # Warm up
@@ -846,13 +855,13 @@ class TestAsyncTokenizer:
                 # Measure async performance
                 # Warm up
                 await asyncio.gather(*[encode_async(i) for i in range(10)])
-                
+
                 # Actual measurement
                 time.sleep(0.03)
                 start = time.perf_counter()
                 await asyncio.gather(*[encode_async(i) for i in range(n_tasks)])
                 async_time = time.perf_counter() - start
-                
+
                 # Log times
                 print(f"sync vs async processing times: {sync_time:.4f}s vs {async_time:.4f}s for {n_tasks} tasks")
                 results_sync.append(sync_time)
@@ -862,4 +871,6 @@ class TestAsyncTokenizer:
             executor.shutdown(wait=False)
 
         # assert async_time < sync_time, ("Async processing was faster than sync processing")
-        assert any(a < s for a, s in zip(results_async, results_sync)), ("Async processing was faster than sync processing")
+        assert any(a < s for a, s in zip(results_async, results_sync)), (
+            "Async processing was faster than sync processing"
+        )

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -172,6 +172,23 @@ impl WordPiece {
         Ok(vocab)
     }
 
+    pub fn read_bytes(vocab: &[u8]) -> Result<Vocab> {
+        let file = BufReader::new(vocab);
+
+        let mut vocab = HashMap::new();
+        for (index, line) in file.lines().enumerate() {
+            let line = line?;
+            vocab.insert(line.trim_end().to_owned(), index as u32);
+        }
+
+        Ok(vocab)
+    }
+
+    pub fn from_bytes<P: AsRef<[u8]>>(bytes: P) -> Result<Self> {
+        let tokenizer = serde_json::from_slice(bytes.as_ref())?;
+        Ok(tokenizer)
+    }
+
     /// Initialize a `WordPiece` model from a vocab mapping file.
     pub fn from_file(vocab: &str) -> WordPieceBuilder {
         WordPiece::builder().files(vocab.to_owned())

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -175,7 +175,7 @@ impl WordPiece {
     pub fn read_bytes(vocab: &[u8]) -> Result<Vocab> {
         let file = BufReader::new(vocab);
 
-        let mut vocab = HashMap::new();
+        let mut vocab = AHashMap::new();
         for (index, line) in file.lines().enumerate() {
             let line = line?;
             vocab.insert(line.trim_end().to_owned(), index as u32);


### PR DESCRIPTION
This PR adds native support via py03-async bindings. https://github.com/PyO3/pyo3-async-runtimes as an extra: 
```
pip install tokenizers[async]
```
gives access to:
```python
from tokenizers import Tokenizer
tokenizer = Tokenizer.from_pretrained("gpt2") 

out = await tokenizer.async_encode("Hey how are you?")
```


### Why is this relevant:
This is mostly relevant for online-inference (vllm, sglang, trt-llm, ..) that have only 1 python thread. 
A common scenario, is that e.g. few users will request very long input (e.g 160k tokens), which typically will take >0.5s to process. 

 A solution is to use the `batch_encode()` py03 api, which releases GIL.  Since the operation is still blocking, you would still starve the asyncio python runtime, which has only 1 thread, for a single task. 
 Relive would be the use of e.g. ray workers, or threadpools.

Quote: vLLM docs: https://docs.vllm.ai/en/v0.8.3/serving/openai_compatible_server.html
```
--tokenizer-pool-size
Size of tokenizer pool to use for asynchronous tokenization. If 0, will use synchronous tokenization.

Default: 0

--tokenizer-pool-type
Type of tokenizer pool to use for asynchronous tokenization. Ignored if tokenizer_pool_size is 0.

Default: “ray”

--tokenizer-pool-extra-config
Extra config for tokenizer pool. This should be a JSON string that will be parsed into a dictionary. Ignored if tokenizer_pool_size is 0.
```

The dependency of ray is much heavier than e.g. py03. For e.g. a small project of mine (github.com/michaelfeil/infinity), it seems overkill.

Summary:
- benefits: async training
- benefits: inference server
- not interesting for: pretraining, dataset preprocessing, torch dataloader etc.

### How is it implemented
I use the same approach that has been tested in py03 here: https://github.com/basetenlabs/truss/tree/main/baseten-performance-client/python_bindings. 
The py03_async runtime requires a non-main thread rust runtime to be initialized. This is done via LazyInit. 
https://github.com/PyO3/pyo3-async-runtimes 

### Performance:
Performance is okay ish. Probably better than the current pools, but worse than the sync bindings. If you have many threads available, and can contend your gil without running the gpu in the same pid, its propably faster

Below a example of what you need to do in async inference endinges;

```
await loop.run_in_executor(
                    executor, 
                    lambda: self.tokenizer.encode_batch_fast(large_batch)
                )
```


```
try:
            executor = concurrent.futures.ThreadPoolExecutor(
                max_workers=2048
            )
            loop = asyncio.get_running_loop()

            async def encode_sync_with_executor(_):
                # Use the pre-initialized executor
                return await loop.run_in_executor(
                    executor, 
                    lambda: self.tokenizer.encode_batch_fast(large_batch)
                )
                
            async def encode_to_thread_sync(_):
                return await asyncio.to_thread(
                    self.tokenizer.encode_batch_fast, large_batch
                )
            
            async def encode_async(_):
                return await self.tokenizer.async_encode_batch_fast(large_batch)
            
            await asyncio.gather(*[encode_sync_with_executor(i) for i in range(2048)])
            await asyncio.gather(*[encode_async(i) for i in range(2048)])
            
            for n_tasks in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]:
                # Measure sync performance with pre-initialized executor
                # Warm up
                await asyncio.gather(*[encode_sync_with_executor(i) for i in range(10)])
                time.sleep(0.03)
                # Actual measurement
                start = time.perf_counter()
                await asyncio.gather(*[encode_sync_with_executor(i) for i in range(n_tasks)])
                sync_time = time.perf_counter() - start

                # Measure async performance
                # Warm up
                await asyncio.gather(*[encode_async(i) for i in range(10)])
                
                # Actual measurement
                time.sleep(0.03)
                start = time.perf_counter()
                await asyncio.gather(*[encode_async(i) for i in range(n_tasks)])
                async_time = time.perf_counter() - start
                
                # Log times
                print(f"sync vs async processing times: {sync_time:.4f}s vs {async_time:.4f}s for {n_tasks} tasks")
                results_sync.append(sync_time)
                results_async.append(async_time)
        finally:
            # Make sure we shut down the executor properly
            executor.shutdown(wait=False)
```

```
sync vs async processing times: 0.0003s vs 0.0004s for 1 tasks
sync vs async processing times: 0.0004s vs 0.0005s for 2 tasks
sync vs async processing times: 0.0004s vs 0.0007s for 4 tasks
sync vs async processing times: 0.0014s vs 0.0011s for 8 tasks
sync vs async processing times: 0.0028s vs 0.0022s for 16 tasks
sync vs async processing times: 0.0057s vs 0.0040s for 32 tasks
sync vs async processing times: 0.0097s vs 0.0065s for 64 tasks
sync vs async processing times: 0.0172s vs 0.0127s for 128 tasks
sync vs async processing times: 0.0324s vs 0.0293s for 256 tasks
sync vs async processing times: 0.0528s vs 0.0487s for 512 tasks
sync vs async processing times: 0.1549s vs 0.0960s for 1024 tasks
sync vs async processing times: 0.3044s vs 0.1846s for 2048 tasks
```

#1797 cc @ArthurZucker 
