### PR TITLE
Avoid full vocab clone in get_vocab_size()

### DIFF
--- a/bindings/node/src/tokenizer.rs
+++ b/bindings/node/src/tokenizer.rs
@@ -458,7 +458,12 @@ impl Tokenizer {
 
   #[napi]
   pub fn get_vocab_size(&self, with_added_tokens: Option<bool>) -> u32 {
-    self.get_vocab(with_added_tokens).len() as u32
+    let with_added_tokens = with_added_tokens.unwrap_or(true);
+    self
+      .tokenizer
+      .read()
+      .unwrap()
+      .get_vocab_size(with_added_tokens) as u32
   }
 
   #[napi]

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -693,12 +693,16 @@ where
 
     /// Get the size of the vocabulary
     pub fn get_vocab_size(&self, with_added_tokens: bool) -> usize {
-        // TODO ArthurZ THIS IS WRONG! We need to measure the length of the `set` because
-        // now some tokens can be both in the added_tokens_encoder and in the vocab
+        let base = self.model.get_vocab_size();
         if with_added_tokens {
-            self.get_vocab(true).len()
+            let added = self.added_vocabulary.get_vocab();
+            let overlapping = added
+                .keys()
+                .filter(|t| self.model.token_to_id(t).is_some())
+                .count();
+            base + added.len() - overlapping
         } else {
-            self.model.get_vocab_size()
+            base
         }
     }
 
@@ -1785,5 +1789,26 @@ mod tests {
             full_b.get_ids(),
             "OnlyFirst should not truncate the second sequence"
         );
+    }
+
+    #[test]
+    fn get_vocab_size_with_overlapping_added_tokens() {
+        // test_tokenizer() builds a WordLevel model with "a"-"j" + "<unk>" = 11 tokens
+        let mut tok = test_tokenizer();
+
+        assert_eq!(tok.get_vocab_size(false), 11);
+        assert_eq!(tok.get_vocab_size(true), 11);
+
+        // Add "a" as a special token — it already exists in the model vocab (overlap)
+        tok.add_special_tokens([AddedToken::from("a", true)])
+            .unwrap();
+        assert_eq!(tok.get_vocab_size(false), 11);
+        assert_eq!(tok.get_vocab_size(true), 11); // must not double-count
+
+        // Add a genuinely new token
+        tok.add_tokens([AddedToken::from("new_token", false)])
+            .unwrap();
+        assert_eq!(tok.get_vocab_size(false), 11);
+        assert_eq!(tok.get_vocab_size(true), 12);
     }
 }


### PR DESCRIPTION
`get_vocab_size(true)` was calling `get_vocab(true).len()`, which clones the entire model vocabulary into a new `HashMap` just to count entries.
For large vocabularies (e.g. LLaMA-3 128k tokens) this allocates ~10MB on every call.

Fix by computing `base + added.len() - overlapping` directly, where `overlapping` counts added tokens already present in the model via `token_to_id`. Zero allocation.

Applies the same fix to the Node binding, which had the identical pattern.

Adds a test covering the overlap scenario (token in both model vocab and added_vocabulary).
