### PR TITLE
Cyrillic normalizer and decoder for south slavic languages

### DIFF
--- a/tokenizers/src/decoders/cyrillic.rs
+++ b/tokenizers/src/decoders/cyrillic.rs
@@ -1,0 +1,58 @@
+use crate::tokenizer::{Decoder, Result};
+use serde::{Deserialize, Serialize};
+use regex::Regex;
+
+use crate::normalizers::cyrillic::latin_to_cyrillic;
+
+#[derive(Deserialize, Clone, Debug, Serialize)]
+#[non_exhaustive]
+/// Decodes Latin text inside <cyr> tags back into Cyrillic,
+/// then removes the tags.
+pub struct CyrillicDecoder;
+
+impl CyrillicDecoder {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for CyrillicDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Decoder for CyrillicDecoder {
+    fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
+        let re = Regex::new(r"<cyr>(.*?)</cyr>").unwrap();
+
+        Ok(tokens
+            .into_iter()
+            .map(|token| {
+                re.replace_all(&token, |caps: &regex::Captures| {
+                    let inner = &caps[1];
+                    latin_to_cyrillic(inner)
+                })
+                .to_string()
+            })
+            .collect())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cyrillic_decoder_replaces_and_strips_tags() {
+        let decoder = CyrillicDecoder::default();
+
+        let original = "1. Hej<cyr> žabo, Pozdravljam te Ya,</cyr> dobri svete, iz<cyr> godine 2029-te.</cyr>";
+        let expected = "1. Hej жабо, Поздрављам те Я, dobri svete, iz године 2029-те.";
+        let tokens = vec![original.to_string()];
+        let decoded = decoder.decode_chain(tokens).unwrap();
+
+        assert_eq!(decoded[0], expected);
+    }
+}

--- a/tokenizers/src/decoders/mod.rs
+++ b/tokenizers/src/decoders/mod.rs
@@ -5,6 +5,8 @@ pub mod fuse;
 pub mod sequence;
 pub mod strip;
 pub mod wordpiece;
+pub mod cyrillic;
+
 
 // Re-export these as decoders
 pub use super::pre_tokenizers::byte_level;

--- a/tokenizers/src/normalizers/cyrillic.rs
+++ b/tokenizers/src/normalizers/cyrillic.rs
@@ -1,0 +1,157 @@
+use crate::tokenizer::{NormalizedString, Normalizer, Result};
+use serde::{Deserialize, Serialize};
+use regex::Regex;
+
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CyrillicNormalizer;
+
+impl CyrillicNormalizer {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+fn cyrillic_to_latin(text: &str) -> String {
+    let mut out = String::new();
+    for ch in text.chars() {
+        let latin: String = match ch {
+            'А' => "A".to_string(), 'а' => "a".to_string(),
+            'Б' => "B".to_string(), 'б' => "b".to_string(),
+            'В' => "V".to_string(), 'в' => "v".to_string(),
+            'Г' => "G".to_string(), 'г' => "g".to_string(),
+            'Д' => "D".to_string(), 'д' => "d".to_string(),
+            'Ђ' => "Đ".to_string(), 'ђ' => "đ".to_string(),
+            'Е' => "E".to_string(), 'е' => "e".to_string(),
+            'Ж' => "Ž".to_string(), 'ж' => "ž".to_string(),
+            'З' => "Z".to_string(), 'з' => "z".to_string(),
+            'И' => "I".to_string(), 'и' => "i".to_string(),
+            'Ј' => "J".to_string(), 'ј' => "j".to_string(),
+            'К' => "K".to_string(), 'к' => "k".to_string(),
+            'Л' => "L".to_string(), 'л' => "l".to_string(),
+            'Љ' => "Lj".to_string(), 'љ' => "lj".to_string(),
+            'М' => "M".to_string(), 'м' => "m".to_string(),
+            'Н' => "N".to_string(), 'н' => "n".to_string(),
+            'Њ' => "Nj".to_string(), 'њ' => "nj".to_string(),
+            'О' => "O".to_string(), 'о' => "o".to_string(),
+            'П' => "P".to_string(), 'п' => "p".to_string(),
+            'Р' => "R".to_string(), 'р' => "r".to_string(),
+            'С' => "S".to_string(), 'с' => "s".to_string(),
+            'Т' => "T".to_string(), 'т' => "t".to_string(),
+            'Ћ' => "Ć".to_string(), 'ћ' => "ć".to_string(),
+            'У' => "U".to_string(), 'у' => "u".to_string(),
+            'Ф' => "F".to_string(), 'ф' => "f".to_string(),
+            'Х' => "H".to_string(), 'х' => "h".to_string(),
+            'Ц' => "C".to_string(), 'ц' => "c".to_string(),
+            'Ч' => "Č".to_string(), 'ч' => "č".to_string(),
+            'Џ' => "Dž".to_string(), 'џ' => "dž".to_string(),
+            'Ш' => "Š".to_string(), 'ш' => "š".to_string(),
+
+            'Й' => "Y".to_string(), 'й' => "y".to_string(),
+            'Ъ' => "Ǎ".to_string(), 'ъ' => "ǎ".to_string(),
+            'Ь' => "".to_string(), 'ь' => "".to_string(),
+            'Ю' => "Yu".to_string(), 'ю' => "yu".to_string(),
+            'Я' => "Ya".to_string(), 'я' => "ya".to_string(),
+            'Щ' => "Šy".to_string(), 'щ' => "šy".to_string(),
+            _ => ch.to_string(),
+        };
+        out.push_str(&latin);
+    }
+    out
+}
+
+pub fn latin_to_cyrillic(text: &str) -> String {
+    let mut out = String::new();
+    let mut chars = text.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        let mapped = match (ch, chars.peek()) {
+            // Serbian digraphs
+            ('n', Some('j')) => { chars.next(); "њ".to_string() }
+            ('N', Some('j')) => { chars.next(); "Њ".to_string() }
+            ('l', Some('j')) => { chars.next(); "љ".to_string() }
+            ('L', Some('j')) => { chars.next(); "Љ".to_string() }
+            ('d', Some('ž')) => { chars.next(); "џ".to_string() }
+            ('D', Some('ž')) => { chars.next(); "Џ".to_string() }
+
+            ('Y', Some('u')) => { chars.next(); "Ю".to_string() }
+            ('y', Some('u')) => { chars.next(); "ю".to_string() }
+            ('Y', Some('a')) => { chars.next(); "Я".to_string() }
+            ('y', Some('a')) => { chars.next(); "я".to_string() }
+            ('Š', Some('y')) => { chars.next(); "Щ".to_string() }
+            ('š', Some('y')) => { chars.next(); "щ".to_string() }
+
+            // Serbian single letters
+            ('a', _) => "а".to_string(), ('A', _) => "А".to_string(),
+            ('b', _) => "б".to_string(), ('B', _) => "Б".to_string(),
+            ('v', _) => "в".to_string(), ('V', _) => "В".to_string(),
+            ('g', _) => "г".to_string(), ('G', _) => "Г".to_string(),
+            ('d', _) => "д".to_string(), ('D', _) => "Д".to_string(),
+            ('đ', _) => "ђ".to_string(), ('Đ', _) => "Ђ".to_string(),
+            ('e', _) => "е".to_string(), ('E', _) => "Е".to_string(),
+            ('ž', _) => "ж".to_string(), ('Ž', _) => "Ж".to_string(),
+            ('z', _) => "з".to_string(), ('Z', _) => "З".to_string(),
+            ('i', _) => "и".to_string(), ('I', _) => "И".to_string(),
+            ('j', _) => "ј".to_string(), ('J', _) => "Ј".to_string(),
+            ('k', _) => "к".to_string(), ('K', _) => "К".to_string(),
+            ('l', _) => "л".to_string(), ('L', _) => "Л".to_string(),
+            ('m', _) => "м".to_string(), ('M', _) => "М".to_string(),
+            ('n', _) => "н".to_string(), ('N', _) => "Н".to_string(),
+            ('o', _) => "о".to_string(), ('O', _) => "О".to_string(),
+            ('p', _) => "п".to_string(), ('P', _) => "П".to_string(),
+            ('r', _) => "р".to_string(), ('R', _) => "Р".to_string(),
+            ('s', _) => "с".to_string(), ('S', _) => "С".to_string(),
+            ('t', _) => "т".to_string(), ('T', _) => "Т".to_string(),
+            ('ć', _) => "ћ".to_string(), ('Ć', _) => "Ћ".to_string(),
+            ('u', _) => "у".to_string(), ('U', _) => "У".to_string(),
+            ('f', _) => "ф".to_string(), ('F', _) => "Ф".to_string(),
+            ('h', _) => "х".to_string(), ('H', _) => "Х".to_string(),
+            ('c', _) => "ц".to_string(), ('C', _) => "Ц".to_string(),
+            ('č', _) => "ч".to_string(), ('Č', _) => "Ч".to_string(),
+            ('š', _) => "ш".to_string(), ('Š', _) => "Ш".to_string(),
+
+            ('Y', _) => "Й".to_string(), ('y', _) => "й".to_string(),
+            ('Ǎ', _) => "Ъ".to_string(), ('ǎ', _) => "ъ".to_string(),
+            // fallback: keep original
+            _ => ch.to_string(),
+        };
+        out.push_str(&mapped);
+    }
+    out
+}
+
+
+
+impl Normalizer for CyrillicNormalizer {
+    fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
+        let re = Regex::new(r"\s?\p{Cyrillic}[^\p{Latin}]*").unwrap();
+        let text = normalized.get().to_string();
+        let new_text = re.replace_all(&text, |caps: &regex::Captures| {
+            let latin = cyrillic_to_latin(&caps[0]);
+            format!("<cyr>{}</cyr>", &latin)
+        }).to_string();
+        let cleanup = Regex::new(r"(\s+)</cyr>").unwrap();
+        let clean_text = cleanup.replace_all(&new_text, |caps: &regex::Captures| {
+            format!("</cyr>{}", &caps[1])
+        }).to_string();
+        *normalized = NormalizedString::from(clean_text);
+        Ok(())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokenizer::NormalizedString;
+
+    #[test]
+    fn test_cyrillic_normalizer() {
+        let original = "1. Hej жабо, Поздрављам те Я, dobri svete, iz године 2029-те.";
+        let expected = "1. Hej<cyr> žabo, Pozdravljam te Ya,</cyr> dobri svete, iz<cyr> godine 2029-te.</cyr>";
+        let mut ns = NormalizedString::from(original);
+        let normalizer = CyrillicNormalizer::new();
+        normalizer.normalize(&mut ns).unwrap();
+        assert_eq!(ns.get(), expected);
+    }
+}

--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -6,6 +6,7 @@ pub mod replace;
 pub mod strip;
 pub mod unicode;
 pub mod utils;
+pub mod cyrillic; 
 pub use crate::normalizers::bert::BertNormalizer;
 pub use crate::normalizers::byte_level::ByteLevel;
 pub use crate::normalizers::precompiled::Precompiled;
@@ -14,6 +15,7 @@ pub use crate::normalizers::replace::Replace;
 pub use crate::normalizers::strip::{Strip, StripAccents};
 pub use crate::normalizers::unicode::{Nmt, NFC, NFD, NFKC, NFKD};
 pub use crate::normalizers::utils::{Lowercase, Sequence};
+pub use crate::normalizers::cyrillic::CyrillicNormalizer;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{NormalizedString, Normalizer};


### PR DESCRIPTION
This PR adds a Cyrillic normalizer and a Cyrillic decoder, ensuring both way transliteration between Latin and Cyrillic scripts.

Normalizer detects Cyrillic text using regex, transliterate it into latin and encloses is between <cyr>...</cyr> tags. This way, the model does not need to learn the same token twice, in both Cyrillic and Latin, and treats them as equal. 

Decoder is used to produce cyrillic output, when necessary. It uses the same logic, but in reverse, locates text enclosed between <cyr>...</cyr> tags and transliterate it back to Cyrillic.

Transliteration is performed using character (or bigram) level mapping. Currently these mappings are set for South Slavic languages (Serbian, Montenegrin, Macedonian, Bulgarian). Serbian and Montenegrin are natively digraphic with defined equivalents.

Examples of usage:

Training data > In Cyrillic žaba is written as жаба.
What the model sees during training >  In Cyrillic žaba is written as<cyr> žaba<cyr>.

Input > Translitarate Baba to Cyrillic
Model sees > Translitarate Baba to Cyrillic
Model outputs > <cyr> Baba<cyr>
Decoder outputs > Баба

Result > Model is learning to transliterate and equalize the text in both scriptures on just a few examples. It only uses latin tokens for training, but can output Cyrillic output if needed.

