### PR TITLE
Add windows arm64 wheel build to python release

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -62,8 +62,7 @@ jobs:
               3.11
               3.12
               3.13
-              3.14
-            interpreter: 3.11 3.12 3.13 3.14
+            interpreter: 3.11 3.12 3.13
               # - os: windows
               #   ls: dir
               #   target: aarch64


### PR DESCRIPTION
Closes #1906 

This adds a wheel build for arm64 windows to `python-release.yml`.