### PR TITLE
ci: split audit in a separate job

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -61,11 +61,6 @@ jobs:
         with:
           workspaces: bindings/python
 
-      - name: Install cargo-audit
-        uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95  # v2.75.20
-        with:
-          tool: cargo-audit
-
       - name: Install Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -81,9 +76,6 @@ jobs:
 
       - name: Lint with Clippy
         run: cargo clippy --manifest-path ./bindings/python/Cargo.toml --all-targets --all-features -- -D warnings
-
-      - name: Run Audit
-        run: cargo audit -D warnings -f ./bindings/python/Cargo.lock --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0014 --ignore RUSTSEC-2025-0119
 
       - name: Install
         working-directory: ./bindings/python
@@ -128,3 +120,24 @@ jobs:
         run: |
           source .env/bin/activate
           make check-style
+
+
+  audit:
+    name: Audit dependencies for vulnerabilities
+    # Runs independently of the build/test matrix so an advisory database hit
+    # (which is OS- and interpreter-invariant) doesn't fail the build.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95  # v2.75.20
+        with:
+          tool: cargo-audit
+
+      - name: Run Audit
+        run: cargo audit -D warnings -f ./bindings/python/Cargo.lock --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0014 --ignore RUSTSEC-2025-0119

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -123,7 +123,7 @@ jobs:
 
 
   audit:
-    name: Audit dependencies for vulnerabilities
+    name: Audit dependencies
     # Runs independently of the build/test matrix so an advisory database hit
     # (which is OS- and interpreter-invariant) doesn't fail the build.
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -139,5 +139,9 @@ jobs:
         with:
           tool: cargo-audit
 
+      # Cargo.lock is gitignored, so generate it (dependency resolution only, no compilation)
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile --manifest-path ./bindings/python/Cargo.toml
+
       - name: Run Audit
         run: cargo audit -D warnings -f ./bindings/python/Cargo.lock --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0014 --ignore RUSTSEC-2025-0119


### PR DESCRIPTION
Move th cargo audit step (for the python bindings) to a separate step:
- does not early stop build+test steps on different platforms
- easier to parse a failure (the job's name is more explicit about what went wrong)