### PR TITLE
fix(bpe): widen pair_counts to i64 + add overflow regression test (#2058)

### DIFF
--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -416,7 +416,7 @@ impl BpeTrainer {
         words: &[Word],
         counts: &[u64],
         p: &Option<ProgressBar>,
-    ) -> (AHashMap<Pair, i32>, AHashMap<Pair, AHashSet<usize>>) {
+    ) -> (AHashMap<Pair, i64>, AHashMap<Pair, AHashSet<usize>>) {
         words
             .maybe_par_iter()
             .enumerate()
@@ -429,7 +429,7 @@ impl BpeTrainer {
 
                     // Initialize pair_counts and where_to_update for this pair if we just saw it
                     // Then update counts
-                    *pair_counts.entry(cur_pair).or_default() += counts[i] as i32;
+                    *pair_counts.entry(cur_pair).or_default() += counts[i] as i64;
                     where_to_update.entry(cur_pair).or_default().insert(i);
                 }
 
@@ -581,7 +581,7 @@ impl BpeTrainer {
 
             // Introduce new formed pairs
             for ((pair, change), iw) in changes {
-                let count = change * counts[iw] as i32;
+                let count = change as i64 * counts[iw] as i64;
                 *pair_counts.entry(pair).or_default() += count;
                 if change > 0 {
                     where_to_update.entry(pair).or_default().insert(iw);
@@ -864,5 +864,35 @@ mod tests {
         .map(|(k, v)| (k.to_string(), v))
         .collect();
         assert_eq!(trained_vocab, expected_vocab)
+    }
+
+    #[test]
+    fn bpe_test_pair_count_no_i32_overflow() {
+        // Regression test for https://github.com/huggingface/tokenizers/issues/2058
+        // Pair counts must be accumulated as i64. A pair whose total frequency
+        // exceeds i32::MAX (2_147_483_647) used to wrap to a negative i32, failing
+        // the `count > 0` guard and silently dropping the high-frequency pair from
+        // the merges.
+        //
+        // Word frequencies are u64, so a single word whose count exceeds i32::MAX
+        // exercises the exact overflow without needing a multi-billion-token corpus.
+        let word_counts: AHashMap<CompactString, u64> =
+            [(CompactString::from("aa"), 3_000_000_000_u64)]
+                .iter()
+                .cloned()
+                .collect();
+        let trainer = BpeTrainer::builder()
+            .show_progress(false)
+            .min_frequency(0)
+            .build();
+        let mut model = BPE::default();
+        trainer.do_train(&word_counts, &mut model).unwrap();
+
+        // The ('a', 'a') pair occurs 3_000_000_000 times, well above i32::MAX,
+        // so it must still be merged into "aa".
+        assert!(
+            model.get_vocab().contains_key("aa"),
+            "high-frequency pair ('a','a') was dropped due to i32 overflow"
+        );
     }
 }


### PR DESCRIPTION
## Motivation

Closes #2058.

`BpeTrainer` accumulates pair counts as `i32`. On large corpora a single pair can
occur more than `i32::MAX` (2,147,483,647) times — e.g. the space-space pair in
heavily indented source code — so the counter wraps negative. A negative count
fails the `count > 0` guard, so the high-frequency pair is silently dropped from
the merges and the merge ordering is corrupted.

## Modifications

- Widen the pair-count accumulator from `i32` to `i64` in `count_pairs` and the
  merge-delta update (`tokenizers/src/models/bpe/trainer.rs`). `i64::MAX` is far
  beyond any realistic pair frequency, the map is short-lived and allocated once
  per training run, so there is no meaningful performance impact, and the
  downstream `as u64` conversions are unaffected.
- The merge-delta computes `change as i64 * counts[iw] as i64`, casting both
  operands before the multiply so the product itself can't overflow `i32` either.

## Tests

- Added `bpe_test_pair_count_no_i32_overflow`, which drives the exact overflow path
  with a single word whose `u64` frequency exceeds `i32::MAX` (the `('a', 'a')` pair
  at 3e9 occurrences) and asserts the pair survives into the merges. It is fast and
  deterministic — no multi-billion-token corpus required. Verified RED before the
  fix and GREEN after.
- Full lib suite passes (`cargo test --lib`, 202 tests); `cargo fmt --check` and
  `cargo clippy` are clean.

## Note on the existing PRs

There are already two open PRs for this issue — #2057 (draft) and #2059 — both of
which widen the field but neither adds a regression test for the overflow. This PR
keeps the same minimal widening and adds a test that pins the behavior so it cannot
silently regress (and also widens the merge-delta multiplication, not just the map
value). Happy to consolidate or defer if a maintainer prefers one of the others —
mainly flagging the coverage gap.
