### PR TITLE
ci: install libcairo on benchmark runners

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,6 +66,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
+      # cairosvg (chart rendering) dlopens the system libcairo, which the
+      # aws-general-8-plus runner image doesn't ship (ubuntu-latest did)
+      - name: Install libcairo
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libcairo2
+
       - name: Download benchmark data
         run: uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-bench-data --repo-type dataset --local-dir data
 
@@ -238,6 +243,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+
+      # cairosvg (chart rendering) dlopens the system libcairo, which the
+      # aws-general-8-plus runner image doesn't ship (ubuntu-latest did)
+      - name: Install libcairo
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libcairo2
 
       - name: Download benchmark data
         run: uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-bench-data --repo-type dataset --local-dir tokenizers/data


### PR DESCRIPTION
`cairosvg` needs `libcairo`

This PR apt-get installs libcairo on the CI runner