### PR TITLE
Add Python 3.14 CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: 3.14
           architecture: "x64"
 
 


### PR DESCRIPTION
Updates CI to use Python 3.14. This is possible now that https://github.com/huggingface/tokenizers/pull/1901 is merged.

I extracted this from https://github.com/huggingface/tokenizers/pull/1864 to make that PR more focused.