### PR TITLE
Fix unclosed annotation span in EncodingVisualizer

### DIFF
--- a/bindings/python/py_src/tokenizers/tools/visualizer.py
+++ b/bindings/python/py_src/tokenizers/tools/visualizer.py
@@ -314,6 +314,11 @@ class EncodingVisualizer:
                 encoding=encoding,
             )
         )
+
+        # Close any remaining open annotation span
+        if cur_anno_ix is not None:
+            spans.append("</span>")
+
         res = HTMLBody(spans)  # Send the list of spans to the body of our html
         return res
 


### PR DESCRIPTION
### Fix: Close annotation span at end of HTML generation

This PR fixes an edge case in `EncodingVisualizer.__make_html` where an annotation `<span>` is not closed if the text ends inside an annotation.

#### Example

**Input**

```python
from tokenizers import Tokenizer
from tokenizers.tools import EncodingVisualizer, Annotation

tokenizer = Tokenizer.from_pretrained("bert-base-cased")
visualizer = EncodingVisualizer(tokenizer, default_to_notebook=False)

text = "Hello world"
annotations = [Annotation(6, 11, "NOUN")]

html_output = visualizer(text, annotations)
print(html_output)
```

**Before**

```html
<html>
    <style>
    </style>
    <body>
        <div class="tokenized-text" dir=auto>
            <span class="token odd-token"  >
                Hello
            </span>
            <span class="non-token"  >            
            </span>
            <span class="annotation" style="color:hsl(10,32%,64%)" data-label="NOUN">
                <span class="token even-token"  >
                    world
                </span>
            <!-- annotation span is not closed -->
        </div>
    </body>
</html>
```

**After**

```html
<html>
    <style>
    </style>
    <body>
        <div class="tokenized-text" dir=auto>
            <span class="token odd-token"  >
                Hello
            </span>
            <span class="non-token"  >            
            </span>
            <span class="annotation" style="color:hsl(10,32%,64%)" data-label="NOUN">
                <span class="token even-token"  >
                    world
                </span>
            </span> <!-- annotation span is now properly closed -->
        </div>
    </body>
</html>
```