### PR TITLE
feat: add unk_token property to Unigram model

### DIFF
--- a/bindings/python/py_src/tokenizers/models/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/models/__init__.pyi
@@ -344,10 +344,17 @@ class Unigram(Model):
     An implementation of the Unigram algorithm
 
     Args:
-        vocab (:obj:`List[Tuple[str, float]]`, `optional`, `optional`):
+        vocab (:obj:`List[Tuple[str, float]]`, `optional`):
             A list of vocabulary items and their relative score [("am", -0.2442),...]
+        unk_id (:obj:`int`, `optional`):
+            The id of the unknown token in the vocabulary
+        byte_fallback (:obj:`bool`, `optional`):
+            Whether to use byte fallback
+        unk_token (:obj:`str`, `optional`):
+            The unknown token string. If provided, the token will be looked up in the vocab
+            to find its index. Cannot be used together with `unk_id`.
     """
-    def __init__(self, vocab=None, unk_id=None, byte_fallback=None):
+    def __init__(self, vocab=None, unk_id=None, byte_fallback=None, unk_token=None):
         pass
 
     def __getstate__(self):
@@ -428,22 +435,6 @@ class Unigram(Model):
             A :obj:`List` of :class:`~tokenizers.Token`: The generated tokens
         """
         pass
-
-    def _resize_cache(self, /, capacity: int) -> None:
-        """Resize the internal cache"""
-        ...
-    @property
-    def unk_token(self, /) -> str | None:
-        """Get the unk_token string"""
-        ...
-    @unk_token.setter
-    def unk_token(self, /, unk_token: str | None) -> None:
-        """Set the unk_token by looking up its index in the vocabulary"""
-        ...
-    @property
-    def unk_id(self, /) -> int | None:
-        """Get the unk_id"""
-        ...
 
 class WordLevel(Model):
     """

--- a/bindings/python/py_src/tokenizers/models/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/models/__init__.pyi
@@ -429,6 +429,22 @@ class Unigram(Model):
         """
         pass
 
+    def _resize_cache(self, /, capacity: int) -> None:
+        """Resize the internal cache"""
+        ...
+    @property
+    def unk_token(self, /) -> str | None:
+        """Get the unk_token string"""
+        ...
+    @unk_token.setter
+    def unk_token(self, /, unk_token: str | None) -> None:
+        """Set the unk_token by looking up its index in the vocabulary"""
+        ...
+    @property
+    def unk_id(self, /) -> int | None:
+        """Get the unk_id"""
+        ...
+
 class WordLevel(Model):
     """
     An implementation of the WordLevel algorithm

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -2,7 +2,7 @@ import pickle
 
 import pytest
 
-from tokenizers.models import BPE, Model, WordLevel, WordPiece, Unigram
+from tokenizers.models import BPE, Model, WordLevel, WordPiece
 from ..utils import bert_files, data_dir, roberta_files
 
 
@@ -99,47 +99,3 @@ class TestWordLevel:
         # Modify these
         model.unk_token = "<unk>"
         assert model.unk_token == "<unk>"
-
-
-class TestUnigram:
-    def test_unk_token_property(self):
-        # Create Unigram with vocab containing <unk>
-        vocab = [
-            ("<unk>", 0.0),
-            ("hello", -1.0),
-            ("world", -1.5),
-        ]
-        model = Unigram(vocab, unk_id=0)
-
-        # Test unk_token getter returns str
-        assert model.unk_token == "<unk>"
-        assert isinstance(model.unk_token, str)
-
-        # Test unk_id getter returns int
-        assert model.unk_id == 0
-        assert isinstance(model.unk_id, int)
-
-        # Test unk_token setter - set to existing token
-        model.unk_token = "hello"
-        assert model.unk_token == "hello"
-        assert model.unk_id == 1
-
-        # Test unk_token setter - non-existent token should raise
-        with pytest.raises(ValueError, match="not found in vocabulary"):
-            model.unk_token = "nonexistent"
-
-        # Test unk_token setter - None should raise
-        with pytest.raises(ValueError, match="Cannot set unk_token to None"):
-            model.unk_token = None
-
-    def test_unk_token_without_unk_id(self):
-        # Create Unigram without unk_id
-        vocab = [
-            ("hello", -1.0),
-            ("world", -1.5),
-        ]
-        model = Unigram(vocab, unk_id=None)
-
-        # unk_token should be None when unk_id is not set
-        assert model.unk_token is None
-        assert model.unk_id is None

--- a/bindings/python/tests/bindings/test_models.py
+++ b/bindings/python/tests/bindings/test_models.py
@@ -2,7 +2,7 @@ import pickle
 
 import pytest
 
-from tokenizers.models import BPE, Model, WordLevel, WordPiece
+from tokenizers.models import BPE, Model, WordLevel, WordPiece, Unigram
 from ..utils import bert_files, data_dir, roberta_files
 
 
@@ -99,3 +99,47 @@ class TestWordLevel:
         # Modify these
         model.unk_token = "<unk>"
         assert model.unk_token == "<unk>"
+
+
+class TestUnigram:
+    def test_unk_token_property(self):
+        # Create Unigram with vocab containing <unk>
+        vocab = [
+            ("<unk>", 0.0),
+            ("hello", -1.0),
+            ("world", -1.5),
+        ]
+        model = Unigram(vocab, unk_id=0)
+
+        # Test unk_token getter returns str
+        assert model.unk_token == "<unk>"
+        assert isinstance(model.unk_token, str)
+
+        # Test unk_id getter returns int
+        assert model.unk_id == 0
+        assert isinstance(model.unk_id, int)
+
+        # Test unk_token setter - set to existing token
+        model.unk_token = "hello"
+        assert model.unk_token == "hello"
+        assert model.unk_id == 1
+
+        # Test unk_token setter - non-existent token should raise
+        with pytest.raises(ValueError, match="not found in vocabulary"):
+            model.unk_token = "nonexistent"
+
+        # Test unk_token setter - None should raise
+        with pytest.raises(ValueError, match="Cannot set unk_token to None"):
+            model.unk_token = None
+
+    def test_unk_token_without_unk_id(self):
+        # Create Unigram without unk_id
+        vocab = [
+            ("hello", -1.0),
+            ("world", -1.5),
+        ]
+        model = Unigram(vocab, unk_id=None)
+
+        # unk_token should be None when unk_id is not set
+        assert model.unk_token is None
+        assert model.unk_id is None

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -153,6 +153,29 @@ impl Unigram {
     pub fn byte_fallback(&self) -> bool {
         self.byte_fallback
     }
+
+    /// Get the unk_id
+    pub fn get_unk_id(&self) -> Option<usize> {
+        self.unk_id
+    }
+
+    /// Set the unk_token by looking up its index in the vocabulary
+    pub fn set_unk_token(&mut self, token: &str) -> Result<()> {
+        if let Some(id) = self.token_to_ids.get(token) {
+            self.unk_id = Some(*id as usize);
+            self.cache = self.cache.fresh();
+            Ok(())
+        } else {
+            Err(Box::new(UnigramError::UnkIdNotInVocabulary))
+        }
+    }
+
+    /// Get the unk_token string if unk_id is set
+    pub fn get_unk_token(&self) -> Option<&str> {
+        self.unk_id
+            .and_then(|id| self.vocab.get(id))
+            .map(|(token, _)| token.as_str())
+    }
     pub(super) fn len(&self) -> usize {
         self.vocab.len()
     }

--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -65,6 +65,32 @@ fn test_train_unigram_from_file() {
     assert_eq!(model.get_vocab_size(), 719);
 }
 
+#[test]
+fn test_unigram_unk_token() {
+    // Create a simple vocab with <unk> token
+    let vocab = vec![
+        ("<unk>".to_string(), 0.0),
+        ("hello".to_string(), -1.0),
+        ("world".to_string(), -1.5),
+    ];
+    let mut model = Unigram::from(vocab, Some(0), false).unwrap();
+
+    // Test get_unk_id
+    assert_eq!(model.get_unk_id(), Some(0));
+
+    // Test get_unk_token
+    assert_eq!(model.get_unk_token(), Some("<unk>"));
+
+    // Test set_unk_token to an existing token
+    model.set_unk_token("hello").unwrap();
+    assert_eq!(model.get_unk_id(), Some(1));
+    assert_eq!(model.get_unk_token(), Some("hello"));
+
+    // Test set_unk_token to non-existent token (should fail)
+    let result = model.set_unk_token("nonexistent");
+    assert!(result.is_err());
+}
+
 #[cfg(not(debug_assertions))]
 #[test]
 fn test_sample() {


### PR DESCRIPTION
## Summary
- Adds getter/setter for `unk_token` on the Unigram model
- Allows users to retrieve and modify the unknown token by its string value (in addition to the existing `unk_id`)

## Changes
- Add `get_unk_id()`, `get_unk_token()`, `set_unk_token()` methods to Rust Unigram model
- Add Python bindings for `unk_token` and `unk_id` properties
- Add Python type hints for new properties
- Add comprehensive tests for Rust and Python

## Example usage

```python
from tokenizers.models import Unigram

vocab = [("<unk>", 0.0), ("hello", -1.0), ("world", -1.5)]
model = Unigram(vocab, unk_id=0)

# Get unk_token
print(model.unk_token)  # "<unk>"
print(model.unk_id)     # 0

# Set unk_token to a different token in vocab
model.unk_token = "hello"
print(model.unk_token)  # "hello"
print(model.unk_id)     # 1
```

## Test plan
- [x] Rust tests for get_unk_id, get_unk_token, set_unk_token methods
- [x] Python tests for unk_token property getter
- [x] Python tests for unk_token property setter
- [x] Python tests for error handling (non-existent token, None value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)