### PR TITLE
Update daachorse from 1.0.1 to 3.0.0

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -84,7 +84,7 @@ log = "0.4"
 derive_builder = "0.20"
 spm_precompiled = "0.1.3"
 hf-hub = { version = "0.4.1", features = ["ureq"], default-features = false, optional = true }
-daachorse = "1.0.1"
+daachorse = "3.0.0"
 paste = "1.0.14"
 macro_rules_attribute = "0.2.0"
 thiserror = "2"


### PR DESCRIPTION
Source diff: https://github.com/daac-tools/daachorse/compare/v1.0.1...v3.0.0

I don’t see any obvious breaking changes in [2.0.0](https://github.com/daac-tools/daachorse/releases/tag/v2.0.0); the MSRV is increased from 1.61 to 1.77. We shouldn’t be affected by the breaking changes in [3.0.0](https://github.com/daac-tools/daachorse/releases/tag/v3.0.0) because we don’t use the `*Stepper` APIs.

I confirmed that `make -C tokenizers/ test` still passes.