### PR TITLE
ByteLevel: single-pass byte-level transform (`apply_byte_map`)

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -38,6 +38,10 @@ name = "bpe_benchmark"
 harness = false
 
 [[bench]]
+name = "bytelevel_normalizer_benchmark"
+harness = false
+
+[[bench]]
 name = "bert_benchmark"
 harness = false
 

--- a/tokenizers/benches/bytelevel_normalizer_benchmark.rs
+++ b/tokenizers/benches/bytelevel_normalizer_benchmark.rs
@@ -1,0 +1,47 @@
+#[macro_use]
+extern crate criterion;
+
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use criterion::{Criterion, Throughput};
+use tokenizers::normalizers::byte_level::ByteLevel;
+use tokenizers::{NormalizedString, Normalizer};
+
+/// Times the `ByteLevel` *normalizer*'s `normalize` over `big.txt`. Inputs are built outside
+/// the timed region so we measure the transform itself, not input allocation. (No end-to-end
+/// bench covers this path — every other bench wires `ByteLevel` as a pre-tokenizer.)
+fn bench_bytelevel_normalizer(c: &mut Criterion) {
+    let norm = ByteLevel::new();
+    let mut group = c.benchmark_group("bytelevel-normalizer");
+    for path in ["data/small.txt", "data/big.txt"] {
+        let data = std::fs::read_to_string(path).unwrap();
+        let lines: Vec<&str> = data.lines().collect();
+        group.throughput(Throughput::Bytes(data.len() as u64));
+        group.bench_function(format!("ByteLevel normalize {path}"), |b| {
+            b.iter_custom(|iters| {
+                let mut duration = Duration::new(0, 0);
+                for _ in 0..iters {
+                    // Pre-build the inputs so only `normalize` is timed.
+                    let mut inputs: Vec<NormalizedString> =
+                        lines.iter().map(|l| NormalizedString::from(*l)).collect();
+                    let start = Instant::now();
+                    for ns in inputs.iter_mut() {
+                        norm.normalize(black_box(ns)).unwrap();
+                    }
+                    duration = duration.checked_add(start.elapsed()).unwrap();
+                    black_box(&inputs);
+                }
+                duration
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = bench_bytelevel_normalizer
+}
+criterion_main!(benches);

--- a/tokenizers/src/normalizers/byte_level.rs
+++ b/tokenizers/src/normalizers/byte_level.rs
@@ -1,14 +1,14 @@
-use crate::processors::byte_level::bytes_char;
+use crate::processors::byte_level::bytes_char_array;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashSet;
 use std::sync::LazyLock;
 
 #[derive(Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct ByteLevel;
 
-static BYTES_CHAR: LazyLock<AHashMap<u8, char>> = LazyLock::new(bytes_char);
+static BYTES_CHAR: LazyLock<[char; 256]> = LazyLock::new(bytes_char_array);
 
 impl Default for ByteLevel {
     fn default() -> Self {
@@ -22,27 +22,14 @@ impl ByteLevel {
     }
 
     pub fn alphabet() -> AHashSet<char> {
-        BYTES_CHAR.values().copied().collect()
+        BYTES_CHAR.iter().copied().collect()
     }
 }
 
 impl Normalizer for ByteLevel {
     /// Strip the normalized string inplace
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        if !normalized.is_empty() {
-            let s = normalized.get();
-            let mut transformations: Vec<(char, isize)> = Vec::with_capacity(s.len());
-            for (i, cur_char) in s.char_indices() {
-                let size = cur_char.len_utf8();
-                transformations.extend(
-                    s.as_bytes()[i..i + size]
-                        .iter()
-                        .enumerate()
-                        .map(|(i, b)| (BYTES_CHAR[b], isize::from(i > 0))),
-                );
-            }
-            normalized.transform(transformations, 0);
-        }
+        normalized.apply_byte_map(&BYTES_CHAR);
         Ok(())
     }
 }

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -38,13 +38,22 @@ pub(crate) fn bytes_char() -> AHashMap<u8, char> {
         .collect()
 }
 
+/// `bytes_char()` as a dense `[char; 256]` lookup table (O(1) index, no hashing).
+pub(crate) fn bytes_char_array() -> [char; 256] {
+    let mut table = ['\0'; 256];
+    for (b, c) in bytes_char() {
+        table[b as usize] = c;
+    }
+    table
+}
+
 /// Regex that matches exactly one token.
 /// See https://github.com/openai/gpt-2/blob/master/src/encoder.py#L98
 static RE: LazyLock<SysRegex> = LazyLock::new(|| {
     SysRegex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+")
         .unwrap()
 });
-static BYTES_CHAR: LazyLock<AHashMap<u8, char>> = LazyLock::new(bytes_char);
+static BYTES_CHAR: LazyLock<[char; 256]> = LazyLock::new(bytes_char_array);
 static CHAR_BYTES: LazyLock<AHashMap<char, u8>> =
     LazyLock::new(|| bytes_char().into_iter().map(|(c, b)| (b, c)).collect());
 
@@ -91,7 +100,7 @@ impl ByteLevel {
     }
 
     pub fn alphabet() -> AHashSet<char> {
-        BYTES_CHAR.values().copied().collect()
+        BYTES_CHAR.iter().copied().collect()
     }
 
     #[must_use]
@@ -130,18 +139,7 @@ impl PreTokenizer for ByteLevel {
             }
         })?;
         pretokenized.normalize(|normalized| {
-            let s = normalized.get();
-            let mut transformations: Vec<(char, isize)> = Vec::with_capacity(s.len());
-            for (i, cur_char) in s.char_indices() {
-                let size = cur_char.len_utf8();
-                transformations.extend(
-                    s.as_bytes()[i..i + size]
-                        .iter()
-                        .enumerate()
-                        .map(|(i, b)| (BYTES_CHAR[b], isize::from(i > 0))),
-                );
-            }
-            normalized.transform(transformations, 0);
+            normalized.apply_byte_map(&BYTES_CHAR);
             Ok(())
         })
     }
@@ -203,12 +201,12 @@ pub fn process_offsets(encoding: &mut Encoding, add_prefix_space: bool) {
     encoding.process_tokens_with_offsets_mut(|(i, (token, offsets))| {
         let mut leading_spaces = token
             .chars()
-            .take_while(|c| *c == BYTES_CHAR[&b' '] || c.is_whitespace())
+            .take_while(|c| *c == BYTES_CHAR[b' ' as usize] || c.is_whitespace())
             .count();
         let trailing_spaces = token
             .chars()
             .rev()
-            .take_while(|c| *c == BYTES_CHAR[&b' '] || c.is_whitespace())
+            .take_while(|c| *c == BYTES_CHAR[b' ' as usize] || c.is_whitespace())
             .count();
 
         if leading_spaces > 0 || trailing_spaces > 0 {

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -445,6 +445,21 @@ impl NormalizedString {
         self.transform_range(Range::Original(..), dest, initial_offset)
     }
 
+    /// Single-pass fast path for a pure per-byte char substitution (e.g. `ByteLevel`): replaces
+    /// each byte by `map[byte]`. Each output char inherits its source byte's alignment, so the
+    /// result is byte-identical to the equivalent [`Self::transform`] but skips its bookkeeping.
+    pub fn apply_byte_map(&mut self, map: &[char; 256]) {
+        let mut normalized = String::with_capacity(self.normalized.len());
+        let mut alignments = Vec::with_capacity(self.alignments.len());
+        for (&byte, &align) in self.normalized.as_bytes().iter().zip(&self.alignments) {
+            let c = map[byte as usize];
+            normalized.push(c);
+            alignments.extend(std::iter::repeat_n(align, c.len_utf8()));
+        }
+        self.normalized = normalized;
+        self.alignments = alignments;
+    }
+
     /// Applies NFD normalization
     pub fn nfd(&mut self) -> &mut Self {
         self.transform(self.get().to_owned().nfd(), 0);


### PR DESCRIPTION
The ByteLevel byte to char remapping is a pure per-byte substitution, but both ByteLevel sites ran it through the general `NormalizedString::transform` (replaced-char collection + per-char size-delta math + splice). 

This adds `NormalizedString::apply_byte_map(&[char; 256])` which is one pass where each output char inherits its source byte's alignment and uses it in both the ByteLevel **pre-tokenizer** and **normalizer**. 

Output is byte-identical output. Benches:

### Normalizer (`benches/bytelevel_normalizer_benchmark`, `normalize` only)

| corpus | before | after | change |
|---|---|---|---|
| small.txt | 51.9 MiB/s | 175.4 MiB/s | −70% time |
| big.txt | 28.6 MiB/s | 45.4 MiB/s | −37% time |

### Pre-tokenizer (`benches/bpe_benchmark`, GPT-2 full encode vs `main`)

| bench | change |
|---|---|
| encode | +16% throughput (−14% time) |
| encode, no cache | +27% throughput (−21% time) |
| encode batch | +6% throughput |
| encode batch, no cache | +14% throughput |

All `cargo test` (lib + doc) pass; `cargo fmt`/`clippy --all-targets --all-features -D warnings` clean.
