### PR TITLE
ci: maintain pipeline-bench report in PR description + comment reactions

### DIFF
--- a/.github/scripts/upsert_pr_section.py
+++ b/.github/scripts/upsert_pr_section.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Insert or replace the pipeline-bench section in a PR body.
+
+Usage: upsert_pr_section.py <current_body_file> <section_file>
+
+Reads the current PR body and the rendered benchmark markdown, then writes an
+updated body to stdout with the benchmark wrapped in a marker-delimited block.
+Replaces the block in place if the markers are already present, otherwise
+appends it — so the maintainer's own description is never clobbered.
+"""
+import re
+import sys
+
+START = "<!-- pipeline-bench:start -->"
+END = "<!-- pipeline-bench:end -->"
+
+
+def main():
+    body = open(sys.argv[1]).read()
+    section = open(sys.argv[2]).read().strip()
+    block = f"{START}\n{section}\n{END}"
+    pattern = re.compile(re.escape(START) + r".*?" + re.escape(END), re.DOTALL)
+    if pattern.search(body):
+        updated = pattern.sub(lambda _: block, body)
+    elif body.strip():
+        updated = f"{body.rstrip()}\n\n{block}\n"
+    else:
+        updated = f"{block}\n"
+    sys.stdout.write(updated)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pipeline-bench-trigger.yml
+++ b/.github/workflows/pipeline-bench-trigger.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   actions: write
   checks: write
+  issues: write
   pull-requests: read
 
 jobs:
@@ -27,6 +28,17 @@ jobs:
        github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     steps:
+      # Immediate feedback that the command was seen; the bench workflow adds
+      # 👍 on success when it finishes.
+      - name: Acknowledge with 👀
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api "repos/$REPOSITORY/issues/comments/$COMMENT_ID/reactions" \
+            -X POST -f "content=eyes"
+
       - name: Get PR info
         id: pr
         env:
@@ -67,4 +79,5 @@ jobs:
             --ref "${{ steps.pr.outputs.head_ref }}" \
             -f pr_number="${{ steps.pr.outputs.pr_number }}" \
             -f check_run_id="${{ steps.check.outputs.check_id }}" \
-            -f head_sha="${{ steps.pr.outputs.head_sha }}"
+            -f head_sha="${{ steps.pr.outputs.head_sha }}" \
+            -f comment_id="${{ github.event.comment.id }}"

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -5,8 +5,10 @@ name: Pipeline Benchmark
 # scripts + English + code/math/agentic modalities) on ~10 kB inputs — the
 # regime where per-input overhead is amortized.
 #
-# Runs on pushes to the base branch, and on demand: comment "/pipeline-bench"
-# on a PR (see pipeline-bench-trigger.yml) or dispatch manually.
+# Runs on pushes to feat/train_encode_split (updating PR #2119's description),
+# and on demand: comment "/pipeline-bench" on any PR (see
+# pipeline-bench-trigger.yml) or dispatch manually. Either way it maintains a
+# benchmark section (graph + table) in the target PR's description.
 
 on:
   push:
@@ -19,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to post the report comment to (optional)"
+        description: "PR number whose description gets the benchmark section (optional)"
         required: false
         type: string
       check_run_id:
@@ -30,11 +32,24 @@ on:
         description: "PR head SHA for the check run (set by pipeline-bench-trigger)"
         required: false
         type: string
+      comment_id:
+        description: "Trigger comment ID to react to on success (set by pipeline-bench-trigger)"
+        required: false
+        type: string
 
 permissions:
   contents: read
   checks: write
+  issues: write
   pull-requests: write
+
+# One live run per target. github.ref is the branch for both entrypoints:
+# feat/train_encode_split on push, the PR's head branch on /pipeline-bench
+# dispatch — so a newer commit/comment supersedes an in-flight bench for the
+# same target, but runs for different PRs never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   RUSTC_WRAPPER: sccache
@@ -119,20 +134,26 @@ jobs:
       - name: Write step summary
         run: cat pipeline_bench.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Post report to PR
-        if: inputs.pr_number != ''
+      # Maintain a marker-delimited benchmark section in the PR *description*
+      # rather than a comment — one always-current graph instead of comment
+      # spam. upsert_pr_section.py replaces the block in place if present, else
+      # appends it, so the author's own description is preserved.
+      # On /pipeline-bench dispatch the PR number is passed in; on pushes to
+      # feat/train_encode_split it defaults to #2119, the tracking PR for that
+      # branch (retire this default when #2119 lands).
+      - name: Update PR description
+        if: inputs.pr_number != '' || github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          existing=$(gh api "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
-            --jq '.[] | select(.body | startswith("## PipelineTokenizer benchmark")) | .id' | head -1)
-          if [ -n "$existing" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/$existing" \
-              -X PATCH -F "body=@pipeline_bench.md"
-          else
-            gh api "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
-              -F "body=@pipeline_bench.md"
-          fi
+          pr="${{ inputs.pr_number }}"
+          pr="${pr:-2119}"
+          gh api "repos/${{ github.repository }}/pulls/$pr" \
+            --jq '.body // ""' > pr_body.md
+          python3 ${{ github.workspace }}/.github/scripts/upsert_pr_section.py \
+            pr_body.md pipeline_bench.md > pr_body_new.md
+          gh api "repos/${{ github.repository }}/pulls/$pr" \
+            -X PATCH -F "body=@pr_body_new.md"
 
       # Broadest correctness net we have: id-equality across every script and
       # modality. A divergence is a bug even when the speedup looks great.
@@ -143,6 +164,17 @@ jobs:
           bad = [r['fixture'] for r in json.load(open('pipeline_bench.json')) if not r['ids_match']]
           sys.exit(f'ids diverge on: {bad}' if bad else 0)
           "
+
+      # 👍 the trigger comment once the bench has run and ids match. Gated on
+      # success() so a failing run leaves only the 👀 — the check run carries
+      # the failure detail.
+      - name: React 👍 on success
+        if: success() && inputs.comment_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/comments/${{ inputs.comment_id }}/reactions" \
+            -X POST -f "content=+1"
 
       - name: Complete check run
         if: always() && inputs.check_run_id != ''


### PR DESCRIPTION
Move the Tokenizer-vs-PipelineTokenizer report out of a PR comment and into a marker-delimited section of the PR description, kept current in place (upsert_pr_section.py). Pushes to feat/train_encode_split now target PR #2119; /pipeline-bench dispatch targets its own PR.

Add emoji feedback to the comment-triggered flow: 👀 when the trigger fires, 👍 from the bench workflow on success. Add a cancel-in-progress concurrency group keyed on github.ref so a newer commit/comment supersedes an in-flight run for the same target without cancelling other PRs' benches.