### PR TITLE
ci: target benchmark runners by group, not nonexistent label

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,11 +34,12 @@ env:
 jobs:
   benchmark:
     name: Run Rust benchmarks
-    # Pinned to a larger, dedicated GitHub-hosted runner for stable timings.
+    # Pinned to a larger, dedicated runner for stable timings.
     # The shared `ubuntu-latest` (2 vCPU) produces noisy, non-comparable baselines.
-    # NOTE: `ubuntu-latest-8-cores` must be provisioned in the org's
-    # Settings → Actions → Runners. Adjust the label if yours differs.
-    runs-on: ubuntu-latest-8-cores
+    # Targets the org's self-hosted runner group (8+ vCPU AWS runners) by group
+    # name rather than a label — the individual runners are ephemeral/autoscaled.
+    runs-on:
+      group: aws-general-8-plus
     defaults:
       run:
         working-directory: tokenizers
@@ -223,8 +224,9 @@ jobs:
 
   benchmark-python:
     name: Run Python benchmarks
-    # Same dedicated runner as the Rust job — keeps Python baselines comparable.
-    runs-on: ubuntu-latest-8-cores
+    # Same dedicated runner group as the Rust job — keeps Python baselines comparable.
+    runs-on:
+      group: aws-general-8-plus
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 


### PR DESCRIPTION
## Why

[#2084](https://github.com/huggingface/tokenizers/pull/2084) pinned the `benchmark` and `benchmark-python` jobs to `runs-on: ubuntu-latest-8-cores` to get stable, comparable timings. But **no runner with that label is provisioned**. The org's larger runners are self-hosted AWS instances in the runner group **`aws-general-8-plus`**:

```
aws-general-8-plus-use1-public-80-t5kbn-runner-7nz7b
aws-general-8-plus-use1-public-80-t5kbn-runner-hdl82
aws-general-8-plus-use1-public-80-t5kbn-runner-756qz
...
Runner group: aws-general-8-plus
```

Those names are ephemeral/autoscaled, so they can't be pinned individually — and `ubuntu-latest-8-cores` matches nothing, so both benchmark jobs queue indefinitely.

## What

Target the runner **group** instead of a label:

\`\`\`yaml
runs-on:
  group: aws-general-8-plus
\`\`\`

for both the Rust (`benchmark`) and Python (`benchmark-python`) jobs. The orchestration-only `benchmark-trigger` job stays on `ubuntu-latest`.

This fixes the dangling-queue regression introduced by #2084 while keeping its goal: stable baselines on 8+ vCPU runners.