### PR TITLE
Add encode_byte_offsets methods for byte-level alignment

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `encode_byte_offsets()` method for single sequence encoding with byte-level offsets
+- Added `encode_batch_byte_offsets()` method for batch encoding with byte-level offsets
+- These methods enable byte-level offset computation useful for cross-tokenizer alignment
+
 ## [0.13.2] 
 
 - [#1096] Python 3.11 support
@@ -510,3 +518,4 @@ delimiter (Works like `.split(delimiter)`)
 [#134]: https://github.com/huggingface/tokenizers/issues/134
 [#131]: https://github.com/huggingface/tokenizers/issues/131
 [#99]: https://github.com/huggingface/tokenizers/pull/99
+[#XXXX]: https://github.com/huggingface/tokenizers/pull/XXXX

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -6,8 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
 - [#2049] Added `encode_byte_offsets()` and `encode_batch_byte_offsets()` methods returning byte-level offsets, enabling cross-tokenizer alignment without repeated `decode()` calls
 
 ## [0.13.2] 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,9 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `encode_byte_offsets()` method for single sequence encoding with byte-level offsets
-- Added `encode_batch_byte_offsets()` method for batch encoding with byte-level offsets
-- These methods enable byte-level offset computation useful for cross-tokenizer alignment
+- [#2049] Added `encode_byte_offsets()` and `encode_batch_byte_offsets()` methods returning byte-level offsets, enabling cross-tokenizer alignment without repeated `decode()` calls
 
 ## [0.13.2] 
 
@@ -401,6 +399,7 @@ delimiter (Works like `.split(delimiter)`)
 - Fix a bug with the IDs associated with added tokens.
 - Fix a bug that was causing crashes in Python 3.5
 
+[#2049]: https://github.com/huggingface/tokenizers/pull/2049
 [#1096]: https://github.com/huggingface/tokenizers/pull/1096
 [#1072]: https://github.com/huggingface/tokenizers/pull/1072
 [#956]: https://github.com/huggingface/tokenizers/pull/956
@@ -518,4 +517,3 @@ delimiter (Works like `.split(delimiter)`)
 [#134]: https://github.com/huggingface/tokenizers/issues/134
 [#131]: https://github.com/huggingface/tokenizers/issues/131
 [#99]: https://github.com/huggingface/tokenizers/pull/99
-[#XXXX]: https://github.com/huggingface/tokenizers/pull/XXXX

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -1001,6 +1001,107 @@ class Tokenizer:
         Returns:
             A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
         """
+    def encode_byte_offsets(
+        self, /, sequence: Any, pair: Any | None = None, is_pretokenized: bool = False, add_special_tokens: bool = True
+    ) -> "Encoding":
+        """
+        Encode the given sequence and pair, using byte-level offsets.
+
+        Example:
+            Here are some examples of the inputs that are accepted::
+
+                encode_byte_offsets("A single sequence")`
+                encode_byte_offsets("A sequence", "And its pair")`
+
+        Args:
+            sequence (:obj:`~tokenizers.InputSequence`):
+                The main input sequence we want to encode. This sequence can be either raw
+                text or pre-tokenized, according to the ``is_pretokenized`` argument:
+
+                - If ``is_pretokenized=False``: :class:`~tokenizers.TextInputSequence`
+                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedInputSequence`
+
+            pair (:obj:`~tokenizers.InputSequence`, `optional`):
+                An optional input sequence. The expected format is the same that for ``sequence``.
+
+            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+                Whether the input is already pre-tokenized
+
+            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+                Whether to add the special tokens
+
+        Returns:
+            :class:`~tokenizers.Encoding`: The encoded result with byte-level offsets
+        """
+    def encode_batch(
+        self, /, input: Sequence[Any], is_pretokenized: bool = False, add_special_tokens: bool = True
+    ) -> "list[Encoding]":
+        """
+        Encode the given batch of inputs. This method accept both raw text sequences
+        as well as already pre-tokenized sequences. The reason we use `PySequence` is
+        because it allows type checking with zero-cost (according to PyO3) as we don't
+        have to convert to check.
+
+        Example:
+            Here are some examples of the inputs that are accepted::
+
+                encode_batch([
+                    "A single sequence",
+                    ("A tuple with a sequence", "And its pair"),
+                    [ "A", "pre", "tokenized", "sequence" ],
+                    ([ "A", "pre", "tokenized", "sequence" ], "And its pair")
+                ])
+
+        Args:
+            input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
+                A list of single sequences or pair sequences to encode. Each sequence
+                can be either raw text or pre-tokenized, according to the ``is_pretokenized``
+                argument:
+
+                - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
+                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
+
+            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+                Whether the input is already pre-tokenized
+
+            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+                Whether to add the special tokens
+
+        Returns:
+            A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
+        """
+    def encode_batch_byte_offsets(
+        self, /, input: Sequence[Any], is_pretokenized: bool = False, add_special_tokens: bool = True
+    ) -> "list[Encoding]":
+        """
+        Encode the given batch of inputs, using byte-level offsets.
+
+        Example:
+            Here are some examples of the inputs that are accepted::
+
+                encode_batch_byte_offsets([
+                    "A single sequence",
+                    ("A tuple with a sequence", "And its pair"),
+                ])
+
+        Args:
+            input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
+                A list of single sequences or pair sequences to encode. Each sequence
+                can be either raw text or pre-tokenized, according to the ``is_pretokenized``
+                argument:
+
+                - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
+                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
+
+            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+                Whether the input is already pre-tokenized
+
+            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+                Whether to add the special tokens
+
+        Returns:
+            A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch with byte-level offsets
+        """
     def encode_batch_fast(
         self, /, input: Sequence[Any], is_pretokenized: bool = False, add_special_tokens: bool = True
     ) -> "list[Encoding]":

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -1005,13 +1005,33 @@ class Tokenizer:
         self, /, sequence: Any, pair: Any | None = None, is_pretokenized: bool = False, add_special_tokens: bool = True
     ) -> "Encoding":
         """
-        Encode the given sequence and pair, using byte-level offsets.
+        Encode the given sequence and pair, returning UTF-8 byte offsets.
+
+        Identical to :meth:`encode` except that each token's offsets are byte indices
+        into the input string (rather than character/codepoint indices). This matters
+        whenever a token's content includes multi-byte UTF-8 characters: byte offsets
+        give consecutive non-overlapping ranges suitable for cross-tokenizer alignment,
+        while character offsets collapse split bytes onto the same character index.
 
         Example:
-            Here are some examples of the inputs that are accepted::
+            For an input ``"café"`` (4 chars, 5 UTF-8 bytes — ``é`` = ``0xC3 0xA9``)
+            tokenized as a single token, the offsets returned by the two methods
+            differ::
 
-                encode_byte_offsets("A single sequence")
-                encode_byte_offsets("A sequence", "And its pair")
+                >>> tokenizer.encode("café").offsets
+                [(0, 4)]
+                >>> tokenizer.encode_byte_offsets("café").offsets
+                [(0, 5)]
+
+            With a byte-level tokenizer that splits ``café`` into 5 byte-level
+            tokens, the last two tokens originate from the single character ``é``
+            so their source span differs between the two modes — char offsets
+            report the 1-codepoint span, byte offsets report the 2-byte span::
+
+                >>> tokenizer.encode("café").offsets
+                [(0, 1), (1, 2), (2, 3), (3, 4), (3, 4)]
+                >>> tokenizer.encode_byte_offsets("café").offsets
+                [(0, 1), (1, 2), (2, 3), (3, 5), (3, 5)]
 
         Args:
             sequence (:obj:`~tokenizers.InputSequence`):
@@ -1037,7 +1057,12 @@ class Tokenizer:
         self, /, input: Sequence[Any], is_pretokenized: bool = False, add_special_tokens: bool = True
     ) -> "list[Encoding]":
         """
-        Encode the given batch of inputs, using byte-level offsets.
+        Encode the given batch of inputs, returning UTF-8 byte offsets.
+
+        Identical to :meth:`encode_batch` except that each token's offsets are byte
+        indices into the input string (rather than character/codepoint indices). See
+        :meth:`encode_byte_offsets` for the byte-vs-character offset semantics on a
+        concrete ``café`` example.
 
         Example:
             Here are some examples of the inputs that are accepted::

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -1033,43 +1033,6 @@ class Tokenizer:
         Returns:
             :class:`~tokenizers.Encoding`: The encoded result with byte-level offsets
         """
-    def encode_batch(
-        self, /, input: Sequence[Any], is_pretokenized: bool = False, add_special_tokens: bool = True
-    ) -> "list[Encoding]":
-        """
-        Encode the given batch of inputs. This method accept both raw text sequences
-        as well as already pre-tokenized sequences. The reason we use `PySequence` is
-        because it allows type checking with zero-cost (according to PyO3) as we don't
-        have to convert to check.
-
-        Example:
-            Here are some examples of the inputs that are accepted::
-
-                encode_batch([
-                    "A single sequence",
-                    ("A tuple with a sequence", "And its pair"),
-                    [ "A", "pre", "tokenized", "sequence" ],
-                    ([ "A", "pre", "tokenized", "sequence" ], "And its pair")
-                ])
-
-        Args:
-            input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
-                A list of single sequences or pair sequences to encode. Each sequence
-                can be either raw text or pre-tokenized, according to the ``is_pretokenized``
-                argument:
-
-                - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
-                - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
-
-            is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
-                Whether the input is already pre-tokenized
-
-            add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
-                Whether to add the special tokens
-
-        Returns:
-            A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch
-        """
     def encode_batch_byte_offsets(
         self, /, input: Sequence[Any], is_pretokenized: bool = False, add_special_tokens: bool = True
     ) -> "list[Encoding]":

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -1010,8 +1010,8 @@ class Tokenizer:
         Example:
             Here are some examples of the inputs that are accepted::
 
-                encode_byte_offsets("A single sequence")`
-                encode_byte_offsets("A sequence", "And its pair")`
+                encode_byte_offsets("A single sequence")
+                encode_byte_offsets("A sequence", "And its pair")
 
         Args:
             sequence (:obj:`~tokenizers.InputSequence`):

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1220,8 +1220,8 @@ impl PyTokenizer {
     /// Example:
     ///     Here are some examples of the inputs that are accepted::
     ///
-    ///         encode_byte_offsets("A single sequence")`
-    ///         encode_byte_offsets("A sequence", "And its pair")`
+    ///         encode_byte_offsets("A single sequence")
+    ///         encode_byte_offsets("A sequence", "And its pair")
     ///
     /// Args:
     ///     sequence (:obj:`~tokenizers.InputSequence`):

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1213,6 +1213,74 @@ impl PyTokenizer {
         .into()
     }
 
+    /// Encode the given sequence and pair, using byte-level offsets.
+    ///
+    /// This method can process raw text sequences as well as already pre-tokenized sequences.
+    ///
+    /// Example:
+    ///     Here are some examples of the inputs that are accepted::
+    ///
+    ///         encode_byte_offsets("A single sequence")`
+    ///         encode_byte_offsets("A sequence", "And its pair")`
+    ///
+    /// Args:
+    ///     sequence (:obj:`~tokenizers.InputSequence`):
+    ///         The main input sequence we want to encode. This sequence can be either raw
+    ///         text or pre-tokenized, according to the ``is_pretokenized`` argument:
+    ///
+    ///         - If ``is_pretokenized=False``: :class:`~tokenizers.TextInputSequence`
+    ///         - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedInputSequence`
+    ///
+    ///     pair (:obj:`~tokenizers.InputSequence`, `optional`):
+    ///         An optional input sequence. The expected format is the same that for ``sequence``.
+    ///
+    ///     is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+    ///         Whether the input is already pre-tokenized
+    ///
+    ///     add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+    ///         Whether to add the special tokens
+    ///
+    /// Returns:
+    ///     :class:`~tokenizers.Encoding`: The encoded result with byte-level offsets
+    ///
+    #[pyo3(signature = (sequence, pair = None, is_pretokenized = false, add_special_tokens = true) -> "Encoding")]
+    #[pyo3(
+        text_signature = "(self, sequence, pair=None, is_pretokenized=False, add_special_tokens=True)"
+    )]
+    fn encode_byte_offsets(
+        &self,
+        sequence: &Bound<'_, PyAny>,
+        pair: Option<&Bound<'_, PyAny>>,
+        is_pretokenized: bool,
+        add_special_tokens: bool,
+    ) -> PyResult<PyEncoding> {
+        let sequence: tk::InputSequence = if is_pretokenized {
+            sequence.extract::<PreTokenizedInputSequence>()?.into()
+        } else {
+            sequence.extract::<TextInputSequence>()?.into()
+        };
+        let input = match pair {
+            Some(pair) => {
+                let pair: tk::InputSequence = if is_pretokenized {
+                    pair.extract::<PreTokenizedInputSequence>()?.into()
+                } else {
+                    pair.extract::<TextInputSequence>()?.into()
+                };
+                tk::EncodeInput::Dual(sequence, pair)
+            }
+            None => tk::EncodeInput::Single(sequence),
+        };
+
+        ToPyResult(
+            self.tokenizer
+                .read()
+                .unwrap()
+                .encode(input, add_special_tokens)
+                .map(|e| e.into()),
+        )
+        .into()
+    }
+
     /// Asynchronously encode the given input with character offsets.
     ///
     /// This is an async version of encode that can be awaited in async Python code.
@@ -1331,6 +1399,66 @@ impl PyTokenizer {
                     .read()
                     .unwrap()
                     .encode_batch_char_offsets(items, add_special_tokens)
+                    .map(|encodings| encodings.into_iter().map(|e| e.into()).collect()),
+            )
+            .into()
+        })
+    }
+
+    /// Encode the given batch of inputs, using byte-level offsets.
+    ///
+    /// This method accept both raw text sequences as well as already pre-tokenized sequences.
+    ///
+    /// Example:
+    ///     Here are some examples of the inputs that are accepted::
+    ///
+    ///         encode_batch_byte_offsets([
+    ///             "A single sequence",
+    ///             ("A tuple with a sequence", "And its pair"),
+    ///         ])
+    ///
+    /// Args:
+    ///     input (A :obj:`List`/:obj:`Tuple` of :obj:`~tokenizers.EncodeInput`):
+    ///         A list of single sequences or pair sequences to encode. Each sequence
+    ///         can be either raw text or pre-tokenized, according to the ``is_pretokenized``
+    ///         argument:
+    ///
+    ///         - If ``is_pretokenized=False``: :class:`~tokenizers.TextEncodeInput`
+    ///         - If ``is_pretokenized=True``: :class:`~tokenizers.PreTokenizedEncodeInput`
+    ///
+    ///     is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
+    ///         Whether the input is already pre-tokenized
+    ///
+    ///     add_special_tokens (:obj:`bool`, defaults to :obj:`True`):
+    ///         Whether to add the special tokens
+    ///
+    /// Returns:
+    ///     A :obj:`List` of :class:`~tokenizers.Encoding`: The encoded batch with byte-level offsets
+    ///
+    #[pyo3(signature = (input, is_pretokenized = false, add_special_tokens = true) -> "list[Encoding]")]
+    #[pyo3(text_signature = "(self, input, is_pretokenized=False, add_special_tokens=True)")]
+    fn encode_batch_byte_offsets(
+        &self,
+        py: Python<'_>,
+        input: Vec<Bound<'_, PyAny>>,
+        is_pretokenized: bool,
+        add_special_tokens: bool,
+    ) -> PyResult<Vec<PyEncoding>> {
+        let mut items = Vec::<tk::EncodeInput>::with_capacity(input.len());
+        for item in &input {
+            let item: tk::EncodeInput = if is_pretokenized {
+                item.extract::<PreTokenizedEncodeInput>()?.into()
+            } else {
+                item.extract::<TextEncodeInput>()?.into()
+            };
+            items.push(item);
+        }
+        py.detach(|| {
+            ToPyResult(
+                self.tokenizer
+                    .read()
+                    .unwrap()
+                    .encode_batch(items, add_special_tokens)
                     .map(|encodings| encodings.into_iter().map(|e| e.into()).collect()),
             )
             .into()

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -646,6 +646,46 @@ impl PyTokenizer {
         Ok(out)
     }
 
+    // Borrow-based input extraction shared by `encode` (char offsets) and
+    // `encode_byte_offsets` (byte offsets). Avoids the String clone the
+    // owned/'static helpers above need for the async path.
+    fn extract_borrowed_encode_input<'py>(
+        sequence: &Bound<'py, PyAny>,
+        pair: Option<&Bound<'py, PyAny>>,
+        is_pretokenized: bool,
+    ) -> PyResult<tk::EncodeInput<'py>> {
+        let to_input_seq = |ob: &Bound<'py, PyAny>| -> PyResult<tk::InputSequence<'py>> {
+            if is_pretokenized {
+                Ok(ob.extract::<PreTokenizedInputSequence>()?.into())
+            } else {
+                Ok(ob.extract::<TextInputSequence>()?.into())
+            }
+        };
+        let sequence = to_input_seq(sequence)?;
+        Ok(match pair {
+            Some(pair) => tk::EncodeInput::Dual(sequence, to_input_seq(pair)?),
+            None => tk::EncodeInput::Single(sequence),
+        })
+    }
+
+    // Borrow-based batch input extraction. Same purpose as the single-item
+    // helper above, for `encode_batch` and `encode_batch_byte_offsets`.
+    fn extract_borrowed_encode_inputs<'py>(
+        items: &[Bound<'py, PyAny>],
+        is_pretokenized: bool,
+    ) -> PyResult<Vec<tk::EncodeInput<'py>>> {
+        items
+            .iter()
+            .map(|item| {
+                if is_pretokenized {
+                    Ok(item.extract::<PreTokenizedEncodeInput>()?.into())
+                } else {
+                    Ok(item.extract::<TextEncodeInput>()?.into())
+                }
+            })
+            .collect()
+    }
+
     // Helper method to build a single owned encode input
     fn build_single_owned_encode_input(
         sequence: &Bound<'_, PyAny>,
@@ -1186,23 +1226,7 @@ impl PyTokenizer {
         is_pretokenized: bool,
         add_special_tokens: bool,
     ) -> PyResult<PyEncoding> {
-        let sequence: tk::InputSequence = if is_pretokenized {
-            sequence.extract::<PreTokenizedInputSequence>()?.into()
-        } else {
-            sequence.extract::<TextInputSequence>()?.into()
-        };
-        let input = match pair {
-            Some(pair) => {
-                let pair: tk::InputSequence = if is_pretokenized {
-                    pair.extract::<PreTokenizedInputSequence>()?.into()
-                } else {
-                    pair.extract::<TextInputSequence>()?.into()
-                };
-                tk::EncodeInput::Dual(sequence, pair)
-            }
-            None => tk::EncodeInput::Single(sequence),
-        };
-
+        let input = Self::extract_borrowed_encode_input(sequence, pair, is_pretokenized)?;
         ToPyResult(
             self.tokenizer
                 .read()
@@ -1213,15 +1237,33 @@ impl PyTokenizer {
         .into()
     }
 
-    /// Encode the given sequence and pair, using byte-level offsets.
+    /// Encode the given sequence and pair, returning UTF-8 byte offsets.
     ///
-    /// This method can process raw text sequences as well as already pre-tokenized sequences.
+    /// Identical to :meth:`encode` except that each token's offsets are byte indices
+    /// into the input string (rather than character/codepoint indices). This matters
+    /// whenever a token's content includes multi-byte UTF-8 characters: byte offsets
+    /// give consecutive non-overlapping ranges suitable for cross-tokenizer alignment,
+    /// while character offsets collapse split bytes onto the same character index.
     ///
     /// Example:
-    ///     Here are some examples of the inputs that are accepted::
+    ///     For an input ``"café"`` (4 chars, 5 UTF-8 bytes — ``é`` = ``0xC3 0xA9``)
+    ///     tokenized as a single token, the offsets returned by the two methods
+    ///     differ::
     ///
-    ///         encode_byte_offsets("A single sequence")
-    ///         encode_byte_offsets("A sequence", "And its pair")
+    ///         >>> tokenizer.encode("café").offsets
+    ///         [(0, 4)]
+    ///         >>> tokenizer.encode_byte_offsets("café").offsets
+    ///         [(0, 5)]
+    ///
+    ///     With a byte-level tokenizer that splits ``café`` into 5 byte-level
+    ///     tokens, the last two tokens originate from the single character ``é``
+    ///     so their source span differs between the two modes — char offsets
+    ///     report the 1-codepoint span, byte offsets report the 2-byte span::
+    ///
+    ///         >>> tokenizer.encode("café").offsets
+    ///         [(0, 1), (1, 2), (2, 3), (3, 4), (3, 4)]
+    ///         >>> tokenizer.encode_byte_offsets("café").offsets
+    ///         [(0, 1), (1, 2), (2, 3), (3, 5), (3, 5)]
     ///
     /// Args:
     ///     sequence (:obj:`~tokenizers.InputSequence`):
@@ -1254,23 +1296,10 @@ impl PyTokenizer {
         is_pretokenized: bool,
         add_special_tokens: bool,
     ) -> PyResult<PyEncoding> {
-        let sequence: tk::InputSequence = if is_pretokenized {
-            sequence.extract::<PreTokenizedInputSequence>()?.into()
-        } else {
-            sequence.extract::<TextInputSequence>()?.into()
-        };
-        let input = match pair {
-            Some(pair) => {
-                let pair: tk::InputSequence = if is_pretokenized {
-                    pair.extract::<PreTokenizedInputSequence>()?.into()
-                } else {
-                    pair.extract::<TextInputSequence>()?.into()
-                };
-                tk::EncodeInput::Dual(sequence, pair)
-            }
-            None => tk::EncodeInput::Single(sequence),
-        };
-
+        let input = Self::extract_borrowed_encode_input(sequence, pair, is_pretokenized)?;
+        // The only behavioral difference from `encode` above: this calls
+        // `Tokenizer::encode` (byte offsets) where `encode` calls
+        // `Tokenizer::encode_char_offsets` (character offsets).
         ToPyResult(
             self.tokenizer
                 .read()
@@ -1384,15 +1413,7 @@ impl PyTokenizer {
         is_pretokenized: bool,
         add_special_tokens: bool,
     ) -> PyResult<Vec<PyEncoding>> {
-        let mut items = Vec::<tk::EncodeInput>::with_capacity(input.len());
-        for item in &input {
-            let item: tk::EncodeInput = if is_pretokenized {
-                item.extract::<PreTokenizedEncodeInput>()?.into()
-            } else {
-                item.extract::<TextEncodeInput>()?.into()
-            };
-            items.push(item);
-        }
+        let items = Self::extract_borrowed_encode_inputs(&input, is_pretokenized)?;
         py.detach(|| {
             ToPyResult(
                 self.tokenizer
@@ -1405,9 +1426,12 @@ impl PyTokenizer {
         })
     }
 
-    /// Encode the given batch of inputs, using byte-level offsets.
+    /// Encode the given batch of inputs, returning UTF-8 byte offsets.
     ///
-    /// This method accepts both raw text sequences as well as already pre-tokenized sequences.
+    /// Identical to :meth:`encode_batch` except that each token's offsets are byte
+    /// indices into the input string (rather than character/codepoint indices). See
+    /// :meth:`encode_byte_offsets` for the byte-vs-character offset semantics on a
+    /// concrete ``café`` example.
     ///
     /// Example:
     ///     Here are some examples of the inputs that are accepted::
@@ -1444,15 +1468,10 @@ impl PyTokenizer {
         is_pretokenized: bool,
         add_special_tokens: bool,
     ) -> PyResult<Vec<PyEncoding>> {
-        let mut items = Vec::<tk::EncodeInput>::with_capacity(input.len());
-        for item in &input {
-            let item: tk::EncodeInput = if is_pretokenized {
-                item.extract::<PreTokenizedEncodeInput>()?.into()
-            } else {
-                item.extract::<TextEncodeInput>()?.into()
-            };
-            items.push(item);
-        }
+        let items = Self::extract_borrowed_encode_inputs(&input, is_pretokenized)?;
+        // The only behavioral difference from `encode_batch` above: this calls
+        // `Tokenizer::encode_batch` (byte offsets) where `encode_batch` calls
+        // `Tokenizer::encode_batch_char_offsets` (character offsets).
         py.detach(|| {
             ToPyResult(
                 self.tokenizer

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1407,7 +1407,7 @@ impl PyTokenizer {
 
     /// Encode the given batch of inputs, using byte-level offsets.
     ///
-    /// This method accept both raw text sequences as well as already pre-tokenized sequences.
+    /// This method accepts both raw text sequences as well as already pre-tokenized sequences.
     ///
     /// Example:
     ///     Here are some examples of the inputs that are accepted::

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -212,6 +212,20 @@ class TestTokenizer:
         output = tokenizer.encode_byte_offsets(["my", "name", "is", "john"], is_pretokenized=True)
         assert output.tokens == ["my", "name", "is", "john"]
 
+        # Offsets index into UTF-8 bytes, not chars — this is the contract that
+        # differs from encode(), and what makes byte offsets usable for
+        # cross-tokenizer alignment when BPE splits multi-byte characters.
+        mb_tokenizer = Tokenizer(BPE())
+        mb_tokenizer.add_tokens(["café"])
+        text = "café"  # 4 chars, 5 UTF-8 bytes (é = 0xC3 0xA9)
+        byte_out = mb_tokenizer.encode_byte_offsets(text)
+        char_out = mb_tokenizer.encode(text)
+        assert byte_out.tokens == char_out.tokens == ["café"]
+        assert byte_out.offsets[0] == (0, 5)
+        assert char_out.offsets[0] == (0, 4)
+        s, e = byte_out.offsets[0]
+        assert text.encode("utf-8")[s:e].decode("utf-8") == "café"
+
     def test_encode_batch_byte_offsets(self):
         tokenizer = Tokenizer(BPE())
         tokenizer.add_tokens(["my", "name", "is", "john", "pair"])

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -193,6 +193,44 @@ class TestTokenizer:
         output = tokenizer.encode_batch(["my name is john", ("my name is john", "pair")])
         assert len(output) == 2
 
+    def test_encode_byte_offsets(self):
+        tokenizer = Tokenizer(BPE())
+        tokenizer.add_tokens(["my", "name", "is", "john", "pair"])
+
+        # Can encode single sequence with byte offsets
+        output = tokenizer.encode_byte_offsets("my name is john")
+        assert output.tokens == ["my", "name", "is", "john"]
+        # Byte offsets should be returned
+        assert type(output.offsets) == list
+        assert len(output.offsets) == len(output.ids)
+
+        # Can encode a pair of sequences with byte offsets
+        output = tokenizer.encode_byte_offsets("my name is john", "pair")
+        assert output.tokens == ["my", "name", "is", "john", "pair"]
+
+        # Can encode a single pre-tokenized sequence with byte offsets
+        output = tokenizer.encode_byte_offsets(["my", "name", "is", "john"], is_pretokenized=True)
+        assert output.tokens == ["my", "name", "is", "john"]
+
+    def test_encode_batch_byte_offsets(self):
+        tokenizer = Tokenizer(BPE())
+        tokenizer.add_tokens(["my", "name", "is", "john", "pair"])
+
+        # Can encode batch with byte offsets
+        output = tokenizer.encode_batch_byte_offsets(["my name is john", "pair"])
+        assert len(output) == 2
+        assert output[0].tokens == ["my", "name", "is", "john"]
+        assert output[1].tokens == ["pair"]
+        # Verify offsets are returned
+        assert type(output[0].offsets) == list
+        assert type(output[1].offsets) == list
+
+        # Can encode batch with both single sequence and pairs
+        output = tokenizer.encode_batch_byte_offsets(
+            ["my name is john", ("my name is john", "pair")]
+        )
+        assert len(output) == 2
+
     @pytest.mark.network
     def test_encode_formats(self, bert_files):
         tokenizer = BertWordPieceTokenizer(bert_files["vocab"])

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -202,9 +202,7 @@ class TestTokenizer:
 
         tokenizer = Tokenizer(BPE())
         tokenizer.pre_tokenizer = ByteLevel(add_prefix_space=False)
-        tokenizer.train_from_iterator(
-            [""], trainer=BpeTrainer(vocab_size=256, initial_alphabet=ByteLevel.alphabet())
-        )
+        tokenizer.train_from_iterator([""], trainer=BpeTrainer(vocab_size=256, initial_alphabet=ByteLevel.alphabet()))
         return tokenizer
 
     def test_encode_byte_offsets(self):

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -240,9 +240,7 @@ class TestTokenizer:
         assert type(output[1].offsets) == list
 
         # Can encode batch with both single sequence and pairs
-        output = tokenizer.encode_batch_byte_offsets(
-            ["my name is john", ("my name is john", "pair")]
-        )
+        output = tokenizer.encode_batch_byte_offsets(["my name is john", ("my name is john", "pair")])
         assert len(output) == 2
 
     @pytest.mark.network

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -193,63 +193,74 @@ class TestTokenizer:
         output = tokenizer.encode_batch(["my name is john", ("my name is john", "pair")])
         assert len(output) == 2
 
+    def _byte_level_bpe(self):
+        """Build a ByteLevel BPE whose vocab is just the 256 byte-level
+        characters (no merges). Every input byte becomes its own token, so
+        multi-byte characters get split across multiple tokens — exactly the
+        scenario where byte vs char offsets diverge."""
+        from tokenizers.trainers import BpeTrainer
+
+        tokenizer = Tokenizer(BPE())
+        tokenizer.pre_tokenizer = ByteLevel(add_prefix_space=False)
+        tokenizer.train_from_iterator(
+            [""], trainer=BpeTrainer(vocab_size=256, initial_alphabet=ByteLevel.alphabet())
+        )
+        return tokenizer
+
     def test_encode_byte_offsets(self):
         tokenizer = Tokenizer(BPE())
         tokenizer.add_tokens(["my", "name", "is", "john", "pair"])
 
-        # Can encode single sequence with byte offsets
+        # Same I/O contract as encode(): single, pair, and pre-tokenized inputs.
         output = tokenizer.encode_byte_offsets("my name is john")
         assert output.tokens == ["my", "name", "is", "john"]
-        # Byte offsets should be returned
-        assert type(output.offsets) == list
         assert len(output.offsets) == len(output.ids)
 
-        # Can encode a pair of sequences with byte offsets
         output = tokenizer.encode_byte_offsets("my name is john", "pair")
         assert output.tokens == ["my", "name", "is", "john", "pair"]
 
-        # Can encode a single pre-tokenized sequence with byte offsets
         output = tokenizer.encode_byte_offsets(["my", "name", "is", "john"], is_pretokenized=True)
         assert output.tokens == ["my", "name", "is", "john"]
 
-        # Offsets index into UTF-8 bytes, not chars — this is the contract that
-        # differs from encode(), and what makes byte offsets usable for
-        # cross-tokenizer alignment when BPE splits multi-byte characters.
-        mb_tokenizer = Tokenizer(BPE())
-        mb_tokenizer.add_tokens(["café"])
-        text = "café"  # 4 chars, 5 UTF-8 bytes (é = 0xC3 0xA9)
-        byte_out = mb_tokenizer.encode_byte_offsets(text)
-        char_out = mb_tokenizer.encode(text)
-        assert byte_out.tokens == char_out.tokens == ["café"]
-        assert byte_out.offsets[0] == (0, 5)
-        assert char_out.offsets[0] == (0, 4)
-        s, e = byte_out.offsets[0]
-        assert text.encode("utf-8")[s:e].decode("utf-8") == "café"
+        # The actual byte-vs-char-offset contract: use a real ByteLevel BPE that
+        # splits "café" (4 chars, 5 UTF-8 bytes — é = 0xC3 0xA9) into 5 byte-level
+        # tokens. The last two tokens both originate from the single character é,
+        # so their source-string spans differ between the two offset modes:
+        #
+        #   char offsets: (3, 4) — codepoint span of é (one char)
+        #   byte offsets: (3, 5) — UTF-8 byte span of é (two bytes)
+        #
+        # This is the property cross-tokenizer alignment relies on: cumulative
+        # byte offsets line up across tokenizers that disagree on multi-byte
+        # boundaries, while cumulative char offsets do not.
+        tokenizer = self._byte_level_bpe()
+        text = "café"
+        char_out = tokenizer.encode(text)
+        byte_out = tokenizer.encode_byte_offsets(text)
+        assert len(byte_out.ids) == 5
+        assert char_out.offsets == [(0, 1), (1, 2), (2, 3), (3, 4), (3, 4)]
+        assert byte_out.offsets == [(0, 1), (1, 2), (2, 3), (3, 5), (3, 5)]
+        # The trailing byte offset (5) matches the UTF-8 byte length of "café".
+        assert byte_out.offsets[-1][1] == len(text.encode("utf-8"))
 
     def test_encode_batch_byte_offsets(self):
         tokenizer = Tokenizer(BPE())
         tokenizer.add_tokens(["my", "name", "is", "john", "pair"])
 
-        # Can encode batch with byte offsets
+        # Same I/O contract as encode_batch(): list of single + pair sequences.
         output = tokenizer.encode_batch_byte_offsets(["my name is john", "pair"])
-        assert len(output) == 2
-        assert output[0].tokens == ["my", "name", "is", "john"]
-        assert output[1].tokens == ["pair"]
-        # Verify offsets are returned
-        assert type(output[0].offsets) == list
-        assert type(output[1].offsets) == list
+        assert [enc.tokens for enc in output] == [["my", "name", "is", "john"], ["pair"]]
 
-        # Can encode batch with both single sequence and pairs
         output = tokenizer.encode_batch_byte_offsets(["my name is john", ("my name is john", "pair")])
         assert len(output) == 2
 
-        # Batch offsets index into UTF-8 bytes, not chars (mirrors test_encode_byte_offsets).
-        mb_tokenizer = Tokenizer(BPE())
-        mb_tokenizer.add_tokens(["café"])
-        byte_batch = mb_tokenizer.encode_batch_byte_offsets(["café"])
-        char_batch = mb_tokenizer.encode_batch(["café"])
-        assert byte_batch[0].offsets[0] == (0, 5)
-        assert char_batch[0].offsets[0] == (0, 4)
+        # Same byte-vs-char distinction as test_encode_byte_offsets, exercised
+        # through the batch entry point on a real ByteLevel BPE.
+        tokenizer = self._byte_level_bpe()
+        char_batch = tokenizer.encode_batch(["café"])
+        byte_batch = tokenizer.encode_batch_byte_offsets(["café"])
+        assert char_batch[0].offsets == [(0, 1), (1, 2), (2, 3), (3, 4), (3, 4)]
+        assert byte_batch[0].offsets == [(0, 1), (1, 2), (2, 3), (3, 5), (3, 5)]
 
     @pytest.mark.network
     def test_encode_formats(self, bert_files):

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -243,6 +243,14 @@ class TestTokenizer:
         output = tokenizer.encode_batch_byte_offsets(["my name is john", ("my name is john", "pair")])
         assert len(output) == 2
 
+        # Batch offsets index into UTF-8 bytes, not chars (mirrors test_encode_byte_offsets).
+        mb_tokenizer = Tokenizer(BPE())
+        mb_tokenizer.add_tokens(["café"])
+        byte_batch = mb_tokenizer.encode_batch_byte_offsets(["café"])
+        char_batch = mb_tokenizer.encode_batch(["café"])
+        assert byte_batch[0].offsets[0] == (0, 5)
+        assert char_batch[0].offsets[0] == (0, 4)
+
     @pytest.mark.network
     def test_encode_formats(self, bert_files):
         tokenizer = BertWordPieceTokenizer(bert_files["vocab"])


### PR DESCRIPTION
Add `encode_byte_offsets()` and `encode_batch_byte_offsets()` methods to enable byte-level offset computation during encoding. This is useful for cross-tokenizer alignment scenarios where byte positions provide more accurate alignment than character positions, especially for multilingual text.

Based on suggestion from @ArthurZucker in older PR #1880 to add a dedicated method instead of modifying the existing encode API.

Fixes #1881