### PR TITLE
feat(ci): enable npm's trusted publisher for releases

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -183,6 +183,7 @@ jobs:
       contents: write
       id-token: write
     name: Publish
+    environment: release
     runs-on: ubuntu-latest
     needs:
       - build
@@ -222,6 +223,3 @@ jobs:
       - name: Publish
         working-directory: ./bindings/node
         run: npm publish --access public --provenance
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
@ArthurZucker can you confirm I can remove the `NPM_TOKEN` from the secrets after that?