### PR TITLE
Update fancy-regex dependency to 0.17

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -67,7 +67,7 @@ aho-corasick = "1.1"
 paste = "1.0.14"
 macro_rules_attribute = "0.2.0"
 thiserror = "2"
-fancy-regex = { version = "0.14", optional = true}
+fancy-regex = { version = "0.17", optional = true}
 getrandom = { version = "0.3" }
 esaxx-rs = { version = "0.1.10", default-features = false, features=[]}
 monostate = "0.1.12"


### PR DESCRIPTION
https://github.com/fancy-regex/fancy-regex/blob/0.17.0/CHANGELOG.md

I tried `make test` and `cargo test -F fancy-regex` and didn’t observe any regressions.