### PR TITLE
refactor: extract pretok algo

### DIFF
--- a/tokenizers/tk-encode/src/pre_tokenizers/bert.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/bert.rs
@@ -1,4 +1,4 @@
-use crate::pipeline;
+use crate::pipeline::{self, SplitPolicy};
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use crate::utils::macro_rules_attribute;
 use std::sync::LazyLock;
@@ -26,7 +26,20 @@ enum CharType {
     Other,
 }
 
-fn bert_classify(c: char) -> CharType {
+impl CharType {
+    #[inline]
+    fn policy(self) -> SplitPolicy {
+        match self {
+            // whitespace is dropped, each punctuation char is isolated, and
+            // everything else is emitted as a single split.
+            CharType::Whitespace => SplitPolicy::Remove,
+            CharType::Punctuation => SplitPolicy::Isolate,
+            CharType::Other => SplitPolicy::Keep,
+        }
+    }
+}
+
+fn classify(c: char) -> CharType {
     if c.is_whitespace() {
         CharType::Whitespace
     } else if is_bert_punc(c) {
@@ -36,47 +49,25 @@ fn bert_classify(c: char) -> CharType {
     }
 }
 
-/// `CharType` of each ASCII codepoint (index == its byte value). Lets the
-/// ASCII fast path skip the Unicode predicates in `bert_classify`; the (cheap)
-/// UTF-8 decode still happens via `char_indices`, and non-ASCII falls back to
-/// `bert_classify`.
 static ASCII_CLASS: LazyLock<[CharType; 128]> =
-    LazyLock::new(|| std::array::from_fn(|b| bert_classify(b as u8 as char)));
+    LazyLock::new(|| std::array::from_fn(|b| classify(b as u8 as char)));
 
 impl pipeline::PreTokenizer for BertPreTokenizer {
+    // XXX: surprisingly, inlining here yields 10-15% slower performance
+    #[inline(never)]
     fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Split>) -> Result<()> {
-        let mut start: u32 = 0;
-        let mut prev_type: Option<CharType> = None;
-
-        for (i, ch) in text.char_indices() {
-            let ct = if ch.is_ascii() {
-                ASCII_CLASS[ch as usize]
-            } else {
-                bert_classify(ch)
-            };
-
-            if let Some(pt) = prev_type {
-                if pt != ct || ct == CharType::Punctuation {
-                    if pt != CharType::Whitespace {
-                        out.push(pipeline::Split {
-                            start,
-                            end: i as u32,
-                        });
-                    }
-                    start = i as u32;
+        pipeline::split(
+            text,
+            out,
+            |ch| {
+                if ch.is_ascii() {
+                    ASCII_CLASS[ch as usize]
+                } else {
+                    classify(ch)
                 }
-            }
-            prev_type = Some(ct);
-        }
-
-        if let Some(pt) = prev_type {
-            if pt != CharType::Whitespace {
-                out.push(pipeline::Split {
-                    start,
-                    end: text.len() as u32,
-                });
-            }
-        }
+            },
+            CharType::policy,
+        );
         Ok(())
     }
 }

--- a/tokenizers/tk-encode/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/whitespace.rs
@@ -2,7 +2,7 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-use crate::pipeline;
+use crate::pipeline::{self, SplitPolicy};
 use crate::tokenizer::{
     pattern::Invert, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior,
 };
@@ -48,6 +48,18 @@ enum CharType {
     Symbol,
 }
 
+impl CharType {
+    #[inline]
+    fn policy(self) -> SplitPolicy {
+        match self {
+            // whitespace is dropped; word and symbol groups are each emitted as one
+            // split, with a boundary between the two classes.
+            CharType::Whitespace => SplitPolicy::Remove,
+            CharType::Word | CharType::Symbol => SplitPolicy::Keep,
+        }
+    }
+}
+
 fn classify(ch: char) -> CharType {
     if ch.is_whitespace() {
         CharType::Whitespace
@@ -72,48 +84,25 @@ pub fn is_word_char(ch: char) -> bool {
         || ch == '\u{200d}' // Zero-Width Joiner
 }
 
-/// `CharType` of each ASCII codepoint (index == its byte value). Lets the
-/// ASCII fast path skip the Unicode predicates in `classify`; the (cheap) UTF-8
-/// decode still happens via `char_indices`, and non-ASCII falls back to
-/// `classify`.
 static ASCII_CLASS: LazyLock<[CharType; 128]> =
     LazyLock::new(|| std::array::from_fn(|b| classify(b as u8 as char)));
 
 impl pipeline::PreTokenizer for Whitespace {
+    // XXX: surprisingly, inlining here yields 10-15% slower performance
+    #[inline(never)]
     fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Split>) -> Result<()> {
-        let mut span_start: u32 = 0;
-        let mut prev_type: Option<CharType> = None;
-
-        for (i, ch) in text.char_indices() {
-            let ct = if ch.is_ascii() {
-                ASCII_CLASS[ch as usize]
-            } else {
-                classify(ch)
-            };
-
-            if let Some(pt) = prev_type {
-                if pt != ct {
-                    if pt != CharType::Whitespace {
-                        out.push(pipeline::Split {
-                            start: span_start,
-                            end: i as u32,
-                        });
-                    }
-                    span_start = i as u32;
+        pipeline::split(
+            text,
+            out,
+            |ch| {
+                if ch.is_ascii() {
+                    ASCII_CLASS[ch as usize]
+                } else {
+                    classify(ch)
                 }
-            }
-            prev_type = Some(ct);
-        }
-
-        if let Some(pt) = prev_type {
-            if pt != CharType::Whitespace {
-                out.push(pipeline::Split {
-                    start: span_start,
-                    end: text.len() as u32,
-                });
-            }
-        }
-
+            },
+            CharType::policy,
+        );
         Ok(())
     }
 }
@@ -183,7 +172,7 @@ mod tests {
 
     #[test]
     fn edge_cases() {
-        // word / symbol / whitespace transitions; whitespace dropped, runs kept whole
+        // word / symbol / whitespace transitions; whitespace dropped, splits kept whole
         let edge_cases = vec![
             ("", vec![]),
             (" ", vec![]),
@@ -212,14 +201,14 @@ mod tests {
             pretokenize("café résumé"),
             vec![("café", (0, 5)), ("résumé", (6, 14))],
         );
-        // CJK ideographs are alphabetic (word chars): one run, no inner split.
+        // CJK ideographs are alphabetic (word chars): one split, no inner boundary.
         assert_eq!(
             pretokenize("中文 text"),
             vec![("中文", (0, 6)), ("text", (7, 11))],
         );
         // '_' is connector punctuation (a word char) -> a single word token.
         assert_eq!(pretokenize("hello_world"), vec![("hello_world", (0, 11))]);
-        // word and symbol runs are each kept whole; only the boundary splits.
+        // word and symbol groups are each one split; only the boundary splits.
         assert_eq!(
             pretokenize("ab!!cd"),
             vec![("ab", (0, 2)), ("!!", (2, 4)), ("cd", (4, 6))],

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -332,3 +332,57 @@ mod tests {
         );
     }
 }
+
+/// What [`split`] does with each split it forms
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SplitPolicy {
+    /// Drop it, emit no split
+    Remove,
+    /// Emit it whole as one split
+    Keep,
+    /// Emit each character as its own split
+    Isolate,
+}
+
+/// Splits `text` into same-class groups, emitting each as a [`Split`]
+/// according to its [`SplitPolicy`].
+///
+/// `classify` maps each char to a small `Copy + Eq` class, the current
+/// split ends whenever the class changes (or on every char of an `Isolate`
+/// class), and `policy` decides what becomes of it. Ranges are byte offsets
+/// into `text`.
+#[inline(always)]
+pub fn split<C: Copy + PartialEq>(
+    text: &str,
+    out: &mut Vec<Split>,
+    classify: impl Fn(char) -> C,
+    policy: impl Fn(C) -> SplitPolicy,
+) {
+    let mut start: u32 = 0;
+    let mut prev: Option<C> = None;
+
+    for (i, ch) in text.char_indices() {
+        let c = classify(ch);
+        if let Some(p) = prev {
+            if p != c || policy(c) == SplitPolicy::Isolate {
+                if policy(p) != SplitPolicy::Remove {
+                    out.push(Split {
+                        start,
+                        end: i as u32,
+                    });
+                }
+                start = i as u32;
+            }
+        }
+        prev = Some(c);
+    }
+
+    if let Some(p) = prev {
+        if policy(p) != SplitPolicy::Remove {
+            out.push(Split {
+                start,
+                end: text.len() as u32,
+            });
+        }
+    }
+}


### PR DESCRIPTION
When going through the punctuation pretokenizer implementation, I noticed that I would have to reimplement the same kind of algo for each variant of its inner `behavior` field, which is also the same as the Whitespace and Bert algo.

Extracting this into an easy to adapt API for each pretokenizer, while maintaining the perf gains shown by the other two variants.