### PR TITLE
Replace dead wikitext s3 link in quicktour with HF dataset mirror

### DIFF
--- a/docs/source-doc-builder/quicktour.mdx
+++ b/docs/source-doc-builder/quicktour.mdx
@@ -12,7 +12,7 @@ tokenizer on [wikitext-103](https://www.salesforce.com/blog/the-wikitext-long-te
 to download this dataset and unzip it with:
 
 ``` bash
-wget https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-raw-v1.zip
+wget https://huggingface.co/datasets/mattdangerw/wikitext-103-raw/resolve/main/wikitext-103-raw-v1.zip
 unzip wikitext-103-raw-v1.zip
 ```
 


### PR DESCRIPTION
## Summary

The `wget` URL in `docs/source-doc-builder/quicktour.mdx` points at
`s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-raw-v1.zip`,
which has been dead since the `research.metamind.io` takedown. It now
301-redirects to a host that no longer responds (or returns 403 directly
on the S3 path, as reported in #1683). Anyone following the quicktour
hits the dead link on the very first command.

PR #1846 fixed the related Salesforce blog link in the surrounding prose
but not the actual download command, so both #1625 and #1683 are still
open.

This swaps the URL to the canonical `wikitext-103-raw-v1.zip` mirrored
on the Hub at `huggingface.co/datasets/mattdangerw/wikitext-103-raw`.
The archive contents and layout are identical, so the existing
`unzip wikitext-103-raw-v1.zip` step and all downstream paths
(`data/wikitext-103-raw/wiki.{train,test,valid}.raw` in
`test_quicktour.py`, `test_pipeline.py`, and `documentation.rs`) keep
working without further changes.

## Verification

```
$ curl -sI https://huggingface.co/datasets/mattdangerw/wikitext-103-raw/resolve/main/wikitext-103-raw-v1.zip | head -5
HTTP/2 302
content-type: text/plain; charset=utf-8
content-length: 1403
location: https://cas-bridge.xethub.hf.co/...wikitext-103-raw-v1.zip...
```

The Hub redirects to its CDN and serves the full 192 MB zip with the
expected filename.

Fixes #1625
Fixes #1683