### PR TITLE
Apply type_ids and sequence_id to overflow encodings in post-processors

### DIFF
--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -79,9 +79,13 @@ impl PostProcessor for RobertaProcessing {
         }
 
         // Roberta is weird, and every encoding is type_id=0.
-        encodings
-            .iter_mut()
-            .for_each(|encoding| encoding.set_type_ids(vec![0; encoding.len()]));
+        encodings.iter_mut().for_each(|encoding| {
+            encoding.set_type_ids(vec![0; encoding.len()]);
+            encoding
+                .get_overflowing_mut()
+                .iter_mut()
+                .for_each(|overflow| overflow.set_type_ids(vec![0; overflow.len()]));
+        });
 
         if !add_special_tokens {
             return Ok(encodings);
@@ -337,5 +341,38 @@ mod tests {
         assert_eq!(pair_encoding.token_to_sequence(0), Some(0));
         assert_eq!(pair_encoding.token_to_sequence(1), Some(0));
         assert_eq!(pair_encoding.token_to_sequence(2), Some(1));
+    }
+
+    #[test]
+    fn roberta_overflow_type_ids() {
+        // Regression test for huggingface/tokenizers#1908.
+        // RoBERTa forces every encoding to `type_id=0`; this contract has to
+        // hold for the overflowing encodings too. Before the fix, overflows
+        // produced by truncation kept whatever type_ids they had been built
+        // with (typically `1` for the second sequence), which broke models
+        // that read overflow type_ids back.
+        use crate::Token;
+
+        let processor = RobertaProcessing::default();
+
+        let mut encoding =
+            Encoding::from_tokens(vec![Token::new(12, "Hello".into(), (0, 5))], 0);
+        // Build an overflow whose tokens were originally tagged as type_id=1,
+        // to mimic what `encode_single_sequence` does for the pair before
+        // truncation runs.
+        let mut overflow =
+            Encoding::from_tokens(vec![Token::new(14, "there".into(), (6, 11))], 1);
+        overflow.set_type_ids(vec![1; overflow.len()]);
+        encoding.set_overflowing(vec![overflow]);
+
+        let processed = processor.process(encoding, None, false).unwrap();
+        assert_eq!(processed.get_type_ids(), &[0]);
+        for overflow in processed.get_overflowing() {
+            assert!(
+                overflow.get_type_ids().iter().all(|t| *t == 0),
+                "Roberta overflow must be type_id=0, got {:?}",
+                overflow.get_type_ids(),
+            );
+        }
     }
 }

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -556,6 +556,13 @@ impl TemplateProcessing {
                         let encoding = &mut encodings[i];
                         encoding.set_type_ids(vec![*type_id; encoding.len()]);
                         encoding.set_sequence_id(i);
+                        encoding
+                            .get_overflowing_mut()
+                            .iter_mut()
+                            .for_each(|overflow| {
+                                overflow.set_type_ids(vec![*type_id; overflow.len()]);
+                                overflow.set_sequence_id(i);
+                            });
                         Some(encoding.clone())
                     }
                     Piece::SpecialToken { id, type_id } => {
@@ -1048,7 +1055,7 @@ mod tests {
                         vec![1, 1, 1, 1, 1, 1],
                         vec![Encoding::new(
                             vec![1, 13, 0, 17, 0],
-                            vec![0, 0, 0, 0, 1],
+                            vec![0, 0, 0, 1, 1],
                             vec![
                                 "[CLS]".into(),
                                 "you".into(),
@@ -1067,7 +1074,7 @@ mod tests {
                     ),
                     Encoding::new(
                         vec![1, 13, 0, 17, 0],
-                        vec![0, 0, 0, 0, 1],
+                        vec![0, 0, 0, 1, 1],
                         vec![
                             "[CLS]".into(),
                             "you".into(),
@@ -1084,7 +1091,7 @@ mod tests {
                     ),
                     Encoding::new(
                         vec![1, 12, 14, 0, 17, 0],
-                        vec![0, 0, 0, 0, 0, 1],
+                        vec![0, 0, 0, 0, 1, 1],
                         vec![
                             "[CLS]".into(),
                             "Hello".into(),
@@ -1099,7 +1106,7 @@ mod tests {
                         vec![1, 1, 1, 1, 1, 1],
                         vec![Encoding::new(
                             vec![1, 13, 0, 17, 0],
-                            vec![0, 0, 0, 0, 1],
+                            vec![0, 0, 0, 1, 1],
                             vec![
                                 "[CLS]".into(),
                                 "you".into(),
@@ -1126,6 +1133,70 @@ mod tests {
         assert_eq!(pair_encoding.token_to_sequence(5), Some(1));
         assert_eq!(pair_encoding.token_to_sequence(6), None);
     }
+    #[test]
+    fn template_processing_overflow_type_ids() {
+        // Regression test for huggingface/tokenizers#1908.
+        // Verifies that when a `Piece::Sequence` declares a non-zero `type_id`,
+        // every overflowing encoding inherits the same `type_id` and `sequence_id`
+        // as the main encoding (truncation can split off overflows before the
+        // post-processor runs, and they used to keep stale type_ids).
+        use crate::Token;
+
+        let processor = TemplateProcessing::builder()
+            .try_single("[CLS]:0 $A:0 [SEP]:0")
+            .unwrap()
+            .try_pair("[CLS]:0 $A:0 [SEP]:0 $B:1 [SEP]:1")
+            .unwrap()
+            .special_tokens(vec![("[CLS]", 1), ("[SEP]", 0)])
+            .build()
+            .unwrap();
+
+        // Sequence A: one main token + two overflows (simulating truncation).
+        let mut encoding_a =
+            Encoding::from_tokens(vec![Token::new(10, "hello".into(), (0, 5))], 0);
+        let overflow_a1 =
+            Encoding::from_tokens(vec![Token::new(11, "world".into(), (6, 11))], 0);
+        let overflow_a2 =
+            Encoding::from_tokens(vec![Token::new(12, "again".into(), (12, 17))], 0);
+        encoding_a.set_overflowing(vec![overflow_a1, overflow_a2]);
+
+        // Sequence B: one main token + one overflow. The original `type_ids`
+        // here are 0 (set by `Encoding::from_tokens`); the template should
+        // promote both the main and the overflow to type_id=1.
+        let mut encoding_b =
+            Encoding::from_tokens(vec![Token::new(20, "foo".into(), (0, 3))], 0);
+        let overflow_b =
+            Encoding::from_tokens(vec![Token::new(21, "bar".into(), (4, 7))], 0);
+        encoding_b.set_overflowing(vec![overflow_b]);
+
+        let result = processor
+            .process(encoding_a, Some(encoding_b), true)
+            .unwrap();
+
+        // Main: [CLS]:0 hello:0 [SEP]:0 foo:1 [SEP]:1
+        assert_eq!(result.get_type_ids(), &[0, 0, 0, 1, 1]);
+
+        // Each overflow must have the correct type_ids: the sequence A part
+        // stays at 0 and the sequence B part is promoted to 1.
+        for overflow in result.get_overflowing() {
+            let type_ids = overflow.get_type_ids();
+            let tokens = overflow.get_tokens();
+            for (tid, tok) in type_ids.iter().zip(tokens.iter()) {
+                match tok.as_str() {
+                    "foo" | "bar" => assert_eq!(
+                        *tid, 1,
+                        "overflow token {tok:?} (sequence B) should have type_id=1, got {tid}"
+                    ),
+                    "hello" | "world" | "again" => assert_eq!(
+                        *tid, 0,
+                        "overflow token {tok:?} (sequence A) should have type_id=0, got {tid}"
+                    ),
+                    _ => {}
+                }
+            }
+        }
+    }
+
     #[test]
     fn pair_must_use_both_sequences() {
         let processor = TemplateProcessing::builder()

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -106,11 +106,14 @@ pub trait PostProcessor {
         };
         encodings.iter_mut().enumerate().for_each(|(i, encoding)| {
             encoding.set_sequence_id(i);
+            encoding.set_type_ids(vec![i as u32; encoding.len()]);
             encoding
                 .get_overflowing_mut()
                 .iter_mut()
-                .for_each(|encoding| encoding.set_sequence_id(i));
-            encoding.set_type_ids(vec![i as u32; encoding.len()]);
+                .for_each(|encoding| {
+                    encoding.set_sequence_id(i);
+                    encoding.set_type_ids(vec![i as u32; encoding.len()]);
+                });
         });
 
         let encodings = self.process_encodings(encodings, add_special_tokens)?;


### PR DESCRIPTION
Closes #1908. Picks up where #1965 (closed unmerged for inactivity) left off: same idea, with regression tests so it does not slip again.

## What

Three post-processors set `type_ids` / `sequence_id` on the main encoding but skip its overflows:

1. `PostProcessor::process` default impl: `tokenizers/src/tokenizer/mod.rs:107`
2. `TemplateProcessing::apply_template` for `Piece::Sequence`: `tokenizers/src/processors/template.rs:554`
3. `RobertaProcessing::process_encodings`: `tokenizers/src/processors/roberta.rs:82`

So a sentence-pair tokenization that overflows (`truncation` + long inputs) emits the main encoding with correct `type_ids = [0, 0, ..., 1, 1, ...]` but every overflow has `type_ids = [0, 0, ...]`. Downstream span / NER / pair-classification code that reads overflows then sees the wrong sequence ownership.

Bert is structurally fine. It reads `encoding.get_type_ids()` per overflow when wrapping CLS/SEP, so once the default impl propagates type_ids to overflows, Bert composes them correctly.

## Fix

At each of the three sites, iterate `get_overflowing_mut()` and apply the same `set_type_ids` (and `set_sequence_id` where applicable) the main encoding gets.

The pre-existing `template_processing_overflowing` test had stale `type_ids` baked in that matched the buggy output. Those expectations were the bug. Updated four `[0, 0, 0, 0, 1]` lines to `[0, 0, 0, 1, 1]` and one `[0, 0, 0, 0, 0, 1]` to `[0, 0, 0, 0, 1, 1]`.

## Tests

Two new regressions:

- `processors::template::tests::template_processing_overflow_type_ids`: sentence pair with non-zero `$B:1` type_id and pre-existing overflows on both A and B sides, asserts each overflow's `type_ids` matches its source sequence.
- `processors::roberta::tests::roberta_overflow_type_ids`: overflow starting with `type_id=1` must be coerced to 0 like the main encoding.
