### PR TITLE
Mark immutable pyclasses as frozen

### DIFF
--- a/bindings/python/src/token.rs
+++ b/bindings/python/src/token.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use tk::Token;
 
-#[pyclass(module = "tokenizers", name = "Token")]
+#[pyclass(module = "tokenizers", name = "Token", frozen)]
 #[derive(Clone)]
 pub struct PyToken {
     token: Token,

--- a/bindings/python/src/utils/regex.rs
+++ b/bindings/python/src/utils/regex.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use tk::utils::SysRegex;
 
 /// Instantiate a new Regex with the given pattern
-#[pyclass(module = "tokenizers", name = "Regex")]
+#[pyclass(module = "tokenizers", name = "Regex", frozen)]
 pub struct PyRegex {
     pub inner: SysRegex,
     pub pattern: String,


### PR DESCRIPTION
The `Regex` and `Token` class are both immutable and can be trivially marked as frozen. The avoids the cost of atomic reference counting for any reads on borrowed data.

It's likely that in the future `frozen` will become the default for pyclasses.

See https://github.com/huggingface/tokenizers/pull/1860#issuecomment-3253764308 and reply for more details.