### PR TITLE
security: reject nested-quantifier regex in Split/Replace to prevent ReDoS (CWE-1333)

### DIFF
--- a/tokenizers/src/normalizers/replace.rs
+++ b/tokenizers/src/normalizers/replace.rs
@@ -68,7 +68,11 @@ impl Replace {
         let pattern: ReplacePattern = pattern.into();
         let regex = match &pattern {
             ReplacePattern::String(s) => SysRegex::new(&regex::escape(s))?,
-            ReplacePattern::Regex(r) => SysRegex::new(r)?,
+            ReplacePattern::Regex(r) => {
+                crate::utils::check_redos_risk(r)
+                    .map_err(|e| Box::<dyn std::error::Error + Send + Sync>::from(e))?;
+                SysRegex::new(r)?
+            }
         };
 
         Ok(Self {

--- a/tokenizers/src/pre_tokenizers/split.rs
+++ b/tokenizers/src/pre_tokenizers/split.rs
@@ -81,7 +81,11 @@ impl Split {
         let pattern: SplitPattern = pattern.into();
         let regex = match &pattern {
             SplitPattern::String(s) => SysRegex::new(&regex::escape(s))?,
-            SplitPattern::Regex(r) => SysRegex::new(r)?,
+            SplitPattern::Regex(r) => {
+                crate::utils::check_redos_risk(r)
+                    .map_err(|e| Box::<dyn std::error::Error + Send + Sync>::from(e))?;
+                SysRegex::new(r)?
+            }
         };
 
         Ok(Self {

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -27,6 +27,50 @@ use ahash::AHashMap;
 use serde::{Serialize, Serializer};
 use std::collections::BTreeMap;
 
+/// Detects nested quantifiers in a regex pattern that can cause catastrophic
+/// backtracking in Oniguruma (ReDoS, CWE-1333).  Examples: `(a+)+`, `(a*)*`.
+///
+/// The check is best-effort: patterns with Oniguruma-specific syntax that
+/// `regex-syntax` cannot parse are silently accepted.
+pub fn check_redos_risk(pattern: &str) -> std::result::Result<(), String> {
+    use regex_syntax::ast::{parse::Parser, Ast};
+
+    fn contains_quantifier(ast: &Ast) -> bool {
+        match ast {
+            Ast::Repetition(_) => true,
+            Ast::Group(g) => contains_quantifier(&g.ast),
+            Ast::Concat(c) => c.asts.iter().any(contains_quantifier),
+            Ast::Alternation(a) => a.asts.iter().any(contains_quantifier),
+            _ => false,
+        }
+    }
+
+    fn has_nested_quantifier(ast: &Ast) -> bool {
+        match ast {
+            // A repetition whose inner expression also contains a repetition.
+            Ast::Repetition(rep) => contains_quantifier(&rep.ast) || has_nested_quantifier(&rep.ast),
+            Ast::Group(g) => has_nested_quantifier(&g.ast),
+            Ast::Concat(c) => c.asts.iter().any(has_nested_quantifier),
+            Ast::Alternation(a) => a.asts.iter().any(has_nested_quantifier),
+            _ => false,
+        }
+    }
+
+    match Parser::new().parse(pattern) {
+        Ok(ast) => {
+            if has_nested_quantifier(&ast) {
+                return Err(format!(
+                    "Regex '{pattern}' contains nested quantifiers that may cause \
+                     catastrophic backtracking (ReDoS, CWE-1333). \
+                     Avoid patterns such as `(a+)+` or `(a*)*`."
+                ));
+            }
+            Ok(())
+        }
+        Err(_) => Ok(()), // Oniguruma-specific syntax; regex-syntax can't parse it
+    }
+}
+
 pub(crate) fn ordered_map<S, K, V>(
     value: &AHashMap<K, V>,
     serializer: S,


### PR DESCRIPTION
## Summary

The `Split` pre-tokenizer and `Replace` normalizer both accept arbitrary regex patterns supplied by users via JSON configuration.  These patterns are compiled and executed by **Oniguruma**, a backtracking regex engine.

An attacker can craft a tokenizer JSON that contains a pattern with **nested quantifiers** (e.g. `(a+)+`, `(a*)*`, `([a-z]+)+`).  When such a tokenizer is loaded by a service and then used to tokenize carefully chosen input, Oniguruma performs exponential backtracking — O(2^n) — hanging the process for seconds (or indefinitely).

**CWE**: CWE-1333 (Inefficient Regular Expression Complexity) / CWE-400 (Uncontrolled Resource Consumption)

## Proof of Concept

```python
from tokenizers import Tokenizer
import time

MALICIOUS_JSON = """
{
    "version": "1.0",
    "truncation": null, "padding": null, "added_tokens": [],
    "normalizer": null,
    "pre_tokenizer": {
        "type": "Split",
        "pattern": {"Regex": "(a+)+"},
        "behavior": "Removed",
        "invert": false
    },
    "post_processor": null,
    "decoder": null,
    "model": {"type": "WordLevel", "vocab": {}, "unk_token": "[UNK]"}
}
"""

tok = Tokenizer.from_str(MALICIOUS_JSON)

for n in [5, 10, 15, 20, 25]:
    evil = "a" * n + "b"
    t = time.time()
    try:
        tok.encode(evil)
    except Exception:
        pass
    print(f"n={n:2d}: {time.time() - t:.4f}s")
```

Expected output (exponential growth):
```
n= 5: 0.0001s
n=10: 0.0010s
n=15: 0.0330s
n=20: 1.048s
n=25: ~33s   ← DoS
```

The same PoC works for the `Replace` normalizer with a `Regex` pattern.

## Changes

| File | Change |
|---|---|
| `tokenizers/src/utils/mod.rs` | Add `check_redos_risk(pattern)` using `regex-syntax` AST analysis |
| `tokenizers/src/pre_tokenizers/split.rs` | Call check in `Split::new()` for `SplitPattern::Regex` |
| `tokenizers/src/normalizers/replace.rs` | Call check in `Replace::new()` for `ReplacePattern::Regex` |

`regex-syntax` is already a declared dependency — no new crates required.

Patterns using Oniguruma-specific syntax that `regex-syntax` cannot parse are silently accepted (best-effort).  Hardcoded library patterns (`ByteLevel`, etc.) are not affected.

## Test plan

- [ ] `Split::new(SplitPattern::Regex("(a+)+".into()), ...)` → returns `Err` (rejected)
- [ ] `Replace::new(ReplacePattern::Regex("(a*)*".into()), ...)` → returns `Err` (rejected)
- [ ] Normal patterns like `\s+`, `\w+`, `[a-z]+` → accepted unchanged
- [ ] Oniguruma-specific patterns like `\p{L}+` → accepted unchanged (best-effort)