### PR TITLE
Python: Add ruff rules for asyncio and performance

### DIFF
--- a/bindings/python/benches/test_tiktoken.py
+++ b/bindings/python/benches/test_tiktoken.py
@@ -29,7 +29,7 @@ def benchmark_batch(model: str, documents: list[str], num_threads: int, document
     os.environ["RAYON_NUM_THREADS"] = str(num_threads)
     num_bytes = sum(map(len, map(str.encode, documents)))
     readable_size, unit = format_byte_size(num_bytes)
-    print(f"==============")
+    print("==============")
     print(
         f"num_threads: {num_threads}, data size: {readable_size}, documents: {len(documents)} Avg Length: {document_length:.0f}"
     )

--- a/bindings/python/examples/using_the_visualizer.ipynb
+++ b/bindings/python/examples/using_the_visualizer.ipynb
@@ -552,7 +552,7 @@
     }
    ],
    "source": [
-    "funnyAnnotations = [dict(startPlace=i, endPlace=i + 3, theTag=str(i)) for i in range(0, 20, 4)]\n",
+    "funnyAnnotations = [{\"startPlace\": i, \"endPlace\": i + 3, \"theTag\": str(i)} for i in range(0, 20, 4)]\n",
     "funnyAnnotations"
    ]
   },

--- a/bindings/python/py_src/tokenizers/tools/visualizer.py
+++ b/bindings/python/py_src/tokenizers/tools/visualizer.py
@@ -173,7 +173,7 @@ class EncodingVisualizer:
         """
         if len(annotations) == 0:
             return {}
-        labels = set(map(lambda x: x.label, annotations))
+        labels = {x.label for x in annotations}
         num_labels = len(labels)
         h_step = int(255 / num_labels)
         if h_step < 20:

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -50,6 +50,11 @@ features = ["pyo3/extension-module", "abi3"]
 [tool.ruff]
 line-length = 119
 target-version = "py311"
+lint.extend-select = [
+  "ASYNC",
+  "C4",
+  "PERF",
+]
 lint.ignore = [
   # a == None in tests vs is None.
   "E711",

--- a/bindings/python/scripts/sentencepiece_extractor.py
+++ b/bindings/python/scripts/sentencepiece_extractor.py
@@ -138,7 +138,7 @@ if __name__ == "__main__":
 
                 # Save content
                 dump(vocab, vocab_f)
-                merges_f.writelines(map(lambda x: f"{x[0]} {x[1]}{linesep}", merges))
+                merges_f.writelines((f"{x[0]} {x[1]}{linesep}" for x in merges))
     finally:
         # If model was downloaded from internet we need to cleanup the tmp folder.
         if hasattr(args, "remote_model") and exists(args.model):

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -380,7 +380,7 @@ class TestTokenizer:
 
         # Can pad to the longest in a batch
         output = tokenizer.encode_batch(["my name", "my name is john"])
-        assert all([len(encoding) == 4 for encoding in output])
+        assert all(len(encoding) == 4 for encoding in output)
 
         # Can pad to the specified length otherwise
         tokenizer.enable_padding(length=4)
@@ -1082,7 +1082,7 @@ class TestAsyncTokenizer:
                 # Measure sync performance with pre-initialized executor
                 # Warm up
                 await asyncio.gather(*[encode_sync_with_executor(i) for i in range(10)])
-                time.sleep(0.03)
+                await asyncio.sleep(0.03)
                 # Actual measurement
                 start = time.perf_counter()
                 await asyncio.gather(*[encode_sync_with_executor(i) for i in range(n_tasks)])
@@ -1093,7 +1093,7 @@ class TestAsyncTokenizer:
                 await asyncio.gather(*[encode_async(i) for i in range(10)])
 
                 # Actual measurement
-                time.sleep(0.03)
+                await asyncio.sleep(0.03)
                 start = time.perf_counter()
                 await asyncio.gather(*[encode_async(i) for i in range(n_tasks)])
                 async_time = time.perf_counter() - start


### PR DESCRIPTION
```toml
lint.extend-select = [
  "ASYNC",
  "C4",
  "PERF",
]
```
https://docs.astral.sh/ruff
* https://docs.astral.sh/ruff/rules/#flake8-async-async
* https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
* https://docs.astral.sh/ruff/rules/#perflint-perf

Extra review please on the `time.sleep() --> asyncio.sleep()` in `bindings/python/tests/bindings/test_tokenizer.py` because these are tests, not production code.

---
% `cd bindings/python`
% `ruff check --extend-select=ASYNC,C4,PERF --output-format=concise`
```
benches/test_tiktoken.py:32:11: F541 [*] f-string without any placeholders
examples/using_the_visualizer.ipynb:cell 13:1:21: C408 Unnecessary `dict()` call (rewrite as a literal)
py_src/tokenizers/tools/visualizer.py:167:18: C417 Unnecessary `map()` usage (rewrite using a set comprehension)
scripts/sentencepiece_extractor.py:141:37: C417 Unnecessary `map()` usage (rewrite using a generator expression)
tests/bindings/test_tokenizer.py:344:20: C419 Unnecessary list comprehension
tests/bindings/test_tokenizer.py:953:17: ASYNC251 Async functions should not call `time.sleep`
tests/bindings/test_tokenizer.py:964:17: ASYNC251 Async functions should not call `time.sleep`
Found 7 errors.
```
% `ruff rule ASYNC251`
# blocking-sleep-in-async-function (ASYNC251)

Derived from the **flake8-async** linter.

## What it does
Checks that async functions do not call `time.sleep`.

## Why is this bad?
Blocking an async function via a `time.sleep` call will block the entire
event loop, preventing it from executing other tasks while waiting for the
`time.sleep`, negating the benefits of asynchronous programming.

Instead of `time.sleep`, use `asyncio.sleep`.

## Example
```python
import time


async def fetch():
    time.sleep(1)
```

Use instead:
```python
import asyncio


async def fetch():
    await asyncio.sleep(1)
```
