### PR TITLE
Improve single thread performance of de-tokenization

### DIFF
--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -1,4 +1,5 @@
 use super::{super::OrderedVocabIter, trainer::BpeTrainer, Error, Pair, Word};
+use crate::pre_tokenizers::byte_level::CHAR_BYTES_TABLE;
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
@@ -20,6 +21,121 @@ use std::{
 pub type Vocab = AHashMap<String, u32>;
 type VocabR = AHashMap<u32, String>;
 pub type MergeMap = AHashMap<Pair, (u32, u32)>;
+
+/// Pre-decoded token bytes packed into one contiguous buffer for zero-copy,
+/// O(1) decode lookups.
+///
+/// Instead of `Vec<Vec<u8>>` (one heap allocation per token, pointer chasing
+/// on every lookup), all decoded bytes are concatenated into a single buffer
+/// with an offset table for O(1) slicing.  For GPT-2 (~50K tokens, ~4 bytes
+/// avg), the flat layout is ~400KB (fits in L2) vs ~2.2MB scattered across
+/// heap with the nested-Vec layout.
+#[derive(Clone, PartialEq)]
+pub(crate) struct FlatVocabDecoded {
+    /// All tokens' decoded bytes concatenated end-to-end.
+    bytes: Vec<u8>,
+    /// `offsets[id]..offsets[id+1]` is the byte range for token `id`.
+    /// Length = vocab_size + 1 (sentinel entry at the end).
+    offsets: Vec<u32>,
+    /// Average decoded bytes per non-empty token, scaled by 256 for
+    /// fixed-point arithmetic.  Used for single-pass capacity estimate.
+    avg_bytes_x256: u32,
+}
+
+impl FlatVocabDecoded {
+    /// Look up the pre-decoded bytes for a token ID.
+    /// Returns `None` if the ID is out of range or the token has no decoded bytes.
+    #[inline]
+    pub(crate) fn get(&self, id: u32) -> Option<&[u8]> {
+        let idx = id as usize;
+        if idx + 1 >= self.offsets.len() {
+            return None;
+        }
+        let start = self.offsets[idx] as usize;
+        let end = self.offsets[idx + 1] as usize;
+        if start == end {
+            return None;
+        }
+        Some(&self.bytes[start..end])
+    }
+
+    /// Estimate output buffer capacity for `n` tokens based on average
+    /// bytes per token.  Adds ~10% headroom to avoid reallocation.
+    #[inline]
+    pub(crate) fn estimate_capacity(&self, n: usize) -> usize {
+        ((n as u64 * self.avg_bytes_x256 as u64 * 11) / (256 * 10)) as usize
+    }
+}
+
+/// Build the flat reverse vocabulary (token ID -> string) indexed by ID.
+/// Empty string at index `i` means no token with that ID exists.
+pub(crate) fn build_vocab_r_vec(vocab_r: &VocabR) -> Vec<String> {
+    let max_id = vocab_r.keys().max().copied().unwrap_or(0) as usize;
+    let mut vocab_r_vec = vec![String::new(); max_id + 1];
+    for (&id, token) in vocab_r {
+        vocab_r_vec[id as usize] = token.clone();
+    }
+    vocab_r_vec
+}
+
+/// Pre-compute decoded bytes for each entry in `vocab_r_vec` and pack them
+/// into a flat contiguous buffer.  Handles ByteLevel char->byte mapping
+/// and, when `byte_fallback` is true, `<0xHH>` -> single-byte decoding.
+///
+/// Tokens whose characters fall outside the ByteLevel range and are not
+/// ByteFallback tokens (e.g. Metaspace `▁`) are left as empty entries, so
+/// the fused decode path returns `None` for them and falls back to the
+/// regular decoder.
+pub(crate) fn build_vocab_decoded(vocab_r_vec: &[String], byte_fallback: bool) -> FlatVocabDecoded {
+    let table = &*CHAR_BYTES_TABLE;
+
+    let mut bytes = Vec::with_capacity(vocab_r_vec.len() * 4);
+    let mut offsets = Vec::with_capacity(vocab_r_vec.len() + 1);
+
+    for token in vocab_r_vec {
+        offsets.push(bytes.len() as u32);
+        if token.is_empty() {
+            continue;
+        }
+        // ByteFallback tokens like "<0x20>" must be checked first: their
+        // characters are printable ASCII that would pass the ByteLevel
+        // mapping, producing the 6-byte literal instead of the single
+        // decoded byte.
+        if byte_fallback && token.len() == 6 && token.starts_with("<0x") && token.ends_with('>') {
+            if let Ok(b) = u8::from_str_radix(&token[3..5], 16) {
+                bytes.push(b);
+                continue;
+            }
+        }
+        // Try ByteLevel char->byte mapping.
+        let start = bytes.len();
+        let mut all_mapped = true;
+        for c in token.chars() {
+            let idx = c as usize;
+            if let Some(&Some(b)) = table.get(idx) {
+                bytes.push(b);
+            } else {
+                all_mapped = false;
+                break;
+            }
+        }
+        if !all_mapped {
+            // Token needs runtime decoder processing (e.g. Metaspace).
+            // Leave an empty entry so the fused decode path falls back.
+            bytes.truncate(start);
+        }
+    }
+    offsets.push(bytes.len() as u32);
+
+    let non_empty = vocab_r_vec.iter().filter(|t| !t.is_empty()).count().max(1);
+    let avg_bytes_x256 = ((bytes.len() as u64 * 256) / non_empty as u64) as u32;
+
+    FlatVocabDecoded {
+        bytes,
+        offsets,
+        avg_bytes_x256,
+    }
+}
 
 /// Process-wide monotonic counter used to assign a unique generation id
 /// to every `BpeCache`, so per-instance thread-local caches never collide.
@@ -237,6 +353,8 @@ impl BpeBuilder {
                 (*val, key.to_owned())
             })
             .collect();
+        let vocab_r_vec = build_vocab_r_vec(&vocab_r);
+        let vocab_decoded = build_vocab_decoded(&vocab_r_vec, self.config.byte_fallback);
         let cache = match self.config.cache_capacity {
             0 => None,
             capacity => Some(BpeCache::new(capacity)),
@@ -279,6 +397,8 @@ impl BpeBuilder {
         Ok(BPE {
             vocab,
             vocab_r,
+            vocab_r_vec,
+            vocab_decoded,
             merges: merge_map,
             cache,
             dropout: self.config.dropout,
@@ -299,6 +419,11 @@ pub struct BPE {
     pub(crate) vocab: Vocab,
     /// Reversed vocabulary, to rebuild sentences.
     pub(crate) vocab_r: VocabR,
+    /// Flat reverse vocabulary indexed by token ID for O(1) decode lookups.
+    /// Empty string at index `i` means no token with that ID exists.
+    pub(crate) vocab_r_vec: Vec<String>,
+    /// Pre-decoded token bytes packed contiguously for zero-copy decode.
+    pub(crate) vocab_decoded: FlatVocabDecoded,
     /// Contains the mapping between Pairs and their (rank, new_id).
     pub(crate) merges: MergeMap,
     /// Contains the cache for optimizing the encoding step.
@@ -351,6 +476,8 @@ impl Clone for BPE {
         Self {
             vocab: self.vocab.clone(),
             vocab_r: self.vocab_r.clone(),
+            vocab_r_vec: self.vocab_r_vec.clone(),
+            vocab_decoded: self.vocab_decoded.clone(),
             merges: self.merges.clone(),
             cache: fresh_cache,
             dropout: self.dropout,
@@ -616,7 +743,18 @@ impl Model for BPE {
     }
 
     fn id_to_token(&self, id: u32) -> Option<String> {
-        self.vocab_r.get(&id).cloned()
+        self.vocab_r_vec
+            .get(id as usize)
+            .filter(|s| !s.is_empty())
+            .cloned()
+    }
+
+    fn id_to_decoded_bytes(&self, id: u32) -> Option<&[u8]> {
+        self.vocab_decoded.get(id)
+    }
+
+    fn estimate_decode_capacity(&self, n: usize) -> usize {
+        self.vocab_decoded.estimate_capacity(n)
     }
 
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>> {

--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -617,6 +617,9 @@ impl BpeTrainer {
             .iter()
             .map(|(key, val)| (*val, key.to_owned()))
             .collect();
+        model.vocab_r_vec = super::model::build_vocab_r_vec(&model.vocab_r);
+        model.vocab_decoded =
+            super::model::build_vocab_decoded(&model.vocab_r_vec, model.byte_fallback);
         model.merges = merges
             .into_iter()
             .enumerate()

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -170,6 +170,20 @@ impl Model for ModelWrapper {
         }
     }
 
+    fn id_to_decoded_bytes(&self, id: u32) -> Option<&[u8]> {
+        match self {
+            Self::BPE(t) => t.id_to_decoded_bytes(id),
+            _ => None,
+        }
+    }
+
+    fn estimate_decode_capacity(&self, n: usize) -> usize {
+        match self {
+            Self::BPE(t) => t.estimate_decode_capacity(n),
+            _ => 0,
+        }
+    }
+
     fn get_vocab(&self) -> HashMap<String, u32> {
         match self {
             Self::WordLevel(t) => t.get_vocab(),

--- a/tokenizers/src/normalizers/byte_level.rs
+++ b/tokenizers/src/normalizers/byte_level.rs
@@ -1,14 +1,11 @@
-use crate::processors::byte_level::bytes_char;
+use crate::processors::byte_level::BYTES_CHAR_TABLE;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
-use ahash::{AHashMap, AHashSet};
-use std::sync::LazyLock;
+use ahash::AHashSet;
 
 #[derive(Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct ByteLevel;
-
-static BYTES_CHAR: LazyLock<AHashMap<u8, char>> = LazyLock::new(bytes_char);
 
 impl Default for ByteLevel {
     fn default() -> Self {
@@ -22,7 +19,7 @@ impl ByteLevel {
     }
 
     pub fn alphabet() -> AHashSet<char> {
-        BYTES_CHAR.values().copied().collect()
+        BYTES_CHAR_TABLE.iter().copied().filter(|c| *c != '\0').collect()
     }
 }
 
@@ -38,7 +35,7 @@ impl Normalizer for ByteLevel {
                     s.as_bytes()[i..i + size]
                         .iter()
                         .enumerate()
-                        .map(|(i, b)| (BYTES_CHAR[b], isize::from(i > 0))),
+                        .map(|(i, b)| (BYTES_CHAR_TABLE[*b as usize], isize::from(i > 0))),
                 );
             }
             normalized.transform(transformations, 0);

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -44,9 +44,28 @@ static RE: LazyLock<SysRegex> = LazyLock::new(|| {
     SysRegex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+")
         .unwrap()
 });
-static BYTES_CHAR: LazyLock<AHashMap<u8, char>> = LazyLock::new(bytes_char);
-static CHAR_BYTES: LazyLock<AHashMap<char, u8>> =
-    LazyLock::new(|| bytes_char().into_iter().map(|(c, b)| (b, c)).collect());
+/// O(1) array lookup: byte → char (256 entries, no hashing).
+pub(crate) static BYTES_CHAR_TABLE: LazyLock<[char; 256]> = LazyLock::new(|| {
+    let map = bytes_char();
+    let mut table = ['\0'; 256];
+    for (b, c) in map {
+        table[b as usize] = c;
+    }
+    table
+});
+/// O(1) reverse lookup: char → Option<u8>. Chars used by byte-level
+/// encoding are in the range 0..512, so a 512-entry array covers all.
+pub(crate) static CHAR_BYTES_TABLE: LazyLock<[Option<u8>; 512]> = LazyLock::new(|| {
+    let map = bytes_char();
+    let mut table = [None; 512];
+    for (b, c) in map {
+        let idx = c as usize;
+        if idx < 512 {
+            table[idx] = Some(b);
+        }
+    }
+    table
+});
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// Provides all the necessary steps to handle the BPE tokenization at the byte-level. Takes care
@@ -91,7 +110,7 @@ impl ByteLevel {
     }
 
     pub fn alphabet() -> AHashSet<char> {
-        BYTES_CHAR.values().copied().collect()
+        BYTES_CHAR_TABLE.iter().copied().filter(|c| *c != '\0').collect()
     }
 
     #[must_use]
@@ -138,7 +157,7 @@ impl PreTokenizer for ByteLevel {
                     s.as_bytes()[i..i + size]
                         .iter()
                         .enumerate()
-                        .map(|(i, b)| (BYTES_CHAR[b], isize::from(i > 0))),
+                        .map(|(i, b)| (BYTES_CHAR_TABLE[*b as usize], isize::from(i > 0))),
                 );
             }
             normalized.transform(transformations, 0);
@@ -159,8 +178,16 @@ impl Decoder for ByteLevel {
             .flat_map(|t| {
                 t.chars()
                     .try_fold(vec![], |mut acc, c| {
-                        CHAR_BYTES.get(&c).map(|b| {
-                            acc.push(*b);
+                        {
+                            let idx = c as usize;
+                            if idx < 512 {
+                                CHAR_BYTES_TABLE[idx]
+                            } else {
+                                None
+                            }
+                        }
+                        .map(|b| {
+                            acc.push(b);
                             acc
                         })
                     })
@@ -201,14 +228,15 @@ impl PostProcessor for ByteLevel {
 
 pub fn process_offsets(encoding: &mut Encoding, add_prefix_space: bool) {
     encoding.process_tokens_with_offsets_mut(|(i, (token, offsets))| {
+        let space_char = BYTES_CHAR_TABLE[b' ' as usize];
         let mut leading_spaces = token
             .chars()
-            .take_while(|c| *c == BYTES_CHAR[&b' '] || c.is_whitespace())
+            .take_while(|c| *c == space_char || c.is_whitespace())
             .count();
         let trailing_spaces = token
             .chars()
             .rev()
-            .take_while(|c| *c == BYTES_CHAR[&b' '] || c.is_whitespace())
+            .take_while(|c| *c == space_char || c.is_whitespace())
             .count();
 
         if leading_spaces > 0 || trailing_spaces > 0 {

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -1005,18 +1005,40 @@ where
         let cap = self.model.estimate_decode_capacity(ids.len());
         let mut buf = Vec::with_capacity(if cap > 0 { cap } else { ids.len() * 4 });
 
-        for &id in ids {
+        let n = ids.len();
+        let mut i = 0;
+        while i < n {
+            let id = ids[i];
             if check_added {
                 if let Some(tok) = added.get(&id) {
                     if !(skip_special_tokens && self.added_vocabulary.is_special_token(&tok.content))
                     {
                         buf.extend_from_slice(tok.content.as_bytes());
                     }
+                    i += 1;
                     continue;
                 }
             }
             let bytes = self.model.id_to_decoded_bytes(id)?;
+
+            // Prefetch the decoded bytes of a token a few positions ahead to
+            // hide the latency of the scattered reads into the vocab_decoded
+            // blob. aarch64-only; a no-op elsewhere.
+            #[cfg(target_arch = "aarch64")]
+            if i + 4 < n {
+                if let Some(future) = self.model.id_to_decoded_bytes(ids[i + 4]) {
+                    unsafe {
+                        core::arch::asm!(
+                            "prfm pldl1keep, [{addr}]",
+                            addr = in(reg) future.as_ptr(),
+                            options(readonly, nostack)
+                        );
+                    }
+                }
+            }
+
             buf.extend_from_slice(bytes);
+            i += 1;
         }
 
         // Bytes come from `vocab_decoded` (built from valid token strings) or

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -76,6 +76,19 @@ pub trait Model {
     fn token_to_id(&self, token: &str) -> Option<u32>;
     /// Find the string token associated to an ID
     fn id_to_token(&self, id: u32) -> Option<String>;
+    /// Return the pre-decoded raw bytes for a token ID, if the model keeps a
+    /// pre-decoded byte table (e.g. byte-level BPE).  Enables the zero-copy
+    /// fused decode fast path.  The default returns `None`, so models without
+    /// such a table fall back to the regular decoder.
+    fn id_to_decoded_bytes(&self, _id: u32) -> Option<&[u8]> {
+        None
+    }
+    /// Estimate the output byte capacity needed to decode `n` tokens.
+    /// Used to size the fused decode buffer in a single allocation.
+    /// The default returns 0 (caller uses a heuristic).
+    fn estimate_decode_capacity(&self, _n: usize) -> usize {
+        0
+    }
     /// Retrieve the entire vocabulary mapping (token -> ID)
     fn get_vocab(&self) -> HashMap<String, u32>;
     /// Retrieve the size of the vocabulary

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -946,6 +946,10 @@ where
 
     /// Decode the given ids, back to a String
     pub fn decode(&self, ids: &[u32], skip_special_tokens: bool) -> Result<String> {
+        if let Some(result) = self.decode_fused(ids, skip_special_tokens) {
+            return result;
+        }
+
         let tokens = ids
             .iter()
             .filter_map(|id| {
@@ -963,6 +967,65 @@ where
         } else {
             Ok(tokens.join(" "))
         }
+    }
+
+    /// Fused decode fast path: single-pass direct write into one output buffer.
+    ///
+    /// For models that expose pre-decoded token bytes (byte-level BPE), each
+    /// token's bytes are a zero-copy `&[u8]` slice into the model's contiguous
+    /// `vocab_decoded` blob; they are concatenated into a single reused buffer
+    /// and validated as UTF-8 once at the end -- no per-token `String` alloc,
+    /// no intermediate `Vec<String>`, no `join`.
+    ///
+    /// Returns `None` (so `decode` uses the regular decoder path) when there is
+    /// no decoder, when the model keeps no pre-decoded byte table, or when any
+    /// token has no pre-decoded bytes -- e.g. Metaspace tokens, which
+    /// `build_vocab_decoded` deliberately leaves empty so the decoder can
+    /// process them correctly.
+    fn decode_fused(&self, ids: &[u32], skip_special_tokens: bool) -> Option<Result<String>> {
+        self.decoder.as_ref()?;
+
+        // Cheap gate: models with no pre-decoded byte table (Unigram,
+        // WordPiece, WordLevel) can never take this fast path. Bail out
+        // before doing any O(n) work so their decode is not slowed down by
+        // a fused attempt that would fail on the first token anyway.
+        if self.model.estimate_decode_capacity(ids.len()) == 0 {
+            return None;
+        }
+
+        let added = self.added_vocabulary.get_added_tokens_decoder();
+
+        // Skip the per-token added-vocab check entirely when every added-vocab
+        // ID is above the max input ID (common: encoded text IDs are below the
+        // added-vocab range). One min/max scan replaces N HashMap probes.
+        let min_added_id = added.keys().min().copied().unwrap_or(u32::MAX);
+        let max_input_id = ids.iter().max().copied().unwrap_or(0);
+        let check_added = !added.is_empty() && max_input_id >= min_added_id;
+
+        let cap = self.model.estimate_decode_capacity(ids.len());
+        let mut buf = Vec::with_capacity(if cap > 0 { cap } else { ids.len() * 4 });
+
+        for &id in ids {
+            if check_added {
+                if let Some(tok) = added.get(&id) {
+                    if !(skip_special_tokens && self.added_vocabulary.is_special_token(&tok.content))
+                    {
+                        buf.extend_from_slice(tok.content.as_bytes());
+                    }
+                    continue;
+                }
+            }
+            let bytes = self.model.id_to_decoded_bytes(id)?;
+            buf.extend_from_slice(bytes);
+        }
+
+        // Bytes come from `vocab_decoded` (built from valid token strings) or
+        // added-vocab content (valid Strings). Pre-decoded byte_fallback tokens
+        // can form partial UTF-8 sequences, so validate with from_utf8
+        // (zero-copy, reuses the buffer on success) and fall back to
+        // from_utf8_lossy for incomplete sequences.
+        Some(Ok(String::from_utf8(buf)
+            .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())))
     }
 
     /// Decode the given ids, back to a String


### PR DESCRIPTION
Brings de-tokenization single thread performance up on arm64 and x86_64.

The change is the sum of 4 separate patches:
- byte-level: O(1) array lookups for byte<->char maps
- BPE: flat reverse-vocab + contiguous pre-decoded byte blob for O(1) decode
- decode: fused single-buffer zero-copy fast path
- decode: prefetch vocab_decoded bytes on aarch64 (optional)

Perf (single-thread decode, taskset-pinned core, origin/main -> this series):
```
byte-level decode       llama3-en (English)    llama3-ja (CJK)
NVIDIA Vera (Olympus)   49.9 -> 109 MiB/s      48.5 -> 434 MiB/s   (2.2x / 9.0x)
Intel Granite Rapids    38.2 ->  75 MiB/s      41.5 -> 259 MiB/s   (2.0x / 6.3x)
AMD Turin 96c  (9655P)  56.2 -> 102 MiB/s      57.5 -> 344 MiB/s   (1.8x / 6.0x)
AMD Turin 128c (9575F)  61.7 -> 113 MiB/s      63.3 -> 383 MiB/s   (1.8x / 6.1x)
```