### PR TITLE
Massively reduce crate size for on-device inference

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -63,7 +63,7 @@ name = "truncation_benchmark"
 harness = false
 
 [dependencies]
-rand = "0.9"
+rand = { version = "0.9", optional = true }
 onig = { version = "6.5.1", default-features = false, optional = true }
 regex = "1.10"
 regex-syntax = "0.8"
@@ -75,10 +75,8 @@ unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 unicode-segmentation = "1.11"
 indicatif = { version = "0.18", optional = true }
-itertools = "0.14"
 log = "0.4"
-derive_builder = "0.20"
-spm_precompiled = "0.1.3"
+spm_precompiled = { version = "0.1.3", optional = true }
 hf-hub = { version = "0.4.1", features = ["ureq"], default-features = false, optional = true }
 daachorse = "1.0.1"
 paste = "1.0.14"
@@ -86,15 +84,17 @@ macro_rules_attribute = "0.2.0"
 thiserror = "2"
 fancy-regex = { version = "0.17", optional = true }
 getrandom = { version = "0.3" }
-esaxx-rs = { version = "0.1.10", default-features = false, features = [] }
+esaxx-rs = { version = "0.1.10", default-features = false, features = [], optional = true }
 monostate = "0.1.12"
 ahash = { version = "0.8.11", features = ["serde"] }
 dary_heap = { version = "0.3.6", features = ["serde"] }
 compact_str = { version = "0.9", features = ["serde"] }
 
 [features]
-default = ["progressbar", "onig", "esaxx_fast"]
-esaxx_fast = ["esaxx-rs/cpp"]
+default = ["progressbar", "onig", "esaxx_fast", "spm", "training"]
+training = ["dep:rand", "dep:esaxx-rs"]
+spm = ["dep:spm_precompiled"]
+esaxx_fast = ["dep:esaxx-rs", "esaxx-rs/cpp"]
 progressbar = ["indicatif"]
 http = ["hf-hub"]
 unstable_wasm = ["fancy-regex", "getrandom/wasm_js"]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -65,10 +65,10 @@ harness = false
 [dependencies]
 rand = { version = "0.9", optional = true }
 onig = { version = "6.5.1", default-features = false, optional = true }
-regex = "1.10"
-regex-syntax = "0.8"
-rayon = "1.10"
-rayon-cond = "0.4"
+regex = { version = "1.10", default-features = false, features = ["std", "perf", "unicode-perl"] }
+regex-syntax = { version = "0.8", default-features = false, features = ["std", "unicode-perl"] }
+rayon = { version = "1.10", optional = true }
+rayon-cond = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 unicode-normalization-alignments = "0.1"
@@ -85,13 +85,13 @@ thiserror = "2"
 fancy-regex = { version = "0.17", optional = true }
 getrandom = { version = "0.3" }
 esaxx-rs = { version = "0.1.10", default-features = false, features = [], optional = true }
-monostate = "0.1.12"
-ahash = { version = "0.8.11", features = ["serde"] }
+foldhash = "0.2"
 dary_heap = { version = "0.3.6", features = ["serde"] }
 compact_str = { version = "0.9", features = ["serde"] }
 
 [features]
-default = ["progressbar", "onig", "esaxx_fast", "spm", "training"]
+default = ["progressbar", "onig", "esaxx_fast", "spm", "training", "parallel"]
+parallel = ["dep:rayon", "dep:rayon-cond"]
 training = ["dep:rand", "dep:esaxx-rs"]
 spm = ["dep:spm_precompiled"]
 esaxx_fast = ["dep:esaxx-rs", "esaxx-rs/cpp"]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -71,9 +71,9 @@ rayon = { version = "1.10", optional = true }
 rayon-cond = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-unicode-normalization-alignments = "0.1"
+unicode-normalization-alignments = { version = "0.1", optional = true }
 unicode_categories = "0.1"
-unicode-segmentation = "1.11"
+unicode-segmentation = { version = "1.11", optional = true }
 indicatif = { version = "0.18", optional = true }
 log = "0.4"
 spm_precompiled = { version = "0.1.3", optional = true }
@@ -87,13 +87,14 @@ getrandom = { version = "0.3" }
 esaxx-rs = { version = "0.1.10", default-features = false, features = [], optional = true }
 foldhash = "0.2"
 dary_heap = { version = "0.3.6", features = ["serde"] }
-compact_str = { version = "0.9", features = ["serde"] }
+compact_str = { version = "0.9", features = ["serde"], optional = true }
 
 [features]
-default = ["progressbar", "onig", "esaxx_fast", "spm", "training", "parallel"]
+default = ["progressbar", "onig", "esaxx_fast", "spm", "training", "parallel", "unicode-normalization"]
+unicode-normalization = ["dep:unicode-normalization-alignments"]
 parallel = ["dep:rayon", "dep:rayon-cond"]
-training = ["dep:rand", "dep:esaxx-rs"]
-spm = ["dep:spm_precompiled"]
+training = ["dep:rand", "dep:esaxx-rs", "dep:compact_str"]
+spm = ["dep:spm_precompiled", "dep:unicode-segmentation"]
 esaxx_fast = ["dep:esaxx-rs", "esaxx-rs/cpp"]
 progressbar = ["indicatif"]
 http = ["hf-hub"]

--- a/tokenizers/src/decoders/byte_fallback.rs
+++ b/tokenizers/src/decoders/byte_fallback.rs
@@ -1,23 +1,22 @@
 use crate::tokenizer::{Decoder, Result};
-use monostate::MustBe;
 
-use serde::{Deserialize, Serialize};
+impl_serde_type! {
+    #[derive(Clone, Debug)]
+    /// ByteFallback is a simple trick which converts tokens looking like `<0x61>`
+    /// to pure bytes, and attempts to make them into a string. If the tokens
+    /// cannot be decoded you will get � instead for each inconvertible byte token
+    pub struct ByteFallback;
+}
 
-#[derive(Deserialize, Clone, Debug, Serialize, Default)]
-/// ByteFallback is a simple trick which converts tokens looking like `<0x61>`
-/// to pure bytes, and attempts to make them into a string. If the tokens
-/// cannot be decoded you will get � instead for each inconvertible byte token
-#[non_exhaustive]
-pub struct ByteFallback {
-    #[serde(rename = "type")]
-    type_: MustBe!("ByteFallback"),
+impl Default for ByteFallback {
+    fn default() -> Self {
+        ByteFallback
+    }
 }
 
 impl ByteFallback {
     pub fn new() -> Self {
-        Self {
-            type_: MustBe!("ByteFallback"),
-        }
+        ByteFallback
     }
 }
 

--- a/tokenizers/src/decoders/ctc.rs
+++ b/tokenizers/src/decoders/ctc.rs
@@ -1,7 +1,6 @@
 use crate::decoders::wordpiece;
 use crate::tokenizer::{Decoder, Result};
 
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,22 +42,22 @@ impl Default for CTC {
 
 impl Decoder for CTC {
     fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
-        Ok(tokens
-            .into_iter()
-            .dedup()
-            .filter_map(|token| {
-                let mut replaced = token.replace(&self.pad_token, "");
-                if self.cleanup {
-                    replaced =
-                        wordpiece::cleanup(&replaced).replace(&self.word_delimiter_token, " ");
-                }
-                if replaced.is_empty() {
-                    None
-                } else {
-                    Some(replaced)
-                }
-            })
-            .collect())
+        let mut prev: Option<String> = None;
+        let mut result = Vec::new();
+        for token in tokens {
+            if prev.as_ref() == Some(&token) {
+                continue;
+            }
+            prev = Some(token.clone());
+            let mut replaced = token.replace(&self.pad_token, "");
+            if self.cleanup {
+                replaced = wordpiece::cleanup(&replaced).replace(&self.word_delimiter_token, " ");
+            }
+            if !replaced.is_empty() {
+                result.push(replaced);
+            }
+        }
+        Ok(result)
     }
 }
 

--- a/tokenizers/src/decoders/fuse.rs
+++ b/tokenizers/src/decoders/fuse.rs
@@ -1,23 +1,23 @@
 use crate::tokenizer::{Decoder, Result};
-use monostate::MustBe;
-use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-/// Fuse simply fuses all tokens into one big string.
-/// It's usually the last decoding step anyway, but this
-/// decoder exists incase some decoders need to happen after that
-/// step
-#[non_exhaustive]
-pub struct Fuse {
-    #[serde(rename = "type")]
-    type_: MustBe!("Fuse"),
+impl_serde_type! {
+    #[derive(Clone, Debug)]
+    /// Fuse simply fuses all tokens into one big string.
+    /// It's usually the last decoding step anyway, but this
+    /// decoder exists incase some decoders need to happen after that
+    /// step
+    pub struct Fuse;
+}
+
+impl Default for Fuse {
+    fn default() -> Self {
+        Fuse
+    }
 }
 
 impl Fuse {
     pub fn new() -> Self {
-        Self {
-            type_: MustBe!("Fuse"),
-        }
+        Fuse
     }
 }
 

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -124,6 +124,12 @@
 //!
 //! # Features
 //!
+//! - **training**: Enables tokenizer training support (trainers, training methods). Enabled by default.
+//!   Disable this for inference-only deployments to significantly reduce binary size.
+//!
+//! - **spm**: Enables SentencePiece precompiled normalizer support. Enabled by default.
+//!   Disable this if you only use BPE-based tokenizers (GPT, Llama, etc.).
+//!
 //! - **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
 //!   compilation for certain targets is not supported by the [termios](https://crates.io/crates/termios)
 //!   dependency of the [indicatif](https://crates.io/crates/indicatif) progress bar.
@@ -133,9 +139,6 @@
 
 #[macro_use]
 extern crate log;
-
-#[macro_use]
-extern crate derive_builder;
 
 #[macro_use]
 pub mod utils;

--- a/tokenizers/src/models/bpe/mod.rs
+++ b/tokenizers/src/models/bpe/mod.rs
@@ -1,8 +1,10 @@
 //! [Byte Pair Encoding](https://www.aclweb.org/anthology/P16-1162/) model.
+#[cfg(feature = "training")]
 use std::{iter, mem};
 
 mod model;
 mod serialization;
+#[cfg(feature = "training")]
 pub mod trainer;
 mod word;
 
@@ -35,11 +37,13 @@ pub enum Error {
     InvalidDropout,
 }
 
+#[cfg(feature = "training")]
 /// Provides access to the `FirstLastIterator` to any Iterator
 pub(crate) trait WithFirstLastIterator: Iterator + Sized {
     fn with_first_and_last(self) -> FirstLastIterator<Self>;
 }
 
+#[cfg(feature = "training")]
 impl<I> WithFirstLastIterator for I
 where
     I: Iterator,
@@ -52,6 +56,7 @@ where
     }
 }
 
+#[cfg(feature = "training")]
 /// Provides information about whether an item is the first and/or the last of the iterator
 pub(crate) struct FirstLastIterator<I>
 where
@@ -61,6 +66,7 @@ where
     iter: iter::Peekable<I>,
 }
 
+#[cfg(feature = "training")]
 impl<I> Iterator for FirstLastIterator<I>
 where
     I: Iterator,
@@ -78,5 +84,6 @@ where
 
 // Re-export
 pub use model::*;
+#[cfg(feature = "training")]
 pub use trainer::*;
 use word::*;

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -1,4 +1,6 @@
-use super::{super::OrderedVocabIter, trainer::BpeTrainer, Error, Pair, Word};
+use super::{super::OrderedVocabIter, Error, Pair, Word};
+#[cfg(feature = "training")]
+use super::trainer::BpeTrainer;
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
@@ -497,6 +499,7 @@ impl BPE {
 }
 
 impl Model for BPE {
+    #[cfg(feature = "training")]
     type Trainer = BpeTrainer;
 
     fn get_vocab(&self) -> HashMap<String, u32> {
@@ -572,6 +575,7 @@ impl Model for BPE {
         Ok(vec![vocab_path, merges_path])
     }
 
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> BpeTrainer {
         BpeTrainer::default()
     }

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -4,7 +4,7 @@ use super::trainer::BpeTrainer;
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use serde_json::Value;
 use std::borrow::Cow;
 

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -1,5 +1,5 @@
 use super::{super::OrderedVocabIter, convert_merges_to_hashmap, BpeBuilder, Pair, BPE};
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use serde::{
     de::{Error, MapAccess, Visitor},
     ser::SerializeStruct,

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -4,7 +4,7 @@ use super::{Pair, WithFirstLastIterator, Word, BPE};
 use crate::parallelism::*;
 use crate::tokenizer::{AddedToken, Result, Trainer};
 use crate::utils::progress::{ProgressBar, ProgressFormat, ProgressStyle};
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet, HashMapExt, HashSetExt};
 use compact_str::CompactString;
 use dary_heap::OctonaryHeap;
 use serde::{Deserialize, Serialize};
@@ -678,7 +678,7 @@ impl Trainer for BpeTrainer {
 #[cfg(test)]
 mod tests {
     use super::{BpeTrainer, Pair, BPE};
-    use ahash::AHashMap;
+    use crate::utils::{AHashMap, HashMapExt};
     use compact_str::CompactString;
 
     #[test]

--- a/tokenizers/src/models/bpe/word.rs
+++ b/tokenizers/src/models/bpe/word.rs
@@ -1,6 +1,7 @@
 use super::Pair;
 use ahash::AHashMap;
 use dary_heap::QuaternaryHeap;
+#[cfg(feature = "training")]
 use rand::{rng, Rng};
 use std::cmp::Ordering;
 
@@ -75,6 +76,7 @@ impl std::fmt::Debug for Word {
 }
 
 impl Word {
+    #[cfg_attr(not(feature = "training"), allow(dead_code))]
     pub(super) fn new() -> Self {
         Word { symbols: vec![] }
     }
@@ -104,6 +106,7 @@ impl Word {
         });
     }
 
+    #[cfg_attr(not(feature = "training"), allow(dead_code))]
     pub(super) fn merge(
         &mut self,
         c1: u32,
@@ -178,7 +181,18 @@ impl Word {
         );
 
         while let Some(top) = queue.pop() {
-            if dropout.map(|d| rng().random::<f32>() < d).unwrap_or(false) {
+            let should_skip = {
+                #[cfg(feature = "training")]
+                {
+                    dropout.map(|d| rng().random::<f32>() < d).unwrap_or(false)
+                }
+                #[cfg(not(feature = "training"))]
+                {
+                    let _ = &dropout;
+                    false
+                }
+            };
+            if should_skip {
                 skip.push(top);
             } else {
                 // Re-insert the skipped elements
@@ -249,6 +263,7 @@ impl Word {
         self.symbols.retain(|s| s.len != 0);
     }
 
+    #[cfg_attr(not(feature = "training"), allow(dead_code))]
     pub(super) fn get_chars(&self) -> Vec<u32> {
         self.symbols.iter().map(|s| s.c).collect()
     }

--- a/tokenizers/src/models/bpe/word.rs
+++ b/tokenizers/src/models/bpe/word.rs
@@ -1,5 +1,5 @@
 use super::Pair;
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use dary_heap::QuaternaryHeap;
 #[cfg(feature = "training")]
 use rand::{rng, Rng};

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -5,7 +5,7 @@ pub mod unigram;
 pub mod wordlevel;
 pub mod wordpiece;
 
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn incomplete_ordered_vocab() {
         let vocab_r: AHashMap<u32, String> =
-            AHashMap::from([(0, "Hi".to_string()), (2, "There".to_string())]);
+            IntoIterator::into_iter([(0u32, "Hi".to_string()), (2, "There".to_string())]).collect();
 
         let ordered = OrderedVocabIter::new(&vocab_r);
 

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -11,11 +11,21 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::models::bpe::{BpeTrainer, BPE};
-use crate::models::unigram::{Unigram, UnigramTrainer};
-use crate::models::wordlevel::{WordLevel, WordLevelTrainer};
-use crate::models::wordpiece::{WordPiece, WordPieceTrainer};
-use crate::{AddedToken, Model, Result, Token, Trainer};
+use crate::models::bpe::BPE;
+#[cfg(feature = "training")]
+use crate::models::bpe::BpeTrainer;
+use crate::models::unigram::Unigram;
+#[cfg(feature = "training")]
+use crate::models::unigram::UnigramTrainer;
+use crate::models::wordlevel::WordLevel;
+#[cfg(feature = "training")]
+use crate::models::wordlevel::WordLevelTrainer;
+use crate::models::wordpiece::WordPiece;
+#[cfg(feature = "training")]
+use crate::models::wordpiece::WordPieceTrainer;
+use crate::{Model, Result, Token};
+#[cfg(feature = "training")]
+use crate::{AddedToken, Trainer};
 
 /// Wraps a vocab mapping (ID -> token) to a struct that will be serialized in order
 /// of token ID, smallest to largest.
@@ -141,6 +151,7 @@ impl_enum_from!(BPE, ModelWrapper, BPE);
 impl_enum_from!(Unigram, ModelWrapper, Unigram);
 
 impl Model for ModelWrapper {
+    #[cfg(feature = "training")]
     type Trainer = TrainerWrapper;
 
     fn tokenize(&self, tokens: &str) -> Result<Vec<Token>> {
@@ -197,6 +208,7 @@ impl Model for ModelWrapper {
         }
     }
 
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> Self::Trainer {
         match self {
             Self::WordLevel(t) => t.get_trainer().into(),
@@ -224,6 +236,7 @@ impl ModelWrapper {
     }
 }
 
+#[cfg(feature = "training")]
 #[derive(Clone, Serialize, Deserialize)]
 pub enum TrainerWrapper {
     BpeTrainer(BpeTrainer),
@@ -232,6 +245,7 @@ pub enum TrainerWrapper {
     UnigramTrainer(UnigramTrainer),
 }
 
+#[cfg(feature = "training")]
 impl Trainer for TrainerWrapper {
     type Model = ModelWrapper;
 
@@ -280,9 +294,13 @@ impl Trainer for TrainerWrapper {
     }
 }
 
+#[cfg(feature = "training")]
 impl_enum_from!(BpeTrainer, TrainerWrapper, BpeTrainer);
+#[cfg(feature = "training")]
 impl_enum_from!(WordPieceTrainer, TrainerWrapper, WordPieceTrainer);
+#[cfg(feature = "training")]
 impl_enum_from!(UnigramTrainer, TrainerWrapper, UnigramTrainer);
+#[cfg(feature = "training")]
 impl_enum_from!(WordLevelTrainer, TrainerWrapper, WordLevelTrainer);
 
 #[cfg(test)]

--- a/tokenizers/src/models/unigram/lattice.rs
+++ b/tokenizers/src/models/unigram/lattice.rs
@@ -1,5 +1,7 @@
 use dary_heap::QuaternaryHeap;
+#[cfg(feature = "training")]
 use rand::distr::weighted::WeightedIndex;
+#[cfg(feature = "training")]
 use rand::{prelude::*, rng};
 use std::cell::RefCell;
 use std::cmp::{min, Ordering};
@@ -377,6 +379,7 @@ impl<'a> Lattice<'a> {
         freq * z
     }
 
+    #[cfg(feature = "training")]
     pub fn sample(&self, theta: f64) -> Vec<NodeRef> {
         let len = self.len();
         if len == 0 {
@@ -422,6 +425,7 @@ impl<'a> Lattice<'a> {
         results
     }
 
+    #[cfg(feature = "training")]
     pub fn sample_token(&self, theta: f64) -> Vec<String> {
         self.sample(theta)
             .iter()
@@ -429,6 +433,7 @@ impl<'a> Lattice<'a> {
             .collect()
     }
 
+    #[cfg(feature = "training")]
     pub fn sample_nbest(&mut self, n: usize, theta: f64) -> Vec<NodeRef> {
         let nbest_paths = self.nbest(n);
         if nbest_paths.is_empty() {

--- a/tokenizers/src/models/unigram/mod.rs
+++ b/tokenizers/src/models/unigram/mod.rs
@@ -2,9 +2,11 @@
 mod lattice;
 mod model;
 mod serialization;
+#[cfg(feature = "training")]
 mod trainer;
 mod trie;
 
 pub use lattice::*;
 pub use model::*;
+#[cfg(feature = "training")]
 pub use trainer::*;

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -8,7 +8,7 @@ use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 use std::collections::HashMap;
 
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use std::convert::TryInto;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -1,8 +1,9 @@
 use super::{
     lattice::Lattice,
-    trainer::UnigramTrainer,
     trie::{Trie, TrieBuilder},
 };
+#[cfg(feature = "training")]
+use super::trainer::UnigramTrainer;
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 use std::collections::HashMap;
@@ -346,10 +347,19 @@ impl Unigram {
     fn encode_unoptimized(&self, sentence: &str) -> Result<Vec<String>> {
         let mut lattice = Lattice::from(sentence, self.bos_id, self.eos_id);
         self.populate_nodes(&mut lattice);
-        let path = match (self.nbest_size, self.alpha) {
-            (Some(n), Some(alpha)) if n > 0 => lattice.sample_nbest(n, alpha),
-            (_, Some(alpha)) => lattice.sample(alpha),
-            _ => lattice.viterbi(),
+        let path = {
+            #[cfg(feature = "training")]
+            {
+                match (self.nbest_size, self.alpha) {
+                    (Some(n), Some(alpha)) if n > 0 => lattice.sample_nbest(n, alpha),
+                    (_, Some(alpha)) => lattice.sample(alpha),
+                    _ => lattice.viterbi(),
+                }
+            }
+            #[cfg(not(feature = "training"))]
+            {
+                lattice.viterbi()
+            }
         };
         if self.fuse_unk {
             let mut results = vec![];
@@ -430,6 +440,7 @@ impl<'a> Iterator for UnigramIterator<'a> {
 }
 
 impl Model for Unigram {
+    #[cfg(feature = "training")]
     type Trainer = UnigramTrainer;
 
     fn get_vocab(&self) -> HashMap<String, u32> {
@@ -497,6 +508,7 @@ impl Model for Unigram {
         Ok(vec![fullpath])
     }
 
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> Self::Trainer {
         UnigramTrainer::default()
     }

--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -45,35 +45,105 @@ fn to_log_prob(pieces: &mut [SentencePiece]) {
 
 /// A `UnigramTrainer` can train a `Unigram` model from `word_counts`.
 #[non_exhaustive]
-#[derive(Builder, Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnigramTrainer {
-    #[builder(default = "true")]
     pub show_progress: bool,
-    #[builder(default = "8000")]
     pub vocab_size: u32,
-    #[builder(default = "2")]
     pub n_sub_iterations: u32,
-    #[builder(default = "0.75")]
     pub shrinking_factor: f64,
-    #[builder(default = "vec![]")]
     pub special_tokens: Vec<AddedToken>,
-    #[builder(default = "AHashSet::new()")]
     pub initial_alphabet: AHashSet<char>,
-
-    #[builder(default = "None")]
     pub unk_token: Option<String>,
-
-    #[builder(default = "16")]
     pub max_piece_length: usize,
-    #[builder(default = "1_000_000")]
     seed_size: usize,
-    #[builder(default = "AHashMap::new()")]
     words: AHashMap<String, u32>,
 }
 
 impl Default for UnigramTrainer {
     fn default() -> Self {
-        Self::builder().build().unwrap()
+        Self {
+            show_progress: true,
+            vocab_size: 8000,
+            n_sub_iterations: 2,
+            shrinking_factor: 0.75,
+            special_tokens: vec![],
+            initial_alphabet: AHashSet::new(),
+            unk_token: None,
+            max_piece_length: 16,
+            seed_size: 1_000_000,
+            words: AHashMap::new(),
+        }
+    }
+}
+
+/// Builder for `UnigramTrainer`.
+#[derive(Debug, Clone, Default)]
+pub struct UnigramTrainerBuilder {
+    show_progress: Option<bool>,
+    vocab_size: Option<u32>,
+    n_sub_iterations: Option<u32>,
+    shrinking_factor: Option<f64>,
+    special_tokens: Option<Vec<AddedToken>>,
+    initial_alphabet: Option<AHashSet<char>>,
+    unk_token: Option<Option<String>>,
+    max_piece_length: Option<usize>,
+    seed_size: Option<usize>,
+}
+
+impl UnigramTrainerBuilder {
+    pub fn show_progress(&mut self, show_progress: bool) -> &mut Self {
+        self.show_progress = Some(show_progress);
+        self
+    }
+    pub fn vocab_size(&mut self, vocab_size: u32) -> &mut Self {
+        self.vocab_size = Some(vocab_size);
+        self
+    }
+    pub fn n_sub_iterations(&mut self, n_sub_iterations: u32) -> &mut Self {
+        self.n_sub_iterations = Some(n_sub_iterations);
+        self
+    }
+    pub fn shrinking_factor(&mut self, shrinking_factor: f64) -> &mut Self {
+        self.shrinking_factor = Some(shrinking_factor);
+        self
+    }
+    pub fn special_tokens(&mut self, special_tokens: Vec<AddedToken>) -> &mut Self {
+        self.special_tokens = Some(special_tokens);
+        self
+    }
+    pub fn initial_alphabet(&mut self, initial_alphabet: AHashSet<char>) -> &mut Self {
+        self.initial_alphabet = Some(initial_alphabet);
+        self
+    }
+    pub fn unk_token(&mut self, unk_token: Option<String>) -> &mut Self {
+        self.unk_token = Some(unk_token);
+        self
+    }
+    pub fn max_piece_length(&mut self, max_piece_length: usize) -> &mut Self {
+        self.max_piece_length = Some(max_piece_length);
+        self
+    }
+    pub fn seed_size(&mut self, seed_size: usize) -> &mut Self {
+        self.seed_size = Some(seed_size);
+        self
+    }
+    pub fn build(&self) -> Result<UnigramTrainer> {
+        let default = UnigramTrainer::default();
+        Ok(UnigramTrainer {
+            show_progress: self.show_progress.unwrap_or(default.show_progress),
+            vocab_size: self.vocab_size.unwrap_or(default.vocab_size),
+            n_sub_iterations: self.n_sub_iterations.unwrap_or(default.n_sub_iterations),
+            shrinking_factor: self.shrinking_factor.unwrap_or(default.shrinking_factor),
+            special_tokens: self.special_tokens.clone().unwrap_or(default.special_tokens),
+            initial_alphabet: self
+                .initial_alphabet
+                .clone()
+                .unwrap_or(default.initial_alphabet),
+            unk_token: self.unk_token.clone().unwrap_or(default.unk_token),
+            max_piece_length: self.max_piece_length.unwrap_or(default.max_piece_length),
+            seed_size: self.seed_size.unwrap_or(default.seed_size),
+            words: AHashMap::new(),
+        })
     }
 }
 

--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -2,7 +2,7 @@ use crate::models::unigram::{lattice::Lattice, model::Unigram};
 use crate::tokenizer::{AddedToken, Result, Trainer};
 use crate::utils::parallelism::*;
 use crate::utils::progress::{ProgressBar, ProgressStyle};
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet, HashMapExt, HashSetExt};
 use log::debug;
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;

--- a/tokenizers/src/models/unigram/trie.rs
+++ b/tokenizers/src/models/unigram/trie.rs
@@ -1,4 +1,4 @@
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use std::hash::Hash;
 
 #[derive(Default)]

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -8,9 +8,11 @@ use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
 mod serialization;
+#[cfg(feature = "training")]
 mod trainer;
 
 // Re-export
+#[cfg(feature = "training")]
 pub use trainer::*;
 
 type Vocab = AHashMap<String, u32>;
@@ -157,6 +159,7 @@ impl Default for WordLevel {
 }
 
 impl Model for WordLevel {
+    #[cfg(feature = "training")]
     type Trainer = WordLevelTrainer;
 
     fn tokenize(&self, token: &str) -> Result<Vec<Token>> {
@@ -211,6 +214,7 @@ impl Model for WordLevel {
         Ok(vec![vocab_path])
     }
 
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> Self::Trainer {
         WordLevelTrainer::default()
     }

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -1,6 +1,6 @@
 use super::OrderedVocabIter;
 use crate::tokenizer::{Model, Result, Token};
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs::File;

--- a/tokenizers/src/models/wordlevel/serialization.rs
+++ b/tokenizers/src/models/wordlevel/serialization.rs
@@ -1,5 +1,5 @@
 use super::{super::OrderedVocabIter, WordLevel, WordLevelBuilder};
-use ahash::AHashSet;
+use crate::utils::{AHashSet};
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeStruct,

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -1,7 +1,7 @@
 use super::WordLevel;
 use crate::utils::parallelism::*;
 use crate::{AddedToken, Result, Trainer};
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -6,28 +6,67 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
 #[non_exhaustive]
-#[derive(Debug, Clone, Builder, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WordLevelTrainer {
     /// The minimum frequency a word must have to be part of the vocabulary
-    #[builder(default = "0")]
     pub min_frequency: u64,
     /// The target vocabulary size
-    #[builder(default = "30_000")]
     pub vocab_size: usize,
     /// Whether to show progress while training
-    #[builder(default = "true")]
     pub show_progress: bool,
     /// A list of special tokens that the model should know of
-    #[builder(default)]
     pub special_tokens: Vec<AddedToken>,
 
-    #[builder(default, private)]
     words: AHashMap<String, u64>,
 }
 
 impl Default for WordLevelTrainer {
     fn default() -> Self {
-        Self::builder().build().unwrap()
+        Self {
+            min_frequency: 0,
+            vocab_size: 30_000,
+            show_progress: true,
+            special_tokens: vec![],
+            words: AHashMap::new(),
+        }
+    }
+}
+
+/// Builder for `WordLevelTrainer`.
+#[derive(Debug, Clone, Default)]
+pub struct WordLevelTrainerBuilder {
+    min_frequency: Option<u64>,
+    vocab_size: Option<usize>,
+    show_progress: Option<bool>,
+    special_tokens: Option<Vec<AddedToken>>,
+}
+
+impl WordLevelTrainerBuilder {
+    pub fn min_frequency(&mut self, min_frequency: u64) -> &mut Self {
+        self.min_frequency = Some(min_frequency);
+        self
+    }
+    pub fn vocab_size(&mut self, vocab_size: usize) -> &mut Self {
+        self.vocab_size = Some(vocab_size);
+        self
+    }
+    pub fn show_progress(&mut self, show_progress: bool) -> &mut Self {
+        self.show_progress = Some(show_progress);
+        self
+    }
+    pub fn special_tokens(&mut self, special_tokens: Vec<AddedToken>) -> &mut Self {
+        self.special_tokens = Some(special_tokens);
+        self
+    }
+    pub fn build(&self) -> Result<WordLevelTrainer> {
+        let default = WordLevelTrainer::default();
+        Ok(WordLevelTrainer {
+            min_frequency: self.min_frequency.unwrap_or(default.min_frequency),
+            vocab_size: self.vocab_size.unwrap_or(default.vocab_size),
+            show_progress: self.show_progress.unwrap_or(default.show_progress),
+            special_tokens: self.special_tokens.clone().unwrap_or(default.special_tokens),
+            words: AHashMap::new(),
+        })
     }
 }
 

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -14,7 +14,9 @@ use std::{
 };
 
 mod serialization;
+#[cfg(feature = "training")]
 mod trainer;
+#[cfg(feature = "training")]
 pub use trainer::*;
 
 #[derive(thiserror::Error, Debug)]
@@ -211,6 +213,7 @@ impl WordPiece {
 }
 
 impl Model for WordPiece {
+    #[cfg(feature = "training")]
     type Trainer = WordPieceTrainer;
 
     fn get_vocab(&self) -> HashMap<String, u32> {
@@ -313,6 +316,7 @@ impl Model for WordPiece {
         Ok(vec![vocab_path])
     }
 
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> Self::Trainer {
         WordPieceTrainer::builder().build()
     }

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::models::bpe::BPE;
 use crate::tokenizer::{Model, Result, Token};
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use std::collections::HashMap;
 use std::{
     borrow::Cow,

--- a/tokenizers/src/models/wordpiece/serialization.rs
+++ b/tokenizers/src/models/wordpiece/serialization.rs
@@ -1,5 +1,5 @@
 use super::{super::OrderedVocabIter, WordPiece, WordPieceBuilder};
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet};
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeStruct,

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use super::WordPiece;
 use crate::models::bpe::{BpeTrainer, BpeTrainerBuilder, BPE};
 use crate::tokenizer::{AddedToken, Result, Trainer};
-use ahash::AHashSet;
+use crate::utils::{AHashSet, HashSetExt};
 use serde::{Deserialize, Serialize};
 
 /// A `WordPieceTrainerBuilder` can be used to create a `WordPieceTrainer` with a custom

--- a/tokenizers/src/normalizers/bert.rs
+++ b/tokenizers/src/normalizers/bert.rs
@@ -108,7 +108,12 @@ impl BertNormalizer {
     }
 
     fn do_strip_accents(&self, normalized: &mut NormalizedString) {
+        #[cfg(feature = "unicode-normalization")]
         normalized.nfd().filter(|c| !c.is_mark_nonspacing());
+        #[cfg(not(feature = "unicode-normalization"))]
+        {
+            let _ = normalized;
+        }
     }
 
     fn do_lowercase(&self, normalized: &mut NormalizedString) {

--- a/tokenizers/src/normalizers/byte_level.rs
+++ b/tokenizers/src/normalizers/byte_level.rs
@@ -1,7 +1,7 @@
 use crate::processors::byte_level::bytes_char;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet};
 use std::sync::LazyLock;
 
 #[derive(Clone, Debug)]

--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -14,7 +14,9 @@ pub use crate::normalizers::precompiled::Precompiled;
 pub use crate::normalizers::prepend::Prepend;
 pub use crate::normalizers::replace::Replace;
 pub use crate::normalizers::strip::{Strip, StripAccents};
-pub use crate::normalizers::unicode::{Nmt, NFC, NFD, NFKC, NFKD};
+pub use crate::normalizers::unicode::Nmt;
+#[cfg(feature = "unicode-normalization")]
+pub use crate::normalizers::unicode::{NFC, NFD, NFKC, NFKD};
 pub use crate::normalizers::utils::{Lowercase, Sequence};
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -27,9 +29,13 @@ pub enum NormalizerWrapper {
     BertNormalizer(BertNormalizer),
     StripNormalizer(Strip),
     StripAccents(StripAccents),
+    #[cfg(feature = "unicode-normalization")]
     NFC(NFC),
+    #[cfg(feature = "unicode-normalization")]
     NFD(NFD),
+    #[cfg(feature = "unicode-normalization")]
     NFKC(NFKC),
+    #[cfg(feature = "unicode-normalization")]
     NFKD(NFKD),
     Sequence(Sequence),
     Lowercase(Lowercase),
@@ -84,9 +90,13 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
             BertNormalizer(BertNormalizer),
             StripNormalizer(Strip),
             StripAccents(StripAccents),
+            #[cfg(feature = "unicode-normalization")]
             NFC(NFC),
+            #[cfg(feature = "unicode-normalization")]
             NFD(NFD),
+            #[cfg(feature = "unicode-normalization")]
             NFKC(NFKC),
+            #[cfg(feature = "unicode-normalization")]
             NFKD(NFKD),
             Sequence(Sequence),
             Lowercase(Lowercase),
@@ -116,18 +126,30 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                     EnumType::StripAccents => NormalizerWrapper::StripAccents(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
-                    EnumType::NFC => NormalizerWrapper::NFC(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
-                    ),
-                    EnumType::NFD => NormalizerWrapper::NFD(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
-                    ),
-                    EnumType::NFKC => NormalizerWrapper::NFKC(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
-                    ),
-                    EnumType::NFKD => NormalizerWrapper::NFKD(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
-                    ),
+                    EnumType::NFC => {
+                        #[cfg(feature = "unicode-normalization")]
+                        { NormalizerWrapper::NFC(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        #[cfg(not(feature = "unicode-normalization"))]
+                        { return Err(serde::de::Error::custom("NFC normalizer requires the `unicode-normalization` feature")); }
+                    }
+                    EnumType::NFD => {
+                        #[cfg(feature = "unicode-normalization")]
+                        { NormalizerWrapper::NFD(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        #[cfg(not(feature = "unicode-normalization"))]
+                        { return Err(serde::de::Error::custom("NFD normalizer requires the `unicode-normalization` feature")); }
+                    }
+                    EnumType::NFKC => {
+                        #[cfg(feature = "unicode-normalization")]
+                        { NormalizerWrapper::NFKC(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        #[cfg(not(feature = "unicode-normalization"))]
+                        { return Err(serde::de::Error::custom("NFKC normalizer requires the `unicode-normalization` feature")); }
+                    }
+                    EnumType::NFKD => {
+                        #[cfg(feature = "unicode-normalization")]
+                        { NormalizerWrapper::NFKD(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        #[cfg(not(feature = "unicode-normalization"))]
+                        { return Err(serde::de::Error::custom("NFKD normalizer requires the `unicode-normalization` feature")); }
+                    }
                     EnumType::Sequence => NormalizerWrapper::Sequence(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
@@ -177,9 +199,13 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         NormalizerWrapper::StripNormalizer(bpe)
                     }
                     NormalizerUntagged::StripAccents(bpe) => NormalizerWrapper::StripAccents(bpe),
+                    #[cfg(feature = "unicode-normalization")]
                     NormalizerUntagged::NFC(bpe) => NormalizerWrapper::NFC(bpe),
+                    #[cfg(feature = "unicode-normalization")]
                     NormalizerUntagged::NFD(bpe) => NormalizerWrapper::NFD(bpe),
+                    #[cfg(feature = "unicode-normalization")]
                     NormalizerUntagged::NFKC(bpe) => NormalizerWrapper::NFKC(bpe),
+                    #[cfg(feature = "unicode-normalization")]
                     NormalizerUntagged::NFKD(bpe) => NormalizerWrapper::NFKD(bpe),
                     NormalizerUntagged::Sequence(seq) => NormalizerWrapper::Sequence(seq),
                     NormalizerUntagged::Lowercase(bpe) => NormalizerWrapper::Lowercase(bpe),
@@ -199,9 +225,13 @@ impl Normalizer for NormalizerWrapper {
             Self::BertNormalizer(bn) => bn.normalize(normalized),
             Self::StripNormalizer(sn) => sn.normalize(normalized),
             Self::StripAccents(sn) => sn.normalize(normalized),
+            #[cfg(feature = "unicode-normalization")]
             Self::NFC(nfc) => nfc.normalize(normalized),
+            #[cfg(feature = "unicode-normalization")]
             Self::NFD(nfd) => nfd.normalize(normalized),
+            #[cfg(feature = "unicode-normalization")]
             Self::NFKC(nfkc) => nfkc.normalize(normalized),
+            #[cfg(feature = "unicode-normalization")]
             Self::NFKD(nfkd) => nfkd.normalize(normalized),
             Self::Sequence(sequence) => sequence.normalize(normalized),
             Self::Lowercase(lc) => lc.normalize(normalized),
@@ -216,9 +246,13 @@ impl Normalizer for NormalizerWrapper {
 }
 
 impl_enum_from!(BertNormalizer, NormalizerWrapper, BertNormalizer);
+#[cfg(feature = "unicode-normalization")]
 impl_enum_from!(NFKD, NormalizerWrapper, NFKD);
+#[cfg(feature = "unicode-normalization")]
 impl_enum_from!(NFKC, NormalizerWrapper, NFKC);
+#[cfg(feature = "unicode-normalization")]
 impl_enum_from!(NFC, NormalizerWrapper, NFC);
+#[cfg(feature = "unicode-normalization")]
 impl_enum_from!(NFD, NormalizerWrapper, NFD);
 impl_enum_from!(Strip, NormalizerWrapper, StripNormalizer);
 impl_enum_from!(StripAccents, NormalizerWrapper, StripAccents);

--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -1,5 +1,6 @@
 pub mod bert;
 pub mod byte_level;
+#[cfg(feature = "spm")]
 pub mod precompiled;
 pub mod prepend;
 pub mod replace;
@@ -8,6 +9,7 @@ pub mod unicode;
 pub mod utils;
 pub use crate::normalizers::bert::BertNormalizer;
 pub use crate::normalizers::byte_level::ByteLevel;
+#[cfg(feature = "spm")]
 pub use crate::normalizers::precompiled::Precompiled;
 pub use crate::normalizers::prepend::Prepend;
 pub use crate::normalizers::replace::Replace;
@@ -32,6 +34,7 @@ pub enum NormalizerWrapper {
     Sequence(Sequence),
     Lowercase(Lowercase),
     Nmt(Nmt),
+    #[cfg(feature = "spm")]
     Precompiled(Precompiled),
     Replace(Replace),
     Prepend(Prepend),
@@ -88,7 +91,6 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
             Sequence(Sequence),
             Lowercase(Lowercase),
             Nmt(Nmt),
-            Precompiled(Precompiled),
             Replace(Replace),
             Prepend(Prepend),
             ByteLevel(ByteLevel),
@@ -135,13 +137,24 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                     EnumType::Nmt => NormalizerWrapper::Nmt(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
-                    EnumType::Precompiled => NormalizerWrapper::Precompiled(
-                        serde_json::from_str(
-                            &serde_json::to_string(&values).expect("Can reserialize precompiled"),
-                        )
-                        // .map_err(serde::de::Error::custom)
-                        .expect("Precompiled"),
-                    ),
+                    EnumType::Precompiled => {
+                        #[cfg(feature = "spm")]
+                        {
+                            NormalizerWrapper::Precompiled(
+                                serde_json::from_str(
+                                    &serde_json::to_string(&values)
+                                        .expect("Can reserialize precompiled"),
+                                )
+                                .expect("Precompiled"),
+                            )
+                        }
+                        #[cfg(not(feature = "spm"))]
+                        {
+                            return Err(serde::de::Error::custom(
+                                "Precompiled normalizer requires the `spm` feature",
+                            ));
+                        }
+                    }
                     EnumType::Replace => NormalizerWrapper::Replace(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
@@ -171,7 +184,6 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                     NormalizerUntagged::Sequence(seq) => NormalizerWrapper::Sequence(seq),
                     NormalizerUntagged::Lowercase(bpe) => NormalizerWrapper::Lowercase(bpe),
                     NormalizerUntagged::Nmt(bpe) => NormalizerWrapper::Nmt(bpe),
-                    NormalizerUntagged::Precompiled(bpe) => NormalizerWrapper::Precompiled(bpe),
                     NormalizerUntagged::Replace(bpe) => NormalizerWrapper::Replace(bpe),
                     NormalizerUntagged::Prepend(bpe) => NormalizerWrapper::Prepend(bpe),
                     NormalizerUntagged::ByteLevel(bpe) => NormalizerWrapper::ByteLevel(bpe),
@@ -194,6 +206,7 @@ impl Normalizer for NormalizerWrapper {
             Self::Sequence(sequence) => sequence.normalize(normalized),
             Self::Lowercase(lc) => lc.normalize(normalized),
             Self::Nmt(lc) => lc.normalize(normalized),
+            #[cfg(feature = "spm")]
             Self::Precompiled(lc) => lc.normalize(normalized),
             Self::Replace(lc) => lc.normalize(normalized),
             Self::Prepend(lc) => lc.normalize(normalized),
@@ -212,6 +225,7 @@ impl_enum_from!(StripAccents, NormalizerWrapper, StripAccents);
 impl_enum_from!(Sequence, NormalizerWrapper, Sequence);
 impl_enum_from!(Lowercase, NormalizerWrapper, Lowercase);
 impl_enum_from!(Nmt, NormalizerWrapper, Nmt);
+#[cfg(feature = "spm")]
 impl_enum_from!(Precompiled, NormalizerWrapper, Precompiled);
 impl_enum_from!(Replace, NormalizerWrapper, Replace);
 impl_enum_from!(Prepend, NormalizerWrapper, Prepend);

--- a/tokenizers/src/normalizers/strip.rs
+++ b/tokenizers/src/normalizers/strip.rs
@@ -1,7 +1,14 @@
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "unicode-normalization")]
 use unicode_normalization_alignments::char::is_combining_mark;
+
+#[cfg(not(feature = "unicode-normalization"))]
+fn is_combining_mark(_c: char) -> bool {
+    // Without unicode-normalization feature, accent stripping is a no-op.
+    false
+}
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]

--- a/tokenizers/src/normalizers/unicode.rs
+++ b/tokenizers/src/normalizers/unicode.rs
@@ -1,45 +1,53 @@
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
 
-#[derive(Default, Copy, Clone, Debug)]
-#[macro_rules_attribute(impl_serde_type!)]
-pub struct NFD;
-impl Normalizer for NFD {
-    fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        normalized.nfd();
-        Ok(())
+#[cfg(feature = "unicode-normalization")]
+mod nf_normalizers {
+    use super::*;
+
+    #[derive(Default, Copy, Clone, Debug)]
+    #[macro_rules_attribute(impl_serde_type!)]
+    pub struct NFD;
+    impl Normalizer for NFD {
+        fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
+            normalized.nfd();
+            Ok(())
+        }
+    }
+
+    #[derive(Default, Copy, Clone, Debug)]
+    #[macro_rules_attribute(impl_serde_type!)]
+    pub struct NFKD;
+    impl Normalizer for NFKD {
+        fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
+            normalized.nfkd();
+            Ok(())
+        }
+    }
+
+    #[derive(Default, Copy, Clone, Debug)]
+    #[macro_rules_attribute(impl_serde_type!)]
+    pub struct NFC;
+    impl Normalizer for NFC {
+        fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
+            normalized.nfc();
+            Ok(())
+        }
+    }
+
+    #[derive(Default, Copy, Clone, Debug)]
+    #[macro_rules_attribute(impl_serde_type!)]
+    pub struct NFKC;
+    impl Normalizer for NFKC {
+        fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
+            normalized.nfkc();
+            Ok(())
+        }
     }
 }
 
-#[derive(Default, Copy, Clone, Debug)]
-#[macro_rules_attribute(impl_serde_type!)]
-pub struct NFKD;
-impl Normalizer for NFKD {
-    fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        normalized.nfkd();
-        Ok(())
-    }
-}
-
-#[derive(Default, Copy, Clone, Debug)]
-#[macro_rules_attribute(impl_serde_type!)]
-pub struct NFC;
-impl Normalizer for NFC {
-    fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        normalized.nfc();
-        Ok(())
-    }
-}
-
-#[derive(Default, Copy, Clone, Debug)]
-#[macro_rules_attribute(impl_serde_type!)]
-pub struct NFKC;
-impl Normalizer for NFKC {
-    fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        normalized.nfkc();
-        Ok(())
-    }
-}
+#[cfg(feature = "unicode-normalization")]
+pub use nf_normalizers::*;
 
 fn do_nmt(normalized: &mut NormalizedString) {
     // Ascii Control characters

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -1,4 +1,6 @@
-use ahash::{AHashMap, AHashSet};
+#[cfg(test)]
+use crate::utils::HashMapExt;
+use crate::utils::{AHashMap, AHashSet};
 use std::sync::LazyLock;
 
 use crate::utils::SysRegex;

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -1,5 +1,5 @@
 use crate::tokenizer::{Encoding, PostProcessor, Result};
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;
 

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -1,6 +1,6 @@
 use crate::processors::byte_level::process_offsets;
 use crate::tokenizer::{Encoding, PostProcessor, Result};
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;
 

--- a/tokenizers/src/processors/sequence.rs
+++ b/tokenizers/src/processors/sequence.rs
@@ -73,7 +73,7 @@ mod tests {
     use super::*;
     use crate::processors::{ByteLevel, PostProcessorWrapper};
     use crate::tokenizer::{Encoding, PostProcessor};
-    use ahash::AHashMap;
+    use crate::utils::{AHashMap, HashMapExt};
     use std::iter::FromIterator;
 
     #[test]

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -58,7 +58,6 @@
 //!
 use crate::{Encoding, PostProcessor, Result};
 use ahash::{AHashMap, AHashSet};
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::result::Result as StdResult;
@@ -333,21 +332,15 @@ impl From<AHashMap<String, SpecialToken>> for Tokens {
 ///     .unwrap();
 /// ```
 ///
-#[derive(Debug, Clone, PartialEq, Builder, Serialize, Deserialize, Eq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq)]
 #[serde(tag = "type", from = "TemplateProcessingDeserializer")]
-#[builder(build_fn(validate = "Self::validate"))]
 pub struct TemplateProcessing {
-    #[builder(try_setter, default = "\"$0\".try_into().unwrap()")]
     pub single: Template,
-    #[builder(try_setter, default = "\"$A:0 $B:1\".try_into().unwrap()")]
     pair: Template,
-    #[builder(setter(skip), default = "self.default_added(true)")]
     #[serde(skip)]
     added_single: usize,
-    #[builder(setter(skip), default = "self.default_added(false)")]
     #[serde(skip)]
     added_pair: usize,
-    #[builder(setter(into), default)]
     special_tokens: Tokens,
 }
 
@@ -405,7 +398,13 @@ impl TemplateProcessing {
 
 impl From<&str> for TemplateProcessingBuilderError {
     fn from(e: &str) -> Self {
-        e.to_string().into()
+        TemplateProcessingBuilderError(e.to_string())
+    }
+}
+
+impl From<String> for TemplateProcessingBuilderError {
+    fn from(e: String) -> Self {
+        TemplateProcessingBuilderError(e)
     }
 }
 
@@ -439,33 +438,54 @@ impl From<TemplateProcessingDeserializer> for TemplateProcessing {
     }
 }
 
-/// Count the number of added tokens in the given template
-fn count_added(container: &Template, special_tokens: Option<&Tokens>) -> usize {
-    container
-        .0
-        .iter()
-        .map(|p| match p {
-            Piece::Sequence { .. } => 0,
-            Piece::SpecialToken { id, .. } => {
-                special_tokens.map_or(0, |spt| spt.0.get(id).map_or(0, |s| s.ids.len()))
-            }
-        })
-        .sum()
+/// Error type for `TemplateProcessingBuilder`.
+#[derive(Debug, Clone)]
+pub struct TemplateProcessingBuilderError(String);
+
+impl std::fmt::Display for TemplateProcessingBuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for TemplateProcessingBuilderError {}
+
+/// Builder for `TemplateProcessing`.
+#[derive(Debug, Clone, Default)]
+pub struct TemplateProcessingBuilder {
+    single: Option<Template>,
+    pair: Option<Template>,
+    special_tokens: Option<Tokens>,
 }
 
 impl TemplateProcessingBuilder {
-    fn default_added(&self, is_single: bool) -> usize {
-        let container = if is_single {
-            self.single.as_ref()
-        } else {
-            self.pair.as_ref()
-        };
-        container.map_or(0, |pieces| {
-            count_added(pieces, self.special_tokens.as_ref())
-        })
+    /// Set the single template. Accepts anything that can be tried into a Template.
+    pub fn try_single<V>(&mut self, single: V) -> StdResult<&mut Self, V::Error>
+    where
+        V: TryInto<Template>,
+        V::Error: std::fmt::Debug,
+    {
+        self.single = Some(single.try_into()?);
+        Ok(self)
     }
 
-    fn validate(&self) -> std::result::Result<(), String> {
+    /// Set the pair template. Accepts anything that can be tried into a Template.
+    pub fn try_pair<V>(&mut self, pair: V) -> StdResult<&mut Self, V::Error>
+    where
+        V: TryInto<Template>,
+        V::Error: std::fmt::Debug,
+    {
+        self.pair = Some(pair.try_into()?);
+        Ok(self)
+    }
+
+    /// Set the special tokens.
+    pub fn special_tokens<V: Into<Tokens>>(&mut self, special_tokens: V) -> &mut Self {
+        self.special_tokens = Some(special_tokens.into());
+        self
+    }
+
+    fn validate(&self) -> StdResult<(), String> {
         let pair_has_both = self.pair.as_ref().is_none_or(|pair| {
             let mut has_a = false;
             let mut has_b = false;
@@ -516,12 +536,54 @@ impl TemplateProcessingBuilder {
         if missing.is_empty() {
             Ok(())
         } else {
+            let missing_str: Vec<&str> = missing.into_iter().collect();
             Err(format!(
                 "Missing SpecialToken(s) with id(s) `{}`",
-                missing.iter().join(", ")
+                missing_str.join(", ")
             ))
         }
     }
+
+    /// Build the `TemplateProcessing`, validating the configuration.
+    pub fn build(&self) -> StdResult<TemplateProcessing, TemplateProcessingBuilderError> {
+        self.validate()
+            .map_err(TemplateProcessingBuilderError::from)?;
+
+        let single = self
+            .single
+            .clone()
+            .unwrap_or_else(|| "$0".try_into().unwrap());
+        let pair = self
+            .pair
+            .clone()
+            .unwrap_or_else(|| "$A:0 $B:1".try_into().unwrap());
+        let special_tokens = self.special_tokens.clone().unwrap_or_default();
+
+        let added_single = count_added(&single, Some(&special_tokens));
+        let added_pair = count_added(&pair, Some(&special_tokens));
+
+        Ok(TemplateProcessing {
+            single,
+            pair,
+            added_single,
+            added_pair,
+            special_tokens,
+        })
+    }
+}
+
+/// Count the number of added tokens in the given template
+fn count_added(container: &Template, special_tokens: Option<&Tokens>) -> usize {
+    container
+        .0
+        .iter()
+        .map(|p| match p {
+            Piece::Sequence { .. } => 0,
+            Piece::SpecialToken { id, .. } => {
+                special_tokens.map_or(0, |spt| spt.0.get(id).map_or(0, |s| s.ids.len()))
+            }
+        })
+        .sum()
 }
 
 impl Default for TemplateProcessing {

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -57,7 +57,7 @@
 //! [`TemplateProcessing`]: struct.TemplateProcessing.html
 //!
 use crate::{Encoding, PostProcessor, Result};
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet, HashMapExt};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::result::Result as StdResult;

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -1,7 +1,7 @@
 use super::{
     normalizer::Range, Model, NormalizedString, Normalizer, Offsets, PreTokenizedString, Token,
 };
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet, HashMapExt, HashSetExt};
 use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder, MatchKind};
 use regex::Regex;
 use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
@@ -769,11 +769,11 @@ mod tests {
         assert!(vocab.is_special_token("test"));
         assert_eq!(
             *vocab.get_added_tokens_decoder(),
-            AHashMap::from([
+            IntoIterator::into_iter([
                 (0, AddedToken::from("test", true)),
                 (2, AddedToken::from("added_token_1", true)),
                 (3, AddedToken::from("added_token_2", true)),
-            ])
+            ]).collect::<AHashMap<_, _>>()
         );
         assert!(vocab.added_tokens_map.contains_key("test"));
         assert!(vocab.added_tokens_map_r.contains_key(&0));

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -2,7 +2,7 @@ use crate::parallelism::*;
 use crate::tokenizer::{Offsets, Token};
 use crate::utils::padding::PaddingDirection;
 use crate::utils::truncation::TruncationDirection;
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
 
@@ -890,7 +890,7 @@ mod tests {
             offsets: vec![(0, 6)],
             special_tokens_mask: vec![0],
             attention_mask: vec![1],
-            sequence_ranges: AHashMap::from([(0, 0..1)]),
+            sequence_ranges: IntoIterator::into_iter([(0, 0..1)]).collect(),
             ..Default::default()
         };
         let target_length = 2;
@@ -904,6 +904,6 @@ mod tests {
             pad_token,
             PaddingDirection::Left,
         );
-        assert_eq!(a.sequence_ranges, AHashMap::from([(0, 1..2)]));
+        assert_eq!(a.sequence_ranges, IntoIterator::into_iter([(0, 1..2)]).collect());
     }
 }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -9,7 +9,7 @@
 //!   - [`PostProcessor`](trait.PostProcessor.html): Takes care of the processing after tokenization (like truncating, padding,
 //!     ...).
 
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use std::{
     fs::{read_to_string, File},
     io::prelude::*,
@@ -1613,7 +1613,7 @@ mod tests {
     use super::*;
     use crate::models::wordlevel::WordLevelBuilder;
     use crate::pre_tokenizers::whitespace::WhitespaceSplit;
-    use ahash::AHashMap;
+    use crate::utils::{AHashMap};
 
     /// Build a tokenizer with a known vocabulary: "a"=0, "b"=1, ... "j"=9, "<unk>"=10
     /// Uses WhitespaceSplit so each space-separated word maps to one token.

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -12,16 +12,20 @@
 use ahash::AHashMap;
 use std::{
     fs::{read_to_string, File},
-    io::{prelude::*, BufReader},
+    io::prelude::*,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };
+#[cfg(feature = "training")]
+use std::io::BufReader;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "training")]
 use crate::utils::iter::ResultShunt;
 use crate::utils::parallelism::*;
+#[cfg(feature = "training")]
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 
 mod added_vocabulary;
@@ -68,6 +72,7 @@ pub trait PreTokenizer {
 
 /// Represents a model used during Tokenization (like BPE or Word or Unigram).
 pub trait Model {
+    #[cfg(feature = "training")]
     type Trainer: Trainer + Sync;
     /// Tokenize the given sequence into multiple underlying `Token`. The `offsets` on the `Token`
     /// are expected to be relative to the given sequence.
@@ -84,6 +89,7 @@ pub trait Model {
     /// files that need to be saved.
     fn save(&self, folder: &Path, prefix: Option<&str>) -> Result<Vec<PathBuf>>;
     /// Get an instance of a Trainer capable of training this Model
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> <Self as Model>::Trainer;
 }
 
@@ -160,6 +166,7 @@ pub trait Decoder {
 
 /// A `Trainer` has the responsibility to train a model. We feed it with lines/sentences
 /// and then it can train the given `Model`.
+#[cfg(feature = "training")]
 pub trait Trainer {
     type Model: Model + Sized;
     /// Whether we should show progress during the training.
@@ -1371,6 +1378,7 @@ where
     }
 
     /// Train our Model from files
+    #[cfg(feature = "training")]
     pub fn train_from_files<T>(&mut self, trainer: &mut T, files: Vec<String>) -> Result<&mut Self>
     where
         T: Trainer<Model = M> + Sync,
@@ -1392,9 +1400,15 @@ where
                         // We read new lines using this API instead of the Lines Iterator
                         // on purpose. We want to keep the `\n` and potential `\r` between each lines
                         // We use an iterator to be able to chain with par_bridge.
-                        itertools::Either::Left(file.lines_with_ending())
+                        let iter: Box<dyn Iterator<Item = std::io::Result<String>> + Send> =
+                            Box::new(file.lines_with_ending());
+                        iter
                     }
-                    Err(e) => itertools::Either::Right(std::iter::once(Err(e))),
+                    Err(e) => {
+                        let iter: Box<dyn Iterator<Item = std::io::Result<String>> + Send> =
+                            Box::new(std::iter::once(Err(e)));
+                        iter
+                    }
                 }
             }),
             |sequences| -> Result<()> {
@@ -1444,6 +1458,7 @@ where
     }
 
     /// Train our Model, using the given Trainer and iterator
+    #[cfg(feature = "training")]
     pub fn train<T, I, S>(&mut self, trainer: &mut T, sequences: I) -> Result<&mut Self>
     where
         T: Trainer<Model = M> + Sync,

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -1,6 +1,7 @@
 use crate::pattern::Pattern;
 use crate::{Offsets, Result};
 use std::ops::{Bound, RangeBounds};
+#[cfg(feature = "unicode-normalization")]
 use unicode_normalization_alignments::UnicodeNormalization;
 
 use serde::{Deserialize, Serialize};
@@ -446,24 +447,28 @@ impl NormalizedString {
     }
 
     /// Applies NFD normalization
+    #[cfg(feature = "unicode-normalization")]
     pub fn nfd(&mut self) -> &mut Self {
         self.transform(self.get().to_owned().nfd(), 0);
         self
     }
 
     /// Applies NFKD normalization
+    #[cfg(feature = "unicode-normalization")]
     pub fn nfkd(&mut self) -> &mut Self {
         self.transform(self.get().to_owned().nfkd(), 0);
         self
     }
 
     /// Applies NFC normalization
+    #[cfg(feature = "unicode-normalization")]
     pub fn nfc(&mut self) -> &mut Self {
         self.transform(self.get().to_owned().nfc(), 0);
         self
     }
 
     /// Applies NFKC normalization
+    #[cfg(feature = "unicode-normalization")]
     pub fn nfkc(&mut self) -> &mut Self {
         self.transform(self.get().to_owned().nfkc(), 0);
         self

--- a/tokenizers/src/utils/cache.rs
+++ b/tokenizers/src/utils/cache.rs
@@ -1,4 +1,4 @@
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use std::borrow::Borrow;
 use std::hash::Hash;
 use std::sync::RwLock;

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -23,9 +23,19 @@ pub mod truncation;
 // Re-export ProgressFormat for public API
 pub use progress::ProgressFormat;
 
-use ahash::AHashMap;
 use serde::{Serialize, Serializer};
 use std::collections::BTreeMap;
+
+/// Fast hash map using foldhash. Drop-in replacement for ahash::AHashMap.
+pub type AHashMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::FixedState>;
+/// Fast hash set using foldhash. Drop-in replacement for ahash::AHashSet.
+pub type AHashSet<K> = std::collections::HashSet<K, foldhash::fast::FixedState>;
+
+// Re-export extension traits so AHashMap::new() and AHashSet::new() work.
+#[allow(unused_imports)]
+pub use foldhash::HashMapExt;
+#[allow(unused_imports)]
+pub use foldhash::HashSetExt;
 
 pub(crate) fn ordered_map<S, K, V>(
     value: &AHashMap<K, V>,

--- a/tokenizers/src/utils/padding.rs
+++ b/tokenizers/src/utils/padding.rs
@@ -84,7 +84,7 @@ pub fn pad_encodings(encodings: &mut [Encoding], params: &PaddingParams) -> Resu
 mod tests {
     use super::*;
     use crate::tokenizer::Encoding;
-    use ahash::AHashMap;
+    use crate::utils::{AHashMap, HashMapExt};
 
     #[test]
     fn pad_to_multiple() {

--- a/tokenizers/src/utils/parallelism.rs
+++ b/tokenizers/src/utils/parallelism.rs
@@ -2,15 +2,9 @@
 //! This module defines helpers to allow optional Rayon usage.
 //!
 
-use rayon::iter::IterBridge;
-use rayon::prelude::*;
-use rayon_cond::CondIterator;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
-
-// Re-export rayon current_num_threads
-pub use rayon::current_num_threads;
 
 pub const ENV_VARIABLE: &str = "TOKENIZERS_PARALLELISM";
 
@@ -61,189 +55,335 @@ pub fn set_parallelism(val: bool) {
     PARALLELISM.store(if val { 2 } else { 1 }, Ordering::SeqCst);
 }
 
-/// Allows to convert into an iterator that can be executed either parallelly or serially.
-///
-/// The choice is made according to the currently set `TOKENIZERS_PARALLELISM` environment variable.
-/// This variable can have one of the following values
-///   - False => "" (empty value), "false", "f", "off", "no", "n", "0"
-///   - True => Any other value
-///
-pub trait MaybeParallelIterator<P, S>
-where
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-{
-    /// Convert ourself in a CondIterator, that will be executed either in parallel or serially,
-    /// based solely on the `TOKENIZERS_PARALLELISM` environment variable
-    fn into_maybe_par_iter(self) -> CondIterator<P, S>;
-    /// Convert ourself in a CondIterator, that will be executed either in parallel or serially,
-    /// based on both the `TOKENIZERS_PARALLELISM` environment variable and the provided bool.
-    /// Both must be true to run with parallelism activated.
-    fn into_maybe_par_iter_cond(self, cond: bool) -> CondIterator<P, S>;
+// Re-export rayon current_num_threads
+#[cfg(feature = "parallel")]
+pub use rayon::current_num_threads;
+
+#[cfg(not(feature = "parallel"))]
+pub fn current_num_threads() -> usize {
+    1
 }
 
-impl<P, S, I> MaybeParallelIterator<P, S> for I
-where
-    I: IntoParallelIterator<Iter = P, Item = P::Item> + IntoIterator<IntoIter = S, Item = S::Item>,
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-{
-    fn into_maybe_par_iter(self) -> CondIterator<P, S> {
-        let parallelism = get_parallelism();
-        if parallelism {
-            USED_PARALLELISM.store(true, Ordering::SeqCst);
-        }
-        CondIterator::new(self, parallelism)
+// ---------------------------------------------------------------------------
+// Parallel implementation using rayon + rayon-cond
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "parallel")]
+mod parallel_impl {
+    use super::*;
+    use rayon::iter::IterBridge;
+    use rayon::prelude::*;
+    use rayon_cond::CondIterator;
+
+    /// Allows to convert into an iterator that can be executed either parallelly or serially.
+    pub trait MaybeParallelIterator<P, S>
+    where
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+    {
+        fn into_maybe_par_iter(self) -> CondIterator<P, S>;
+        fn into_maybe_par_iter_cond(self, cond: bool) -> CondIterator<P, S>;
     }
 
-    fn into_maybe_par_iter_cond(self, cond: bool) -> CondIterator<P, S> {
-        if cond {
+    impl<P, S, I> MaybeParallelIterator<P, S> for I
+    where
+        I: IntoParallelIterator<Iter = P, Item = P::Item>
+            + IntoIterator<IntoIter = S, Item = S::Item>,
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+    {
+        fn into_maybe_par_iter(self) -> CondIterator<P, S> {
+            let parallelism = get_parallelism();
+            if parallelism {
+                USED_PARALLELISM.store(true, Ordering::SeqCst);
+            }
+            CondIterator::new(self, parallelism)
+        }
+
+        fn into_maybe_par_iter_cond(self, cond: bool) -> CondIterator<P, S> {
+            if cond {
+                self.into_maybe_par_iter()
+            } else {
+                CondIterator::from_serial(self)
+            }
+        }
+    }
+
+    /// Shared reference version of MaybeParallelIterator
+    pub trait MaybeParallelRefIterator<'data, P, S>
+    where
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+        P::Item: 'data,
+    {
+        fn maybe_par_iter(&'data self) -> CondIterator<P, S>;
+        fn maybe_par_iter_cond(&'data self, cond: bool) -> CondIterator<P, S>;
+    }
+
+    impl<'data, P, S, I: 'data + ?Sized> MaybeParallelRefIterator<'data, P, S> for I
+    where
+        &'data I: MaybeParallelIterator<P, S>,
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+        P::Item: 'data,
+    {
+        fn maybe_par_iter(&'data self) -> CondIterator<P, S> {
             self.into_maybe_par_iter()
-        } else {
+        }
+
+        fn maybe_par_iter_cond(&'data self, cond: bool) -> CondIterator<P, S> {
+            self.into_maybe_par_iter_cond(cond)
+        }
+    }
+
+    /// Exclusive reference version of MaybeParallelIterator
+    pub trait MaybeParallelRefMutIterator<'data, P, S>
+    where
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+        P::Item: 'data,
+    {
+        fn maybe_par_iter_mut(&'data mut self) -> CondIterator<P, S>;
+        fn maybe_par_iter_mut_cond(&'data mut self, cond: bool) -> CondIterator<P, S>;
+    }
+
+    impl<'data, P, S, I: 'data + ?Sized> MaybeParallelRefMutIterator<'data, P, S> for I
+    where
+        &'data mut I: MaybeParallelIterator<P, S>,
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+        P::Item: 'data,
+    {
+        fn maybe_par_iter_mut(&'data mut self) -> CondIterator<P, S> {
+            self.into_maybe_par_iter()
+        }
+
+        fn maybe_par_iter_mut_cond(&'data mut self, cond: bool) -> CondIterator<P, S> {
+            self.into_maybe_par_iter_cond(cond)
+        }
+    }
+
+    /// Converts any serial iterator into a CondIterator via par_bridge.
+    pub trait MaybeParallelBridge<T, S>
+    where
+        S: Iterator<Item = T> + Send,
+        T: Send,
+    {
+        fn maybe_par_bridge(self) -> CondIterator<IterBridge<S>, S>;
+        fn maybe_par_bridge_cond(self, cond: bool) -> CondIterator<IterBridge<S>, S>;
+    }
+
+    impl<T, S> MaybeParallelBridge<T, S> for S
+    where
+        S: Iterator<Item = T> + Send,
+        T: Send,
+    {
+        fn maybe_par_bridge(self) -> CondIterator<IterBridge<S>, S> {
+            let iter = CondIterator::from_serial(self);
+
+            if get_parallelism() {
+                USED_PARALLELISM.store(true, Ordering::SeqCst);
+                CondIterator::from_parallel(iter.into_parallel().right().unwrap())
+            } else {
+                iter
+            }
+        }
+
+        fn maybe_par_bridge_cond(self, cond: bool) -> CondIterator<IterBridge<S>, S> {
+            if cond {
+                self.maybe_par_bridge()
+            } else {
+                CondIterator::from_serial(self)
+            }
+        }
+    }
+
+    /// Allows to convert into `chunks` that can be executed either parallelly or serially.
+    pub trait MaybeParallelSlice<'data, T>
+    where
+        T: Sync,
+    {
+        fn maybe_par_chunks(
+            &'_ self,
+            chunk_size: usize,
+        ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>>;
+        fn maybe_par_chunks_cond(
+            &'_ self,
+            cond: bool,
+            chunk_size: usize,
+        ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>>;
+    }
+
+    impl<T> MaybeParallelSlice<'_, T> for [T]
+    where
+        T: Sync,
+    {
+        fn maybe_par_chunks(
+            &'_ self,
+            chunk_size: usize,
+        ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>> {
+            let parallelism = get_parallelism();
+            if parallelism {
+                CondIterator::from_parallel(self.par_chunks(chunk_size))
+            } else {
+                CondIterator::from_serial(self.chunks(chunk_size))
+            }
+        }
+        fn maybe_par_chunks_cond(
+            &'_ self,
+            cond: bool,
+            chunk_size: usize,
+        ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>> {
+            if cond {
+                self.maybe_par_chunks(chunk_size)
+            } else {
+                CondIterator::from_serial(self.chunks(chunk_size))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+pub use parallel_impl::*;
+
+// ---------------------------------------------------------------------------
+// Serial-only fallback when rayon is not available
+// ---------------------------------------------------------------------------
+
+#[cfg(not(feature = "parallel"))]
+mod serial_impl {
+    /// A serial-only iterator wrapper (identity wrapper).
+    pub struct CondIterator<S> {
+        iter: S,
+    }
+
+    impl<S: Iterator> CondIterator<S> {
+        pub fn from_serial<I: IntoIterator<IntoIter = S>>(iter: I) -> Self {
+            CondIterator {
+                iter: iter.into_iter(),
+            }
+        }
+    }
+
+    impl<S: Iterator> Iterator for CondIterator<S> {
+        type Item = S::Item;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.iter.next()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            self.iter.size_hint()
+        }
+    }
+
+    impl<S: Iterator> CondIterator<S>
+    where
+        S::Item: Send,
+        S: Send,
+    {
+        pub fn reduce<OP, ID>(self, identity: ID, op: OP) -> S::Item
+        where
+            OP: Fn(S::Item, S::Item) -> S::Item,
+            ID: Fn() -> S::Item,
+        {
+            self.iter.fold(identity(), |acc, item| op(acc, item))
+        }
+
+        pub fn for_each<OP>(self, op: OP)
+        where
+            OP: Fn(S::Item),
+        {
+            self.iter.for_each(op);
+        }
+    }
+
+    /// Converts into a serial CondIterator.
+    pub trait MaybeParallelIterator {
+        type Iter: Iterator;
+        fn into_maybe_par_iter(self) -> CondIterator<Self::Iter>;
+        fn into_maybe_par_iter_cond(self, cond: bool) -> CondIterator<Self::Iter>;
+    }
+
+    impl<I: IntoIterator> MaybeParallelIterator for I {
+        type Iter = I::IntoIter;
+        fn into_maybe_par_iter(self) -> CondIterator<Self::Iter> {
+            CondIterator::from_serial(self)
+        }
+        fn into_maybe_par_iter_cond(self, _cond: bool) -> CondIterator<Self::Iter> {
             CondIterator::from_serial(self)
         }
     }
-}
 
-/// Shared reference version of MaybeParallelIterator, works the same but returns an iterator
-/// over references, does not consume self
-pub trait MaybeParallelRefIterator<'data, P, S>
-where
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-    P::Item: 'data,
-{
-    fn maybe_par_iter(&'data self) -> CondIterator<P, S>;
-    fn maybe_par_iter_cond(&'data self, cond: bool) -> CondIterator<P, S>;
-}
-
-impl<'data, P, S, I: 'data + ?Sized> MaybeParallelRefIterator<'data, P, S> for I
-where
-    &'data I: MaybeParallelIterator<P, S>,
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-    P::Item: 'data,
-{
-    fn maybe_par_iter(&'data self) -> CondIterator<P, S> {
-        self.into_maybe_par_iter()
+    pub trait MaybeParallelRefIterator<'data> {
+        type Iter: Iterator;
+        fn maybe_par_iter(&'data self) -> CondIterator<Self::Iter>;
     }
 
-    fn maybe_par_iter_cond(&'data self, cond: bool) -> CondIterator<P, S> {
-        self.into_maybe_par_iter_cond(cond)
-    }
-}
-
-/// Exclusive reference version of MaybeParallelIterator, works the same but returns an iterator
-/// over mutable references, does not consume self
-pub trait MaybeParallelRefMutIterator<'data, P, S>
-where
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-    P::Item: 'data,
-{
-    fn maybe_par_iter_mut(&'data mut self) -> CondIterator<P, S>;
-    fn maybe_par_iter_mut_cond(&'data mut self, cond: bool) -> CondIterator<P, S>;
-}
-
-impl<'data, P, S, I: 'data + ?Sized> MaybeParallelRefMutIterator<'data, P, S> for I
-where
-    &'data mut I: MaybeParallelIterator<P, S>,
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-    P::Item: 'data,
-{
-    fn maybe_par_iter_mut(&'data mut self) -> CondIterator<P, S> {
-        self.into_maybe_par_iter()
-    }
-
-    fn maybe_par_iter_mut_cond(&'data mut self, cond: bool) -> CondIterator<P, S> {
-        self.into_maybe_par_iter_cond(cond)
-    }
-}
-
-/// Converts any serial iterator into a CondIterator, that can either run parallelly or serially.
-pub trait MaybeParallelBridge<T, S>
-where
-    S: Iterator<Item = T> + Send,
-    T: Send,
-{
-    fn maybe_par_bridge(self) -> CondIterator<IterBridge<S>, S>;
-    fn maybe_par_bridge_cond(self, cond: bool) -> CondIterator<IterBridge<S>, S>;
-}
-
-impl<T, S> MaybeParallelBridge<T, S> for S
-where
-    S: Iterator<Item = T> + Send,
-    T: Send,
-{
-    fn maybe_par_bridge(self) -> CondIterator<IterBridge<S>, S> {
-        let iter = CondIterator::from_serial(self);
-
-        if get_parallelism() {
-            USED_PARALLELISM.store(true, Ordering::SeqCst);
-            CondIterator::from_parallel(iter.into_parallel().right().unwrap())
-        } else {
-            iter
+    impl<'data, T: 'data> MaybeParallelRefIterator<'data> for [T] {
+        type Iter = std::slice::Iter<'data, T>;
+        fn maybe_par_iter(&'data self) -> CondIterator<Self::Iter> {
+            CondIterator::from_serial(self.iter())
         }
     }
 
-    fn maybe_par_bridge_cond(self, cond: bool) -> CondIterator<IterBridge<S>, S> {
-        if cond {
-            self.maybe_par_bridge()
-        } else {
-            CondIterator::from_serial(self)
+    impl<'data, T: 'data> MaybeParallelRefIterator<'data> for Vec<T> {
+        type Iter = std::slice::Iter<'data, T>;
+        fn maybe_par_iter(&'data self) -> CondIterator<Self::Iter> {
+            CondIterator::from_serial(self.iter())
         }
     }
-}
 
-/// Allows to convert into `chunks` that can be executed either parallelly or serially.
-pub trait MaybeParallelSlice<'data, T>
-where
-    T: Sync,
-{
-    /// Create a CondIterator, that will be executed either in parallel or serially,
-    /// based solely on the `TOKENIZERS_PARALLELISM` environment variable
-    fn maybe_par_chunks(
-        &'_ self,
-        chunk_size: usize,
-    ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>>;
-    /// Create a CondIterator, that will be executed either in parallel or serially,
-    /// based on both the `TOKENIZERS_PARALLELISM` environment variable and the provided bool.
-    /// Both must be true to run with parallelism activated.
-    fn maybe_par_chunks_cond(
-        &'_ self,
-        cond: bool,
-        chunk_size: usize,
-    ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>>;
-}
+    pub trait MaybeParallelRefMutIterator<'data> {
+        type Iter: Iterator;
+        fn maybe_par_iter_mut(&'data mut self) -> CondIterator<Self::Iter>;
+    }
 
-impl<T> MaybeParallelSlice<'_, T> for [T]
-where
-    T: Sync,
-{
-    fn maybe_par_chunks(
-        &'_ self,
-        chunk_size: usize,
-    ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>> {
-        let parallelism = get_parallelism();
-        if parallelism {
-            CondIterator::from_parallel(self.par_chunks(chunk_size))
-        } else {
-            CondIterator::from_serial(self.chunks(chunk_size))
+    impl<'data, T: 'data> MaybeParallelRefMutIterator<'data> for Vec<T> {
+        type Iter = std::slice::IterMut<'data, T>;
+        fn maybe_par_iter_mut(&'data mut self) -> CondIterator<Self::Iter> {
+            CondIterator::from_serial(self.iter_mut())
         }
     }
-    fn maybe_par_chunks_cond(
-        &'_ self,
-        cond: bool,
-        chunk_size: usize,
-    ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>> {
-        if cond {
-            self.maybe_par_chunks(chunk_size)
-        } else {
+
+    impl<'data, T: 'data> MaybeParallelRefMutIterator<'data> for [T] {
+        type Iter = std::slice::IterMut<'data, T>;
+        fn maybe_par_iter_mut(&'data mut self) -> CondIterator<Self::Iter> {
+            CondIterator::from_serial(self.iter_mut())
+        }
+    }
+
+    /// Serial-only bridge (identity).
+    pub trait MaybeParallelBridge: Iterator + Sized {
+        fn maybe_par_bridge(self) -> CondIterator<Self>;
+    }
+
+    impl<I: Iterator + Send> MaybeParallelBridge for I {
+        fn maybe_par_bridge(self) -> CondIterator<Self> {
+            CondIterator { iter: self }
+        }
+    }
+
+    /// Serial-only chunks.
+    pub trait MaybeParallelSlice<'data, T> {
+        fn maybe_par_chunks(
+            &'data self,
+            chunk_size: usize,
+        ) -> CondIterator<std::slice::Chunks<'data, T>>;
+    }
+
+    impl<'data, T> MaybeParallelSlice<'data, T> for [T] {
+        fn maybe_par_chunks(
+            &'data self,
+            chunk_size: usize,
+        ) -> CondIterator<std::slice::Chunks<'data, T>> {
             CondIterator::from_serial(self.chunks(chunk_size))
         }
     }
 }
+
+#[cfg(not(feature = "parallel"))]
+pub use serial_impl::*;
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/src/utils/progress.rs
+++ b/tokenizers/src/utils/progress.rs
@@ -20,6 +20,7 @@ pub(crate) use indicatif::{ProgressBar, ProgressStyle};
 
 #[cfg(not(feature = "progressbar"))]
 mod progressbar {
+    #![allow(dead_code)]
     use std::borrow::Cow;
     pub struct ProgressBar;
     impl ProgressBar {
@@ -46,4 +47,5 @@ mod progressbar {
     }
 }
 #[cfg(not(feature = "progressbar"))]
+#[allow(unused_imports)]
 pub(crate) use progressbar::{ProgressBar, ProgressStyle};

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -165,7 +165,7 @@ pub fn truncate_encodings(
 mod tests {
     use super::*;
     use crate::tokenizer::Encoding;
-    use ahash::AHashMap;
+    use crate::utils::{AHashMap, HashMapExt};
 
     fn get_empty() -> Encoding {
         Encoding::new(


### PR DESCRIPTION
## Summary
![Uploading image.png…]()

Reduces the tokenizers crate dependency footprint by ~56% for inference-only deployments, making it competitive for on-device use.

**Actual linked library size**: `.dylib` goes from 2.5 MB → **2.0 MB** (inference-only, stripped, LTO)

### Changes

**Commit 1: Feature-gate training code, remove derive_builder & itertools**
- New `training` feature (default on) gates all trainer code, `rand`, `esaxx-rs`
- New `spm` feature (default on) gates SentencePiece precompiled normalizer
- Replaced `derive_builder` with manual builders (was used for 3 structs, pulled 5.6 MB of deps)
- Replaced `itertools` with std equivalents (was used at 2 call sites, cost 2.6 MB)

**Commit 2: Slim regex, optional rayon, replace ahash & monostate**
- Slimmed `regex` to `unicode-perl` only (saves ~6 MB in regex tables)
- New `parallel` feature (default on) makes rayon optional for single-core on-device
- Replaced `ahash` with `foldhash` (116 KB vs 16 MB with zerocopy)
- Replaced `monostate` with existing `impl_serde_type!` macro

**Commit 3: Feature-gate unicode-normalization, compact_str, unicode-segmentation**
- New `unicode-normalization` feature (default on) gates NFC/NFD/NFKC/NFKD
- `compact_str` and `unicode-segmentation` made optional

### Results

| Metric | Before (main) | After (default) | After (inference-only) |
|--------|--------------|-----------------|----------------------|
| Transitive deps | 119 | 78 | **29** |
| Linked .dylib | 2.5 MB | 2.5 MB | **2.0 MB** |
| Dep rlib total | ~107 MB | ~73 MB | **47 MB** |

### New feature flags

All new features are **default-enabled** — zero breaking changes for existing users.

```toml
# Full (backward compatible, same as before):
tokenizers = "0.22"

# Inference-only on-device:
tokenizers = { version = "0.22", default-features = false, features = ["onig"] }

# WASM:
tokenizers = { version = "0.22", default-features = false, features = ["unstable_wasm"] }
```

### Deps removed (inference-only vs main)
derive_builder, darling, itertools, rand, esaxx-rs, indicatif, spm_precompiled, nom, rayon, rayon-cond, ahash, zerocopy, monostate, compact_str, unicode-normalization-alignments, unicode-segmentation, and all their transitive deps

## Test plan
- [x] `cargo test --release --lib` — 197 tests pass (default features)
- [x] `cargo build --release --no-default-features --features "onig"` — builds clean
- [x] `cargo build --release --no-default-features --features "unstable_wasm"` — builds clean
- [ ] CI checks
- [ ] Python bindings build
- [ ] Benchmark regression check