### PR TITLE
Fix typo in EncodingVisualizer.annotation_converter attribute

### DIFF
--- a/bindings/python/py_src/tokenizers/tools/visualizer.py
+++ b/bindings/python/py_src/tokenizers/tools/visualizer.py
@@ -104,7 +104,7 @@ class EncodingVisualizer:
                     raise ImportError(msg) from None
         self.tokenizer = tokenizer
         self.default_to_notebook = default_to_notebook
-        self.annotation_coverter = annotation_converter
+        self.annotation_converter = annotation_converter
         pass
 
     def __call__(
@@ -150,8 +150,8 @@ class EncodingVisualizer:
                     raise ImportError(msg) from None
         if annotations is None:
             annotations = []
-        if self.annotation_coverter is not None:
-            annotations = list(map(self.annotation_coverter, annotations))
+        if self.annotation_converter is not None:
+            annotations = list(map(self.annotation_converter, annotations))
         encoding = self.tokenizer.encode(text)
         html = EncodingVisualizer.__make_html(text, encoding, annotations)
         if final_default_to_notebook:


### PR DESCRIPTION
Tiny fix found while reading the visualizer code.

\`EncodingVisualizer.__init__\` stashes the converter under \`self.annotation_coverter\` (missing 'n'), and \`__call__\` reads from the same misspelled attribute. The keyword argument and the docstring both spell it correctly, so the public name and the attribute name don't match. Anyone trying to set or read \`viz.annotation_converter\` after instantiation would silently end up with a separate attribute, while the misspelled one keeps being used internally.

Renamed the attribute to match the public spelling. No behavior change otherwise, just makes \`self.annotation_converter\` actually do what its name says.