### PR TITLE
Add missing test dependency

### DIFF
--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -23,7 +23,7 @@ TESTS_RESOURCES = $(DATA_DIR)/small.txt $(DATA_DIR)/roberta.json
 
 # Launch the test suite
 test: $(TESTS_RESOURCES)
-	pip install pytest requests setuptools_rust numpy pyarrow datasets
+	pip install pytest pytest-asyncio requests setuptools_rust numpy pyarrow datasets
 	python -m pytest -s -v tests
 	cargo test --no-default-features
 


### PR DESCRIPTION
This adds `pytest-asyncio` to the list of test dependencies that will be automatically installed.

I found this when running the dev-test-loop of installing the local package into my (brand-new) virtual environment and running the tests with `make test`, which initially didn't work.