### PR TITLE
Fix empty Encoding.overflowing when truncation is enabled

### DIFF
--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -6,8 +6,8 @@ import numpy as np
 import asyncio
 from tokenizers import AddedToken, Encoding, Tokenizer, decoders
 from tokenizers.implementations import BertWordPieceTokenizer
-from tokenizers.models import BPE, Model, Unigram
-from tokenizers.pre_tokenizers import ByteLevel, Metaspace
+from tokenizers.models import BPE, Model, Unigram, WordLevel
+from tokenizers.pre_tokenizers import ByteLevel, Metaspace, Whitespace
 from tokenizers.processors import RobertaProcessing, TemplateProcessing
 from tokenizers.normalizers import Strip, Lowercase, Sequence
 from tokenizers.normalizers import ByteLevel as NormalizerByteLevel
@@ -368,6 +368,23 @@ class TestTokenizer:
 
         output = tokenizer.encode("my name is john", "pair")
         assert output.tokens == ["john", "pair"]
+
+    def test_truncation_populates_overflowing(self):
+        # https://github.com/huggingface/tokenizers/issues/2091
+        vocab = {"[UNK]": 0, **{str(i): i + 1 for i in range(50)}}
+        tokenizer = Tokenizer(WordLevel(vocab=vocab, unk_token="[UNK]"))
+        tokenizer.pre_tokenizer = Whitespace()
+        tokenizer.enable_truncation(max_length=10, stride=2)
+
+        output = tokenizer.encode(" ".join(str(i) for i in range(50)))
+        assert output.ids == [vocab[str(i)] for i in range(10)]
+
+        # The truncated tokens must remain available through `overflowing`,
+        # with consecutive pieces overlapping by `stride` tokens
+        assert len(output.overflowing) == 5
+        assert [piece.ids for piece in output.overflowing] == [
+            [vocab[str(i)] for i in range(start, start + 10)] for start in (8, 16, 24, 32, 40)
+        ]
 
     def test_padding(self):
         tokenizer = Tokenizer(BPE())

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -90,7 +90,9 @@ pub trait Model {
     ///
     /// When `truncation` is `Some((max_tokens, direction))`, the
     /// `tokenize_with_limit` early-exit path is taken; otherwise every
-    /// pre-token is tokenized.
+    /// pre-token is tokenized. Note that the encode pipeline always passes
+    /// `None`: exiting early would drop the tokens that `Encoding::truncate`
+    /// moves into `Encoding::overflowing` (#2091).
     ///
     /// The default calls `self.tokenize()` per pre-token, which is correct
     /// for self-contained `Model` implementations.  Implementations that
@@ -1183,19 +1185,12 @@ where
         offsets_type: OffsetType,
     ) -> Result<Encoding> {
         let mut pretokenized: PreTokenizedString = pretokenized.into();
-        let truncation = match self.truncation.as_ref() {
-            Some(TruncationParams {
-                direction,
-                max_length,
-                strategy,
-                ..
-            }) if *strategy != TruncationStrategy::OnlySecond || type_id != 0 => {
-                Some((*max_length, *direction))
-            }
-            _ => None,
-        };
+        // Tokenize every pre-token, even when truncation is enabled: the tokens
+        // beyond `max_length` are moved by `Encoding::truncate` into
+        // `Encoding::overflowing` during post-processing, so exiting early
+        // would silently drop them (#2091).
         self.model
-            .tokenize_in_pretokenized(&mut pretokenized, truncation)?;
+            .tokenize_in_pretokenized(&mut pretokenized, None)?;
         pretokenized.into_encoding(word_idx, type_id, offsets_type)
     }
 }
@@ -1717,6 +1712,69 @@ mod tests {
             truncated.get_ids(),
             &full.get_ids()[n - 3..],
             "Left-truncated should match last 3 tokens of full encoding"
+        );
+    }
+
+    #[test]
+    fn right_truncation_populates_overflowing() {
+        // https://github.com/huggingface/tokenizers/issues/2091
+        // "a b c d e f g h i j" → 10 tokens [0,1,2,3,4,5,6,7,8,9]
+        // Right truncation to 4 with stride 2 → [0,1,2,3], and the rest must
+        // remain available through `Encoding::overflowing`, with consecutive
+        // pieces overlapping by `stride` tokens.
+        let input = "a b c d e f g h i j";
+
+        let mut tok = test_tokenizer();
+        tok.with_truncation(Some(TruncationParams {
+            max_length: 4,
+            strategy: TruncationStrategy::LongestFirst,
+            stride: 2,
+            direction: TruncationDirection::Right,
+        }))
+        .unwrap();
+        let truncated = tok.encode(input, false).unwrap();
+
+        assert_eq!(truncated.get_ids(), &[0, 1, 2, 3]);
+        let overflowing_ids: Vec<&[u32]> = truncated
+            .get_overflowing()
+            .iter()
+            .map(|encoding| encoding.get_ids())
+            .collect();
+        assert_eq!(
+            overflowing_ids,
+            [&[2, 3, 4, 5][..], &[4, 5, 6, 7], &[6, 7, 8, 9]],
+            "Truncation should keep the remaining tokens in `overflowing`"
+        );
+    }
+
+    #[test]
+    fn left_truncation_populates_overflowing() {
+        // https://github.com/huggingface/tokenizers/issues/2091
+        // "a b c d e f g h i j" → 10 tokens [0,1,2,3,4,5,6,7,8,9]
+        // Left truncation to 3 → [7,8,9], with the leading tokens chunked
+        // right-to-left into `Encoding::overflowing`.
+        let input = "a b c d e f g h i j";
+
+        let mut tok = test_tokenizer();
+        tok.with_truncation(Some(TruncationParams {
+            max_length: 3,
+            strategy: TruncationStrategy::LongestFirst,
+            stride: 0,
+            direction: TruncationDirection::Left,
+        }))
+        .unwrap();
+        let truncated = tok.encode(input, false).unwrap();
+
+        assert_eq!(truncated.get_ids(), &[7, 8, 9]);
+        let overflowing_ids: Vec<&[u32]> = truncated
+            .get_overflowing()
+            .iter()
+            .map(|encoding| encoding.get_ids())
+            .collect();
+        assert_eq!(
+            overflowing_ids,
+            [&[4, 5, 6][..], &[1, 2, 3], &[0]],
+            "Truncation should keep the remaining tokens in `overflowing`"
         );
     }
 


### PR DESCRIPTION
Fixes #2091.

Since 0.23.1, `do_tokenize` sends every truncating encode through the #1990 `tokenize_with_limit` early exit, which stops tokenizing once `max_length` tokens exist — but the dropped pre-token splits are exactly the tokens `Encoding::truncate` later chunks into `overflowing`. Because the encode pipeline always materializes overflow when it truncates, there is no configuration where the early exit preserves observable behavior.

The fix has the encode pipeline tokenize all pre-tokens again (0.22.2 behavior); `tokenize_with_limit` and the #2072 bindings overrides stay intact, so the #1990 perf win could return behind an explicit opt-in (e.g. a `TruncationParams` flag) — happy to do that as a follow-up if wanted.

New Rust tests for both truncation directions and the issue's repro as a Python binding test fail before the fix (`overflowing` empty) and pass after; the #1990 regression tests still pass.
