### PR TITLE
Reduce crate size

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -146,6 +146,11 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: 'true'
+        env:
+          # abi3 extension modules resolve Python symbols at runtime;
+          # explicit --target triggers cross-compilation mode which
+          # doesn't pass this flag automatically on macOS.
+          RUSTFLAGS: "-C link-arg=-undefined -C link-arg=dynamic_lookup"
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -143,13 +143,24 @@ jobs:
         run: |
           echo "## 🐍 Python Wheel Size — ${{ matrix.os }} ${{ matrix.target }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Wheel | Size |" >> $GITHUB_STEP_SUMMARY
-          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "Wheel (.whl) = compressed archive downloaded from PyPI." >> $GITHUB_STEP_SUMMARY
+          echo "Installed .so/.pyd = actual shared library loaded at runtime." >> $GITHUB_STEP_SUMMARY
+          echo "The installed size is what matters for on-device deployment." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Wheel | Wheel size | Installed .so/.pyd |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|---|" >> $GITHUB_STEP_SUMMARY
+          EXTRACT_DIR=$(mktemp -d)
           for f in dist/*.whl; do
-            SIZE=$(du -h "$f" | cut -f1)
+            WHL_SIZE=$(du -h "$f" | cut -f1)
             NAME=$(basename "$f")
-            echo "| \`${NAME}\` | ${SIZE} |" >> $GITHUB_STEP_SUMMARY
+            rm -rf "$EXTRACT_DIR"/*
+            (cd "$EXTRACT_DIR" && unzip -q "$(realpath -- "$OLDPWD/$f" 2>/dev/null || echo "$OLDPWD/$f")" 2>/dev/null) \
+              || unzip -q -o "$f" -d "$EXTRACT_DIR" 2>/dev/null || true
+            SO_SIZE=$(find "$EXTRACT_DIR" \( -name '*.so' -o -name '*.pyd' -o -name '*.dylib' \) -exec du -h {} \; | head -1 | cut -f1)
+            [ -z "$SO_SIZE" ] && SO_SIZE="n/a"
+            echo "| \`${NAME}\` | ${WHL_SIZE} | ${SO_SIZE} |" >> $GITHUB_STEP_SUMMARY
           done
+          rm -rf "$EXTRACT_DIR"
           echo "" >> $GITHUB_STEP_SUMMARY
 
       - uses: actions/upload-artifact@v4
@@ -200,20 +211,34 @@ jobs:
         run: |
           echo "## 📦 All Python Wheel Sizes" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Wheel | Size |" >> $GITHUB_STEP_SUMMARY
-          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
-          TOTAL=0
+          echo "| Wheel | Wheel size | Installed .so/.pyd |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|---|" >> $GITHUB_STEP_SUMMARY
+          TOTAL_WHL=0
+          TOTAL_SO=0
+          EXTRACT_DIR=$(mktemp -d)
           for f in dist/*.whl; do
-            BYTES=$(stat --format=%s "$f" 2>/dev/null || stat -f%z "$f")
-            SIZE=$(du -h "$f" | cut -f1)
+            WHL_BYTES=$(stat --format=%s "$f" 2>/dev/null || stat -f%z "$f")
+            WHL_SIZE=$(du -h "$f" | cut -f1)
             NAME=$(basename "$f")
-            echo "| \`${NAME}\` | ${SIZE} |" >> $GITHUB_STEP_SUMMARY
-            TOTAL=$((TOTAL + BYTES))
+            rm -rf "$EXTRACT_DIR"/*
+            unzip -q -o "$f" -d "$EXTRACT_DIR" 2>/dev/null || true
+            SO_FILE=$(find "$EXTRACT_DIR" \( -name '*.so' -o -name '*.pyd' -o -name '*.dylib' \) | head -1)
+            if [ -n "$SO_FILE" ]; then
+              SO_BYTES=$(stat --format=%s "$SO_FILE" 2>/dev/null || stat -f%z "$SO_FILE")
+              SO_SIZE=$(du -h "$SO_FILE" | cut -f1)
+              TOTAL_SO=$((TOTAL_SO + SO_BYTES))
+            else
+              SO_SIZE="n/a"
+            fi
+            echo "| \`${NAME}\` | ${WHL_SIZE} | ${SO_SIZE} |" >> $GITHUB_STEP_SUMMARY
+            TOTAL_WHL=$((TOTAL_WHL + WHL_BYTES))
           done
+          rm -rf "$EXTRACT_DIR"
           echo "" >> $GITHUB_STEP_SUMMARY
-          TOTAL_MB=$(echo "scale=2; $TOTAL / 1048576" | bc)
+          TOTAL_WHL_MB=$(echo "scale=2; $TOTAL_WHL / 1048576" | bc)
+          TOTAL_SO_MB=$(echo "scale=2; $TOTAL_SO / 1048576" | bc)
           WHL_COUNT=$(ls dist/*.whl 2>/dev/null | wc -l | tr -d ' ')
-          echo "**Total**: ${WHL_COUNT} wheels, ${TOTAL_MB} MB" >> $GITHUB_STEP_SUMMARY
+          echo "**Total**: ${WHL_COUNT} wheels | wheel: ${TOTAL_WHL_MB} MB | installed: ${TOTAL_SO_MB} MB" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Temporary deactivation while testing abi3 CI

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -142,6 +142,20 @@ jobs:
       - run: twine check --strict dist/*
         working-directory: ./bindings/python
 
+      - name: Report wheel sizes
+        working-directory: ./bindings/python
+        run: |
+          echo "## 🐍 Python Wheel Size — ${{ matrix.os }} ${{ matrix.target }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Wheel | Size |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          for f in dist/*.whl; do
+            SIZE=$(du -h "$f" | cut -f1)
+            NAME=$(basename "$f")
+            echo "| \`${NAME}\` | ${SIZE} |" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+
       - uses: actions/upload-artifact@v4
         with:
           name: pypi_files-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux }}
@@ -182,6 +196,28 @@ jobs:
         with:
           path: ./bindings/python/dist
           merge-multiple: true
+
+      - name: Wheel size summary
+        working-directory: ./bindings/python
+        run: |
+          echo "## 📦 All Python Wheel Sizes" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Wheel | Size |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          TOTAL=0
+          for f in dist/*.whl; do
+            BYTES=$(stat --format=%s "$f" 2>/dev/null || stat -f%z "$f")
+            SIZE=$(du -h "$f" | cut -f1)
+            NAME=$(basename "$f")
+            echo "| \`${NAME}\` | ${SIZE} |" >> $GITHUB_STEP_SUMMARY
+            TOTAL=$((TOTAL + BYTES))
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+          TOTAL_MB=$(echo "scale=2; $TOTAL / 1048576" | bc)
+          WHL_COUNT=$(ls dist/*.whl 2>/dev/null | wc -l | tr -d ' ')
+          echo "**Total**: ${WHL_COUNT} wheels, ${TOTAL_MB} MB" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
           # Temporary deactivation while testing abi3 CI
           # - name: Upload to PyPi
           #   working-directory: ./bindings/python

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -24,6 +24,51 @@ jobs:
           path: ~/.cargo/registry
           key: ubuntu-latest-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
 
+      - name: Measure crate size
+        working-directory: ./tokenizers
+        run: |
+          echo "## 📦 Crate Size Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Packed crate size (what gets uploaded to crates.io)
+          cargo package --list --allow-dirty > /tmp/crate_files.txt
+          CRATE_FILE_COUNT=$(wc -l < /tmp/crate_files.txt | tr -d ' ')
+          PACKED_SIZE=$(cargo package --allow-dirty 2>&1 | grep -oP 'Packaged \d+ files?, \K[\d.]+ \w+' || echo "unknown")
+          echo "### Packed crate (crates.io)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Size**: ${PACKED_SIZE}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Files**: ${CRATE_FILE_COUNT}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Compiled size for various feature combinations
+          echo "### Compiled library size (release, LTO)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Feature set | .rlib size |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+
+          for FEATURES in \
+            "--no-default-features" \
+            "--no-default-features --features training" \
+            "--no-default-features --features spm" \
+            "--no-default-features --features parallel" \
+            "--features default" \
+          ; do
+            cargo build --release $FEATURES 2>/dev/null
+            RLIB=$(find target/release/deps -name 'libtokenizers-*.rlib' -newer /tmp/crate_files.txt | head -1)
+            if [ -n "$RLIB" ]; then
+              SIZE=$(du -h "$RLIB" | cut -f1)
+            else
+              # fallback: find any matching rlib
+              RLIB=$(find target/release/deps -name 'libtokenizers-*.rlib' | head -1)
+              SIZE=$(du -h "$RLIB" 2>/dev/null | cut -f1 || echo "N/A")
+            fi
+            LABEL=$(echo "$FEATURES" | sed 's/--no-default-features/no-default/' | sed 's/--features /+/g' | sed 's/  */ /g')
+            echo "| \`${LABEL}\` | ${SIZE} |" >> $GITHUB_STEP_SUMMARY
+            # Touch marker so next iteration can detect newer files
+            touch /tmp/crate_files.txt
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+
       - name: Publish package rust
         working-directory: ./tokenizers
         if: ${{ !contains(github.ref, 'rc') }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -39,34 +39,68 @@ jobs:
           echo "- **Files**: ${CRATE_FILE_COUNT}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Compiled size for various feature combinations
-          echo "### Compiled library size (release, LTO)" >> $GITHUB_STEP_SUMMARY
+          # Linked shared library size for various feature combinations.
+          # This is the actual on-device size — what ships to users — NOT the
+          # .rlib, which contains unused code the final linker strips.
+          # We build a minimal cdylib that uses the Tokenizer API and measure it.
+          TEST_DIR=$(mktemp -d)
+          TOK_PATH="$(pwd)"
+          mkdir -p "$TEST_DIR/src"
+          cat > "$TEST_DIR/src/lib.rs" << 'RS'
+          use tokenizers::Tokenizer;
+          #[no_mangle]
+          pub extern "C" fn tokenize(path: *const u8, len: usize, input: *const u8, input_len: usize) -> usize {
+              let path = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(path, len)) };
+              let input = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(input, input_len)) };
+              let tok = Tokenizer::from_file(path).unwrap();
+              tok.encode(input, false).unwrap().get_ids().len()
+          }
+          RS
+
+          measure() {
+            local LABEL="$1"
+            local FEATURES="$2"
+            cat > "$TEST_DIR/Cargo.toml" << TOML
+          [package]
+          name = "size-test"
+          version = "0.1.0"
+          edition = "2021"
+          [lib]
+          crate-type = ["cdylib"]
+          [dependencies]
+          tokenizers = { path = "$TOK_PATH", ${FEATURES} }
+          [profile.release]
+          lto = "fat"
+          opt-level = "s"
+          strip = true
+          codegen-units = 1
+          panic = "abort"
+          TOML
+            (cd "$TEST_DIR" && cargo build --release >/dev/null 2>&1)
+            local LIB=$(find "$TEST_DIR/target/release" -maxdepth 1 \( -name '*.so' -o -name '*.dylib' -o -name '*.dll' \) | head -1)
+            if [ -n "$LIB" ]; then
+              local BYTES=$(stat --format=%s "$LIB" 2>/dev/null || stat -f%z "$LIB")
+              local KB=$((BYTES / 1024))
+              echo "| ${LABEL} | ${KB} KB |" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "| ${LABEL} | build failed |" >> $GITHUB_STEP_SUMMARY
+            fi
+          }
+
+          echo "### Linked shared library size (stripped cdylib, LTO fat, opt-level=s, panic=abort)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Feature set | .rlib size |" >> $GITHUB_STEP_SUMMARY
+          echo "This is the actual on-device size — what ships to end users." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Feature set | Size |" >> $GITHUB_STEP_SUMMARY
           echo "|---|---|" >> $GITHUB_STEP_SUMMARY
 
-          for FEATURES in \
-            "--no-default-features" \
-            "--no-default-features --features training" \
-            "--no-default-features --features spm" \
-            "--no-default-features --features parallel" \
-            "--features default" \
-          ; do
-            cargo build --release $FEATURES 2>/dev/null
-            RLIB=$(find target/release/deps -name 'libtokenizers-*.rlib' -newer /tmp/crate_files.txt | head -1)
-            if [ -n "$RLIB" ]; then
-              SIZE=$(du -h "$RLIB" | cut -f1)
-            else
-              # fallback: find any matching rlib
-              RLIB=$(find target/release/deps -name 'libtokenizers-*.rlib' | head -1)
-              SIZE=$(du -h "$RLIB" 2>/dev/null | cut -f1 || echo "N/A")
-            fi
-            LABEL=$(echo "$FEATURES" | sed 's/--no-default-features/no-default/' | sed 's/--features /+/g' | sed 's/  */ /g')
-            echo "| \`${LABEL}\` | ${SIZE} |" >> $GITHUB_STEP_SUMMARY
-            # Touch marker so next iteration can detect newer files
-            touch /tmp/crate_files.txt
-          done
+          measure "default (all features)" ''
+          measure "inference (onig + unicode-norm + spm)" 'default-features = false, features = ["inference"]'
+          measure "minimal onig-only" 'default-features = false, features = ["onig"]'
+          measure "no-default + training" 'default-features = false, features = ["onig", "training"]'
+          measure "no-default + parallel" 'default-features = false, features = ["onig", "parallel"]'
 
+          rm -rf "$TEST_DIR"
           echo "" >> $GITHUB_STEP_SUMMARY
 
       - name: Publish package rust

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -14,7 +14,6 @@ napi        = "2"
 napi-derive = "2"
 serde       = { version = "1.0.163", features = ["derive"] }
 tokenizers  = { path = "../../tokenizers/" }
-ahash = { version = "0.8.11", features = ["serde"] }
 
 [build-dependencies]
 napi-build = "2"

--- a/bindings/node/src/models.rs
+++ b/bindings/node/src/models.rs
@@ -1,7 +1,7 @@
 use crate::arc_rwlock_serde;
 use crate::tasks::models::{BPEFromFilesTask, WordLevelFromFilesTask, WordPieceFromFilesTask};
 use crate::trainers::Trainer;
-use ahash::AHashMap;
+use tokenizers::utils::AHashMap;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use serde::{Deserialize, Serialize};

--- a/bindings/node/src/models.rs
+++ b/bindings/node/src/models.rs
@@ -1,7 +1,6 @@
 use crate::arc_rwlock_serde;
 use crate::tasks::models::{BPEFromFilesTask, WordLevelFromFilesTask, WordPieceFromFilesTask};
 use crate::trainers::Trainer;
-use tokenizers::utils::AHashMap;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use serde::{Deserialize, Serialize};
@@ -12,6 +11,7 @@ use tokenizers as tk;
 use tokenizers::models::bpe::{BpeBuilder, Merges};
 use tokenizers::models::wordlevel::WordLevelBuilder;
 use tokenizers::models::wordpiece::WordPieceBuilder;
+use tokenizers::utils::AHashMap;
 
 #[napi]
 #[derive(Clone, Serialize, Deserialize)]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -33,3 +33,7 @@ pyo3 = { version = "0.28", features = ["auto-initialize", "experimental-inspect"
 [features]
 default = ["ext-module"]
 ext-module = ["pyo3/extension-module"]
+
+[profile.release]
+strip = true
+lto = "fat"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -21,7 +21,6 @@ once_cell = "1.19.0"
 numpy = "0.28"
 ndarray = "0.16"
 itertools = "0.14"
-ahash = { version = "0.8.11", features = ["serde"] }
 pyo3-ffi = { version = "0.28" }
 
 [dependencies.tokenizers]

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::token::PyToken;
 use crate::trainers::PyTrainer;
-use ahash::AHashMap;
+use tk::utils::AHashMap;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, RwLock};
 
 use crate::token::PyToken;
 use crate::trainers::PyTrainer;
-use tk::utils::AHashMap;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
@@ -14,6 +13,7 @@ use tk::models::unigram::Unigram;
 use tk::models::wordlevel::WordLevel;
 use tk::models::wordpiece::{WordPiece, WordPieceBuilder};
 use tk::models::ModelWrapper;
+use tk::utils::AHashMap;
 use tk::{Model, Token};
 use tokenizers as tk;
 

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -101,6 +101,7 @@ spm = ["dep:spm_precompiled", "dep:unicode-segmentation"]
 esaxx_fast = ["dep:esaxx-rs", "esaxx-rs/cpp"]
 progressbar = ["indicatif"]
 http = ["hf-hub"]
+inference = ["onig", "unicode-normalization", "spm"]
 unstable_wasm = ["fancy-regex", "getrandom/wasm_js"]
 rustls-tls = ["hf-hub?/rustls-tls"]
 
@@ -115,11 +116,13 @@ tracing-subscriber = "0.3.18"
 lto = "fat"
 
 # Use this profile for minimal binary size (e.g. on-device deployment).
-# Build with: cargo build --profile release-small
+# Pair with the `inference` feature for all inference capabilities without training/parallel:
+#   cargo build --profile release-small --no-default-features --features inference
 # For even smaller builds (nightly only):
 #   RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" cargo +nightly build \
 #     -Z build-std=std,panic_abort -Z build-std-features="optimize_for_size" \
-#     --target <your-target-triple> --profile release-small
+#     --target <your-target-triple> --profile release-small \
+#     --no-default-features --features inference
 [profile.release-small]
 inherits = "release"
 opt-level = "s"

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -69,8 +69,7 @@ harness = false
 [dependencies]
 rand = { version = "0.9", optional = true }
 onig = { version = "6.5.1", default-features = false, optional = true }
-regex = { version = "1.10", default-features = false, features = ["std", "perf", "unicode-perl"] }
-regex-syntax = { version = "0.8", default-features = false, features = ["std", "unicode-perl"] }
+regex = { version = "1.10", default-features = false, features = ["std", "perf", "unicode-perl"], optional = true }
 rayon = { version = "1.10", optional = true }
 rayon-cond = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -90,11 +89,11 @@ fancy-regex = { version = "0.17", optional = true }
 getrandom = { version = "0.3" }
 esaxx-rs = { version = "0.1.10", default-features = false, features = [], optional = true }
 foldhash = "0.2"
-dary_heap = { version = "0.3.6", features = ["serde"] }
+dary_heap = "0.3.6"
 compact_str = { version = "0.9", features = ["serde"], optional = true }
 
 [features]
-default = ["progressbar", "onig", "esaxx_fast", "spm", "training", "parallel", "unicode-normalization"]
+default = ["progressbar", "onig", "esaxx_fast", "spm", "training", "parallel", "unicode-normalization", "regex"]
 unicode-normalization = ["dep:unicode-normalization-alignments"]
 parallel = ["dep:rayon", "dep:rayon-cond"]
 training = ["dep:rand", "dep:esaxx-rs", "dep:compact_str"]
@@ -114,6 +113,19 @@ tracing-subscriber = "0.3.18"
 
 [profile.release]
 lto = "fat"
+
+# Use this profile for minimal binary size (e.g. on-device deployment).
+# Build with: cargo build --profile release-small
+# For even smaller builds (nightly only):
+#   RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" cargo +nightly build \
+#     -Z build-std=std,panic_abort -Z build-std-features="optimize_for_size" \
+#     --target <your-target-triple> --profile release-small
+[profile.release-small]
+inherits = "release"
+opt-level = "s"
+strip = true
+panic = "abort"
+codegen-units = 1
 
 [profile.profiling]
 inherits = "release"

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -63,7 +63,7 @@ name = "truncation_benchmark"
 harness = false
 
 [dependencies]
-rand = "0.9"
+rand = { version = "0.9", optional = true }
 onig = { version = "6.5.1", default-features = false, optional = true }
 regex = "1.10"
 regex-syntax = "0.8"
@@ -75,10 +75,8 @@ unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 unicode-segmentation = "1.11"
 indicatif = { version = "0.18", optional = true }
-itertools = "0.14"
 log = "0.4"
-derive_builder = "0.20"
-spm_precompiled = "0.1.3"
+spm_precompiled = { version = "0.1.3", optional = true }
 hf-hub = { version = "0.4.1", features = ["ureq"], default-features = false, optional = true }
 daachorse = "1.0.1"
 paste = "1.0.14"
@@ -86,15 +84,17 @@ macro_rules_attribute = "0.2.0"
 thiserror = "2"
 fancy-regex = { version = "0.17", optional = true }
 getrandom = { version = "0.3" }
-esaxx-rs = { version = "0.1.10", default-features = false, features = [] }
+esaxx-rs = { version = "0.1.10", default-features = false, features = [], optional = true }
 monostate = "0.1.12"
 ahash = { version = "0.8.11", features = ["serde"] }
 dary_heap = { version = "0.3.6", features = ["serde"] }
 compact_str = { version = "0.9", features = ["serde"] }
 
 [features]
-default = ["progressbar", "onig", "esaxx_fast"]
-esaxx_fast = ["esaxx-rs/cpp"]
+default = ["progressbar", "onig", "esaxx_fast", "spm", "training"]
+training = ["dep:rand", "dep:esaxx-rs"]
+spm = ["dep:spm_precompiled"]
+esaxx_fast = ["dep:esaxx-rs", "esaxx-rs/cpp"]
 progressbar = ["indicatif"]
 http = ["hf-hub"]
 unstable_wasm = ["fancy-regex", "getrandom/wasm_js"]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -65,10 +65,10 @@ harness = false
 [dependencies]
 rand = { version = "0.9", optional = true }
 onig = { version = "6.5.1", default-features = false, optional = true }
-regex = "1.10"
-regex-syntax = "0.8"
-rayon = "1.10"
-rayon-cond = "0.4"
+regex = { version = "1.10", default-features = false, features = ["std", "perf", "unicode-perl"] }
+regex-syntax = { version = "0.8", default-features = false, features = ["std", "unicode-perl"] }
+rayon = { version = "1.10", optional = true }
+rayon-cond = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 unicode-normalization-alignments = "0.1"
@@ -85,13 +85,13 @@ thiserror = "2"
 fancy-regex = { version = "0.17", optional = true }
 getrandom = { version = "0.3" }
 esaxx-rs = { version = "0.1.10", default-features = false, features = [], optional = true }
-monostate = "0.1.12"
-ahash = { version = "0.8.11", features = ["serde"] }
+foldhash = "0.2"
 dary_heap = { version = "0.3.6", features = ["serde"] }
 compact_str = { version = "0.9", features = ["serde"] }
 
 [features]
-default = ["progressbar", "onig", "esaxx_fast", "spm", "training"]
+default = ["progressbar", "onig", "esaxx_fast", "spm", "training", "parallel"]
+parallel = ["dep:rayon", "dep:rayon-cond"]
 training = ["dep:rand", "dep:esaxx-rs"]
 spm = ["dep:spm_precompiled"]
 esaxx_fast = ["dep:esaxx-rs", "esaxx-rs/cpp"]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -71,9 +71,9 @@ rayon = { version = "1.10", optional = true }
 rayon-cond = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-unicode-normalization-alignments = "0.1"
+unicode-normalization-alignments = { version = "0.1", optional = true }
 unicode_categories = "0.1"
-unicode-segmentation = "1.11"
+unicode-segmentation = { version = "1.11", optional = true }
 indicatif = { version = "0.18", optional = true }
 log = "0.4"
 spm_precompiled = { version = "0.1.3", optional = true }
@@ -87,13 +87,14 @@ getrandom = { version = "0.3" }
 esaxx-rs = { version = "0.1.10", default-features = false, features = [], optional = true }
 foldhash = "0.2"
 dary_heap = { version = "0.3.6", features = ["serde"] }
-compact_str = { version = "0.9", features = ["serde"] }
+compact_str = { version = "0.9", features = ["serde"], optional = true }
 
 [features]
-default = ["progressbar", "onig", "esaxx_fast", "spm", "training", "parallel"]
+default = ["progressbar", "onig", "esaxx_fast", "spm", "training", "parallel", "unicode-normalization"]
+unicode-normalization = ["dep:unicode-normalization-alignments"]
 parallel = ["dep:rayon", "dep:rayon-cond"]
-training = ["dep:rand", "dep:esaxx-rs"]
-spm = ["dep:spm_precompiled"]
+training = ["dep:rand", "dep:esaxx-rs", "dep:compact_str"]
+spm = ["dep:spm_precompiled", "dep:unicode-segmentation"]
 esaxx_fast = ["dep:esaxx-rs", "esaxx-rs/cpp"]
 progressbar = ["indicatif"]
 http = ["hf-hub"]

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -135,9 +135,134 @@ fn main() -> Result<()> {
 
 ## Features
 
-- **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
-  compilation for certain targets is not supported by the [termios](https://crates.io/crates/termios)
-  dependency of the [indicatif](https://crates.io/crates/indicatif) progress bar.
+All features are **enabled by default** for backward compatibility. Disable them for on-device/embedded use.
 
-- **http**: This feature enables downloading the tokenizer via HTTP. It is disabled by default.
-  With this feature enabled, `Tokenizer::from_pretrained` becomes accessible.
+| Feature | Default | Description | Deps saved |
+|---------|---------|-------------|------------|
+| `training` | on | Tokenizer training (trainers, `train()` method) | rand, esaxx-rs, compact_str |
+| `parallel` | on | Multi-threaded encoding via rayon | rayon, rayon-cond, crossbeam |
+| `spm` | on | SentencePiece precompiled normalizer (T5, mBART) | spm_precompiled, nom, unicode-segmentation |
+| `unicode-normalization` | on | NFC/NFD/NFKC/NFKD normalizers | unicode-normalization-alignments |
+| `progressbar` | on | Progress bars during training | indicatif |
+| `onig` | on | Oniguruma regex engine (C binding) | onig, onig_sys |
+| `http` | off | Download tokenizers from Hugging Face Hub | hf-hub, ureq |
+| `unstable_wasm` | off | WASM target support (uses fancy-regex) | fancy-regex |
+
+### On-device / embedded configuration
+
+```toml
+# Minimal inference-only (with Oniguruma regex):
+tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
+
+# WASM (pure Rust, no C dependencies):
+tokenizers = { version = "0.22", default-features = false, features = ["unstable_wasm"] }
+```
+
+## Bundle size
+
+The deployed library size depends on how you link it. Here are measured sizes on macOS arm64:
+
+| Configuration | .dylib (shared) | .a (static) | After final link |
+|---------------|----------------|-------------|-----------------|
+| Default (all features) | 2.5 MB | 9.2 MB | ~2.5 MB |
+| Inference-only (`onig`) | 2.0 MB | 8.0 MB | ~2.0 MB |
+
+> **Note**: `.a` (static archive) files contain all object code including unused functions.
+> The linker strips dead code at final link time, so the actual contribution to your app
+> binary is close to the `.dylib` size. The `.a` size is NOT what ships to users.
+
+### Comparison with Meta pytorch/tokenizers (C++)
+
+| | Meta (C++) | HuggingFace (Rust) |
+|---|---|---|
+| Stripped binary (all tokenizer types) | **0.8 MB** | **2.0 MB** |
+| Static .a (pre-link, all deps) | 5.5 MB | 8.0 MB |
+| Features | SP, Tiktoken, Llama2c | BPE, WordPiece, Unigram, WordLevel + normalizers, pre-tokenizers, decoders, added vocab |
+
+HuggingFace is ~2.5x larger because it includes full `tokenizer.json` parsing (serde), Unicode-aware
+regex, all normalizer/pre-tokenizer/decoder types, and added vocabulary matching — features Meta's
+library doesn't have.
+
+### How to measure bundle size
+
+**1. Measure the linked shared library (what ships to users):**
+
+```bash
+# Create a test crate that links tokenizers as a cdylib
+cargo new --lib measure-size && cd measure-size
+cat >> Cargo.toml << 'EOF'
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+tokenizers = { path = "../tokenizers", default-features = false, features = ["onig"] }
+
+[profile.release]
+lto = "fat"
+opt-level = "s"
+strip = true
+EOF
+
+echo 'use tokenizers::Tokenizer;
+#[no_mangle]
+pub extern "C" fn tokenize() { let _ = Tokenizer::from_file("t.json"); }' > src/lib.rs
+
+cargo build --release
+ls -lh target/release/*.dylib  # macOS
+ls -lh target/release/*.so     # Linux
+```
+
+**2. Measure per-crate contribution with cargo-bloat:**
+
+```bash
+cargo install cargo-bloat
+cargo bloat --release --crates -n 30
+```
+
+**3. Measure dependency rlib sizes (compile-time cost):**
+
+```bash
+# Total rlib for runtime deps only
+cargo tree --edges=normal --prefix none -f '{p}' | awk '{print $1}' | sort -u | sed 's/-/_/g' > /tmp/deps.txt
+
+for f in target/release/deps/*.rlib; do
+  sz=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null)
+  name=$(basename "$f" | sed 's/-[a-f0-9]*\.rlib//' | sed 's/^lib//')
+  echo "$sz $name"
+done | sort -t' ' -k2 | awk '!seen[$2]++ {print}' | sort -k2 > /tmp/rlibs.txt
+
+join -1 2 -2 1 /tmp/rlibs.txt /tmp/deps.txt | awk '{
+  total+=$2
+  printf "%8.1f KB  %s\n", $2/1024, $1
+} END {
+  printf "\nTOTAL: %.1f MB\n", total/1048576
+}' | sort -rn
+```
+
+**4. Track size in CI (regression test):**
+
+```bash
+#!/bin/bash
+# scripts/check-bundle-size.sh
+set -e
+
+MAX_DYLIB_KB=2500  # 2.5 MB threshold
+
+cargo build --release --no-default-features --features "onig" \
+  --target-dir /tmp/size-check
+
+SIZE=$(stat -f%z /tmp/size-check/release/libtokenizers.rlib 2>/dev/null \
+    || stat -c%s /tmp/size-check/release/libtokenizers.rlib)
+SIZE_KB=$((SIZE / 1024))
+
+echo "libtokenizers.rlib: ${SIZE_KB} KB"
+
+# For the actual linked size, build a cdylib test crate
+# (see step 1 above) and check the .dylib/.so size
+
+if [ "$SIZE_KB" -gt "$MAX_DYLIB_KB" ]; then
+  echo "FAIL: bundle size ${SIZE_KB} KB exceeds threshold ${MAX_DYLIB_KB} KB"
+  exit 1
+fi
+echo "PASS: bundle size OK"
+```

--- a/tokenizers/src/decoders/byte_fallback.rs
+++ b/tokenizers/src/decoders/byte_fallback.rs
@@ -1,23 +1,22 @@
 use crate::tokenizer::{Decoder, Result};
-use monostate::MustBe;
 
-use serde::{Deserialize, Serialize};
+impl_serde_type! {
+    #[derive(Clone, Debug)]
+    /// ByteFallback is a simple trick which converts tokens looking like `<0x61>`
+    /// to pure bytes, and attempts to make them into a string. If the tokens
+    /// cannot be decoded you will get � instead for each inconvertible byte token
+    pub struct ByteFallback;
+}
 
-#[derive(Deserialize, Clone, Debug, Serialize, Default)]
-/// ByteFallback is a simple trick which converts tokens looking like `<0x61>`
-/// to pure bytes, and attempts to make them into a string. If the tokens
-/// cannot be decoded you will get � instead for each inconvertible byte token
-#[non_exhaustive]
-pub struct ByteFallback {
-    #[serde(rename = "type")]
-    type_: MustBe!("ByteFallback"),
+impl Default for ByteFallback {
+    fn default() -> Self {
+        ByteFallback
+    }
 }
 
 impl ByteFallback {
     pub fn new() -> Self {
-        Self {
-            type_: MustBe!("ByteFallback"),
-        }
+        ByteFallback
     }
 }
 

--- a/tokenizers/src/decoders/ctc.rs
+++ b/tokenizers/src/decoders/ctc.rs
@@ -1,7 +1,6 @@
 use crate::decoders::wordpiece;
 use crate::tokenizer::{Decoder, Result};
 
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,22 +42,22 @@ impl Default for CTC {
 
 impl Decoder for CTC {
     fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
-        Ok(tokens
-            .into_iter()
-            .dedup()
-            .filter_map(|token| {
-                let mut replaced = token.replace(&self.pad_token, "");
-                if self.cleanup {
-                    replaced =
-                        wordpiece::cleanup(&replaced).replace(&self.word_delimiter_token, " ");
-                }
-                if replaced.is_empty() {
-                    None
-                } else {
-                    Some(replaced)
-                }
-            })
-            .collect())
+        let mut prev: Option<String> = None;
+        let mut result = Vec::new();
+        for token in tokens {
+            if prev.as_ref() == Some(&token) {
+                continue;
+            }
+            prev = Some(token.clone());
+            let mut replaced = token.replace(&self.pad_token, "");
+            if self.cleanup {
+                replaced = wordpiece::cleanup(&replaced).replace(&self.word_delimiter_token, " ");
+            }
+            if !replaced.is_empty() {
+                result.push(replaced);
+            }
+        }
+        Ok(result)
     }
 }
 

--- a/tokenizers/src/decoders/fuse.rs
+++ b/tokenizers/src/decoders/fuse.rs
@@ -1,23 +1,23 @@
 use crate::tokenizer::{Decoder, Result};
-use monostate::MustBe;
-use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-/// Fuse simply fuses all tokens into one big string.
-/// It's usually the last decoding step anyway, but this
-/// decoder exists incase some decoders need to happen after that
-/// step
-#[non_exhaustive]
-pub struct Fuse {
-    #[serde(rename = "type")]
-    type_: MustBe!("Fuse"),
+impl_serde_type! {
+    #[derive(Clone, Debug)]
+    /// Fuse simply fuses all tokens into one big string.
+    /// It's usually the last decoding step anyway, but this
+    /// decoder exists incase some decoders need to happen after that
+    /// step
+    pub struct Fuse;
+}
+
+impl Default for Fuse {
+    fn default() -> Self {
+        Fuse
+    }
 }
 
 impl Fuse {
     pub fn new() -> Self {
-        Self {
-            type_: MustBe!("Fuse"),
-        }
+        Fuse
     }
 }
 

--- a/tokenizers/src/decoders/mod.rs
+++ b/tokenizers/src/decoders/mod.rs
@@ -91,8 +91,7 @@ impl<'de> Deserialize<'de> for DecoderWrapper {
         Ok(match helper {
             DecoderHelper::Tagged(model) => {
                 let mut values: serde_json::Map<String, serde_json::Value> =
-                    crate::utils::from_value_via_str(model.rest)
-                        .map_err(serde::de::Error::custom)?;
+                    serde_json::from_value(model.rest).map_err(serde::de::Error::custom)?;
                 values.insert(
                     "type".to_string(),
                     serde_json::to_value(&model.variant).map_err(serde::de::Error::custom)?,
@@ -100,50 +99,39 @@ impl<'de> Deserialize<'de> for DecoderWrapper {
                 let values = serde_json::Value::Object(values);
                 match model.variant {
                     EnumType::BPEDecoder => DecoderWrapper::BPE(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::ByteLevel => DecoderWrapper::ByteLevel(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::WordPiece => DecoderWrapper::WordPiece(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Metaspace => DecoderWrapper::Metaspace(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::CTC => DecoderWrapper::CTC(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Sequence => DecoderWrapper::Sequence(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Replace => DecoderWrapper::Replace(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Fuse => DecoderWrapper::Fuse(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Strip => DecoderWrapper::Strip(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::ByteFallback => DecoderWrapper::ByteFallback(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                 }
             }
             DecoderHelper::Legacy(value) => {
-                let untagged =
-                    crate::utils::from_value_via_str(value).map_err(serde::de::Error::custom)?;
+                let untagged = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
                 match untagged {
                     DecoderUntagged::BPE(dec) => DecoderWrapper::BPE(dec),
                     DecoderUntagged::ByteLevel(dec) => DecoderWrapper::ByteLevel(dec),
@@ -218,10 +206,9 @@ mod tests {
         let json = r#"{"type":"Sequence","decoders":[{},{"type":"Metaspace","replacement":"▁","prepend_scheme":"always"}]}"#;
         let parse = serde_json::from_str::<DecoderWrapper>(json);
         match parse {
-            Err(err) => assert!(
-                format!("{err}")
-                    .starts_with("data did not match any variant of untagged enum DecoderUntagged"),
-                "Unexpected error: {}", err
+            Err(err) => assert_eq!(
+                format!("{err}"),
+                "data did not match any variant of untagged enum DecoderUntagged"
             ),
             _ => panic!("Expected error"),
         }
@@ -229,10 +216,9 @@ mod tests {
         let json = r#"{"replacement":"▁","prepend_scheme":"always"}"#;
         let parse = serde_json::from_str::<DecoderWrapper>(json);
         match parse {
-            Err(err) => assert!(
-                format!("{err}")
-                    .starts_with("data did not match any variant of untagged enum DecoderUntagged"),
-                "Unexpected error: {}", err
+            Err(err) => assert_eq!(
+                format!("{err}"),
+                "data did not match any variant of untagged enum DecoderUntagged"
             ),
             _ => panic!("Expected error"),
         }
@@ -240,10 +226,7 @@ mod tests {
         let json = r#"{"type":"Sequence","prepend_scheme":"always"}"#;
         let parse = serde_json::from_str::<DecoderWrapper>(json);
         match parse {
-            Err(err) => assert!(
-                format!("{err}").starts_with("missing field `decoders`"),
-                "Unexpected error: {}", err
-            ),
+            Err(err) => assert_eq!(format!("{err}"), "missing field `decoders`"),
             _ => panic!("Expected error"),
         }
     }

--- a/tokenizers/src/decoders/mod.rs
+++ b/tokenizers/src/decoders/mod.rs
@@ -91,7 +91,8 @@ impl<'de> Deserialize<'de> for DecoderWrapper {
         Ok(match helper {
             DecoderHelper::Tagged(model) => {
                 let mut values: serde_json::Map<String, serde_json::Value> =
-                    serde_json::from_value(model.rest).map_err(serde::de::Error::custom)?;
+                    crate::utils::from_value_via_str(model.rest)
+                        .map_err(serde::de::Error::custom)?;
                 values.insert(
                     "type".to_string(),
                     serde_json::to_value(&model.variant).map_err(serde::de::Error::custom)?,
@@ -99,39 +100,50 @@ impl<'de> Deserialize<'de> for DecoderWrapper {
                 let values = serde_json::Value::Object(values);
                 match model.variant {
                     EnumType::BPEDecoder => DecoderWrapper::BPE(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::ByteLevel => DecoderWrapper::ByteLevel(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::WordPiece => DecoderWrapper::WordPiece(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Metaspace => DecoderWrapper::Metaspace(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::CTC => DecoderWrapper::CTC(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Sequence => DecoderWrapper::Sequence(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Replace => DecoderWrapper::Replace(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Fuse => DecoderWrapper::Fuse(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Strip => DecoderWrapper::Strip(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::ByteFallback => DecoderWrapper::ByteFallback(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                 }
             }
             DecoderHelper::Legacy(value) => {
-                let untagged = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                let untagged =
+                    crate::utils::from_value_via_str(value).map_err(serde::de::Error::custom)?;
                 match untagged {
                     DecoderUntagged::BPE(dec) => DecoderWrapper::BPE(dec),
                     DecoderUntagged::ByteLevel(dec) => DecoderWrapper::ByteLevel(dec),
@@ -206,9 +218,10 @@ mod tests {
         let json = r#"{"type":"Sequence","decoders":[{},{"type":"Metaspace","replacement":"▁","prepend_scheme":"always"}]}"#;
         let parse = serde_json::from_str::<DecoderWrapper>(json);
         match parse {
-            Err(err) => assert_eq!(
-                format!("{err}"),
-                "data did not match any variant of untagged enum DecoderUntagged"
+            Err(err) => assert!(
+                format!("{err}")
+                    .starts_with("data did not match any variant of untagged enum DecoderUntagged"),
+                "Unexpected error: {}", err
             ),
             _ => panic!("Expected error"),
         }
@@ -216,9 +229,10 @@ mod tests {
         let json = r#"{"replacement":"▁","prepend_scheme":"always"}"#;
         let parse = serde_json::from_str::<DecoderWrapper>(json);
         match parse {
-            Err(err) => assert_eq!(
-                format!("{err}"),
-                "data did not match any variant of untagged enum DecoderUntagged"
+            Err(err) => assert!(
+                format!("{err}")
+                    .starts_with("data did not match any variant of untagged enum DecoderUntagged"),
+                "Unexpected error: {}", err
             ),
             _ => panic!("Expected error"),
         }
@@ -226,7 +240,10 @@ mod tests {
         let json = r#"{"type":"Sequence","prepend_scheme":"always"}"#;
         let parse = serde_json::from_str::<DecoderWrapper>(json);
         match parse {
-            Err(err) => assert_eq!(format!("{err}"), "missing field `decoders`"),
+            Err(err) => assert!(
+                format!("{err}").starts_with("missing field `decoders`"),
+                "Unexpected error: {}", err
+            ),
             _ => panic!("Expected error"),
         }
     }

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -124,18 +124,137 @@
 //!
 //! # Features
 //!
-//! - **training**: Enables tokenizer training support (trainers, training methods). Enabled by default.
-//!   Disable this for inference-only deployments to significantly reduce binary size.
+//! All features are **enabled by default** for backward compatibility. Disable them for on-device/embedded use.
 //!
-//! - **spm**: Enables SentencePiece precompiled normalizer support. Enabled by default.
-//!   Disable this if you only use BPE-based tokenizers (GPT, Llama, etc.).
+//! | Feature | Default | Description | Deps saved |
+//! |---------|---------|-------------|------------|
+//! | `training` | on | Tokenizer training (trainers, `train()` method) | rand, esaxx-rs, compact_str |
+//! | `parallel` | on | Multi-threaded encoding via rayon | rayon, rayon-cond, crossbeam |
+//! | `spm` | on | SentencePiece precompiled normalizer (T5, mBART) | spm_precompiled, nom, unicode-segmentation |
+//! | `unicode-normalization` | on | NFC/NFD/NFKC/NFKD normalizers | unicode-normalization-alignments |
+//! | `progressbar` | on | Progress bars during training | indicatif |
+//! | `onig` | on | Oniguruma regex engine (C binding) | onig, onig_sys |
+//! | `http` | off | Download tokenizers from Hugging Face Hub | hf-hub, ureq |
+//! | `unstable_wasm` | off | WASM target support (uses fancy-regex) | fancy-regex |
 //!
-//! - **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
-//!   compilation for certain targets is not supported by the [termios](https://crates.io/crates/termios)
-//!   dependency of the [indicatif](https://crates.io/crates/indicatif) progress bar.
+//! ## On-device / embedded configuration
 //!
-//! - **http**: This feature enables downloading the tokenizer via HTTP. It is disabled by default.
-//!   With this feature enabled, `Tokenizer::from_pretrained` becomes accessible.
+//! ```toml
+//! # Minimal inference-only (with Oniguruma regex):
+//! tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
+//!
+//! # WASM (pure Rust, no C dependencies):
+//! tokenizers = { version = "0.22", default-features = false, features = ["unstable_wasm"] }
+//! ```
+//!
+//! # Bundle size
+//!
+//! The deployed library size depends on how you link it. Here are measured sizes on macOS arm64:
+//!
+//! | Configuration | .dylib (shared) | .a (static) | After final link |
+//! |---------------|----------------|-------------|-----------------|
+//! | Default (all features) | 2.5 MB | 9.2 MB | ~2.5 MB |
+//! | Inference-only (`onig`) | 2.0 MB | 8.0 MB | ~2.0 MB |
+//!
+//! > **Note**: `.a` (static archive) files contain all object code including unused functions.
+//! > The linker strips dead code at final link time, so the actual contribution to your app
+//! > binary is close to the `.dylib` size. The `.a` size is NOT what ships to users.
+//!
+//! ## Comparison with Meta pytorch/tokenizers (C++)
+//!
+//! | | Meta (C++) | HuggingFace (Rust) |
+//! |---|---|---|
+//! | Stripped binary (all tokenizer types) | **0.8 MB** | **2.0 MB** |
+//! | Static .a (pre-link, all deps) | 5.5 MB | 8.0 MB |
+//! | Features | SP, Tiktoken, Llama2c | BPE, WordPiece, Unigram, WordLevel + normalizers, pre-tokenizers, decoders, added vocab |
+//!
+//! HuggingFace is ~2.5x larger because it includes full `tokenizer.json` parsing (serde), Unicode-aware
+//! regex, all normalizer/pre-tokenizer/decoder types, and added vocabulary matching — features Meta's
+//! library doesn't have.
+//!
+//! ## How to measure bundle size
+//!
+//! **1. Measure the linked shared library (what ships to users):**
+//!
+//! ```bash
+//! # Create a test crate that links tokenizers as a cdylib
+//! cargo new --lib measure-size && cd measure-size
+//! cat >> Cargo.toml << 'EOF'
+//! [lib]
+//! crate-type = ["cdylib"]
+//!
+//! [dependencies]
+//! tokenizers = { path = "../tokenizers", default-features = false, features = ["onig"] }
+//!
+//! [profile.release]
+//! lto = "fat"
+//! opt-level = "s"
+//! strip = true
+//! EOF
+//!
+//! echo 'use tokenizers::Tokenizer;
+//! #[no_mangle]
+//! pub extern "C" fn tokenize() { let _ = Tokenizer::from_file("t.json"); }' > src/lib.rs
+//!
+//! cargo build --release
+//! ls -lh target/release/*.dylib  # macOS
+//! ls -lh target/release/*.so     # Linux
+//! ```
+//!
+//! **2. Measure per-crate contribution with cargo-bloat:**
+//!
+//! ```bash
+//! cargo install cargo-bloat
+//! cargo bloat --release --crates -n 30
+//! ```
+//!
+//! **3. Measure dependency rlib sizes (compile-time cost):**
+//!
+//! ```bash
+//! # Total rlib for runtime deps only
+//! cargo tree --edges=normal --prefix none -f '{p}' | awk '{print $1}' | sort -u | sed 's/-/_/g' > /tmp/deps.txt
+//!
+//! for f in target/release/deps/*.rlib; do
+//!   sz=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null)
+//!   name=$(basename "$f" | sed 's/-[a-f0-9]*\.rlib//' | sed 's/^lib//')
+//!   echo "$sz $name"
+//! done | sort -t' ' -k2 | awk '!seen[$2]++ {print}' | sort -k2 > /tmp/rlibs.txt
+//!
+//! join -1 2 -2 1 /tmp/rlibs.txt /tmp/deps.txt | awk '{
+//!   total+=$2
+//!   printf "%8.1f KB  %s\n", $2/1024, $1
+//! } END {
+//!   printf "\nTOTAL: %.1f MB\n", total/1048576
+//! }' | sort -rn
+//! ```
+//!
+//! **4. Track size in CI (regression test):**
+//!
+//! ```bash
+//! #!/bin/bash
+//! # scripts/check-bundle-size.sh
+//! set -e
+//!
+//! MAX_DYLIB_KB=2500  # 2.5 MB threshold
+//!
+//! cargo build --release --no-default-features --features "onig" \
+//!   --target-dir /tmp/size-check
+//!
+//! SIZE=$(stat -f%z /tmp/size-check/release/libtokenizers.rlib 2>/dev/null \
+//!     || stat -c%s /tmp/size-check/release/libtokenizers.rlib)
+//! SIZE_KB=$((SIZE / 1024))
+//!
+//! echo "libtokenizers.rlib: ${SIZE_KB} KB"
+//!
+//! # For the actual linked size, build a cdylib test crate
+//! # (see step 1 above) and check the .dylib/.so size
+//!
+//! if [ "$SIZE_KB" -gt "$MAX_DYLIB_KB" ]; then
+//!   echo "FAIL: bundle size ${SIZE_KB} KB exceeds threshold ${MAX_DYLIB_KB} KB"
+//!   exit 1
+//! fi
+//! echo "PASS: bundle size OK"
+//! ```
 
 #[macro_use]
 extern crate log;

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -124,6 +124,12 @@
 //!
 //! # Features
 //!
+//! - **training**: Enables tokenizer training support (trainers, training methods). Enabled by default.
+//!   Disable this for inference-only deployments to significantly reduce binary size.
+//!
+//! - **spm**: Enables SentencePiece precompiled normalizer support. Enabled by default.
+//!   Disable this if you only use BPE-based tokenizers (GPT, Llama, etc.).
+//!
 //! - **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
 //!   compilation for certain targets is not supported by the [termios](https://crates.io/crates/termios)
 //!   dependency of the [indicatif](https://crates.io/crates/indicatif) progress bar.
@@ -133,9 +139,6 @@
 
 #[macro_use]
 extern crate log;
-
-#[macro_use]
-extern crate derive_builder;
 
 #[macro_use]
 pub mod utils;

--- a/tokenizers/src/models/bpe/mod.rs
+++ b/tokenizers/src/models/bpe/mod.rs
@@ -1,8 +1,10 @@
 //! [Byte Pair Encoding](https://www.aclweb.org/anthology/P16-1162/) model.
+#[cfg(feature = "training")]
 use std::{iter, mem};
 
 mod model;
 mod serialization;
+#[cfg(feature = "training")]
 pub mod trainer;
 mod word;
 
@@ -35,11 +37,13 @@ pub enum Error {
     InvalidDropout,
 }
 
+#[cfg(feature = "training")]
 /// Provides access to the `FirstLastIterator` to any Iterator
 pub(crate) trait WithFirstLastIterator: Iterator + Sized {
     fn with_first_and_last(self) -> FirstLastIterator<Self>;
 }
 
+#[cfg(feature = "training")]
 impl<I> WithFirstLastIterator for I
 where
     I: Iterator,
@@ -52,6 +56,7 @@ where
     }
 }
 
+#[cfg(feature = "training")]
 /// Provides information about whether an item is the first and/or the last of the iterator
 pub(crate) struct FirstLastIterator<I>
 where
@@ -61,6 +66,7 @@ where
     iter: iter::Peekable<I>,
 }
 
+#[cfg(feature = "training")]
 impl<I> Iterator for FirstLastIterator<I>
 where
     I: Iterator,
@@ -78,5 +84,6 @@ where
 
 // Re-export
 pub use model::*;
+#[cfg(feature = "training")]
 pub use trainer::*;
 use word::*;

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -1,6 +1,6 @@
-use super::{super::OrderedVocabIter, Error, Pair, Word};
 #[cfg(feature = "training")]
 use super::trainer::BpeTrainer;
+use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -1,4 +1,6 @@
-use super::{super::OrderedVocabIter, trainer::BpeTrainer, Error, Pair, Word};
+use super::{super::OrderedVocabIter, Error, Pair, Word};
+#[cfg(feature = "training")]
+use super::trainer::BpeTrainer;
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
@@ -497,6 +499,7 @@ impl BPE {
 }
 
 impl Model for BPE {
+    #[cfg(feature = "training")]
     type Trainer = BpeTrainer;
 
     fn get_vocab(&self) -> HashMap<String, u32> {
@@ -572,6 +575,7 @@ impl Model for BPE {
         Ok(vec![vocab_path, merges_path])
     }
 
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> BpeTrainer {
         BpeTrainer::default()
     }

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -4,7 +4,7 @@ use super::trainer::BpeTrainer;
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use serde_json::Value;
 use std::borrow::Cow;
 

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -1,5 +1,5 @@
 use super::{super::OrderedVocabIter, convert_merges_to_hashmap, BpeBuilder, Pair, BPE};
-use crate::utils::{AHashMap};
+use crate::utils::AHashMap;
 use serde::{
     de::{Error, MapAccess, Visitor},
     ser::SerializeStruct,

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -1,5 +1,5 @@
 use super::{super::OrderedVocabIter, convert_merges_to_hashmap, BpeBuilder, Pair, BPE};
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use serde::{
     de::{Error, MapAccess, Visitor},
     ser::SerializeStruct,

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -4,7 +4,7 @@ use super::{Pair, WithFirstLastIterator, Word, BPE};
 use crate::parallelism::*;
 use crate::tokenizer::{AddedToken, Result, Trainer};
 use crate::utils::progress::{ProgressBar, ProgressFormat, ProgressStyle};
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet, HashMapExt, HashSetExt};
 use compact_str::CompactString;
 use dary_heap::OctonaryHeap;
 use serde::{Deserialize, Serialize};
@@ -678,7 +678,7 @@ impl Trainer for BpeTrainer {
 #[cfg(test)]
 mod tests {
     use super::{BpeTrainer, Pair, BPE};
-    use ahash::AHashMap;
+    use crate::utils::{AHashMap, HashMapExt};
     use compact_str::CompactString;
 
     #[test]

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -608,9 +608,9 @@ impl BpeTrainer {
         // Transfer new vocab & options to model
         //model.vocab = word_to_id;
         model.vocab = word_to_id
-            .into_iter()
+            .into_values()
             // we have to look up the string in id_to_word because the key in word_to_id is a hash
-            .map(|(_key, val)| (id_to_word[val as usize].to_string(), val))
+            .map(|val| (id_to_word[val as usize].to_string(), val))
             .collect();
         model.vocab_r = model
             .vocab
@@ -678,7 +678,7 @@ impl Trainer for BpeTrainer {
 #[cfg(test)]
 mod tests {
     use super::{BpeTrainer, Pair, BPE};
-    use crate::utils::{AHashMap, HashMapExt};
+    use crate::utils::AHashMap;
     use compact_str::CompactString;
 
     #[test]

--- a/tokenizers/src/models/bpe/word.rs
+++ b/tokenizers/src/models/bpe/word.rs
@@ -1,6 +1,7 @@
 use super::Pair;
 use ahash::AHashMap;
 use dary_heap::QuaternaryHeap;
+#[cfg(feature = "training")]
 use rand::{rng, Rng};
 use std::cmp::Ordering;
 
@@ -75,6 +76,7 @@ impl std::fmt::Debug for Word {
 }
 
 impl Word {
+    #[cfg_attr(not(feature = "training"), allow(dead_code))]
     pub(super) fn new() -> Self {
         Word { symbols: vec![] }
     }
@@ -104,6 +106,7 @@ impl Word {
         });
     }
 
+    #[cfg_attr(not(feature = "training"), allow(dead_code))]
     pub(super) fn merge(
         &mut self,
         c1: u32,
@@ -178,7 +181,18 @@ impl Word {
         );
 
         while let Some(top) = queue.pop() {
-            if dropout.map(|d| rng().random::<f32>() < d).unwrap_or(false) {
+            let should_skip = {
+                #[cfg(feature = "training")]
+                {
+                    dropout.map(|d| rng().random::<f32>() < d).unwrap_or(false)
+                }
+                #[cfg(not(feature = "training"))]
+                {
+                    let _ = &dropout;
+                    false
+                }
+            };
+            if should_skip {
                 skip.push(top);
             } else {
                 // Re-insert the skipped elements
@@ -249,6 +263,7 @@ impl Word {
         self.symbols.retain(|s| s.len != 0);
     }
 
+    #[cfg_attr(not(feature = "training"), allow(dead_code))]
     pub(super) fn get_chars(&self) -> Vec<u32> {
         self.symbols.iter().map(|s| s.c).collect()
     }

--- a/tokenizers/src/models/bpe/word.rs
+++ b/tokenizers/src/models/bpe/word.rs
@@ -1,5 +1,5 @@
 use super::Pair;
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use dary_heap::QuaternaryHeap;
 #[cfg(feature = "training")]
 use rand::{rng, Rng};

--- a/tokenizers/src/models/bpe/word.rs
+++ b/tokenizers/src/models/bpe/word.rs
@@ -1,5 +1,5 @@
 use super::Pair;
-use crate::utils::{AHashMap};
+use crate::utils::AHashMap;
 use dary_heap::QuaternaryHeap;
 #[cfg(feature = "training")]
 use rand::{rng, Rng};

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -5,7 +5,7 @@ pub mod unigram;
 pub mod wordlevel;
 pub mod wordpiece;
 
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn incomplete_ordered_vocab() {
         let vocab_r: AHashMap<u32, String> =
-            AHashMap::from([(0, "Hi".to_string()), (2, "There".to_string())]);
+            IntoIterator::into_iter([(0u32, "Hi".to_string()), (2, "There".to_string())]).collect();
 
         let ordered = OrderedVocabIter::new(&vocab_r);
 

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -11,11 +11,21 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::models::bpe::{BpeTrainer, BPE};
-use crate::models::unigram::{Unigram, UnigramTrainer};
-use crate::models::wordlevel::{WordLevel, WordLevelTrainer};
-use crate::models::wordpiece::{WordPiece, WordPieceTrainer};
-use crate::{AddedToken, Model, Result, Token, Trainer};
+use crate::models::bpe::BPE;
+#[cfg(feature = "training")]
+use crate::models::bpe::BpeTrainer;
+use crate::models::unigram::Unigram;
+#[cfg(feature = "training")]
+use crate::models::unigram::UnigramTrainer;
+use crate::models::wordlevel::WordLevel;
+#[cfg(feature = "training")]
+use crate::models::wordlevel::WordLevelTrainer;
+use crate::models::wordpiece::WordPiece;
+#[cfg(feature = "training")]
+use crate::models::wordpiece::WordPieceTrainer;
+use crate::{Model, Result, Token};
+#[cfg(feature = "training")]
+use crate::{AddedToken, Trainer};
 
 /// Wraps a vocab mapping (ID -> token) to a struct that will be serialized in order
 /// of token ID, smallest to largest.
@@ -141,6 +151,7 @@ impl_enum_from!(BPE, ModelWrapper, BPE);
 impl_enum_from!(Unigram, ModelWrapper, Unigram);
 
 impl Model for ModelWrapper {
+    #[cfg(feature = "training")]
     type Trainer = TrainerWrapper;
 
     fn tokenize(&self, tokens: &str) -> Result<Vec<Token>> {
@@ -197,6 +208,7 @@ impl Model for ModelWrapper {
         }
     }
 
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> Self::Trainer {
         match self {
             Self::WordLevel(t) => t.get_trainer().into(),
@@ -224,6 +236,7 @@ impl ModelWrapper {
     }
 }
 
+#[cfg(feature = "training")]
 #[derive(Clone, Serialize, Deserialize)]
 pub enum TrainerWrapper {
     BpeTrainer(BpeTrainer),
@@ -232,6 +245,7 @@ pub enum TrainerWrapper {
     UnigramTrainer(UnigramTrainer),
 }
 
+#[cfg(feature = "training")]
 impl Trainer for TrainerWrapper {
     type Model = ModelWrapper;
 
@@ -280,9 +294,13 @@ impl Trainer for TrainerWrapper {
     }
 }
 
+#[cfg(feature = "training")]
 impl_enum_from!(BpeTrainer, TrainerWrapper, BpeTrainer);
+#[cfg(feature = "training")]
 impl_enum_from!(WordPieceTrainer, TrainerWrapper, WordPieceTrainer);
+#[cfg(feature = "training")]
 impl_enum_from!(UnigramTrainer, TrainerWrapper, UnigramTrainer);
+#[cfg(feature = "training")]
 impl_enum_from!(WordLevelTrainer, TrainerWrapper, WordLevelTrainer);
 
 #[cfg(test)]

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -120,20 +120,25 @@ impl<'de> Deserialize<'de> for ModelWrapper {
         Ok(match helper {
             ModelHelper::Tagged(model) => match model.variant {
                 EnumType::BPE => ModelWrapper::BPE(
-                    serde_json::from_value(model.rest).map_err(serde::de::Error::custom)?,
+                    crate::utils::from_value_via_str(model.rest)
+                        .map_err(serde::de::Error::custom)?,
                 ),
                 EnumType::WordPiece => ModelWrapper::WordPiece(
-                    serde_json::from_value(model.rest).map_err(serde::de::Error::custom)?,
+                    crate::utils::from_value_via_str(model.rest)
+                        .map_err(serde::de::Error::custom)?,
                 ),
                 EnumType::WordLevel => ModelWrapper::WordLevel(
-                    serde_json::from_value(model.rest).map_err(serde::de::Error::custom)?,
+                    crate::utils::from_value_via_str(model.rest)
+                        .map_err(serde::de::Error::custom)?,
                 ),
                 EnumType::Unigram => ModelWrapper::Unigram(
-                    serde_json::from_value(model.rest).map_err(serde::de::Error::custom)?,
+                    crate::utils::from_value_via_str(model.rest)
+                        .map_err(serde::de::Error::custom)?,
                 ),
             },
             ModelHelper::Legacy(value) => {
-                let untagged = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                let untagged =
+                    crate::utils::from_value_via_str(value).map_err(serde::de::Error::custom)?;
                 match untagged {
                     ModelUntagged::BPE(bpe) => ModelWrapper::BPE(bpe),
                     ModelUntagged::WordPiece(bpe) => ModelWrapper::WordPiece(bpe),
@@ -368,7 +373,11 @@ mod tests {
         let reconstructed: std::result::Result<ModelWrapper, serde_json::Error> =
             serde_json::from_str(invalid);
         match reconstructed {
-            Err(err) => assert_eq!(err.to_string(), "Merges text file invalid at line 1"),
+            Err(err) => assert!(
+                err.to_string()
+                    .starts_with("Merges text file invalid at line 1"),
+                "Unexpected error: {}", err
+            ),
             _ => panic!("Expected an error here"),
         }
     }

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -120,25 +120,20 @@ impl<'de> Deserialize<'de> for ModelWrapper {
         Ok(match helper {
             ModelHelper::Tagged(model) => match model.variant {
                 EnumType::BPE => ModelWrapper::BPE(
-                    crate::utils::from_value_via_str(model.rest)
-                        .map_err(serde::de::Error::custom)?,
+                    serde_json::from_value(model.rest).map_err(serde::de::Error::custom)?,
                 ),
                 EnumType::WordPiece => ModelWrapper::WordPiece(
-                    crate::utils::from_value_via_str(model.rest)
-                        .map_err(serde::de::Error::custom)?,
+                    serde_json::from_value(model.rest).map_err(serde::de::Error::custom)?,
                 ),
                 EnumType::WordLevel => ModelWrapper::WordLevel(
-                    crate::utils::from_value_via_str(model.rest)
-                        .map_err(serde::de::Error::custom)?,
+                    serde_json::from_value(model.rest).map_err(serde::de::Error::custom)?,
                 ),
                 EnumType::Unigram => ModelWrapper::Unigram(
-                    crate::utils::from_value_via_str(model.rest)
-                        .map_err(serde::de::Error::custom)?,
+                    serde_json::from_value(model.rest).map_err(serde::de::Error::custom)?,
                 ),
             },
             ModelHelper::Legacy(value) => {
-                let untagged =
-                    crate::utils::from_value_via_str(value).map_err(serde::de::Error::custom)?;
+                let untagged = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
                 match untagged {
                     ModelUntagged::BPE(bpe) => ModelWrapper::BPE(bpe),
                     ModelUntagged::WordPiece(bpe) => ModelWrapper::WordPiece(bpe),
@@ -373,11 +368,7 @@ mod tests {
         let reconstructed: std::result::Result<ModelWrapper, serde_json::Error> =
             serde_json::from_str(invalid);
         match reconstructed {
-            Err(err) => assert!(
-                err.to_string()
-                    .starts_with("Merges text file invalid at line 1"),
-                "Unexpected error: {}", err
-            ),
+            Err(err) => assert_eq!(err.to_string(), "Merges text file invalid at line 1"),
             _ => panic!("Expected an error here"),
         }
     }

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -5,15 +5,15 @@ pub mod unigram;
 pub mod wordlevel;
 pub mod wordpiece;
 
-use crate::utils::{AHashMap};
+use crate::utils::AHashMap;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::models::bpe::BPE;
 #[cfg(feature = "training")]
 use crate::models::bpe::BpeTrainer;
+use crate::models::bpe::BPE;
 use crate::models::unigram::Unigram;
 #[cfg(feature = "training")]
 use crate::models::unigram::UnigramTrainer;
@@ -23,9 +23,9 @@ use crate::models::wordlevel::WordLevelTrainer;
 use crate::models::wordpiece::WordPiece;
 #[cfg(feature = "training")]
 use crate::models::wordpiece::WordPieceTrainer;
-use crate::{Model, Result, Token};
 #[cfg(feature = "training")]
 use crate::{AddedToken, Trainer};
+use crate::{Model, Result, Token};
 
 /// Wraps a vocab mapping (ID -> token) to a struct that will be serialized in order
 /// of token ID, smallest to largest.

--- a/tokenizers/src/models/unigram/lattice.rs
+++ b/tokenizers/src/models/unigram/lattice.rs
@@ -1,5 +1,7 @@
 use dary_heap::QuaternaryHeap;
+#[cfg(feature = "training")]
 use rand::distr::weighted::WeightedIndex;
+#[cfg(feature = "training")]
 use rand::{prelude::*, rng};
 use std::cell::RefCell;
 use std::cmp::{min, Ordering};
@@ -377,6 +379,7 @@ impl<'a> Lattice<'a> {
         freq * z
     }
 
+    #[cfg(feature = "training")]
     pub fn sample(&self, theta: f64) -> Vec<NodeRef> {
         let len = self.len();
         if len == 0 {
@@ -422,6 +425,7 @@ impl<'a> Lattice<'a> {
         results
     }
 
+    #[cfg(feature = "training")]
     pub fn sample_token(&self, theta: f64) -> Vec<String> {
         self.sample(theta)
             .iter()
@@ -429,6 +433,7 @@ impl<'a> Lattice<'a> {
             .collect()
     }
 
+    #[cfg(feature = "training")]
     pub fn sample_nbest(&mut self, n: usize, theta: f64) -> Vec<NodeRef> {
         let nbest_paths = self.nbest(n);
         if nbest_paths.is_empty() {

--- a/tokenizers/src/models/unigram/mod.rs
+++ b/tokenizers/src/models/unigram/mod.rs
@@ -2,9 +2,11 @@
 mod lattice;
 mod model;
 mod serialization;
+#[cfg(feature = "training")]
 mod trainer;
 mod trie;
 
 pub use lattice::*;
 pub use model::*;
+#[cfg(feature = "training")]
 pub use trainer::*;

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -8,7 +8,7 @@ use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 use std::collections::HashMap;
 
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use std::convert::TryInto;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -1,9 +1,9 @@
+#[cfg(feature = "training")]
+use super::trainer::UnigramTrainer;
 use super::{
     lattice::Lattice,
     trie::{Trie, TrieBuilder},
 };
-#[cfg(feature = "training")]
-use super::trainer::UnigramTrainer;
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 use std::collections::HashMap;

--- a/tokenizers/src/models/unigram/model.rs
+++ b/tokenizers/src/models/unigram/model.rs
@@ -1,8 +1,9 @@
 use super::{
     lattice::Lattice,
-    trainer::UnigramTrainer,
     trie::{Trie, TrieBuilder},
 };
+#[cfg(feature = "training")]
+use super::trainer::UnigramTrainer;
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 use std::collections::HashMap;
@@ -346,10 +347,19 @@ impl Unigram {
     fn encode_unoptimized(&self, sentence: &str) -> Result<Vec<String>> {
         let mut lattice = Lattice::from(sentence, self.bos_id, self.eos_id);
         self.populate_nodes(&mut lattice);
-        let path = match (self.nbest_size, self.alpha) {
-            (Some(n), Some(alpha)) if n > 0 => lattice.sample_nbest(n, alpha),
-            (_, Some(alpha)) => lattice.sample(alpha),
-            _ => lattice.viterbi(),
+        let path = {
+            #[cfg(feature = "training")]
+            {
+                match (self.nbest_size, self.alpha) {
+                    (Some(n), Some(alpha)) if n > 0 => lattice.sample_nbest(n, alpha),
+                    (_, Some(alpha)) => lattice.sample(alpha),
+                    _ => lattice.viterbi(),
+                }
+            }
+            #[cfg(not(feature = "training"))]
+            {
+                lattice.viterbi()
+            }
         };
         if self.fuse_unk {
             let mut results = vec![];
@@ -430,6 +440,7 @@ impl<'a> Iterator for UnigramIterator<'a> {
 }
 
 impl Model for Unigram {
+    #[cfg(feature = "training")]
     type Trainer = UnigramTrainer;
 
     fn get_vocab(&self) -> HashMap<String, u32> {
@@ -497,6 +508,7 @@ impl Model for Unigram {
         Ok(vec![fullpath])
     }
 
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> Self::Trainer {
         UnigramTrainer::default()
     }

--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -45,35 +45,105 @@ fn to_log_prob(pieces: &mut [SentencePiece]) {
 
 /// A `UnigramTrainer` can train a `Unigram` model from `word_counts`.
 #[non_exhaustive]
-#[derive(Builder, Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnigramTrainer {
-    #[builder(default = "true")]
     pub show_progress: bool,
-    #[builder(default = "8000")]
     pub vocab_size: u32,
-    #[builder(default = "2")]
     pub n_sub_iterations: u32,
-    #[builder(default = "0.75")]
     pub shrinking_factor: f64,
-    #[builder(default = "vec![]")]
     pub special_tokens: Vec<AddedToken>,
-    #[builder(default = "AHashSet::new()")]
     pub initial_alphabet: AHashSet<char>,
-
-    #[builder(default = "None")]
     pub unk_token: Option<String>,
-
-    #[builder(default = "16")]
     pub max_piece_length: usize,
-    #[builder(default = "1_000_000")]
     seed_size: usize,
-    #[builder(default = "AHashMap::new()")]
     words: AHashMap<String, u32>,
 }
 
 impl Default for UnigramTrainer {
     fn default() -> Self {
-        Self::builder().build().unwrap()
+        Self {
+            show_progress: true,
+            vocab_size: 8000,
+            n_sub_iterations: 2,
+            shrinking_factor: 0.75,
+            special_tokens: vec![],
+            initial_alphabet: AHashSet::new(),
+            unk_token: None,
+            max_piece_length: 16,
+            seed_size: 1_000_000,
+            words: AHashMap::new(),
+        }
+    }
+}
+
+/// Builder for `UnigramTrainer`.
+#[derive(Debug, Clone, Default)]
+pub struct UnigramTrainerBuilder {
+    show_progress: Option<bool>,
+    vocab_size: Option<u32>,
+    n_sub_iterations: Option<u32>,
+    shrinking_factor: Option<f64>,
+    special_tokens: Option<Vec<AddedToken>>,
+    initial_alphabet: Option<AHashSet<char>>,
+    unk_token: Option<Option<String>>,
+    max_piece_length: Option<usize>,
+    seed_size: Option<usize>,
+}
+
+impl UnigramTrainerBuilder {
+    pub fn show_progress(&mut self, show_progress: bool) -> &mut Self {
+        self.show_progress = Some(show_progress);
+        self
+    }
+    pub fn vocab_size(&mut self, vocab_size: u32) -> &mut Self {
+        self.vocab_size = Some(vocab_size);
+        self
+    }
+    pub fn n_sub_iterations(&mut self, n_sub_iterations: u32) -> &mut Self {
+        self.n_sub_iterations = Some(n_sub_iterations);
+        self
+    }
+    pub fn shrinking_factor(&mut self, shrinking_factor: f64) -> &mut Self {
+        self.shrinking_factor = Some(shrinking_factor);
+        self
+    }
+    pub fn special_tokens(&mut self, special_tokens: Vec<AddedToken>) -> &mut Self {
+        self.special_tokens = Some(special_tokens);
+        self
+    }
+    pub fn initial_alphabet(&mut self, initial_alphabet: AHashSet<char>) -> &mut Self {
+        self.initial_alphabet = Some(initial_alphabet);
+        self
+    }
+    pub fn unk_token(&mut self, unk_token: Option<String>) -> &mut Self {
+        self.unk_token = Some(unk_token);
+        self
+    }
+    pub fn max_piece_length(&mut self, max_piece_length: usize) -> &mut Self {
+        self.max_piece_length = Some(max_piece_length);
+        self
+    }
+    pub fn seed_size(&mut self, seed_size: usize) -> &mut Self {
+        self.seed_size = Some(seed_size);
+        self
+    }
+    pub fn build(&self) -> Result<UnigramTrainer> {
+        let default = UnigramTrainer::default();
+        Ok(UnigramTrainer {
+            show_progress: self.show_progress.unwrap_or(default.show_progress),
+            vocab_size: self.vocab_size.unwrap_or(default.vocab_size),
+            n_sub_iterations: self.n_sub_iterations.unwrap_or(default.n_sub_iterations),
+            shrinking_factor: self.shrinking_factor.unwrap_or(default.shrinking_factor),
+            special_tokens: self.special_tokens.clone().unwrap_or(default.special_tokens),
+            initial_alphabet: self
+                .initial_alphabet
+                .clone()
+                .unwrap_or(default.initial_alphabet),
+            unk_token: self.unk_token.clone().unwrap_or(default.unk_token),
+            max_piece_length: self.max_piece_length.unwrap_or(default.max_piece_length),
+            seed_size: self.seed_size.unwrap_or(default.seed_size),
+            words: AHashMap::new(),
+        })
     }
 }
 

--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -134,7 +134,10 @@ impl UnigramTrainerBuilder {
             vocab_size: self.vocab_size.unwrap_or(default.vocab_size),
             n_sub_iterations: self.n_sub_iterations.unwrap_or(default.n_sub_iterations),
             shrinking_factor: self.shrinking_factor.unwrap_or(default.shrinking_factor),
-            special_tokens: self.special_tokens.clone().unwrap_or(default.special_tokens),
+            special_tokens: self
+                .special_tokens
+                .clone()
+                .unwrap_or(default.special_tokens),
             initial_alphabet: self
                 .initial_alphabet
                 .clone()

--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -2,7 +2,7 @@ use crate::models::unigram::{lattice::Lattice, model::Unigram};
 use crate::tokenizer::{AddedToken, Result, Trainer};
 use crate::utils::parallelism::*;
 use crate::utils::progress::{ProgressBar, ProgressStyle};
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet, HashMapExt, HashSetExt};
 use log::debug;
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;

--- a/tokenizers/src/models/unigram/trie.rs
+++ b/tokenizers/src/models/unigram/trie.rs
@@ -1,4 +1,4 @@
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use std::hash::Hash;
 
 #[derive(Default)]

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -8,9 +8,11 @@ use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
 mod serialization;
+#[cfg(feature = "training")]
 mod trainer;
 
 // Re-export
+#[cfg(feature = "training")]
 pub use trainer::*;
 
 type Vocab = AHashMap<String, u32>;
@@ -157,6 +159,7 @@ impl Default for WordLevel {
 }
 
 impl Model for WordLevel {
+    #[cfg(feature = "training")]
     type Trainer = WordLevelTrainer;
 
     fn tokenize(&self, token: &str) -> Result<Vec<Token>> {
@@ -211,6 +214,7 @@ impl Model for WordLevel {
         Ok(vec![vocab_path])
     }
 
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> Self::Trainer {
         WordLevelTrainer::default()
     }

--- a/tokenizers/src/models/wordlevel/mod.rs
+++ b/tokenizers/src/models/wordlevel/mod.rs
@@ -1,6 +1,6 @@
 use super::OrderedVocabIter;
 use crate::tokenizer::{Model, Result, Token};
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs::File;

--- a/tokenizers/src/models/wordlevel/serialization.rs
+++ b/tokenizers/src/models/wordlevel/serialization.rs
@@ -1,5 +1,5 @@
 use super::{super::OrderedVocabIter, WordLevel, WordLevelBuilder};
-use ahash::AHashSet;
+use crate::utils::{AHashSet};
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeStruct,

--- a/tokenizers/src/models/wordlevel/serialization.rs
+++ b/tokenizers/src/models/wordlevel/serialization.rs
@@ -1,5 +1,5 @@
 use super::{super::OrderedVocabIter, WordLevel, WordLevelBuilder};
-use crate::utils::{AHashSet};
+use crate::utils::AHashSet;
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeStruct,

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -1,7 +1,7 @@
 use super::WordLevel;
 use crate::utils::parallelism::*;
 use crate::{AddedToken, Result, Trainer};
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -1,7 +1,7 @@
 use super::WordLevel;
 use crate::utils::parallelism::*;
-use crate::{AddedToken, Result, Trainer};
 use crate::utils::{AHashMap, HashMapExt};
+use crate::{AddedToken, Result, Trainer};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
@@ -64,7 +64,10 @@ impl WordLevelTrainerBuilder {
             min_frequency: self.min_frequency.unwrap_or(default.min_frequency),
             vocab_size: self.vocab_size.unwrap_or(default.vocab_size),
             show_progress: self.show_progress.unwrap_or(default.show_progress),
-            special_tokens: self.special_tokens.clone().unwrap_or(default.special_tokens),
+            special_tokens: self
+                .special_tokens
+                .clone()
+                .unwrap_or(default.special_tokens),
             words: AHashMap::new(),
         })
     }

--- a/tokenizers/src/models/wordlevel/trainer.rs
+++ b/tokenizers/src/models/wordlevel/trainer.rs
@@ -6,28 +6,67 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
 #[non_exhaustive]
-#[derive(Debug, Clone, Builder, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WordLevelTrainer {
     /// The minimum frequency a word must have to be part of the vocabulary
-    #[builder(default = "0")]
     pub min_frequency: u64,
     /// The target vocabulary size
-    #[builder(default = "30_000")]
     pub vocab_size: usize,
     /// Whether to show progress while training
-    #[builder(default = "true")]
     pub show_progress: bool,
     /// A list of special tokens that the model should know of
-    #[builder(default)]
     pub special_tokens: Vec<AddedToken>,
 
-    #[builder(default, private)]
     words: AHashMap<String, u64>,
 }
 
 impl Default for WordLevelTrainer {
     fn default() -> Self {
-        Self::builder().build().unwrap()
+        Self {
+            min_frequency: 0,
+            vocab_size: 30_000,
+            show_progress: true,
+            special_tokens: vec![],
+            words: AHashMap::new(),
+        }
+    }
+}
+
+/// Builder for `WordLevelTrainer`.
+#[derive(Debug, Clone, Default)]
+pub struct WordLevelTrainerBuilder {
+    min_frequency: Option<u64>,
+    vocab_size: Option<usize>,
+    show_progress: Option<bool>,
+    special_tokens: Option<Vec<AddedToken>>,
+}
+
+impl WordLevelTrainerBuilder {
+    pub fn min_frequency(&mut self, min_frequency: u64) -> &mut Self {
+        self.min_frequency = Some(min_frequency);
+        self
+    }
+    pub fn vocab_size(&mut self, vocab_size: usize) -> &mut Self {
+        self.vocab_size = Some(vocab_size);
+        self
+    }
+    pub fn show_progress(&mut self, show_progress: bool) -> &mut Self {
+        self.show_progress = Some(show_progress);
+        self
+    }
+    pub fn special_tokens(&mut self, special_tokens: Vec<AddedToken>) -> &mut Self {
+        self.special_tokens = Some(special_tokens);
+        self
+    }
+    pub fn build(&self) -> Result<WordLevelTrainer> {
+        let default = WordLevelTrainer::default();
+        Ok(WordLevelTrainer {
+            min_frequency: self.min_frequency.unwrap_or(default.min_frequency),
+            vocab_size: self.vocab_size.unwrap_or(default.vocab_size),
+            show_progress: self.show_progress.unwrap_or(default.show_progress),
+            special_tokens: self.special_tokens.clone().unwrap_or(default.special_tokens),
+            words: AHashMap::new(),
+        })
     }
 }
 

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -14,7 +14,9 @@ use std::{
 };
 
 mod serialization;
+#[cfg(feature = "training")]
 mod trainer;
+#[cfg(feature = "training")]
 pub use trainer::*;
 
 #[derive(thiserror::Error, Debug)]
@@ -211,6 +213,7 @@ impl WordPiece {
 }
 
 impl Model for WordPiece {
+    #[cfg(feature = "training")]
     type Trainer = WordPieceTrainer;
 
     fn get_vocab(&self) -> HashMap<String, u32> {
@@ -313,6 +316,7 @@ impl Model for WordPiece {
         Ok(vec![vocab_path])
     }
 
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> Self::Trainer {
         WordPieceTrainer::builder().build()
     }

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::models::bpe::BPE;
 use crate::tokenizer::{Model, Result, Token};
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use std::collections::HashMap;
 use std::{
     borrow::Cow,

--- a/tokenizers/src/models/wordpiece/serialization.rs
+++ b/tokenizers/src/models/wordpiece/serialization.rs
@@ -1,5 +1,5 @@
 use super::{super::OrderedVocabIter, WordPiece, WordPieceBuilder};
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet};
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeStruct,

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use super::WordPiece;
 use crate::models::bpe::{BpeTrainer, BpeTrainerBuilder, BPE};
 use crate::tokenizer::{AddedToken, Result, Trainer};
-use ahash::AHashSet;
+use crate::utils::{AHashSet, HashSetExt};
 use serde::{Deserialize, Serialize};
 
 /// A `WordPieceTrainerBuilder` can be used to create a `WordPieceTrainer` with a custom

--- a/tokenizers/src/normalizers/bert.rs
+++ b/tokenizers/src/normalizers/bert.rs
@@ -108,7 +108,12 @@ impl BertNormalizer {
     }
 
     fn do_strip_accents(&self, normalized: &mut NormalizedString) {
+        #[cfg(feature = "unicode-normalization")]
         normalized.nfd().filter(|c| !c.is_mark_nonspacing());
+        #[cfg(not(feature = "unicode-normalization"))]
+        {
+            let _ = normalized;
+        }
     }
 
     fn do_lowercase(&self, normalized: &mut NormalizedString) {

--- a/tokenizers/src/normalizers/byte_level.rs
+++ b/tokenizers/src/normalizers/byte_level.rs
@@ -1,7 +1,7 @@
 use crate::processors::byte_level::bytes_char;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet};
 use std::sync::LazyLock;
 
 #[derive(Clone, Debug)]

--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -110,7 +110,7 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
         Ok(match helper {
             NormalizerHelper::Tagged(model) => {
                 let mut values: serde_json::Map<String, serde_json::Value> =
-                    crate::utils::from_value_via_str(model.rest).expect("Parsed values");
+                    serde_json::from_value(model.rest).expect("Parsed values");
                 values.insert(
                     "type".to_string(),
                     serde_json::to_value(&model.variant).expect("Reinsert"),
@@ -118,23 +118,19 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                 let values = serde_json::Value::Object(values);
                 match model.variant {
                     EnumType::Bert => NormalizerWrapper::BertNormalizer(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Strip => NormalizerWrapper::StripNormalizer(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::StripAccents => NormalizerWrapper::StripAccents(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::NFC => {
                         #[cfg(feature = "unicode-normalization")]
                         {
                             NormalizerWrapper::NFC(
-                                crate::utils::from_value_via_str(values)
-                                    .map_err(serde::de::Error::custom)?,
+                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                             )
                         }
                         #[cfg(not(feature = "unicode-normalization"))]
@@ -148,8 +144,7 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         #[cfg(feature = "unicode-normalization")]
                         {
                             NormalizerWrapper::NFD(
-                                crate::utils::from_value_via_str(values)
-                                    .map_err(serde::de::Error::custom)?,
+                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                             )
                         }
                         #[cfg(not(feature = "unicode-normalization"))]
@@ -163,8 +158,7 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         #[cfg(feature = "unicode-normalization")]
                         {
                             NormalizerWrapper::NFKC(
-                                crate::utils::from_value_via_str(values)
-                                    .map_err(serde::de::Error::custom)?,
+                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                             )
                         }
                         #[cfg(not(feature = "unicode-normalization"))]
@@ -178,8 +172,7 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         #[cfg(feature = "unicode-normalization")]
                         {
                             NormalizerWrapper::NFKD(
-                                crate::utils::from_value_via_str(values)
-                                    .map_err(serde::de::Error::custom)?,
+                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                             )
                         }
                         #[cfg(not(feature = "unicode-normalization"))]
@@ -190,16 +183,13 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         }
                     }
                     EnumType::Sequence => NormalizerWrapper::Sequence(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Lowercase => NormalizerWrapper::Lowercase(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Nmt => NormalizerWrapper::Nmt(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Precompiled => {
                         #[cfg(feature = "spm")]
@@ -220,23 +210,19 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         }
                     }
                     EnumType::Replace => NormalizerWrapper::Replace(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Prepend => NormalizerWrapper::Prepend(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::ByteLevel => NormalizerWrapper::ByteLevel(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                 }
             }
 
             NormalizerHelper::Legacy(value) => {
-                let untagged =
-                    crate::utils::from_value_via_str(value).map_err(serde::de::Error::custom)?;
+                let untagged = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
                 match untagged {
                     NormalizerUntagged::BertNormalizer(bpe) => {
                         NormalizerWrapper::BertNormalizer(bpe)
@@ -326,11 +312,9 @@ mod tests {
         let json = r#"{"trim_offsets":true, "add_prefix_space":true}"#;
         let reconstructed = serde_json::from_str::<NormalizerWrapper>(json);
         match reconstructed {
-            Err(err) => assert!(
-                err.to_string().starts_with(
-                    "data did not match any variant of untagged enum NormalizerUntagged"
-                ),
-                "Unexpected error: {}", err
+            Err(err) => assert_eq!(
+                err.to_string(),
+                "data did not match any variant of untagged enum NormalizerUntagged"
             ),
             _ => panic!("Expected an error here"),
         }
@@ -350,11 +334,9 @@ mod tests {
         let json = r#"{"type":"Sequence","normalizers":[{}]}"#;
         let parse = serde_json::from_str::<NormalizerWrapper>(json);
         match parse {
-            Err(err) => assert!(
-                format!("{err}").starts_with(
-                    "data did not match any variant of untagged enum NormalizerUntagged"
-                ),
-                "Unexpected error: {}", err
+            Err(err) => assert_eq!(
+                format!("{err}"),
+                "data did not match any variant of untagged enum NormalizerUntagged"
             ),
             _ => panic!("Expected error"),
         }
@@ -362,11 +344,9 @@ mod tests {
         let json = r#"{"replacement":"▁","prepend_scheme":"always"}"#;
         let parse = serde_json::from_str::<NormalizerWrapper>(json);
         match parse {
-            Err(err) => assert!(
-                format!("{err}").starts_with(
-                    "data did not match any variant of untagged enum NormalizerUntagged"
-                ),
-                "Unexpected error: {}", err
+            Err(err) => assert_eq!(
+                format!("{err}"),
+                "data did not match any variant of untagged enum NormalizerUntagged"
             ),
             _ => panic!("Expected error"),
         }
@@ -374,10 +354,7 @@ mod tests {
         let json = r#"{"type":"Sequence","prepend_scheme":"always"}"#;
         let parse = serde_json::from_str::<NormalizerWrapper>(json);
         match parse {
-            Err(err) => assert!(
-                format!("{err}").starts_with("missing field `normalizers`"),
-                "Unexpected error: {}", err
-            ),
+            Err(err) => assert_eq!(format!("{err}"), "missing field `normalizers`"),
             _ => panic!("Expected error"),
         }
     }

--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -14,7 +14,9 @@ pub use crate::normalizers::precompiled::Precompiled;
 pub use crate::normalizers::prepend::Prepend;
 pub use crate::normalizers::replace::Replace;
 pub use crate::normalizers::strip::{Strip, StripAccents};
-pub use crate::normalizers::unicode::{Nmt, NFC, NFD, NFKC, NFKD};
+pub use crate::normalizers::unicode::Nmt;
+#[cfg(feature = "unicode-normalization")]
+pub use crate::normalizers::unicode::{NFC, NFD, NFKC, NFKD};
 pub use crate::normalizers::utils::{Lowercase, Sequence};
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -27,9 +29,13 @@ pub enum NormalizerWrapper {
     BertNormalizer(BertNormalizer),
     StripNormalizer(Strip),
     StripAccents(StripAccents),
+    #[cfg(feature = "unicode-normalization")]
     NFC(NFC),
+    #[cfg(feature = "unicode-normalization")]
     NFD(NFD),
+    #[cfg(feature = "unicode-normalization")]
     NFKC(NFKC),
+    #[cfg(feature = "unicode-normalization")]
     NFKD(NFKD),
     Sequence(Sequence),
     Lowercase(Lowercase),
@@ -84,9 +90,13 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
             BertNormalizer(BertNormalizer),
             StripNormalizer(Strip),
             StripAccents(StripAccents),
+            #[cfg(feature = "unicode-normalization")]
             NFC(NFC),
+            #[cfg(feature = "unicode-normalization")]
             NFD(NFD),
+            #[cfg(feature = "unicode-normalization")]
             NFKC(NFKC),
+            #[cfg(feature = "unicode-normalization")]
             NFKD(NFKD),
             Sequence(Sequence),
             Lowercase(Lowercase),
@@ -116,18 +126,30 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                     EnumType::StripAccents => NormalizerWrapper::StripAccents(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
-                    EnumType::NFC => NormalizerWrapper::NFC(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
-                    ),
-                    EnumType::NFD => NormalizerWrapper::NFD(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
-                    ),
-                    EnumType::NFKC => NormalizerWrapper::NFKC(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
-                    ),
-                    EnumType::NFKD => NormalizerWrapper::NFKD(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
-                    ),
+                    EnumType::NFC => {
+                        #[cfg(feature = "unicode-normalization")]
+                        { NormalizerWrapper::NFC(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        #[cfg(not(feature = "unicode-normalization"))]
+                        { return Err(serde::de::Error::custom("NFC normalizer requires the `unicode-normalization` feature")); }
+                    }
+                    EnumType::NFD => {
+                        #[cfg(feature = "unicode-normalization")]
+                        { NormalizerWrapper::NFD(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        #[cfg(not(feature = "unicode-normalization"))]
+                        { return Err(serde::de::Error::custom("NFD normalizer requires the `unicode-normalization` feature")); }
+                    }
+                    EnumType::NFKC => {
+                        #[cfg(feature = "unicode-normalization")]
+                        { NormalizerWrapper::NFKC(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        #[cfg(not(feature = "unicode-normalization"))]
+                        { return Err(serde::de::Error::custom("NFKC normalizer requires the `unicode-normalization` feature")); }
+                    }
+                    EnumType::NFKD => {
+                        #[cfg(feature = "unicode-normalization")]
+                        { NormalizerWrapper::NFKD(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        #[cfg(not(feature = "unicode-normalization"))]
+                        { return Err(serde::de::Error::custom("NFKD normalizer requires the `unicode-normalization` feature")); }
+                    }
                     EnumType::Sequence => NormalizerWrapper::Sequence(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
@@ -177,9 +199,13 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         NormalizerWrapper::StripNormalizer(bpe)
                     }
                     NormalizerUntagged::StripAccents(bpe) => NormalizerWrapper::StripAccents(bpe),
+                    #[cfg(feature = "unicode-normalization")]
                     NormalizerUntagged::NFC(bpe) => NormalizerWrapper::NFC(bpe),
+                    #[cfg(feature = "unicode-normalization")]
                     NormalizerUntagged::NFD(bpe) => NormalizerWrapper::NFD(bpe),
+                    #[cfg(feature = "unicode-normalization")]
                     NormalizerUntagged::NFKC(bpe) => NormalizerWrapper::NFKC(bpe),
+                    #[cfg(feature = "unicode-normalization")]
                     NormalizerUntagged::NFKD(bpe) => NormalizerWrapper::NFKD(bpe),
                     NormalizerUntagged::Sequence(seq) => NormalizerWrapper::Sequence(seq),
                     NormalizerUntagged::Lowercase(bpe) => NormalizerWrapper::Lowercase(bpe),
@@ -199,9 +225,13 @@ impl Normalizer for NormalizerWrapper {
             Self::BertNormalizer(bn) => bn.normalize(normalized),
             Self::StripNormalizer(sn) => sn.normalize(normalized),
             Self::StripAccents(sn) => sn.normalize(normalized),
+            #[cfg(feature = "unicode-normalization")]
             Self::NFC(nfc) => nfc.normalize(normalized),
+            #[cfg(feature = "unicode-normalization")]
             Self::NFD(nfd) => nfd.normalize(normalized),
+            #[cfg(feature = "unicode-normalization")]
             Self::NFKC(nfkc) => nfkc.normalize(normalized),
+            #[cfg(feature = "unicode-normalization")]
             Self::NFKD(nfkd) => nfkd.normalize(normalized),
             Self::Sequence(sequence) => sequence.normalize(normalized),
             Self::Lowercase(lc) => lc.normalize(normalized),
@@ -216,9 +246,13 @@ impl Normalizer for NormalizerWrapper {
 }
 
 impl_enum_from!(BertNormalizer, NormalizerWrapper, BertNormalizer);
+#[cfg(feature = "unicode-normalization")]
 impl_enum_from!(NFKD, NormalizerWrapper, NFKD);
+#[cfg(feature = "unicode-normalization")]
 impl_enum_from!(NFKC, NormalizerWrapper, NFKC);
+#[cfg(feature = "unicode-normalization")]
 impl_enum_from!(NFC, NormalizerWrapper, NFC);
+#[cfg(feature = "unicode-normalization")]
 impl_enum_from!(NFD, NormalizerWrapper, NFD);
 impl_enum_from!(Strip, NormalizerWrapper, StripNormalizer);
 impl_enum_from!(StripAccents, NormalizerWrapper, StripAccents);

--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -110,7 +110,7 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
         Ok(match helper {
             NormalizerHelper::Tagged(model) => {
                 let mut values: serde_json::Map<String, serde_json::Value> =
-                    serde_json::from_value(model.rest).expect("Parsed values");
+                    crate::utils::from_value_via_str(model.rest).expect("Parsed values");
                 values.insert(
                     "type".to_string(),
                     serde_json::to_value(&model.variant).expect("Reinsert"),
@@ -118,19 +118,23 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                 let values = serde_json::Value::Object(values);
                 match model.variant {
                     EnumType::Bert => NormalizerWrapper::BertNormalizer(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Strip => NormalizerWrapper::StripNormalizer(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::StripAccents => NormalizerWrapper::StripAccents(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::NFC => {
                         #[cfg(feature = "unicode-normalization")]
                         {
                             NormalizerWrapper::NFC(
-                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                                crate::utils::from_value_via_str(values)
+                                    .map_err(serde::de::Error::custom)?,
                             )
                         }
                         #[cfg(not(feature = "unicode-normalization"))]
@@ -144,7 +148,8 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         #[cfg(feature = "unicode-normalization")]
                         {
                             NormalizerWrapper::NFD(
-                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                                crate::utils::from_value_via_str(values)
+                                    .map_err(serde::de::Error::custom)?,
                             )
                         }
                         #[cfg(not(feature = "unicode-normalization"))]
@@ -158,7 +163,8 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         #[cfg(feature = "unicode-normalization")]
                         {
                             NormalizerWrapper::NFKC(
-                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                                crate::utils::from_value_via_str(values)
+                                    .map_err(serde::de::Error::custom)?,
                             )
                         }
                         #[cfg(not(feature = "unicode-normalization"))]
@@ -172,7 +178,8 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         #[cfg(feature = "unicode-normalization")]
                         {
                             NormalizerWrapper::NFKD(
-                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                                crate::utils::from_value_via_str(values)
+                                    .map_err(serde::de::Error::custom)?,
                             )
                         }
                         #[cfg(not(feature = "unicode-normalization"))]
@@ -183,13 +190,16 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         }
                     }
                     EnumType::Sequence => NormalizerWrapper::Sequence(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Lowercase => NormalizerWrapper::Lowercase(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Nmt => NormalizerWrapper::Nmt(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Precompiled => {
                         #[cfg(feature = "spm")]
@@ -210,19 +220,23 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                         }
                     }
                     EnumType::Replace => NormalizerWrapper::Replace(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Prepend => NormalizerWrapper::Prepend(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::ByteLevel => NormalizerWrapper::ByteLevel(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                 }
             }
 
             NormalizerHelper::Legacy(value) => {
-                let untagged = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                let untagged =
+                    crate::utils::from_value_via_str(value).map_err(serde::de::Error::custom)?;
                 match untagged {
                     NormalizerUntagged::BertNormalizer(bpe) => {
                         NormalizerWrapper::BertNormalizer(bpe)
@@ -312,9 +326,11 @@ mod tests {
         let json = r#"{"trim_offsets":true, "add_prefix_space":true}"#;
         let reconstructed = serde_json::from_str::<NormalizerWrapper>(json);
         match reconstructed {
-            Err(err) => assert_eq!(
-                err.to_string(),
-                "data did not match any variant of untagged enum NormalizerUntagged"
+            Err(err) => assert!(
+                err.to_string().starts_with(
+                    "data did not match any variant of untagged enum NormalizerUntagged"
+                ),
+                "Unexpected error: {}", err
             ),
             _ => panic!("Expected an error here"),
         }
@@ -334,9 +350,11 @@ mod tests {
         let json = r#"{"type":"Sequence","normalizers":[{}]}"#;
         let parse = serde_json::from_str::<NormalizerWrapper>(json);
         match parse {
-            Err(err) => assert_eq!(
-                format!("{err}"),
-                "data did not match any variant of untagged enum NormalizerUntagged"
+            Err(err) => assert!(
+                format!("{err}").starts_with(
+                    "data did not match any variant of untagged enum NormalizerUntagged"
+                ),
+                "Unexpected error: {}", err
             ),
             _ => panic!("Expected error"),
         }
@@ -344,9 +362,11 @@ mod tests {
         let json = r#"{"replacement":"▁","prepend_scheme":"always"}"#;
         let parse = serde_json::from_str::<NormalizerWrapper>(json);
         match parse {
-            Err(err) => assert_eq!(
-                format!("{err}"),
-                "data did not match any variant of untagged enum NormalizerUntagged"
+            Err(err) => assert!(
+                format!("{err}").starts_with(
+                    "data did not match any variant of untagged enum NormalizerUntagged"
+                ),
+                "Unexpected error: {}", err
             ),
             _ => panic!("Expected error"),
         }
@@ -354,7 +374,10 @@ mod tests {
         let json = r#"{"type":"Sequence","prepend_scheme":"always"}"#;
         let parse = serde_json::from_str::<NormalizerWrapper>(json);
         match parse {
-            Err(err) => assert_eq!(format!("{err}"), "missing field `normalizers`"),
+            Err(err) => assert!(
+                format!("{err}").starts_with("missing field `normalizers`"),
+                "Unexpected error: {}", err
+            ),
             _ => panic!("Expected error"),
         }
     }

--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -128,27 +128,59 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                     ),
                     EnumType::NFC => {
                         #[cfg(feature = "unicode-normalization")]
-                        { NormalizerWrapper::NFC(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        {
+                            NormalizerWrapper::NFC(
+                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                            )
+                        }
                         #[cfg(not(feature = "unicode-normalization"))]
-                        { return Err(serde::de::Error::custom("NFC normalizer requires the `unicode-normalization` feature")); }
+                        {
+                            return Err(serde::de::Error::custom(
+                                "NFC normalizer requires the `unicode-normalization` feature",
+                            ));
+                        }
                     }
                     EnumType::NFD => {
                         #[cfg(feature = "unicode-normalization")]
-                        { NormalizerWrapper::NFD(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        {
+                            NormalizerWrapper::NFD(
+                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                            )
+                        }
                         #[cfg(not(feature = "unicode-normalization"))]
-                        { return Err(serde::de::Error::custom("NFD normalizer requires the `unicode-normalization` feature")); }
+                        {
+                            return Err(serde::de::Error::custom(
+                                "NFD normalizer requires the `unicode-normalization` feature",
+                            ));
+                        }
                     }
                     EnumType::NFKC => {
                         #[cfg(feature = "unicode-normalization")]
-                        { NormalizerWrapper::NFKC(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        {
+                            NormalizerWrapper::NFKC(
+                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                            )
+                        }
                         #[cfg(not(feature = "unicode-normalization"))]
-                        { return Err(serde::de::Error::custom("NFKC normalizer requires the `unicode-normalization` feature")); }
+                        {
+                            return Err(serde::de::Error::custom(
+                                "NFKC normalizer requires the `unicode-normalization` feature",
+                            ));
+                        }
                     }
                     EnumType::NFKD => {
                         #[cfg(feature = "unicode-normalization")]
-                        { NormalizerWrapper::NFKD(serde_json::from_value(values).map_err(serde::de::Error::custom)?) }
+                        {
+                            NormalizerWrapper::NFKD(
+                                serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                            )
+                        }
                         #[cfg(not(feature = "unicode-normalization"))]
-                        { return Err(serde::de::Error::custom("NFKD normalizer requires the `unicode-normalization` feature")); }
+                        {
+                            return Err(serde::de::Error::custom(
+                                "NFKD normalizer requires the `unicode-normalization` feature",
+                            ));
+                        }
                     }
                     EnumType::Sequence => NormalizerWrapper::Sequence(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,

--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -1,5 +1,6 @@
 pub mod bert;
 pub mod byte_level;
+#[cfg(feature = "spm")]
 pub mod precompiled;
 pub mod prepend;
 pub mod replace;
@@ -8,6 +9,7 @@ pub mod unicode;
 pub mod utils;
 pub use crate::normalizers::bert::BertNormalizer;
 pub use crate::normalizers::byte_level::ByteLevel;
+#[cfg(feature = "spm")]
 pub use crate::normalizers::precompiled::Precompiled;
 pub use crate::normalizers::prepend::Prepend;
 pub use crate::normalizers::replace::Replace;
@@ -32,6 +34,7 @@ pub enum NormalizerWrapper {
     Sequence(Sequence),
     Lowercase(Lowercase),
     Nmt(Nmt),
+    #[cfg(feature = "spm")]
     Precompiled(Precompiled),
     Replace(Replace),
     Prepend(Prepend),
@@ -88,7 +91,6 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
             Sequence(Sequence),
             Lowercase(Lowercase),
             Nmt(Nmt),
-            Precompiled(Precompiled),
             Replace(Replace),
             Prepend(Prepend),
             ByteLevel(ByteLevel),
@@ -135,13 +137,24 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                     EnumType::Nmt => NormalizerWrapper::Nmt(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
-                    EnumType::Precompiled => NormalizerWrapper::Precompiled(
-                        serde_json::from_str(
-                            &serde_json::to_string(&values).expect("Can reserialize precompiled"),
-                        )
-                        // .map_err(serde::de::Error::custom)
-                        .expect("Precompiled"),
-                    ),
+                    EnumType::Precompiled => {
+                        #[cfg(feature = "spm")]
+                        {
+                            NormalizerWrapper::Precompiled(
+                                serde_json::from_str(
+                                    &serde_json::to_string(&values)
+                                        .expect("Can reserialize precompiled"),
+                                )
+                                .expect("Precompiled"),
+                            )
+                        }
+                        #[cfg(not(feature = "spm"))]
+                        {
+                            return Err(serde::de::Error::custom(
+                                "Precompiled normalizer requires the `spm` feature",
+                            ));
+                        }
+                    }
                     EnumType::Replace => NormalizerWrapper::Replace(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
@@ -171,7 +184,6 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                     NormalizerUntagged::Sequence(seq) => NormalizerWrapper::Sequence(seq),
                     NormalizerUntagged::Lowercase(bpe) => NormalizerWrapper::Lowercase(bpe),
                     NormalizerUntagged::Nmt(bpe) => NormalizerWrapper::Nmt(bpe),
-                    NormalizerUntagged::Precompiled(bpe) => NormalizerWrapper::Precompiled(bpe),
                     NormalizerUntagged::Replace(bpe) => NormalizerWrapper::Replace(bpe),
                     NormalizerUntagged::Prepend(bpe) => NormalizerWrapper::Prepend(bpe),
                     NormalizerUntagged::ByteLevel(bpe) => NormalizerWrapper::ByteLevel(bpe),
@@ -194,6 +206,7 @@ impl Normalizer for NormalizerWrapper {
             Self::Sequence(sequence) => sequence.normalize(normalized),
             Self::Lowercase(lc) => lc.normalize(normalized),
             Self::Nmt(lc) => lc.normalize(normalized),
+            #[cfg(feature = "spm")]
             Self::Precompiled(lc) => lc.normalize(normalized),
             Self::Replace(lc) => lc.normalize(normalized),
             Self::Prepend(lc) => lc.normalize(normalized),
@@ -212,6 +225,7 @@ impl_enum_from!(StripAccents, NormalizerWrapper, StripAccents);
 impl_enum_from!(Sequence, NormalizerWrapper, Sequence);
 impl_enum_from!(Lowercase, NormalizerWrapper, Lowercase);
 impl_enum_from!(Nmt, NormalizerWrapper, Nmt);
+#[cfg(feature = "spm")]
 impl_enum_from!(Precompiled, NormalizerWrapper, Precompiled);
 impl_enum_from!(Replace, NormalizerWrapper, Replace);
 impl_enum_from!(Prepend, NormalizerWrapper, Prepend);

--- a/tokenizers/src/normalizers/replace.rs
+++ b/tokenizers/src/normalizers/replace.rs
@@ -67,7 +67,7 @@ impl Replace {
     pub fn new<I: Into<ReplacePattern>, C: Into<String>>(pattern: I, content: C) -> Result<Self> {
         let pattern: ReplacePattern = pattern.into();
         let regex = match &pattern {
-            ReplacePattern::String(s) => SysRegex::new(&regex::escape(s))?,
+            ReplacePattern::String(s) => SysRegex::new(&crate::utils::regex_escape(s))?,
             ReplacePattern::Regex(r) => SysRegex::new(r)?,
         };
 

--- a/tokenizers/src/normalizers/strip.rs
+++ b/tokenizers/src/normalizers/strip.rs
@@ -1,7 +1,14 @@
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "unicode-normalization")]
 use unicode_normalization_alignments::char::is_combining_mark;
+
+#[cfg(not(feature = "unicode-normalization"))]
+fn is_combining_mark(_c: char) -> bool {
+    // Without unicode-normalization feature, accent stripping is a no-op.
+    false
+}
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]

--- a/tokenizers/src/normalizers/unicode.rs
+++ b/tokenizers/src/normalizers/unicode.rs
@@ -1,45 +1,53 @@
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
 
-#[derive(Default, Copy, Clone, Debug)]
-#[macro_rules_attribute(impl_serde_type!)]
-pub struct NFD;
-impl Normalizer for NFD {
-    fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        normalized.nfd();
-        Ok(())
+#[cfg(feature = "unicode-normalization")]
+mod nf_normalizers {
+    use super::*;
+
+    #[derive(Default, Copy, Clone, Debug)]
+    #[macro_rules_attribute(impl_serde_type!)]
+    pub struct NFD;
+    impl Normalizer for NFD {
+        fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
+            normalized.nfd();
+            Ok(())
+        }
+    }
+
+    #[derive(Default, Copy, Clone, Debug)]
+    #[macro_rules_attribute(impl_serde_type!)]
+    pub struct NFKD;
+    impl Normalizer for NFKD {
+        fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
+            normalized.nfkd();
+            Ok(())
+        }
+    }
+
+    #[derive(Default, Copy, Clone, Debug)]
+    #[macro_rules_attribute(impl_serde_type!)]
+    pub struct NFC;
+    impl Normalizer for NFC {
+        fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
+            normalized.nfc();
+            Ok(())
+        }
+    }
+
+    #[derive(Default, Copy, Clone, Debug)]
+    #[macro_rules_attribute(impl_serde_type!)]
+    pub struct NFKC;
+    impl Normalizer for NFKC {
+        fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
+            normalized.nfkc();
+            Ok(())
+        }
     }
 }
 
-#[derive(Default, Copy, Clone, Debug)]
-#[macro_rules_attribute(impl_serde_type!)]
-pub struct NFKD;
-impl Normalizer for NFKD {
-    fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        normalized.nfkd();
-        Ok(())
-    }
-}
-
-#[derive(Default, Copy, Clone, Debug)]
-#[macro_rules_attribute(impl_serde_type!)]
-pub struct NFC;
-impl Normalizer for NFC {
-    fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        normalized.nfc();
-        Ok(())
-    }
-}
-
-#[derive(Default, Copy, Clone, Debug)]
-#[macro_rules_attribute(impl_serde_type!)]
-pub struct NFKC;
-impl Normalizer for NFKC {
-    fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        normalized.nfkc();
-        Ok(())
-    }
-}
+#[cfg(feature = "unicode-normalization")]
+pub use nf_normalizers::*;
 
 fn do_nmt(normalized: &mut NormalizedString) {
     // Ascii Control characters

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -1,4 +1,6 @@
-use ahash::{AHashMap, AHashSet};
+#[cfg(test)]
+use crate::utils::HashMapExt;
+use crate::utils::{AHashMap, AHashSet};
 use std::sync::LazyLock;
 
 use crate::utils::SysRegex;

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -174,8 +174,6 @@ impl Decoder for Metaspace {
 
 #[cfg(test)]
 mod tests {
-    use regex::Regex;
-
     use super::*;
     use crate::{OffsetReferential, OffsetType};
 
@@ -278,7 +276,7 @@ mod tests {
 
         let pretok = Metaspace::new('▁', PrependScheme::First, false);
         let mut pretokenized = PreTokenizedString::from("Hey my friend <s>how▁are you");
-        let re_ref = Regex::new(r"(<s>)").unwrap();
+        let re_ref = crate::utils::SysRegex::new(r"(<s>)").unwrap();
         pretokenized
             .split(|_, sequence| sequence.split(&re_ref, SplitDelimiterBehavior::Isolated))
             .expect("Bad split");

--- a/tokenizers/src/pre_tokenizers/mod.rs
+++ b/tokenizers/src/pre_tokenizers/mod.rs
@@ -118,7 +118,8 @@ impl<'de> Deserialize<'de> for PreTokenizerWrapper {
         Ok(match helper {
             PreTokenizerHelper::Tagged(pretok) => {
                 let mut values: serde_json::Map<String, serde_json::Value> =
-                    serde_json::from_value(pretok.rest).map_err(serde::de::Error::custom)?;
+                    crate::utils::from_value_via_str(pretok.rest)
+                        .map_err(serde::de::Error::custom)?;
                 values.insert(
                     "type".to_string(),
                     serde_json::to_value(&pretok.variant).map_err(serde::de::Error::custom)?,
@@ -126,46 +127,59 @@ impl<'de> Deserialize<'de> for PreTokenizerWrapper {
                 let values = serde_json::Value::Object(values);
                 match pretok.variant {
                     EnumType::BertPreTokenizer => PreTokenizerWrapper::BertPreTokenizer(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::ByteLevel => PreTokenizerWrapper::ByteLevel(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Delimiter => PreTokenizerWrapper::Delimiter(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Metaspace => PreTokenizerWrapper::Metaspace(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Whitespace => PreTokenizerWrapper::Whitespace(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Sequence => PreTokenizerWrapper::Sequence(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Split => PreTokenizerWrapper::Split(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Punctuation => PreTokenizerWrapper::Punctuation(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::WhitespaceSplit => PreTokenizerWrapper::WhitespaceSplit(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Digits => PreTokenizerWrapper::Digits(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::UnicodeScripts => PreTokenizerWrapper::UnicodeScripts(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::FixedLength => PreTokenizerWrapper::FixedLength(
-                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
+                        crate::utils::from_value_via_str(values)
+                            .map_err(serde::de::Error::custom)?,
                     ),
                 }
             }
 
             PreTokenizerHelper::Legacy(value) => {
-                let untagged = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                let untagged =
+                    crate::utils::from_value_via_str(value).map_err(serde::de::Error::custom)?;
                 match untagged {
                     PreTokenizerUntagged::BertPreTokenizer(bert) => {
                         PreTokenizerWrapper::BertPreTokenizer(bert)
@@ -316,7 +330,10 @@ mod tests {
         let json = r#"{"type":"Metaspace", "add_prefix_space":true }"#;
         let reconstructed = serde_json::from_str::<PreTokenizerWrapper>(json);
         match reconstructed {
-            Err(err) => assert_eq!(err.to_string(), "missing field `replacement`"),
+            Err(err) => assert!(
+                err.to_string().starts_with("missing field `replacement`"),
+                "Unexpected error: {}", err
+            ),
             _ => panic!("Expected an error here"),
         }
         let json = r#"{"behavior":"default_split"}"#;

--- a/tokenizers/src/pre_tokenizers/mod.rs
+++ b/tokenizers/src/pre_tokenizers/mod.rs
@@ -118,8 +118,7 @@ impl<'de> Deserialize<'de> for PreTokenizerWrapper {
         Ok(match helper {
             PreTokenizerHelper::Tagged(pretok) => {
                 let mut values: serde_json::Map<String, serde_json::Value> =
-                    crate::utils::from_value_via_str(pretok.rest)
-                        .map_err(serde::de::Error::custom)?;
+                    serde_json::from_value(pretok.rest).map_err(serde::de::Error::custom)?;
                 values.insert(
                     "type".to_string(),
                     serde_json::to_value(&pretok.variant).map_err(serde::de::Error::custom)?,
@@ -127,59 +126,46 @@ impl<'de> Deserialize<'de> for PreTokenizerWrapper {
                 let values = serde_json::Value::Object(values);
                 match pretok.variant {
                     EnumType::BertPreTokenizer => PreTokenizerWrapper::BertPreTokenizer(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::ByteLevel => PreTokenizerWrapper::ByteLevel(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Delimiter => PreTokenizerWrapper::Delimiter(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Metaspace => PreTokenizerWrapper::Metaspace(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Whitespace => PreTokenizerWrapper::Whitespace(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Sequence => PreTokenizerWrapper::Sequence(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Split => PreTokenizerWrapper::Split(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Punctuation => PreTokenizerWrapper::Punctuation(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::WhitespaceSplit => PreTokenizerWrapper::WhitespaceSplit(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Digits => PreTokenizerWrapper::Digits(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::UnicodeScripts => PreTokenizerWrapper::UnicodeScripts(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::FixedLength => PreTokenizerWrapper::FixedLength(
-                        crate::utils::from_value_via_str(values)
-                            .map_err(serde::de::Error::custom)?,
+                        serde_json::from_value(values).map_err(serde::de::Error::custom)?,
                     ),
                 }
             }
 
             PreTokenizerHelper::Legacy(value) => {
-                let untagged =
-                    crate::utils::from_value_via_str(value).map_err(serde::de::Error::custom)?;
+                let untagged = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
                 match untagged {
                     PreTokenizerUntagged::BertPreTokenizer(bert) => {
                         PreTokenizerWrapper::BertPreTokenizer(bert)
@@ -330,10 +316,7 @@ mod tests {
         let json = r#"{"type":"Metaspace", "add_prefix_space":true }"#;
         let reconstructed = serde_json::from_str::<PreTokenizerWrapper>(json);
         match reconstructed {
-            Err(err) => assert!(
-                err.to_string().starts_with("missing field `replacement`"),
-                "Unexpected error: {}", err
-            ),
+            Err(err) => assert_eq!(err.to_string(), "missing field `replacement`"),
             _ => panic!("Expected an error here"),
         }
         let json = r#"{"behavior":"default_split"}"#;

--- a/tokenizers/src/pre_tokenizers/split.rs
+++ b/tokenizers/src/pre_tokenizers/split.rs
@@ -80,7 +80,7 @@ impl Split {
     ) -> Result<Self> {
         let pattern: SplitPattern = pattern.into();
         let regex = match &pattern {
-            SplitPattern::String(s) => SysRegex::new(&regex::escape(s))?,
+            SplitPattern::String(s) => SysRegex::new(&crate::utils::regex_escape(s))?,
             SplitPattern::Regex(r) => SysRegex::new(r)?,
         };
 

--- a/tokenizers/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/src/pre_tokenizers/whitespace.rs
@@ -1,11 +1,10 @@
 use std::sync::LazyLock;
 
-use regex::Regex;
-
 use crate::tokenizer::{
     pattern::Invert, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior,
 };
 use crate::utils::macro_rules_attribute;
+use crate::utils::SysRegex;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -19,8 +18,8 @@ impl Default for Whitespace {
 
 impl PreTokenizer for Whitespace {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
-        static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\w+|[^\w\s]+").unwrap());
-        let re_ref: &Regex = &RE;
+        static RE: LazyLock<SysRegex> = LazyLock::new(|| SysRegex::new(r"\w+|[^\w\s]+").unwrap());
+        let re_ref: &SysRegex = &RE;
 
         pretokenized.split(|_, normalized| {
             normalized.split(Invert(re_ref), SplitDelimiterBehavior::Removed)

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -1,5 +1,5 @@
 use crate::tokenizer::{Encoding, PostProcessor, Result};
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;
 

--- a/tokenizers/src/processors/bert.rs
+++ b/tokenizers/src/processors/bert.rs
@@ -1,5 +1,5 @@
 use crate::tokenizer::{Encoding, PostProcessor, Result};
-use crate::utils::{AHashMap};
+use crate::utils::AHashMap;
 use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;
 

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -1,6 +1,6 @@
 use crate::processors::byte_level::process_offsets;
 use crate::tokenizer::{Encoding, PostProcessor, Result};
-use crate::utils::{AHashMap};
+use crate::utils::AHashMap;
 use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;
 

--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -1,6 +1,6 @@
 use crate::processors::byte_level::process_offsets;
 use crate::tokenizer::{Encoding, PostProcessor, Result};
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;
 

--- a/tokenizers/src/processors/sequence.rs
+++ b/tokenizers/src/processors/sequence.rs
@@ -73,7 +73,7 @@ mod tests {
     use super::*;
     use crate::processors::{ByteLevel, PostProcessorWrapper};
     use crate::tokenizer::{Encoding, PostProcessor};
-    use ahash::AHashMap;
+    use crate::utils::{AHashMap, HashMapExt};
     use std::iter::FromIterator;
 
     #[test]

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -56,8 +56,8 @@
 //!
 //! [`TemplateProcessing`]: struct.TemplateProcessing.html
 //!
-use crate::{Encoding, PostProcessor, Result};
 use crate::utils::{AHashMap, AHashSet, HashMapExt};
+use crate::{Encoding, PostProcessor, Result};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::result::Result as StdResult;

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -58,7 +58,6 @@
 //!
 use crate::{Encoding, PostProcessor, Result};
 use ahash::{AHashMap, AHashSet};
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::result::Result as StdResult;
@@ -333,21 +332,15 @@ impl From<AHashMap<String, SpecialToken>> for Tokens {
 ///     .unwrap();
 /// ```
 ///
-#[derive(Debug, Clone, PartialEq, Builder, Serialize, Deserialize, Eq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq)]
 #[serde(tag = "type", from = "TemplateProcessingDeserializer")]
-#[builder(build_fn(validate = "Self::validate"))]
 pub struct TemplateProcessing {
-    #[builder(try_setter, default = "\"$0\".try_into().unwrap()")]
     pub single: Template,
-    #[builder(try_setter, default = "\"$A:0 $B:1\".try_into().unwrap()")]
     pair: Template,
-    #[builder(setter(skip), default = "self.default_added(true)")]
     #[serde(skip)]
     added_single: usize,
-    #[builder(setter(skip), default = "self.default_added(false)")]
     #[serde(skip)]
     added_pair: usize,
-    #[builder(setter(into), default)]
     special_tokens: Tokens,
 }
 
@@ -405,7 +398,13 @@ impl TemplateProcessing {
 
 impl From<&str> for TemplateProcessingBuilderError {
     fn from(e: &str) -> Self {
-        e.to_string().into()
+        TemplateProcessingBuilderError(e.to_string())
+    }
+}
+
+impl From<String> for TemplateProcessingBuilderError {
+    fn from(e: String) -> Self {
+        TemplateProcessingBuilderError(e)
     }
 }
 
@@ -439,33 +438,54 @@ impl From<TemplateProcessingDeserializer> for TemplateProcessing {
     }
 }
 
-/// Count the number of added tokens in the given template
-fn count_added(container: &Template, special_tokens: Option<&Tokens>) -> usize {
-    container
-        .0
-        .iter()
-        .map(|p| match p {
-            Piece::Sequence { .. } => 0,
-            Piece::SpecialToken { id, .. } => {
-                special_tokens.map_or(0, |spt| spt.0.get(id).map_or(0, |s| s.ids.len()))
-            }
-        })
-        .sum()
+/// Error type for `TemplateProcessingBuilder`.
+#[derive(Debug, Clone)]
+pub struct TemplateProcessingBuilderError(String);
+
+impl std::fmt::Display for TemplateProcessingBuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for TemplateProcessingBuilderError {}
+
+/// Builder for `TemplateProcessing`.
+#[derive(Debug, Clone, Default)]
+pub struct TemplateProcessingBuilder {
+    single: Option<Template>,
+    pair: Option<Template>,
+    special_tokens: Option<Tokens>,
 }
 
 impl TemplateProcessingBuilder {
-    fn default_added(&self, is_single: bool) -> usize {
-        let container = if is_single {
-            self.single.as_ref()
-        } else {
-            self.pair.as_ref()
-        };
-        container.map_or(0, |pieces| {
-            count_added(pieces, self.special_tokens.as_ref())
-        })
+    /// Set the single template. Accepts anything that can be tried into a Template.
+    pub fn try_single<V>(&mut self, single: V) -> StdResult<&mut Self, V::Error>
+    where
+        V: TryInto<Template>,
+        V::Error: std::fmt::Debug,
+    {
+        self.single = Some(single.try_into()?);
+        Ok(self)
     }
 
-    fn validate(&self) -> std::result::Result<(), String> {
+    /// Set the pair template. Accepts anything that can be tried into a Template.
+    pub fn try_pair<V>(&mut self, pair: V) -> StdResult<&mut Self, V::Error>
+    where
+        V: TryInto<Template>,
+        V::Error: std::fmt::Debug,
+    {
+        self.pair = Some(pair.try_into()?);
+        Ok(self)
+    }
+
+    /// Set the special tokens.
+    pub fn special_tokens<V: Into<Tokens>>(&mut self, special_tokens: V) -> &mut Self {
+        self.special_tokens = Some(special_tokens.into());
+        self
+    }
+
+    fn validate(&self) -> StdResult<(), String> {
         let pair_has_both = self.pair.as_ref().is_none_or(|pair| {
             let mut has_a = false;
             let mut has_b = false;
@@ -516,12 +536,54 @@ impl TemplateProcessingBuilder {
         if missing.is_empty() {
             Ok(())
         } else {
+            let missing_str: Vec<&str> = missing.into_iter().collect();
             Err(format!(
                 "Missing SpecialToken(s) with id(s) `{}`",
-                missing.iter().join(", ")
+                missing_str.join(", ")
             ))
         }
     }
+
+    /// Build the `TemplateProcessing`, validating the configuration.
+    pub fn build(&self) -> StdResult<TemplateProcessing, TemplateProcessingBuilderError> {
+        self.validate()
+            .map_err(TemplateProcessingBuilderError::from)?;
+
+        let single = self
+            .single
+            .clone()
+            .unwrap_or_else(|| "$0".try_into().unwrap());
+        let pair = self
+            .pair
+            .clone()
+            .unwrap_or_else(|| "$A:0 $B:1".try_into().unwrap());
+        let special_tokens = self.special_tokens.clone().unwrap_or_default();
+
+        let added_single = count_added(&single, Some(&special_tokens));
+        let added_pair = count_added(&pair, Some(&special_tokens));
+
+        Ok(TemplateProcessing {
+            single,
+            pair,
+            added_single,
+            added_pair,
+            special_tokens,
+        })
+    }
+}
+
+/// Count the number of added tokens in the given template
+fn count_added(container: &Template, special_tokens: Option<&Tokens>) -> usize {
+    container
+        .0
+        .iter()
+        .map(|p| match p {
+            Piece::Sequence { .. } => 0,
+            Piece::SpecialToken { id, .. } => {
+                special_tokens.map_or(0, |spt| spt.0.get(id).map_or(0, |s| s.ids.len()))
+            }
+        })
+        .sum()
 }
 
 impl Default for TemplateProcessing {

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -479,6 +479,18 @@ impl TemplateProcessingBuilder {
         Ok(self)
     }
 
+    /// Set the single template directly.
+    pub fn single(&mut self, single: Template) -> &mut Self {
+        self.single = Some(single);
+        self
+    }
+
+    /// Set the pair template directly.
+    pub fn pair(&mut self, pair: Template) -> &mut Self {
+        self.pair = Some(pair);
+        self
+    }
+
     /// Set the special tokens.
     pub fn special_tokens<V: Into<Tokens>>(&mut self, special_tokens: V) -> &mut Self {
         self.special_tokens = Some(special_tokens.into());

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -57,7 +57,7 @@
 //! [`TemplateProcessing`]: struct.TemplateProcessing.html
 //!
 use crate::{Encoding, PostProcessor, Result};
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet, HashMapExt};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::result::Result as StdResult;

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -2,11 +2,10 @@ use super::{
     normalizer::Range, Model, NormalizedString, Normalizer, Offsets, PreTokenizedString, Result,
     Token,
 };
+use crate::utils::is_word_char;
 use crate::utils::{AHashMap, AHashSet, HashMapExt, HashSetExt};
 use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder, MatchKind};
-use regex::Regex;
 use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
-use std::sync::LazyLock;
 
 /// Represent a token added by the user on top of the existing Model vocabulary.
 /// AddedToken can be configured to specify the behavior they should have in various situations
@@ -96,32 +95,27 @@ impl std::hash::Hash for AddedToken {
 
 type MatchingSet = Option<DoubleArrayAhoCorasick<u32>>;
 
-static STARTS_WITH_WORD: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\w").unwrap());
-static ENDS_WITH_WORD: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\w$").unwrap());
-static RIGHTMOST_SPACE_AT_START: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\s*").unwrap());
-static LEFTMOST_SPACE_AT_END: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s*$").unwrap());
-
 fn ends_with_word(sentence: &str) -> bool {
-    ENDS_WITH_WORD.is_match(sentence)
+    sentence.chars().next_back().is_some_and(is_word_char)
 }
 
 fn starts_with_word(sentence: &str) -> bool {
-    STARTS_WITH_WORD.is_match(sentence)
+    sentence.chars().next().is_some_and(is_word_char)
 }
 
 fn space_leftmost_at_end(sentence: &str) -> usize {
-    if let Some(match_) = LEFTMOST_SPACE_AT_END.find(sentence) {
-        match_.start()
-    } else {
-        sentence.len()
-    }
+    sentence
+        .char_indices()
+        .rev()
+        .find(|(_, c)| !c.is_whitespace())
+        .map_or(0, |(i, c)| i + c.len_utf8())
 }
+
 fn space_rightmost_at_start(sentence: &str) -> usize {
-    if let Some(match_) = RIGHTMOST_SPACE_AT_START.find(sentence) {
-        match_.end()
-    } else {
-        0
-    }
+    sentence
+        .char_indices()
+        .find(|(_, c)| !c.is_whitespace())
+        .map_or(sentence.len(), |(i, _)| i)
 }
 ///
 /// A vocabulary built on top of the Model

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -773,7 +773,8 @@ mod tests {
                 (0, AddedToken::from("test", true)),
                 (2, AddedToken::from("added_token_1", true)),
                 (3, AddedToken::from("added_token_2", true)),
-            ]).collect::<AHashMap<_, _>>()
+            ])
+            .collect::<AHashMap<_, _>>()
         );
         assert!(vocab.added_tokens_map.contains_key("test"));
         assert!(vocab.added_tokens_map_r.contains_key(&0));

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -1,7 +1,7 @@
 use super::{
     normalizer::Range, Model, NormalizedString, Normalizer, Offsets, PreTokenizedString, Token,
 };
-use ahash::{AHashMap, AHashSet};
+use crate::utils::{AHashMap, AHashSet, HashMapExt, HashSetExt};
 use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder, MatchKind};
 use regex::Regex;
 use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
@@ -769,11 +769,11 @@ mod tests {
         assert!(vocab.is_special_token("test"));
         assert_eq!(
             *vocab.get_added_tokens_decoder(),
-            AHashMap::from([
+            IntoIterator::into_iter([
                 (0, AddedToken::from("test", true)),
                 (2, AddedToken::from("added_token_1", true)),
                 (3, AddedToken::from("added_token_2", true)),
-            ])
+            ]).collect::<AHashMap<_, _>>()
         );
         assert!(vocab.added_tokens_map.contains_key("test"));
         assert!(vocab.added_tokens_map_r.contains_key(&0));

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -2,7 +2,7 @@ use crate::parallelism::*;
 use crate::tokenizer::{Offsets, Token};
 use crate::utils::padding::PaddingDirection;
 use crate::utils::truncation::TruncationDirection;
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
 
@@ -890,7 +890,7 @@ mod tests {
             offsets: vec![(0, 6)],
             special_tokens_mask: vec![0],
             attention_mask: vec![1],
-            sequence_ranges: AHashMap::from([(0, 0..1)]),
+            sequence_ranges: IntoIterator::into_iter([(0, 0..1)]).collect(),
             ..Default::default()
         };
         let target_length = 2;
@@ -904,6 +904,6 @@ mod tests {
             pad_token,
             PaddingDirection::Left,
         );
-        assert_eq!(a.sequence_ranges, AHashMap::from([(0, 1..2)]));
+        assert_eq!(a.sequence_ranges, IntoIterator::into_iter([(0, 1..2)]).collect());
     }
 }

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -904,6 +904,9 @@ mod tests {
             pad_token,
             PaddingDirection::Left,
         );
-        assert_eq!(a.sequence_ranges, IntoIterator::into_iter([(0, 1..2)]).collect());
+        assert_eq!(
+            a.sequence_ranges,
+            IntoIterator::into_iter([(0, 1..2)]).collect()
+        );
     }
 }

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -9,15 +9,15 @@
 //!   - [`PostProcessor`](trait.PostProcessor.html): Takes care of the processing after tokenization (like truncating, padding,
 //!     ...).
 
-use crate::utils::{AHashMap};
+use crate::utils::AHashMap;
+#[cfg(feature = "training")]
+use std::io::BufReader;
 use std::{
     fs::{read_to_string, File},
     io::prelude::*,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };
-#[cfg(feature = "training")]
-use std::io::BufReader;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -1613,7 +1613,7 @@ mod tests {
     use super::*;
     use crate::models::wordlevel::WordLevelBuilder;
     use crate::pre_tokenizers::whitespace::WhitespaceSplit;
-    use crate::utils::{AHashMap};
+    use crate::utils::AHashMap;
 
     /// Build a tokenizer with a known vocabulary: "a"=0, "b"=1, ... "j"=9, "<unk>"=10
     /// Uses WhitespaceSplit so each space-separated word maps to one token.

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -9,7 +9,7 @@
 //!   - [`PostProcessor`](trait.PostProcessor.html): Takes care of the processing after tokenization (like truncating, padding,
 //!     ...).
 
-use ahash::AHashMap;
+use crate::utils::{AHashMap};
 use std::{
     fs::{read_to_string, File},
     io::prelude::*,
@@ -1613,7 +1613,7 @@ mod tests {
     use super::*;
     use crate::models::wordlevel::WordLevelBuilder;
     use crate::pre_tokenizers::whitespace::WhitespaceSplit;
-    use ahash::AHashMap;
+    use crate::utils::{AHashMap};
 
     /// Build a tokenizer with a known vocabulary: "a"=0, "b"=1, ... "j"=9, "<unk>"=10
     /// Uses WhitespaceSplit so each space-separated word maps to one token.

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -12,16 +12,20 @@
 use ahash::AHashMap;
 use std::{
     fs::{read_to_string, File},
-    io::{prelude::*, BufReader},
+    io::prelude::*,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };
+#[cfg(feature = "training")]
+use std::io::BufReader;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "training")]
 use crate::utils::iter::ResultShunt;
 use crate::utils::parallelism::*;
+#[cfg(feature = "training")]
 use crate::utils::progress::{ProgressBar, ProgressStyle};
 
 mod added_vocabulary;
@@ -68,6 +72,7 @@ pub trait PreTokenizer {
 
 /// Represents a model used during Tokenization (like BPE or Word or Unigram).
 pub trait Model {
+    #[cfg(feature = "training")]
     type Trainer: Trainer + Sync;
     /// Tokenize the given sequence into multiple underlying `Token`. The `offsets` on the `Token`
     /// are expected to be relative to the given sequence.
@@ -84,6 +89,7 @@ pub trait Model {
     /// files that need to be saved.
     fn save(&self, folder: &Path, prefix: Option<&str>) -> Result<Vec<PathBuf>>;
     /// Get an instance of a Trainer capable of training this Model
+    #[cfg(feature = "training")]
     fn get_trainer(&self) -> <Self as Model>::Trainer;
 }
 
@@ -160,6 +166,7 @@ pub trait Decoder {
 
 /// A `Trainer` has the responsibility to train a model. We feed it with lines/sentences
 /// and then it can train the given `Model`.
+#[cfg(feature = "training")]
 pub trait Trainer {
     type Model: Model + Sized;
     /// Whether we should show progress during the training.
@@ -1371,6 +1378,7 @@ where
     }
 
     /// Train our Model from files
+    #[cfg(feature = "training")]
     pub fn train_from_files<T>(&mut self, trainer: &mut T, files: Vec<String>) -> Result<&mut Self>
     where
         T: Trainer<Model = M> + Sync,
@@ -1392,9 +1400,15 @@ where
                         // We read new lines using this API instead of the Lines Iterator
                         // on purpose. We want to keep the `\n` and potential `\r` between each lines
                         // We use an iterator to be able to chain with par_bridge.
-                        itertools::Either::Left(file.lines_with_ending())
+                        let iter: Box<dyn Iterator<Item = std::io::Result<String>> + Send> =
+                            Box::new(file.lines_with_ending());
+                        iter
                     }
-                    Err(e) => itertools::Either::Right(std::iter::once(Err(e))),
+                    Err(e) => {
+                        let iter: Box<dyn Iterator<Item = std::io::Result<String>> + Send> =
+                            Box::new(std::iter::once(Err(e)));
+                        iter
+                    }
                 }
             }),
             |sequences| -> Result<()> {
@@ -1444,6 +1458,7 @@ where
     }
 
     /// Train our Model, using the given Trainer and iterator
+    #[cfg(feature = "training")]
     pub fn train<T, I, S>(&mut self, trainer: &mut T, sequences: I) -> Result<&mut Self>
     where
         T: Trainer<Model = M> + Sync,

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -1027,7 +1027,6 @@ impl From<&str> for NormalizedString {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use regex::Regex;
     use unicode_categories::UnicodeCategories;
 
     #[test]
@@ -1487,9 +1486,9 @@ mod tests {
         s.replace("aaa", "b").unwrap();
         assert_eq!(s.get(), "bab");
 
-        // Regex
+        // Regex (via SysRegex)
         let mut s = NormalizedString::from(" Hello   friend ");
-        let re = Regex::new(r"\s+").unwrap();
+        let re = crate::utils::SysRegex::new(r"\s+").unwrap();
         s.replace(&re, "_").unwrap();
         assert_eq!(s.get(), "_Hello_friend_");
     }

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -1,6 +1,7 @@
 use crate::pattern::Pattern;
 use crate::{Offsets, Result};
 use std::ops::{Bound, RangeBounds};
+#[cfg(feature = "unicode-normalization")]
 use unicode_normalization_alignments::UnicodeNormalization;
 
 use serde::{Deserialize, Serialize};
@@ -446,24 +447,28 @@ impl NormalizedString {
     }
 
     /// Applies NFD normalization
+    #[cfg(feature = "unicode-normalization")]
     pub fn nfd(&mut self) -> &mut Self {
         self.transform(self.get().to_owned().nfd(), 0);
         self
     }
 
     /// Applies NFKD normalization
+    #[cfg(feature = "unicode-normalization")]
     pub fn nfkd(&mut self) -> &mut Self {
         self.transform(self.get().to_owned().nfkd(), 0);
         self
     }
 
     /// Applies NFC normalization
+    #[cfg(feature = "unicode-normalization")]
     pub fn nfc(&mut self) -> &mut Self {
         self.transform(self.get().to_owned().nfc(), 0);
         self
     }
 
     /// Applies NFKC normalization
+    #[cfg(feature = "unicode-normalization")]
     pub fn nfkc(&mut self) -> &mut Self {
         self.transform(self.get().to_owned().nfkc(), 0);
         self

--- a/tokenizers/src/tokenizer/pattern.rs
+++ b/tokenizers/src/tokenizer/pattern.rs
@@ -1,6 +1,5 @@
 use crate::utils::SysRegex;
 use crate::{Offsets, Result};
-use regex::Regex;
 
 /// Pattern used to split a NormalizedString
 pub trait Pattern {
@@ -26,8 +25,23 @@ impl Pattern for &str {
             return Ok(vec![((0, inside.chars().count()), false)]);
         }
 
-        let re = Regex::new(&regex::escape(self))?;
-        (&re).find_matches(inside)
+        if inside.is_empty() {
+            return Ok(vec![((0, 0), false)]);
+        }
+
+        let mut prev = 0;
+        let mut splits = Vec::with_capacity(inside.len());
+        for (start, part) in inside.match_indices(self) {
+            if prev != start {
+                splits.push(((prev, start), false));
+            }
+            splits.push(((start, start + part.len()), true));
+            prev = start + part.len();
+        }
+        if prev != inside.len() {
+            splits.push(((prev, inside.len()), false));
+        }
+        Ok(splits)
     }
 }
 
@@ -38,7 +52,8 @@ impl Pattern for &String {
     }
 }
 
-impl Pattern for &Regex {
+#[cfg(feature = "regex")]
+impl Pattern for &regex::Regex {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
         if inside.is_empty() {
             return Ok(vec![((0, 0), false)]);
@@ -140,7 +155,6 @@ impl<P: Pattern> Pattern for Invert<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use regex::Regex;
 
     macro_rules! do_test {
         ($inside: expr, $pattern: expr => @ERROR) => {
@@ -191,8 +205,10 @@ mod tests {
         do_test!("aaa", is_b => vec![((0, 3), false)]);
     }
 
+    #[cfg(feature = "regex")]
     #[test]
     fn regex() {
+        use regex::Regex;
         let is_whitespace = Regex::new(r"\s+").unwrap();
         do_test!("a   b", &is_whitespace => vec![((0, 1), false), ((1, 4), true), ((4, 5), false)]);
         do_test!("   a   b   ", &is_whitespace =>

--- a/tokenizers/src/utils/cache.rs
+++ b/tokenizers/src/utils/cache.rs
@@ -1,4 +1,4 @@
-use ahash::AHashMap;
+use crate::utils::{AHashMap, HashMapExt};
 use std::borrow::Borrow;
 use std::hash::Hash;
 use std::sync::RwLock;

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -234,6 +234,17 @@ macro_rules! impl_serde_type{
 // Re-export macro_rules_attribute
 pub use macro_rules_attribute::macro_rules_attribute;
 
+/// Deserialize from a `serde_json::Value` via string round-trip.
+/// This avoids monomorphizing `serde_json::from_value<T>` per type — the
+/// `from_str` path shares a single `Deserializer<SliceRead>` across all types,
+/// saving ~66 KB of binary size compared to `serde_json::from_value`.
+pub(crate) fn from_value_via_str<T: serde::de::DeserializeOwned>(
+    value: serde_json::Value,
+) -> serde_json::Result<T> {
+    let s = value.to_string();
+    serde_json::from_str(&s)
+}
+
 /// Escape special regex metacharacters in a string so it can be used as a literal pattern.
 /// This replaces the dependency on `regex::escape`.
 pub fn regex_escape(text: &str) -> String {

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -23,9 +23,19 @@ pub mod truncation;
 // Re-export ProgressFormat for public API
 pub use progress::ProgressFormat;
 
-use ahash::AHashMap;
 use serde::{Serialize, Serializer};
 use std::collections::BTreeMap;
+
+/// Fast hash map using foldhash. Drop-in replacement for ahash::AHashMap.
+pub type AHashMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::FixedState>;
+/// Fast hash set using foldhash. Drop-in replacement for ahash::AHashSet.
+pub type AHashSet<K> = std::collections::HashSet<K, foldhash::fast::FixedState>;
+
+// Re-export extension traits so AHashMap::new() and AHashSet::new() work.
+#[allow(unused_imports)]
+pub use foldhash::HashMapExt;
+#[allow(unused_imports)]
+pub use foldhash::HashSetExt;
 
 pub(crate) fn ordered_map<S, K, V>(
     value: &AHashMap<K, V>,

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -234,17 +234,6 @@ macro_rules! impl_serde_type{
 // Re-export macro_rules_attribute
 pub use macro_rules_attribute::macro_rules_attribute;
 
-/// Deserialize from a `serde_json::Value` via string round-trip.
-/// This avoids monomorphizing `serde_json::from_value<T>` per type — the
-/// `from_str` path shares a single `Deserializer<SliceRead>` across all types,
-/// saving ~66 KB of binary size compared to `serde_json::from_value`.
-pub(crate) fn from_value_via_str<T: serde::de::DeserializeOwned>(
-    value: serde_json::Value,
-) -> serde_json::Result<T> {
-    let s = value.to_string();
-    serde_json::from_str(&s)
-}
-
 /// Escape special regex metacharacters in a string so it can be used as a literal pattern.
 /// This replaces the dependency on `regex::escape`.
 pub fn regex_escape(text: &str) -> String {

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -233,3 +233,28 @@ macro_rules! impl_serde_type{
 
 // Re-export macro_rules_attribute
 pub use macro_rules_attribute::macro_rules_attribute;
+
+/// Escape special regex metacharacters in a string so it can be used as a literal pattern.
+/// This replaces the dependency on `regex::escape`.
+pub fn regex_escape(text: &str) -> String {
+    let mut escaped = String::with_capacity(text.len() + 4);
+    for c in text.chars() {
+        match c {
+            '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$'
+            | '#' | '&' | '-' | '~' => {
+                escaped.push('\\');
+                escaped.push(c);
+            }
+            _ => escaped.push(c),
+        }
+    }
+    escaped
+}
+
+/// Check if a character is a "word" character (equivalent to `\w` in Unicode-aware regex).
+/// Matches `[a-zA-Z0-9_]`, Unicode alphabetic/numeric characters, and Unicode combining marks
+/// (category M), matching Perl/PCRE `\w` with Unicode enabled.
+pub(crate) fn is_word_char(c: char) -> bool {
+    use unicode_categories::UnicodeCategories;
+    c == '_' || c.is_alphanumeric() || c.is_mark()
+}

--- a/tokenizers/src/utils/padding.rs
+++ b/tokenizers/src/utils/padding.rs
@@ -84,7 +84,7 @@ pub fn pad_encodings(encodings: &mut [Encoding], params: &PaddingParams) -> Resu
 mod tests {
     use super::*;
     use crate::tokenizer::Encoding;
-    use ahash::AHashMap;
+    use crate::utils::{AHashMap, HashMapExt};
 
     #[test]
     fn pad_to_multiple() {

--- a/tokenizers/src/utils/parallelism.rs
+++ b/tokenizers/src/utils/parallelism.rs
@@ -2,15 +2,9 @@
 //! This module defines helpers to allow optional Rayon usage.
 //!
 
-use rayon::iter::IterBridge;
-use rayon::prelude::*;
-use rayon_cond::CondIterator;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
-
-// Re-export rayon current_num_threads
-pub use rayon::current_num_threads;
 
 pub const ENV_VARIABLE: &str = "TOKENIZERS_PARALLELISM";
 
@@ -61,189 +55,335 @@ pub fn set_parallelism(val: bool) {
     PARALLELISM.store(if val { 2 } else { 1 }, Ordering::SeqCst);
 }
 
-/// Allows to convert into an iterator that can be executed either parallelly or serially.
-///
-/// The choice is made according to the currently set `TOKENIZERS_PARALLELISM` environment variable.
-/// This variable can have one of the following values
-///   - False => "" (empty value), "false", "f", "off", "no", "n", "0"
-///   - True => Any other value
-///
-pub trait MaybeParallelIterator<P, S>
-where
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-{
-    /// Convert ourself in a CondIterator, that will be executed either in parallel or serially,
-    /// based solely on the `TOKENIZERS_PARALLELISM` environment variable
-    fn into_maybe_par_iter(self) -> CondIterator<P, S>;
-    /// Convert ourself in a CondIterator, that will be executed either in parallel or serially,
-    /// based on both the `TOKENIZERS_PARALLELISM` environment variable and the provided bool.
-    /// Both must be true to run with parallelism activated.
-    fn into_maybe_par_iter_cond(self, cond: bool) -> CondIterator<P, S>;
+// Re-export rayon current_num_threads
+#[cfg(feature = "parallel")]
+pub use rayon::current_num_threads;
+
+#[cfg(not(feature = "parallel"))]
+pub fn current_num_threads() -> usize {
+    1
 }
 
-impl<P, S, I> MaybeParallelIterator<P, S> for I
-where
-    I: IntoParallelIterator<Iter = P, Item = P::Item> + IntoIterator<IntoIter = S, Item = S::Item>,
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-{
-    fn into_maybe_par_iter(self) -> CondIterator<P, S> {
-        let parallelism = get_parallelism();
-        if parallelism {
-            USED_PARALLELISM.store(true, Ordering::SeqCst);
-        }
-        CondIterator::new(self, parallelism)
+// ---------------------------------------------------------------------------
+// Parallel implementation using rayon + rayon-cond
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "parallel")]
+mod parallel_impl {
+    use super::*;
+    use rayon::iter::IterBridge;
+    use rayon::prelude::*;
+    use rayon_cond::CondIterator;
+
+    /// Allows to convert into an iterator that can be executed either parallelly or serially.
+    pub trait MaybeParallelIterator<P, S>
+    where
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+    {
+        fn into_maybe_par_iter(self) -> CondIterator<P, S>;
+        fn into_maybe_par_iter_cond(self, cond: bool) -> CondIterator<P, S>;
     }
 
-    fn into_maybe_par_iter_cond(self, cond: bool) -> CondIterator<P, S> {
-        if cond {
+    impl<P, S, I> MaybeParallelIterator<P, S> for I
+    where
+        I: IntoParallelIterator<Iter = P, Item = P::Item>
+            + IntoIterator<IntoIter = S, Item = S::Item>,
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+    {
+        fn into_maybe_par_iter(self) -> CondIterator<P, S> {
+            let parallelism = get_parallelism();
+            if parallelism {
+                USED_PARALLELISM.store(true, Ordering::SeqCst);
+            }
+            CondIterator::new(self, parallelism)
+        }
+
+        fn into_maybe_par_iter_cond(self, cond: bool) -> CondIterator<P, S> {
+            if cond {
+                self.into_maybe_par_iter()
+            } else {
+                CondIterator::from_serial(self)
+            }
+        }
+    }
+
+    /// Shared reference version of MaybeParallelIterator
+    pub trait MaybeParallelRefIterator<'data, P, S>
+    where
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+        P::Item: 'data,
+    {
+        fn maybe_par_iter(&'data self) -> CondIterator<P, S>;
+        fn maybe_par_iter_cond(&'data self, cond: bool) -> CondIterator<P, S>;
+    }
+
+    impl<'data, P, S, I: 'data + ?Sized> MaybeParallelRefIterator<'data, P, S> for I
+    where
+        &'data I: MaybeParallelIterator<P, S>,
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+        P::Item: 'data,
+    {
+        fn maybe_par_iter(&'data self) -> CondIterator<P, S> {
             self.into_maybe_par_iter()
-        } else {
+        }
+
+        fn maybe_par_iter_cond(&'data self, cond: bool) -> CondIterator<P, S> {
+            self.into_maybe_par_iter_cond(cond)
+        }
+    }
+
+    /// Exclusive reference version of MaybeParallelIterator
+    pub trait MaybeParallelRefMutIterator<'data, P, S>
+    where
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+        P::Item: 'data,
+    {
+        fn maybe_par_iter_mut(&'data mut self) -> CondIterator<P, S>;
+        fn maybe_par_iter_mut_cond(&'data mut self, cond: bool) -> CondIterator<P, S>;
+    }
+
+    impl<'data, P, S, I: 'data + ?Sized> MaybeParallelRefMutIterator<'data, P, S> for I
+    where
+        &'data mut I: MaybeParallelIterator<P, S>,
+        P: ParallelIterator,
+        S: Iterator<Item = P::Item>,
+        P::Item: 'data,
+    {
+        fn maybe_par_iter_mut(&'data mut self) -> CondIterator<P, S> {
+            self.into_maybe_par_iter()
+        }
+
+        fn maybe_par_iter_mut_cond(&'data mut self, cond: bool) -> CondIterator<P, S> {
+            self.into_maybe_par_iter_cond(cond)
+        }
+    }
+
+    /// Converts any serial iterator into a CondIterator via par_bridge.
+    pub trait MaybeParallelBridge<T, S>
+    where
+        S: Iterator<Item = T> + Send,
+        T: Send,
+    {
+        fn maybe_par_bridge(self) -> CondIterator<IterBridge<S>, S>;
+        fn maybe_par_bridge_cond(self, cond: bool) -> CondIterator<IterBridge<S>, S>;
+    }
+
+    impl<T, S> MaybeParallelBridge<T, S> for S
+    where
+        S: Iterator<Item = T> + Send,
+        T: Send,
+    {
+        fn maybe_par_bridge(self) -> CondIterator<IterBridge<S>, S> {
+            let iter = CondIterator::from_serial(self);
+
+            if get_parallelism() {
+                USED_PARALLELISM.store(true, Ordering::SeqCst);
+                CondIterator::from_parallel(iter.into_parallel().right().unwrap())
+            } else {
+                iter
+            }
+        }
+
+        fn maybe_par_bridge_cond(self, cond: bool) -> CondIterator<IterBridge<S>, S> {
+            if cond {
+                self.maybe_par_bridge()
+            } else {
+                CondIterator::from_serial(self)
+            }
+        }
+    }
+
+    /// Allows to convert into `chunks` that can be executed either parallelly or serially.
+    pub trait MaybeParallelSlice<'data, T>
+    where
+        T: Sync,
+    {
+        fn maybe_par_chunks(
+            &'_ self,
+            chunk_size: usize,
+        ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>>;
+        fn maybe_par_chunks_cond(
+            &'_ self,
+            cond: bool,
+            chunk_size: usize,
+        ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>>;
+    }
+
+    impl<T> MaybeParallelSlice<'_, T> for [T]
+    where
+        T: Sync,
+    {
+        fn maybe_par_chunks(
+            &'_ self,
+            chunk_size: usize,
+        ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>> {
+            let parallelism = get_parallelism();
+            if parallelism {
+                CondIterator::from_parallel(self.par_chunks(chunk_size))
+            } else {
+                CondIterator::from_serial(self.chunks(chunk_size))
+            }
+        }
+        fn maybe_par_chunks_cond(
+            &'_ self,
+            cond: bool,
+            chunk_size: usize,
+        ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>> {
+            if cond {
+                self.maybe_par_chunks(chunk_size)
+            } else {
+                CondIterator::from_serial(self.chunks(chunk_size))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+pub use parallel_impl::*;
+
+// ---------------------------------------------------------------------------
+// Serial-only fallback when rayon is not available
+// ---------------------------------------------------------------------------
+
+#[cfg(not(feature = "parallel"))]
+mod serial_impl {
+    /// A serial-only iterator wrapper (identity wrapper).
+    pub struct CondIterator<S> {
+        iter: S,
+    }
+
+    impl<S: Iterator> CondIterator<S> {
+        pub fn from_serial<I: IntoIterator<IntoIter = S>>(iter: I) -> Self {
+            CondIterator {
+                iter: iter.into_iter(),
+            }
+        }
+    }
+
+    impl<S: Iterator> Iterator for CondIterator<S> {
+        type Item = S::Item;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.iter.next()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            self.iter.size_hint()
+        }
+    }
+
+    impl<S: Iterator> CondIterator<S>
+    where
+        S::Item: Send,
+        S: Send,
+    {
+        pub fn reduce<OP, ID>(self, identity: ID, op: OP) -> S::Item
+        where
+            OP: Fn(S::Item, S::Item) -> S::Item,
+            ID: Fn() -> S::Item,
+        {
+            self.iter.fold(identity(), |acc, item| op(acc, item))
+        }
+
+        pub fn for_each<OP>(self, op: OP)
+        where
+            OP: Fn(S::Item),
+        {
+            self.iter.for_each(op);
+        }
+    }
+
+    /// Converts into a serial CondIterator.
+    pub trait MaybeParallelIterator {
+        type Iter: Iterator;
+        fn into_maybe_par_iter(self) -> CondIterator<Self::Iter>;
+        fn into_maybe_par_iter_cond(self, cond: bool) -> CondIterator<Self::Iter>;
+    }
+
+    impl<I: IntoIterator> MaybeParallelIterator for I {
+        type Iter = I::IntoIter;
+        fn into_maybe_par_iter(self) -> CondIterator<Self::Iter> {
+            CondIterator::from_serial(self)
+        }
+        fn into_maybe_par_iter_cond(self, _cond: bool) -> CondIterator<Self::Iter> {
             CondIterator::from_serial(self)
         }
     }
-}
 
-/// Shared reference version of MaybeParallelIterator, works the same but returns an iterator
-/// over references, does not consume self
-pub trait MaybeParallelRefIterator<'data, P, S>
-where
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-    P::Item: 'data,
-{
-    fn maybe_par_iter(&'data self) -> CondIterator<P, S>;
-    fn maybe_par_iter_cond(&'data self, cond: bool) -> CondIterator<P, S>;
-}
-
-impl<'data, P, S, I: 'data + ?Sized> MaybeParallelRefIterator<'data, P, S> for I
-where
-    &'data I: MaybeParallelIterator<P, S>,
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-    P::Item: 'data,
-{
-    fn maybe_par_iter(&'data self) -> CondIterator<P, S> {
-        self.into_maybe_par_iter()
+    pub trait MaybeParallelRefIterator<'data> {
+        type Iter: Iterator;
+        fn maybe_par_iter(&'data self) -> CondIterator<Self::Iter>;
     }
 
-    fn maybe_par_iter_cond(&'data self, cond: bool) -> CondIterator<P, S> {
-        self.into_maybe_par_iter_cond(cond)
-    }
-}
-
-/// Exclusive reference version of MaybeParallelIterator, works the same but returns an iterator
-/// over mutable references, does not consume self
-pub trait MaybeParallelRefMutIterator<'data, P, S>
-where
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-    P::Item: 'data,
-{
-    fn maybe_par_iter_mut(&'data mut self) -> CondIterator<P, S>;
-    fn maybe_par_iter_mut_cond(&'data mut self, cond: bool) -> CondIterator<P, S>;
-}
-
-impl<'data, P, S, I: 'data + ?Sized> MaybeParallelRefMutIterator<'data, P, S> for I
-where
-    &'data mut I: MaybeParallelIterator<P, S>,
-    P: ParallelIterator,
-    S: Iterator<Item = P::Item>,
-    P::Item: 'data,
-{
-    fn maybe_par_iter_mut(&'data mut self) -> CondIterator<P, S> {
-        self.into_maybe_par_iter()
-    }
-
-    fn maybe_par_iter_mut_cond(&'data mut self, cond: bool) -> CondIterator<P, S> {
-        self.into_maybe_par_iter_cond(cond)
-    }
-}
-
-/// Converts any serial iterator into a CondIterator, that can either run parallelly or serially.
-pub trait MaybeParallelBridge<T, S>
-where
-    S: Iterator<Item = T> + Send,
-    T: Send,
-{
-    fn maybe_par_bridge(self) -> CondIterator<IterBridge<S>, S>;
-    fn maybe_par_bridge_cond(self, cond: bool) -> CondIterator<IterBridge<S>, S>;
-}
-
-impl<T, S> MaybeParallelBridge<T, S> for S
-where
-    S: Iterator<Item = T> + Send,
-    T: Send,
-{
-    fn maybe_par_bridge(self) -> CondIterator<IterBridge<S>, S> {
-        let iter = CondIterator::from_serial(self);
-
-        if get_parallelism() {
-            USED_PARALLELISM.store(true, Ordering::SeqCst);
-            CondIterator::from_parallel(iter.into_parallel().right().unwrap())
-        } else {
-            iter
+    impl<'data, T: 'data> MaybeParallelRefIterator<'data> for [T] {
+        type Iter = std::slice::Iter<'data, T>;
+        fn maybe_par_iter(&'data self) -> CondIterator<Self::Iter> {
+            CondIterator::from_serial(self.iter())
         }
     }
 
-    fn maybe_par_bridge_cond(self, cond: bool) -> CondIterator<IterBridge<S>, S> {
-        if cond {
-            self.maybe_par_bridge()
-        } else {
-            CondIterator::from_serial(self)
+    impl<'data, T: 'data> MaybeParallelRefIterator<'data> for Vec<T> {
+        type Iter = std::slice::Iter<'data, T>;
+        fn maybe_par_iter(&'data self) -> CondIterator<Self::Iter> {
+            CondIterator::from_serial(self.iter())
         }
     }
-}
 
-/// Allows to convert into `chunks` that can be executed either parallelly or serially.
-pub trait MaybeParallelSlice<'data, T>
-where
-    T: Sync,
-{
-    /// Create a CondIterator, that will be executed either in parallel or serially,
-    /// based solely on the `TOKENIZERS_PARALLELISM` environment variable
-    fn maybe_par_chunks(
-        &'_ self,
-        chunk_size: usize,
-    ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>>;
-    /// Create a CondIterator, that will be executed either in parallel or serially,
-    /// based on both the `TOKENIZERS_PARALLELISM` environment variable and the provided bool.
-    /// Both must be true to run with parallelism activated.
-    fn maybe_par_chunks_cond(
-        &'_ self,
-        cond: bool,
-        chunk_size: usize,
-    ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>>;
-}
+    pub trait MaybeParallelRefMutIterator<'data> {
+        type Iter: Iterator;
+        fn maybe_par_iter_mut(&'data mut self) -> CondIterator<Self::Iter>;
+    }
 
-impl<T> MaybeParallelSlice<'_, T> for [T]
-where
-    T: Sync,
-{
-    fn maybe_par_chunks(
-        &'_ self,
-        chunk_size: usize,
-    ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>> {
-        let parallelism = get_parallelism();
-        if parallelism {
-            CondIterator::from_parallel(self.par_chunks(chunk_size))
-        } else {
-            CondIterator::from_serial(self.chunks(chunk_size))
+    impl<'data, T: 'data> MaybeParallelRefMutIterator<'data> for Vec<T> {
+        type Iter = std::slice::IterMut<'data, T>;
+        fn maybe_par_iter_mut(&'data mut self) -> CondIterator<Self::Iter> {
+            CondIterator::from_serial(self.iter_mut())
         }
     }
-    fn maybe_par_chunks_cond(
-        &'_ self,
-        cond: bool,
-        chunk_size: usize,
-    ) -> CondIterator<rayon::slice::Chunks<'_, T>, std::slice::Chunks<'_, T>> {
-        if cond {
-            self.maybe_par_chunks(chunk_size)
-        } else {
+
+    impl<'data, T: 'data> MaybeParallelRefMutIterator<'data> for [T] {
+        type Iter = std::slice::IterMut<'data, T>;
+        fn maybe_par_iter_mut(&'data mut self) -> CondIterator<Self::Iter> {
+            CondIterator::from_serial(self.iter_mut())
+        }
+    }
+
+    /// Serial-only bridge (identity).
+    pub trait MaybeParallelBridge: Iterator + Sized {
+        fn maybe_par_bridge(self) -> CondIterator<Self>;
+    }
+
+    impl<I: Iterator + Send> MaybeParallelBridge for I {
+        fn maybe_par_bridge(self) -> CondIterator<Self> {
+            CondIterator { iter: self }
+        }
+    }
+
+    /// Serial-only chunks.
+    pub trait MaybeParallelSlice<'data, T> {
+        fn maybe_par_chunks(
+            &'data self,
+            chunk_size: usize,
+        ) -> CondIterator<std::slice::Chunks<'data, T>>;
+    }
+
+    impl<'data, T> MaybeParallelSlice<'data, T> for [T] {
+        fn maybe_par_chunks(
+            &'data self,
+            chunk_size: usize,
+        ) -> CondIterator<std::slice::Chunks<'data, T>> {
             CondIterator::from_serial(self.chunks(chunk_size))
         }
     }
 }
+
+#[cfg(not(feature = "parallel"))]
+pub use serial_impl::*;
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/src/utils/progress.rs
+++ b/tokenizers/src/utils/progress.rs
@@ -20,6 +20,7 @@ pub(crate) use indicatif::{ProgressBar, ProgressStyle};
 
 #[cfg(not(feature = "progressbar"))]
 mod progressbar {
+    #![allow(dead_code)]
     use std::borrow::Cow;
     pub struct ProgressBar;
     impl ProgressBar {
@@ -46,4 +47,5 @@ mod progressbar {
     }
 }
 #[cfg(not(feature = "progressbar"))]
+#[allow(unused_imports)]
 pub(crate) use progressbar::{ProgressBar, ProgressStyle};

--- a/tokenizers/src/utils/truncation.rs
+++ b/tokenizers/src/utils/truncation.rs
@@ -165,7 +165,7 @@ pub fn truncate_encodings(
 mod tests {
     use super::*;
     use crate::tokenizer::Encoding;
-    use ahash::AHashMap;
+    use crate::utils::{AHashMap, HashMapExt};
 
     fn get_empty() -> Encoding {
         Encoding::new(

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -1,10 +1,10 @@
 use std::iter::FromIterator;
 
-use tokenizers::utils::AHashMap;
 use tokenizers::decoders::byte_fallback::ByteFallback;
 use tokenizers::models::bpe::{BpeTrainerBuilder, BPE};
 use tokenizers::normalizers::{Sequence, Strip, NFC};
 use tokenizers::pre_tokenizers::byte_level::ByteLevel;
+use tokenizers::utils::AHashMap;
 use tokenizers::{AddedToken, TokenizerBuilder};
 use tokenizers::{DecoderWrapper, NormalizerWrapper, PostProcessorWrapper, PreTokenizerWrapper};
 use tokenizers::{Tokenizer, TokenizerImpl};

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -1,6 +1,6 @@
 use std::iter::FromIterator;
 
-use ahash::AHashMap;
+use tokenizers::utils::AHashMap;
 use tokenizers::decoders::byte_fallback::ByteFallback;
 use tokenizers::models::bpe::{BpeTrainerBuilder, BPE};
 use tokenizers::normalizers::{Sequence, Strip, NFC};

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -111,7 +111,7 @@ fn streaming_tokenizer() {
         ])))
         .with_pre_tokenizer(Some(ByteLevel::default()))
         .with_post_processor(Some(ByteLevel::default()))
-        .with_decoder(Some(ByteFallback::default()))
+        .with_decoder(Some(ByteFallback))
         .build()
         .unwrap();
     let mut decode_stream = tokenizer.decode_stream(false);


### PR DESCRIPTION
## Reduce tokenizers crate size

Reduce the on-device library size of the `tokenizers` crate from **2.65 MB → 0.96 MB** (64% reduction) for inference-only deployments.

### Size reduction breakdown

Measured on macOS arm64, stripped cdylib, LTO fat, opt-level=s:

```
main (today, all features)                                     2.65 MB
├── drop deps (derive_builder, itertools, monostate, ahash)   -0.32 MB  (done)
├── feature-gate training/spm/parallel/unicode-norm           -0.34 MB  (done)
├── make regex optional                                       -0.65 MB  (done)
├── drop dary_heap serde feature                              -tiny     (done)
├── codegen-units = 1                                         -0.03 MB  (done, in profile)
├── panic = "abort"                                        \
├── -Zlocation-detail=none -Zfmt-debug=none                 } -0.35 MB combined
├── build-std=std,panic_abort optimize_for_size            /
└───────────────────────────────────────────────
    TOTAL with nightly build-std                               0.96 MB ✓
    TOTAL with stable (codegen-units=1, panic=abort)          ~1.18 MB
```

### Comparison with [Meta pytorch/tokenizers](https://github.com/meta-pytorch/tokenizers) (C++)

|  | Meta (C++) | HuggingFace (Rust, this PR) |
|---|---|---|
| **Stripped binary** | **~0.8 MB** | **0.96 MB** (nightly) / **1.18 MB** (stable) |
| Models | BPE, SentencePiece, Tiktoken | BPE, WordPiece, Unigram, WordLevel |
| Normalizers | Replace, Prepend, NFC, Sequence | All of the above + NFKC/NFD/NFKD, Bert, Lowercase, Strip, StripAccents, ByteLevel, NMT |
| Pre-tokenizers | Regex, Digits, ByteLevel, Sequence | All of the above + Whitespace, Metaspace, Punctuation, Split, UnicodeScripts, BertPreTokenizer, CharDelimiter, FixedLength |
| Post-processors | TemplateProcessing, Sequence | All of the above + BertProcessing, RobertaProcessing, ByteLevel |
| Decoders | Basic token decoder | BPE, ByteLevel, WordPiece, Metaspace, CTC, ByteFallback, Fuse, Strip, Replace, Sequence |
| Added tokens | Basic special tokens only | Full `AddedToken` with single-word, lstrip/rstrip, normalized, per-token config |
| Training | ❌ | ✅ (feature-gated) |
| Padding / Truncation | ❌ | ✅ |
| Batch encoding | ❌ | ✅ (with optional rayon parallelism) |
| `tokenizer.json` loading | ✅ (partial — many post-processors are TODO) | ✅ (full) |

We're ~20% larger than Meta's C++ implementation while supporting **significantly more features**. The gap is primarily serde's JSON deserialization infrastructure (~225 KB) which Meta avoids by using hardcoded loaders.

### What changed

**Dependency cleanup:**
- Replaced `derive_builder` with manual builders
- Replaced `itertools` with std equivalents
- Replaced `ahash` with `foldhash` (smaller, faster on benchmarks)
- Dropped `monostate`
- Removed `serde` feature from `dary_heap` (never serialized)

**Feature gates (all backward-compatible, enabled by default):**
- `training` — gates rand, esaxx-rs, compact_str, all trainer impls
- `spm` — gates spm_precompiled, unicode-segmentation
- `parallel` — gates rayon, rayon-cond
- `unicode-normalization` — gates NFC/NFD/NFKC/NFKD normalizers
- `regex` — **new**: gates the Rust `regex` crate. When disabled, all regex operations use the system regex engine (onig or fancy-regex). Replaced 4 regex statics in `added_vocabulary.rs` with char ops, `Whitespace` pre-tokenizer with `SysRegex`, `Pattern for &str` with `str::match_indices`.

**Build profiles:**
- Added `release-small` profile with `opt-level = "s"`, `strip = true`, `panic = "abort"`, `codegen-units = 1`
- Documented nightly `build-std` command for sub-1MB builds

**CI:**
- Added bundle size reporting via `$GITHUB_STEP_SUMMARY` to Rust and Python release workflows
- Fixed macOS abi3 cross-compilation `RUSTFLAGS` in CI

### Minimal inference-only configuration

```toml
# Cargo.toml — smallest possible, uses Oniguruma regex (C dep)
tokenizers = { version = "0.22", default-features = false, features = ["onig"] }

# Or pure Rust for WASM (no C dependencies)
tokenizers = { version = "0.22", default-features = false, features = ["unstable_wasm"] }
```

For the absolute smallest binary (nightly):
```bash
RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" cargo +nightly build \
  -Z build-std=std,panic_abort -Z build-std-features="optimize_for_size" \
  --target aarch64-apple-darwin --profile release-small
```

### Benchmark results (ahash → foldhash)

Foldhash is equal-or-faster on all benchmarks. Training is 7-10% faster, encoding is 2-3% faster.

| Benchmark | ahash (main) | foldhash (this PR) | Delta |
|---|---|---|---|
| BPE GPT2 encode | 1.718 s | 1.668 s | **-3.0%** |
| BPE train large | 958 ms | 883 ms | **-7.8%** |
| llama3 encode | 1.687 s | 1.644 s | **-2.6%** |
| llama3 train big | 1.124 s | 1.016 s | **-9.6%** |
| unigram train big | 675 ms | 614 ms | **-9.1%** |
| BERT encode | 1.560 s | 1.558 s | -0.1% |
| BERT train big | 901 ms | 871 ms | **-3.3%** |