### PR TITLE
(wip) perf: Reduce allocations during normalization and pre-tokenization

### DIFF
--- a/tokenizers/src/normalizers/byte_level.rs
+++ b/tokenizers/src/normalizers/byte_level.rs
@@ -64,8 +64,8 @@ mod tests {
         assert_eq!(
             n,
             NormalizedString::new(
-                original.to_string(),
-                normalized.to_string(),
+                original,
+                normalized.into(),
                 vec![
                     (0, 1),
                     (1, 2),

--- a/tokenizers/src/normalizers/prepend.rs
+++ b/tokenizers/src/normalizers/prepend.rs
@@ -39,8 +39,8 @@ mod tests {
         assert_eq!(
             n,
             NormalizedString::new(
-                original.to_string(),
-                normalized.to_string(),
+                original,
+                normalized.into(),
                 vec![
                     (0, 1),
                     (0, 1),

--- a/tokenizers/src/normalizers/strip.rs
+++ b/tokenizers/src/normalizers/strip.rs
@@ -69,7 +69,7 @@ mod tests {
         let original: String = "Me llamó".nfkd().map(|(c, _)| c).collect();
         let normalized = "Me llamo";
         assert_ne!(original, normalized);
-        let mut n = NormalizedString::from(original);
+        let mut n = NormalizedString::from(original.as_str());
         StripAccents.normalize(&mut n).unwrap();
         assert_eq!(&n.get(), &normalized);
 
@@ -85,14 +85,14 @@ mod tests {
         let original: String = "这很简单".nfkd().map(|(c, _)| c).collect();
         let normalized = "这很简单";
         assert_eq!(original, normalized);
-        let mut n = NormalizedString::from(original);
+        let mut n = NormalizedString::from(original.as_str());
         StripAccents.normalize(&mut n).unwrap();
         assert_eq!(&n.get(), &normalized);
     }
 
     #[test]
     fn test_vietnamese_bug() {
-        let original: String = "ậ…".to_string();
+        let original: &str = "ậ…";
         let normalized = "a...".to_string();
         assert_ne!(original, normalized);
         let mut n = NormalizedString::from(original);
@@ -102,7 +102,7 @@ mod tests {
         Lowercase.normalize(&mut n).unwrap();
         assert_eq!(&n.get(), &normalized);
 
-        let original: String = "Cụ thể, bạn sẽ tham gia một nhóm các giám đốc điều hành tổ chức, các nhà lãnh đạo doanh nghiệp, các học giả, chuyên gia phát triển và tình nguyện viên riêng biệt trong lĩnh vực phi lợi nhuận…".to_string();
+        let original: &str = "Cụ thể, bạn sẽ tham gia một nhóm các giám đốc điều hành tổ chức, các nhà lãnh đạo doanh nghiệp, các học giả, chuyên gia phát triển và tình nguyện viên riêng biệt trong lĩnh vực phi lợi nhuận…";
         let normalized = "cu the, ban se tham gia mot nhom cac giam đoc đieu hanh to chuc, cac nha lanh đao doanh nghiep, cac hoc gia, chuyen gia phat trien va tinh nguyen vien rieng biet trong linh vuc phi loi nhuan...".to_string();
         let mut n = NormalizedString::from(original);
         NFKD.normalize(&mut n).unwrap();
@@ -116,7 +116,7 @@ mod tests {
         let original = "ำน\u{e49}ำ3ลำ".to_string();
         let normalized = "านา3ลา".to_string();
         assert_ne!(original, normalized);
-        let mut n = NormalizedString::from(original);
+        let mut n = NormalizedString::from(original.as_str());
         NFKD.normalize(&mut n).unwrap();
         StripAccents.normalize(&mut n).unwrap();
         Lowercase.normalize(&mut n).unwrap();
@@ -133,12 +133,7 @@ mod tests {
         assert_eq!(&n.get(), &normalized);
         assert_eq!(
             n,
-            NormalizedString::new(
-                original.to_string(),
-                normalized.to_string(),
-                vec![(0, 1), (7, 8)],
-                0
-            )
+            NormalizedString::new(original, normalized.into(), vec![(0, 1), (7, 8)], 0)
         );
         assert_eq!(
             n.alignments_original(),

--- a/tokenizers/src/normalizers/unicode.rs
+++ b/tokenizers/src/normalizers/unicode.rs
@@ -84,13 +84,15 @@ impl Normalizer for Nmt {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::borrow::Cow;
+
+use super::*;
 
     #[test]
     fn test_nfkc() {
-        let original = "\u{fb01}".to_string();
-        let normalized = "fi".to_string();
-        let mut n = NormalizedString::from(original.clone());
+        let original = "\u{fb01}";
+        let normalized = Cow::from("fi");
+        let mut n = NormalizedString::from(original);
         NFKC.normalize(&mut n).unwrap();
 
         assert_eq!(

--- a/tokenizers/src/tokenizer/added_vocabulary.rs
+++ b/tokenizers/src/tokenizer/added_vocabulary.rs
@@ -441,7 +441,7 @@ impl AddedVocabulary {
                 return vec![(None, (0, sentence.len()))];
             }
         };
-        for mat in trie.leftmost_find_iter(sentence) {
+        for mat in trie.leftmost_find_iter(sentence.as_bytes()) {
             let mut start = mat.start();
             let mut stop = mat.end();
             let id = mat.value();
@@ -492,15 +492,15 @@ impl AddedVocabulary {
     /// Split the input sentence to extract anything we found from the `MatchingSet`, as well as
     /// the list of corresponding IDs
     /// The list of IDs have the exact same number of elements than the Iterator.
-    fn split_with_indices(
+    fn split_with_indices<'input>(
         &self,
-        sentence: NormalizedString,
+        sentence: NormalizedString<'input>,
         split_re: &MatchingSet,
-    ) -> Vec<(NormalizedString, Option<Vec<Token>>)> {
+    ) -> Vec<(NormalizedString<'input>, Option<Vec<Token>>)> {
         self.find_matches(sentence.get(), split_re)
             .into_iter()
             .map(|(id, byte_offsets)| {
-                let slice = sentence
+                let slice: NormalizedString<'input> = sentence
                     .slice(Range::Normalized(byte_offsets.0..byte_offsets.1))
                     .expect("AddedVocabulary bad split");
                 if let Some(id) = id {
@@ -520,12 +520,12 @@ impl AddedVocabulary {
     /// non-normalized one. For example, when we expect to extract the token `yesterday` in the
     /// input sentence `I read a book Yesterday`, if the normalizer is supposed to lowercase
     /// everything, we expect a match.
-    pub fn extract_and_normalize<N: Normalizer>(
+    pub fn extract_and_normalize<'input, N: Normalizer>(
         &self,
         normalizer: Option<&N>,
-        sequence: &str,
-    ) -> PreTokenizedString {
-        let mut pretokenized: PreTokenizedString = sequence.into();
+        sequence: &'input str,
+    ) -> PreTokenizedString<'input> {
+        let mut pretokenized: PreTokenizedString<'input> = sequence.into();
 
         // 1. We extract all the non-normalized tokens from the non-normalized string
         pretokenized
@@ -638,7 +638,9 @@ mod tests {
         }
     }
 
-    fn simplify_output(result: &'_ PreTokenizedString) -> Vec<(&'_ str, Option<Vec<u32>>)> {
+    fn simplify_output<'input, 'a>(
+        result: &'a PreTokenizedString<'input>,
+    ) -> Vec<(&'a str, Option<Vec<u32>>)> {
         result
             .get_splits(OffsetReferential::Original, OffsetType::Byte)
             .into_iter()
@@ -935,7 +937,7 @@ mod tests {
     #[test]
     fn empty_matches() {
         let vocab = AddedVocabulary::new();
-        let matches = vocab.find_matches("", &vocab.split_trie);
+        let matches = vocab.find_matches("".into(), &vocab.split_trie);
         assert_eq!(matches, vec![(None, (0, 0))]);
     }
 

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -557,7 +557,7 @@ pub struct TokenizerImpl<M, N, PT, PP, D> {
     padding: Option<PaddingParams>,
 }
 
-impl<M, N, PT, PP, D> TokenizerImpl<M, N, PT, PP, D>
+impl<'input, M, N, PT, PP, D> TokenizerImpl<M, N, PT, PP, D>
 where
     M: Model,
     N: Normalizer,
@@ -761,7 +761,7 @@ where
     /// Encode a single sequence
     fn encode_single_sequence(
         &self,
-        sequence: InputSequence,
+        sequence: InputSequence<'input>,
         type_id: u32,
         offsets_type: OffsetType,
     ) -> Result<Encoding> {
@@ -1169,13 +1169,13 @@ where
         Ok(None)
     }
 }
-impl<M, N, PT, PP, D> TokenizerImpl<M, N, PT, PP, D>
+impl<'input, M, N, PT, PP, D> TokenizerImpl<M, N, PT, PP, D>
 where
     M: Model,
 {
     /// Tokenization logic, makes the bridge between the pre-tokenization phase and the real
     /// tokenization phase, and converting offsets back to the original referential.
-    fn do_tokenize<P: Into<PreTokenizedString>>(
+    fn do_tokenize<P: Into<PreTokenizedString<'input>>>(
         &self,
         pretokenized: P,
         type_id: u32,
@@ -1201,12 +1201,12 @@ where
 }
 
 #[allow(dead_code)]
-impl<M, N, PT, PP, D> TokenizerImpl<M, N, PT, PP, D>
+impl<'input, M, N, PT, PP, D> TokenizerImpl<M, N, PT, PP, D>
 where
     N: Normalizer,
 {
     /// Normalization logic, go through all normalizers
-    fn do_normalize<V: Into<NormalizedString>>(&self, normalized: V) -> Result<NormalizedString> {
+    fn do_normalize<V: Into<NormalizedString<'input>>>(&self, normalized: V) -> Result<NormalizedString<'input>> {
         let mut normalized: NormalizedString = normalized.into();
 
         if let Some(ref normalizer) = self.normalizer {
@@ -1239,15 +1239,15 @@ where
     }
 }
 
-impl<M, N, PT, PP, D> TokenizerImpl<M, N, PT, PP, D>
+impl<'input, M, N, PT, PP, D> TokenizerImpl<M, N, PT, PP, D>
 where
     PT: PreTokenizer,
 {
     /// PreTokenization logic, handling the case where there is no PreTokenizer set
-    fn do_pre_tokenize<P: Into<PreTokenizedString>>(
+    fn do_pre_tokenize<P: Into<PreTokenizedString<'input>>>(
         &self,
         pretokenized: P,
-    ) -> Result<PreTokenizedString> {
+    ) -> Result<PreTokenizedString<'input>> {
         let mut pretokenized: PreTokenizedString = pretokenized.into();
         if let Some(ref pretok) = self.pre_tokenizer {
             pretok.pre_tokenize(&mut pretokenized)?;

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -1,5 +1,6 @@
 use crate::pattern::Pattern;
 use crate::{Offsets, Result};
+use std::borrow::Cow;
 use std::ops::{Bound, RangeBounds};
 use unicode_normalization_alignments::UnicodeNormalization;
 
@@ -102,11 +103,11 @@ impl std::fmt::Display for SplitDelimiterBehavior {
 /// offsets from the normalized one, and the other way around too. It is also
 /// possible to convert offsets from one referential to the other one easily.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub struct NormalizedString {
+pub struct NormalizedString<'input> {
     /// The original version of the string, before any modification
-    original: String,
+    original: &'input str,
     /// The normalized version of the string, after all modifications
-    normalized: String,
+    normalized: Cow<'input, str>,
     /// Mapping from normalized string to original one: (start, end) for each
     /// byte of the normalized string
     alignments: Vec<(usize, usize)>,
@@ -116,11 +117,11 @@ pub struct NormalizedString {
     original_shift: usize,
 }
 
-impl NormalizedString {
+impl<'input> NormalizedString<'input> {
     #[cfg(test)]
     pub(crate) fn new(
-        original: String,
-        normalized: String,
+        original:  &'input str,
+        normalized: Cow<'input, str>,
         alignments: Vec<(usize, usize)>,
         original_shift: usize,
     ) -> Self {
@@ -136,9 +137,13 @@ impl NormalizedString {
         &self.normalized
     }
 
+    pub fn take(self) -> Cow<'input, str> {
+        self.normalized
+    }
+
     /// Return the original string
-    pub fn get_original(&self) -> &str {
-        &self.original
+    pub fn get_original(&self) -> &'input str {
+        self.original
     }
 
     /// Return the original offsets
@@ -269,7 +274,7 @@ impl NormalizedString {
 
     /// Return a slice of the current NormalizedString
     /// If the range is not on char boundaries, return None
-    pub fn slice<T>(&self, range: Range<T>) -> Option<NormalizedString>
+    pub fn slice<T>(&self, range: Range<T>) -> Option<NormalizedString<'input>>
     where
         T: RangeBounds<usize> + Clone,
     {
@@ -277,22 +282,24 @@ impl NormalizedString {
         let (normalized_range, original_range) = match full_range {
             Range::Original(_) => (
                 self.convert_offsets(full_range.clone())?,
-                full_range.clone().unwrap(),
+                full_range.unwrap(),
             ),
-            Range::Normalized(_) => (
-                full_range.clone().unwrap(),
-                self.convert_offsets(full_range.clone())?,
-            ),
+            Range::Normalized(_) => (full_range.clone().unwrap(), self.convert_offsets(full_range)?),
         };
 
         let n_shift = original_range.start;
 
+        // `original` always borrows from the `'input`-lived original string, and `normalized`
+        // reborrows the same `'input` data when untouched (zero-copy), only copying once a
+        // normalizer has actually rewritten the text into an owned buffer.
+        let normalized: Cow<'input, str> = match &self.normalized {
+            Cow::Borrowed(s) => Cow::Borrowed(s.get(normalized_range.clone()).unwrap_or_default()),
+            Cow::Owned(s) => Cow::Owned(s.get(normalized_range.clone()).unwrap_or_default().to_owned()),
+        };
+
         Some(Self {
-            original: self
-                .get_range_original(full_range.clone())
-                .unwrap_or_default()
-                .into(),
-            normalized: self.get_range(full_range).unwrap_or_default().into(),
+            original: self.original.get(original_range.clone()).unwrap_or_default(),
+            normalized,
             alignments: self
                 .alignments
                 .get(normalized_range)?
@@ -422,6 +429,7 @@ impl NormalizedString {
                 // Safety: This is safe as long as we do not splice across a
                 // UTF-8 character, and we only add UTF-8 text. `normalized` is a String
                 // so the latter is trivially true, and we assert for the former above.
+                .to_mut()
                 .as_mut_vec()
                 .splice(n_range, normalized.bytes());
         }
@@ -668,7 +676,7 @@ impl NormalizedString {
         new_normalized.push_str(&self.normalized[last_end..]);
         new_alignments.extend(&self.alignments[last_end..]);
 
-        self.normalized = new_normalized;
+        self.normalized = Cow::Owned(new_normalized);
         self.alignments = new_alignments;
         Ok(())
     }
@@ -695,7 +703,7 @@ impl NormalizedString {
         &self,
         pattern: P,
         behavior: SplitDelimiterBehavior,
-    ) -> Result<Vec<NormalizedString>> {
+    ) -> Result<Vec<NormalizedString<'input>>> {
         let matches = pattern.find_matches(&self.normalized)?;
 
         // Process the matches according to the selected behavior: Vec<(Offsets, should_remove)>
@@ -995,8 +1003,8 @@ pub fn char_to_bytes(s: &str, range: std::ops::Range<usize>) -> Option<std::ops:
     Some(start?..end?)
 }
 
-impl From<String> for NormalizedString {
-    fn from(s: String) -> Self {
+impl<'input> From<&'input str> for NormalizedString<'input> {
+    fn from(s: &'input str) -> Self {
         let alignments = s
             .char_indices()
             .flat_map(|(b, c)| {
@@ -1005,17 +1013,11 @@ impl From<String> for NormalizedString {
             })
             .collect::<Vec<_>>();
         Self {
-            original: s.clone(),
-            normalized: s,
+            original: s,
+            normalized: Cow::from(s),
             alignments,
             original_shift: 0,
         }
-    }
-}
-
-impl From<&str> for NormalizedString {
-    fn from(s: &str) -> Self {
-        Self::from(s.to_owned())
     }
 }
 

--- a/tokenizers/src/tokenizer/pre_tokenizer.rs
+++ b/tokenizers/src/tokenizer/pre_tokenizer.rs
@@ -18,17 +18,17 @@ pub enum OffsetType {
 /// in the original string. These offsets are in the `original` referential.
 /// It also contains any `Token` associated to the current split
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Split {
+pub struct Split<'input> {
     /// The underlying `NormalizedString`. Each SubString is represented by a `NormalizedString`
     /// and in the end we might be carrying a lot of SubString representing various parts of the
     /// original input string.
-    normalized: NormalizedString,
+    normalized: NormalizedString<'input>,
     /// Optional Tokens associated to this Split
     tokens: Option<Vec<Token>>,
 }
 
-impl From<NormalizedString> for Split {
-    fn from(n: NormalizedString) -> Self {
+impl<'input> From<NormalizedString<'input>> for Split<'input> {
+    fn from(n: NormalizedString<'input>) -> Self {
         Self {
             normalized: n,
             tokens: None,
@@ -36,8 +36,8 @@ impl From<NormalizedString> for Split {
     }
 }
 
-impl From<(NormalizedString, Option<Vec<Token>>)> for Split {
-    fn from(f: (NormalizedString, Option<Vec<Token>>)) -> Self {
+impl<'input> From<(NormalizedString<'input>, Option<Vec<Token>>)> for Split<'input> {
+    fn from(f: (NormalizedString<'input>, Option<Vec<Token>>)) -> Self {
         Self {
             normalized: f.0,
             tokens: f.1,
@@ -52,12 +52,12 @@ impl From<(NormalizedString, Option<Vec<Token>>)> for Split {
 /// to build an `Encoding` with all the relevant offsets and word ids, relative to the
 /// original string.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PreTokenizedString {
-    original: String,
-    splits: Vec<Split>,
+pub struct PreTokenizedString<'input> {
+    original: &'input str,
+    splits: Vec<Split<'input>>,
 }
 
-impl PreTokenizedString {
+impl<'input> PreTokenizedString<'input> {
     /// Split the `PreTokenizedString` by providing a `split_fn` in charge of splitting
     /// each substring (`NormalizedString`) into multiple parts.
     ///
@@ -72,9 +72,9 @@ impl PreTokenizedString {
     /// > "splits" of the original string.
     pub fn split<F, U, R>(&mut self, mut split_fn: F) -> Result<()>
     where
-        F: FnMut(usize, NormalizedString) -> Result<U>,
+        F: FnMut(usize, NormalizedString<'input>) -> Result<U>,
         U: IntoIterator<Item = R>,
-        R: Into<Split>,
+        R: Into<Split<'input>>,
     {
         // new_splits is at least as big as self.splits
         let mut new_splits = Vec::with_capacity(self.splits.len());
@@ -300,10 +300,10 @@ impl PreTokenizedString {
     }
 }
 
-impl From<NormalizedString> for PreTokenizedString {
-    fn from(s: NormalizedString) -> Self {
+impl<'input> From<NormalizedString<'input>> for PreTokenizedString<'input> {
+    fn from(s: NormalizedString<'input>) -> Self {
         Self {
-            original: s.get_original().to_owned(),
+            original: s.get_original(),
             splits: vec![Split {
                 normalized: s,
                 tokens: None,
@@ -312,19 +312,13 @@ impl From<NormalizedString> for PreTokenizedString {
     }
 }
 
-impl From<&str> for PreTokenizedString {
-    fn from(s: &str) -> Self {
+impl<'input> From<&'input str> for PreTokenizedString<'input> {
+    fn from(s: &'input str) -> Self {
         let normalized: NormalizedString = s.into();
         normalized.into()
     }
 }
 
-impl From<String> for PreTokenizedString {
-    fn from(s: String) -> Self {
-        let normalized: NormalizedString = s.into();
-        normalized.into()
-    }
-}
 
 struct BytesToCharOffsetConverter {
     map: HashMap<usize, usize>,


### PR DESCRIPTION
BLOCKED: `NormalizedString` and `PreTokenizedString` are part of the Python API. `pyclass` objects can't hold references to external stuff because they can be GCed at anytime. This PR has `NormalizedString` and `PreTokenizedString` reference the input sequence (not own a copy of it), which is incompatible with the Python API as is.
