### PR TITLE
Fix multithreaded concurrency test to use shared tokenizer instance

### DIFF
--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -578,14 +578,15 @@ class TestTokenizer:
         multiprocessing_with_parallelism(tokenizer, True)
 
     def test_multithreaded_concurrency(self):
-        # Thread worker functions
+        # Create a single shared tokenizer instance (thread-safe)
+        shared_tokenizer = Tokenizer(BPE())
+
+        # Thread worker functions that use the SAME tokenizer instance
         def encode_batch(batch):
-            tokenizer = Tokenizer(BPE())
-            return tokenizer.encode_batch(batch)
+            return shared_tokenizer.encode_batch(batch)
 
         def encode_batch_fast(batch):
-            tokenizer = Tokenizer(BPE())
-            return tokenizer.encode_batch_fast(batch)
+            return shared_tokenizer.encode_batch_fast(batch)
 
         # Create some significant workload
         batches = [
@@ -594,7 +595,7 @@ class TestTokenizer:
             ["my name is ringo " * 50] * 20,
         ]
 
-        # Many encoding operations to run concurrently
+        # Many encoding operations to run concurrently using the same tokenizer
         tasks = [
             (encode_batch, batches[0]),
             (encode_batch_fast, batches[1]),


### PR DESCRIPTION
## Summary
  This PR fixes the `test_multithreaded_concurrency` test to properly verify thread safety by using a shared
  tokenizer instance across multiple threads, rather than creating separate instances per thread.

## Problem
  The existing test in commit `6eba494a` (#1864) was designed to test thread safety, but it created a new
  `Tokenizer(BPE())` instance within each worker function. This meant each thread was using its own tokenizer,
  which doesn't test the actual scenario where multiple threads access the **same** tokenizer instance.