### PR TITLE
fix(typing): correct encode() input typing (PreTokenizedInputSequence tuple + stub Any)

### DIFF
--- a/bindings/python/py_src/tokenizers/__init__.py
+++ b/bindings/python/py_src/tokenizers/__init__.py
@@ -18,7 +18,7 @@ Offsets = Tuple[int, int]
 TextInputSequence = str
 """A :obj:`str` that represents an input sequence """
 
-PreTokenizedInputSequence = Union[List[str], Tuple[str]]
+PreTokenizedInputSequence = Union[List[str], Tuple[str, ...]]
 """A pre-tokenized input sequence. Can be one of:
 
     - A :obj:`List` of :obj:`str`

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -12,6 +12,10 @@ from tokenizers.processors import PostProcessor
 from tokenizers.trainers import Trainer
 from typing import Any, Final, final
 
+TextInputSequence = str
+PreTokenizedInputSequence = list[str] | tuple[str, ...]
+InputSequence = TextInputSequence | PreTokenizedInputSequence
+
 __version__: Final[str]
 
 @final
@@ -737,7 +741,7 @@ class Tokenizer:
             :obj:`List[str]`: A list of decoded strings
         """
     def async_encode(
-        self, /, sequence: Any, pair: Any | None = None, is_pretokenized: bool = False, add_special_tokens: bool = True
+        self, /, sequence: InputSequence, pair: InputSequence | None = None, is_pretokenized: bool = False, add_special_tokens: bool = True
     ) -> Any:
         """
         Asynchronously encode the given input with character offsets.
@@ -927,7 +931,7 @@ class Tokenizer:
                 Truncate direction
         """
     def encode(
-        self, /, sequence: Any, pair: Any | None = None, is_pretokenized: bool = False, add_special_tokens: bool = True
+        self, /, sequence: InputSequence, pair: InputSequence | None = None, is_pretokenized: bool = False, add_special_tokens: bool = True
     ) -> "Encoding":
         """
         Encode the given sequence and pair. This method can process raw text sequences


### PR DESCRIPTION
## What

Fixes the two input-typing issues reported in #2088 so that type checkers correctly type `Tokenizer.encode()` (and `async_encode()`).

**1. `PreTokenizedInputSequence` (`__init__.py`)** — was `Union[List[str], Tuple[str]]`. `Tuple[str]` means a tuple of **exactly one** `str`, so type checkers reject correct programs that pass a pre-tokenized tuple of any other length. The intended meaning is an arbitrary-length tuple of strings, spelled `Tuple[str, ...]` ([typing spec](https://typing.python.org/en/latest/spec/tuples.html)). This also matches the docstring ("A `Tuple` of `str`") and the `List[str]` alternative in the same union.

```python
PreTokenizedInputSequence = Union[List[str], Tuple[str, ...]]
```

**2. `Tokenizer.encode` / `async_encode` stub (`__init__.pyi`)** — the stub annotated `sequence: Any` (and `pair: Any | None`). Because a `.pyi` stub takes precedence over `__init__.py` for type checkers, this `Any` **masked** issue 1 entirely and let invalid calls like `tokenizer.encode(3.14)` pass `mypy` even though they fail at runtime with `TypeError: TextInputSequence must be str`.

The stub now defines the input-sequence aliases (mirroring `__init__.py`) and types the `sequence`/`pair` parameters as `InputSequence`:

```python
TextInputSequence = str
PreTokenizedInputSequence = list[str] | tuple[str, ...]
InputSequence = TextInputSequence | PreTokenizedInputSequence
```

This is consistent with the existing docstrings, which already document `sequence (~tokenizers.InputSequence)`.

## Why

Without these, `mypy` cannot catch invalid `encode()` inputs, and correct programs that pass tuple-of-str pre-tokenized input are wrongly rejected.

Closes #2088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
