### PR TITLE
Fix broken source links in documentation

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -16,6 +16,7 @@ jobs:
       package: tokenizers
       path_to_docs: tokenizers/docs/source-doc-builder/
       package_path: tokenizers/bindings/python/
+      version_tag_suffix: bindings/python/py_src/
       install_rust: true
     secrets:
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -16,4 +16,5 @@ jobs:
       package: tokenizers
       path_to_docs: tokenizers/docs/source-doc-builder/
       package_path: tokenizers/bindings/python/
+      version_tag_suffix: bindings/python/py_src/
       install_rust: true


### PR DESCRIPTION
## What does this PR do?
Fixes broken GitHub source links in the API documentation (e.g., Visualizer page).

The doc-builder was generating links to `src/tokenizers/...` but the Python source files are located at `bindings/python/py_src/tokenizers/...`.

Example broken link:
`https://github.com/huggingface/tokenizers/blob/v0.20.3/src/tokenizers/tools/visualizer.py` → 404

Correct path:
`https://github.com/huggingface/tokenizers/blob/main/bindings/python/py_src/tokenizers/tools/visualizer.py`

## Fix
Added `version_tag_suffix: bindings/python/py_src/` parameter to documentation build workflows to generate correct source links.

Fixes #1910