### PR TITLE
ci: pin benchmark jobs to a larger dedicated runner

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,11 @@ env:
 jobs:
   benchmark:
     name: Run Rust benchmarks
-    runs-on: ubuntu-latest
+    # Pinned to a larger, dedicated GitHub-hosted runner for stable timings.
+    # The shared `ubuntu-latest` (2 vCPU) produces noisy, non-comparable baselines.
+    # NOTE: `ubuntu-latest-8-cores` must be provisioned in the org's
+    # Settings → Actions → Runners. Adjust the label if yours differs.
+    runs-on: ubuntu-latest-8-cores
     defaults:
       run:
         working-directory: tokenizers
@@ -219,7 +223,8 @@ jobs:
 
   benchmark-python:
     name: Run Python benchmarks
-    runs-on: ubuntu-latest
+    # Same dedicated runner as the Rust job — keeps Python baselines comparable.
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 


### PR DESCRIPTION
## Why

The `Benchmarks` workflow runs on the shared `ubuntu-latest` (2 vCPU) runner. Those timings drift ~10–35% run-to-run, which pollutes the baselines stored on [`hf-internal-testing/tokenizers-bench`](https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench).

Concretely, the baseline at #2074 *Avoid full vocab clone in `get_vocab_size()`* showed +8–17% "regressions" across the batch and serialization benches — while single-encode paths simultaneously got **faster**. That split (encode down, everything else up) is a runner-noise fingerprint, not a real regression:

- The entire diff of #2074 is `get_vocab_size()` (+ the node binding), and `get_vocab_size` is **never called inside any encode / decode / serialization loop** — only during `add_tokens`/training setup.
- A same-machine local A/B of #2074 vs its parent put nearly everything within noise; the few flagged benches (`bpe-from-file`, `from-file-llama3`, `encode-char-offsets`) exercise code paths that are **byte-for-byte identical** between the two commits, so they cannot have regressed from this change.

## What

Pin both the Rust (`benchmark`) and Python (`benchmark-python`) jobs to `ubuntu-latest-8-cores` for stable, comparable baselines. The orchestration-only `benchmark-trigger` job stays on `ubuntu-latest`.

## ⚠️ Before merge

The `ubuntu-latest-8-cores` label must be **provisioned in the org's Settings → Actions → Runners**. If your available larger-runner label is named differently, change the two `runs-on:` lines accordingly — otherwise the jobs will queue indefinitely.