### PR TITLE
Fix identity comparison in toctree_tags.py

### DIFF
--- a/docs/source/_ext/toctree_tags.py
+++ b/docs/source/_ext/toctree_tags.py
@@ -9,7 +9,7 @@ class TocTreeTags(TocTree):
         filtered = []
         for e in entries:
             m = self.hasPat.match(e)
-            if m != None:
+            if m is not None:
                 if self.env.app.tags.has(m.groups()[0]):
                     filtered.append(m.groups()[1])
             else:


### PR DESCRIPTION
Replaced `!= None` with `is not None` in `docs/source/_ext/toctree_tags.py`.

Comparisons to singletons like `None` should always be done with `is` or `is not`, never the equality operators (PEP 8 recommendations).