### PR TITLE
No alloc normalizers

### DIFF
--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -2333,6 +2333,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -2524,6 +2525,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -58,6 +58,7 @@ dary_heap = { version = "0.3.6", features = ["serde"] }
 compact_str = { version = "0.9", features = ["serde"] }
 ptr_hash = { version = "1.1.0" }
 memchr = "2.8.2"
+unicode-normalization = "0.1.25"
 
 [features]
 default = ["progressbar", "onig"]

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -1,4 +1,7 @@
-use crate::tokenizer::{NormalizedString, Normalizer, Result};
+use crate::{
+    pipeline,
+    tokenizer::{NormalizedString, Normalizer, Result},
+};
 
 use serde::{Deserialize, Serialize};
 use unicode_categories::UnicodeCategories;
@@ -133,5 +136,28 @@ impl Normalizer for BertNormalizer {
         }
 
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for BertNormalizer {
+    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
+        let input = input.into();
+       // todo
+       input
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pipeline_bert_matches_legacy() {
+        let n = BertNormalizer::default();
+        for input in &["Héllo World", "中文字", "  spaced  ", "abc", "", "\tTab\n"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     pipeline,
     tokenizer::{NormalizedString, Normalizer, Result},
@@ -5,6 +7,7 @@ use crate::{
 
 use serde::{Deserialize, Serialize};
 use unicode_categories::UnicodeCategories;
+use unicode_normalization::{is_nfd_quick, IsNormalized, UnicodeNormalization};
 
 /// Checks whether a character is whitespace
 fn is_whitespace(c: char) -> bool {
@@ -25,6 +28,12 @@ fn is_control(c: char) -> bool {
         // cf. https://unicode.org/reports/tr44/ (Table 12)
         _ => c.is_other(),
     }
+}
+
+/// Whether lowercasing `c` leaves it unchanged (a single, identical char)
+fn lowercases_to_self(c: char) -> bool {
+    let mut it = c.to_lowercase();
+    matches!((it.next(), it.next()), (Some(first), None) if first == c)
 }
 
 /// Checks whether a character is chinese
@@ -117,6 +126,23 @@ impl BertNormalizer {
     fn do_lowercase(&self, normalized: &mut NormalizedString) {
         normalized.lowercase();
     }
+
+    fn is_noop(&self, input: &str, strip_accents: bool) -> bool {
+        if strip_accents && !matches!(is_nfd_quick(input.chars()), IsNormalized::Yes) {
+            return false;
+        }
+        let changes = |c: char| {
+            (self.clean_text
+                && (c as usize == 0
+                    || c as usize == 0xfffd
+                    || is_control(c)
+                    || (is_whitespace(c) && c != ' ')))
+                || (self.handle_chinese_chars && is_chinese_char(c))
+                || (strip_accents && c.is_mark_nonspacing())
+                || (self.lowercase && !lowercases_to_self(c))
+        };
+        !input.chars().any(changes)
+    }
 }
 
 impl Normalizer for BertNormalizer {
@@ -140,10 +166,46 @@ impl Normalizer for BertNormalizer {
 }
 
 impl pipeline::Normalizer for BertNormalizer {
-    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
-        let input = input.into();
-       // todo
-       input
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let strip_accents = self.strip_accents.unwrap_or(self.lowercase);
+
+        if self.is_noop(input, strip_accents) {
+           return input.into()
+        }
+
+        let cleaned: String = input
+            .chars()
+            .filter(|&c| {
+                !(self.clean_text && (c as usize == 0 || c as usize == 0xfffd || is_control(c)))
+            })
+            .flat_map(|c| {
+                let c = if self.clean_text && is_whitespace(c) {
+                    ' '
+                } else {
+                    c
+                };
+                if self.handle_chinese_chars && is_chinese_char(c) {
+                    [Some(' '), Some(c), Some(' ')]
+                } else {
+                    [Some(c), None, None]
+                }
+            })
+            .flatten()
+            .collect();
+
+        let stripped = if strip_accents {
+            cleaned.nfd().filter(|c| !c.is_mark_nonspacing()).collect()
+        } else {
+            cleaned
+        };
+
+        let lowered = if self.lowercase {
+            stripped.chars().flat_map(char::to_lowercase).collect()
+        } else {
+            stripped
+        };
+
+        Cow::Owned(lowered)
     }
 }
 
@@ -151,13 +213,67 @@ impl pipeline::Normalizer for BertNormalizer {
 mod tests {
     use super::*;
 
+    const INPUTS: &[&str] = &[
+        "Héllo World",
+        "中文字",
+        "a中b文c",
+        "  spaced  ",
+        "abc",
+        "",
+        "\tTab\n\r",
+        "MiXeD Café",
+        "e\u{0301}",           // already-NFD combining acute
+        "\u{fb01}ligature",    // NFKC ligature (unchanged by NFD)
+        "null\0here",
+        "repl\u{fffd}char",
+        "ctrl\u{0007}char",
+        "ǅ",                   // titlecase, lowercases to multi-mapping
+        "İstanbul",            // dotted capital I: lowercases to 2 chars
+        "straße",
+    ];
+
     #[test]
     fn pipeline_bert_matches_legacy() {
+        for &clean_text in &[true, false] {
+            for &handle_chinese_chars in &[true, false] {
+                for &strip_accents in &[None, Some(true), Some(false)] {
+                    for &lowercase in &[true, false] {
+                        let n = BertNormalizer::new(
+                            clean_text,
+                            handle_chinese_chars,
+                            strip_accents,
+                            lowercase,
+                        );
+                        for input in INPUTS {
+                            let mut ns = NormalizedString::from(*input);
+                            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+                            assert_eq!(
+                                ns.get(),
+                                &*pipeline::Normalizer::normalize(&n, input),
+                                "config={n:?} input={input:?}",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn pipeline_bert_borrows_when_noop() {
         let n = BertNormalizer::default();
-        for input in &["Héllo World", "中文字", "  spaced  ", "abc", "", "\tTab\n"] {
-            let mut ns = NormalizedString::from(*input);
-            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        for input in &["hello world", "already lowercase ascii", ""] {
+            assert!(matches!(
+                pipeline::Normalizer::normalize(&n, input),
+                Cow::Borrowed(_)
+            ));
+        }
+        // Anything that must change is owned.
+        for input in &["Héllo", "中", "\tx", "ABC"] {
+            assert!(matches!(
+                pipeline::Normalizer::normalize(&n, input),
+                Cow::Owned(_)
+            ));
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -170,7 +170,7 @@ impl pipeline::Normalizer for BertNormalizer {
         let strip_accents = self.strip_accents.unwrap_or(self.lowercase);
 
         if self.is_noop(input, strip_accents) {
-           return input.into()
+            return input.into();
         }
 
         let cleaned: String = input
@@ -222,13 +222,13 @@ mod tests {
         "",
         "\tTab\n\r",
         "MiXeD Café",
-        "e\u{0301}",           // already-NFD combining acute
-        "\u{fb01}ligature",    // NFKC ligature (unchanged by NFD)
+        "e\u{0301}",        // already-NFD combining acute
+        "\u{fb01}ligature", // NFKC ligature (unchanged by NFD)
         "null\0here",
         "repl\u{fffd}char",
         "ctrl\u{0007}char",
-        "ǅ",                   // titlecase, lowercases to multi-mapping
-        "İstanbul",            // dotted capital I: lowercases to 2 chars
+        "ǅ",        // titlecase, lowercases to multi-mapping
+        "İstanbul", // dotted capital I: lowercases to 2 chars
         "straße",
     ];
 

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -5,6 +5,8 @@ use crate::{
     tokenizer::{NormalizedString, Normalizer, Result},
 };
 
+use super::utils::lowercases_to_self;
+
 use serde::{Deserialize, Serialize};
 use unicode_categories::UnicodeCategories;
 use unicode_normalization::{is_nfd_quick, IsNormalized, UnicodeNormalization};
@@ -30,10 +32,18 @@ fn is_control(c: char) -> bool {
     }
 }
 
-/// Whether lowercasing `c` leaves it unchanged (a single, identical char)
-fn lowercases_to_self(c: char) -> bool {
-    let mut it = c.to_lowercase();
-    matches!((it.next(), it.next()), (Some(first), None) if first == c)
+/// Whether BERT text cleaning removes `c` entirely
+fn clean_text_removes(c: char) -> bool {
+    c == '\0' || c == '\u{fffd}' || is_control(c)
+}
+
+/// The whitespace folding BERT text cleaning applies to kept characters
+fn clean_text_map(c: char) -> char {
+    if is_whitespace(c) {
+        ' '
+    } else {
+        c
+    }
 }
 
 /// Checks whether a character is chinese
@@ -103,8 +113,8 @@ impl BertNormalizer {
 
     fn do_clean_text(&self, normalized: &mut NormalizedString) {
         normalized
-            .filter(|c| !(c as usize == 0 || c as usize == 0xfffd || is_control(c)))
-            .map(|c| if is_whitespace(c) { ' ' } else { c });
+            .filter(|c| !clean_text_removes(c))
+            .map(clean_text_map);
     }
 
     fn do_handle_chinese_chars(&self, normalized: &mut NormalizedString) {
@@ -132,11 +142,7 @@ impl BertNormalizer {
             return false;
         }
         let changes = |c: char| {
-            (self.clean_text
-                && (c as usize == 0
-                    || c as usize == 0xfffd
-                    || is_control(c)
-                    || (is_whitespace(c) && c != ' ')))
+            (self.clean_text && (clean_text_removes(c) || clean_text_map(c) != c))
                 || (self.handle_chinese_chars && is_chinese_char(c))
                 || (strip_accents && c.is_mark_nonspacing())
                 || (self.lowercase && !lowercases_to_self(c))
@@ -175,12 +181,10 @@ impl pipeline::Normalizer for BertNormalizer {
 
         let cleaned: String = input
             .chars()
-            .filter(|&c| {
-                !(self.clean_text && (c as usize == 0 || c as usize == 0xfffd || is_control(c)))
-            })
+            .filter(|&c| !(self.clean_text && clean_text_removes(c)))
             .flat_map(|c| {
-                let c = if self.clean_text && is_whitespace(c) {
-                    ' '
+                let c = if self.clean_text {
+                    clean_text_map(c)
                 } else {
                     c
                 };

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -179,7 +179,7 @@ impl pipeline::Normalizer for BertNormalizer {
             return Ok(input.into());
         }
 
-        let cleaned: String = input
+        let cleaned = input
             .chars()
             .filter(|&c| !(self.clean_text && clean_text_removes(c)))
             .flat_map(|c| {
@@ -194,22 +194,25 @@ impl pipeline::Normalizer for BertNormalizer {
                     [Some(c), None, None]
                 }
             })
-            .flatten()
-            .collect();
+            .flatten();
 
-        let stripped = if strip_accents {
-            cleaned.nfd().filter(|c| !c.is_mark_nonspacing()).collect()
-        } else {
-            cleaned
-        };
+        // `.nfd()` changes the iterator's type, so the stage toggles can't be
+        // plain `if`s mid-chain: each config combination gets its own
+        // statically-typed chain, all funneled into one pre-sized String.
+        let mut normalized = String::with_capacity(input.len());
+        match (strip_accents, self.lowercase) {
+            (true, true) => normalized.extend(
+                cleaned
+                    .nfd()
+                    .filter(|c| !c.is_mark_nonspacing())
+                    .flat_map(char::to_lowercase),
+            ),
+            (true, false) => normalized.extend(cleaned.nfd().filter(|c| !c.is_mark_nonspacing())),
+            (false, true) => normalized.extend(cleaned.flat_map(char::to_lowercase)),
+            (false, false) => normalized.extend(cleaned),
+        }
 
-        let lowered = if self.lowercase {
-            stripped.chars().flat_map(char::to_lowercase).collect()
-        } else {
-            stripped
-        };
-
-        Ok(Cow::Owned(lowered))
+        Ok(Cow::Owned(normalized))
     }
 }
 

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -166,11 +166,11 @@ impl Normalizer for BertNormalizer {
 }
 
 impl pipeline::Normalizer for BertNormalizer {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         let strip_accents = self.strip_accents.unwrap_or(self.lowercase);
 
         if self.is_noop(input, strip_accents) {
-            return input.into();
+            return Ok(input.into());
         }
 
         let cleaned: String = input
@@ -205,7 +205,7 @@ impl pipeline::Normalizer for BertNormalizer {
             stripped
         };
 
-        Cow::Owned(lowered)
+        Ok(Cow::Owned(lowered))
     }
 }
 
@@ -249,7 +249,7 @@ mod tests {
                             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
                             assert_eq!(
                                 ns.get(),
-                                &*pipeline::Normalizer::normalize(&n, input),
+                                &*pipeline::Normalizer::normalize(&n, input).unwrap(),
                                 "config={n:?} input={input:?}",
                             );
                         }
@@ -264,14 +264,14 @@ mod tests {
         let n = BertNormalizer::default();
         for input in &["hello world", "already lowercase ascii", ""] {
             assert!(matches!(
-                pipeline::Normalizer::normalize(&n, input),
+                pipeline::Normalizer::normalize(&n, input).unwrap(),
                 Cow::Borrowed(_)
             ));
         }
         // Anything that must change is owned.
         for input in &["Héllo", "中", "\tx", "ABC"] {
             assert!(matches!(
-                pipeline::Normalizer::normalize(&n, input),
+                pipeline::Normalizer::normalize(&n, input).unwrap(),
                 Cow::Owned(_)
             ));
         }

--- a/tokenizers/tk-encode/src/normalizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/normalizers/byte_level.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::byte_level::{byte_level_transform, BYTES_CHAR_LOOKUP};
 use crate::utils::macro_rules_attribute;
@@ -31,5 +34,31 @@ impl Normalizer for ByteLevel {
             normalized.transform(byte_level_transform(s), 0);
         }
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for ByteLevel {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let table = &*BYTES_CHAR_LOOKUP;
+        let mut out = String::with_capacity(input.len());
+        for &b in input.as_bytes() {
+            out.push(table[b as usize]);
+        }
+        Cow::Owned(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pipeline_byte_level_matches_legacy() {
+        let n = ByteLevel::new();
+        for input in &["Hello world", "Hello 我今天", "abc", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/normalizers/byte_level.rs
@@ -38,13 +38,13 @@ impl Normalizer for ByteLevel {
 }
 
 impl pipeline::Normalizer for ByteLevel {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         let table = &*BYTES_CHAR_LOOKUP;
-        let mut out = String::with_capacity(input.len());
+        let mut out = String::with_capacity(2 * input.len());
         for &b in input.as_bytes() {
             out.push(table[b as usize]);
         }
-        Cow::Owned(out)
+        Ok(Cow::Owned(out))
     }
 }
 
@@ -58,7 +58,10 @@ mod tests {
         for input in &["Hello world", "Hello 我今天", "abc", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/mod.rs
+++ b/tokenizers/tk-encode/src/normalizers/mod.rs
@@ -16,7 +16,7 @@ pub use crate::normalizers::unicode::{Nmt, NFC, NFD, NFKC, NFKD};
 pub use crate::normalizers::utils::{Lowercase, Sequence};
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::{NormalizedString, Normalizer};
+use crate::{NormalizedString, Normalizer, pipeline};
 
 /// Wrapper for known Normalizers.
 #[derive(Clone, Debug, Serialize)]
@@ -216,6 +216,27 @@ impl_enum_from!(Precompiled, NormalizerWrapper, Precompiled);
 impl_enum_from!(Replace, NormalizerWrapper, Replace);
 impl_enum_from!(Prepend, NormalizerWrapper, Prepend);
 impl_enum_from!(ByteLevel, NormalizerWrapper, ByteLevel);
+
+impl pipeline::Normalizer for NormalizerWrapper {
+    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
+        match self {
+            Self::BertNormalizer(bn) => pipeline::Normalizer::normalize(bn, input),
+            Self::StripNormalizer(sn) => pipeline::Normalizer::normalize(sn, input),
+            Self::StripAccents(sn) => pipeline::Normalizer::normalize(sn, input),
+            Self::NFC(nfc) => pipeline::Normalizer::normalize(nfc, input),
+            Self::NFD(nfd) => pipeline::Normalizer::normalize(nfd, input),
+            Self::NFKC(nfkc) => pipeline::Normalizer::normalize(nfkc, input),
+            Self::NFKD(nfkd) => pipeline::Normalizer::normalize(nfkd, input),
+            Self::Sequence(sequence) => pipeline::Normalizer::normalize(sequence, input),
+            Self::Lowercase(lc) => pipeline::Normalizer::normalize(lc, input),
+            Self::Nmt(nmt) => pipeline::Normalizer::normalize(nmt, input),
+            Self::Precompiled(pc) => pipeline::Normalizer::normalize(pc, input),
+            Self::Replace(rp) => pipeline::Normalizer::normalize(rp, input),
+            Self::Prepend(pp) => pipeline::Normalizer::normalize(pp, input),
+            Self::ByteLevel(bl) => pipeline::Normalizer::normalize(bl, input),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/normalizers/mod.rs
+++ b/tokenizers/tk-encode/src/normalizers/mod.rs
@@ -16,7 +16,7 @@ pub use crate::normalizers::unicode::{Nmt, NFC, NFD, NFKC, NFKD};
 pub use crate::normalizers::utils::{Lowercase, Sequence};
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::{NormalizedString, Normalizer, pipeline};
+use crate::{pipeline, NormalizedString, Normalizer};
 
 /// Wrapper for known Normalizers.
 #[derive(Clone, Debug, Serialize)]

--- a/tokenizers/tk-encode/src/normalizers/mod.rs
+++ b/tokenizers/tk-encode/src/normalizers/mod.rs
@@ -218,7 +218,7 @@ impl_enum_from!(Prepend, NormalizerWrapper, Prepend);
 impl_enum_from!(ByteLevel, NormalizerWrapper, ByteLevel);
 
 impl pipeline::Normalizer for NormalizerWrapper {
-    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> crate::Result<std::borrow::Cow<'a, str>> {
         match self {
             Self::BertNormalizer(bn) => pipeline::Normalizer::normalize(bn, input),
             Self::StripNormalizer(sn) => pipeline::Normalizer::normalize(sn, input),

--- a/tokenizers/tk-encode/src/normalizers/precompiled.rs
+++ b/tokenizers/tk-encode/src/normalizers/precompiled.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 pub use spm_precompiled::Precompiled;
 use std::cmp::Ordering;
@@ -65,6 +68,13 @@ impl Normalizer for Precompiled {
             normalized.transform(transformations, 0);
         }
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for Precompiled {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        // todo
+        input.into()
     }
 }
 

--- a/tokenizers/tk-encode/src/normalizers/precompiled.rs
+++ b/tokenizers/tk-encode/src/normalizers/precompiled.rs
@@ -72,7 +72,7 @@ impl Normalizer for Precompiled {
 }
 
 impl pipeline::Normalizer for Precompiled {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         let mut transformed: Option<String> = None;
         for (g_idx, grapheme) in input.grapheme_indices(true) {
             if grapheme.len() < 6 {
@@ -102,9 +102,9 @@ impl pipeline::Normalizer for Precompiled {
             }
         }
         if let Some(string) = transformed {
-            Cow::Owned(string)
+            Ok(Cow::Owned(string))
         } else {
-            Cow::Borrowed(input)
+            Ok(Cow::Borrowed(input))
         }
     }
 }
@@ -148,7 +148,7 @@ mod tests {
             any_modified |= ns.get() != *input;
             assert_eq!(
                 ns.get(),
-                &*pipeline::Normalizer::normalize(&n, input),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap(),
                 "pipeline output diverges from legacy for {input:?}"
             );
         }

--- a/tokenizers/tk-encode/src/normalizers/precompiled.rs
+++ b/tokenizers/tk-encode/src/normalizers/precompiled.rs
@@ -73,14 +73,88 @@ impl Normalizer for Precompiled {
 
 impl pipeline::Normalizer for Precompiled {
     fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        // todo
-        input.into()
+        let mut transformed: Option<String> = None;
+        for (g_idx, grapheme) in input.grapheme_indices(true) {
+            if grapheme.len() < 6 {
+                if let Some(replacement) = self.transform(grapheme) {
+                    let string = transformed.get_or_insert_with(|| {
+                        let mut s = String::with_capacity(input.len());
+                        s.push_str(&input[..g_idx]);
+                        s
+                    });
+                    string.push_str(replacement);
+                    continue;
+                }
+            }
+            for (c_idx, character) in grapheme.char_indices() {
+                if let Some(replacement) =
+                    self.transform(&grapheme[c_idx..c_idx + character.len_utf8()])
+                {
+                    let string = transformed.get_or_insert_with(|| {
+                        let mut s = String::with_capacity(input.len());
+                        s.push_str(&input[..g_idx + c_idx]);
+                        s
+                    });
+                    string.push_str(replacement);
+                } else if let Some(transformed) = transformed.as_mut() {
+                    transformed.push(character);
+                }
+            }
+        }
+        if let Some(string) = transformed {
+            Cow::Owned(string)
+        } else {
+            Cow::Borrowed(input)
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn albert_precompiled() -> Precompiled {
+        let json = std::fs::read_to_string("../data/albert-base-v1-tokenizer.json").unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let precompiled = value["normalizer"]["normalizers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|n| n["type"] == "Precompiled")
+            .unwrap();
+        // Precompiled can't deserialize through serde_json::Value (the base64
+        // charsmap only decodes via the string deserializer) — same dance as
+        // NormalizerWrapper's Deserialize impl
+        serde_json::from_str(&serde_json::to_string(precompiled).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn pipeline_precompiled_matches_legacy() {
+        let n = albert_precompiled();
+        let mut any_modified = false;
+        for input in &[
+            "™\x1eg",
+            "ＫＡＤＯＫＡＷＡ",
+            "１２３",
+            "…",
+            "\u{fb01}",
+            "e\u{0301}",
+            "㍿",
+            "abc def",
+            "",
+        ] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            any_modified |= ns.get() != *input;
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input),
+                "pipeline output diverges from legacy for {input:?}"
+            );
+        }
+        // Guard against the oracle silently becoming a no-op on these inputs
+        assert!(any_modified);
+    }
 
     #[test]
     fn expansion_followed_by_removal() {

--- a/tokenizers/tk-encode/src/normalizers/prepend.rs
+++ b/tokenizers/tk-encode/src/normalizers/prepend.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use serde::{Deserialize, Serialize};
 
@@ -20,6 +23,15 @@ impl Normalizer for Prepend {
             normalized.prepend(&self.prepend);
         }
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for Prepend {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if input.is_empty() {
+            return Cow::Borrowed(input);
+        }
+        Cow::Owned(format!("{prepend}{input}", prepend = &self.prepend))
     }
 }
 
@@ -58,5 +70,15 @@ mod tests {
             n.alignments_original(),
             vec![(0, 4), (4, 5), (5, 6), (6, 7), (7, 8)]
         );
+    }
+
+    #[test]
+    fn pipeline_prepend_matches_legacy() {
+        let n = Prepend::new("▁".to_string());
+        for input in &["Hello", "world", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/prepend.rs
+++ b/tokenizers/tk-encode/src/normalizers/prepend.rs
@@ -27,11 +27,14 @@ impl Normalizer for Prepend {
 }
 
 impl pipeline::Normalizer for Prepend {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         if input.is_empty() {
-            return Cow::Borrowed(input);
+            return Ok(Cow::Borrowed(input));
         }
-        Cow::Owned(format!("{prepend}{input}", prepend = &self.prepend))
+        Ok(Cow::Owned(format!(
+            "{prepend}{input}",
+            prepend = &self.prepend
+        )))
     }
 }
 
@@ -78,7 +81,10 @@ mod tests {
         for input in &["Hello", "world", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::pattern::Pattern;
 use crate::tokenizer::Decoder;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
@@ -85,6 +88,24 @@ impl Normalizer for Replace {
     }
 }
 
+impl pipeline::Normalizer for Replace {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let parts = (&self.regex).find_matches(&input).unwrap();
+
+        if parts.iter().any(|(_, is_match)| *is_match) {
+            let replaced: String = parts.into_iter().map(|((start, end), is_match)| {
+                if is_match {
+                    &self.content
+                } else {
+                    &input[start..end]
+                }
+            }).collect();
+            return Cow::Owned(replaced)
+        }
+        input.into()
+    }
+}
+
 impl Decoder for Replace {
     fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
         tokens
@@ -155,5 +176,22 @@ mod tests {
             replace.decode_chain(original).unwrap(),
             vec!["hello", " hello"]
         );
+    }
+
+    #[test]
+    fn pipeline_replace_matches_legacy() {
+        let n = Replace::new("''", "\"").unwrap();
+        for input in &["This is a ''test''", "no quotes", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+
+        let n = Replace::new(ReplacePattern::Regex(r"\s+".into()), " ").unwrap();
+        for input in &["a   b   c", "single", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -90,17 +90,20 @@ impl Normalizer for Replace {
 
 impl pipeline::Normalizer for Replace {
     fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        let parts = (&self.regex).find_matches(&input).unwrap();
+        let parts = (&self.regex).find_matches(input).unwrap();
 
         if parts.iter().any(|(_, is_match)| *is_match) {
-            let replaced: String = parts.into_iter().map(|((start, end), is_match)| {
-                if is_match {
-                    &self.content
-                } else {
-                    &input[start..end]
-                }
-            }).collect();
-            return Cow::Owned(replaced)
+            let replaced: String = parts
+                .into_iter()
+                .map(|((start, end), is_match)| {
+                    if is_match {
+                        &self.content
+                    } else {
+                        &input[start..end]
+                    }
+                })
+                .collect();
+            return Cow::Owned(replaced);
         }
         input.into()
     }

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -89,23 +89,25 @@ impl Normalizer for Replace {
 }
 
 impl pipeline::Normalizer for Replace {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        let parts = (&self.regex).find_matches(input).unwrap();
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
+        let iter = self.regex.find_iter(input);
+        let mut replaced: Option<String> = None;
+        let mut last_end = 0;
 
-        if parts.iter().any(|(_, is_match)| *is_match) {
-            let replaced: String = parts
-                .into_iter()
-                .map(|((start, end), is_match)| {
-                    if is_match {
-                        &self.content
-                    } else {
-                        &input[start..end]
-                    }
-                })
-                .collect();
-            return Cow::Owned(replaced);
+        for (start, end) in iter {
+            let replaced: &mut String =
+                replaced.get_or_insert_with(|| String::with_capacity(input.len()));
+            replaced.push_str(&input[last_end..start]);
+            replaced.push_str(&self.content);
+            last_end = end;
         }
-        input.into()
+        if let Some(mut replaced) = replaced {
+            if last_end < input.len() {
+                replaced.push_str(&input[last_end..]);
+            }
+            return Ok(Cow::Owned(replaced));
+        }
+        Ok(input.into())
     }
 }
 
@@ -187,14 +189,20 @@ mod tests {
         for input in &["This is a ''test''", "no quotes", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
 
         let n = Replace::new(ReplacePattern::Regex(r"\s+".into()), " ").unwrap();
         for input in &["a   b   c", "single", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/strip.rs
+++ b/tokenizers/tk-encode/src/normalizers/strip.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
 use serde::{Deserialize, Serialize};
@@ -40,6 +43,18 @@ impl Normalizer for Strip {
     }
 }
 
+impl pipeline::Normalizer for Strip {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let s = if self.strip_left {
+            input.trim_start()
+        } else {
+            input
+        };
+        let s = if self.strip_right { s.trim_end() } else { s };
+        Cow::Borrowed(s)
+    }
+}
+
 // This normalizer removes combining marks from a normalized string
 // It's different from unidecode as it does not attempt to modify
 // non ascii languages.
@@ -52,6 +67,16 @@ impl Normalizer for StripAccents {
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
         normalized.filter(|c| !is_combining_mark(c));
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for StripAccents {
+    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
+        if input.chars().any(is_combining_mark) {
+            Cow::Owned(input.chars().filter(|&c| !is_combining_mark(c)).collect())
+        } else {
+            Cow::Borrowed(input)
+        }
     }
 }
 
@@ -153,5 +178,27 @@ mod tests {
                 (1, 2)
             ]
         );
+    }
+
+    #[test]
+    fn pipeline_strip_accents_matches_legacy() {
+        let n = StripAccents;
+        for input in &["café", "abc", "", "å ç ñ", "     hello"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_strip_matches_legacy() {
+        for (strip_left, strip_right) in [(true, true), (true, false), (false, true)] {
+            let n = Strip::new(strip_left, strip_right);
+            for input in &["  hello  ", "hello", "", "   ", "\t hi \n"] {
+                let mut ns = NormalizedString::from(*input);
+                Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+                assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            }
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/strip.rs
+++ b/tokenizers/tk-encode/src/normalizers/strip.rs
@@ -44,14 +44,14 @@ impl Normalizer for Strip {
 }
 
 impl pipeline::Normalizer for Strip {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         let s = if self.strip_left {
             input.trim_start()
         } else {
             input
         };
         let s = if self.strip_right { s.trim_end() } else { s };
-        Cow::Borrowed(s)
+        Ok(Cow::Borrowed(s))
     }
 }
 
@@ -71,11 +71,13 @@ impl Normalizer for StripAccents {
 }
 
 impl pipeline::Normalizer for StripAccents {
-    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         if input.chars().any(is_combining_mark) {
-            Cow::Owned(input.chars().filter(|&c| !is_combining_mark(c)).collect())
+            Ok(Cow::Owned(
+                input.chars().filter(|&c| !is_combining_mark(c)).collect(),
+            ))
         } else {
-            Cow::Borrowed(input)
+            Ok(Cow::Borrowed(input))
         }
     }
 }
@@ -186,7 +188,10 @@ mod tests {
         for input in &["café", "abc", "", "å ç ñ", "     hello"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
     }
 
@@ -197,7 +202,10 @@ mod tests {
             for input in &["  hello  ", "hello", "", "   ", "\t hi \n"] {
                 let mut ns = NormalizedString::from(*input);
                 Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-                assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+                assert_eq!(
+                    ns.get(),
+                    &*pipeline::Normalizer::normalize(&n, input).unwrap()
+                );
             }
         }
     }

--- a/tokenizers/tk-encode/src/normalizers/unicode.rs
+++ b/tokenizers/tk-encode/src/normalizers/unicode.rs
@@ -1,5 +1,12 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
+
+use unicode_normalization::{
+    is_nfc_quick, is_nfd_quick, is_nfkc_quick, is_nfkd_quick, IsNormalized, UnicodeNormalization,
+};
 
 #[derive(Default, Copy, Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -8,6 +15,15 @@ impl Normalizer for NFD {
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
         normalized.nfd();
         Ok(())
+    }
+}
+impl pipeline::Normalizer for NFD {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if let IsNormalized::Yes = is_nfd_quick(input.chars()) {
+            input.into()
+        } else {
+            Cow::Owned(input.nfd().collect())
+        }
     }
 }
 
@@ -20,6 +36,15 @@ impl Normalizer for NFKD {
         Ok(())
     }
 }
+impl pipeline::Normalizer for NFKD {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if let IsNormalized::Yes = is_nfkd_quick(input.chars()) {
+            input.into()
+        } else {
+            Cow::Owned(input.nfkd().collect())
+        }
+    }
+}
 
 #[derive(Default, Copy, Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -30,6 +55,15 @@ impl Normalizer for NFC {
         Ok(())
     }
 }
+impl pipeline::Normalizer for NFC {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if let IsNormalized::Yes = is_nfc_quick(input.chars()) {
+            input.into()
+        } else {
+            Cow::Owned(input.nfc().collect())
+        }
+    }
+}
 
 #[derive(Default, Copy, Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -38,6 +72,15 @@ impl Normalizer for NFKC {
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
         normalized.nfkc();
         Ok(())
+    }
+}
+impl pipeline::Normalizer for NFKC {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if let IsNormalized::Yes = is_nfkc_quick(input.chars()) {
+            input.into()
+        } else {
+            Cow::Owned(input.nfkc().collect())
+        }
     }
 }
 
@@ -81,6 +124,40 @@ impl Normalizer for Nmt {
         Ok(())
     }
 }
+impl pipeline::Normalizer for Nmt {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let normalized: String = input
+            .chars()
+            .filter(|&c| {
+                !matches!(
+                    c as u32,
+                    0x0001..=0x0008 |
+                    0x000B |
+                    0x000E..=0x001F |
+                    0x007F |
+                    0x008F |
+                    0x009F
+                )
+            })
+            // Other code points considered as whitespace.
+            .map(|c| match c as u32 {
+                0x0009 => ' ',
+                0x000A => ' ',
+                0x000C => ' ',
+                0x000D => ' ',
+                0x1680 => ' ',
+                0x200B..=0x200F => ' ',
+                0x2028 => ' ',
+                0x2029 => ' ',
+                0x2581 => ' ',
+                0xFEFF => ' ',
+                0xFFFD => ' ',
+                _ => c,
+            })
+            .collect();
+        Cow::Owned(normalized)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -99,5 +176,55 @@ mod tests {
         );
 
         assert_eq!(n.alignments_original(), vec![(0, 2), (0, 2), (0, 2)]);
+    }
+
+    #[test]
+    fn pipeline_nfd_matches_legacy() {
+        let n = NFD;
+        for input in &["é", "café", "abc", "", "Å"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_nfkd_matches_legacy() {
+        let n = NFKD;
+        for input in &["\u{fb01}", "²", "café", "abc", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_nfc_matches_legacy() {
+        let n = NFC;
+        for input in &["e\u{0301}", "abc", "", "cafe\u{0301}"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_nfkc_matches_legacy() {
+        let n = NFKC;
+        for input in &["\u{fb01}", "²", "e\u{0301}", "abc", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_nmt_matches_legacy() {
+        let n = Nmt;
+        for input in &["a\tb", "x\u{200b}y", "abc", "", "\u{feff}hi", "c\u{0007}d"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/unicode.rs
+++ b/tokenizers/tk-encode/src/normalizers/unicode.rs
@@ -84,35 +84,39 @@ impl pipeline::Normalizer for NFKC {
     }
 }
 
+/// Control characters the NMT normalizer removes
+fn nmt_removes(c: char) -> bool {
+    matches!(
+        c as u32,
+        0x0001..=0x0008 |
+        0x000B |
+        0x000E..=0x001F |
+        0x007F |
+        0x008F |
+        0x009F
+    )
+}
+
+/// Code points the NMT normalizer considers whitespace, folded to ' '
+fn nmt_to_space(c: char) -> char {
+    match c as u32 {
+        0x0009
+        | 0x000A
+        | 0x000C
+        | 0x000D
+        | 0x1680
+        | 0x200B..=0x200F
+        | 0x2028
+        | 0x2029
+        | 0x2581
+        | 0xFEFF
+        | 0xFFFD => ' ',
+        _ => c,
+    }
+}
+
 fn do_nmt(normalized: &mut NormalizedString) {
-    // Ascii Control characters
-    normalized
-        .filter(|c| {
-            !matches!(
-                c as u32,
-                0x0001..=0x0008 |
-                0x000B |
-                0x000E..=0x001F |
-                0x007F |
-                0x008F |
-                0x009F
-            )
-        })
-        // Other code points considered as whitespace.
-        .map(|c| match c as u32 {
-            0x0009 => ' ',
-            0x000A => ' ',
-            0x000C => ' ',
-            0x000D => ' ',
-            0x1680 => ' ',
-            0x200B..=0x200F => ' ',
-            0x2028 => ' ',
-            0x2029 => ' ',
-            0x2581 => ' ',
-            0xFEFF => ' ',
-            0xFFFD => ' ',
-            _ => c,
-        });
+    normalized.filter(|c| !nmt_removes(c)).map(nmt_to_space);
 }
 
 #[derive(Default, Copy, Clone, Debug)]
@@ -127,56 +131,14 @@ impl Normalizer for Nmt {
 
 impl pipeline::Normalizer for Nmt {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
-        if input.chars().any(|c| {
-            matches!(
-                c as u32,
-                0x0001..=0x0008 |
-                0x000B |
-                0x000E..=0x001F |
-                0x007F |
-                0x008F |
-                0x009F |
-                0x0009 |
-                0x000A |
-                0x000C |
-                0x000D |
-                0x1680 |
-                0x200B..=0x200F |
-                0x2028 |
-                0x2029 |
-                0x2581 |
-                0xFEFF |
-                0xFFFD
-            )
-        }) {
+        if input
+            .chars()
+            .any(|c| nmt_removes(c) || nmt_to_space(c) != c)
+        {
             let normalized: String = input
                 .chars()
-                .filter(|&c| {
-                    !matches!(
-                        c as u32,
-                        0x0001..=0x0008 |
-                        0x000B |
-                        0x000E..=0x001F |
-                        0x007F |
-                        0x008F |
-                        0x009F
-                    )
-                })
-                // Other code points considered as whitespace.
-                .map(|c| match c as u32 {
-                    0x0009 => ' ',
-                    0x000A => ' ',
-                    0x000C => ' ',
-                    0x000D => ' ',
-                    0x1680 => ' ',
-                    0x200B..=0x200F => ' ',
-                    0x2028 => ' ',
-                    0x2029 => ' ',
-                    0x2581 => ' ',
-                    0xFEFF => ' ',
-                    0xFFFD => ' ',
-                    _ => c,
-                })
+                .filter(|&c| !nmt_removes(c))
+                .map(nmt_to_space)
                 .collect();
             return Ok(Cow::Owned(normalized));
         }

--- a/tokenizers/tk-encode/src/normalizers/unicode.rs
+++ b/tokenizers/tk-encode/src/normalizers/unicode.rs
@@ -18,11 +18,11 @@ impl Normalizer for NFD {
     }
 }
 impl pipeline::Normalizer for NFD {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         if let IsNormalized::Yes = is_nfd_quick(input.chars()) {
-            input.into()
+            Ok(input.into())
         } else {
-            Cow::Owned(input.nfd().collect())
+            Ok(Cow::Owned(input.nfd().collect()))
         }
     }
 }
@@ -37,11 +37,11 @@ impl Normalizer for NFKD {
     }
 }
 impl pipeline::Normalizer for NFKD {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         if let IsNormalized::Yes = is_nfkd_quick(input.chars()) {
-            input.into()
+            Ok(input.into())
         } else {
-            Cow::Owned(input.nfkd().collect())
+            Ok(Cow::Owned(input.nfkd().collect()))
         }
     }
 }
@@ -56,11 +56,11 @@ impl Normalizer for NFC {
     }
 }
 impl pipeline::Normalizer for NFC {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         if let IsNormalized::Yes = is_nfc_quick(input.chars()) {
-            input.into()
+            Ok(input.into())
         } else {
-            Cow::Owned(input.nfc().collect())
+            Ok(Cow::Owned(input.nfc().collect()))
         }
     }
 }
@@ -75,11 +75,11 @@ impl Normalizer for NFKC {
     }
 }
 impl pipeline::Normalizer for NFKC {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         if let IsNormalized::Yes = is_nfkc_quick(input.chars()) {
-            input.into()
+            Ok(input.into())
         } else {
-            Cow::Owned(input.nfkc().collect())
+            Ok(Cow::Owned(input.nfkc().collect()))
         }
     }
 }
@@ -124,38 +124,64 @@ impl Normalizer for Nmt {
         Ok(())
     }
 }
+
 impl pipeline::Normalizer for Nmt {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        let normalized: String = input
-            .chars()
-            .filter(|&c| {
-                !matches!(
-                    c as u32,
-                    0x0001..=0x0008 |
-                    0x000B |
-                    0x000E..=0x001F |
-                    0x007F |
-                    0x008F |
-                    0x009F
-                )
-            })
-            // Other code points considered as whitespace.
-            .map(|c| match c as u32 {
-                0x0009 => ' ',
-                0x000A => ' ',
-                0x000C => ' ',
-                0x000D => ' ',
-                0x1680 => ' ',
-                0x200B..=0x200F => ' ',
-                0x2028 => ' ',
-                0x2029 => ' ',
-                0x2581 => ' ',
-                0xFEFF => ' ',
-                0xFFFD => ' ',
-                _ => c,
-            })
-            .collect();
-        Cow::Owned(normalized)
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
+        if input.chars().any(|c| {
+            matches!(
+                c as u32,
+                0x0001..=0x0008 |
+                0x000B |
+                0x000E..=0x001F |
+                0x007F |
+                0x008F |
+                0x009F |
+                0x0009 |
+                0x000A |
+                0x000C |
+                0x000D |
+                0x1680 |
+                0x200B..=0x200F |
+                0x2028 |
+                0x2029 |
+                0x2581 |
+                0xFEFF |
+                0xFFFD
+            )
+        }) {
+            let normalized: String = input
+                .chars()
+                .filter(|&c| {
+                    !matches!(
+                        c as u32,
+                        0x0001..=0x0008 |
+                        0x000B |
+                        0x000E..=0x001F |
+                        0x007F |
+                        0x008F |
+                        0x009F
+                    )
+                })
+                // Other code points considered as whitespace.
+                .map(|c| match c as u32 {
+                    0x0009 => ' ',
+                    0x000A => ' ',
+                    0x000C => ' ',
+                    0x000D => ' ',
+                    0x1680 => ' ',
+                    0x200B..=0x200F => ' ',
+                    0x2028 => ' ',
+                    0x2029 => ' ',
+                    0x2581 => ' ',
+                    0xFEFF => ' ',
+                    0xFFFD => ' ',
+                    _ => c,
+                })
+                .collect();
+            return Ok(Cow::Owned(normalized));
+        }
+
+        Ok(input.into())
     }
 }
 
@@ -184,7 +210,10 @@ mod tests {
         for input in &["é", "café", "abc", "", "Å"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
     }
 
@@ -194,7 +223,10 @@ mod tests {
         for input in &["\u{fb01}", "²", "café", "abc", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
     }
 
@@ -204,7 +236,10 @@ mod tests {
         for input in &["e\u{0301}", "abc", "", "cafe\u{0301}"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
     }
 
@@ -214,7 +249,10 @@ mod tests {
         for input in &["\u{fb01}", "²", "e\u{0301}", "abc", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
     }
 
@@ -224,7 +262,10 @@ mod tests {
         for input in &["a\tb", "x\u{200b}y", "abc", "", "\u{feff}hi", "c\u{0007}d"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/utils.rs
+++ b/tokenizers/tk-encode/src/normalizers/utils.rs
@@ -1,6 +1,9 @@
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 use crate::normalizers::NormalizerWrapper;
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
 
@@ -48,6 +51,26 @@ impl Normalizer for Sequence {
     }
 }
 
+impl pipeline::Normalizer for Sequence {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let mut cow: Cow<'a, str> = Cow::Borrowed(input);
+        for normalizer in &self.normalizers {
+            cow = match cow {
+                // Still borrowing `input` ('a): chain directly so an all-no-op
+                // sequence stays zero-alloc and returns a borrow of `input`.
+                Cow::Borrowed(s) => pipeline::Normalizer::normalize(normalizer, s),
+                // Owned locally: the next step may borrow from it, so materialize
+                // its result before the local `String` is dropped.
+                Cow::Owned(s) => match pipeline::Normalizer::normalize(normalizer, &s) {
+                    Cow::Borrowed(b) => Cow::Owned(b.to_owned()),
+                    Cow::Owned(o) => Cow::Owned(o),
+                },
+            };
+        }
+        cow
+    }
+}
+
 /// Lowercases the input
 #[derive(Copy, Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -56,5 +79,37 @@ impl Normalizer for Lowercase {
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
         normalized.lowercase();
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for Lowercase {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        Cow::Owned(input.to_lowercase())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::normalizers::{StripAccents, NFD};
+
+    #[test]
+    fn pipeline_lowercase_matches_legacy() {
+        let n = Lowercase;
+        for input in &["HELLO", "Hello World", "abc", "", "ÀÉ"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_sequence_matches_legacy() {
+        let n = Sequence::new(vec![NFD.into(), StripAccents.into(), Lowercase.into()]);
+        for input in &["Café", "HÉLLO", "abc", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/utils.rs
+++ b/tokenizers/tk-encode/src/normalizers/utils.rs
@@ -87,7 +87,7 @@ impl Normalizer for Lowercase {
 }
 
 /// Whether lowercasing `c` leaves it unchanged (a single, identical char)
-fn lowercases_to_self(c: char) -> bool {
+pub(crate) fn lowercases_to_self(c: char) -> bool {
     let mut it = c.to_lowercase();
     matches!((it.next(), it.next()), (Some(first), None) if first == c)
 }
@@ -140,7 +140,14 @@ mod tests {
         // Strip returns a sub-borrow of the previous step's owned output —
         // the one case where a Borrowed result must not be mistaken for a no-op
         let n = Sequence::new(vec![Lowercase.into(), Strip::new(true, true).into()]);
-        for input in &["  HELLO  ", "\tMiXeD Case\n", "NOPAD", "  hello  ", "", "   "] {
+        for input in &[
+            "  HELLO  ",
+            "\tMiXeD Case\n",
+            "NOPAD",
+            "  hello  ",
+            "",
+            "   ",
+        ] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
             assert_eq!(

--- a/tokenizers/tk-encode/src/normalizers/utils.rs
+++ b/tokenizers/tk-encode/src/normalizers/utils.rs
@@ -52,22 +52,26 @@ impl Normalizer for Sequence {
 }
 
 impl pipeline::Normalizer for Sequence {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
         let mut cow: Cow<'a, str> = Cow::Borrowed(input);
         for normalizer in &self.normalizers {
             cow = match cow {
                 // Still borrowing `input` ('a): chain directly so an all-no-op
                 // sequence stays zero-alloc and returns a borrow of `input`.
-                Cow::Borrowed(s) => pipeline::Normalizer::normalize(normalizer, s),
+                Cow::Borrowed(s) => pipeline::Normalizer::normalize(normalizer, s)?,
                 // Owned locally: the next step may borrow from it, so materialize
                 // its result before the local `String` is dropped.
-                Cow::Owned(s) => match pipeline::Normalizer::normalize(normalizer, &s) {
-                    Cow::Borrowed(b) => Cow::Owned(b.to_owned()),
-                    Cow::Owned(o) => Cow::Owned(o),
-                },
+                Cow::Owned(s) => {
+                    let out = match pipeline::Normalizer::normalize(normalizer, &s)? {
+                        Cow::Owned(o) => Some(o),
+                        Cow::Borrowed(b) if b.as_ptr() == s.as_ptr() && b.len() == s.len() => None,
+                        Cow::Borrowed(b) => Some(b.to_owned()),
+                    };
+                    Cow::Owned(out.unwrap_or(s))
+                }
             };
         }
-        cow
+        Ok(cow)
     }
 }
 
@@ -82,34 +86,68 @@ impl Normalizer for Lowercase {
     }
 }
 
+/// Whether lowercasing `c` leaves it unchanged (a single, identical char)
+fn lowercases_to_self(c: char) -> bool {
+    let mut it = c.to_lowercase();
+    matches!((it.next(), it.next()), (Some(first), None) if first == c)
+}
+
 impl pipeline::Normalizer for Lowercase {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        Cow::Owned(input.to_lowercase())
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
+        if input.chars().all(lowercases_to_self) {
+            Ok(input.into())
+        } else {
+            Ok(Cow::Owned(
+                input.chars().flat_map(|c| c.to_lowercase()).collect(),
+            ))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::normalizers::{StripAccents, NFD};
+    use crate::normalizers::{Strip, StripAccents, NFD};
 
     #[test]
     fn pipeline_lowercase_matches_legacy() {
         let n = Lowercase;
-        for input in &["HELLO", "Hello World", "abc", "", "ÀÉ"] {
+        for input in &["HELLO", "Hello World", "abc", "", "ÀÉ", "ΟΔΟΣ"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
         }
     }
 
     #[test]
     fn pipeline_sequence_matches_legacy() {
         let n = Sequence::new(vec![NFD.into(), StripAccents.into(), Lowercase.into()]);
-        for input in &["Café", "HÉLLO", "abc", ""] {
+        for input in &["Café", "HÉLLO", "abc", "", "ΟΔΟΣ"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn pipeline_sequence_strip_after_owned_matches_legacy() {
+        // Strip returns a sub-borrow of the previous step's owned output —
+        // the one case where a Borrowed result must not be mistaken for a no-op
+        let n = Sequence::new(vec![Lowercase.into(), Strip::new(true, true).into()]);
+        for input in &["  HELLO  ", "\tMiXeD Case\n", "NOPAD", "  hello  ", "", "   "] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input).unwrap(),
+                "input={input:?}"
+            );
         }
     }
 }

--- a/tokenizers/tk-encode/src/pre_tokenizers/bert.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/bert.rs
@@ -2,11 +2,8 @@ use crate::pipeline::{self, SplitPolicy};
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use crate::utils::macro_rules_attribute;
 use std::sync::LazyLock;
-use unicode_categories::UnicodeCategories;
 
-fn is_bert_punc(x: char) -> bool {
-    char::is_ascii_punctuation(&x) || x.is_punctuation()
-}
+use super::punctuation::is_punc;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -15,7 +12,7 @@ pub struct BertPreTokenizer;
 impl PreTokenizer for BertPreTokenizer {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
         pretokenized.split(|_, s| s.split(char::is_whitespace, SplitDelimiterBehavior::Removed))?;
-        pretokenized.split(|_, s| s.split(is_bert_punc, SplitDelimiterBehavior::Isolated))
+        pretokenized.split(|_, s| s.split(is_punc, SplitDelimiterBehavior::Isolated))
     }
 }
 
@@ -42,7 +39,7 @@ impl CharType {
 fn classify(c: char) -> CharType {
     if c.is_whitespace() {
         CharType::Whitespace
-    } else if is_bert_punc(c) {
+    } else if is_punc(c) {
         CharType::Punctuation
     } else {
         CharType::Other

--- a/tokenizers/tk-encode/src/pre_tokenizers/punctuation.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/punctuation.rs
@@ -5,7 +5,7 @@ use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterB
 use crate::utils::macro_rules_attribute;
 use unicode_categories::UnicodeCategories;
 
-fn is_punc(x: char) -> bool {
+pub(crate) fn is_punc(x: char) -> bool {
     char::is_ascii_punctuation(&x) || x.is_punctuation()
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,10 +1,11 @@
-use std::convert::TryFrom;
 use std::ops::Range;
+use std::{borrow::Cow, convert::TryFrom};
 
 use crate::added_vocabulary::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
 use crate::{
+    normalizers::NormalizerWrapper,
     pre_tokenizers::{
         bert::BertPreTokenizer,
         delimiter::CharDelimiterSplit,
@@ -14,8 +15,7 @@ use crate::{
         unicode_scripts::UnicodeScripts,
         whitespace::{Whitespace, WhitespaceSplit},
     },
-    Model, ModelWrapper, NormalizedString, Normalizer, NormalizerWrapper, PostProcessorWrapper,
-    PreTokenizerWrapper, Token, Tokenizer,
+    Model, ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer,
 };
 
 use super::{Result, SplitDelimiterBehavior};
@@ -32,6 +32,10 @@ impl Split {
     pub fn range(self) -> Range<usize> {
         self.start as usize..self.end as usize
     }
+}
+
+pub trait Normalizer {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str>;
 }
 
 /// Range-based pre-tokenization: yields spans into the input rather than owned
@@ -276,15 +280,15 @@ impl PipelineTokenizer {
                     output.push(PipelineToken { id: token });
                 }
                 Segment::Text(chunk) => {
-                    // Normalize the text segment
-                    let mut normalized: NormalizedString = chunk.into();
-                    if let Some(normalizer) = &self.normalizer {
-                        normalizer.normalize(&mut normalized)?;
-                    }
+                    let normalized: &str = if let Some(normalizer) = &self.normalizer {
+                        &normalizer.normalize(chunk)
+                    } else {
+                        chunk
+                    };
 
                     // Extract special tokens from the normalized input
                     for segment in
-                        SpecialSegmentIterator::new(normalized.get(), &self.added_vocabulary, true)
+                        SpecialSegmentIterator::new(normalized, &self.added_vocabulary, true)
                     {
                         match segment {
                             Segment::SpecialToken(token) => {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -35,7 +35,7 @@ impl Split {
 }
 
 pub trait Normalizer {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str>;
+    fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>>;
 }
 
 /// Range-based pre-tokenization: yields spans into the input rather than owned
@@ -281,7 +281,7 @@ impl PipelineTokenizer {
                 }
                 Segment::Text(chunk) => {
                     let normalized: &str = if let Some(normalizer) = &self.normalizer {
-                        &normalizer.normalize(chunk)
+                        &normalizer.normalize(chunk)?
                     } else {
                         chunk
                     };


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**1 / 4 models supported** · geomean ×2.52 across supported · 18 fixtures each — ~10 kB inputs · single thread

`6f8926800 · 2026-07-06 21:45 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 8 cores

> **Not yet supported:** `deepseek-v4` (BPE · Split+ByteLevel), `llama-3` (BPE · Split+ByteLevel), `t5-base` (Unigram · WhitespaceSplit+Metaspace) — roadmap cards below.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28825152901-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28825152901-bert-base-uncased-light.png" width="860">
</picture>

### Not yet supported

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28825152901-deepseek-v4-dark.png">
  <img alt="deepseek-v4 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28825152901-deepseek-v4-light.png" width="420">
</picture>
</td>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28825152901-llama-3-dark.png">
  <img alt="llama-3 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28825152901-llama-3-light.png" width="420">
</picture>
</td>
</tr>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28825152901-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28825152901-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

<details><summary>Per-fixture results</summary>

#### bert-base-uncased — WordPiece · Bert

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| cmn_Hani | lang | 3.5 | 13.0 | ×3.70 | match |
| eng_Latn | lang | 4.1 | 15.0 | ×3.66 | match |
| amh_Ethi | lang | 7.5 | 20.1 | ×2.69 | match |
| jpn_Jpan | lang | 4.0 | 10.7 | ×2.67 | match |
| hin_Deva | lang | 6.0 | 14.3 | ×2.39 | match |
| ben_Beng | lang | 5.5 | 12.4 | ×2.23 | match |
| tam_Taml | lang | 6.7 | 14.5 | ×2.17 | match |
| arb_Arab | lang | 3.8 | 8.2 | ×2.15 | match |
| heb_Hebr | lang | 3.8 | 7.9 | ×2.10 | match |
| ell_Grek | lang | 3.5 | 6.9 | ×2.00 | match |
| rus_Cyrl | lang | 3.3 | 6.3 | ×1.88 | match |
| kat_Geor | lang | 5.8 | 10.8 | ×1.86 | match |
| kor_Hang | lang | 2.2 | 3.9 | ×1.74 | match |
| tha_Thai | lang | 8.2 | 13.3 | ×1.63 | match |
| agentic-traces | modalities | 3.5 | 13.4 | ×3.81 | match |
| math_latex | modalities | 3.7 | 13.7 | ×3.66 | match |
| agentic_swe | modalities | 3.8 | 13.8 | ×3.63 | match |
| code_mixed | modalities | 3.7 | 12.3 | ×3.36 | match |

</details>
<!-- pipeline-bench:end -->


