### PR TITLE
Add riscv64 build, make Linux wheel build matrix more explicit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,9 @@ jobs:
           - runner: ubuntu-latest
             arch: ppc64le
             target: powerpc64le-unknown-linux-gnu
+          - runner: ubuntu-latest
+            arch: riscv64
+            target: riscv64gc-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
maturin supports riscv64 cross build, but the arch string and the target toolchain for rustc don't exactly match up (this is also the case for other architectures like ppc64le and x86). To make the riscv64 addition consistent with the others, change the platform list so that arch and target are distinct fields.

Note that this is being done on behalf of the [RISE Project](https://riseproject.dev/) to improve Python ecosystem support on riscv64 platforms.