### PR TITLE
Add scaling_bench: encode_batch vs worker-pool comparison (#1900)

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -66,6 +66,10 @@ harness = false
 name = "ci_benchmark"
 harness = false
 
+[[bench]]
+name = "scaling_bench"
+harness = false
+
 [dependencies]
 rand = "0.9"
 onig = { version = "6.5.1", default-features = false, optional = true }

--- a/tokenizers/benches/scaling_bench.rs
+++ b/tokenizers/benches/scaling_bench.rs
@@ -1,0 +1,534 @@
+//! Scaling bench for the `encode_batch` vs manual worker-pool comparison
+//! described in https://github.com/huggingface/tokenizers/issues/1900.
+//!
+//! This is a deep-dive benchmark, not a CI watchdog. It is structured as a
+//! standalone binary (with `harness = false`) rather than a criterion bench
+//! because the regression it measures only manifests on machines with many
+//! cores (≥16, ideally ≥64) under realistic batch shapes (large documents,
+//! batch sizes ≥ 1024, hundreds of documents). The default GitHub Actions
+//! `ubuntu-latest` runner has 4 vCPUs, where the asymmetry is small (≤1.2×)
+//! and indistinguishable from noise; running the bench there would not
+//! produce a useful regression signal. Maintainers run this manually on a
+//! large machine; the existing `ci_benchmark.rs::concurrent-4t` group is
+//! the in-CI watchdog.
+//!
+//! Two methods, both via the public Tokenizer API:
+//!
+//! * **`worker-pool`** — explicit `rayon::ThreadPoolBuilder` + `par_iter()`
+//!   over `Tokenizer::encode`. Each `Encoding` is consumed (token count
+//!   read, then dropped) inside the closure, so it is allocated and freed
+//!   on the same worker thread.
+//!
+//! * **`encode-batch`** — stock `Tokenizer::encode_batch` per chunk of
+//!   `--batch-size`. The returned `Vec<Encoding>` is iterated on the main
+//!   thread and dropped there.
+//!
+//! Headline metric: `encode_batch_elapsed / worker_pool_elapsed`. On a
+//! 128-core x86_64 box with glibc, against current `main` (which already
+//! includes the per-thread BPE cache fix from #2028), this is ~2×. After
+//! @sebpop's planned `Encoding`-recycling work lands, it should drop to
+//! ~1×. See https://github.com/stargazerZJ/tokenizers-1900-repro for a
+//! standalone reproducer with drop-site A/B, allocator-swap, and
+//! `MALLOC_ARENA_MAX` experiments separating the contributing effects.
+//!
+//! Two workloads (run by default; pick one with `--workload`):
+//!
+//! * **`random-letters`** — synthesized random a-zA-Z with no whitespace,
+//!   exercising the BPE merge path (low cache hit rate).
+//! * **`repeated-words`** — synthesized short pseudo-words separated by
+//!   spaces, exercising the BPE cache (high cache hit rate).
+//!
+//! The two regimes respond differently to fixes; running only one risks
+//! over-fitting future PRs to one and silently regressing the other.
+//!
+//! Run it:
+//!
+//! ```text
+//! cargo bench --bench scaling_bench --
+//! cargo bench --bench scaling_bench -- --workers 32 --batch-size 1024 --count 1000 --length 8192
+//! cargo bench --bench scaling_bench -- --quick     # small, finishes in < 30s
+//! cargo bench --bench scaling_bench -- --workload repeated-words
+//! cargo bench --bench scaling_bench -- --input data/big.txt    # real corpus
+//! ```
+//!
+//! Allocator caveat: the magnitude of the ratio depends heavily on the
+//! system allocator. On glibc the gap is widest; jemalloc roughly halves it;
+//! mimalloc is workload-dependent. The *direction* of the asymmetry is
+//! stable across allocators — that is the regression signal.
+
+use rayon::prelude::*;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+use tokenizers::Tokenizer;
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/// Default tokenizer (already fetched by `make bench` into `data/`).
+const DEFAULT_TOKENIZER: &str = "data/llama-3-tokenizer.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Method {
+    WorkerPool,
+    EncodeBatch,
+    Both,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Workload {
+    RandomLetters,
+    RepeatedWords,
+    Both,
+}
+
+#[derive(Debug)]
+struct Args {
+    tokenizer: PathBuf,
+    workers: usize,
+    batch_size: usize,
+    count: usize,
+    length: usize,
+    word_vocab_size: usize,
+    word_len: usize,
+    seed: u64,
+    method: Method,
+    workload: Workload,
+    input: Option<PathBuf>,
+}
+
+impl Args {
+    fn defaults() -> Self {
+        Self {
+            tokenizer: PathBuf::from(DEFAULT_TOKENIZER),
+            // 0 = num_cpus (resolved later)
+            workers: 0,
+            batch_size: 1024,
+            count: 500,
+            length: 51200,
+            word_vocab_size: 2048,
+            word_len: 8,
+            seed: 42,
+            method: Method::Both,
+            workload: Workload::Both,
+            input: None,
+        }
+    }
+
+    fn quick() -> Self {
+        Self {
+            count: 100,
+            length: 8192,
+            batch_size: 256,
+            ..Self::defaults()
+        }
+    }
+
+    fn parse() -> Result<Self, String> {
+        // First pass: was --quick passed? If so, start from quick defaults.
+        let raw: Vec<String> = std::env::args().skip(1).collect();
+        let mut args = if raw.iter().any(|a| a == "--quick") {
+            Self::quick()
+        } else {
+            Self::defaults()
+        };
+
+        let mut i = 0;
+        while i < raw.len() {
+            let a = &raw[i];
+            let take_value = |label: &str, i: &mut usize| -> Result<String, String> {
+                *i += 1;
+                raw.get(*i)
+                    .cloned()
+                    .ok_or_else(|| format!("{label} needs a value"))
+            };
+            match a.as_str() {
+                "-h" | "--help" => {
+                    print_help();
+                    std::process::exit(0);
+                }
+                "--quick" => { /* handled above */ }
+                "-t" | "--tokenizer" => {
+                    args.tokenizer = PathBuf::from(take_value("--tokenizer", &mut i)?);
+                }
+                "-w" | "--workers" => {
+                    args.workers = take_value("--workers", &mut i)?
+                        .parse()
+                        .map_err(|e| format!("--workers: {e}"))?;
+                }
+                "-b" | "--batch-size" => {
+                    args.batch_size = take_value("--batch-size", &mut i)?
+                        .parse()
+                        .map_err(|e| format!("--batch-size: {e}"))?;
+                }
+                "--count" => {
+                    args.count = take_value("--count", &mut i)?
+                        .parse()
+                        .map_err(|e| format!("--count: {e}"))?;
+                }
+                "--length" => {
+                    args.length = take_value("--length", &mut i)?
+                        .parse()
+                        .map_err(|e| format!("--length: {e}"))?;
+                }
+                "--word-vocab-size" => {
+                    args.word_vocab_size = take_value("--word-vocab-size", &mut i)?
+                        .parse()
+                        .map_err(|e| format!("--word-vocab-size: {e}"))?;
+                }
+                "--word-len" => {
+                    args.word_len = take_value("--word-len", &mut i)?
+                        .parse()
+                        .map_err(|e| format!("--word-len: {e}"))?;
+                }
+                "--seed" => {
+                    args.seed = take_value("--seed", &mut i)?
+                        .parse()
+                        .map_err(|e| format!("--seed: {e}"))?;
+                }
+                "--method" => {
+                    args.method = match take_value("--method", &mut i)?.as_str() {
+                        "worker-pool" | "worker_pool" => Method::WorkerPool,
+                        "encode-batch" | "encode_batch" => Method::EncodeBatch,
+                        "both" => Method::Both,
+                        other => {
+                            return Err(format!(
+                                "--method: {other:?} (want worker-pool|encode-batch|both)"
+                            ))
+                        }
+                    };
+                }
+                "--workload" => {
+                    args.workload = match take_value("--workload", &mut i)?.as_str() {
+                        "random-letters" | "random_letters" => Workload::RandomLetters,
+                        "repeated-words" | "repeated_words" => Workload::RepeatedWords,
+                        "both" => Workload::Both,
+                        other => {
+                            return Err(format!(
+                                "--workload: {other:?} \
+                                 (want random-letters|repeated-words|both)"
+                            ))
+                        }
+                    };
+                }
+                "--input" => {
+                    args.input = Some(PathBuf::from(take_value("--input", &mut i)?));
+                }
+                // Criterion-compatibility: ignore noise from `cargo bench`.
+                "--bench" | "--test" | "--save-baseline" | "--baseline" => {
+                    if a == "--save-baseline" || a == "--baseline" {
+                        // these take values
+                        let _ = take_value(a, &mut i);
+                    }
+                }
+                other => return Err(format!("unknown argument: {other}")),
+            }
+            i += 1;
+        }
+
+        if args.workers == 0 {
+            args.workers = std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(8);
+        }
+        Ok(args)
+    }
+}
+
+fn print_help() {
+    eprintln!(
+        "scaling_bench — encode_batch vs worker-pool comparison for tokenizers#1900\n\
+         \n\
+         USAGE:\n  \
+           cargo bench --bench scaling_bench -- [OPTIONS]\n\
+         \n\
+         OPTIONS:\n  \
+           -t, --tokenizer <PATH>   Path to tokenizer.json [default: {DEFAULT_TOKENIZER}]\n  \
+           -w, --workers <N>        Worker threads (0 = num_cpus) [default: num_cpus]\n  \
+           -b, --batch-size <N>     Batch size for encode_batch [default: 1024]\n      \
+               --count <N>          Number of synthetic documents [default: 500]\n      \
+               --length <N>         Bytes per synthetic document [default: 51200]\n      \
+               --word-vocab-size <N>  Vocab size (repeated-words workload) [default: 2048]\n      \
+               --word-len <N>       Word length (repeated-words workload) [default: 8]\n      \
+               --seed <N>           PRNG seed [default: 42]\n      \
+               --method <M>         worker-pool|encode-batch|both [default: both]\n      \
+               --workload <W>       random-letters|repeated-words|both [default: both]\n      \
+               --input <PATH>       Use file lines instead of synthetic data\n      \
+               --quick              Smaller defaults (~30s on a many-core box)\n      \
+               --help               Show this help\n\
+         \n\
+         The headline metric is encode_batch_elapsed / worker_pool_elapsed.\n\
+         See https://github.com/huggingface/tokenizers/issues/1900 for context\n\
+         and https://github.com/stargazerZJ/tokenizers-1900-repro for the\n\
+         standalone reproducer with allocator-swap and drop-site experiments."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic data generators
+// ---------------------------------------------------------------------------
+
+fn generate_random_letters(count: usize, length: usize, seed: u64) -> Vec<String> {
+    use rand::{Rng, SeedableRng};
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    eprintln!("[scaling_bench] generating {count} random-letters strings × {length} bytes");
+    (0..count)
+        .map(|_| {
+            (0..length)
+                .map(|_| {
+                    let idx: u8 = rng.random_range(0u8..52);
+                    if idx < 26 {
+                        (b'a' + idx) as char
+                    } else {
+                        (b'A' + idx - 26) as char
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn generate_repeated_words(
+    count: usize,
+    length: usize,
+    seed: u64,
+    vocab_size: usize,
+    word_len: usize,
+) -> Vec<String> {
+    use rand::{Rng, SeedableRng};
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    eprintln!(
+        "[scaling_bench] generating {count} repeated-words strings × {length} bytes \
+         (vocab={vocab_size}, word_len={word_len})"
+    );
+    let vocab: Vec<String> = (0..vocab_size)
+        .map(|_| {
+            (0..word_len)
+                .map(|_| {
+                    let idx: u8 = rng.random_range(0u8..52);
+                    if idx < 26 {
+                        (b'a' + idx) as char
+                    } else {
+                        (b'A' + idx - 26) as char
+                    }
+                })
+                .collect()
+        })
+        .collect();
+
+    (0..count)
+        .map(|_| {
+            let mut s = String::with_capacity(length + word_len + 1);
+            while s.len() < length {
+                if !s.is_empty() {
+                    s.push(' ');
+                }
+                s.push_str(&vocab[rng.random_range(0..vocab.len())]);
+            }
+            s.truncate(length);
+            s
+        })
+        .collect()
+}
+
+fn load_input_file(path: &std::path::Path, target_count: usize) -> Result<Vec<String>, String> {
+    let data = std::fs::read_to_string(path).map_err(|e| format!("read {path:?}: {e}"))?;
+    let lines: Vec<String> = data.lines().map(|s| s.to_string()).collect();
+    if lines.is_empty() {
+        return Err(format!("{path:?}: no lines"));
+    }
+    eprintln!(
+        "[scaling_bench] loaded {} lines from {path:?}; cycling to reach {target_count} docs",
+        lines.len()
+    );
+    Ok((0..target_count)
+        .map(|i| lines[i % lines.len()].clone())
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Stats accumulator
+// ---------------------------------------------------------------------------
+
+struct Stats {
+    docs: AtomicUsize,
+    tokens: AtomicU64,
+    bytes: AtomicU64,
+    start: Instant,
+}
+
+impl Stats {
+    fn new() -> Self {
+        Self {
+            docs: AtomicUsize::new(0),
+            tokens: AtomicU64::new(0),
+            bytes: AtomicU64::new(0),
+            start: Instant::now(),
+        }
+    }
+    fn add(&self, t: usize, b: usize) {
+        self.docs.fetch_add(1, Ordering::Relaxed);
+        self.tokens.fetch_add(t as u64, Ordering::Relaxed);
+        self.bytes.fetch_add(b as u64, Ordering::Relaxed);
+    }
+    fn report(&self, label: &str) -> f64 {
+        let elapsed = self.start.elapsed().as_secs_f64();
+        let d = self.docs.load(Ordering::Relaxed);
+        let t = self.tokens.load(Ordering::Relaxed);
+        let b = self.bytes.load(Ordering::Relaxed) as f64;
+        println!(
+            "[{label}] docs={d} ({:.1}/s) tokens={t} ({:.1}/s) \
+             bytes={:.2}MiB ({:.2}MiB/s) elapsed={:.2}s",
+            d as f64 / elapsed,
+            t as f64 / elapsed,
+            b / (1024.0 * 1024.0),
+            b / (1024.0 * 1024.0) / elapsed,
+            elapsed,
+        );
+        elapsed
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Methods
+// ---------------------------------------------------------------------------
+
+/// Manual rayon worker-pool: encode in parallel, consume + drop each
+/// `Encoding` inside the worker closure (alloc + free on the same thread).
+fn run_worker_pool(
+    tokenizer: &Tokenizer,
+    texts: &[String],
+    num_workers: usize,
+) -> Result<f64, String> {
+    let stats = Stats::new();
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(num_workers)
+        .build()
+        .map_err(|e| format!("rayon pool: {e}"))?;
+
+    pool.install(|| {
+        texts.par_iter().for_each(|text| {
+            if let Ok(enc) = tokenizer.encode(text.as_str(), false) {
+                stats.add(enc.get_ids().len(), text.len());
+                // enc dropped here, on the worker thread that allocated it.
+            }
+        });
+    });
+
+    Ok(stats.report("worker_pool"))
+}
+
+/// Stock `Tokenizer::encode_batch` per chunk; iterate the returned vec on
+/// main and drop there.
+fn run_encode_batch(
+    tokenizer: &Tokenizer,
+    texts: &[String],
+    batch_size: usize,
+) -> Result<f64, String> {
+    let stats = Stats::new();
+    for chunk in texts.chunks(batch_size) {
+        let inputs: Vec<&str> = chunk.iter().map(|s| s.as_str()).collect();
+        let encs = tokenizer
+            .encode_batch(inputs, false)
+            .map_err(|e| format!("encode_batch: {e}"))?;
+        for (i, e) in encs.iter().enumerate() {
+            stats.add(e.get_ids().len(), chunk[i].len());
+        }
+        // encs drops here, on main; this is the cross-thread free site.
+    }
+    Ok(stats.report("encode_batch"))
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+fn run_workload(
+    label: &str,
+    args: &Args,
+    tokenizer: &Tokenizer,
+    texts: &[String],
+) -> Result<(), String> {
+    println!("\n=== workload: {label} ===");
+    let mut wp: Option<f64> = None;
+    let mut eb: Option<f64> = None;
+
+    if matches!(args.method, Method::WorkerPool | Method::Both) {
+        wp = Some(run_worker_pool(tokenizer, texts, args.workers)?);
+    }
+    if matches!(args.method, Method::EncodeBatch | Method::Both) {
+        eb = Some(run_encode_batch(tokenizer, texts, args.batch_size)?);
+    }
+
+    if let (Some(wp), Some(eb)) = (wp, eb) {
+        println!(
+            "[ratio:{label}] encode_batch / worker_pool = {:.2}× \
+             ({eb:.2}s / {wp:.2}s)",
+            eb / wp,
+        );
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), String> {
+    let args = Args::parse().map_err(|e| {
+        eprintln!("{e}\n");
+        print_help();
+        e
+    })?;
+
+    println!(
+        "[scaling_bench] tokenizer={:?} workers={} batch_size={} count={} length={} method={:?} workload={:?}",
+        args.tokenizer, args.workers, args.batch_size, args.count, args.length, args.method, args.workload,
+    );
+    if !args.tokenizer.exists() {
+        return Err(format!(
+            "tokenizer file not found: {:?}\n\
+             Run `make bench` from the tokenizers/ directory to fetch it, \
+             or pass --tokenizer <path>.",
+            args.tokenizer
+        ));
+    }
+
+    let tokenizer =
+        Tokenizer::from_file(&args.tokenizer).map_err(|e| format!("load tokenizer: {e}"))?;
+    let tokenizer = Arc::new(tokenizer);
+
+    let workloads: &[Workload] = match args.workload {
+        Workload::Both => &[Workload::RandomLetters, Workload::RepeatedWords],
+        single => std::slice::from_ref(match &single {
+            Workload::RandomLetters => &Workload::RandomLetters,
+            Workload::RepeatedWords => &Workload::RepeatedWords,
+            Workload::Both => unreachable!(),
+        }),
+    };
+
+    for &w in workloads {
+        let (label, texts) = match (w, &args.input) {
+            (_, Some(path)) => ("input-file", load_input_file(path, args.count)?),
+            (Workload::RandomLetters, _) => (
+                "random-letters",
+                generate_random_letters(args.count, args.length, args.seed),
+            ),
+            (Workload::RepeatedWords, _) => (
+                "repeated-words",
+                generate_repeated_words(
+                    args.count,
+                    args.length,
+                    args.seed,
+                    args.word_vocab_size,
+                    args.word_len,
+                ),
+            ),
+            (Workload::Both, _) => unreachable!(),
+        };
+        run_workload(label, &args, &tokenizer, &texts)?;
+        // If --input is set, the workload distinction is moot — only run once.
+        if args.input.is_some() {
+            break;
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds `tokenizers/benches/scaling_bench.rs`, a standalone-binary benchmark (`harness = false`) that compares the two parallel-tokenization API shapes a real user can write today, on the same data, in the same process, and reports the ratio of their wall times.

Scope: a single new file; one new `[[bench]]` entry in `tokenizers/Cargo.toml`. No new dependencies, no CI changes, no library changes.

This is a **deep-dive benchmark for maintainers and contributors**, not a CI gate. The regression it measures only manifests at scale (≥16 cores, large documents, large batches); GitHub Actions' `ubuntu-latest` runner has 4 vCPUs and cannot reproduce it. The existing `ci_benchmark.rs` `concurrent-4t` group remains the in-CI watchdog; this bench complements it for the cases where 4-thread, ~80 KB total data isn't enough to expose the scaling problem.

## Background

Issue #1900 reports that `Tokenizer::encode_batch` is several times slower than a manual `rayon::ThreadPoolBuilder` + `par_iter()` over `Tokenizer::encode` on many-core x86_64. PRs #2028 (merged) and #2029 (open) move the needle but don't close the gap on a 128-core dual-socket Xeon 8375C.  A standalone reproducer with full numerical findings — including drop-site A/B isolation, allocator-swap experiments (jemalloc/mimalloc), `MALLOC_ARENA_MAX` sweep, and futex/syscall counts — lives at https://github.com/stargazerZJ/tokenizers-1900-repro.

This PR brings the *core* comparison in-tree as a permanent reference for contributors working on the parallel-encode path, leaving the diagnostic surface area (allocator swaps, drop-site A/B, etc.) in the standalone repo where it belongs.

## What the bench measures

Two `--method` values, both run on the same generated input via the public `Tokenizer` API only:

- **`worker-pool`**: explicit `rayon::ThreadPoolBuilder::new().num_threads(W).build()`, then `pool.install(|| texts.par_iter().for_each(|t| { let enc = tok.encode(t, false)?; consume(enc) }))`.  Each `Encoding` is consumed (token count read, then dropped) inside the closure, so it is allocated and freed on the same worker thread. This is the natural shape for Rust users calling into `tokenizers` directly — work on each doc in a parallel closure and never ship the `Encoding`s across threads.

- **`encode-batch`**: stock `Tokenizer::encode_batch(texts, false)` per chunk of `--batch-size`, returning `Vec<Encoding>` to the caller. The caller iterates the returned vec on the main thread and drops there.

Reported metric: **`encode_batch_elapsed / worker_pool_elapsed`**. On a 128-core x86_64 box with glibc, against current `main`, this ratio is ~2-3×. After @sebpop's planned `Encoding`-recycling fix it should drop to ≈ 1.0.

Two synthesized workloads, both run by default:

- **`random-letters`** — random a-zA-Z, no whitespace. Essentially no BPE cache hits; exercises the encode hot path.
- **`repeated-words`** — short pseudo-words separated by spaces. Cache fires aggressively; exercises the cache + memory-pressure path.

The two regimes respond very differently to fixes; running only one risks over-fitting future PRs to one and silently regressing the other.  `--input <file>` overrides the synthesized data with a real corpus (e.g. `data/big.txt`) for ad-hoc experiments.

## Why standalone, not criterion?

The other benches in `tokenizers/benches/` are criterion-based, including the consolidated `ci_benchmark.rs` that the `benchmarks.yml` workflow runs.  Two reasons this bench is structurally different:

1. **Scale.** The regression doesn't manifest below ~16 cores; the benchmarks workflow runs on `ubuntu-latest` (4 vCPUs). On a 4-core box, the ratio is ≤ 1.2× and indistinguishable from noise. A criterion bench wired into `ci_benchmark.rs` would either no-op (useless watchdog) or produce noise. There is no "small N that exposes the regression" — it's a function of contention on the destination thread's allocator arena and scales with worker count.

2. **Iteration shape.** Each bench iteration here is a whole batch — many thousands of `encode` calls — taking tens of seconds at realistic sizes.  Criterion's sampling model expects much shorter iterations; while `sample_size(10)` can paper over this, it costs both wall time and statistical interpretability. A standalone binary measures one full run with knobs the user controls.

The bench therefore lives next to the criterion benches but uses `harness = false`, prints its own summary, and is invoked manually via `cargo bench --bench scaling_bench --`. This matches `harness = false` precedent already established for every other bench in the directory; only the omission of criterion is new.

## A note on "fair comparison"

A reviewer might reasonably ask: shouldn't both methods do the same thing to the `Encoding`s — e.g. both should return a `Vec<Encoding>` to the caller — to be a "fair" comparison?

We deliberately don't, for two reasons:

1. **The bench measures user-visible cost of the `encode_batch` API shape**, not algorithmic equivalence between two synthetic shapes. `encode_batch` is what every Python caller (including `transformers`) routes to, because that's the shape the Python binding exposes ergonomically — and it's also what Rust users reach for when they want "give me back a `Vec<Encoding>` I can iterate." The worker-pool shape is what Rust users write directly when they want per-doc parallel work without the cross-thread hand-off — the shape this issue's original reporter and reviewer both reached for in #1900. Forcing the worker-pool variant to also collect into `Vec<Encoding>` would measure something nobody invokes and would *hide* the very asymmetry the bench exists to expose — an asymmetry that every Python caller of `encode_batch` pays today whether they know it or not.

2. **The local drop is the cause of the cheap path, not a benchmarking gimmick.** This was confirmed experimentally in the standalone reproducer (drop-site A/B, see https://github.com/stargazerZJ/tokenizers-1900-repro/blob/main/REPORT.md): the same scope/queue shape as `encode_batch`, but with each `Encoding` dropped on the worker that allocated it, takes essentially the same time as `worker-pool`. The asymmetry the bench measures *is* the cost of the API choice.

The headline ratio is therefore "how much more does the `encode_batch` path cost, today, than the cheap worker-pool path would on the same work." Python callers and Rust users routing through `encode_batch` pay this cost; Rust users who write the manual worker-pool shape don't. Once `Encoding` recycling lands the ratio collapses to ~1× and the bench's job becomes documenting the equalized state.

## Allocator caveat

Numbers vary across allocators. On glibc the gap is widest; jemalloc roughly halves it on the cache-friendly workload; mimalloc is workload-dependent.  The bench is documented as glibc-default; the *direction* of the ratio is what carries the regression signal, not the absolute magnitude.

## Knobs (CLI)

`--workers <N>`, `--batch-size <N>` (default 1024),
`--count <N>` (default 500), `--length <N>` (default 51200),
`--workload random-letters|repeated-words|both` (default both),
`--method worker-pool|encode-batch|both` (default both),
`--tokenizer <path>` (default `data/llama-3-tokenizer.json`),
`--input <path>` (real-corpus override),
`--quick` (small enough to run in seconds on any machine; will not produce
a meaningful ratio on small machines but verifies the bench compiles and
runs).

Argument parsing is hand-rolled — no new dependency on `clap`.

## Reference numbers

128-core dual-socket Xeon 8375C, glibc 2.35, current `main` (commit `22d54d37`, which already includes the per-thread BPE cache fix from #2028), `--workers 32 --batch-size 1024 --count 500 --length 51200`:

| Workload         | worker_pool | encode_batch | ratio  |
|------------------|-------------|--------------|--------|
| random-letters   | 0.27 s      | 0.59 s       | 2.18×  |
| repeated-words   | 0.36 s      | 0.78 s       | 2.15×  |

Numbers from a single run on the author's hardware, included for calibration only — your numbers will differ; the *shape* of the asymmetry is what the bench guards against, not the absolute magnitude.

## What's left to close the gap

Two fixes are still in flight:

1. **#2029 (open)** — persistent-barrier worker pool, targeting the per-`rayon::scope` wake/sleep cost (sebpop's "claim 1" in his [2026-04-27 comment on #1900](https://github.com/huggingface/tokenizers/issues/1900)).
2. **`Encoding` recycling** — a planned follow-up from @sebpop targeting cross-thread free of `Encoding` on the main thread's destructor sweep (sebpop's "claim 2").

The standalone reproducer at https://github.com/stargazerZJ/tokenizers-1900-repro experimentally separates the two effects (drop-site A/B, full numbers in its REPORT.md): at the batch sizes this bench measures (`-b 1024` and up), **cross-thread free is the dominant cost** and the per-scope wake/sleep cost is second-order. #2029 alone is therefore not expected to materially move this bench; the recycling work is what brings the ratio to ~1×. Both should land for the in-tree reference to converge.

## Open questions for the maintainers

1. **Tokenizer file.** Default is `data/llama-3-tokenizer.json` (already wired up by `make bench`). Happy to switch to `gpt2-vocab.json` / `bert-base-uncased-vocab.txt` if you prefer; the tokenizer choice does not affect whether the asymmetry shows up.
2. **Documentation placement.** Top-of-file doc comment links #1900, #2028, #2029, the standalone repo, and `ci_benchmark.rs`'s `concurrent-4t` group. Happy to also add a section to `CONTRIBUTING.md` under the "benchmarks" subsection if you'd like a pointer.
3. **`Makefile` integration.** `make bench` runs `cargo bench` (no args), which currently runs every bench file. Since `scaling_bench` is manual-run-only and produces ~tens of seconds of output even on a 4-core box, should I either (a) gate it behind an env var so `make bench` skips it, or (b) leave as-is and let users opt in via `cargo bench --bench scaling_bench`? Currently as-is.

## Files

- `tokenizers/benches/scaling_bench.rs` (new, ~530 lines including doc comments)
- `tokenizers/Cargo.toml` (4-line addition: new `[[bench]]` entry)

## Test plan

- [x] `cargo build --release --bench scaling_bench` succeeds.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt -- ./benches/scaling_bench.rs --check` clean.
- [x] `cargo bench --bench scaling_bench -- --quick` runs end-to-end on a
      128-core box (~1s).
- [x] `cargo bench --bench scaling_bench --` (full default) runs
      end-to-end and reports a ratio in the expected direction.
- [ ] Verified by a maintainer on a smaller box (e.g. an 8-core dev
      laptop) that `--quick` runs cleanly and the bench compiles.

This PR by itself is a watchdog/reference, not the fix. The companion fix is @sebpop's `Encoding`-recycling work, planned as a separate PR.
Closes #1900 only after that fix lands and ratios drop to ≈ 1×.
