### PR TITLE
fix: propagate type_ids to overflow encodings in post-processors

### DIFF
--- a/tokenizers/src/processors/roberta.rs
+++ b/tokenizers/src/processors/roberta.rs
@@ -79,9 +79,14 @@ impl PostProcessor for RobertaProcessing {
         }
 
         // Roberta is weird, and every encoding is type_id=0.
-        encodings
-            .iter_mut()
-            .for_each(|encoding| encoding.set_type_ids(vec![0; encoding.len()]));
+        // Roberta is weird, and every encoding is type_id=0.
+        encodings.iter_mut().for_each(|encoding| {
+            encoding.set_type_ids(vec![0; encoding.len()]);
+            encoding
+                .get_overflowing_mut()
+                .iter_mut()
+                .for_each(|overflow| overflow.set_type_ids(vec![0; overflow.len()]));
+        });
 
         if !add_special_tokens {
             return Ok(encodings);

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -555,6 +555,12 @@ impl TemplateProcessing {
                         let i = usize::from(*id != Sequence::A);
                         let encoding = &mut encodings[i];
                         encoding.set_type_ids(vec![*type_id; encoding.len()]);
+                        encoding
+                            .get_overflowing_mut()
+                            .iter_mut()
+                            .for_each(|overflow| {
+                                overflow.set_type_ids(vec![*type_id; overflow.len()]);
+                            });
                         encoding.set_sequence_id(i);
                         Some(encoding.clone())
                     }
@@ -1048,7 +1054,7 @@ mod tests {
                         vec![1, 1, 1, 1, 1, 1],
                         vec![Encoding::new(
                             vec![1, 13, 0, 17, 0],
-                            vec![0, 0, 0, 0, 1],
+                            vec![0, 0, 0, 1, 1],
                             vec![
                                 "[CLS]".into(),
                                 "you".into(),
@@ -1067,7 +1073,7 @@ mod tests {
                     ),
                     Encoding::new(
                         vec![1, 13, 0, 17, 0],
-                        vec![0, 0, 0, 0, 1],
+                        vec![0, 0, 0, 1, 1],
                         vec![
                             "[CLS]".into(),
                             "you".into(),
@@ -1084,7 +1090,7 @@ mod tests {
                     ),
                     Encoding::new(
                         vec![1, 12, 14, 0, 17, 0],
-                        vec![0, 0, 0, 0, 0, 1],
+                        vec![0, 0, 0, 0, 1, 1],
                         vec![
                             "[CLS]".into(),
                             "Hello".into(),
@@ -1099,7 +1105,7 @@ mod tests {
                         vec![1, 1, 1, 1, 1, 1],
                         vec![Encoding::new(
                             vec![1, 13, 0, 17, 0],
-                            vec![0, 0, 0, 0, 1],
+                            vec![0, 0, 0, 1, 1],
                             vec![
                                 "[CLS]".into(),
                                 "you".into(),
@@ -1126,6 +1132,49 @@ mod tests {
         assert_eq!(pair_encoding.token_to_sequence(5), Some(1));
         assert_eq!(pair_encoding.token_to_sequence(6), None);
     }
+    #[test]
+    fn pair_overflow_type_ids_propagated() {
+        // Regression test for https://github.com/huggingface/tokenizers/issues/1908
+        //
+        // When a pair sequence has overflowing encodings, those overflows must
+        // carry the type_id declared in the template piece (e.g. `$B:2`), not
+        // the default type_id=0.
+        let processor = TemplateProcessing::builder()
+            .try_single("$A:0")
+            .unwrap()
+            .try_pair("$A:0 $B:2")
+            .unwrap()
+            .build()
+            .unwrap();
+
+        use crate::Token;
+        let encoding =
+            Encoding::from_tokens(vec![Token::new(1, "A".into(), (0, 1))], 0);
+
+        let mut pair =
+            Encoding::from_tokens(vec![Token::new(2, "B".into(), (0, 1))], 0);
+        let pair_overflow =
+            Encoding::from_tokens(vec![Token::new(3, "B2".into(), (2, 4))], 0);
+        pair.set_overflowing(vec![pair_overflow]);
+
+        let result = processor.process(encoding, Some(pair), false).unwrap();
+
+        // Main: [A, B] → type_ids must be [0, 2]
+        assert_eq!(
+            result.get_type_ids(),
+            &[0u32, 2u32],
+            "main encoding: A→0, B→2"
+        );
+
+        // The one overflow is [A, B2]; B2 belongs to sequence B so must be type_id=2.
+        assert_eq!(result.get_overflowing().len(), 1);
+        assert_eq!(
+            result.get_overflowing()[0].get_type_ids(),
+            &[0u32, 2u32],
+            "overflow encoding: A→0, B2 should carry sequence B type_id=2"
+        );
+    }
+
     #[test]
     fn pair_must_use_both_sequences() {
         let processor = TemplateProcessing::builder()

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -141,6 +141,10 @@ pub trait PostProcessor {
                 .iter_mut()
                 .for_each(|encoding| encoding.set_sequence_id(i));
             encoding.set_type_ids(vec![i as u32; encoding.len()]);
+            encoding
+                .get_overflowing_mut()
+                .iter_mut()
+                .for_each(|overflow| overflow.set_type_ids(vec![i as u32; overflow.len()]));
         });
 
         let encodings = self.process_encodings(encodings, add_special_tokens)?;


### PR DESCRIPTION
## Bug

When encoding a pair where one or both sequences produce overflow chunks (due to truncation), the overflow encodings do not receive the `type_id` declared in the template/post-processor — only the **main** encoding is updated.  This means pair-sequence overflows silently keep `type_id=0` instead of the template-declared value (e.g. `$B:1`).

Reported in #1908.

## Root cause

Three independent call sites call `set_type_ids` on the main encoding but not on `get_overflowing_mut()`:

| File | Location | Effect |
|------|----------|--------|
| `tokenizers/src/processors/template.rs` | `apply_template()`, Piece::Sequence arm | Overflow encodings ignore the template's `type_id` |
| `tokenizers/src/tokenizer/mod.rs` | `PostProcessor::process()` | Overflow encodings miss the sequence-index type_id (already fixed for `set_sequence_id` but not `set_type_ids`) |
| `tokenizers/src/processors/roberta.rs` | `process_encodings()`, all-zero override | Overflow encodings do not receive Roberta's type_id=0 invariant |

## Fix

After each `encoding.set_type_ids(…)` call, mirror the operation onto overflow encodings:

```rust
encoding
    .get_overflowing_mut()
    .iter_mut()
    .for_each(|overflow| overflow.set_type_ids(vec![type_id; overflow.len()]));
```

All three sites are patched consistently.

## Verification

```
cargo test processors -p tokenizers
```



> This PR was created with the assistance of an AI coding tool.