### PR TITLE
bindings & bench: use mimalloc as global allocator on tested  targets

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,28 +23,41 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
+        # `manylinux` selects the build image per target.  x86_64 and
+        # aarch64 use manylinux_2_28 (gcc 12, glibc 2.28) because mimalloc
+        # requires a C11 <stdatomic.h>-capable compiler, which the default
+        # manylinux2014 cross-gcc (4.8.5) lacks.  The other targets keep
+        # `auto` (manylinux2014): manylinux_2_28 has no image for them and
+        # they do not build mimalloc anyway.
         platform:
           - runner: ubuntu-latest
             arch: x86_64
             target: x86_64-unknown-linux-gnu
+            manylinux: '2_28'
           - runner: ubuntu-latest
             arch: x86
             target: i686-unknown-linux-gnu
+            manylinux: auto
           - runner: ubuntu-latest
             arch: aarch64
             target: aarch64-unknown-linux-gnu
+            manylinux: '2_28'
           - runner: ubuntu-latest
             arch: armv7
             target: armv7-unknown-linux-gnueabihf
+            manylinux: auto
           - runner: ubuntu-latest
             arch: s390x
             target: s390x-unknown-linux-gnu
+            manylinux: auto
           - runner: ubuntu-latest
             arch: ppc64le
             target: powerpc64le-unknown-linux-gnu
+            manylinux: auto
           - runner: ubuntu-latest
             arch: riscv64
             target: riscv64gc-unknown-linux-gnu
+            manylinux: auto
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -56,7 +69,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: 'true'
-          manylinux: auto
+          manylinux: ${{ matrix.platform.manylinux }}
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -16,6 +16,22 @@ serde       = { version = "1.0.163", features = ["derive"] }
 tokenizers  = { path = "../../tokenizers/" }
 ahash = { version = "0.8.11", features = ["serde"] }
 
+[features]
+default = ["mimalloc"]
+# Use mimalloc as the global allocator inside this cdylib.  Cuts per-call
+# malloc/free traffic.  The dependency is declared only on targets where
+# mimalloc has been tested (see target-conditional [dependencies] below),
+# so on other targets enabling this feature is a no-op and the system
+# allocator is used.  Disable with `--no-default-features` to opt out
+# even on supported targets.
+mimalloc = ["dep:mimalloc"]
+
+# mimalloc is restricted to targets where it has been tested.  Other
+# targets fall back to the system allocator until community testing
+# adds them.
+[target.'cfg(any(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64"), target_env = "gnu"), all(target_os = "macos", target_arch = "aarch64")))'.dependencies]
+mimalloc = { version = "0.1", optional = true }
+
 [build-dependencies]
 napi-build = "2"
 

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -1,5 +1,29 @@
 #![deny(clippy::all)]
 
+// Use mimalloc as the global allocator inside this cdylib (the Rust
+// "binary" loaded by Node).  Replaces glibc malloc for every
+// allocation made by Rust code inside tokenizers; cuts the per-call
+// malloc/free LSE atomic traffic that shows up on aarch64.  The
+// choice is local to this cdylib and does not affect the
+// `tokenizers` library crate or any Rust binary that consumes it
+// directly.
+//
+// The same cfg expression as the target-conditional dependency in
+// `Cargo.toml`.  Keep these in sync when adding platforms.
+#[cfg(all(
+  feature = "mimalloc",
+  any(
+    all(
+      target_os = "linux",
+      any(target_arch = "x86_64", target_arch = "aarch64"),
+      target_env = "gnu"
+    ),
+    all(target_os = "macos", target_arch = "aarch64"),
+  )
+))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 mod arc_rwlock_serde;

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -35,6 +35,19 @@ tempfile = "3.10"
 pyo3 = { version = "0.28", features = ["auto-initialize", "experimental-inspect"] }
 
 [features]
-default = ["ext-module", "abi3"]
+default = ["ext-module", "abi3", "mimalloc"]
 ext-module = ["pyo3/extension-module"]
 abi3 = ["pyo3/abi3", "pyo3/abi3-py310"]
+# Use mimalloc as the global allocator inside this cdylib.  Cuts per-call
+# malloc/free traffic.  The dependency is declared only on targets where
+# mimalloc has been tested (see target-conditional [dependencies] below),
+# so on other targets enabling this feature is a no-op and the system
+# allocator is used.  Disable with `--no-default-features` to opt out
+# even on supported targets.
+mimalloc = ["dep:mimalloc"]
+
+# mimalloc is restricted to targets where it has been tested.  Other
+# targets (Windows, musl, 32-bit, exotic Linux arches, macOS x86_64)
+# fall back to the system allocator until community testing adds them.
+[target.'cfg(any(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64"), target_env = "gnu"), all(target_os = "macos", target_arch = "aarch64")))'.dependencies]
+mimalloc = { version = "0.1", optional = true }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3,6 +3,30 @@
 // Many false positives with pyo3 it seems &str, and &PyAny get flagged
 #![allow(clippy::borrow_deref_ref)]
 
+// Use mimalloc as the global allocator inside this cdylib (the Rust
+// "binary" loaded by the Python interpreter).  Replaces glibc malloc
+// for every allocation made by Rust code inside tokenizers; cuts the
+// per-call malloc/free LSE atomic traffic that shows up on aarch64.
+// The choice is local to this cdylib and does not affect the
+// `tokenizers` library crate or any Rust binary that consumes it
+// directly.
+//
+// The same cfg expression as the target-conditional dependency in
+// `Cargo.toml`.  Keep these in sync when adding platforms.
+#[cfg(all(
+    feature = "mimalloc",
+    any(
+        all(
+            target_os = "linux",
+            any(target_arch = "x86_64", target_arch = "aarch64"),
+            target_env = "gnu"
+        ),
+        all(target_os = "macos", target_arch = "aarch64"),
+    )
+))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 extern crate tokenizers as tk;
 
 use once_cell::sync::Lazy;

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -111,6 +111,14 @@ assert_approx_eq = "1.1"
 tracing = "0.1"
 tracing-subscriber = "0.3.18"
 
+# Used only by the in-crate benches so they measure the same allocator
+# the production cdylib bindings ship with.  Target-conditional to
+# match the binding crates: on platforms where mimalloc has not been
+# tested, the bench falls back to the system allocator.  Does not
+# propagate to library consumers (dev-dependencies are crate-local).
+[target.'cfg(any(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64"), target_env = "gnu"), all(target_os = "macos", target_arch = "aarch64")))'.dev-dependencies]
+mimalloc = "0.1"
+
 [profile.release]
 lto = "fat"
 

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -1,6 +1,26 @@
 #[macro_use]
 extern crate criterion;
 
+// Use mimalloc as the global allocator for this benchmark binary so
+// numbers reflect what the production cdylib bindings (Python / Node)
+// ship with.  Setting `#[global_allocator]` here applies only to this
+// bench binary, not to the `tokenizers` library crate, so downstream
+// Rust consumers of the library are not affected.
+//
+// The same cfg expression as the target-conditional dev-dependency in
+// `Cargo.toml`.  On targets where mimalloc has not been tested, the
+// bench falls back to the system allocator.
+#[cfg(any(
+    all(
+        target_os = "linux",
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        target_env = "gnu"
+    ),
+    all(target_os = "macos", target_arch = "aarch64"),
+))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 mod common;
 
 use criterion::{Criterion, Throughput};


### PR DESCRIPTION
Profiles of `tokenizer.encode_batch(...)` show `malloc`/`free`/`realloc`
calls inside libc costing a measurable fraction of CPU cycles.  At high
thread counts they emit cross-thread atomic operations on every free.
mimalloc has a thread-local free-list fast path (no atomics until a
cross-thread free is delayed) and is faster per call than glibc malloc.

`#[global_allocator]` is a process-wide setting; declaring it in a
library crate would make the choice global for every downstream Rust
binary that depends on `tokenizers`, conflict with any other
`#[global_allocator]` chosen by a consumer, and is broadly considered
bad practice.  This patch therefore opts each *binary* into mimalloc
independently:

- `bindings/python/` (cdylib loaded by the Python interpreter) gains
  an optional `mimalloc` feature, enabled by default, that registers
  `mimalloc::MiMalloc` as the cdylib's global allocator.
- `bindings/node/` (cdylib loaded by Node) gains the same feature
  and default.
- `tokenizers/benches/bpe_benchmark.rs` registers mimalloc as the
  bench binary's global allocator via `mimalloc` in
  `[dev-dependencies]`.  This way `cargo bench` numbers reflect the
  same allocator the production wheels ship with, without imposing
  any allocator choice on library consumers (dev-dependencies do not
  propagate).

The `tokenizers/` library crate (`src/lib.rs`, runtime feature set)
is intentionally unchanged.

# Restricted to tested targets

The first iteration of this patch broke CI on every target other than
musllinux and recent macOS, for two distinct reasons:

- libmimalloc-sys 0.1.49 passes `-Werror=date-time` unconditionally,
  which fails on the older cross-compile gcc shipped by the
  ubuntu-latest manylinux2014 builders for s390x, ppc64le, armv7,
  riscv64, and 32-bit x86.
- MSVC linker mismatch on Windows: mimalloc's C objects use the static
  CRT (`MT_StaticRelease`) while esaxx_rs uses the dynamic CRT
  (`MD_DynamicRelease`), producing `LNK2038`.

Rather than work around each of those, the mimalloc dependency and
the `#[global_allocator]` declaration are now restricted by a
`cfg(...)` predicate to platforms where the patch author has measured
the change:

  - `aarch64-unknown-linux-gnu`
  - `x86_64-unknown-linux-gnu`
  - `aarch64-apple-darwin`

On any other target the mimalloc crate is not pulled in (Cargo
honours `[target.cfg.dependencies]`) and the `#[global_allocator]`
line is `#[cfg(false)]`, so the cdylib falls back transparently to
the system allocator and the build proceeds without error.  The
`mimalloc` feature stays in `default` features so users on tested
targets get the win automatically; users on tested targets who
want the system allocator can `--no-default-features`.

Community testing of additional triples is welcome.  Adding a triple
requires extending the same `cfg(...)` predicate in three places
(both binding Cargo.toml's + lib.rs, and the bench Cargo.toml +
bpe_benchmark.rs); the expressions are kept identical and reference
each other in comments.
```
cargo test --lib --features http 
 (tokenizers/, unchanged by this PR)
 201 passed, 0 failed.
```
# Throughput on tested platforms

`cargo bench --bench bpe_benchmark`, `bpe-encode/BPE GPT2 encode batch`
(`data/big.txt`, 6.5 MB through the full post-processor):
```
  platform                                              threads  before        after         change
  --------                                              -------  ------        ------        ------
  Vera, NVIDIA, Linux aarch64, 88 physical cores         1T      3.96 MiB/s    6.18 MiB/s    +56 %
                                                         88T     17.75 MiB/s   19.40 MiB/s   +9.3 %
  AMD EPYC 9124, Linux x86_64, 16 physical cores         1T      3.84 MiB/s    5.19 MiB/s    +35 %
                                                         16T     23.40 MiB/s   42.72 MiB/s   +83 %
  Apple M3 Pro, macOS aarch64, 12 unified cores          1T      4.64 MiB/s    6.90 MiB/s    +48 %
                                                         12T     17.53 MiB/s   34.60 MiB/s   +97 %
```
The 1T wins (+35-56 %) are the same mechanism on every platform: per-
call malloc/free is on the critical path when there is no contention,
and mimalloc's single-thread fast path is roughly twice as cheap as
glibc / libsystem malloc.

The at-full-physical-cores wins differ by platform: large on EPYC
(+83 %) and M3 Pro (+97 %), modest on Vera (+9.3 %).  On Vera the
`bpe_benchmark` hot path at 88T is bottlenecked by other
synchronisation primitives that this patch does not address; combined
with separate changes that target those primitives, mimalloc's
share-of-cycles win becomes a throughput win as well.  Measured here
on top of `main` alone, the +9.3 % is honest.

Perf evidence on Vera (88 physical cores) at 88T,
`perf record -g --call-graph fp -F 4999` on a Python process calling
`tokenizer.encode_batch(docs, false)` in a loop for 15 s (`docs` is
`data/big.txt` split into 999 ~6.5 KB chunks).  Wheels built
`-Ctarget-feature=+lse,+rcpc`:
```
  symbol                                         before     after
  libc malloc / cfree / realloc (combined)       ~1.8 %      ~0.13 %  (-13x)
  mimalloc family (mi_page_malloc, mi_free, ...) -           ~0.96 %
  std::thread::local::LocalKey<T>::with          -          14.25 %
```
The libc malloc family drops by an order of magnitude.  mimalloc's
fast path costs about half as much (~0.96 %) and brings in ~14 % of
cycles in `LocalKey::with`, the price of its thread-local heap.

# Memory footprint

The throughput win above comes from mimalloc caching freed memory in
thread-local pools rather than returning it immediately to the OS;
the same mechanism increases the steady-state resident size of the
Python process.  Measured on Vera, same Python script that ran the
throughput sweep above, RSS read from `/proc/self/status` after 50
calls to `tokenizer.encode_batch(docs, false)`:
```
  metric                          before        after         delta
  ------                          ------        ------        ------
  cdylib `.so` on disk            10.08 MiB     10.24 MiB     +0.15 MiB
  process VmRSS (1T)              237 MiB       704 MiB       x2.97
  process VmRSS (88T)             720 MiB       2 035 MiB     x2.83
  process VmPeak virtual (88T)    6.1 GiB       9.2 GiB       x1.50
```
The on-disk cost is ~155 KiB of embedded libmimalloc.  At runtime,
mimalloc holds onto free pages in per-thread heaps for reuse instead
of returning them to the kernel after every `encode_batch` call;
that cache is what makes the next call cheap, and what makes the
steady-state RSS ~3x larger.  mimalloc does eventually purge unused
pages back to the OS, but on its own schedule, not synchronously.

This is the explicit trade-off: ~3x physical RSS for +56 % (1T) /
+9 % (88T) on this benchmark.  Users for whom that trade is wrong
can `--no-default-features` to fall back to the system allocator.