### PR TITLE
serialize tokenizer vocab and added_tokens compactly

### DIFF
--- a/bindings/node/lib/bindings/post-processors.test.ts
+++ b/bindings/node/lib/bindings/post-processors.test.ts
@@ -9,7 +9,9 @@ describe('bertProcessing', () => {
   })
 
   it('throws if only one argument is provided', () => {
-    expect(() => (bertProcessing as any)(['sep', 1])).toThrow('Given napi value is not an array')
+    expect(() => (bertProcessing as any)(['sep', 1])).toThrow(
+      /Given napi value is not an array|Failed to get Array length/,
+    )
   })
 
   it('throws if arguments are malformed', () => {

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 rayon = "1.10"
 serde = { version = "1.0", features = ["rc", "derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 libc = "0.2"
 env_logger = "0.11"
 pyo3 = { version = "=0.28.2", default-features = false, features = ["py-clone", "experimental-inspect"] }

--- a/bindings/python/src/utils/serde_pyo3.rs
+++ b/bindings/python/src/utils/serde_pyo3.rs
@@ -2,6 +2,13 @@ use serde::de::value::Error;
 use serde::{ser, Serialize};
 type Result<T> = ::std::result::Result<T, Error>;
 
+/// Magic name serde_json's `RawValue` uses to smuggle pre-serialized JSON through a
+/// `Serializer`. The core tokenizers crate uses `RawValue` to keep vocab/merges/added_tokens
+/// on a single line in tokenizer.json; when our custom Python-repr serializer encounters
+/// the same protocol it must unwrap the inner JSON and render it normally, otherwise the
+/// repr leaks `$serde_json::private::RawValue(...)` markers.
+const RAW_VALUE_TOKEN: &str = "$serde_json::private::RawValue";
+
 pub struct Serializer {
     // This string starts empty and JSON is appended as values are serialized.
     output: String,
@@ -13,6 +20,13 @@ pub struct Serializer {
     /// Maximum string representation
     /// Useful to ellipsis precompiled_charmap
     max_string: usize,
+    /// Set while we are inside a `serde_json::value::RawValue` struct: the next
+    /// `SerializeStruct::serialize_field` should treat its payload as raw JSON, parse it,
+    /// and recurse so the inner shape renders as Python repr instead of the raw token.
+    in_raw_value: bool,
+    /// Number of `SerializeStruct::end` calls that should suppress their closing paren
+    /// because they correspond to RawValue structs we already consumed.
+    raw_value_pending_ends: usize,
 }
 
 // By convention, the public API of a Serde serializer is one or more `to_abc`
@@ -34,6 +48,8 @@ where
         max_elements,
         num_elements: vec![0; max_depth],
         max_string,
+        in_raw_value: false,
+        raw_value_pending_ends: 0,
     };
     value.serialize(&mut serializer)?;
     Ok(serializer.output)
@@ -52,6 +68,8 @@ where
         max_elements: 100,
         num_elements: vec![0; max_depth],
         max_string,
+        in_raw_value: false,
+        raw_value_pending_ends: 0,
     };
     value.serialize(&mut serializer)?;
     Ok(serializer.output)
@@ -317,6 +335,14 @@ impl ser::Serializer for &mut Serializer {
     // Deserialize implementation is required to know what the keys are without
     // looking at the serialized data.
     fn serialize_struct(self, name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        // serde_json's `RawValue` smuggles pre-serialized JSON through a fake struct with
+        // this magic name. Don't emit the marker — set a flag so the upcoming field is
+        // parsed back into a `serde_json::Value` and rendered through Self normally.
+        if name == RAW_VALUE_TOKEN {
+            self.in_raw_value = true;
+            self.raw_value_pending_ends += 1;
+            return Ok(self);
+        }
         // self.serialize_map(Some(len))
         // name.serialize(&mut *self)?;
         if let Some(stripped) = name.strip_suffix("Helper") {
@@ -567,6 +593,19 @@ impl ser::SerializeStruct for &mut Serializer {
     where
         T: ?Sized + Serialize,
     {
+        if self.in_raw_value && key == RAW_VALUE_TOKEN {
+            // Inside a serde_json::value::RawValue: the payload is a `&str` carrying raw
+            // JSON. Pull the str out via serde_json::to_value, parse it back into a Value,
+            // then recurse so the inner shape renders through Self in the normal way.
+            self.in_raw_value = false;
+            let v = serde_json::to_value(value).map_err(|e| ser::Error::custom(e.to_string()))?;
+            let raw_json = v
+                .as_str()
+                .ok_or_else(|| ser::Error::custom("RawValue payload was not a string"))?;
+            let parsed: serde_json::Value =
+                serde_json::from_str(raw_json).map_err(|e| ser::Error::custom(e.to_string()))?;
+            return parsed.serialize(&mut **self);
+        }
         if !self.output.ends_with('(') {
             self.output += ", ";
         }
@@ -581,6 +620,12 @@ impl ser::SerializeStruct for &mut Serializer {
     }
 
     fn end(self) -> Result<()> {
+        if self.raw_value_pending_ends > 0 {
+            // This `end()` closes a RawValue struct whose body we already rendered above;
+            // skip the closing paren and the level decrement we never applied.
+            self.raw_value_pending_ends -= 1;
+            return Ok(());
+        }
         self.num_elements[self.level] = 0;
         self.level = self.level.saturating_sub(1);
         self.output += ")";
@@ -622,6 +667,38 @@ fn test_basic() {
     assert_eq!(to_string(&true).unwrap(), "True");
     assert_eq!(to_string(&Some(1)).unwrap(), "1");
     assert_eq!(to_string(&None::<usize>).unwrap(), "None");
+}
+
+#[test]
+fn test_raw_value_unwraps_to_python_repr() {
+    use serde_json::value::RawValue;
+
+    #[derive(Serialize)]
+    struct Outer<'a> {
+        inline: &'a RawValue,
+    }
+
+    // RawValue contents must be rendered through Self (Python-style), not as the
+    // `$serde_json::private::RawValue(...)` marker that serde_json's protocol leaks.
+    let empty_arr = RawValue::from_string("[]".to_string()).unwrap();
+    let empty_obj = RawValue::from_string("{}".to_string()).unwrap();
+    let nested = RawValue::from_string(
+        r#"[{"id":0,"content":"x","flag":true,"score":1.5,"none":null}]"#.to_string(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        to_string(&Outer { inline: &empty_arr }).unwrap(),
+        "Outer(inline=[])"
+    );
+    assert_eq!(
+        to_string(&Outer { inline: &empty_obj }).unwrap(),
+        "Outer(inline={})"
+    );
+    assert_eq!(
+        to_string(&Outer { inline: &nested }).unwrap(),
+        r#"Outer(inline=[{"id":0, "content":"x", "flag":True, "score":1.5, "none":None}])"#
+    );
 }
 
 #[test]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -74,7 +74,7 @@ regex-syntax = "0.8"
 rayon = "1.10"
 rayon-cond = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["raw_value"] }
 unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
 unicode-segmentation = "1.11"

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -6,7 +6,7 @@ dir_guard=@mkdir -p $(@D)
 
 SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2-merges.txt $(DATA_DIR)/bert-base-uncased-vocab.txt $(DATA_DIR)/big.txt $(DATA_DIR)/small.txt $(DATA_DIR)/albert-base-v1-tokenizer.json  $(DATA_DIR)/llama-3-tokenizer.json
 BENCHMARK_RESOURCES = $(SHARED_RESOURCES)
-TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json
+TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/deepseek-v4-flash-base-tokenizer.json
 
 .PHONY : build
 build :
@@ -94,3 +94,9 @@ $(DATA_DIR)/bert-wiki.json :
 $(DATA_DIR)/llama-3-tokenizer.json :
 	$(dir_guard)
 	wget $(HF_TEST_DATA)/llama-3-tokenizer.json -O $@
+
+# Old-format (pretty) tokenizer.json used to assert backward compatibility with
+# files produced before vocab/merges/added_tokens were compacted on save.
+$(DATA_DIR)/deepseek-v4-flash-base-tokenizer.json :
+	$(dir_guard)
+	wget https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base/resolve/main/tokenizer.json -O $@

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -6,9 +6,9 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-/// Wraps the BPE merges so that each `[left, right]` pair is emitted on a single line even
-/// when the outer serializer is pretty. The outer array still respects the pretty flag, so
-/// pretty output stays diff-friendly (one merge per line).
+/// Wraps the BPE merges so the entire array is emitted as a single compact line even when
+/// the outer serializer is pretty. Avoids the multi-line per-pair indentation that bloats
+/// tokenizer.json files.
 struct CompactMerges<'a> {
     merges: &'a [(String, String)],
 }
@@ -18,15 +18,10 @@ impl Serialize for CompactMerges<'_> {
     where
         S: Serializer,
     {
-        use serde::ser::SerializeSeq;
-        let mut seq = serializer.serialize_seq(Some(self.merges.len()))?;
-        for pair in self.merges {
-            let compact = serde_json::to_string(pair).map_err(serde::ser::Error::custom)?;
-            let raw = serde_json::value::RawValue::from_string(compact)
-                .map_err(serde::ser::Error::custom)?;
-            seq.serialize_element(&raw)?;
-        }
-        seq.end()
+        let compact = serde_json::to_string(self.merges).map_err(serde::ser::Error::custom)?;
+        let raw =
+            serde_json::value::RawValue::from_string(compact).map_err(serde::ser::Error::custom)?;
+        raw.serialize(serializer)
     }
 }
 

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -6,6 +6,30 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
+/// Wraps the BPE merges so that each `[left, right]` pair is emitted on a single line even
+/// when the outer serializer is pretty. The outer array still respects the pretty flag, so
+/// pretty output stays diff-friendly (one merge per line).
+struct CompactMerges<'a> {
+    merges: &'a [(String, String)],
+}
+
+impl Serialize for CompactMerges<'_> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.merges.len()))?;
+        for pair in self.merges {
+            let compact = serde_json::to_string(pair).map_err(serde::ser::Error::custom)?;
+            let raw = serde_json::value::RawValue::from_string(compact)
+                .map_err(serde::ser::Error::custom)?;
+            seq.serialize_element(&raw)?;
+        }
+        seq.end()
+    }
+}
+
 impl Serialize for BPE {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -35,9 +59,10 @@ impl Serialize for BPE {
             .map(|(pair, _)| (self.vocab_r[&pair.0].clone(), self.vocab_r[&pair.1].clone()))
             .collect::<Vec<_>>();
         let ordered_vocab = OrderedVocabIter::new(&self.vocab_r);
+        let compact_merges = CompactMerges { merges: &merges };
 
         model.serialize_field("vocab", &ordered_vocab)?;
-        model.serialize_field("merges", &merges)?;
+        model.serialize_field("merges", &compact_merges)?;
 
         model.end()
     }

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -36,24 +36,36 @@ impl Serialize for OrderedVocabIter<'_> {
     {
         // There could be holes so max + 1 is more correct than vocab_r.len()
         let mut holes = vec![];
-        let result = if let Some(max) = self.vocab_r.keys().max() {
-            let iter = (0..*max + 1).filter_map(|i| {
+        let mut buf = String::from("{");
+        if let Some(max) = self.vocab_r.keys().max() {
+            let mut first = true;
+            for i in 0..*max + 1 {
                 if let Some(token) = self.vocab_r.get(&i) {
-                    Some((token, i))
+                    if !first {
+                        buf.push(',');
+                    }
+                    first = false;
+                    let key =
+                        serde_json::to_string(token).map_err(serde::ser::Error::custom)?;
+                    buf.push_str(&key);
+                    buf.push(':');
+                    buf.push_str(&i.to_string());
                 } else {
                     holes.push(i);
-                    None
                 }
-            });
-            serializer.collect_map(iter)
-        } else {
-            serializer.collect_map(std::iter::empty::<(&str, u32)>())
-        };
+            }
+        }
+        buf.push('}');
 
         if !holes.is_empty() {
             warn!("The OrderedVocab you are attempting to serialize contains holes for indices {holes:?}, your vocabulary could be corrupted!");
         }
-        result
+
+        // Emit the vocab as a pre-serialized compact JSON value so that pretty-printers
+        // do not expand it across thousands of lines.
+        let raw = serde_json::value::RawValue::from_string(buf)
+            .map_err(serde::ser::Error::custom)?;
+        raw.serialize(serializer)
     }
 }
 

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -45,8 +45,7 @@ impl Serialize for OrderedVocabIter<'_> {
                         buf.push(',');
                     }
                     first = false;
-                    let key =
-                        serde_json::to_string(token).map_err(serde::ser::Error::custom)?;
+                    let key = serde_json::to_string(token).map_err(serde::ser::Error::custom)?;
                     buf.push_str(&key);
                     buf.push(':');
                     buf.push_str(&i.to_string());
@@ -63,8 +62,8 @@ impl Serialize for OrderedVocabIter<'_> {
 
         // Emit the vocab as a pre-serialized compact JSON value so that pretty-printers
         // do not expand it across thousands of lines.
-        let raw = serde_json::value::RawValue::from_string(buf)
-            .map_err(serde::ser::Error::custom)?;
+        let raw =
+            serde_json::value::RawValue::from_string(buf).map_err(serde::ser::Error::custom)?;
         raw.serialize(serializer)
     }
 }

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -595,9 +595,16 @@ impl Serialize for AddedVocabulary {
         // We need to have these added tokens ordered by ascending ID
         added_tokens.sort_unstable_by_key(|o| o.id);
 
+        // Serialize each AddedToken as a compact, single-line JSON object. The outer array
+        // still respects the serializer's pretty/compact mode, so pretty output remains
+        // diff-friendly (one token per line) without the per-field indentation that bloats
+        // tokenizer.json files.
         let mut vocabulary = serializer.serialize_seq(Some(added_tokens.len()))?;
-        for token in added_tokens {
-            vocabulary.serialize_element(&token)?;
+        for token in &added_tokens {
+            let compact = serde_json::to_string(token).map_err(serde::ser::Error::custom)?;
+            let raw = serde_json::value::RawValue::from_string(compact)
+                .map_err(serde::ser::Error::custom)?;
+            vocabulary.serialize_element(&raw)?;
         }
 
         vocabulary.end()

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -5,7 +5,7 @@ use super::{
 use ahash::{AHashMap, AHashSet};
 use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder, MatchKind};
 use regex::Regex;
-use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use std::sync::LazyLock;
 
 /// Represent a token added by the user on top of the existing Model vocabulary.
@@ -595,19 +595,11 @@ impl Serialize for AddedVocabulary {
         // We need to have these added tokens ordered by ascending ID
         added_tokens.sort_unstable_by_key(|o| o.id);
 
-        // Serialize each AddedToken as a compact, single-line JSON object. The outer array
-        // still respects the serializer's pretty/compact mode, so pretty output remains
-        // diff-friendly (one token per line) without the per-field indentation that bloats
-        // tokenizer.json files.
-        let mut vocabulary = serializer.serialize_seq(Some(added_tokens.len()))?;
-        for token in &added_tokens {
-            let compact = serde_json::to_string(token).map_err(serde::ser::Error::custom)?;
-            let raw = serde_json::value::RawValue::from_string(compact)
-                .map_err(serde::ser::Error::custom)?;
-            vocabulary.serialize_element(&raw)?;
-        }
-
-        vocabulary.end()
+        // Serialize the whole array compactly so pretty output keeps it on a single line.
+        let compact = serde_json::to_string(&added_tokens).map_err(serde::ser::Error::custom)?;
+        let raw =
+            serde_json::value::RawValue::from_string(compact).map_err(serde::ser::Error::custom)?;
+        raw.serialize(serializer)
     }
 }
 

--- a/tokenizers/src/tokenizer/serialization.rs
+++ b/tokenizers/src/tokenizer/serialization.rs
@@ -228,11 +228,7 @@ mod tests {
   "version": "1.0",
   "truncation": null,
   "padding": null,
-  "added_tokens": [
-    {"id":0,"content":"[SPECIAL_0]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false,"special":true},
-    {"id":1,"content":"[SPECIAL_1]","single_word":false,"lstrip":false,"rstrip":false,"normalized":true,"special":false},
-    {"id":2,"content":"[SPECIAL_2]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false,"special":true}
-  ],
+  "added_tokens": [{"id":0,"content":"[SPECIAL_0]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false,"special":true},{"id":1,"content":"[SPECIAL_1]","single_word":false,"lstrip":false,"rstrip":false,"normalized":true,"special":false},{"id":2,"content":"[SPECIAL_2]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false,"special":true}],
   "normalizer": null,
   "pre_tokenizer": null,
   "post_processor": null,
@@ -252,16 +248,13 @@ mod tests {
 
         // The compact form should round-trip into an identical Tokenizer.
         let reparsed = Tokenizer::from_str(&tok_str).unwrap();
-        assert_eq!(
-            serde_json::to_string_pretty(&reparsed).unwrap(),
-            tok_str,
-        );
+        assert_eq!(serde_json::to_string_pretty(&reparsed).unwrap(), tok_str,);
     }
 
     #[test]
     fn test_pretty_bpe_vocab_and_merges_are_compact() {
-        // BPE model with non-empty vocab + merges: each vocab map and each merge pair
-        // should be emitted on a single line under pretty output.
+        // BPE model with non-empty vocab + merges: vocab map and merges array
+        // are emitted as single compact lines under pretty output.
         let tok_json_in = r#"{
   "version": "1.0",
   "truncation": null,
@@ -281,10 +274,7 @@ mod tests {
     "byte_fallback": false,
     "ignore_merges": false,
     "vocab": {"<unk>":0,"a":1,"b":2,"c":3,"ab":4,"bc":5},
-    "merges": [
-      ["a","b"],
-      ["b","c"]
-    ]
+    "merges": [["a","b"],["b","c"]]
   }
 }"#;
         let tokenizer = Tokenizer::from_str(tok_json_in).unwrap();

--- a/tokenizers/src/tokenizer/serialization.rs
+++ b/tokenizers/src/tokenizer/serialization.rs
@@ -282,6 +282,77 @@ mod tests {
         assert_eq!(tok_str, tok_json_in);
     }
 
+    /// Backward compatibility: pre-compaction tokenizer.json files used multi-line vocab,
+    /// multi-line added_tokens, and the legacy `"a b"` merges representation. They must
+    /// still deserialize and round-trip through the new compact serializer.
+    #[test]
+    fn test_legacy_pretty_format_is_still_deserializable() {
+        let legacy = r#"{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [
+    {
+      "id": 0,
+      "content": "<unk>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    },
+    {
+      "id": 1,
+      "content": "<s>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    }
+  ],
+  "normalizer": null,
+  "pre_tokenizer": null,
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "BPE",
+    "dropout": null,
+    "unk_token": "<unk>",
+    "continuing_subword_prefix": null,
+    "end_of_word_suffix": null,
+    "fuse_unk": false,
+    "byte_fallback": false,
+    "ignore_merges": false,
+    "vocab": {
+      "<unk>": 0,
+      "<s>": 1,
+      "a": 2,
+      "b": 3,
+      "c": 4,
+      "ab": 5,
+      "bc": 6
+    },
+    "merges": [
+      "a b",
+      "b c"
+    ]
+  }
+}"#;
+        let tokenizer = Tokenizer::from_str(legacy).unwrap();
+
+        // Compact re-serialization should be strictly smaller than the legacy pretty form.
+        let compact = serde_json::to_string_pretty(&tokenizer).unwrap();
+        assert!(compact.len() < legacy.len());
+
+        // And re-parsing the compact form must reproduce the same Tokenizer.
+        let reparsed = Tokenizer::from_str(&compact).unwrap();
+        assert_eq!(
+            serde_json::to_string(&tokenizer).unwrap(),
+            serde_json::to_string(&reparsed).unwrap(),
+        );
+    }
+
     #[cfg(feature = "http")]
     #[test]
     fn test_from_pretrained() {

--- a/tokenizers/src/tokenizer/serialization.rs
+++ b/tokenizers/src/tokenizer/serialization.rs
@@ -177,7 +177,9 @@ mod tests {
 
     #[test]
     fn test_deserialization_serialization_invariant() {
-        let tok_json = r#"{
+        // Pretty output keeps the top-level structure indented but emits each added_token
+        // and the vocab map on a single line each (see OrderedVocabIter + AddedVocabulary).
+        let tok_json_in = r#"{
   "version": "1.0",
   "truncation": null,
   "padding": null,
@@ -222,11 +224,38 @@ mod tests {
     "vocab": {}
   }
 }"#;
-        let tokenizer = Tokenizer::from_str(tok_json).unwrap();
+        let tok_json_out = r#"{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [
+    {"id":0,"content":"[SPECIAL_0]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false,"special":true},
+    {"id":1,"content":"[SPECIAL_1]","single_word":false,"lstrip":false,"rstrip":false,"normalized":true,"special":false},
+    {"id":2,"content":"[SPECIAL_2]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false,"special":true}
+  ],
+  "normalizer": null,
+  "pre_tokenizer": null,
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "WordPiece",
+    "unk_token": "[UNK]",
+    "continuing_subword_prefix": "",
+    "max_input_chars_per_word": 100,
+    "vocab": {}
+  }
+}"#;
+        let tokenizer = Tokenizer::from_str(tok_json_in).unwrap();
 
         let tok_str = serde_json::to_string_pretty(&tokenizer).unwrap();
-        // It should be exactly the same as above
-        assert_eq!(tok_str, tok_json);
+        assert_eq!(tok_str, tok_json_out);
+
+        // The compact form should round-trip into an identical Tokenizer.
+        let reparsed = Tokenizer::from_str(&tok_str).unwrap();
+        assert_eq!(
+            serde_json::to_string_pretty(&reparsed).unwrap(),
+            tok_str,
+        );
     }
 
     #[cfg(feature = "http")]

--- a/tokenizers/src/tokenizer/serialization.rs
+++ b/tokenizers/src/tokenizer/serialization.rs
@@ -258,6 +258,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_pretty_bpe_vocab_and_merges_are_compact() {
+        // BPE model with non-empty vocab + merges: each vocab map and each merge pair
+        // should be emitted on a single line under pretty output.
+        let tok_json_in = r#"{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [],
+  "normalizer": null,
+  "pre_tokenizer": null,
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "BPE",
+    "dropout": null,
+    "unk_token": "<unk>",
+    "continuing_subword_prefix": null,
+    "end_of_word_suffix": null,
+    "fuse_unk": false,
+    "byte_fallback": false,
+    "ignore_merges": false,
+    "vocab": {"<unk>":0,"a":1,"b":2,"c":3,"ab":4,"bc":5},
+    "merges": [
+      ["a","b"],
+      ["b","c"]
+    ]
+  }
+}"#;
+        let tokenizer = Tokenizer::from_str(tok_json_in).unwrap();
+        let tok_str = serde_json::to_string_pretty(&tokenizer).unwrap();
+        assert_eq!(tok_str, tok_json_in);
+    }
+
     #[cfg(feature = "http")]
     #[test]
     fn test_from_pretrained() {

--- a/tokenizers/tests/serialization.rs
+++ b/tokenizers/tests/serialization.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::*;
+use std::str::FromStr;
 use tokenizers::decoders::byte_level::ByteLevel;
 use tokenizers::decoders::DecoderWrapper;
 use tokenizers::models::bpe::BPE;
@@ -247,4 +248,30 @@ fn bpe_with_dropout_serde() {
 #[test]
 fn test_deserialize_long_file() {
     let _tokenizer = Tokenizer::from_file("data/albert-base-v1-tokenizer.json").unwrap();
+}
+
+/// Backward compatibility: the DeepSeek-V4-Flash-Base tokenizer.json was published in the
+/// old pretty-printed layout, including the legacy `"a b"` merges representation. Loading
+/// it must succeed, round-trip through our (now-compact) serializer, and re-load to the
+/// same `Tokenizer`. The compact re-serialization must also be strictly smaller than the
+/// original file — that's the whole point of the change.
+#[test]
+fn test_deserialize_deepseek_v4_flash_base_backward_compat() {
+    let path = "data/deepseek-v4-flash-base-tokenizer.json";
+    let original = std::fs::read_to_string(path).unwrap();
+    let tokenizer = Tokenizer::from_file(path).unwrap();
+
+    let pretty = serde_json::to_string_pretty(&tokenizer).unwrap();
+    assert!(
+        pretty.len() < original.len(),
+        "compact pretty output ({} bytes) should be smaller than the legacy pretty file ({} bytes)",
+        pretty.len(),
+        original.len(),
+    );
+
+    let reparsed = Tokenizer::from_str(&pretty).unwrap();
+    assert_eq!(
+        serde_json::to_string(&tokenizer).unwrap(),
+        serde_json::to_string(&reparsed).unwrap(),
+    );
 }


### PR DESCRIPTION
## Summary

- `OrderedVocabIter` (used by BPE / WordPiece / WordLevel) now serializes the whole vocab map as a single line.
- `AddedVocabulary` now emits each entry of `added_tokens` as a single line, one token per array element — the outer array still wraps so diffs stay clean.

`serde_json`'s `raw_value` feature is enabled to support `RawValue::from_string` / `RawValue::serialize`.

Result: pretty output now looks like
```json
{
  "version": "1.0",
  ...
  "added_tokens": [
    {"id":0,"content":"[SPECIAL_0]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false,"special":true},
    ...
  ],
  ...
  "model": {
    "type": "BPE",
    "vocab": {"<unk>":0,"a":1,"b":2,...},
    "merges": [...]
  }
}
```
