### PR TITLE
Document that train_new_from_iterator uses BPE for WordPiece

### DIFF
--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -425,6 +425,12 @@ impl PyBpeTrainer {
 
 /// Trainer capable of training a WordPiece model
 ///
+/// Note:
+///     ``Tokenizer.train_new_from_iterator()`` always uses the BPE trainer
+///     internally, even when the underlying model is WordPiece. To train a
+///     true WordPiece tokenizer, use ``WordPieceTrainer`` with
+///     ``tokenizer.train(...)`` directly, as shown in the example below.
+///
 /// Args:
 ///     vocab_size (:obj:`int`, `optional`):
 ///         The size of the final vocabulary, including all tokens and alphabet.

--- a/docs/source-doc-builder/components.mdx
+++ b/docs/source-doc-builder/components.mdx
@@ -128,6 +128,14 @@ they are the only mandatory component of a Tokenizer.
 | WordPiece | This is a subword tokenization algorithm quite similar to BPE, used mainly by Google in models like BERT. It uses a greedy algorithm, that tries to build long words first, splitting in multiple tokens when entire words don’t exist in the vocabulary. This is different from BPE that starts from characters, building bigger tokens as possible. It uses the famous `##` prefix to identify tokens that are part of a word (ie not starting a word).  |
 | Unigram | Unigram is also a subword tokenization algorithm, and works by trying to identify the best set of subword tokens to maximize the probability for a given sentence. This is different from BPE in the way that this is not deterministic based on a set of rules applied sequentially. Instead Unigram will be able to compute multiple ways of tokenizing, while choosing the most probable one. |
 
+<Tip warning={true}>
+
+`Tokenizer.train_new_from_iterator()` always uses the BPE trainer internally,
+even when the underlying model is WordPiece. To train a true WordPiece
+tokenizer, use `WordPieceTrainer` with `tokenizer.train(...)` directly.
+
+</Tip>
+
 ## Post-Processors
 
 After the whole pipeline, we sometimes want to insert some special


### PR DESCRIPTION
## Summary

Closes #1777.

Users following the [HF LLM course](https://huggingface.co/learn/llm-course/en/chapter6/6) call `train_new_from_iterator()` on a WordPiece tokenizer and silently get a BPE-trained vocabulary, because the library uses BPE internally for that path. @ArthurZucker confirmed in #1777 that this should be documented.

This PR adds the clarification in two places:

- `docs/source-doc-builder/components.mdx`: a `<Tip warning>` callout under the Models section pointing readers to `WordPieceTrainer` + `tokenizer.train(...)` when they actually want WordPiece.
- `bindings/python/src/trainers.rs`: a `Note:` block in the `WordPieceTrainer` Python docstring so the same caveat surfaces in API help.

No code changes. I skipped regenerating the `.pyi` stubs since this is docstring-only and my local toolchain may not match CI; happy to add a stub refresh commit if you want.

## Test plan

- [x] `git diff` shows only docs/docstring edits, no code changes
- [x] `<Tip>` syntax matches existing usage in `quicktour.mdx`
- [x] Docstring `Note:` block follows the existing `Args:` / `Example:` style in `trainers.rs`