### PR TITLE
Fix escape HTML characters in EncodingVisualizer output

### DIFF
--- a/bindings/python/py_src/tokenizers/tools/visualizer.py
+++ b/bindings/python/py_src/tokenizers/tools/visualizer.py
@@ -1,12 +1,11 @@
+import html
 import itertools
 import os
 import re
 from string import Template
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
-import html
 from tokenizers import Encoding, Tokenizer
-
 
 dirname = os.path.dirname(__file__)
 css_filename = os.path.join(dirname, "visualizer-styles.css")


### PR DESCRIPTION
## What
Escaped the text content used in EncodingVisualizer by using html.escape.

## Why
When visualizing text containing special HTML characters (e.g., <, >), such as in the string "a<b<c", the characters were directly inserted into the HTML output. This caused the browser to misinterpret them as HTML tags, breaking the visualization layout and causing incorrect display. Escaping ensures these characters are correctly rendered as text (e.g., `&lt;`).

This fix is ​​important not only to prevent display issues, but also to mitigate potential XSS risks caused by unintentional HTML tag insertion.

## Changes
- Imported the html module.
- Applied html.escape() to the span_text in the consecutive_chars_to_html method before embedding it into the HTML span.

## Example
```python
from IPython.display import display, HTML
from tokenizers import Tokenizer
from tokenizers.tools import EncodingVisualizer, Annotation

tokenizer = Tokenizer.from_pretrained("Qwen/Qwen3-0.6B")
visualizer = EncodingVisualizer(tokenizer, default_to_notebook=False)

text = "a<b<c"

html_output = visualizer(text)
print(html_output)
display(HTML(html_output))
```

### before

<img width="334" height="140" alt="image" src="https://github.com/user-attachments/assets/325a2c70-d6fb-4cc0-8614-5e8e4b1f003d" />

```html
<body>
    <div class="tokenized-text" dir=auto>
        <span class="token even-token"  >a</span>
        <span class="token odd-token"  ><b</span>
        <span class="token even-token"  ><c</span>
    </div>
</body>
```

### after

<img width="173" height="85" alt="image-1" src="https://github.com/user-attachments/assets/860bf46d-7c6f-4fdb-9968-b6bb11406adf" />

```html
<body>
    <div class="tokenized-text" dir=auto>
        <span class="token even-token"  >a</span>
        <span class="token odd-token"  >&lt;b</span>
        <span class="token even-token"  >&lt;c</span>
        </div>
</body>
```
