### PR TITLE
Bindings: acquire model read-lock once per call instead of per pre-token

### DIFF
--- a/bindings/node/src/models.rs
+++ b/bindings/node/src/models.rs
@@ -93,6 +93,24 @@ impl tk::Model for Model {
       .tokenize(sequence)
   }
 
+  /// See [`tk::Model::tokenize_in_pretokenized`] for the lock-once rationale.
+  fn tokenize_in_pretokenized(
+    &self,
+    pretokenized: &mut tk::tokenizer::PreTokenizedString,
+    truncation: Option<(usize, tk::TruncationDirection)>,
+  ) -> tk::Result<()> {
+    let model = self.model.as_ref().ok_or("Uninitialized Model")?;
+    let guard = model.read().unwrap();
+    match truncation {
+      Some((max_tokens, direction)) => pretokenized.tokenize_with_limit(
+        |normalized| guard.tokenize(normalized.get()),
+        max_tokens,
+        direction,
+      ),
+      None => pretokenized.tokenize(|normalized| guard.tokenize(normalized.get())),
+    }
+  }
+
   fn token_to_id(&self, token: &str) -> Option<u32> {
     self.model.as_ref()?.read().unwrap().token_to_id(token)
   }

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -14,6 +14,7 @@ use tk::models::unigram::Unigram;
 use tk::models::wordlevel::WordLevel;
 use tk::models::wordpiece::{WordPiece, WordPieceBuilder};
 use tk::models::ModelWrapper;
+use tk::tokenizer::PreTokenizedString;
 use tk::{Model, Token};
 use tokenizers as tk;
 
@@ -49,6 +50,23 @@ impl Model for PyModel {
 
     fn tokenize(&self, tokens: &str) -> tk::Result<Vec<Token>> {
         self.model.read().unwrap().tokenize(tokens)
+    }
+
+    /// See [`Model::tokenize_in_pretokenized`] for the lock-once rationale.
+    fn tokenize_in_pretokenized(
+        &self,
+        pretokenized: &mut PreTokenizedString,
+        truncation: Option<(usize, tk::TruncationDirection)>,
+    ) -> tk::Result<()> {
+        let guard = self.model.read().unwrap();
+        match truncation {
+            Some((max_tokens, direction)) => pretokenized.tokenize_with_limit(
+                |normalized| guard.tokenize(normalized.get()),
+                max_tokens,
+                direction,
+            ),
+            None => pretokenized.tokenize(|normalized| guard.tokenize(normalized.get())),
+        }
     }
 
     fn token_to_id(&self, token: &str) -> Option<u32> {

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -85,6 +85,36 @@ pub trait Model {
     fn save(&self, folder: &Path, prefix: Option<&str>) -> Result<Vec<PathBuf>>;
     /// Get an instance of a Trainer capable of training this Model
     fn get_trainer(&self) -> <Self as Model>::Trainer;
+
+    /// Tokenize every pre-token within a `PreTokenizedString` in one call.
+    ///
+    /// When `truncation` is `Some((max_tokens, direction))`, the
+    /// `tokenize_with_limit` early-exit path is taken; otherwise every
+    /// pre-token is tokenized.
+    ///
+    /// The default calls `self.tokenize()` per pre-token, which is correct
+    /// for self-contained `Model` implementations.  Implementations that
+    /// wrap their inner model behind a lock (e.g. the `PyModel` and Node
+    /// `Model` bindings, both `Arc<RwLock<_>>`) can override this to
+    /// acquire the lock once for the whole sequence of pre-tokens; that
+    /// removes ~one atomic load/store pair per pre-token from the hot path
+    /// (~1 500 pre-tokens per ~10 KB document).  Both the truncated and
+    /// non-truncated paths benefit from the override because they share
+    /// this entry point.
+    fn tokenize_in_pretokenized(
+        &self,
+        pretokenized: &mut PreTokenizedString,
+        truncation: Option<(usize, TruncationDirection)>,
+    ) -> Result<()> {
+        match truncation {
+            Some((max_tokens, direction)) => pretokenized.tokenize_with_limit(
+                |normalized| self.tokenize(normalized.get()),
+                max_tokens,
+                direction,
+            ),
+            None => pretokenized.tokenize(|normalized| self.tokenize(normalized.get())),
+        }
+    }
 }
 
 /// A `PostProcessor` has the responsibility to post process an encoded output of the `Tokenizer`.
@@ -1153,20 +1183,19 @@ where
         offsets_type: OffsetType,
     ) -> Result<Encoding> {
         let mut pretokenized: PreTokenizedString = pretokenized.into();
-        match self.truncation.as_ref() {
+        let truncation = match self.truncation.as_ref() {
             Some(TruncationParams {
                 direction,
                 max_length,
                 strategy,
                 ..
-            }) if *strategy != TruncationStrategy::OnlySecond || type_id != 0 => pretokenized
-                .tokenize_with_limit(
-                    |normalized| self.model.tokenize(normalized.get()),
-                    *max_length,
-                    *direction,
-                )?,
-            _ => pretokenized.tokenize(|normalized| self.model.tokenize(normalized.get()))?,
-        }
+            }) if *strategy != TruncationStrategy::OnlySecond || type_id != 0 => {
+                Some((*max_length, *direction))
+            }
+            _ => None,
+        };
+        self.model
+            .tokenize_in_pretokenized(&mut pretokenized, truncation)?;
         pretokenized.into_encoding(word_idx, type_id, offsets_type)
     }
 }


### PR DESCRIPTION
The Python and Node bindings both wrap the inner model in
`Arc<RwLock<ModelWrapper>>`.  Their `Model::tokenize()` impls each do
`self.model.read().unwrap().tokenize(seq)`, so a single `read()` lock
acquisition per call is unavoidable -- but `TokenizerImpl::do_tokenize`
calls `tokenize()` once per pre-token, and a typical ~6 KB document
contains ~1 500 pre-tokens.  Each acquire/release pair on the
`RwLock` becomes one atomic operation per pre-token that produces no
useful work.

Add a default `Model::tokenize_in_pretokenized` trait method that
takes the optional truncation parameters and dispatches to either
`PreTokenizedString::tokenize` or `tokenize_with_limit`.  Override it
in `PyModel` (Python binding) and `Model` (Node binding) so that
both bindings acquire the read lock once and tokenize every
pre-token under the same guard.  `TokenizerImpl::do_tokenize` calls
the new method instead of dispatching per pre-token, which makes
both the truncated and the non-truncated paths benefit from the
override.  The full doc lives once on the trait method; the
overrides just point at it.

The default implementation preserves the old behaviour byte-for-byte
for any `Model` that is not behind a `RwLock`, so adding the method
to the public trait is non-breaking: external implementors do not
need to override it.

```
cargo test --lib --features http
 201 passed, 0 failed.

cargo clippy --lib --tests --features http -- -D warnings
 clean on tokenizers/, bindings/python/, bindings/node/.
```
Throughput on a Python script that calls `tokenizer.encode_batch
(docs, false)` in a 15 s wall-clock loop, where `docs` is
`tokenizers/data/big.txt` (6.5 MB) split into 999 ~6.5 KB chunks.
`encode_batch` calls completed (more is better):
```
  platform                              cores   threads  before   after
  ---------                             -----   -------  ------   -----
  NVIDIA Vera (aarch64)                  89P    1T          10      10
                                                88T         57     147   (+158 %)
  AMD EPYC 9124 (x86_64)                 16P    1T           8       8
                                                16T         63      68   (+8 %)
                                                32T         65      70   (+8 %)
  Apple M3 (aarch64, no SMT)             12P    1T          11      11
                                                6T          43      45   (+5 %)
                                                12T         47      54   (+15 %)
```
The 1T cases are flat on every platform because tokenisation is
dominated by BPE merging itself; there is no contention on a single
thread.  The win scales with thread count and is largest on
many-core aarch64 (where each LSE acquire/release pair takes
substantially more cycles than x86 `lock cmpxchg` under contention).

Perf evidence on Vera at 88T, wheels built `-Ctarget-feature=
+lse,+rcpc`, `perf record -g --call-graph fp -F 4999`:
```
  symbol                                                before    after
  <PyModel as Model>::tokenize                          75.36%    -
  <PyModel as Model>::tokenize_in_pretokenized          -          0.00%
  <ModelWrapper as Model>::tokenize                      0.01%     0.21%
  tokenizers::models::bpe::word::Word::merge_all         -         3.72%
  tokenizers::models::bpe::model::BPE::merge_word        0.17%     1.25%
  std::sys::sync::rwlock::futex::RwLock::read_contended  0.07%     0.00%
```
Before, 75 % of CPU cycles are inside `PyModel::tokenize`, the
wrapper that takes an `Arc<RwLock>::read` per pre-token, calls the
inner BPE, then drops the guard.  After, that wrapper is replaced by
a single call to `tokenize_in_pretokenized` which takes the lock
once for the whole pre-token sequence; the actual BPE merging
(`Word::merge_all`, `BPE::merge_word`) surfaces in the profile where
it should have been all along.

Perf on AMD EPYC 9124 at 16T (built without `+lse`, atomics inlined
as native x86 `lock` instructions):
```
  symbol                                                before    after
  <BPE as Model>::tokenize                              0.70%     0.50%
  <PyModel as Model>::tokenize                          0.60%     -
  <ModelWrapper as Model>::tokenize                     0.15%     0.16%
  std::sys::sync::rwlock::futex::RwLock::read_contended 0.01%     0.00%
```
The relative magnitudes are vastly smaller on x86 because uncontended
`lock cmpxchg` is fast, but the wall-clock direction is the same.

The Rust-only `bpe_benchmark` (which builds `BPE` directly via
`BpeBuilder` and never goes through `PyModel`) is unaffected by this
change: 3.93 -> 3.94 MiB/s at 1T and 17.97 -> 17.93 MiB/s at 88T,
both within run-to-run noise.