### PR TITLE
feat: add new faster whitespace split pretok

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,14 @@ jobs:
         working-directory: ./tokenizers
         run: make test
 
-      # Skip integration tests for now on Windows
+      - name: Download xnli test dataset on Windows for whitespace equivalence test
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        working-directory: ./tokenizers
+        run: |
+          mkdir -p data
+          curl -L https://huggingface.co/datasets/hf-internal-testing/tokenizers-test-data/resolve/main/xnli.txt -o data/xnli.txt
+
       - name: Run lib Tests on Windows
         if: matrix.os == 'windows-latest'
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -62,6 +62,10 @@ harness = false
 name = "truncation_benchmark"
 harness = false
 
+[[bench]]
+name = "whitespace_pretok_benchmark"
+harness = false
+
 [dependencies]
 rand = "0.9"
 onig = { version = "6.5.1", default-features = false, optional = true }

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -6,7 +6,7 @@ dir_guard=@mkdir -p $(@D)
 
 SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2-merges.txt $(DATA_DIR)/bert-base-uncased-vocab.txt $(DATA_DIR)/big.txt $(DATA_DIR)/small.txt $(DATA_DIR)/albert-base-v1-tokenizer.json  $(DATA_DIR)/llama-3-tokenizer.json
 BENCHMARK_RESOURCES = $(SHARED_RESOURCES)
-TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json
+TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/xnli.txt
 
 .PHONY : build
 build :
@@ -94,3 +94,7 @@ $(DATA_DIR)/bert-wiki.json :
 $(DATA_DIR)/llama-3-tokenizer.json :
 	$(dir_guard)
 	wget $(HF_TEST_DATA)/llama-3-tokenizer.json -O $@
+
+$(DATA_DIR)/xnli.txt :
+	$(dir_guard)
+	wget $(HF_TEST_DATA)/xnli.txt -O $@

--- a/tokenizers/benches/whitespace_pretok_benchmark.rs
+++ b/tokenizers/benches/whitespace_pretok_benchmark.rs
@@ -1,0 +1,96 @@
+#[macro_use]
+extern crate criterion;
+
+use criterion::{BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
+use tokenizers::pre_tokenizers::whitespace::{ManualWhitespaceSplit, Whitespace};
+use tokenizers::{PreTokenizedString, PreTokenizer};
+
+fn bench_pretokenizer(c: &mut Criterion) {
+    let data = std::fs::read_to_string("data/big.txt").unwrap();
+    let lines: Vec<&str> = data.lines().collect();
+
+    let mut group = c.benchmark_group("whitespace-pretok");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+
+    // Full corpus as a single string
+    group.bench_function("regex/full-corpus", |b| {
+        let pretok = Whitespace {};
+        b.iter(|| {
+            let mut pre = PreTokenizedString::from(black_box(data.as_str()));
+            pretok.pre_tokenize(&mut pre).unwrap();
+            pre
+        })
+    });
+
+    group.bench_function("manual/full-corpus", |b| {
+        let pretok = ManualWhitespaceSplit {};
+        b.iter(|| {
+            let mut pre = PreTokenizedString::from(black_box(data.as_str()));
+            pretok.pre_tokenize(&mut pre).unwrap();
+            pre
+        })
+    });
+
+    // Line-by-line (many short strings — tests per-call overhead)
+    group.bench_function("regex/line-by-line", |b| {
+        let pretok = Whitespace {};
+        b.iter(|| {
+            for line in &lines {
+                let mut pre = PreTokenizedString::from(black_box(*line));
+                pretok.pre_tokenize(&mut pre).unwrap();
+                black_box(&pre);
+            }
+        })
+    });
+
+    group.bench_function("manual/line-by-line", |b| {
+        let pretok = ManualWhitespaceSplit {};
+        b.iter(|| {
+            for line in &lines {
+                let mut pre = PreTokenizedString::from(black_box(*line));
+                pretok.pre_tokenize(&mut pre).unwrap();
+                black_box(&pre);
+            }
+        })
+    });
+
+    group.finish();
+
+    // --- Scaling with input size ---
+
+    let mut group = c.benchmark_group("whitespace-pretok-scaling");
+
+    for size in [100, 1_000, 10_000, 100_000] {
+        let input: String = data.chars().take(size).collect();
+        group.throughput(Throughput::Bytes(input.len() as u64));
+
+        group.bench_with_input(BenchmarkId::new("regex", size), &input, |b, input| {
+            let pretok = Whitespace {};
+            b.iter(|| {
+                let mut pre = PreTokenizedString::from(black_box(input.as_str()));
+                pretok.pre_tokenize(&mut pre).unwrap();
+                pre
+            })
+        });
+
+        group.bench_with_input(BenchmarkId::new("manual", size), &input, |b, input| {
+            let pretok = ManualWhitespaceSplit {};
+            b.iter(|| {
+                let mut pre = PreTokenizedString::from(black_box(input.as_str()));
+                pretok.pre_tokenize(&mut pre).unwrap();
+                pre
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = whitespace_pretok;
+    config = Criterion::default().sample_size(50);
+    targets = bench_pretokenizer
+}
+
+criterion_main!(whitespace_pretok);

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -2,6 +2,7 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
+use crate::pattern::Pattern;
 use crate::tokenizer::{
     pattern::Invert, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior,
 };
@@ -38,6 +39,87 @@ impl PreTokenizer for WhitespaceSplit {
             normalized.split(char::is_whitespace, SplitDelimiterBehavior::Removed)
         })
     }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[macro_rules_attribute(impl_serde_type!)]
+pub struct ManualWhitespaceSplit;
+
+impl PreTokenizer for ManualWhitespaceSplit {
+    fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
+        pretokenized.split(|_, normalized| {
+            normalized.split(WhiteSpacePattern, SplitDelimiterBehavior::Removed)
+        })
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum CharType {
+    Whitespace,
+    Word,
+    Symbol,
+}
+
+struct WhiteSpacePattern;
+
+impl Pattern for WhiteSpacePattern {
+    fn find_matches(&self, inside: &str) -> Result<Vec<(crate::Offsets, bool)>> {
+        if inside.is_empty() {
+            return Ok(vec![((0, 0), false)]);
+        }
+
+        let mut matches = Vec::new();
+        let mut span_start = 0;
+        let mut prev_type: Option<CharType> = None;
+
+        for (i, ch) in inside.char_indices() {
+            let ct = classify(ch);
+
+            if let Some(pt) = prev_type {
+                if pt != ct {
+                    // Emit the previous span:
+                    // - whitespace spans are non-matches (false)
+                    // - word/symbol spans are matches (true)
+                    matches.push(((span_start, i), pt == CharType::Whitespace));
+                    span_start = i;
+                }
+            }
+            prev_type = Some(ct);
+        }
+
+        // Emit the final span
+        if let Some(pt) = prev_type {
+            matches.push(((span_start, inside.len()), pt == CharType::Whitespace));
+        }
+
+        Ok(matches)
+    }
+}
+
+fn classify(ch: char) -> CharType {
+    if ch.is_whitespace() {
+        CharType::Whitespace
+    } else if is_word_char(ch) {
+        CharType::Word
+    } else {
+        CharType::Symbol
+    }
+}
+
+/// Matches the same characters as the `\w` regex class (Unicode-aware).
+/// This is: Alphabetic + Nd (decimal digit) + Pc (connector punctuation) +
+/// M (marks) + Join_Control — NOT Nl/No (which Rust's is_alphanumeric includes).
+fn is_word_char(ch: char) -> bool {
+    use unicode_categories::UnicodeCategories;
+
+    ch.is_alphabetic()               // Unicode Alphabetic property (L* + some others)
+        || ch.is_number_decimal_digit()  // Nd only (not Nl/No like superscripts, fractions)
+        || ch.is_punctuation_connector() // Pc: underscore, undertie, fullwidth low line, etc.
+        || ch.is_mark_nonspacing()       // Mn: combining diacriticals, nukta, etc.
+        || ch.is_mark_spacing_combining() // Mc: spacing combining marks (vowel signs)
+        || ch.is_mark_enclosing()        // Me: enclosing marks
+        || ch == '\u{200c}'              // Zero-Width Non-Joiner
+        || ch == '\u{200d}'              // Zero-Width Joiner
 }
 
 #[cfg(test)]
@@ -99,6 +181,122 @@ mod tests {
                     .map(|(s, o, _)| (s, o))
                     .collect::<Vec<_>>(),
                 res
+            );
+        }
+    }
+
+    #[test]
+    fn assert_equivalent() {
+        let test_cases = vec![
+            "Hello world!",
+            "How are you doing?",
+            "This is a test with numbers 123 and symbols @#$%",
+            "Multiple    spaces",
+            "Tabs\tand\nnewlines",
+            "Unicode: café résumé naïve",
+            "Mixed: Hello123!@# world",
+            "Edge cases: a.b,c;d:e",
+            "Empty string:",
+            "Only spaces:   ",
+            "Only symbols: !@#$%",
+            "Only words: hello world",
+            "Numbers: 123 456 789",
+            "Underscores: hello_world test_case",
+            "Special chars: αβγ δέζ ηθι",
+        ];
+
+        for test_case in test_cases {
+            let mut original = PreTokenizedString::from(test_case);
+            let mut manual = PreTokenizedString::from(test_case);
+
+            let original_pretok = Whitespace {};
+            let manual_pretok = ManualWhitespaceSplit {};
+
+            original_pretok.pre_tokenize(&mut original).unwrap();
+            manual_pretok.pre_tokenize(&mut manual).unwrap();
+
+            let original_splits = original
+                .get_splits(OffsetReferential::Original, OffsetType::Byte)
+                .into_iter()
+                .map(|(s, o, _)| (s, o))
+                .collect::<Vec<_>>();
+
+            let manual_splits = manual
+                .get_splits(OffsetReferential::Original, OffsetType::Byte)
+                .into_iter()
+                .map(|(s, o, _)| (s, o))
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                original_splits, manual_splits,
+                "Mismatch for test case: '{}'",
+                test_case
+            );
+        }
+    }
+
+    #[test]
+    fn manual_edge_cases() {
+        let pretok = ManualWhitespaceSplit {};
+
+        // Test various edge cases
+        let edge_cases = vec![
+            ("", vec![]),
+            (" ", vec![]),
+            ("  ", vec![]),
+            ("a", vec![("a", (0, 1))]),
+            ("!", vec![("!", (0, 1))]),
+            ("a!", vec![("a", (0, 1)), ("!", (1, 2))]),
+            ("!a", vec![("!", (0, 1)), ("a", (1, 2))]),
+            ("a b", vec![("a", (0, 1)), ("b", (2, 3))]),
+            ("a  b", vec![("a", (0, 1)), ("b", (3, 4))]),
+            ("a\tb", vec![("a", (0, 1)), ("b", (2, 3))]),
+            ("a\nb", vec![("a", (0, 1)), ("b", (2, 3))]),
+            ("a\r\nb", vec![("a", (0, 1)), ("b", (3, 4))]),
+        ];
+
+        for (input, expected) in edge_cases {
+            let mut pretokenized = PreTokenizedString::from(input);
+            pretok.pre_tokenize(&mut pretokenized).unwrap();
+            let result = pretokenized
+                .get_splits(OffsetReferential::Original, OffsetType::Byte)
+                .into_iter()
+                .map(|(s, o, _)| (s, o))
+                .collect::<Vec<_>>();
+            assert_eq!(result, expected, "Failed for input: '{}'", input);
+        }
+    }
+
+    #[test]
+    fn assert_equivalent_xnli() {
+        let data = std::fs::read_to_string("data/xnli.txt").unwrap();
+        let original_pretok = Whitespace {};
+        let manual_pretok = ManualWhitespaceSplit {};
+
+        for (i, line) in data.lines().enumerate() {
+            let mut original = PreTokenizedString::from(line);
+            let mut manual = PreTokenizedString::from(line);
+
+            original_pretok.pre_tokenize(&mut original).unwrap();
+            manual_pretok.pre_tokenize(&mut manual).unwrap();
+
+            let original_splits = original
+                .get_splits(OffsetReferential::Original, OffsetType::Byte)
+                .into_iter()
+                .map(|(s, o, _)| (s, o))
+                .collect::<Vec<_>>();
+            let manual_splits = manual
+                .get_splits(OffsetReferential::Original, OffsetType::Byte)
+                .into_iter()
+                .map(|(s, o, _)| (s, o))
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                original_splits,
+                manual_splits,
+                "Mismatch on line {}: '{}'",
+                i,
+                &line.chars().take(80).collect::<String>(),
             );
         }
     }

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -112,14 +112,14 @@ fn classify(ch: char) -> CharType {
 fn is_word_char(ch: char) -> bool {
     use unicode_categories::UnicodeCategories;
 
-    ch.is_alphabetic()               // Unicode Alphabetic property (L* + some others)
-        || ch.is_number_decimal_digit()  // Nd only (not Nl/No like superscripts, fractions)
+    ch.is_alphabetic() // Unicode Alphabetic property (L* + some others)
+        || ch.is_number_decimal_digit() // Nd only (not Nl/No like superscripts, fractions)
         || ch.is_punctuation_connector() // Pc: underscore, undertie, fullwidth low line, etc.
-        || ch.is_mark_nonspacing()       // Mn: combining diacriticals, nukta, etc.
+        || ch.is_mark_nonspacing() // Mn: combining diacriticals, nukta, etc.
         || ch.is_mark_spacing_combining() // Mc: spacing combining marks (vowel signs)
-        || ch.is_mark_enclosing()        // Me: enclosing marks
-        || ch == '\u{200c}'              // Zero-Width Non-Joiner
-        || ch == '\u{200d}'              // Zero-Width Joiner
+        || ch.is_mark_enclosing() // Me: enclosing marks
+        || ch == '\u{200c}' // Zero-Width Non-Joiner
+        || ch == '\u{200d}' // Zero-Width Joiner
 }
 
 #[cfg(test)]

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -267,7 +267,10 @@ mod tests {
 
     #[test]
     fn assert_equivalent_xnli() {
-        let data = std::fs::read_to_string("data/xnli.txt").unwrap();
+        let Ok(data) = std::fs::read_to_string("data/xnli.txt") else {
+            eprintln!("Could not read data/xnli.txt, skipping test");
+            return;
+        };
         let original_pretok = Whitespace {};
         let manual_pretok = ManualWhitespaceSplit {};
 

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -112,12 +112,10 @@ fn classify(ch: char) -> CharType {
 fn is_word_char(ch: char) -> bool {
     use unicode_categories::UnicodeCategories;
 
-    ch.is_alphabetic() // Unicode Alphabetic property (L* + some others)
-        || ch.is_number_decimal_digit() // Nd only (not Nl/No like superscripts, fractions)
-        || ch.is_punctuation_connector() // Pc: underscore, undertie, fullwidth low line, etc.
-        || ch.is_mark_nonspacing() // Mn: combining diacriticals, nukta, etc.
-        || ch.is_mark_spacing_combining() // Mc: spacing combining marks (vowel signs)
-        || ch.is_mark_enclosing() // Me: enclosing marks
+    ch.is_alphabetic()
+        || ch.is_number_decimal_digit()
+        || ch.is_punctuation_connector()
+        || ch.is_mark()
         || ch == '\u{200c}' // Zero-Width Non-Joiner
         || ch == '\u{200d}' // Zero-Width Joiner
 }


### PR DESCRIPTION
Building on the work in #1822 and #1841, I've implemented and tested a faster whitespace split pretokenizer. Tested on xnli, no regressions observed, results are coherent with the regex split.

I've setup a benchmark to validate this and created a correctness test as well. We can probably refactor or remove these bits as they depened on a hardcoded path to a `data/xnli.txt` file, but leaving them there if someone wants to reproduce the results.

```
whitespace-pretok/regex/full-corpus
                        time:   [189.05 ms 190.64 ms 192.34 ms]
                        thrpt:  [32.173 MiB/s 32.459 MiB/s 32.732 MiB/s]
Found 9 outliers among 50 measurements (18.00%)
  5 (10.00%) low mild
  3 (6.00%) high mild
  1 (2.00%) high severe
whitespace-pretok/manual/full-corpus
                        time:   [165.67 ms 166.23 ms 166.75 ms]
                        thrpt:  [37.109 MiB/s 37.226 MiB/s 37.352 MiB/s]
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) low mild
  1 (2.00%) high mild
whitespace-pretok/regex/line-by-line
                        time:   [196.79 ms 197.70 ms 198.76 ms]
                        thrpt:  [31.134 MiB/s 31.300 MiB/s 31.445 MiB/s]
Found 8 outliers among 50 measurements (16.00%)
  3 (6.00%) low mild
  2 (4.00%) high mild
  3 (6.00%) high severe
whitespace-pretok/manual/line-by-line
                        time:   [171.48 ms 172.15 ms 172.82 ms]
                        thrpt:  [35.807 MiB/s 35.946 MiB/s 36.085 MiB/s]

whitespace-pretok-scaling/regex/100
                        time:   [2.3880 µs 2.3905 µs 2.3932 µs]
                        thrpt:  [39.849 MiB/s 39.895 MiB/s 39.936 MiB/s]
whitespace-pretok-scaling/manual/100
                        time:   [2.1645 µs 2.1887 µs 2.2119 µs]
                        thrpt:  [43.115 MiB/s 43.573 MiB/s 44.059 MiB/s]
Found 1 outliers among 50 measurements (2.00%)
  1 (2.00%) high mild
whitespace-pretok-scaling/regex/1000
                        time:   [20.116 µs 20.126 µs 20.139 µs]
                        thrpt:  [47.354 MiB/s 47.385 MiB/s 47.410 MiB/s]
Found 4 outliers among 50 measurements (8.00%)
  3 (6.00%) high mild
  1 (2.00%) high severe
whitespace-pretok-scaling/manual/1000
                        time:   [15.967 µs 16.036 µs 16.097 µs]
                        thrpt:  [59.246 MiB/s 59.469 MiB/s 59.727 MiB/s]
Found 11 outliers among 50 measurements (22.00%)
  3 (6.00%) high mild
  8 (16.00%) high severe
whitespace-pretok-scaling/regex/10000
                        time:   [248.21 µs 248.37 µs 248.58 µs]
                        thrpt:  [38.365 MiB/s 38.397 MiB/s 38.423 MiB/s]
Found 4 outliers among 50 measurements (8.00%)
  3 (6.00%) high mild
  1 (2.00%) high severe
whitespace-pretok-scaling/manual/10000
                        time:   [188.85 µs 188.96 µs 189.06 µs]
                        thrpt:  [50.443 MiB/s 50.470 MiB/s 50.500 MiB/s]
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) high mild
  1 (2.00%) high severe
whitespace-pretok-scaling/regex/100000
                        time:   [2.6126 ms 2.6139 ms 2.6156 ms]
                        thrpt:  [36.462 MiB/s 36.485 MiB/s 36.503 MiB/s]
Found 6 outliers among 50 measurements (12.00%)
  2 (4.00%) high mild
  4 (8.00%) high severe
whitespace-pretok-scaling/manual/100000
                        time:   [2.0381 ms 2.0405 ms 2.0435 ms]
                        thrpt:  [46.669 MiB/s 46.737 MiB/s 46.793 MiB/s]
Found 5 outliers among 50 measurements (10.00%)
  3 (6.00%) high mild
  2 (4.00%) high severe
```

`regex` is the current impl and `manual` is the new implementation. It works by simply iterating on individual chars and handles unicode properly.

Closes #1821, #1825 