### PR TITLE
Move huggingface-hub dependency to optional test dependencies.

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 keywords = ["NLP", "tokenizer", "BPE", "transformer", "deep learning"]
 dynamic = ["description", "license", "readme", "version"]
-dependencies = ["huggingface_hub>=0.16.4,<1.0"]
+dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/huggingface/tokenizers"
@@ -31,7 +31,7 @@ Source = "https://github.com/huggingface/tokenizers"
 
 
 [project.optional-dependencies]
-testing = ["pytest", "requests", "numpy", "datasets", "black==22.3", "ruff"]
+testing = ["pytest", "requests", "numpy", "datasets", "black==22.3", "ruff","huggingface_hub>=0.16.4,<1.0"]
 docs = ["sphinx", "sphinx_rtd_theme", "setuptools_rust"]
 dev = ["tokenizers[testing]"]
 


### PR DESCRIPTION
References the issue I created #1845 
https://github.com/huggingface/tokenizers/issues/1845

I propose moving the huggingface_hub dependency to the optional testing dependencies to make installs easier and cleaner.