### PR TITLE
Fix missing parenthesis in `EncodingVisualizer.calculate_label_colors`

### DIFF
--- a/bindings/python/py_src/tokenizers/tools/visualizer.py
+++ b/bindings/python/py_src/tokenizers/tools/visualizer.py
@@ -175,7 +175,7 @@ class EncodingVisualizer:
         colors = {}
 
         for label in sorted(labels):  # sort so we always get the same colors for a given set of labels
-            colors[label] = f"hsl({h},{s}%,{l}%"
+            colors[label] = f"hsl({h},{s}%,{l}%)"
             h += h_step
         return colors
 


### PR DESCRIPTION
```python
from tokenizers.tools import EncodingVisualizer, Annotation

annotations = [Annotation(start=0, end=1, label="annotation")]
# actual   hsl(10,32%,64%
# expected hsl(10,32%,64%)
EncodingVisualizer.calculate_label_colors(annotations)["annotation"]
```

fwiw: I found this bug during a research project I'm working on which uses LLMs to write property-based tests in [Hypothesis](https://github.com/HypothesisWorks/hypothesis). This property, that the hsl string should be valid, was proposed and written "autonomously" by the agent. I wrote this PR myself and take full responsibility for it.

