### PR TITLE
ci: add riscv64 target to linux wheel build matrix

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -98,6 +98,10 @@ jobs:
             platform: linux
             target: s390x
             interpreter: 3.9 3.10 3.11 3.12 3.13
+          - os: ubuntu
+            platform: linux
+            target: riscv64
+            interpreter: 3.9 3.10 3.11 3.12 3.13
         exclude:
           - os: windows
             target: aarch64


### PR DESCRIPTION
## Summary

Add `riscv64` to the maturin-action linux build matrix in `python-release.yml` so that `linux_riscv64` wheels are built and published to PyPI.

maturin-action cross-compiles via `riscv64gc-unknown-linux-gnu` cargo target — no QEMU or additional infrastructure needed.

## Evidence

- Tested wheel: [`tokenizers-0.22.2-cp39-abi3-manylinux_2_34_riscv64.whl`](https://github.com/gounthar/riscv64-python-wheels/releases/download/v2026.03.11-cp313/tokenizers-0.22.2-cp39-abi3-manylinux_2_34_riscv64.whl)
- Built natively on BananaPi F3 (SpacemiT K1, rv64imafdcv, 8 cores @ 1.6 GHz)
- Build time: ~20 min
- Imports and passes basic smoke test on riscv64

## Context

- `riscv64gc-unknown-linux-gnu` is a Rust tier-2 target with std available
- maturin-action handles cross-compilation transparently
- Sibling HuggingFace project safetensors has a similar PR open
- RISC-V hardware is shipping (SiFive, SpacemiT, Sophgo SG2044)

Fixes #1961