### PR TITLE
Reduce BPE merge update allocations and add file progress logs

### DIFF
--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -560,9 +560,9 @@ impl BpeTrainer {
             unsafe impl Sync for WordPtr {}
             let word_start = WordPtr(words.as_mut_ptr());
 
-            let changes = pos
+            let (pair_deltas, mut new_where_to_update) = pos
                 .maybe_par_iter()
-                .flat_map(|&i| {
+                .map(|&i| {
                     // We can merge each of these words in parallel here because each position
                     // can be there only once (AHashSet). So this is safe.
                     unsafe {
@@ -570,24 +570,37 @@ impl BpeTrainer {
                         // This is words[i], but avoids needing to go through &T (which triggers UB)
                         let word = word_start.0.add(i);
                         // let word: &mut Word = &mut (*word);
-                        (*word)
-                            .merge(top.pair.0, top.pair.1, new_token_id, max_token_length)
-                            .into_iter()
-                            .map(|c| (c, i))
-                            .collect::<Vec<_>>()
+                        let mut pair_deltas: AHashMap<Pair, i32> = AHashMap::new();
+                        let mut where_to_update: AHashMap<Pair, AHashSet<usize>> = AHashMap::new();
+                        for (pair, change) in
+                            (*word).merge(top.pair.0, top.pair.1, new_token_id, max_token_length)
+                        {
+                            *pair_deltas.entry(pair).or_default() += change * counts[i] as i32;
+                            if change > 0 {
+                                where_to_update.entry(pair).or_default().insert(i);
+                            }
+                        }
+                        (pair_deltas, where_to_update)
                     }
                 })
-                .collect::<Vec<_>>();
+                .reduce(
+                    || (AHashMap::new(), AHashMap::new()),
+                    |(mut pair_deltas, mut where_to_update), (pd, wtu)| {
+                        for (pair, delta) in pd {
+                            *pair_deltas.entry(pair).or_default() += delta;
+                        }
+                        for (pair, positions) in wtu {
+                            where_to_update.entry(pair).or_default().extend(positions);
+                        }
+                        (pair_deltas, where_to_update)
+                    },
+                );
 
             // Introduce new formed pairs
-            for ((pair, change), iw) in changes {
-                let count = change * counts[iw] as i32;
-                *pair_counts.entry(pair).or_default() += count;
-                if change > 0 {
-                    where_to_update.entry(pair).or_default().insert(iw);
-                }
+            for (pair, count_delta) in pair_deltas {
+                *pair_counts.entry(pair).or_default() += count_delta;
             }
-            where_to_update.drain().for_each(|(pair, pos)| {
+            new_where_to_update.drain().for_each(|(pair, pos)| {
                 let count = pair_counts[&pair];
                 if count > 0 {
                     queue.push(Merge {

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -15,6 +15,11 @@ use std::{
     io::{prelude::*, BufReader},
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicU64, Ordering as AtomicOrdering},
+        Mutex,
+    },
+    time::{Duration, Instant},
 };
 
 use serde::de::DeserializeOwned;
@@ -1399,6 +1404,13 @@ where
         }
 
         let max_read = 1_000_000;
+        let progress_log_interval = std::env::var("TOKENIZERS_PROGRESS_LOG_INTERVAL_SECONDS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .map(Duration::from_secs);
+        let progress_bytes = AtomicU64::new(0);
+        let progress_start = Instant::now();
+        let last_progress_log = Mutex::new(Instant::now());
 
         ResultShunt::process(
             files.into_iter().flat_map(|filename| {
@@ -1432,6 +1444,48 @@ where
                     sequences.inspect(|s| {
                         if let Some(progress) = &progress {
                             progress.inc(s.len() as u64)
+                        }
+                        if let Some(interval) = progress_log_interval {
+                            let processed =
+                                progress_bytes.fetch_add(s.len() as u64, AtomicOrdering::Relaxed)
+                                    + s.len() as u64;
+                            if let Ok(mut last_log) = last_progress_log.lock() {
+                                let now = Instant::now();
+                                if now.duration_since(*last_log) >= interval {
+                                    let elapsed = progress_start.elapsed().as_secs_f64();
+                                    let mb_per_sec = if elapsed > 0.0 {
+                                        processed as f64 / 1_000_000.0 / elapsed
+                                    } else {
+                                        0.0
+                                    };
+                                    let pct = if len > 0 {
+                                        processed as f64 * 100.0 / len as f64
+                                    } else {
+                                        100.0
+                                    };
+                                    let remaining = len.saturating_sub(processed);
+                                    let eta_seconds = if mb_per_sec > 0.0 {
+                                        remaining as f64 / 1_000_000.0 / mb_per_sec
+                                    } else {
+                                        f64::INFINITY
+                                    };
+                                    let eta_text = if eta_seconds.is_finite() {
+                                        format!("{:.1}", eta_seconds)
+                                    } else {
+                                        "unknown".to_string()
+                                    };
+                                    eprintln!(
+                                        "[tokenizers progress] preprocess_files bytes_done={} bytes_total={} pct={:.2} mb_per_s={:.2} eta_s={} elapsed_s={:.1}",
+                                        processed,
+                                        len,
+                                        pct,
+                                        mb_per_sec,
+                                        eta_text,
+                                        elapsed,
+                                    );
+                                    *last_log = now;
+                                }
+                            }
                         }
                     }),
                     |seq| {


### PR DESCRIPTION
## Summary
- aggregate BPE pair count deltas and update positions per worker before updating global merge tables
- avoid collecting all per-word merge changes into a single intermediate vector
- add optional file preprocessing stderr progress controlled by `TOKENIZERS_PROGRESS_LOG_INTERVAL_SECONDS`

## Testing
- `cargo check`
- `cargo test models::bpe::trainer -- --nocapture`