### PR TITLE
feat: `impl pipeline::PreTokenizer for UnicodeScripts`

### DIFF
--- a/tokenizers/tk-encode/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
@@ -79,8 +79,9 @@ impl PreTokenizer for UnicodeScripts {
     }
 }
 
-static ASCII_CLASS: LazyLock<[Script; 128]> =
-    LazyLock::new(|| std::array::from_fn(|b| fixed_script(b as u8 as char)));
+static BMP_SCRIPT: LazyLock<[Script; 0x10000]> = LazyLock::new(|| {
+    std::array::from_fn(|i| char::from_u32(i as u32).map_or(Script::Common, fixed_script))
+});
 
 impl pipeline::PreTokenizer for UnicodeScripts {
     fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Split>) -> Result<()> {
@@ -88,8 +89,9 @@ impl pipeline::PreTokenizer for UnicodeScripts {
         let mut last_script = None;
 
         for (i, ch) in text.char_indices() {
-            let script = if ch.is_ascii() {
-                ASCII_CLASS[ch as usize]
+            let cp = ch as u32;
+            let script = if cp < 0x10000 {
+                BMP_SCRIPT[cp as usize]
             } else {
                 fixed_script(ch)
             };

--- a/tokenizers/tk-encode/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
@@ -1,3 +1,6 @@
+use std::sync::LazyLock;
+
+use crate::pipeline;
 use crate::pre_tokenizers::unicode_scripts::scripts::{get_script, Script};
 use crate::tokenizer::{normalizer::Range, PreTokenizedString, PreTokenizer, Result};
 use crate::utils::macro_rules_attribute;
@@ -76,6 +79,46 @@ impl PreTokenizer for UnicodeScripts {
     }
 }
 
+static ASCII_CLASS: LazyLock<[Script; 128]> =
+    LazyLock::new(|| std::array::from_fn(|b| fixed_script(b as u8 as char)));
+
+impl pipeline::PreTokenizer for UnicodeScripts {
+    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Split>) -> Result<()> {
+        let mut start = None;
+        let mut last_script = None;
+
+        for (i, ch) in text.char_indices() {
+            let script = if ch.is_ascii() {
+                ASCII_CLASS[ch as usize]
+            } else {
+                fixed_script(ch)
+            };
+            if script == Script::Any {
+                continue;
+            }
+            if last_script.is_none_or(|ls| ls != script) {
+                if let Some(s) = start {
+                    out.push(pipeline::Split {
+                        start: s,
+                        end: i as u32,
+                    });
+                }
+                start = Some(i as u32);
+            }
+            last_script = Some(script);
+        }
+
+        if let Some(start) = start {
+            out.push(pipeline::Split {
+                start,
+                end: text.len() as u32,
+            });
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,6 +169,50 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![("Apples are ", (0, 11)), ("りんご 林檎", (11, 27))]
         );
+    }
+
+    fn pretokenize(text: &str) -> Vec<(&str, (u32, u32))> {
+        let pretok = UnicodeScripts;
+        let mut splits = Vec::new();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        splits
+            .iter()
+            .map(|s| (&text[s.range()], (s.start, s.end)))
+            .collect()
+    }
+
+    #[test]
+    fn pipeline_basic() {
+        // same oracle as the legacy `basic` test: kana+kanji collapse to one Han
+        // run, the CJK full stop is its own script, then Latin.
+        assert_eq!(
+            pretokenize("どこで生れ。Yes"),
+            vec![("どこで生れ", (0, 15)), ("。", (15, 18)), ("Yes", (18, 21))],
+        );
+    }
+
+    #[test]
+    fn pipeline_spaces_are_neutral() {
+        // spaces (`Script::Any`) never trigger a boundary and stick to the run
+        // around them; only the Latin -> Japanese change splits.
+        assert_eq!(
+            pretokenize("Apples are りんご 林檎"),
+            vec![("Apples are ", (0, 11)), ("りんご 林檎", (11, 27))],
+        );
+        // a trailing space stays attached to the preceding run
+        assert_eq!(pretokenize("hi 京"), vec![("hi ", (0, 3)), ("京", (3, 6))],);
+    }
+
+    #[test]
+    fn pipeline_edge_cases() {
+        let empty = Vec::<(&str, (u32, u32))>::new();
+        assert_eq!(pretokenize(""), empty);
+        // all-neutral input produces nothing (no real script ever seen)
+        assert_eq!(pretokenize("   "), empty);
+        // single script -> one split
+        assert_eq!(pretokenize("hello"), vec![("hello", (0, 5))]);
+        // leading spaces are dropped (nothing before the first real script)
+        assert_eq!(pretokenize(" hi"), vec![("hi", (1, 3))]);
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
@@ -5,7 +5,7 @@ use crate::pre_tokenizers::unicode_scripts::scripts::{get_script, Script};
 use crate::tokenizer::{normalizer::Range, PreTokenizedString, PreTokenizer, Result};
 use crate::utils::macro_rules_attribute;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct UnicodeScripts;
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -7,7 +7,7 @@ use crate::added_vocabulary::bucket_added_vocabulary::{
 use crate::{
     pre_tokenizers::{
         bert::BertPreTokenizer, delimiter::CharDelimiterSplit, digits::Digits,
-        fixed_length::FixedLength, whitespace::Whitespace,
+        fixed_length::FixedLength, unicode_scripts::UnicodeScripts, whitespace::Whitespace,
     },
     Model, ModelWrapper, NormalizedString, Normalizer, NormalizerWrapper, PostProcessorWrapper,
     PreTokenizerWrapper, Token, Tokenizer,
@@ -42,6 +42,7 @@ pub enum PipelinePreTokenizer {
     Delimiter(CharDelimiterSplit),
     Digits(Digits),
     FixedLength(FixedLength),
+    UnicodeScripts(UnicodeScripts),
     Whitespace(Whitespace),
     None,
 }
@@ -54,6 +55,7 @@ impl PreTokenizer for PipelinePreTokenizer {
             Self::Delimiter(pretok) => pretok.pre_tokenize(text, out),
             Self::Digits(pretok) => pretok.pre_tokenize(text, out),
             Self::FixedLength(pretok) => pretok.pre_tokenize(text, out),
+            Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, out),
             Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
         }
     }
@@ -203,6 +205,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             Some(PreTokenizerWrapper::Delimiter(p)) => PipelinePreTokenizer::Delimiter(*p),
             Some(PreTokenizerWrapper::Digits(p)) => PipelinePreTokenizer::Digits(p.clone()),
             Some(PreTokenizerWrapper::FixedLength(p)) => PipelinePreTokenizer::FixedLength(*p),
+            Some(PreTokenizerWrapper::UnicodeScripts(p)) => PipelinePreTokenizer::UnicodeScripts(*p),
             Some(PreTokenizerWrapper::Whitespace(p)) => PipelinePreTokenizer::Whitespace(p.clone()),
             Some(other) => {
                 return Err(format!(


### PR DESCRIPTION
Not relying on `pipeline::split` because of the `Script::Any` variant, which requires specific logic for defining the end of a given split.

```
unicode_scripts (ascii):  (10000 splits)
  old (PreTokenizedString)     3463876 ns/iter
  new (Vec<Split>)              225123 ns/iter   15.39x

multilingual corpus: 162000 bytes,  100 iters/measurement

unicode_scripts (mixed):  (11000 splits)
  old (PreTokenizedString)     3805905 ns/iter
  new (Vec<Split>)             2015314 ns/iter    1.89x
```
