### PR TITLE
fix: replace wget/norvig with HF Hub for test data downloads

### DIFF
--- a/bindings/node/Makefile
+++ b/bindings/node/Makefile
@@ -4,6 +4,8 @@ DATA_DIR = data
 
 dir_guard=@mkdir -p $(@D)
 
+HF_DATA = https://huggingface.co/datasets/hf-internal-testing/tokenizers-test-data/resolve/main
+
 # Format source code automatically
 style:
 	npm run lint
@@ -20,19 +22,19 @@ test: $(TESTS_RESOURCES)
 
 $(DATA_DIR)/big.txt :
 	$(dir_guard)
-	wget https://norvig.com/big.txt -O $@
+	curl -sL $(HF_DATA)/big.txt -o $@
 
 $(DATA_DIR)/small.txt : $(DATA_DIR)/big.txt
 	head -100 $(DATA_DIR)/big.txt > $@
 
 $(DATA_DIR)/roberta.json :
 	$(dir_guard)
-	wget https://huggingface.co/roberta-large/raw/main/tokenizer.json -O $@
+	curl -sL $(HF_DATA)/roberta.json -o $@
 
 $(DATA_DIR)/tokenizer-wiki.json :
 	$(dir_guard)
-	wget https://s3.amazonaws.com/models.huggingface.co/bert/anthony/doc-quicktour/tokenizer.json -O $@
+	curl -sL $(HF_DATA)/tokenizer-wiki.json -o $@
 
 $(DATA_DIR)/bert-wiki.json :
 	$(dir_guard)
-	wget https://s3.amazonaws.com/models.huggingface.co/bert/anthony/doc-pipeline/tokenizer.json -O $@
+	curl -sL $(HF_DATA)/bert-wiki.json -o $@

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -56,12 +56,12 @@ HF_TEST_DATA = https://huggingface.co/datasets/hf-internal-testing/tokenizers-te
 
 $(DATA_DIR)/big.txt :
 	$(dir_guard)
-	wget $(HF_TEST_DATA)/big.txt -O $@
+	curl -sL $(HF_TEST_DATA)/big.txt -o $@
 
 $(DATA_DIR)/small.txt :
 	$(dir_guard)
-	wget $(HF_TEST_DATA)/small.txt -O $@
+	curl -sL $(HF_TEST_DATA)/small.txt -o $@
 
 $(DATA_DIR)/roberta.json :
 	$(dir_guard)
-	wget $(HF_TEST_DATA)/roberta.json -O $@
+	curl -sL $(HF_TEST_DATA)/roberta.json -o $@


### PR DESCRIPTION
norvig.com/big.txt returns 415 now, breaking node tests.

- Node Makefile: replace `wget https://norvig.com/big.txt` and S3 URLs with `curl -sL` from `hf-internal-testing/tokenizers-test-data`
- Python Makefile: replace `wget` with `curl -sL` (same HF dataset, no wget dependency)

All test data now consistently served from `hf-internal-testing/tokenizers-test-data`.