### PR TITLE
ci: Simple bench workflow for PipelineTokenizer

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -11,6 +11,9 @@ Colors follow the validated reference palette (light + dark variants).
 import argparse
 import json
 import math
+import os
+import subprocess
+from datetime import datetime, timezone
 from html import escape
 from pathlib import Path
 
@@ -27,7 +30,7 @@ INK = {
     },
 }
 FONT = "-apple-system,'Segoe UI',Helvetica,Arial,sans-serif"
-GUTTER, PLOT_W, PAD_R, ROW_H, BAR_H = 150, 540, 110, 26, 16
+GUTTER, PLOT_W, PAD_R, COL_W, ROW_H, BAR_H = 150, 540, 110, 150, 26, 16
 TICKS = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0]
 GROUPS = [("lang", "Languages"), ("modalities", "Modalities")]
 
@@ -47,7 +50,7 @@ def bar_path(x0, x1, y, h, r):
             f"V{y + h - r:.1f} q0,{r:.1f} {r:.1f},{r:.1f} H{right:.1f} Z")
 
 
-def render_svg(rows, mode, subtitle):
+def render_svg(rows, mode, subtitle, meta):
     ink = INK[mode]
     lo = min(0.75, min(r["speedup"] for r in rows) / 1.08)
     hi = max(1.5, max(r["speedup"] for r in rows) * 1.08)
@@ -57,7 +60,9 @@ def render_svg(rows, mode, subtitle):
         return GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * PLOT_W
 
     top = 74
-    body = []
+    col_x = GUTTER + PLOT_W + PAD_R + COL_W - 16
+    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+            f'text-anchor="end">MB/s: Tokenizer → Pipeline</text>']
     y = top
     for key, title in GROUPS:
         group_rows = sorted((r for r in rows if r["group"] == key),
@@ -88,6 +93,9 @@ def render_svg(rows, mode, subtitle):
             body.append(f'<text x="{lx:.1f}" y="{y + ROW_H / 2 + 4}" fill="{fill}" font-size="12" '
                         f'font-weight="600" text-anchor="{anchor}" '
                         f'style="font-variant-numeric:tabular-nums">{label}</text>')
+            body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
+                        f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
+                        f'{r["legacy_mbps"]:.1f} → {r["pipeline_mbps"]:.1f}</text>')
             y += ROW_H
         y += 10
 
@@ -104,19 +112,37 @@ def render_svg(rows, mode, subtitle):
              f'<text x="{x(1.0) + 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
              f'text-anchor="start">faster →</text>')
 
-    width = GUTTER + PLOT_W + PAD_R
+    width = GUTTER + PLOT_W + PAD_R + COL_W
     return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}"
   viewBox="0 0 {width} {height}" font-family="{FONT}">
 <rect width="{width}" height="{height}" fill="{ink["surface"]}"/>
 <text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="600">PipelineTokenizer vs Tokenizer — encode throughput</text>
 <text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
+<text x="{width - 16}" y="26" fill="{ink["muted"]}" font-size="11" text-anchor="end"
+  style="font-variant-numeric:tabular-nums">{escape(meta[0])}</text>
+<text x="{width - 16}" y="44" fill="{ink["muted"]}" font-size="11" text-anchor="end">{escape(meta[1])}</text>
 {"".join(grid)}
 {hints}
 {"".join(body)}
 </svg>'''
 
 
-def render_markdown(rows, subtitle, img_light, img_dark):
+def detect_hardware():
+    try:
+        cpu = Path("/proc/cpuinfo").read_text()
+        cpu = next(l.split(":", 1)[1].strip() for l in cpu.splitlines()
+                   if l.startswith("model name"))
+    except (OSError, StopIteration):
+        try:
+            cpu = subprocess.run(["sysctl", "-n", "machdep.cpu.brand_string"],
+                                 capture_output=True, text=True, check=True).stdout.strip()
+        except (OSError, subprocess.CalledProcessError):
+            import platform
+            cpu = platform.processor() or platform.machine() or "unknown cpu"
+    return f"{cpu} · {os.cpu_count()} cores"
+
+
+def render_markdown(rows, subtitle, meta, img_light, img_dark):
     overall = geomean([r["speedup"] for r in rows])
     parts = []
     for key, title in GROUPS:
@@ -129,6 +155,8 @@ def render_markdown(rows, subtitle, img_light, img_dark):
           "",
           f"**Geomean speedup ×{overall:.2f}** across {len(rows)} fixtures "
           f"({', '.join(parts)}) — {subtitle}",
+          "",
+          f"`{meta[0]}` · {meta[1]}",
           ""]
     if mismatches:
         md += [f"> ⚠️ **Token ids diverge from the reference on: "
@@ -156,16 +184,27 @@ def main():
     ap.add_argument("results")
     ap.add_argument("--out-dir", default=".")
     ap.add_argument("--subtitle", default="bert-wiki WordPiece · ~10 kB inputs · single thread")
+    ap.add_argument("--revision", default="")
     ap.add_argument("--img-light-url", default="")
     ap.add_argument("--img-dark-url", default="")
     args = ap.parse_args()
 
+    rev = args.revision
+    if not rev:
+        try:
+            rev = subprocess.run(["git", "rev-parse", "HEAD"],
+                                 capture_output=True, text=True, check=True).stdout.strip()
+        except (OSError, subprocess.CalledProcessError):
+            rev = "unknown"
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    meta = (f"{rev[:9]} · {stamp}", detect_hardware())
+
     rows = json.loads(Path(args.results).read_text())
     out = Path(args.out_dir)
     for mode in ("light", "dark"):
-        (out / f"pipeline_bench_{mode}.svg").write_text(render_svg(rows, mode, args.subtitle))
+        (out / f"pipeline_bench_{mode}.svg").write_text(render_svg(rows, mode, args.subtitle, meta))
     (out / "pipeline_bench.md").write_text(
-        render_markdown(rows, args.subtitle, args.img_light_url, args.img_dark_url))
+        render_markdown(rows, args.subtitle, meta, args.img_light_url, args.img_dark_url))
     print(f"geomean x{geomean([r['speedup'] for r in rows]):.3f}, "
           f"{sum(not r['ids_match'] for r in rows)} id mismatches")
 

--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Render the fixture_bench JSON comparison as an SVG chart + markdown report.
+
+Input: JSON array from `cargo run --release -p tk-encode --example fixture_bench`
+(one row per fixture: legacy_mbps, pipeline_mbps, speedup, ids_match).
+
+The chart is a diverging horizontal bar chart of per-fixture speedup on a log2
+scale around the x1.0 baseline: blue = PipelineTokenizer faster, red = slower.
+Colors follow the validated reference palette (light + dark variants).
+"""
+import argparse
+import json
+import math
+from html import escape
+from pathlib import Path
+
+INK = {
+    "light": {
+        "surface": "#fcfcfb", "primary": "#0b0b0b", "secondary": "#52514e",
+        "muted": "#898781", "grid": "#e1e0d9", "baseline": "#c3c2b7",
+        "faster": "#2a78d6", "slower": "#e34948", "critical": "#d03b3b",
+    },
+    "dark": {
+        "surface": "#1a1a19", "primary": "#ffffff", "secondary": "#c3c2b7",
+        "muted": "#898781", "grid": "#2c2c2a", "baseline": "#383835",
+        "faster": "#3987e5", "slower": "#e66767", "critical": "#e66767",
+    },
+}
+FONT = "-apple-system,'Segoe UI',Helvetica,Arial,sans-serif"
+GUTTER, PLOT_W, PAD_R, ROW_H, BAR_H = 150, 540, 110, 26, 16
+TICKS = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0]
+GROUPS = [("lang", "Languages"), ("modalities", "Modalities")]
+
+
+def geomean(values):
+    return math.exp(sum(math.log(v) for v in values) / len(values))
+
+
+def bar_path(x0, x1, y, h, r):
+    # square at the baseline (x0), rounded at the data end (x1)
+    left, right = min(x0, x1), max(x0, x1)
+    r = min(r, (right - left) / 2, h / 2)
+    if x1 >= x0:
+        return (f"M{left:.1f},{y:.1f} H{right - r:.1f} q{r:.1f},0 {r:.1f},{r:.1f} "
+                f"V{y + h - r:.1f} q0,{r:.1f} -{r:.1f},{r:.1f} H{left:.1f} Z")
+    return (f"M{right:.1f},{y:.1f} H{left + r:.1f} q-{r:.1f},0 -{r:.1f},{r:.1f} "
+            f"V{y + h - r:.1f} q0,{r:.1f} {r:.1f},{r:.1f} H{right:.1f} Z")
+
+
+def render_svg(rows, mode, subtitle):
+    ink = INK[mode]
+    lo = min(0.75, min(r["speedup"] for r in rows) / 1.08)
+    hi = max(1.5, max(r["speedup"] for r in rows) * 1.08)
+    ticks = [t for t in TICKS if lo <= t <= hi]
+
+    def x(v):
+        return GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * PLOT_W
+
+    top = 74
+    body = []
+    y = top
+    for key, title in GROUPS:
+        group_rows = sorted((r for r in rows if r["group"] == key),
+                            key=lambda r: -r["speedup"])
+        if not group_rows:
+            continue
+        body.append(f'<text x="{GUTTER}" y="{y + 12}" fill="{ink["secondary"]}" font-size="11" '
+                    f'font-weight="600" letter-spacing="1.2" text-anchor="end" dx="-10">{title.upper()}</text>')
+        y += 22
+        for r in group_rows:
+            v, x0, x1 = r["speedup"], x(1.0), x(r["speedup"])
+            if abs(math.log2(v)) < math.log2(1.02):  # within noise of the baseline
+                color = ink["muted"]
+            else:
+                color = ink["faster"] if v >= 1 else ink["slower"]
+            by = y + (ROW_H - BAR_H) / 2
+            body.append(f'<text x="{GUTTER - 10}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
+                        f'font-size="12.5" text-anchor="end">{escape(r["fixture"])}</text>')
+            if abs(x1 - x0) < 1.5:
+                body.append(f'<rect x="{min(x0, x1):.1f}" y="{by}" width="1.5" height="{BAR_H}" fill="{color}"/>')
+            else:
+                body.append(f'<path d="{bar_path(x0, x1, by, BAR_H, 4)}" fill="{color}"/>')
+            label = f"×{v:.2f}"
+            anchor, lx = ("start", max(x0, x1) + 6) if v >= 1 else ("end", min(x0, x1) - 6)
+            if not r["ids_match"]:
+                label += "  ⚠ ids differ"
+            fill = ink["primary"] if r["ids_match"] else ink["critical"]
+            body.append(f'<text x="{lx:.1f}" y="{y + ROW_H / 2 + 4}" fill="{fill}" font-size="12" '
+                        f'font-weight="600" text-anchor="{anchor}" '
+                        f'style="font-variant-numeric:tabular-nums">{label}</text>')
+            y += ROW_H
+        y += 10
+
+    height = y + 34
+    grid = []
+    for t in ticks:
+        strong = t == 1.0
+        grid.append(f'<line x1="{x(t):.1f}" y1="{top - 6}" x2="{x(t):.1f}" y2="{y - 6}" '
+                    f'stroke="{ink["baseline"] if strong else ink["grid"]}" stroke-width="1"/>')
+        grid.append(f'<text x="{x(t):.1f}" y="{y + 12}" fill="{ink["muted"]}" font-size="11" '
+                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">×{t:g}</text>')
+    hints = (f'<text x="{x(1.0) - 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+             f'text-anchor="end">← slower</text>'
+             f'<text x="{x(1.0) + 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+             f'text-anchor="start">faster →</text>')
+
+    width = GUTTER + PLOT_W + PAD_R
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}"
+  viewBox="0 0 {width} {height}" font-family="{FONT}">
+<rect width="{width}" height="{height}" fill="{ink["surface"]}"/>
+<text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="600">PipelineTokenizer vs Tokenizer — encode throughput</text>
+<text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
+{"".join(grid)}
+{hints}
+{"".join(body)}
+</svg>'''
+
+
+def render_markdown(rows, subtitle, img_light, img_dark):
+    overall = geomean([r["speedup"] for r in rows])
+    parts = []
+    for key, title in GROUPS:
+        vals = [r["speedup"] for r in rows if r["group"] == key]
+        if vals:
+            parts.append(f"{title.lower()} ×{geomean(vals):.2f}")
+    mismatches = [r["fixture"] for r in rows if not r["ids_match"]]
+
+    md = ["## PipelineTokenizer benchmark",
+          "",
+          f"**Geomean speedup ×{overall:.2f}** across {len(rows)} fixtures "
+          f"({', '.join(parts)}) — {subtitle}",
+          ""]
+    if mismatches:
+        md += [f"> ⚠️ **Token ids diverge from the reference on: "
+               f"{', '.join(mismatches)}** — speedups there are meaningless until fixed.",
+               ""]
+    if img_light:
+        md += ["<picture>",
+               f'  <source media="(prefers-color-scheme: dark)" srcset="{img_dark or img_light}">',
+               f'  <img alt="Per-fixture speedup chart" src="{img_light}">',
+               "</picture>",
+               ""]
+    md += ["<details><summary>Per-fixture results</summary>", "",
+           "| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |",
+           "|---|---|---:|---:|---:|:--|"]
+    for r in sorted(rows, key=lambda r: (r["group"], -r["speedup"])):
+        ids = "match" if r["ids_match"] else "⚠️ differ"
+        md.append(f"| {r['fixture']} | {r['group']} | {r['legacy_mbps']:.1f} "
+                  f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} | {ids} |")
+    md += ["", "</details>", ""]
+    return "\n".join(md)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("results")
+    ap.add_argument("--out-dir", default=".")
+    ap.add_argument("--subtitle", default="bert-wiki WordPiece · ~10 kB inputs · single thread")
+    ap.add_argument("--img-light-url", default="")
+    ap.add_argument("--img-dark-url", default="")
+    args = ap.parse_args()
+
+    rows = json.loads(Path(args.results).read_text())
+    out = Path(args.out_dir)
+    for mode in ("light", "dark"):
+        (out / f"pipeline_bench_{mode}.svg").write_text(render_svg(rows, mode, args.subtitle))
+    (out / "pipeline_bench.md").write_text(
+        render_markdown(rows, args.subtitle, args.img_light_url, args.img_dark_url))
+    print(f"geomean x{geomean([r['speedup'] for r in rows]):.3f}, "
+          f"{sum(not r['ids_match'] for r in rows)} id mismatches")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pipeline-bench-trigger.yml
+++ b/.github/workflows/pipeline-bench-trigger.yml
@@ -1,0 +1,70 @@
+name: Pipeline Benchmark Trigger
+
+# A maintainer comments "/pipeline-bench" on a PR to trigger the comparative
+# Tokenizer-vs-PipelineTokenizer benchmark over all fixtures. Creates a check
+# run on the PR's head SHA so results surface in the PR's checks list.
+# NOTE: issue_comment workflows only run from the default branch — this file
+# activates once merged to main; the benchmark workflow itself must exist on
+# the PR's head branch.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  checks: write
+  pull-requests: read
+
+jobs:
+  trigger:
+    name: Trigger pipeline benchmark
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/pipeline-bench') &&
+      (github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          pr_number=$PR_NUMBER
+          head_sha=$(gh api "repos/$REPOSITORY/pulls/$pr_number" --jq '.head.sha')
+          head_ref=$(gh api "repos/$REPOSITORY/pulls/$pr_number" --jq '.head.ref')
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Create check run on PR
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          check_id=$(gh api "repos/$REPOSITORY/check-runs" \
+            -X POST \
+            -f "name=Pipeline Benchmark Results" \
+            -f "head_sha=${{ steps.pr.outputs.head_sha }}" \
+            -f "status=queued" \
+            -f "output[title]=Pipeline benchmark queued" \
+            -f "output[summary]=Benchmark workflow has been dispatched. Results will appear here when complete." \
+            --jq '.id')
+          echo "check_id=$check_id" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch pipeline benchmark workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh workflow run pipeline-bench.yml \
+            --repo "$REPOSITORY" \
+            --ref "${{ steps.pr.outputs.head_ref }}" \
+            -f pr_number="${{ steps.pr.outputs.pr_number }}" \
+            -f check_run_id="${{ steps.check.outputs.check_id }}" \
+            -f head_sha="${{ steps.pr.outputs.head_sha }}"

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -1,0 +1,168 @@
+name: Pipeline Benchmark
+
+# Comparative benchmark: reference `Tokenizer` vs experimental
+# `PipelineTokenizer`, across every corpus in data/fixtures/ (13 non-Latin
+# scripts + English + code/math/agentic modalities) on ~10 kB inputs — the
+# regime where per-input overhead is amortized.
+#
+# Runs on pushes to the base branch, and on demand: comment "/pipeline-bench"
+# on a PR (see pipeline-bench-trigger.yml) or dispatch manually.
+
+on:
+  push:
+    branches: [feat/train_encode_split]
+    paths:
+      - "tokenizers/tk-encode/**"
+      - "tokenizers/src/**"
+      - ".github/workflows/pipeline-bench.yml"
+      - ".github/scripts/render_pipeline_bench.py"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to post the report comment to (optional)"
+        required: false
+        type: string
+      check_run_id:
+        description: "Check run ID to update with results (set by pipeline-bench-trigger)"
+        required: false
+        type: string
+      head_sha:
+        description: "PR head SHA for the check run (set by pipeline-bench-trigger)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+env:
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  pipeline-bench:
+    name: Tokenizer vs PipelineTokenizer
+    # Same dedicated runner group as benchmarks.yml — shared 2-vCPU runners
+    # produce noisy timings. The comparison is within-run (both impls, same
+    # machine, interleaved), so absolute noise matters less than for baselines,
+    # but keep the environment consistent anyway.
+    runs-on:
+      group: aws-general-8-plus
+    defaults:
+      run:
+        working-directory: tokenizers
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Mark check run in progress
+        if: inputs.check_run_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/check-runs/${{ inputs.check_run_id }}" \
+            -X PATCH \
+            -f "status=in_progress" \
+            -f "output[title]=Pipeline benchmark running" \
+            -f "output[summary]=Compiling and benchmarking all fixtures..."
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      # cairosvg (chart rendering) dlopens the system libcairo, which the
+      # aws-general-8-plus runner image doesn't ship
+      - name: Install libcairo
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libcairo2
+
+      - name: Download fixtures
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: make fixtures data/bert-wiki.json HF="uvx --from huggingface_hub hf"
+
+      - name: Run comparative benchmark
+        run: |
+          cargo run --release -p tk-encode --example fixture_bench > pipeline_bench.json
+          cat pipeline_bench.json
+
+      - name: Render report
+        id: render
+        run: |
+          base_url="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts"
+          python3 ${{ github.workspace }}/.github/scripts/render_pipeline_bench.py \
+            pipeline_bench.json \
+            --subtitle "bert-wiki WordPiece · ~10 kB inputs · single thread · ${{ inputs.head_sha || github.sha }}" \
+            --img-light-url "$base_url/pipeline-${{ github.run_id }}-light.png" \
+            --img-dark-url "$base_url/pipeline-${{ github.run_id }}-dark.png"
+          uvx --with cairosvg python -c "
+          import cairosvg
+          for m in ('light', 'dark'):
+              cairosvg.svg2png(url=f'pipeline_bench_{m}.svg', write_to=f'pipeline_bench_{m}.png', scale=2)
+          "
+
+      - name: Upload charts to HF Hub
+        continue-on-error: true
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          for m in light dark; do
+            uvx --from huggingface_hub hf upload hf-internal-testing/tokenizers-bench \
+              "pipeline_bench_${m}.png" "charts/pipeline-${{ github.run_id }}-${m}.png" --repo-type dataset
+          done
+
+      - name: Write step summary
+        run: cat pipeline_bench.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post report to PR
+        if: inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh api "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
+            --jq '.[] | select(.body | startswith("## PipelineTokenizer benchmark")) | .id' | head -1)
+          if [ -n "$existing" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/$existing" \
+              -X PATCH -F "body=@pipeline_bench.md"
+          else
+            gh api "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
+              -F "body=@pipeline_bench.md"
+          fi
+
+      # Broadest correctness net we have: id-equality across every script and
+      # modality. A divergence is a bug even when the speedup looks great.
+      - name: Fail on id mismatches
+        run: |
+          python3 -c "
+          import json, sys
+          bad = [r['fixture'] for r in json.load(open('pipeline_bench.json')) if not r['ids_match']]
+          sys.exit(f'ids diverge on: {bad}' if bad else 0)
+          "
+
+      - name: Complete check run
+        if: always() && inputs.check_run_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/check-runs/${{ inputs.check_run_id }}" \
+            -X PATCH \
+            -f "status=completed" \
+            -f "conclusion=${{ job.status == 'success' && 'success' || 'failure' }}" \
+            -f "output[title]=Pipeline benchmark results" \
+            -F "output[summary]=@pipeline_bench.md" || true
+
+      - name: Upload results artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: pipeline-bench
+          path: |
+            tokenizers/pipeline_bench.json
+            tokenizers/pipeline_bench.md
+            tokenizers/pipeline_bench_*.svg
+            tokenizers/pipeline_bench_*.png
+          retention-days: 30

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -96,7 +96,8 @@ jobs:
           base_url="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts"
           python3 ${{ github.workspace }}/.github/scripts/render_pipeline_bench.py \
             pipeline_bench.json \
-            --subtitle "bert-wiki WordPiece · ~10 kB inputs · single thread · ${{ inputs.head_sha || github.sha }}" \
+            --subtitle "bert-wiki WordPiece · ~10 kB inputs · single thread" \
+            --revision "${{ inputs.head_sha || github.sha }}" \
             --img-light-url "$base_url/pipeline-${{ github.run_id }}-light.png" \
             --img-dark-url "$base_url/pipeline-${{ github.run_id }}-dark.png"
           uvx --with cairosvg python -c "

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -5,8 +5,12 @@ TESTS_DIR = tests
 dir_guard=@mkdir -p $(@D)
 
 SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2-merges.txt $(DATA_DIR)/bert-base-uncased-vocab.txt $(DATA_DIR)/big.txt $(DATA_DIR)/small.txt $(DATA_DIR)/albert-base-v1-tokenizer.json  $(DATA_DIR)/llama-3-tokenizer.json
-BENCHMARK_RESOURCES = $(SHARED_RESOURCES)
-TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json
+BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/fixtures/modalities/agentic-traces.txt
+TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/fixtures/modalities/agentic-traces.txt
+
+FIXTURE_LANGS = amh_Ethi arb_Arab ben_Beng cmn_Hani ell_Grek eng_Latn heb_Hebr hin_Deva jpn_Jpan kat_Geor kor_Hang rus_Cyrl tam_Taml tha_Thai
+FIXTURE_MODALITIES = agentic_swe agentic-traces code_mixed math_latex
+FIXTURES_RESOURCES = $(FIXTURE_LANGS:%=$(DATA_DIR)/fixtures/lang/%.txt) $(FIXTURE_MODALITIES:%=$(DATA_DIR)/fixtures/modalities/%.txt)
 
 .PHONY : build
 build :
@@ -45,12 +49,18 @@ all-checks : lint test doc
 bench : $(BENCHMARK_RESOURCES)
 	cargo bench -- --verbose
 
+# Multilingual + modality corpora for cross-language benchmarks; see
+# fixtures/FIXTURES.md in $(HF_TEST_REPO) for provenance.
+.PHONY : fixtures
+fixtures : $(FIXTURES_RESOURCES)
+
 HF_TEST_REPO = hf-internal-testing/tokenizers-test-data
 # Fetch fixtures through the huggingface_hub CLI: it handles auth (HF_TOKEN),
 # retry/backoff on rate limits, and caching for us. CI overrides HF with
 # `uvx --from huggingface_hub hf` to avoid a separate install step.
 HF ?= hf
+HF_REVISION ?= main
 
 $(DATA_DIR)/% :
 	$(dir_guard)
-	$(HF) download $(HF_TEST_REPO) $* --repo-type dataset --local-dir $(DATA_DIR)
+	$(HF) download $(HF_TEST_REPO) $* --repo-type dataset --revision $(HF_REVISION) --local-dir $(DATA_DIR)

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -1,0 +1,132 @@
+//! Comparative throughput of the reference `Tokenizer` vs the experimental
+//! `PipelineTokenizer` over every corpus in `data/fixtures/` (languages +
+//! modalities), on ~10 kB inputs — the regime where per-input overhead is
+//! amortized (see `pipeline_benchmark.rs` for the size sweep).
+//!
+//! Emits one JSON object per fixture on stdout, consumed by
+//! `.github/scripts/render_pipeline_bench.py` in CI.
+
+use std::convert::TryFrom;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use tk_encode::pipeline::PipelineTokenizer;
+use tk_encode::Tokenizer;
+
+const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
+const CHUNK_BYTES: usize = 10 * 1024;
+const MAX_CHUNKS: usize = 100;
+const REPS: usize = 5;
+
+fn make_chunks(text: &str) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut cur = String::new();
+    for line in text.lines().filter(|l| !l.trim().is_empty()) {
+        if !cur.is_empty() {
+            cur.push('\n');
+        }
+        cur.push_str(line);
+        if cur.len() >= CHUNK_BYTES {
+            chunks.push(std::mem::take(&mut cur));
+            if chunks.len() == MAX_CHUNKS {
+                return chunks;
+            }
+        }
+    }
+    if !cur.is_empty() {
+        chunks.push(cur);
+    }
+    chunks
+}
+
+fn median_secs(mut samples: Vec<f64>) -> f64 {
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    samples[samples.len() / 2]
+}
+
+fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
+    let start = Instant::now();
+    let mut n = 0usize;
+    for chunk in chunks {
+        n += encode(chunk);
+    }
+    black_box(n);
+    start.elapsed().as_secs_f64()
+}
+
+fn fixture_files() -> Vec<(String, PathBuf)> {
+    let mut files = Vec::new();
+    for group in ["lang", "modalities"] {
+        let dir = Path::new(DATA_DIR).join("fixtures").join(group);
+        let mut entries: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("{}: {e} — run `make fixtures` first", dir.display()))
+            .map(|e| e.unwrap().path())
+            .filter(|p| p.extension().is_some_and(|x| x == "txt"))
+            .collect();
+        entries.sort();
+        for path in entries {
+            files.push((group.to_string(), path));
+        }
+    }
+    files
+}
+
+fn main() {
+    let oracle = Tokenizer::from_file(format!("{DATA_DIR}/bert-wiki.json")).unwrap();
+    let pipeline = PipelineTokenizer::try_from(&oracle).unwrap();
+
+    let legacy_enc = |s: &str| oracle.encode(s, false).unwrap().len();
+    let pipeline_enc = |s: &str| pipeline.encode(s, false).unwrap().len();
+
+    println!("[");
+    let files = fixture_files();
+    for (i, (group, path)) in files.iter().enumerate() {
+        let name = path.file_stem().unwrap().to_str().unwrap().to_string();
+        let text = std::fs::read_to_string(path).unwrap();
+        let chunks = make_chunks(&text);
+        let bytes: usize = chunks.iter().map(String::len).sum();
+
+        let ids_match = chunks.iter().take(3).all(|c| {
+            let expected = oracle.encode(c.as_str(), false).unwrap();
+            let got: Vec<u32> = pipeline
+                .encode(c, false)
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect();
+            expected.get_ids() == got
+        });
+
+        // interleave impls so frequency/thermal drift hits both equally
+        time_pass(&legacy_enc, &chunks);
+        time_pass(&pipeline_enc, &chunks);
+        let (mut legacy_s, mut pipeline_s) = (Vec::new(), Vec::new());
+        for _ in 0..REPS {
+            legacy_s.push(time_pass(&legacy_enc, &chunks));
+            pipeline_s.push(time_pass(&pipeline_enc, &chunks));
+        }
+        let (l, p) = (median_secs(legacy_s), median_secs(pipeline_s));
+
+        eprintln!(
+            "{name}: legacy {:.1} MB/s, pipeline {:.1} MB/s",
+            bytes as f64 / l / 1e6,
+            bytes as f64 / p / 1e6
+        );
+        println!(
+            "{}{}",
+            serde_json::json!({
+                "fixture": name,
+                "group": group,
+                "bytes": bytes,
+                "chunks": chunks.len(),
+                "legacy_mbps": bytes as f64 / l / 1e6,
+                "pipeline_mbps": bytes as f64 / p / 1e6,
+                "speedup": l / p,
+                "ids_match": ids_match,
+            }),
+            if i + 1 < files.len() { "," } else { "" }
+        );
+    }
+    println!("]");
+}


### PR DESCRIPTION
# TL;DR

Automatic benchmark for feat/train_encode_split improvements, across a set of different scripts and modalities

## Example

<img width="1900" height="1280" alt="image" src="https://github.com/user-attachments/assets/519fc629-0d24-40e8-b99b-dd651163971a" />
