### PR TITLE
Bump `huggingface_hub`  upper version

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 keywords = ["NLP", "tokenizer", "BPE", "transformer", "deep learning"]
 dynamic = ["description", "license", "readme", "version"]
-dependencies = ["huggingface_hub>=1.0.0.rc0"]
+dependencies = ["huggingface_hub>=0.16.4,<2.0"]
 
 [project.urls]
 Homepage = "https://github.com/huggingface/tokenizers"


### PR DESCRIPTION
`huggingface_hub` will soon be officially released as `v1.0.0` ( :tada: )

A first pre-release version has been published yesterday: https://pypi.org/project/huggingface-hub/1.0.0rc0/. This PR relaxes `tokenizers`'s constraints on `huggingface_hub` dependency to allow both 0.x and 1.x versions. No breaking changes have been introduced that impacts `tokenizers` (which uses only `hf_hub_download` wih `repo_id`/`filename`/`revision` kwargs).

It would be really nice to have this PR merged + make a patch release for `tokenizers` so that I can start to test `transformers`, `diffusers`, `datasets`, etc. on the new `huggingface_hub` prerelease. Since they all depend on tokenizers, I'm a bit blocked (or need to make a lot of changes to CI files - see [example](https://github.com/huggingface/transformers/pull/40889/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47)).

See https://github.com/huggingface/huggingface_hub/issues/3340 for ongoing changes.