### PR TITLE
mismatch in wordpiece vocab to use AHashMap instead of HashMap

### DIFF
--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -175,7 +175,7 @@ impl WordPiece {
     pub fn read_bytes(vocab: &[u8]) -> Result<Vocab> {
         let file = BufReader::new(vocab);
 
-        let mut vocab = HashMap::new();
+        let mut vocab = AHashMap::new();
         for (index, line) in file.lines().enumerate() {
             let line = line?;
             vocab.insert(line.trim_end().to_owned(), index as u32);


### PR DESCRIPTION
The wordpiece module’s vocab variable is currently a std::collections::HashMap, but the function expects an ahash::AHashMap. This mismatch causes a compilation error E0308.

Fixes the compilation error

