### PR TITLE
Add cargo-semver-checks to Rust CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,3 +102,9 @@ jobs:
         shell: bash
         working-directory: ./tokenizers
         run: cargo readme > must_match_readme.md && diff must_match_readme.md README.md
+
+      - name: Check semver
+        if: matrix.os == 'ubuntu-latest'
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          manifest-path: ./tokenizers/Cargo.toml


### PR DESCRIPTION
## Summary
- Adds `cargo-semver-checks` to the Rust CI workflow according to #1855 

## Benefits
- Catches breaking API changes before release
- Helps maintain proper semantic versioning
- Uses the official `obi1kenobi/cargo-semver-checks-action@v2`

## Test plan
- [x] CI passes with the new check on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)