### PR TITLE
ci: add support for building Win-ARM64 wheels

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,12 +94,14 @@ jobs:
             target: x64
           - runner: windows-latest
             target: x86
+          - runner: windows-11-arm
+            target: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-          architecture: ${{ matrix.platform.target }}
+          architecture: ${{ matrix.platform.target == 'aarch64' && 'arm64' || matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
- The adoption of Windows on ARM (WoA) devices is steadily increasing, yet many Python wheels are still not available for this platform.
- GitHub Actions now offer native CI runners for Windows on ARM devices (windows-11-arm), enabling automated builds and testing.
- Currently, official tokenizers Python wheels are not provided for Windows ARM64 and thus users/developers were facing difficulties using popular tokenizers library natively.
- This PR introduces support for building tokenizers wheels on Windows ARM64, improving accessibility for developers and end users on this emerging platform.