### PR TITLE
Ci test fixes

### DIFF
--- a/bindings/node/lib/bindings/post-processors.test.ts
+++ b/bindings/node/lib/bindings/post-processors.test.ts
@@ -9,7 +9,7 @@ describe('bertProcessing', () => {
   })
 
   it('throws if only one argument is provided', () => {
-    expect(() => (bertProcessing as any)(['sep', 1])).toThrow('Given napi value is not an array')
+    expect(() => (bertProcessing as any)(['sep', 1])).toThrow('Failed to get Array length')
   })
 
   it('throws if arguments are malformed', () => {

--- a/bindings/python/tests/documentation/test_tutorial_train_from_iterators.py
+++ b/bindings/python/tests/documentation/test_tutorial_train_from_iterators.py
@@ -34,7 +34,9 @@ class TestTrainFromIterators:
         # START load_dataset
         import datasets  # type: ignore[import-not-found]
 
-        dataset = datasets.load_dataset("wikitext", "wikitext-103-raw-v1", split="train+test+validation")
+        dataset = datasets.load_dataset(
+            "Salesforce/wikitext", "wikitext-103-raw-v1", split="train+test+validation"
+        )
         # END load_dataset
 
     @pytest.fixture(scope="class")
@@ -68,7 +70,7 @@ class TestTrainFromIterators:
 
         # In order to keep tests fast, we only use the first 100 examples
         os.environ["TOKENIZERS_PARALLELISM"] = "true"
-        dataset = datasets.load_dataset("wikitext", "wikitext-103-raw-v1", split="train[0:100]")
+        dataset = datasets.load_dataset("Salesforce/wikitext", "wikitext-103-raw-v1", split="train[0:100]")
 
         # START def_batch_iterator
         def batch_iterator(batch_size=1000):

--- a/bindings/python/tests/documentation/test_tutorial_train_from_iterators.py
+++ b/bindings/python/tests/documentation/test_tutorial_train_from_iterators.py
@@ -34,9 +34,7 @@ class TestTrainFromIterators:
         # START load_dataset
         import datasets  # type: ignore[import-not-found]
 
-        dataset = datasets.load_dataset(
-            "Salesforce/wikitext", "wikitext-103-raw-v1", split="train+test+validation"
-        )
+        dataset = datasets.load_dataset("Salesforce/wikitext", "wikitext-103-raw-v1", split="train+test+validation")
         # END load_dataset
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
Two pre-existing CI failures on main, neither related to any code change in tokenizers/ or bindings/{python,node}/src/:

tests/python: use canonical Salesforce/wikitext dataset id — huggingface_hub enforces namespace/name for HF URIs; the bare id "wikitext" (which was relocated on the Hub) now produces HfUriError: Invalid HF URI 'hf://datasets/wikitext@/.huggingface.yaml'. Updates both datasets.load_dataset(...) call sites in test_tutorial_train_from_iterators.py.

tests/node: update bertProcessing error message to match napi-rs — napi-rs now reports "Failed to get Array length" for invalid array args (was "Given napi value is not an array"). Updates the assertion in post-processors.test.ts.

Each is a one-line / two-line change in tests only; no production code touched.