### PR TITLE
Port to PyO3 0.27

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -14,11 +14,11 @@ serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
 libc = "0.2"
 env_logger = "0.11"
-pyo3 = { version = "0.26", features = ["abi3", "abi3-py39", "py-clone"] }
-pyo3-async-runtimes = { version = "0.26", features = ["tokio-runtime"] }
+pyo3 = { version = "0.27", features = ["abi3", "abi3-py39", "py-clone"] }
+pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
 tokio = { version = "1.47.1", features = ["rt", "rt-multi-thread", "macros", "signal"] }
 once_cell = "1.19.0"
-numpy = "0.26"
+numpy = "0.27"
 ndarray = "0.16"
 itertools = "0.14"
 ahash = { version = "0.8.11", features = ["serde"] }
@@ -28,7 +28,7 @@ path = "../../tokenizers"
 
 [dev-dependencies]
 tempfile = "3.10"
-pyo3 = { version = "0.26", features = ["auto-initialize"] }
+pyo3 = { version = "0.27", features = ["auto-initialize"] }
 
 [features]
 default = ["pyo3/extension-module"]

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -98,7 +98,7 @@ impl PyDecoder {
                 })?;
                 Ok(())
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -630,8 +630,10 @@ enum StreamInput {
     Ids(Vec<u32>),
 }
 
-impl FromPyObject<'_> for StreamInput {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for StreamInput {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(id) = obj.extract::<u32>() {
             Ok(StreamInput::Id(id))
         } else if let Ok(ids) = obj.extract::<Vec<u32>>() {

--- a/bindings/python/src/encoding.rs
+++ b/bindings/python/src/encoding.rs
@@ -49,7 +49,7 @@ impl PyEncoding {
                 })?;
                 Ok(())
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -116,7 +116,7 @@ impl PyModel {
                 })?;
                 Ok(())
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/bindings/python/src/normalizers.rs
+++ b/bindings/python/src/normalizers.rs
@@ -135,7 +135,7 @@ impl PyNormalizer {
                 })?;
                 Ok(())
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -142,7 +142,7 @@ impl PyPreTokenizer {
                 self.pretok = unpickled;
                 Ok(())
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/bindings/python/src/processors.rs
+++ b/bindings/python/src/processors.rs
@@ -117,7 +117,7 @@ impl PyPostProcessor {
                 })?;
                 Ok(())
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -549,8 +549,10 @@ impl From<PySpecialToken> for SpecialToken {
     }
 }
 
-impl FromPyObject<'_> for PySpecialToken {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for PySpecialToken {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(v) = ob.extract::<(String, u32)>() {
             Ok(Self(v.into()))
         } else if let Ok(v) = ob.extract::<(u32, String)>() {
@@ -589,8 +591,10 @@ impl From<PyTemplate> for Template {
     }
 }
 
-impl FromPyObject<'_> for PyTemplate {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for PyTemplate {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(s) = ob.extract::<String>() {
             Ok(Self(
                 s.try_into().map_err(exceptions::PyValueError::new_err)?,

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -266,8 +266,10 @@ impl PyAddedToken {
 }
 
 struct TextInputSequence<'s>(tk::InputSequence<'s>);
-impl<'s> FromPyObject<'s> for TextInputSequence<'s> {
-    fn extract_bound(ob: &Bound<'s, PyAny>) -> PyResult<Self> {
+impl<'s> FromPyObject<'_, 's> for TextInputSequence<'s> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, 's, PyAny>) -> Result<Self, Self::Error> {
         let err = exceptions::PyTypeError::new_err("TextInputSequence must be str");
         if let Ok(s) = ob.extract::<String>() {
             Ok(Self(s.into()))
@@ -283,8 +285,10 @@ impl<'s> From<TextInputSequence<'s>> for tk::InputSequence<'s> {
 }
 
 struct PyArrayUnicode(Vec<String>);
-impl FromPyObject<'_> for PyArrayUnicode {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for PyArrayUnicode {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         // SAFETY Making sure the pointer is a valid numpy array requires calling numpy C code
         if unsafe { npyffi::PyArray_Check(ob.py(), ob.as_ptr()) } == 0 {
             return Err(exceptions::PyTypeError::new_err("Expected an np.array"));
@@ -352,8 +356,10 @@ impl From<PyArrayUnicode> for tk::InputSequence<'_> {
 
 struct PyArrayStr(Vec<String>);
 
-impl FromPyObject<'_> for PyArrayStr {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for PyArrayStr {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let array = ob.downcast::<PyArray1<Py<PyAny>>>()?;
         let seq = array
             .readonly()
@@ -375,8 +381,10 @@ impl From<PyArrayStr> for tk::InputSequence<'_> {
 }
 
 struct PreTokenizedInputSequence<'s>(tk::InputSequence<'s>);
-impl<'s> FromPyObject<'s> for PreTokenizedInputSequence<'s> {
-    fn extract_bound(ob: &Bound<'s, PyAny>) -> PyResult<Self> {
+impl<'s> FromPyObject<'_, 's> for PreTokenizedInputSequence<'s> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, 's, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(seq) = ob.extract::<PyArrayUnicode>() {
             return Ok(Self(seq.into()));
         }
@@ -405,8 +413,10 @@ impl<'s> From<PreTokenizedInputSequence<'s>> for tk::InputSequence<'s> {
 }
 
 struct TextEncodeInput<'s>(tk::EncodeInput<'s>);
-impl<'s> FromPyObject<'s> for TextEncodeInput<'s> {
-    fn extract_bound(ob: &Bound<'s, PyAny>) -> PyResult<Self> {
+impl<'s> FromPyObject<'_, 's> for TextEncodeInput<'s> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, 's, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(i) = ob.extract::<TextInputSequence>() {
             return Ok(Self(i.into()));
         }
@@ -431,8 +441,10 @@ impl<'s> From<TextEncodeInput<'s>> for tk::tokenizer::EncodeInput<'s> {
     }
 }
 struct PreTokenizedEncodeInput<'s>(tk::EncodeInput<'s>);
-impl<'s> FromPyObject<'s> for PreTokenizedEncodeInput<'s> {
-    fn extract_bound(ob: &Bound<'s, PyAny>) -> PyResult<Self> {
+impl<'s> FromPyObject<'_, 's> for PreTokenizedEncodeInput<'s> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, 's, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(i) = ob.extract::<PreTokenizedInputSequence>() {
             return Ok(Self(i.into()));
         }
@@ -617,7 +629,7 @@ impl PyTokenizer {
                 })?;
                 Ok(())
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -64,7 +64,7 @@ impl PyTrainer {
                 self.trainer = unpickled;
                 Ok(())
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/bindings/python/src/utils/normalization.rs
+++ b/bindings/python/src/utils/normalization.rs
@@ -90,8 +90,10 @@ impl PyRange<'_> {
 #[derive(Clone)]
 pub struct PySplitDelimiterBehavior(pub SplitDelimiterBehavior);
 
-impl FromPyObject<'_> for PySplitDelimiterBehavior {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for PySplitDelimiterBehavior {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let s = obj.extract::<String>()?;
 
         Ok(Self(match s.as_ref() {


### PR DESCRIPTION
This is a mechanical port of the codebase to PyO3 0.27.

I am very much not sure if it is idiomatic, efficient, or correct (beyond typing), but it is based on the transformations suggested in the [official migration guide](https://pyo3.rs/main/migration.html#from-026-to-027).