### PR TITLE
Python release fix

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,8 +1,6 @@
 name: Python Release
 on:
   push:
-    branches:
-      - python-release-fix
     tags:
       - v*
 
@@ -26,8 +24,8 @@ jobs:
   build:
     name: build on ${{ matrix.platform || matrix.os }} (${{ matrix.target }} - ${{ matrix.manylinux || 'auto' }})
     # only run on push to main and on release
-    # needs: [lock_exists]
-    # if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build')
+    needs: [lock_exists]
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes #1904 

This adds a list of interpreters to install for maturin to fix the failing windows i686 wheel build.