### PR TITLE
perf: do not allocate for alignments in `encode_fast`

### DIFF
--- a/bindings/python/tests/documentation/test_tutorial_train_from_iterators.py
+++ b/bindings/python/tests/documentation/test_tutorial_train_from_iterators.py
@@ -34,7 +34,7 @@ class TestTrainFromIterators:
         # START load_dataset
         import datasets  # type: ignore[import-not-found]
 
-        dataset = datasets.load_dataset("wikitext", "wikitext-103-raw-v1", split="train+test+validation")
+        dataset = datasets.load_dataset("Salesforce/wikitext", "wikitext-103-raw-v1", split="train+test+validation")
         # END load_dataset
 
     @pytest.fixture(scope="class")
@@ -68,7 +68,7 @@ class TestTrainFromIterators:
 
         # In order to keep tests fast, we only use the first 100 examples
         os.environ["TOKENIZERS_PARALLELISM"] = "true"
-        dataset = datasets.load_dataset("wikitext", "wikitext-103-raw-v1", split="train[0:100]")
+        dataset = datasets.load_dataset("Salesforce/wikitext", "wikitext-103-raw-v1", split="train[0:100]")
 
         # START def_batch_iterator
         def batch_iterator(batch_size=1000):

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -243,6 +243,31 @@ mod tests {
     use std::iter::FromIterator;
 
     #[test]
+    fn pre_tokenization_unaligned_matches_aligned() {
+        use crate::NormalizedString;
+        for bytelevel in [
+            ByteLevel::default().add_prefix_space(false),
+            ByteLevel::default().add_prefix_space(true),
+        ] {
+            let input = "Hello my friend, how is your day going? voilà ça été 😀";
+            let mut aligned: PreTokenizedString = input.into();
+            let mut unaligned: PreTokenizedString =
+                NormalizedString::unaligned(input.to_string()).into();
+            bytelevel.pre_tokenize(&mut aligned).unwrap();
+            bytelevel.pre_tokenize(&mut unaligned).unwrap();
+
+            let texts = |p: &PreTokenizedString| {
+                p.get_splits(OffsetReferential::Normalized, OffsetType::None)
+                    .into_iter()
+                    .map(|(s, _, _)| s.to_string())
+                    .collect::<Vec<_>>()
+            };
+            assert_eq!(texts(&aligned), texts(&unaligned));
+            assert!(unaligned.splits_are_unaligned());
+        }
+    }
+
+    #[test]
     fn pre_tokenization() {
         let bytelevel = ByteLevel::default().add_prefix_space(false);
         let mut pretokenized: PreTokenizedString = "Hello my friend, how is your day going?".into();

--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -121,7 +121,7 @@ impl Default for Metaspace {
 
 impl PreTokenizer for Metaspace {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
-        pretokenized.split(|_, mut normalized| {
+        pretokenized.split(|split_idx, mut normalized| {
             normalized.replace(' ', &self.str_rep)?;
             match self.prepend_scheme {
                 PrependScheme::Always => {
@@ -130,9 +130,7 @@ impl PreTokenizer for Metaspace {
                     }
                 }
                 PrependScheme::First => {
-                    if !normalized.get().starts_with(self.replacement)
-                        && normalized.offsets_original().0 == 0
-                    {
+                    if !normalized.get().starts_with(self.replacement) && split_idx == 0 {
                         normalized.prepend(&self.str_rep);
                     }
                 }

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -563,18 +563,19 @@ impl AddedVocabulary {
         pretokenized
     }
 
-    /// Like [`extract_and_normalize`] but uses [`Normalizer::normalize_str`]
-    /// instead of [`Normalizer::normalize`], skipping alignment tracking.
+    /// Like [`extract_and_normalize`] but skips alignment tracking entirely:
+    /// the pipeline runs on unaligned `NormalizedString`s (no original clone,
+    /// no per-byte alignment vectors — neither at construction, nor in
+    /// normalization via [`Normalizer::normalize_str`], nor when splitting).
     ///
-    /// This is used by `encode_fast` where offsets are not needed. The
-    /// normalization step avoids building per-byte alignment vectors, which
-    /// saves O(n) allocations per split.
+    /// This is used by `encode_fast` where offsets are not needed.
     pub fn extract_and_normalize_fast<N: Normalizer>(
         &self,
         normalizer: Option<&N>,
         sequence: &str,
     ) -> PreTokenizedString {
-        let mut pretokenized: PreTokenizedString = sequence.into();
+        let mut pretokenized: PreTokenizedString =
+            NormalizedString::unaligned(sequence.to_string()).into();
 
         // 1. Extract non-normalized tokens from the raw string
         pretokenized
@@ -1226,5 +1227,33 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![("my", Some(vec![0])), ("ä»Ĭ", Some(vec![1])),]
         );
+    }
+
+    #[test]
+    fn extract_and_normalize_fast_is_unaligned_and_text_equivalent() {
+        let model = ModelMock::new(&[("hey", 0), ("friend", 1)]);
+        let normalizer = Lowercase;
+        let mut vocab = AddedVocabulary::new();
+        vocab
+            .add_tokens(
+                vec![
+                    AddedToken::from("<mask>", false).lstrip(true).rstrip(true),
+                    AddedToken::from("yesterday", false).normalized(true),
+                ],
+                &model,
+                Some(&normalizer),
+            )
+            .unwrap();
+
+        let input = "Hey <mask> friend, I saw You YESTERDAY <mask>!";
+        let slow = vocab.extract_and_normalize(Some(&normalizer), input);
+        let fast = vocab.extract_and_normalize_fast(Some(&normalizer), input);
+
+        assert_eq!(simplify_output(&slow), simplify_output(&fast));
+        assert!(fast
+            .get_splits(OffsetReferential::Normalized, OffsetType::None)
+            .iter()
+            .all(|(s, _, _)| !s.is_empty()));
+        assert!(fast.splits_are_unaligned());
     }
 }

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -563,10 +563,13 @@ impl AddedVocabulary {
         pretokenized
     }
 
-    /// Like [`extract_and_normalize`] but skips alignment tracking entirely:
-    /// the pipeline runs on unaligned `NormalizedString`s (no original clone,
-    /// no per-byte alignment vectors — neither at construction, nor in
-    /// normalization via [`Normalizer::normalize_str`], nor when splitting).
+    /// Like [`extract_and_normalize`] but skips alignment tracking: the
+    /// pipeline runs on unaligned `NormalizedString`s — no original clone and
+    /// no per-byte alignment vector at construction, when splitting, or in any
+    /// downstream pre-tokenizer transform. Normalization goes through
+    /// [`Normalizer::normalize_str`]; normalizers still on its default
+    /// implementation allocate one transient aligned `NormalizedString`
+    /// internally until they get a dedicated override.
     ///
     /// This is used by `encode_fast` where offsets are not needed.
     pub fn extract_and_normalize_fast<N: Normalizer>(

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -563,15 +563,12 @@ impl AddedVocabulary {
         pretokenized
     }
 
-    /// Like [`extract_and_normalize`] but skips alignment tracking: the
-    /// pipeline runs on unaligned `NormalizedString`s — no original clone and
-    /// no per-byte alignment vector at construction, when splitting, or in any
-    /// downstream pre-tokenizer transform. Normalization goes through
-    /// [`Normalizer::normalize_str`]; normalizers still on its default
-    /// implementation allocate one transient aligned `NormalizedString`
-    /// internally until they get a dedicated override.
+    /// Like [`extract_and_normalize`], but the whole pipeline runs on
+    /// unaligned `NormalizedString`s — no alignment tracking anywhere
+    /// (see [`NormalizedString::is_unaligned`]). Used by `encode_fast`.
     ///
-    /// This is used by `encode_fast` where offsets are not needed.
+    /// Normalizers without a [`Normalizer::normalize_str`] override still
+    /// allocate one temporary aligned string internally.
     pub fn extract_and_normalize_fast<N: Normalizer>(
         &self,
         normalizer: Option<&N>,

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -136,16 +136,32 @@ impl NormalizedString {
         &self.normalized
     }
 
-    /// Replace the normalized content without tracking alignments.
-    ///
-    /// This is significantly cheaper than going through `transform()` since it
-    /// skips the per-byte alignment bookkeeping.  Use this when offset tracking
-    /// is not needed (e.g. `encode_fast`).
+    /// Create a `NormalizedString` that doesn't track alignments with an
+    /// original string: no string clone, no per-byte alignment vector.
+    /// For pipelines that never need offsets (`encode_fast`).
+    pub(crate) fn unaligned(normalized: String) -> Self {
+        Self {
+            original: String::new(),
+            normalized,
+            alignments: Vec::new(),
+            original_shift: 0,
+        }
+    }
+
+    /// Whether this string skips alignment tracking. Transforms and slices
+    /// preserve unalignedness; offsets in the original referential are
+    /// unavailable. `original_shift` still tracks slice positions so that
+    /// `offsets_original().0 == 0` keeps meaning "first piece".
+    pub(crate) fn is_unaligned(&self) -> bool {
+        self.alignments.is_empty() && !self.normalized.is_empty()
+    }
+
+    /// Replace the normalized content without tracking alignments, switching
+    /// this string into unaligned mode (see [`is_unaligned`]): offsets against
+    /// the original string are no longer available.
     pub fn set_normalized(&mut self, new: String) {
-        // Build trivial 1:1 alignments so that slice() still works for
-        // splitting, but no real offset mapping is preserved.
-        self.alignments = new.as_bytes().iter().enumerate().map(|(i, _)| (i, i + 1)).collect();
         self.normalized = new;
+        self.alignments.clear();
     }
 
     /// Return the original string
@@ -286,6 +302,18 @@ impl NormalizedString {
         T: RangeBounds<usize> + Clone,
     {
         let full_range = self.validate_range(range)?;
+
+        if self.is_unaligned() {
+            return match full_range {
+                Range::Original(_) => None,
+                Range::Normalized(r) => Some(Self {
+                    original: String::new(),
+                    normalized: self.normalized[r.clone()].to_owned(),
+                    alignments: Vec::new(),
+                    original_shift: self.original_shift + r.start,
+                }),
+            };
+        }
         let (normalized_range, original_range) = match full_range {
             Range::Original(_) => (
                 self.convert_offsets(full_range.clone())?,
@@ -331,6 +359,23 @@ impl NormalizedString {
         T: RangeBounds<usize> + Clone,
         I: IntoIterator<Item = (char, isize)>,
     {
+        if self.is_unaligned() {
+            let n_range = match &range {
+                Range::Normalized(_) => range.clone().into_full_range(self.len()),
+                // The only original range that maps onto an unaligned string is
+                // the unbounded one (e.g. `transform()`), meaning "everything".
+                // Bounded original ranges are unmappable, like unmappable
+                // ranges on the aligned path: no-op.
+                Range::Original(r) => match (r.start_bound(), r.end_bound()) {
+                    (Bound::Unbounded, Bound::Unbounded) => 0..self.len(),
+                    _ => return,
+                },
+            };
+            let normalized: String = dest.into_iter().map(|(c, _)| c).collect();
+            self.normalized.replace_range(n_range, &normalized);
+            return;
+        }
+
         let n_range = match range {
             Range::Normalized(_) => range.into_full_range(self.len()),
             Range::Original(_) => match self.convert_offsets(range) {
@@ -580,6 +625,21 @@ impl NormalizedString {
 
     /// Replace anything that matches the pattern with the given content.
     pub fn replace<P: Pattern>(&mut self, pattern: P, content: &str) -> Result<()> {
+        if self.is_unaligned() {
+            let mut new_normalized = String::with_capacity(self.normalized.len());
+            let mut last_end = 0;
+            for ((start, end), is_match) in pattern.find_matches(&self.normalized)? {
+                if is_match {
+                    new_normalized.push_str(&self.normalized[last_end..start]);
+                    new_normalized.push_str(content);
+                    last_end = end;
+                }
+            }
+            new_normalized.push_str(&self.normalized[last_end..]);
+            self.normalized = new_normalized;
+            return Ok(());
+        }
+
         let mut new_normalized = String::with_capacity(self.normalized.len()); // Initially allocate for the input size
         let mut new_alignments: Vec<(usize, usize)> = Vec::with_capacity(self.alignments.len());
         let mut last_end = 0; // Keep track of the last end position
@@ -2319,5 +2379,129 @@ mod tests {
         assert_eq!(n.get_range_original(Range::Normalized(0..6)), Some(""));
 
         assert_eq!(n.get_range(Range::Normalized(0..6)), Some(" World"));
+    }
+
+    #[test]
+    fn unaligned_construction() {
+        let n = NormalizedString::unaligned("Hello".to_string());
+        assert!(n.is_unaligned());
+        assert_eq!(n.get(), "Hello");
+        assert!(n.alignments.is_empty());
+        assert!(n.original.is_empty());
+
+        // Aligned strings are not unaligned, empty strings neither
+        assert!(!NormalizedString::from("Hello").is_unaligned());
+        assert!(!NormalizedString::from("").is_unaligned());
+    }
+
+    #[test]
+    fn unaligned_slice() {
+        let n = NormalizedString::unaligned("Hello world".to_string());
+
+        let slice = n.slice(Range::Normalized(6..11)).unwrap();
+        assert!(slice.is_unaligned());
+        assert_eq!(slice.get(), "world");
+        assert!(slice.alignments.is_empty());
+        // original_shift tracks the position so `offsets_original().0 == 0`
+        // remains a valid "is this the first piece" predicate (Metaspace First)
+        assert_eq!(
+            n.slice(Range::Normalized(0..5))
+                .unwrap()
+                .offsets_original()
+                .0,
+            0
+        );
+        assert_ne!(slice.offsets_original().0, 0);
+
+        // Nested slices keep accumulating
+        let nested = slice.slice(Range::Normalized(1..5)).unwrap();
+        assert!(nested.is_unaligned());
+        assert_eq!(nested.get(), "orld");
+        assert_ne!(nested.offsets_original().0, 0);
+
+        // No mapping to original coordinates exists
+        assert!(n.slice(Range::Original(0..5)).is_none());
+    }
+
+    #[test]
+    fn unaligned_transform_matches_aligned() {
+        let s = "Hello friend";
+        let mut aligned = NormalizedString::from(s);
+        let mut unaligned = NormalizedString::unaligned(s.to_string());
+
+        // ByteLevel-style transform: replace chars 1:1, with one multi-byte char
+        let transformations: Vec<(char, isize)> = s
+            .chars()
+            .map(|c| if c == ' ' { ('Ġ', 0) } else { (c, 0) })
+            .collect();
+        aligned.transform(transformations.clone(), 0);
+        unaligned.transform(transformations, 0);
+
+        assert_eq!(aligned.get(), unaligned.get());
+        assert_eq!(unaligned.get(), "HelloĠfriend");
+        assert!(unaligned.is_unaligned());
+        assert!(unaligned.alignments.is_empty());
+    }
+
+    #[test]
+    fn unaligned_prepend_append() {
+        let mut aligned = NormalizedString::from("there");
+        let mut unaligned = NormalizedString::unaligned("there".to_string());
+
+        aligned.prepend(" ").append("!");
+        unaligned.prepend(" ").append("!");
+
+        assert_eq!(aligned.get(), unaligned.get());
+        assert_eq!(unaligned.get(), " there!");
+        assert!(unaligned.is_unaligned());
+    }
+
+    #[test]
+    fn unaligned_replace() {
+        let mut aligned = NormalizedString::from("Hey friend!     How are you?");
+        let mut unaligned = NormalizedString::unaligned("Hey friend!     How are you?".to_string());
+
+        aligned.replace(' ', "▁").unwrap();
+        unaligned.replace(' ', "▁").unwrap();
+
+        assert_eq!(aligned.get(), unaligned.get());
+        assert!(unaligned.is_unaligned());
+        assert!(unaligned.alignments.is_empty());
+    }
+
+    #[test]
+    fn unaligned_split() {
+        let aligned = NormalizedString::from("the-final--countdown");
+        let unaligned = NormalizedString::unaligned("the-final--countdown".to_string());
+
+        for behavior in [
+            SplitDelimiterBehavior::Removed,
+            SplitDelimiterBehavior::Isolated,
+            SplitDelimiterBehavior::MergedWithPrevious,
+            SplitDelimiterBehavior::MergedWithNext,
+            SplitDelimiterBehavior::Contiguous,
+        ] {
+            let aligned_texts: Vec<String> = aligned
+                .split('-', behavior)
+                .unwrap()
+                .iter()
+                .map(|n| n.get().to_string())
+                .collect();
+            let pieces = unaligned.split('-', behavior).unwrap();
+            let unaligned_texts: Vec<String> = pieces.iter().map(|n| n.get().to_string()).collect();
+            assert_eq!(aligned_texts, unaligned_texts, "behavior {behavior:?}");
+            assert!(pieces.iter().all(|p| p.is_unaligned()));
+            // Only the first piece can claim original position 0
+            assert!(pieces[1..].iter().all(|p| p.offsets_original().0 != 0));
+        }
+    }
+
+    #[test]
+    fn set_normalized_enters_unaligned_mode() {
+        let mut n = NormalizedString::from("HELLO");
+        n.set_normalized("hello".to_string());
+        assert!(n.is_unaligned());
+        assert!(n.alignments.is_empty());
+        assert_eq!(n.get(), "hello");
     }
 }

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -136,9 +136,8 @@ impl NormalizedString {
         &self.normalized
     }
 
-    /// Create a `NormalizedString` that doesn't track alignments with an
-    /// original string: no string clone, no per-byte alignment vector.
-    /// For pipelines that never need offsets (`encode_fast`).
+    /// Build a `NormalizedString` that doesn't track alignments.
+    /// See [`Self::is_unaligned`].
     pub(crate) fn unaligned(normalized: String) -> Self {
         Self {
             original: String::new(),
@@ -148,22 +147,26 @@ impl NormalizedString {
         }
     }
 
-    /// Whether this string skips alignment tracking. Transforms and slices
-    /// preserve unalignedness; offsets in the original referential are
-    /// unavailable. `original_shift` still tracks slice positions (in
-    /// normalized coordinates) so that `offsets_original().0 == 0` keeps
-    /// meaning "first piece" — see Metaspace's `PrependScheme::First`.
+    /// Whether this string skips alignment tracking.
     ///
-    /// Empty strings report aligned: both modes behave identically on them
-    /// (all offsets degenerate to `0..0`), at worst re-entering aligned mode
-    /// with a tiny alignment vector if content is later appended.
+    /// The trick: an aligned string always has one alignment entry per byte
+    /// of `normalized`, so "alignments empty but normalized not empty" is
+    /// normally impossible. We use that impossible state to mean "no
+    /// alignment tracking". This is what `encode_fast` runs on: same text
+    /// operations, no offsets, no per-byte bookkeeping. (Empty strings count
+    /// as aligned; both modes behave the same on them.)
+    ///
+    /// One exception: `slice()` still updates `original_shift`, because
+    /// Metaspace(First) needs to know whether a piece is the first one
+    /// (`offsets_original().0 == 0`). That answer is wrong when a normalizer
+    /// removed characters at the start of the input — known quirk, see the
+    /// `metaspace_first_leading_strip_known_divergence` test.
     pub(crate) fn is_unaligned(&self) -> bool {
         self.alignments.is_empty() && !self.normalized.is_empty()
     }
 
-    /// Replace the normalized content without tracking alignments, switching
-    /// this string into unaligned mode (see [`is_unaligned`]): offsets against
-    /// the original string are no longer available.
+    /// Replace the normalized content and stop tracking alignments.
+    /// See [`Self::is_unaligned`].
     pub fn set_normalized(&mut self, new: String) {
         self.normalized = new;
         self.alignments.clear();
@@ -308,15 +311,10 @@ impl NormalizedString {
     {
         let full_range = self.validate_range(range)?;
 
+        // encode_fast path: copy the text, keep the shift for Metaspace(First)
         if self.is_unaligned() {
             return match full_range {
                 Range::Original(_) => None,
-                // The shift accumulates normalized positions, not original
-                // ones: exact enough for the only consumer (`offsets_original`
-                // as a first-piece predicate), except when a normalizer
-                // removed leading content from the sequence start — a known
-                // encode_fast divergence for Metaspace(First) pipelines,
-                // pre-dating this mode (introduced with `normalize_str`).
                 Range::Normalized(r) => Some(Self {
                     original: String::new(),
                     normalized: self.normalized[r.clone()].to_owned(),
@@ -370,13 +368,12 @@ impl NormalizedString {
         T: RangeBounds<usize> + Clone,
         I: IntoIterator<Item = (char, isize)>,
     {
+        // encode_fast path: just rewrite the text
         if self.is_unaligned() {
             let n_range = match &range {
                 Range::Normalized(_) => range.clone().into_full_range(self.len()),
-                // The only original range that maps onto an unaligned string is
-                // the unbounded one (e.g. `transform()`), meaning "everything".
-                // Bounded original ranges are unmappable, like unmappable
-                // ranges on the aligned path: no-op.
+                // an original range can't be mapped without alignments → no-op,
+                // except `..` which simply means "everything" (what transform() sends)
                 Range::Original(r) => match (r.start_bound(), r.end_bound()) {
                     (Bound::Unbounded, Bound::Unbounded) => 0..self.len(),
                     _ => return,
@@ -636,6 +633,7 @@ impl NormalizedString {
 
     /// Replace anything that matches the pattern with the given content.
     pub fn replace<P: Pattern>(&mut self, pattern: P, content: &str) -> Result<()> {
+        // encode_fast path: just rewrite the text
         if self.is_unaligned() {
             let mut new_normalized = String::with_capacity(self.normalized.len());
             let mut last_end = 0;
@@ -2413,8 +2411,7 @@ mod tests {
         assert!(slice.is_unaligned());
         assert_eq!(slice.get(), "world");
         assert!(slice.alignments.is_empty());
-        // original_shift tracks the position so `offsets_original().0 == 0`
-        // remains a valid "is this the first piece" predicate (Metaspace First)
+        // the shift keeps tracking positions, for Metaspace(First)
         assert_eq!(
             n.slice(Range::Normalized(0..5))
                 .unwrap()
@@ -2482,9 +2479,8 @@ mod tests {
 
     #[test]
     fn unaligned_emptied_then_extended_keeps_working() {
-        // An unaligned string whose content is removed re-enters aligned mode
-        // (the sentinel can't distinguish the two on empty strings); both
-        // modes behave identically there, so operations keep working.
+        // an emptied unaligned string counts as aligned again — fine, both
+        // modes do the same thing on empty strings
         let mut n = NormalizedString::unaligned("hello".to_string());
         n.clear();
         assert_eq!(n.get(), "");
@@ -2505,8 +2501,7 @@ mod tests {
 
     #[test]
     fn unaligned_transform_range_bounded_original_is_noop() {
-        // Bounded original ranges are unmappable without alignments: no-op,
-        // mirroring the aligned path's behavior for unmappable ranges.
+        // bounded original ranges can't be mapped → no-op
         let mut n = NormalizedString::unaligned("Hello".to_string());
         n.transform_range(Range::Original(0..2), vec![('X', 0)], 0);
         assert_eq!(n.get(), "Hello");

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -2481,6 +2481,45 @@ mod tests {
     }
 
     #[test]
+    fn unaligned_emptied_then_extended_keeps_working() {
+        // An unaligned string whose content is removed re-enters aligned mode
+        // (the sentinel can't distinguish the two on empty strings); both
+        // modes behave identically there, so operations keep working.
+        let mut n = NormalizedString::unaligned("hello".to_string());
+        n.clear();
+        assert_eq!(n.get(), "");
+        assert!(!n.is_unaligned());
+
+        n.append("x");
+        assert_eq!(n.get(), "x");
+
+        // prepend on an emptied string is a no-op — same as on aligned
+        let mut emptied = NormalizedString::unaligned("   ".to_string());
+        emptied.replace(' ', "").unwrap();
+        assert_eq!(emptied.get(), "");
+        emptied.prepend("y");
+        let mut aligned_empty = NormalizedString::from("");
+        aligned_empty.prepend("y");
+        assert_eq!(emptied.get(), aligned_empty.get());
+    }
+
+    #[test]
+    fn unaligned_transform_range_bounded_original_is_noop() {
+        // Bounded original ranges are unmappable without alignments: no-op,
+        // mirroring the aligned path's behavior for unmappable ranges.
+        let mut n = NormalizedString::unaligned("Hello".to_string());
+        n.transform_range(Range::Original(0..2), vec![('X', 0)], 0);
+        assert_eq!(n.get(), "Hello");
+        assert!(n.is_unaligned());
+
+        // Unbounded original means "everything" (the `transform()` case)
+        let mut n = NormalizedString::unaligned("ab".to_string());
+        n.transform_range(Range::Original(..), vec![('X', 0), ('Y', 0)], 0);
+        assert_eq!(n.get(), "XY");
+        assert!(n.is_unaligned());
+    }
+
+    #[test]
     fn unaligned_split() {
         let aligned = NormalizedString::from("the-final--countdown");
         let unaligned = NormalizedString::unaligned("the-final--countdown".to_string());

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -150,8 +150,13 @@ impl NormalizedString {
 
     /// Whether this string skips alignment tracking. Transforms and slices
     /// preserve unalignedness; offsets in the original referential are
-    /// unavailable. `original_shift` still tracks slice positions so that
-    /// `offsets_original().0 == 0` keeps meaning "first piece".
+    /// unavailable. `original_shift` still tracks slice positions (in
+    /// normalized coordinates) so that `offsets_original().0 == 0` keeps
+    /// meaning "first piece" — see Metaspace's `PrependScheme::First`.
+    ///
+    /// Empty strings report aligned: both modes behave identically on them
+    /// (all offsets degenerate to `0..0`), at worst re-entering aligned mode
+    /// with a tiny alignment vector if content is later appended.
     pub(crate) fn is_unaligned(&self) -> bool {
         self.alignments.is_empty() && !self.normalized.is_empty()
     }
@@ -306,6 +311,12 @@ impl NormalizedString {
         if self.is_unaligned() {
             return match full_range {
                 Range::Original(_) => None,
+                // The shift accumulates normalized positions, not original
+                // ones: exact enough for the only consumer (`offsets_original`
+                // as a first-piece predicate), except when a normalizer
+                // removed leading content from the sequence start — a known
+                // encode_fast divergence for Metaspace(First) pipelines,
+                // pre-dating this mode (introduced with `normalize_str`).
                 Range::Normalized(r) => Some(Self {
                     original: String::new(),
                     normalized: self.normalized[r.clone()].to_owned(),

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -155,12 +155,6 @@ impl NormalizedString {
     /// alignment tracking". This is what `encode_fast` runs on: same text
     /// operations, no offsets, no per-byte bookkeeping. (Empty strings count
     /// as aligned; both modes behave the same on them.)
-    ///
-    /// One exception: `slice()` still updates `original_shift`, because
-    /// Metaspace(First) needs to know whether a piece is the first one
-    /// (`offsets_original().0 == 0`). That answer is wrong when a normalizer
-    /// removed characters at the start of the input — known quirk, see the
-    /// `metaspace_first_leading_strip_known_divergence` test.
     pub(crate) fn is_unaligned(&self) -> bool {
         self.alignments.is_empty() && !self.normalized.is_empty()
     }
@@ -311,7 +305,7 @@ impl NormalizedString {
     {
         let full_range = self.validate_range(range)?;
 
-        // encode_fast path: copy the text, keep the shift for Metaspace(First)
+        // encode_fast path: copy the text
         if self.is_unaligned() {
             return match full_range {
                 Range::Original(_) => None,
@@ -2411,7 +2405,7 @@ mod tests {
         assert!(slice.is_unaligned());
         assert_eq!(slice.get(), "world");
         assert!(slice.alignments.is_empty());
-        // the shift keeps tracking positions, for Metaspace(First)
+        // slices keep best-effort position info in original_shift
         assert_eq!(
             n.slice(Range::Normalized(0..5))
                 .unwrap()

--- a/tokenizers/src/tokenizer/pre_tokenizer.rs
+++ b/tokenizers/src/tokenizer/pre_tokenizer.rs
@@ -262,6 +262,13 @@ impl PreTokenizedString {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn splits_are_unaligned(&self) -> bool {
+        self.splits
+            .iter()
+            .all(|s| s.normalized.is_unaligned() || s.normalized.is_empty())
+    }
+
     /// Returns a list of splits, each of them being a slice of the normalized
     /// string, the associated offsets either in original or normalized
     /// referential, as well as the potention tokens

--- a/tokenizers/tests/encode_fast_equivalence.rs
+++ b/tokenizers/tests/encode_fast_equivalence.rs
@@ -1,0 +1,110 @@
+//! encode_fast must produce the same ids/type_ids/special-tokens-mask as encode,
+//! across real tokenizer pipelines. Offsets, token strings and word ids are
+//! explicitly out of contract for encode_fast.
+
+use tokenizers::tokenizer::EncodeInput;
+use tokenizers::{AddedToken, Tokenizer};
+
+fn test_inputs() -> Vec<String> {
+    let data = std::fs::read_to_string("data/big.txt").unwrap();
+    let mut inputs: Vec<String> = data.lines().take(200).map(|s| s.to_string()).collect();
+    inputs.extend(
+        [
+            "",
+            " ",
+            "    ",
+            "Hello world",
+            " leading space",
+            "trailing space ",
+            "punct!!! ... and 123 numbers",
+            "unicode: héllo wörld précis ça",
+            "CJK: 你好世界 こんにちは 안녕하세요",
+            "emoji: 👋🌍 family: 👨‍👩‍👧‍👦",
+            "combining: e\u{301} a\u{30A} ﬀ ligature",
+            "mixed العربية and עברית rtl",
+            "tabs\tand\nnewlines\r\nhere",
+            "'s 't 're 've 'm 'll 'd contractions",
+        ]
+        .iter()
+        .map(|s| s.to_string()),
+    );
+    inputs
+}
+
+fn check_tokenizer(tokenizer: &Tokenizer, inputs: &[String]) {
+    for input in inputs {
+        let slow = tokenizer.encode(input.as_str(), true).unwrap();
+        let fast = tokenizer.encode_fast(input.as_str(), true).unwrap();
+        assert_eq!(slow.get_ids(), fast.get_ids(), "ids differ on {input:?}");
+        assert_eq!(
+            slow.get_type_ids(),
+            fast.get_type_ids(),
+            "type_ids differ on {input:?}"
+        );
+        assert_eq!(
+            slow.get_special_tokens_mask(),
+            fast.get_special_tokens_mask(),
+            "special tokens mask differs on {input:?}"
+        );
+        assert_eq!(
+            slow.get_attention_mask(),
+            fast.get_attention_mask(),
+            "attention mask differs on {input:?}"
+        );
+    }
+
+    // Pair encoding
+    let slow = tokenizer
+        .encode(("First sequence", "Second sequence"), true)
+        .unwrap();
+    let fast = tokenizer
+        .encode_fast(("First sequence", "Second sequence"), true)
+        .unwrap();
+    assert_eq!(slow.get_ids(), fast.get_ids());
+    assert_eq!(slow.get_type_ids(), fast.get_type_ids());
+
+    // Batch
+    let batch: Vec<EncodeInput> = inputs.iter().map(|s| s.as_str().into()).collect();
+    let slow_batch = tokenizer.encode_batch(batch.clone(), true).unwrap();
+    let fast_batch = tokenizer.encode_batch_fast(batch, true).unwrap();
+    assert_eq!(slow_batch.len(), fast_batch.len());
+    for (i, (slow, fast)) in slow_batch.iter().zip(fast_batch.iter()).enumerate() {
+        assert_eq!(slow.get_ids(), fast.get_ids(), "batch ids differ at {i}");
+    }
+}
+
+#[test]
+fn gpt2_with_added_tokens() {
+    let mut tokenizer = Tokenizer::from_file("data/roberta.json").unwrap();
+    tokenizer
+        .add_tokens(vec![AddedToken::from("procedural", true)])
+        .unwrap();
+    tokenizer
+        .add_special_tokens(vec![AddedToken::from("<custom>", true)
+            .lstrip(true)
+            .rstrip(true)])
+        .unwrap();
+
+    let mut inputs = test_inputs();
+    inputs.push("a procedural text with <custom> tokens procedural".into());
+    inputs.push("  <custom>  spaces around <custom>".into());
+    check_tokenizer(&tokenizer, &inputs);
+}
+
+#[test]
+fn llama3() {
+    let tokenizer = Tokenizer::from_file("data/llama-3-tokenizer.json").unwrap();
+    check_tokenizer(&tokenizer, &test_inputs());
+}
+
+#[test]
+fn bert_wiki() {
+    let tokenizer = Tokenizer::from_file("data/bert-wiki.json").unwrap();
+    check_tokenizer(&tokenizer, &test_inputs());
+}
+
+#[test]
+fn albert_metaspace() {
+    let tokenizer = Tokenizer::from_file("data/albert-base-v1-tokenizer.json").unwrap();
+    check_tokenizer(&tokenizer, &test_inputs());
+}

--- a/tokenizers/tests/encode_fast_equivalence.rs
+++ b/tokenizers/tests/encode_fast_equivalence.rs
@@ -109,6 +109,71 @@ fn albert_metaspace() {
     check_tokenizer(&tokenizer, &test_inputs());
 }
 
+/// Every other pre-tokenizer, swapped into the bert-wiki WordPiece pipeline.
+#[test]
+fn pre_tokenizer_sweep() {
+    use tokenizers::pre_tokenizers::bert::BertPreTokenizer;
+    use tokenizers::pre_tokenizers::delimiter::CharDelimiterSplit;
+    use tokenizers::pre_tokenizers::digits::Digits;
+    use tokenizers::pre_tokenizers::fixed_length::FixedLength;
+    use tokenizers::pre_tokenizers::punctuation::Punctuation;
+    use tokenizers::pre_tokenizers::sequence::Sequence;
+    use tokenizers::pre_tokenizers::split::{Split, SplitPattern};
+    use tokenizers::pre_tokenizers::unicode_scripts::UnicodeScripts;
+    use tokenizers::pre_tokenizers::whitespace::{Whitespace, WhitespaceSplit};
+    use tokenizers::pre_tokenizers::PreTokenizerWrapper;
+    use tokenizers::SplitDelimiterBehavior::*;
+
+    let pre_tokenizers: Vec<(&str, PreTokenizerWrapper)> = vec![
+        ("bert", BertPreTokenizer.into()),
+        ("whitespace", Whitespace.into()),
+        ("whitespace_split", WhitespaceSplit.into()),
+        ("punctuation_isolated", Punctuation::new(Isolated).into()),
+        ("punctuation_removed", Punctuation::new(Removed).into()),
+        (
+            "punctuation_merged_prev",
+            Punctuation::new(MergedWithPrevious).into(),
+        ),
+        (
+            "punctuation_merged_next",
+            Punctuation::new(MergedWithNext).into(),
+        ),
+        (
+            "punctuation_contiguous",
+            Punctuation::new(Contiguous).into(),
+        ),
+        ("digits_grouped", Digits::new(false).into()),
+        ("digits_individual", Digits::new(true).into()),
+        ("char_delimiter", CharDelimiterSplit::new(' ').into()),
+        ("fixed_length", FixedLength::new(4).into()),
+        ("unicode_scripts", UnicodeScripts::new().into()),
+        (
+            "split_regex",
+            Split::new(SplitPattern::Regex(r"\w+|[^\w\s]+".into()), Isolated, false)
+                .unwrap()
+                .into(),
+        ),
+        (
+            "split_invert",
+            Split::new(SplitPattern::Regex(r"\s+".into()), Removed, true)
+                .unwrap()
+                .into(),
+        ),
+        (
+            "sequence_whitespace_digits",
+            Sequence::new(vec![Whitespace.into(), Digits::new(true).into()]).into(),
+        ),
+    ];
+
+    let inputs = test_inputs();
+    for (name, pre_tokenizer) in pre_tokenizers {
+        eprintln!("pre_tokenizer: {name}");
+        let mut tokenizer = Tokenizer::from_file("data/bert-wiki.json").unwrap();
+        let _ = tokenizer.with_pre_tokenizer(Some(pre_tokenizer));
+        check_tokenizer(&tokenizer, &inputs);
+    }
+}
+
 fn metaspace_first_tokenizer(normalizer: tokenizers::NormalizerWrapper) -> Tokenizer {
     use tokenizers::models::wordlevel::WordLevel;
     use tokenizers::pre_tokenizers::metaspace::{Metaspace, PrependScheme};

--- a/tokenizers/tests/encode_fast_equivalence.rs
+++ b/tokenizers/tests/encode_fast_equivalence.rs
@@ -108,3 +108,56 @@ fn albert_metaspace() {
     let tokenizer = Tokenizer::from_file("data/albert-base-v1-tokenizer.json").unwrap();
     check_tokenizer(&tokenizer, &test_inputs());
 }
+
+/// Metaspace(First) prepends only to the piece at original position 0 — the
+/// one consumer of original-referential offsets on the fast path. The vocab
+/// distinguishes prepended from bare tokens so any divergence shows in ids.
+///
+/// Known limitation, pre-dating the unaligned mode: a normalizer that strips
+/// leading content from the sequence start (e.g. `Strip`) makes encode_fast
+/// prepend where encode does not. No such normalizer is used here.
+#[test]
+fn metaspace_first_prepend_scheme() {
+    use tokenizers::models::wordlevel::WordLevel;
+    use tokenizers::normalizers::utils::Lowercase;
+    use tokenizers::pre_tokenizers::metaspace::{Metaspace, PrependScheme};
+
+    let vocab: ahash::AHashMap<String, u32> = [
+        "▁hello", "hello", "▁world", "world", "▁how", "how", "▁are", "are", "▁you", "you",
+        "<mask>", "<unk>", "▁",
+    ]
+    .iter()
+    .enumerate()
+    .map(|(i, s)| (s.to_string(), i as u32))
+    .collect();
+    let model = WordLevel::builder()
+        .vocab(vocab)
+        .unk_token("<unk>".into())
+        .build()
+        .unwrap();
+
+    let mut tokenizer = Tokenizer::new(model);
+    let _ = tokenizer.with_normalizer(Some(Lowercase));
+    let _ = tokenizer.with_pre_tokenizer(Some(Metaspace::new('▁', PrependScheme::First, true)));
+    tokenizer
+        .add_special_tokens(vec![AddedToken::from("<mask>", true)])
+        .unwrap();
+
+    for input in [
+        "Hello world how are you",
+        "<mask> hello world",
+        "hello <mask> world",
+        " hello world",
+        "hello",
+        "<mask>",
+    ] {
+        let slow = tokenizer.encode(input, false).unwrap();
+        let fast = tokenizer.encode_fast(input, false).unwrap();
+        assert_eq!(slow.get_ids(), fast.get_ids(), "ids differ on {input:?}");
+        // The prepended form must actually occur, or this test proves nothing
+        if input == "Hello world how are you" {
+            assert_eq!(slow.get_ids()[0], 0, "expected ▁hello first");
+            assert!(!slow.get_ids()[1..].contains(&0));
+        }
+    }
+}

--- a/tokenizers/tests/encode_fast_equivalence.rs
+++ b/tokenizers/tests/encode_fast_equivalence.rs
@@ -1,6 +1,6 @@
-//! encode_fast must produce the same ids/type_ids/special-tokens-mask as encode,
-//! across real tokenizer pipelines. Offsets, token strings and word ids are
-//! explicitly out of contract for encode_fast.
+//! encode_fast must produce the same ids, type_ids and masks as encode,
+//! across real tokenizer pipelines. encode_fast does not promise offsets,
+//! token strings or word ids — those are not compared here.
 
 use tokenizers::tokenizer::EncodeInput;
 use tokenizers::{AddedToken, Tokenizer};
@@ -133,14 +133,9 @@ fn metaspace_first_tokenizer(normalizer: tokenizers::NormalizerWrapper) -> Token
     tokenizer
 }
 
-/// Metaspace(First) prepends only to the piece at original position 0 — the
-/// one consumer of original-referential offsets on the fast path. The vocab
-/// distinguishes prepended from bare tokens so any divergence shows in ids.
-///
-/// Known limitation, pre-dating the unaligned mode: a normalizer that strips
-/// leading content from the sequence start makes encode_fast prepend where
-/// encode does not — pinned by `metaspace_first_leading_strip_known_divergence`
-/// below. No such normalizer is used here.
+/// Metaspace(First) prepends "▁" only to the first piece — the only thing on
+/// the fast path that reads original offsets. The vocab has both "▁hello"
+/// and "hello", so a wrong prepend changes the ids.
 #[test]
 fn metaspace_first_prepend_scheme() {
     use tokenizers::normalizers::utils::Lowercase;
@@ -169,15 +164,12 @@ fn metaspace_first_prepend_scheme() {
     }
 }
 
-/// Canary for the KNOWN encode/encode_fast divergence: without alignments the
-/// fast path cannot know a normalizer stripped leading content, so the first
-/// piece keeps original_shift 0 and Metaspace(First) prepends where encode
-/// does not. Introduced with `normalize_str` (the trivial-alignments
-/// `set_normalized`), kept by the unaligned mode.
-///
-/// If this test starts failing because both sides agree, the limitation got
-/// fixed: delete this test and the caveats referencing it (slice() comment in
-/// normalizer.rs, doc of metaspace_first_prepend_scheme above).
+/// Pins a KNOWN difference between encode and encode_fast: without
+/// alignments, the fast path can't see that Strip removed the leading
+/// spaces, so Metaspace(First) prepends "▁" — encode does not. Pre-existing
+/// quirk (came in with `normalize_str`), not introduced by the unaligned
+/// mode. If both sides ever agree, the limitation got fixed: delete this
+/// test and the doc on `NormalizedString::is_unaligned` pointing at it.
 #[test]
 fn metaspace_first_leading_strip_known_divergence() {
     use tokenizers::normalizers::Strip;

--- a/tokenizers/tests/encode_fast_equivalence.rs
+++ b/tokenizers/tests/encode_fast_equivalence.rs
@@ -109,17 +109,8 @@ fn albert_metaspace() {
     check_tokenizer(&tokenizer, &test_inputs());
 }
 
-/// Metaspace(First) prepends only to the piece at original position 0 — the
-/// one consumer of original-referential offsets on the fast path. The vocab
-/// distinguishes prepended from bare tokens so any divergence shows in ids.
-///
-/// Known limitation, pre-dating the unaligned mode: a normalizer that strips
-/// leading content from the sequence start (e.g. `Strip`) makes encode_fast
-/// prepend where encode does not. No such normalizer is used here.
-#[test]
-fn metaspace_first_prepend_scheme() {
+fn metaspace_first_tokenizer(normalizer: tokenizers::NormalizerWrapper) -> Tokenizer {
     use tokenizers::models::wordlevel::WordLevel;
-    use tokenizers::normalizers::utils::Lowercase;
     use tokenizers::pre_tokenizers::metaspace::{Metaspace, PrependScheme};
 
     let vocab: ahash::AHashMap<String, u32> = [
@@ -137,8 +128,24 @@ fn metaspace_first_prepend_scheme() {
         .unwrap();
 
     let mut tokenizer = Tokenizer::new(model);
-    let _ = tokenizer.with_normalizer(Some(Lowercase));
+    let _ = tokenizer.with_normalizer(Some(normalizer));
     let _ = tokenizer.with_pre_tokenizer(Some(Metaspace::new('▁', PrependScheme::First, true)));
+    tokenizer
+}
+
+/// Metaspace(First) prepends only to the piece at original position 0 — the
+/// one consumer of original-referential offsets on the fast path. The vocab
+/// distinguishes prepended from bare tokens so any divergence shows in ids.
+///
+/// Known limitation, pre-dating the unaligned mode: a normalizer that strips
+/// leading content from the sequence start makes encode_fast prepend where
+/// encode does not — pinned by `metaspace_first_leading_strip_known_divergence`
+/// below. No such normalizer is used here.
+#[test]
+fn metaspace_first_prepend_scheme() {
+    use tokenizers::normalizers::utils::Lowercase;
+
+    let mut tokenizer = metaspace_first_tokenizer(Lowercase.into());
     tokenizer
         .add_special_tokens(vec![AddedToken::from("<mask>", true)])
         .unwrap();
@@ -160,4 +167,28 @@ fn metaspace_first_prepend_scheme() {
             assert!(!slow.get_ids()[1..].contains(&0));
         }
     }
+}
+
+/// Canary for the KNOWN encode/encode_fast divergence: without alignments the
+/// fast path cannot know a normalizer stripped leading content, so the first
+/// piece keeps original_shift 0 and Metaspace(First) prepends where encode
+/// does not. Introduced with `normalize_str` (the trivial-alignments
+/// `set_normalized`), kept by the unaligned mode.
+///
+/// If this test starts failing because both sides agree, the limitation got
+/// fixed: delete this test and the caveats referencing it (slice() comment in
+/// normalizer.rs, doc of metaspace_first_prepend_scheme above).
+#[test]
+fn metaspace_first_leading_strip_known_divergence() {
+    use tokenizers::normalizers::Strip;
+
+    let tokenizer = metaspace_first_tokenizer(Strip::new(true, true).into());
+
+    let slow = tokenizer.encode("  hello world", false).unwrap();
+    let fast = tokenizer.encode_fast("  hello world", false).unwrap();
+
+    // encode: stripped first piece maps to original position 2 → no prepend
+    assert_eq!(slow.get_ids(), [1, 2], "hello, ▁world");
+    // encode_fast: position information lost → prepend
+    assert_eq!(fast.get_ids(), [0, 2], "▁hello, ▁world");
 }

--- a/tokenizers/tests/encode_fast_equivalence.rs
+++ b/tokenizers/tests/encode_fast_equivalence.rs
@@ -133,9 +133,8 @@ fn metaspace_first_tokenizer(normalizer: tokenizers::NormalizerWrapper) -> Token
     tokenizer
 }
 
-/// Metaspace(First) prepends "▁" only to the first piece — the only thing on
-/// the fast path that reads original offsets. The vocab has both "▁hello"
-/// and "hello", so a wrong prepend changes the ids.
+/// Metaspace(First) prepends "▁" only to the first split. The vocab has both
+/// "▁hello" and "hello", so a wrong prepend changes the ids.
 #[test]
 fn metaspace_first_prepend_scheme() {
     use tokenizers::normalizers::utils::Lowercase;
@@ -164,14 +163,11 @@ fn metaspace_first_prepend_scheme() {
     }
 }
 
-/// Pins a KNOWN difference between encode and encode_fast: without
-/// alignments, the fast path can't see that Strip removed the leading
-/// spaces, so Metaspace(First) prepends "▁" — encode does not. Pre-existing
-/// quirk (came in with `normalize_str`), not introduced by the unaligned
-/// mode. If both sides ever agree, the limitation got fixed: delete this
-/// test and the doc on `NormalizedString::is_unaligned` pointing at it.
+/// A normalizer that removes leading characters (Strip) must not make
+/// encode and encode_fast disagree. Metaspace(First) decides "first piece"
+/// by split index, so both paths prepend "▁" here.
 #[test]
-fn metaspace_first_leading_strip_known_divergence() {
+fn metaspace_first_with_leading_strip() {
     use tokenizers::normalizers::Strip;
 
     let tokenizer = metaspace_first_tokenizer(Strip::new(true, true).into());
@@ -179,8 +175,6 @@ fn metaspace_first_leading_strip_known_divergence() {
     let slow = tokenizer.encode("  hello world", false).unwrap();
     let fast = tokenizer.encode_fast("  hello world", false).unwrap();
 
-    // encode: stripped first piece maps to original position 2 → no prepend
-    assert_eq!(slow.get_ids(), [1, 2], "hello, ▁world");
-    // encode_fast: position information lost → prepend
-    assert_eq!(fast.get_ids(), [0, 2], "▁hello, ▁world");
+    assert_eq!(slow.get_ids(), [0, 2], "▁hello, ▁world");
+    assert_eq!(slow.get_ids(), fast.get_ids());
 }


### PR DESCRIPTION
Builds on top of #2022 

`encode_fast` only cares about token ids. Offsets, token strings, etc get dropped at the very end of the pipeline: [ref](https://github.com/huggingface/tokenizers/blob/bcdd25b9/tokenizers/src/tokenizer/pre_tokenizer.rs#L212-L224)

#2022 improved the perf of encode_fast by not computing alignment offsets during normalization, but the alignment `Vec` were still fully allocated at construction (`NormalizedString::from`), in `set_normalized` [ref](https://github.com/huggingface/tokenizers/blob/38eec91d/tokenizers/src/tokenizer/normalizer.rs#L144-L149) and at every `slice()` call during pre-tokenization: [ref](https://github.com/huggingface/tokenizers/blob/38eec91d/tokenizers/src/tokenizer/normalizer.rs#L308-L313)

This PR adds a "no alignment" fast path on NormalizedString methods that skip allocation (`String::new` and `Vec::new` do not allocate) when in the `encode_fast` path, by relying on a invariant that cannot happen when computing alignments through `encode`: empty `alignments` vec + non-empty `normalized` string

https://github.com/huggingface/tokenizers/blob/f5aa6c08ff481bdd7ce4cf185a7671b0acbcdf66/tokenizers/src/tokenizer/normalizer.rs#L139-L160

On my machine this results in a +42% throughput improvement on llama-3 vs the base branch (would love a /benchmark to back it up)
```
cargo bench --bench ci_becnhmark -- 'llama3'
```

----

A possible next step would be to stop copying the String around at every slice() call but it's a much bigger and deeper change