### PR TITLE
feat: `impl pipeline::PreTokenizer for FixedLength`

### DIFF
--- a/tokenizers/tk-encode/src/pre_tokenizers/fixed_length.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/fixed_length.rs
@@ -1,4 +1,5 @@
 use crate::normalizer::Range;
+use crate::pipeline;
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result};
 use serde::{Deserialize, Serialize};
 
@@ -49,10 +50,98 @@ impl PreTokenizer for FixedLength {
     }
 }
 
+impl pipeline::PreTokenizer for FixedLength {
+    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Split>) -> Result<()> {
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        if self.length == 0 {
+            out.push(pipeline::Split {
+                start: 0,
+                end: text.len() as u32,
+            });
+            return Ok(());
+        }
+
+        // `step_by` yields the byte offset of every `length`-th char — i.e. the
+        // start of each chunk. `skip(1)` turns those into the *end* of the
+        // preceding chunk; the final chunk runs to `text.len()`.
+        let mut start: u32 = 0;
+        for (end, _) in text.char_indices().step_by(self.length).skip(1) {
+            out.push(pipeline::Split {
+                start,
+                end: end as u32,
+            });
+            start = end as u32;
+        }
+        out.push(pipeline::Split {
+            start,
+            end: text.len() as u32,
+        });
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{OffsetReferential, OffsetType, PreTokenizer};
+
+    fn pretokenize(length: usize, text: &str) -> Vec<(&str, (u32, u32))> {
+        let pretok = FixedLength { length };
+        let mut splits = Vec::new();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        splits
+            .iter()
+            .map(|s| (&text[s.range()], (s.start, s.end)))
+            .collect()
+    }
+
+    #[test]
+    fn pipeline_basic() {
+        // same expectations as the legacy `basic`/`custom_length` tests
+        assert_eq!(
+            pretokenize(5, "Hello world"),
+            vec![("Hello", (0, 5)), (" worl", (5, 10)), ("d", (10, 11))],
+        );
+        assert_eq!(
+            pretokenize(3, "Hello world"),
+            vec![
+                ("Hel", (0, 3)),
+                ("lo ", (3, 6)),
+                ("wor", (6, 9)),
+                ("ld", (9, 11)),
+            ],
+        );
+    }
+
+    #[test]
+    fn pipeline_utf8() {
+        // chunks are counted in chars; offsets are bytes (👋 is 4 bytes)
+        assert_eq!(
+            pretokenize(3, "Hello 👋 world"),
+            vec![
+                ("Hel", (0, 3)),
+                ("lo ", (3, 6)),
+                ("👋 w", (6, 12)),
+                ("orl", (12, 15)),
+                ("d", (15, 16)),
+            ],
+        );
+    }
+
+    #[test]
+    fn pipeline_edge_cases() {
+        let empty = Vec::<(&str, (u32, u32))>::new();
+        assert_eq!(pretokenize(5, ""), empty);
+        // length >= char count -> one chunk
+        assert_eq!(pretokenize(5, "Short"), vec![("Short", (0, 5))]);
+        assert_eq!(pretokenize(10, "abc"), vec![("abc", (0, 3))]);
+        // length == 0 -> whole text as a single split (no panic)
+        assert_eq!(pretokenize(0, "abc"), vec![("abc", (0, 3))]);
+    }
 
     #[test]
     fn basic() {

--- a/tokenizers/tk-encode/src/pre_tokenizers/fixed_length.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/fixed_length.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::utils::macro_rules_attribute;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct FixedLength {
     #[serde(default = "default_length")]

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -5,7 +5,7 @@ use crate::added_vocabulary::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
 use crate::{
-    pre_tokenizers::{bert::BertPreTokenizer, whitespace::Whitespace},
+    pre_tokenizers::{bert::BertPreTokenizer, fixed_length::FixedLength, whitespace::Whitespace},
     Model, ModelWrapper, NormalizedString, Normalizer, NormalizerWrapper, PostProcessorWrapper,
     PreTokenizerWrapper, Token, Tokenizer,
 };
@@ -36,6 +36,7 @@ pub trait PreTokenizer {
 /// The pre-tokenizers a [`PipelineTokenizer`] can run.
 pub enum PipelinePreTokenizer {
     Bert(BertPreTokenizer),
+    FixedLength(FixedLength),
     Whitespace(Whitespace),
     None,
 }
@@ -45,6 +46,7 @@ impl PreTokenizer for PipelinePreTokenizer {
         match self {
             Self::None => Ok(()),
             Self::Bert(pretok) => pretok.pre_tokenize(text, out),
+            Self::FixedLength(pretok) => pretok.pre_tokenize(text, out),
             Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
         }
     }
@@ -191,6 +193,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
         let pre_tokenizer = match tok.get_pre_tokenizer() {
             None => PipelinePreTokenizer::None,
             Some(PreTokenizerWrapper::BertPreTokenizer(p)) => PipelinePreTokenizer::Bert(*p),
+            Some(PreTokenizerWrapper::FixedLength(p)) => PipelinePreTokenizer::FixedLength(*p),
             Some(PreTokenizerWrapper::Whitespace(p)) => PipelinePreTokenizer::Whitespace(p.clone()),
             Some(other) => {
                 return Err(format!(


### PR DESCRIPTION
This one doesn't need the `pipeline::split` method as its quite trivial