### PR TITLE
Avoid walking sparse vocab holes during serialization

### DIFF
--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -34,26 +34,22 @@ impl Serialize for OrderedVocabIter<'_> {
     where
         S: Serializer,
     {
-        // There could be holes so max + 1 is more correct than vocab_r.len()
-        let mut holes = vec![];
-        let result = if let Some(max) = self.vocab_r.keys().max() {
-            let iter = (0..*max + 1).filter_map(|i| {
-                if let Some(token) = self.vocab_r.get(&i) {
-                    Some((token, i))
-                } else {
-                    holes.push(i);
-                    None
-                }
-            });
-            serializer.collect_map(iter)
-        } else {
-            serializer.collect_map(std::iter::empty::<(&str, u32)>())
-        };
+        let mut entries: Vec<_> = self
+            .vocab_r
+            .iter()
+            .map(|(id, token)| (*id, token.as_str()))
+            .collect();
+        entries.sort_unstable_by_key(|(id, _)| *id);
 
-        if !holes.is_empty() {
-            warn!("The OrderedVocab you are attempting to serialize contains holes for indices {holes:?}, your vocabulary could be corrupted!");
+        if entries
+            .iter()
+            .enumerate()
+            .any(|(expected, (id, _))| *id != expected as u32)
+        {
+            warn!("The OrderedVocab you are attempting to serialize contains holes, your vocabulary could be corrupted!");
         }
-        result
+
+        serializer.collect_map(entries.into_iter().map(|(id, token)| (token, id)))
     }
 }
 

--- a/tokenizers/src/models/wordlevel/serialization.rs
+++ b/tokenizers/src/models/wordlevel/serialization.rs
@@ -111,6 +111,23 @@ mod tests {
     }
 
     #[test]
+    fn sparse_large_vocab_id_serializes_without_walking_holes() {
+        let vocab: Vocab = [("<unk>".into(), 0), ("far".into(), u32::MAX)]
+            .iter()
+            .cloned()
+            .collect();
+        let wordlevel = WordLevelBuilder::default()
+            .vocab(vocab)
+            .unk_token("<unk>".to_string())
+            .build()
+            .unwrap();
+
+        let wl_s =
+            r#"{"type":"WordLevel","vocab":{"<unk>":0,"far":4294967295},"unk_token":"<unk>"}"#;
+        assert_eq!(serde_json::to_string(&wordlevel).unwrap(), wl_s);
+    }
+
+    #[test]
     fn deserialization_should_fail() {
         let missing_unk = r#"{"type":"WordLevel","vocab":{}}"#;
         assert!(serde_json::from_str::<WordLevel>(missing_unk)


### PR DESCRIPTION
### Summary

This changes `OrderedVocabIter` to serialize only actual vocabulary entries sorted by ID, instead of iterating from `0..max_id` and collecting every missing ID into a `holes` vector.

A tokenizer with a sparse vocabulary can currently make serialization work proportional to the largest token ID rather than the number of tokens. For example, a vocab containing IDs `0` and `u32::MAX` would attempt to walk billions of missing IDs before serializing two entries.

### Changes

- Sort existing `(id, token)` entries by ID before serialization.
- Keep the sparse-vocab warning, but avoid collecting every missing ID.
- Add a regression test for a sparse `WordLevel` vocab containing `u32::MAX`.

### Validation

```text
cargo test models::wordlevel::serialization::tests::sparse_large_vocab_id_serializes_without_walking_holes
cargo test models::wordlevel::serialization::tests::serde
cargo test models::wordpiece::serialization::tests::serde
cargo test models::bpe::serialization::test::test_serialization
cargo fmt --manifest-path tokenizers/Cargo.toml
git diff --check
```