### PR TITLE
Fix undefined names in docs/source/_ext/entities.py

### DIFF
--- a/docs/source/_ext/entities.py
+++ b/docs/source/_ext/entities.py
@@ -7,7 +7,7 @@ from docutils.parsers.rst import Directive
 import sphinx
 from sphinx.locale import _
 from sphinx.util.docutils import SphinxDirective
-from sphinx.errors import ExtensionError
+from sphinx.errors import ExtensionError, NoUri
 
 from conf import languages as LANGUAGES
 
@@ -84,7 +84,7 @@ class AllEntities:
 
             name, _ = node.children
             if name.tagname != "field_name":
-                raise Exception(f"Expected a field name here, found {name_node.tagname}")
+                raise Exception(f"Expected a field name here, found {name.tagname}")
 
             if str(name.children[0]) == "global":
                 return True


### PR DESCRIPTION
An undefined name is likely to raise `NameError` at runtime.

% `ruff check --output-format=concise --select=F821 docs/source/_ext/entities.py`
```
docs/source/_ext/entities.py:87:70: F821 Undefined name `name_node`
docs/source/_ext/entities.py:160:39: F821 Undefined name `NoUri`
docs/source/_ext/entities.py:164:28: F821 Undefined name `NoUri`
```
`NoUri`: https://www.sphinx-doc.org/en/master/_modules/sphinx/errors.html

% `ruff rule F821`
# undefined-name (F821)

Derived from the **Pyflakes** linter.

## What it does
Checks for uses of undefined names.

## Why is this bad?
An undefined name is likely to raise `NameError` at runtime.

## Example
```python
def double():
    return n * 2  # raises `NameError` if `n` is undefined when `double` is called
```

Use instead:
```python
def double(n):
    return n * 2
```

## Options
- [`target-version`]: Can be used to configure which symbols Ruff will understand
  as being available in the `builtins` namespace.

## References
- [Python documentation: Naming and binding](https://docs.python.org/3/reference/executionmodel.html#naming-and-binding)
