### PR TITLE
fix: used normalize_str in BaseTokenizer.normalize

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
+++ b/bindings/python/py_src/tokenizers/implementations/base_tokenizer.py
@@ -187,7 +187,7 @@ class BaseTokenizer:
         Returns:
             The normalized string
         """
-        return self._tokenizer.normalize(sequence)
+        return self._tokenizer.normalizer.normalize_str(sequence)
 
     def encode(
         self,


### PR DESCRIPTION
This PR resolves the `AttributeError` caused by `BaseTokenizer.normalize()` calling a non-existent method.
Fixes #1882 

### Before
The `normalize` method was calling `self._tokenizer.normalize(sequence)`, which does not exist on the internal `Tokenizer` object. This was raising an `AttributeError`.

### After
Changed to use `self._tokenizer.normalizer.normalize_str(sequence)` which is the correct public API for normalizing plain strings.
