### PR TITLE
ci: run benches on more tokenizers

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python3
-"""Render the multi-model fixture_bench JSON as a grid of per-model SVG cards
-+ a markdown report for a PR description.
+"""Render the multi-model fixture_bench JSON as full-size per-model charts +
+a markdown report for a PR description.
 
 Input: JSON array from `cargo run --release -p tk-encode --example fixture_bench`,
 one object per model:
-    {model, repo, shape, supported, [reason], results: [{fixture, group,
+    {model, shape, supported, [reason], results: [{fixture, group,
      legacy_mbps, pipeline_mbps, speedup, ids_match}, ...]}
 
-Each model becomes one fixed-size card (light + dark SVG):
-  • supported  → a diverging bar chart of per-fixture speedup (log2 around ×1.0):
-                 blue = PipelineTokenizer faster, red = slower.
-  • unsupported → a "not supported yet" placeholder showing the pipeline shape.
-All cards share one x-scale (comparable) and one height (a tidy grid). The
-markdown lays them out two-per-row and links each to its uploaded PNG.
+Each supported model gets a full-size diverging bar chart (log2 around ×1.0):
+per-fixture ×speedup + the `MB/s: Tokenizer → Pipeline` throughput column, with
+group headers, slower/faster hints, ticks and an inline "⚠ ids differ" flag.
+Unsupported models (byte-level BPE, Unigram/Metaspace, …) get a compact
+"not supported" card. Charts are rendered full-size so readers can zoom.
 """
 import argparse
 import json
@@ -39,21 +38,11 @@ INK = {
     },
 }
 FONT = "-apple-system,'Segoe UI',Helvetica,Arial,sans-serif"
-TICKS = [0.5, 0.67, 0.8, 1.0, 1.25, 1.5, 2.0, 3.0]
+GUTTER, PLOT_W, PAD_R, COL_W, ROW_H, BAR_H = 150, 540, 110, 150, 26, 16
+CHART_W = GUTTER + PLOT_W + PAD_R + COL_W
+TICKS = [0.5, 0.67, 0.75, 0.8, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0, 5.0]
 GROUPS = [("lang", "Languages"), ("modalities", "Modalities")]
-
-CARD_W = 470
-PAD = 16
-HEADER_H = 56
-GROUP_H = 22
-ROW_H = 17
-BAR_H = 10
-AXIS_H = 28
-LABEL_R = PAD + 94          # right edge of fixture labels
-PLOT_L = LABEL_R + 10       # bars start here
-VAL_W = 62                  # room for the ×value label
-PLOT_R = CARD_W - PAD - VAL_W
-PLOT_W = PLOT_R - PLOT_L
+CARD_W, CARD_H = 470, 150
 
 
 def slugify(name):
@@ -65,6 +54,7 @@ def geomean(values):
 
 
 def bar_path(x0, x1, y, h, r):
+    # square at the baseline (x0), rounded at the data end (x1)
     left, right = min(x0, x1), max(x0, x1)
     r = min(r, (right - left) / 2, h / 2)
     if x1 >= x0:
@@ -74,188 +64,115 @@ def bar_path(x0, x1, y, h, r):
             f"V{y + h - r:.1f} q0,{r:.1f} {r:.1f},{r:.1f} H{right:.1f} Z")
 
 
-def layout_of(models):
-    """Ordered {group: fixture_count} from the first model that has results."""
-    for m in models:
-        if m["results"]:
-            counts = {}
-            for r in m["results"]:
-                counts[r["group"]] = counts.get(r["group"], 0) + 1
-            return counts
-    return {}
-
-
-def body_height(layout):
-    h = sum(GROUP_H + layout[k] * ROW_H for k, _ in GROUPS if layout.get(k))
-    return (h + AXIS_H) if h else 180
-
-
 def scale(models):
-    """Shared log2 x-range across every supported fixture speedup."""
+    """Shared log2 x-range across every supported fixture speedup, so charts
+    for different models are directly comparable."""
     vals = [r["speedup"] for m in models if m["supported"] for r in m["results"]]
     if not vals:
         return 0.75, 1.5
-    lo = min(0.75, min(vals) / 1.08)
-    hi = max(1.5, max(vals) * 1.08)
-    return lo, hi
+    return min(0.75, min(vals) / 1.08), max(1.5, max(vals) * 1.08)
 
 
-def card_svg(model, mode, lo, hi, card_h):
+def chart_svg(model, mode, subtitle_base, meta, lo, hi):
+    """Full-size per-fixture speedup chart for a supported model."""
     ink = INK[mode]
-    b = [f'<rect x="0.5" y="0.5" width="{CARD_W - 1}" height="{card_h - 1}" rx="10" '
-         f'fill="{ink["card"]}" stroke="{ink["border"]}" stroke-width="1"/>']
-
-    # ── header ──────────────────────────────────────────────────────────
-    b.append(f'<text x="{PAD}" y="26" fill="{ink["primary"]}" font-size="15" '
-             f'font-weight="700">{escape(model["model"])}</text>')
-    b.append(f'<text x="{PAD}" y="44" fill="{ink["muted"]}" font-size="11.5">'
-             f'{escape(model["shape"])}</text>')
-
-    if model["supported"]:
-        rows = model["results"]
-        g = geomean([r["speedup"] for r in rows])
-        gc = ink["faster"] if g >= 1 else ink["slower"]
-        b.append(f'<text x="{CARD_W - PAD}" y="24" fill="{gc}" font-size="19" '
-                 f'font-weight="700" text-anchor="end" '
-                 f'style="font-variant-numeric:tabular-nums">×{g:.2f}</text>')
-        b.append(f'<text x="{CARD_W - PAD}" y="42" fill="{ink["muted"]}" font-size="10.5" '
-                 f'text-anchor="end">geomean</text>')
-    else:
-        pill_w = 96
-        b.append(f'<rect x="{CARD_W - PAD - pill_w}" y="11" width="{pill_w}" height="19" rx="9.5" '
-                 f'fill="none" stroke="{ink["border"]}" stroke-width="1"/>')
-        b.append(f'<text x="{CARD_W - PAD - pill_w / 2}" y="24" fill="{ink["muted"]}" '
-                 f'font-size="11" text-anchor="middle">not supported</text>')
-
-    b.append(f'<line x1="{PAD}" y1="{HEADER_H - 8}" x2="{CARD_W - PAD}" y2="{HEADER_H - 8}" '
-             f'stroke="{ink["grid"]}" stroke-width="1"/>')
-
-    # ── unsupported placeholder (compact card) ──────────────────────────
-    if not model["supported"]:
-        pretok = model["shape"].split("·")[-1].strip()
-        cy = HEADER_H + (card_h - HEADER_H) / 2
-        b.append(f'<text x="{CARD_W / 2}" y="{cy - 2}" fill="{ink["secondary"]}" font-size="12.5" '
-                 f'font-weight="600" text-anchor="middle">Not benchmarked yet</text>')
-        b.append(f'<text x="{CARD_W / 2}" y="{cy + 16}" fill="{ink["muted"]}" font-size="11.5" '
-                 f'text-anchor="middle">PipelineTokenizer has no <tspan font-weight="600">'
-                 f'{escape(pretok)}</tspan> pre-tokenizer</text>')
-        return "".join(b)
-
-    # ── supported: diverging bars ───────────────────────────────────────
-    def x(v):
-        return PLOT_L + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * PLOT_W
-
+    rows = model["results"]
     ticks = [t for t in TICKS if lo <= t <= hi]
-    body_top = HEADER_H + 6
-    y = body_top
+
+    def x(v):
+        return GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * PLOT_W
+
+    top = 74
+    col_x = GUTTER + PLOT_W + PAD_R + COL_W - 16
+    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+            f'text-anchor="end">MB/s: Tokenizer → Pipeline</text>']
+    y = top
     for key, title in GROUPS:
-        group_rows = sorted((r for r in model["results"] if r["group"] == key),
+        group_rows = sorted((r for r in rows if r["group"] == key),
                             key=lambda r: -r["speedup"])
         if not group_rows:
             continue
-        b.append(f'<text x="{LABEL_R}" y="{y + 13}" fill="{ink["secondary"]}" font-size="10" '
-                 f'font-weight="700" letter-spacing="1.1" text-anchor="end">{title.upper()}</text>')
-        y += GROUP_H
+        body.append(f'<text x="{GUTTER}" y="{y + 12}" fill="{ink["secondary"]}" font-size="11" '
+                    f'font-weight="600" letter-spacing="1.2" text-anchor="end" dx="-10">{title.upper()}</text>')
+        y += 22
         for r in group_rows:
             v, x0, x1 = r["speedup"], x(1.0), x(r["speedup"])
-            if abs(math.log2(v)) < math.log2(1.02):
+            if abs(math.log2(v)) < math.log2(1.02):  # within noise of the baseline
                 color = ink["muted"]
             else:
                 color = ink["faster"] if v >= 1 else ink["slower"]
             by = y + (ROW_H - BAR_H) / 2
-            b.append(f'<text x="{LABEL_R}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
-                     f'font-size="11.5" text-anchor="end">{escape(r["fixture"])}</text>')
+            body.append(f'<text x="{GUTTER - 10}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
+                        f'font-size="12.5" text-anchor="end">{escape(r["fixture"])}</text>')
             if abs(x1 - x0) < 1.5:
-                b.append(f'<rect x="{min(x0, x1):.1f}" y="{by}" width="1.5" height="{BAR_H}" fill="{color}"/>')
+                body.append(f'<rect x="{min(x0, x1):.1f}" y="{by}" width="1.5" height="{BAR_H}" fill="{color}"/>')
             else:
-                b.append(f'<path d="{bar_path(x0, x1, by, BAR_H, 3)}" fill="{color}"/>')
+                body.append(f'<path d="{bar_path(x0, x1, by, BAR_H, 4)}" fill="{color}"/>')
             label = f"×{v:.2f}"
-            anchor, lx = ("start", max(x0, x1) + 5) if v >= 1 else ("end", min(x0, x1) - 5)
-            fill = ink["primary"] if r["ids_match"] else ink["critical"]
+            anchor, lx = ("start", max(x0, x1) + 6) if v >= 1 else ("end", min(x0, x1) - 6)
             if not r["ids_match"]:
-                label += " ⚠"
-            b.append(f'<text x="{lx:.1f}" y="{y + ROW_H / 2 + 4}" fill="{fill}" font-size="11" '
-                     f'font-weight="600" text-anchor="{anchor}" '
-                     f'style="font-variant-numeric:tabular-nums">{label}</text>')
+                label += "  ⚠ ids differ"
+            fill = ink["primary"] if r["ids_match"] else ink["critical"]
+            body.append(f'<text x="{lx:.1f}" y="{y + ROW_H / 2 + 4}" fill="{fill}" font-size="12" '
+                        f'font-weight="600" text-anchor="{anchor}" '
+                        f'style="font-variant-numeric:tabular-nums">{label}</text>')
+            body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
+                        f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
+                        f'{r["legacy_mbps"]:.1f} → {r["pipeline_mbps"]:.1f}</text>')
             y += ROW_H
-        y += 4
+        y += 10
 
-    axis_bottom = y
+    height = y + 34
     grid = []
     for t in ticks:
         strong = t == 1.0
-        grid.append(f'<line x1="{x(t):.1f}" y1="{body_top}" x2="{x(t):.1f}" y2="{axis_bottom}" '
-                    f'stroke="{ink["baseline"] if strong else ink["grid"]}" '
-                    f'stroke-width="1"{"" if strong else ""}/>')
-        grid.append(f'<text x="{x(t):.1f}" y="{axis_bottom + 15}" fill="{ink["muted"]}" font-size="10" '
+        grid.append(f'<line x1="{x(t):.1f}" y1="{top - 6}" x2="{x(t):.1f}" y2="{y - 6}" '
+                    f'stroke="{ink["baseline"] if strong else ink["grid"]}" stroke-width="1"/>')
+        grid.append(f'<text x="{x(t):.1f}" y="{y + 12}" fill="{ink["muted"]}" font-size="11" '
                     f'text-anchor="middle" style="font-variant-numeric:tabular-nums">×{t:g}</text>')
-    # frame (b[0]) first, gridlines behind the bars/labels (b[1:])
-    return b[0] + "".join(grid) + "".join(b[1:])
+    hints = (f'<text x="{x(1.0) - 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+             f'text-anchor="end">← slower</text>'
+             f'<text x="{x(1.0) + 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+             f'text-anchor="start">faster →</text>')
+
+    g = geomean([r["speedup"] for r in rows])
+    subtitle = f'{model["shape"]} · geomean ×{g:.2f} · {subtitle_base}'
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{CHART_W}" height="{height}"
+  viewBox="0 0 {CHART_W} {height}" font-family="{FONT}">
+<rect width="{CHART_W}" height="{height}" fill="{ink["surface"]}"/>
+<text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="700">{escape(model["model"])} — Pipeline vs Tokenizer encode throughput</text>
+<text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
+<text x="{CHART_W - 16}" y="26" fill="{ink["muted"]}" font-size="11" text-anchor="end"
+  style="font-variant-numeric:tabular-nums">{escape(meta[0])}</text>
+<text x="{CHART_W - 16}" y="44" fill="{ink["muted"]}" font-size="11" text-anchor="end">{escape(meta[1])}</text>
+{"".join(grid)}
+{hints}
+{"".join(body)}
+</svg>'''
 
 
-def wrap_svg(inner, card_h):
-    return (f'<svg xmlns="http://www.w3.org/2000/svg" width="{CARD_W}" height="{card_h}" '
-            f'viewBox="0 0 {CARD_W} {card_h}" font-family="{FONT}">{inner}</svg>')
-
-
-def img_url(base, run_id, slug, mode):
-    if base:
-        return f"{base}/pipeline-{run_id}-{slug}-{mode}.png"
-    return f"pipeline_bench_{slug}_{mode}.png"
-
-
-def render_markdown(models, subtitle, meta, base, run_id):
-    supported = [m for m in models if m["supported"]]
-    ordered = supported + [m for m in models if not m["supported"]]
-    mismatches = [f"{m['model']}/{r['fixture']}"
-                  for m in supported for r in m["results"] if not r["ids_match"]]
-
-    md = ["## PipelineTokenizer benchmark", ""]
-    head = f"**{len(supported)} / {len(models)} models supported**"
-    if supported:
-        g = geomean([r["speedup"] for m in supported for r in m["results"]])
-        nfix = len(supported[0]["results"])
-        head += f" · geomean ×{g:.2f} across supported · {nfix} fixtures each"
-    md += [f"{head} — {subtitle}", "", f"`{meta[0]}` · {meta[1]}", ""]
-
-    unsupported = [m for m in models if not m["supported"]]
-    if unsupported:
-        items = ", ".join(f"`{m['model']}` ({m['shape']})" for m in unsupported)
-        md += [f"> **Not yet supported:** {items} — shown as roadmap cards below.", ""]
-    if mismatches:
-        md += [f"> ⚠️ **Token ids diverge from the reference on: {', '.join(mismatches)}** "
-               f"— speedups there are meaningless until fixed.", ""]
-
-    # two-per-row grid of picture embeds
-    md.append("<table>")
-    for i in range(0, len(ordered), 2):
-        md.append("<tr>")
-        for m in ordered[i:i + 2]:
-            slug = slugify(m["model"])
-            light = img_url(base, run_id, slug, "light")
-            dark = img_url(base, run_id, slug, "dark")
-            md += ['<td align="center" valign="top">',
-                   "<picture>",
-                   f'  <source media="(prefers-color-scheme: dark)" srcset="{dark}">',
-                   f'  <img alt="{escape(m["model"])} speedup" src="{light}" width="430">',
-                   "</picture>",
-                   "</td>"]
-        md.append("</tr>")
-    md += ["</table>", ""]
-
-    if supported:
-        md += ["<details><summary>Per-fixture results (supported models)</summary>", ""]
-        for m in supported:
-            md += [f"#### {m['model']} — {m['shape']}", "",
-                   "| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |",
-                   "|---|---|---:|---:|---:|:--|"]
-            for r in sorted(m["results"], key=lambda r: (r["group"], -r["speedup"])):
-                ids = "match" if r["ids_match"] else "⚠️ differ"
-                md.append(f"| {r['fixture']} | {r['group']} | {r['legacy_mbps']:.1f} "
-                          f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} | {ids} |")
-            md.append("")
-        md += ["</details>", ""]
-    return "\n".join(md)
+def card_svg(model, mode):
+    """Compact 'not supported' card for a model the pipeline can't build."""
+    ink = INK[mode]
+    pretok = model["shape"].split("·")[-1].strip()
+    header = 54
+    b = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{CARD_W}" height="{CARD_H}" '
+         f'viewBox="0 0 {CARD_W} {CARD_H}" font-family="{FONT}">',
+         f'<rect x="0.5" y="0.5" width="{CARD_W - 1}" height="{CARD_H - 1}" rx="10" '
+         f'fill="{ink["card"]}" stroke="{ink["border"]}" stroke-width="1"/>',
+         f'<text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="700">{escape(model["model"])}</text>',
+         f'<text x="16" y="44" fill="{ink["muted"]}" font-size="11.5">{escape(model["shape"])}</text>',
+         f'<rect x="{CARD_W - 16 - 96}" y="11" width="96" height="19" rx="9.5" fill="none" '
+         f'stroke="{ink["border"]}" stroke-width="1"/>',
+         f'<text x="{CARD_W - 16 - 48}" y="24" fill="{ink["muted"]}" font-size="11" '
+         f'text-anchor="middle">not supported</text>',
+         f'<line x1="16" y1="{header - 8}" x2="{CARD_W - 16}" y2="{header - 8}" stroke="{ink["grid"]}" stroke-width="1"/>',
+         f'<text x="{CARD_W / 2}" y="{(CARD_H + header) / 2 - 2}" fill="{ink["secondary"]}" font-size="12.5" '
+         f'font-weight="600" text-anchor="middle">Not benchmarked yet</text>',
+         f'<text x="{CARD_W / 2}" y="{(CARD_H + header) / 2 + 16}" fill="{ink["muted"]}" font-size="11.5" '
+         f'text-anchor="middle">PipelineTokenizer has no <tspan font-weight="600">{escape(pretok)}</tspan> pre-tokenizer</text>',
+         "</svg>"]
+    return "".join(b)
 
 
 def detect_hardware():
@@ -271,6 +188,72 @@ def detect_hardware():
             import platform
             cpu = platform.processor() or platform.machine() or "unknown cpu"
     return f"{cpu} · {os.cpu_count()} cores"
+
+
+def img_url(base, run_id, slug, mode):
+    if base:
+        return f"{base}/pipeline-{run_id}-{slug}-{mode}.png"
+    return f"pipeline_bench_{slug}_{mode}.png"
+
+
+def picture(base, run_id, slug, alt, width):
+    return "\n".join([
+        "<picture>",
+        f'  <source media="(prefers-color-scheme: dark)" srcset="{img_url(base, run_id, slug, "dark")}">',
+        f'  <img alt="{escape(alt)}" src="{img_url(base, run_id, slug, "light")}" width="{width}">',
+        "</picture>"])
+
+
+def render_markdown(models, subtitle_base, meta, base, run_id):
+    supported = [m for m in models if m["supported"]]
+    unsupported = [m for m in models if not m["supported"]]
+    mismatches = [f"{m['model']}/{r['fixture']}"
+                  for m in supported for r in m["results"] if not r["ids_match"]]
+
+    md = ["## PipelineTokenizer benchmark", ""]
+    head = f"**{len(supported)} / {len(models)} models supported**"
+    if supported:
+        g = geomean([r["speedup"] for m in supported for r in m["results"]])
+        nfix = len(supported[0]["results"])
+        head += f" · geomean ×{g:.2f} across supported · {nfix} fixtures each"
+    md += [f"{head} — {subtitle_base}", "", f"`{meta[0]}` · {meta[1]}", ""]
+
+    if unsupported:
+        items = ", ".join(f"`{m['model']}` ({m['shape']})" for m in unsupported)
+        md += [f"> **Not yet supported:** {items} — roadmap cards below.", ""]
+    if mismatches:
+        md += [f"> ⚠️ **Token ids diverge from the reference on: {', '.join(mismatches)}** "
+               f"— speedups there are meaningless until fixed.", ""]
+
+    # Supported models: full-size chart each (readable inline, click to zoom).
+    for m in supported:
+        md += [picture(base, run_id, slugify(m["model"]), f"{m['model']} speedup", 860), ""]
+
+    # Unsupported models: compact roadmap cards, two per row.
+    if unsupported:
+        md += ["### Not yet supported", "", "<table>"]
+        for i in range(0, len(unsupported), 2):
+            md.append("<tr>")
+            for m in unsupported[i:i + 2]:
+                md += ['<td align="center" valign="top">',
+                       picture(base, run_id, slugify(m["model"]), f"{m['model']} not supported", 420),
+                       "</td>"]
+            md.append("</tr>")
+        md += ["</table>", ""]
+
+    if supported:
+        md += ["<details><summary>Per-fixture results</summary>", ""]
+        for m in supported:
+            md += [f"#### {m['model']} — {m['shape']}", "",
+                   "| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |",
+                   "|---|---|---:|---:|---:|:--|"]
+            for r in sorted(m["results"], key=lambda r: (r["group"], -r["speedup"])):
+                ids = "match" if r["ids_match"] else "⚠️ differ"
+                md.append(f"| {r['fixture']} | {r['group']} | {r['legacy_mbps']:.1f} "
+                          f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} | {ids} |")
+            md.append("")
+        md += ["</details>", ""]
+    return "\n".join(md)
 
 
 def main():
@@ -295,15 +278,12 @@ def main():
 
     models = json.loads(Path(args.results).read_text())
     lo, hi = scale(models)
-    tall_h = HEADER_H + body_height(layout_of(models)) + PAD
-    mini_h = HEADER_H + 62
-
     out = Path(args.out_dir)
     for m in models:
         slug = slugify(m["model"])
-        h = tall_h if m["supported"] else mini_h
         for mode in ("light", "dark"):
-            svg = wrap_svg(card_svg(m, mode, lo, hi, h), h)
+            svg = (chart_svg(m, mode, args.subtitle, meta, lo, hi)
+                   if m["supported"] else card_svg(m, mode))
             (out / f"pipeline_bench_{slug}_{mode}.svg").write_text(svg)
 
     (out / "pipeline_bench.md").write_text(
@@ -311,8 +291,7 @@ def main():
 
     supported = [m for m in models if m["supported"]]
     g = geomean([r["speedup"] for m in supported for r in m["results"]]) if supported else 0
-    print(f"{len(supported)}/{len(models)} supported, geomean x{g:.3f}, "
-          f"cards {CARD_W}x{tall_h} / {CARD_W}x{mini_h}")
+    print(f"{len(supported)}/{len(models)} supported, geomean x{g:.3f}")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
-"""Render the fixture_bench JSON comparison as an SVG chart + markdown report.
+"""Render the multi-model fixture_bench JSON as a grid of per-model SVG cards
++ a markdown report for a PR description.
 
-Input: JSON array from `cargo run --release -p tk-encode --example fixture_bench`
-(one row per fixture: legacy_mbps, pipeline_mbps, speedup, ids_match).
+Input: JSON array from `cargo run --release -p tk-encode --example fixture_bench`,
+one object per model:
+    {model, repo, shape, supported, [reason], results: [{fixture, group,
+     legacy_mbps, pipeline_mbps, speedup, ids_match}, ...]}
 
-The chart is a diverging horizontal bar chart of per-fixture speedup on a log2
-scale around the x1.0 baseline: blue = PipelineTokenizer faster, red = slower.
-Colors follow the validated reference palette (light + dark variants).
+Each model becomes one fixed-size card (light + dark SVG):
+  • supported  → a diverging bar chart of per-fixture speedup (log2 around ×1.0):
+                 blue = PipelineTokenizer faster, red = slower.
+  • unsupported → a "not supported yet" placeholder showing the pipeline shape.
+All cards share one x-scale (comparable) and one height (a tidy grid). The
+markdown lays them out two-per-row and links each to its uploaded PNG.
 """
 import argparse
 import json
 import math
 import os
+import re
 import subprocess
 from datetime import datetime, timezone
 from html import escape
@@ -19,20 +26,38 @@ from pathlib import Path
 
 INK = {
     "light": {
-        "surface": "#fcfcfb", "primary": "#0b0b0b", "secondary": "#52514e",
-        "muted": "#898781", "grid": "#e1e0d9", "baseline": "#c3c2b7",
+        "surface": "#fcfcfb", "card": "#ffffff", "primary": "#0b0b0b",
+        "secondary": "#52514e", "muted": "#898781", "grid": "#e1e0d9",
+        "border": "#e1e0d9", "baseline": "#c3c2b7",
         "faster": "#2a78d6", "slower": "#e34948", "critical": "#d03b3b",
     },
     "dark": {
-        "surface": "#1a1a19", "primary": "#ffffff", "secondary": "#c3c2b7",
-        "muted": "#898781", "grid": "#2c2c2a", "baseline": "#383835",
+        "surface": "#1a1a19", "card": "#212120", "primary": "#ffffff",
+        "secondary": "#c3c2b7", "muted": "#898781", "grid": "#2c2c2a",
+        "border": "#33332f", "baseline": "#4a4a46",
         "faster": "#3987e5", "slower": "#e66767", "critical": "#e66767",
     },
 }
 FONT = "-apple-system,'Segoe UI',Helvetica,Arial,sans-serif"
-GUTTER, PLOT_W, PAD_R, COL_W, ROW_H, BAR_H = 150, 540, 110, 150, 26, 16
-TICKS = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0]
+TICKS = [0.5, 0.67, 0.8, 1.0, 1.25, 1.5, 2.0, 3.0]
 GROUPS = [("lang", "Languages"), ("modalities", "Modalities")]
+
+CARD_W = 470
+PAD = 16
+HEADER_H = 56
+GROUP_H = 22
+ROW_H = 17
+BAR_H = 10
+AXIS_H = 28
+LABEL_R = PAD + 94          # right edge of fixture labels
+PLOT_L = LABEL_R + 10       # bars start here
+VAL_W = 62                  # room for the ×value label
+PLOT_R = CARD_W - PAD - VAL_W
+PLOT_W = PLOT_R - PLOT_L
+
+
+def slugify(name):
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
 
 
 def geomean(values):
@@ -40,7 +65,6 @@ def geomean(values):
 
 
 def bar_path(x0, x1, y, h, r):
-    # square at the baseline (x0), rounded at the data end (x1)
     left, right = min(x0, x1), max(x0, x1)
     r = min(r, (right - left) / 2, h / 2)
     if x1 >= x0:
@@ -50,81 +74,188 @@ def bar_path(x0, x1, y, h, r):
             f"V{y + h - r:.1f} q0,{r:.1f} {r:.1f},{r:.1f} H{right:.1f} Z")
 
 
-def render_svg(rows, mode, subtitle, meta):
+def layout_of(models):
+    """Ordered {group: fixture_count} from the first model that has results."""
+    for m in models:
+        if m["results"]:
+            counts = {}
+            for r in m["results"]:
+                counts[r["group"]] = counts.get(r["group"], 0) + 1
+            return counts
+    return {}
+
+
+def body_height(layout):
+    h = sum(GROUP_H + layout[k] * ROW_H for k, _ in GROUPS if layout.get(k))
+    return (h + AXIS_H) if h else 180
+
+
+def scale(models):
+    """Shared log2 x-range across every supported fixture speedup."""
+    vals = [r["speedup"] for m in models if m["supported"] for r in m["results"]]
+    if not vals:
+        return 0.75, 1.5
+    lo = min(0.75, min(vals) / 1.08)
+    hi = max(1.5, max(vals) * 1.08)
+    return lo, hi
+
+
+def card_svg(model, mode, lo, hi, card_h):
     ink = INK[mode]
-    lo = min(0.75, min(r["speedup"] for r in rows) / 1.08)
-    hi = max(1.5, max(r["speedup"] for r in rows) * 1.08)
-    ticks = [t for t in TICKS if lo <= t <= hi]
+    b = [f'<rect x="0.5" y="0.5" width="{CARD_W - 1}" height="{card_h - 1}" rx="10" '
+         f'fill="{ink["card"]}" stroke="{ink["border"]}" stroke-width="1"/>']
 
+    # ── header ──────────────────────────────────────────────────────────
+    b.append(f'<text x="{PAD}" y="26" fill="{ink["primary"]}" font-size="15" '
+             f'font-weight="700">{escape(model["model"])}</text>')
+    b.append(f'<text x="{PAD}" y="44" fill="{ink["muted"]}" font-size="11.5">'
+             f'{escape(model["shape"])}</text>')
+
+    if model["supported"]:
+        rows = model["results"]
+        g = geomean([r["speedup"] for r in rows])
+        gc = ink["faster"] if g >= 1 else ink["slower"]
+        b.append(f'<text x="{CARD_W - PAD}" y="24" fill="{gc}" font-size="19" '
+                 f'font-weight="700" text-anchor="end" '
+                 f'style="font-variant-numeric:tabular-nums">×{g:.2f}</text>')
+        b.append(f'<text x="{CARD_W - PAD}" y="42" fill="{ink["muted"]}" font-size="10.5" '
+                 f'text-anchor="end">geomean</text>')
+    else:
+        pill_w = 96
+        b.append(f'<rect x="{CARD_W - PAD - pill_w}" y="11" width="{pill_w}" height="19" rx="9.5" '
+                 f'fill="none" stroke="{ink["border"]}" stroke-width="1"/>')
+        b.append(f'<text x="{CARD_W - PAD - pill_w / 2}" y="24" fill="{ink["muted"]}" '
+                 f'font-size="11" text-anchor="middle">not supported</text>')
+
+    b.append(f'<line x1="{PAD}" y1="{HEADER_H - 8}" x2="{CARD_W - PAD}" y2="{HEADER_H - 8}" '
+             f'stroke="{ink["grid"]}" stroke-width="1"/>')
+
+    # ── unsupported placeholder (compact card) ──────────────────────────
+    if not model["supported"]:
+        pretok = model["shape"].split("·")[-1].strip()
+        cy = HEADER_H + (card_h - HEADER_H) / 2
+        b.append(f'<text x="{CARD_W / 2}" y="{cy - 2}" fill="{ink["secondary"]}" font-size="12.5" '
+                 f'font-weight="600" text-anchor="middle">Not benchmarked yet</text>')
+        b.append(f'<text x="{CARD_W / 2}" y="{cy + 16}" fill="{ink["muted"]}" font-size="11.5" '
+                 f'text-anchor="middle">PipelineTokenizer has no <tspan font-weight="600">'
+                 f'{escape(pretok)}</tspan> pre-tokenizer</text>')
+        return "".join(b)
+
+    # ── supported: diverging bars ───────────────────────────────────────
     def x(v):
-        return GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * PLOT_W
+        return PLOT_L + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * PLOT_W
 
-    top = 74
-    col_x = GUTTER + PLOT_W + PAD_R + COL_W - 16
-    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-            f'text-anchor="end">MB/s: Tokenizer → Pipeline</text>']
-    y = top
+    ticks = [t for t in TICKS if lo <= t <= hi]
+    body_top = HEADER_H + 6
+    y = body_top
     for key, title in GROUPS:
-        group_rows = sorted((r for r in rows if r["group"] == key),
+        group_rows = sorted((r for r in model["results"] if r["group"] == key),
                             key=lambda r: -r["speedup"])
         if not group_rows:
             continue
-        body.append(f'<text x="{GUTTER}" y="{y + 12}" fill="{ink["secondary"]}" font-size="11" '
-                    f'font-weight="600" letter-spacing="1.2" text-anchor="end" dx="-10">{title.upper()}</text>')
-        y += 22
+        b.append(f'<text x="{LABEL_R}" y="{y + 13}" fill="{ink["secondary"]}" font-size="10" '
+                 f'font-weight="700" letter-spacing="1.1" text-anchor="end">{title.upper()}</text>')
+        y += GROUP_H
         for r in group_rows:
             v, x0, x1 = r["speedup"], x(1.0), x(r["speedup"])
-            if abs(math.log2(v)) < math.log2(1.02):  # within noise of the baseline
+            if abs(math.log2(v)) < math.log2(1.02):
                 color = ink["muted"]
             else:
                 color = ink["faster"] if v >= 1 else ink["slower"]
             by = y + (ROW_H - BAR_H) / 2
-            body.append(f'<text x="{GUTTER - 10}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
-                        f'font-size="12.5" text-anchor="end">{escape(r["fixture"])}</text>')
+            b.append(f'<text x="{LABEL_R}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
+                     f'font-size="11.5" text-anchor="end">{escape(r["fixture"])}</text>')
             if abs(x1 - x0) < 1.5:
-                body.append(f'<rect x="{min(x0, x1):.1f}" y="{by}" width="1.5" height="{BAR_H}" fill="{color}"/>')
+                b.append(f'<rect x="{min(x0, x1):.1f}" y="{by}" width="1.5" height="{BAR_H}" fill="{color}"/>')
             else:
-                body.append(f'<path d="{bar_path(x0, x1, by, BAR_H, 4)}" fill="{color}"/>')
+                b.append(f'<path d="{bar_path(x0, x1, by, BAR_H, 3)}" fill="{color}"/>')
             label = f"×{v:.2f}"
-            anchor, lx = ("start", max(x0, x1) + 6) if v >= 1 else ("end", min(x0, x1) - 6)
-            if not r["ids_match"]:
-                label += "  ⚠ ids differ"
+            anchor, lx = ("start", max(x0, x1) + 5) if v >= 1 else ("end", min(x0, x1) - 5)
             fill = ink["primary"] if r["ids_match"] else ink["critical"]
-            body.append(f'<text x="{lx:.1f}" y="{y + ROW_H / 2 + 4}" fill="{fill}" font-size="12" '
-                        f'font-weight="600" text-anchor="{anchor}" '
-                        f'style="font-variant-numeric:tabular-nums">{label}</text>')
-            body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
-                        f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
-                        f'{r["legacy_mbps"]:.1f} → {r["pipeline_mbps"]:.1f}</text>')
+            if not r["ids_match"]:
+                label += " ⚠"
+            b.append(f'<text x="{lx:.1f}" y="{y + ROW_H / 2 + 4}" fill="{fill}" font-size="11" '
+                     f'font-weight="600" text-anchor="{anchor}" '
+                     f'style="font-variant-numeric:tabular-nums">{label}</text>')
             y += ROW_H
-        y += 10
+        y += 4
 
-    height = y + 34
+    axis_bottom = y
     grid = []
     for t in ticks:
         strong = t == 1.0
-        grid.append(f'<line x1="{x(t):.1f}" y1="{top - 6}" x2="{x(t):.1f}" y2="{y - 6}" '
-                    f'stroke="{ink["baseline"] if strong else ink["grid"]}" stroke-width="1"/>')
-        grid.append(f'<text x="{x(t):.1f}" y="{y + 12}" fill="{ink["muted"]}" font-size="11" '
+        grid.append(f'<line x1="{x(t):.1f}" y1="{body_top}" x2="{x(t):.1f}" y2="{axis_bottom}" '
+                    f'stroke="{ink["baseline"] if strong else ink["grid"]}" '
+                    f'stroke-width="1"{"" if strong else ""}/>')
+        grid.append(f'<text x="{x(t):.1f}" y="{axis_bottom + 15}" fill="{ink["muted"]}" font-size="10" '
                     f'text-anchor="middle" style="font-variant-numeric:tabular-nums">×{t:g}</text>')
-    hints = (f'<text x="{x(1.0) - 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-             f'text-anchor="end">← slower</text>'
-             f'<text x="{x(1.0) + 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-             f'text-anchor="start">faster →</text>')
+    # frame (b[0]) first, gridlines behind the bars/labels (b[1:])
+    return b[0] + "".join(grid) + "".join(b[1:])
 
-    width = GUTTER + PLOT_W + PAD_R + COL_W
-    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}"
-  viewBox="0 0 {width} {height}" font-family="{FONT}">
-<rect width="{width}" height="{height}" fill="{ink["surface"]}"/>
-<text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="600">PipelineTokenizer vs Tokenizer — encode throughput</text>
-<text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
-<text x="{width - 16}" y="26" fill="{ink["muted"]}" font-size="11" text-anchor="end"
-  style="font-variant-numeric:tabular-nums">{escape(meta[0])}</text>
-<text x="{width - 16}" y="44" fill="{ink["muted"]}" font-size="11" text-anchor="end">{escape(meta[1])}</text>
-{"".join(grid)}
-{hints}
-{"".join(body)}
-</svg>'''
+
+def wrap_svg(inner, card_h):
+    return (f'<svg xmlns="http://www.w3.org/2000/svg" width="{CARD_W}" height="{card_h}" '
+            f'viewBox="0 0 {CARD_W} {card_h}" font-family="{FONT}">{inner}</svg>')
+
+
+def img_url(base, run_id, slug, mode):
+    if base:
+        return f"{base}/pipeline-{run_id}-{slug}-{mode}.png"
+    return f"pipeline_bench_{slug}_{mode}.png"
+
+
+def render_markdown(models, subtitle, meta, base, run_id):
+    supported = [m for m in models if m["supported"]]
+    ordered = supported + [m for m in models if not m["supported"]]
+    mismatches = [f"{m['model']}/{r['fixture']}"
+                  for m in supported for r in m["results"] if not r["ids_match"]]
+
+    md = ["## PipelineTokenizer benchmark", ""]
+    head = f"**{len(supported)} / {len(models)} models supported**"
+    if supported:
+        g = geomean([r["speedup"] for m in supported for r in m["results"]])
+        nfix = len(supported[0]["results"])
+        head += f" · geomean ×{g:.2f} across supported · {nfix} fixtures each"
+    md += [f"{head} — {subtitle}", "", f"`{meta[0]}` · {meta[1]}", ""]
+
+    unsupported = [m for m in models if not m["supported"]]
+    if unsupported:
+        items = ", ".join(f"`{m['model']}` ({m['shape']})" for m in unsupported)
+        md += [f"> **Not yet supported:** {items} — shown as roadmap cards below.", ""]
+    if mismatches:
+        md += [f"> ⚠️ **Token ids diverge from the reference on: {', '.join(mismatches)}** "
+               f"— speedups there are meaningless until fixed.", ""]
+
+    # two-per-row grid of picture embeds
+    md.append("<table>")
+    for i in range(0, len(ordered), 2):
+        md.append("<tr>")
+        for m in ordered[i:i + 2]:
+            slug = slugify(m["model"])
+            light = img_url(base, run_id, slug, "light")
+            dark = img_url(base, run_id, slug, "dark")
+            md += ['<td align="center" valign="top">',
+                   "<picture>",
+                   f'  <source media="(prefers-color-scheme: dark)" srcset="{dark}">',
+                   f'  <img alt="{escape(m["model"])} speedup" src="{light}" width="430">',
+                   "</picture>",
+                   "</td>"]
+        md.append("</tr>")
+    md += ["</table>", ""]
+
+    if supported:
+        md += ["<details><summary>Per-fixture results (supported models)</summary>", ""]
+        for m in supported:
+            md += [f"#### {m['model']} — {m['shape']}", "",
+                   "| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |",
+                   "|---|---|---:|---:|---:|:--|"]
+            for r in sorted(m["results"], key=lambda r: (r["group"], -r["speedup"])):
+                ids = "match" if r["ids_match"] else "⚠️ differ"
+                md.append(f"| {r['fixture']} | {r['group']} | {r['legacy_mbps']:.1f} "
+                          f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} | {ids} |")
+            md.append("")
+        md += ["</details>", ""]
+    return "\n".join(md)
 
 
 def detect_hardware():
@@ -142,51 +273,14 @@ def detect_hardware():
     return f"{cpu} · {os.cpu_count()} cores"
 
 
-def render_markdown(rows, subtitle, meta, img_light, img_dark):
-    overall = geomean([r["speedup"] for r in rows])
-    parts = []
-    for key, title in GROUPS:
-        vals = [r["speedup"] for r in rows if r["group"] == key]
-        if vals:
-            parts.append(f"{title.lower()} ×{geomean(vals):.2f}")
-    mismatches = [r["fixture"] for r in rows if not r["ids_match"]]
-
-    md = ["## PipelineTokenizer benchmark",
-          "",
-          f"**Geomean speedup ×{overall:.2f}** across {len(rows)} fixtures "
-          f"({', '.join(parts)}) — {subtitle}",
-          "",
-          f"`{meta[0]}` · {meta[1]}",
-          ""]
-    if mismatches:
-        md += [f"> ⚠️ **Token ids diverge from the reference on: "
-               f"{', '.join(mismatches)}** — speedups there are meaningless until fixed.",
-               ""]
-    if img_light:
-        md += ["<picture>",
-               f'  <source media="(prefers-color-scheme: dark)" srcset="{img_dark or img_light}">',
-               f'  <img alt="Per-fixture speedup chart" src="{img_light}">',
-               "</picture>",
-               ""]
-    md += ["<details><summary>Per-fixture results</summary>", "",
-           "| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |",
-           "|---|---|---:|---:|---:|:--|"]
-    for r in sorted(rows, key=lambda r: (r["group"], -r["speedup"])):
-        ids = "match" if r["ids_match"] else "⚠️ differ"
-        md.append(f"| {r['fixture']} | {r['group']} | {r['legacy_mbps']:.1f} "
-                  f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} | {ids} |")
-    md += ["", "</details>", ""]
-    return "\n".join(md)
-
-
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("results")
     ap.add_argument("--out-dir", default=".")
-    ap.add_argument("--subtitle", default="bert-wiki WordPiece · ~10 kB inputs · single thread")
+    ap.add_argument("--subtitle", default="~10 kB inputs · single thread")
     ap.add_argument("--revision", default="")
-    ap.add_argument("--img-light-url", default="")
-    ap.add_argument("--img-dark-url", default="")
+    ap.add_argument("--img-base", default="", help="base URL for uploaded PNGs")
+    ap.add_argument("--run-id", default="local")
     args = ap.parse_args()
 
     rev = args.revision
@@ -199,14 +293,26 @@ def main():
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     meta = (f"{rev[:9]} · {stamp}", detect_hardware())
 
-    rows = json.loads(Path(args.results).read_text())
+    models = json.loads(Path(args.results).read_text())
+    lo, hi = scale(models)
+    tall_h = HEADER_H + body_height(layout_of(models)) + PAD
+    mini_h = HEADER_H + 62
+
     out = Path(args.out_dir)
-    for mode in ("light", "dark"):
-        (out / f"pipeline_bench_{mode}.svg").write_text(render_svg(rows, mode, args.subtitle, meta))
+    for m in models:
+        slug = slugify(m["model"])
+        h = tall_h if m["supported"] else mini_h
+        for mode in ("light", "dark"):
+            svg = wrap_svg(card_svg(m, mode, lo, hi, h), h)
+            (out / f"pipeline_bench_{slug}_{mode}.svg").write_text(svg)
+
     (out / "pipeline_bench.md").write_text(
-        render_markdown(rows, args.subtitle, meta, args.img_light_url, args.img_dark_url))
-    print(f"geomean x{geomean([r['speedup'] for r in rows]):.3f}, "
-          f"{sum(not r['ids_match'] for r in rows)} id mismatches")
+        render_markdown(models, args.subtitle, meta, args.img_base, args.run_id))
+
+    supported = [m for m in models if m["supported"]]
+    g = geomean([r["speedup"] for m in supported for r in m["results"]]) if supported else 0
+    print(f"{len(supported)}/{len(models)} supported, geomean x{g:.3f}, "
+          f"cards {CARD_W}x{tall_h} / {CARD_W}x{mini_h}")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -1,10 +1,8 @@
 name: Pipeline Benchmark
 
 # Comparative benchmark: reference `Tokenizer` vs experimental
-# `PipelineTokenizer`, across every corpus in data/fixtures/ (13 non-Latin
-# scripts + English + code/math/agentic modalities) on ~10 kB inputs — the
-# regime where per-input overhead is amortized.
-#
+# `PipelineTokenizer`, for every model in tk-encode/examples/bench_models.json
+# across every corpus in data/fixtures/ on ~10 kB inputs
 # Triggers:
 #   • push to feat/train_encode_split → benches and updates PR #2119's description.
 #   • add the "run-pipeline-bench" label to any PR → benches that PR and updates
@@ -25,6 +23,7 @@ on:
       - "tokenizers/src/**"
       - ".github/workflows/pipeline-bench.yml"
       - ".github/scripts/render_pipeline_bench.py"
+      - "tokenizers/tk-encode/examples/bench_models.json"
   pull_request:
     types: [labeled]
   workflow_dispatch:
@@ -82,10 +81,10 @@ jobs:
       - name: Install libcairo
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libcairo2
 
-      - name: Download fixtures
+      - name: Download fixtures and model tokenizers
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: make fixtures data/bert-wiki.json HF="uvx --from huggingface_hub hf"
+        run: make fixtures bench-models HF="uvx --from huggingface_hub hf"
 
       - name: Run comparative benchmark
         run: |
@@ -97,24 +96,27 @@ jobs:
           base_url="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts"
           python3 ${{ github.workspace }}/.github/scripts/render_pipeline_bench.py \
             pipeline_bench.json \
-            --subtitle "bert-wiki WordPiece · ~10 kB inputs · single thread" \
+            --subtitle "all models · ~10 kB inputs · single thread" \
             --revision "${{ github.event.pull_request.head.sha || github.sha }}" \
-            --img-light-url "$base_url/pipeline-${{ github.run_id }}-light.png" \
-            --img-dark-url "$base_url/pipeline-${{ github.run_id }}-dark.png"
+            --img-base "$base_url" \
+            --run-id "${{ github.run_id }}"
           uvx --with cairosvg python -c "
-          import cairosvg
-          for m in ('light', 'dark'):
-              cairosvg.svg2png(url=f'pipeline_bench_{m}.svg', write_to=f'pipeline_bench_{m}.png', scale=2)
+          import cairosvg, glob
+          for f in glob.glob('pipeline_bench_*.svg'):
+              cairosvg.svg2png(url=f, write_to=f[:-4] + '.png', scale=2)
           "
-
       - name: Upload charts to HF Hub
         continue-on-error: true
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          for m in light dark; do
+          for png in pipeline_bench_*.png; do
+            rest="${png#pipeline_bench_}"   # <slug>_<mode>.png
+            base="${rest%.png}"             # <slug>_<mode>
+            mode="${base##*_}"              # light | dark
+            slug="${base%_*}"               # <slug>
             uvx --from huggingface_hub hf upload hf-internal-testing/tokenizers-bench \
-              "pipeline_bench_${m}.png" "charts/pipeline-${{ github.run_id }}-${m}.png" --repo-type dataset
+              "$png" "charts/pipeline-${{ github.run_id }}-${slug}-${mode}.png" --repo-type dataset
           done
 
       - name: Write step summary
@@ -153,14 +155,13 @@ jobs:
           gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/run-pipeline-bench" \
             -X DELETE || true
 
-      # Broadest correctness net we have: id-equality across every script and
-      # modality. A divergence is a bug even when the speedup looks great. Last
-      # so the description/chart still land (with the ⚠ banner) before we go red.
       - name: Fail on id mismatches
         run: |
           python3 -c "
           import json, sys
-          bad = [r['fixture'] for r in json.load(open('pipeline_bench.json')) if not r['ids_match']]
+          models = json.load(open('pipeline_bench.json'))
+          bad = [f\"{m['model']}/{r['fixture']}\" for m in models
+                 if m['supported'] for r in m['results'] if not r['ids_match']]
           sys.exit(f'ids diverge on: {bad}' if bad else 0)
           "
 

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -96,7 +96,7 @@ jobs:
           base_url="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts"
           python3 ${{ github.workspace }}/.github/scripts/render_pipeline_bench.py \
             pipeline_bench.json \
-            --subtitle "all models · ~10 kB inputs · single thread" \
+            --subtitle "~10 kB inputs · single thread" \
             --revision "${{ github.event.pull_request.head.sha || github.sha }}" \
             --img-base "$base_url" \
             --run-id "${{ github.run_id }}"

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -12,6 +12,10 @@ FIXTURE_LANGS = amh_Ethi arb_Arab ben_Beng cmn_Hani ell_Grek eng_Latn heb_Hebr h
 FIXTURE_MODALITIES = agentic_swe agentic-traces code_mixed math_latex
 FIXTURES_RESOURCES = $(FIXTURE_LANGS:%=$(DATA_DIR)/fixtures/lang/%.txt) $(FIXTURE_MODALITIES:%=$(DATA_DIR)/fixtures/modalities/%.txt)
 
+# Models benched by tk-encode/examples/fixture_bench.rs; the manifest is the
+# single source of truth (Rust reads it too).
+BENCH_MODELS = tk-encode/examples/bench_models.json
+
 .PHONY : build
 build :
 	cargo build --workspace --all-targets
@@ -53,6 +57,16 @@ bench : $(BENCHMARK_RESOURCES)
 # fixtures/FIXTURES.md in $(HF_TEST_REPO) for provenance.
 .PHONY : fixtures
 fixtures : $(FIXTURES_RESOURCES)
+
+# Fetch each bench model's tokenizer config (the `file` listed in the manifest)
+# from the test-data dataset via the generic data/% rule — same controlled
+# mirror as the fixtures, so no direct pulls from model repos (supply chain).
+.PHONY : bench-models
+bench-models :
+	@python3 -c "import json; [print(m.get('file') or m['name'] + '.json') for m in json.load(open('$(BENCH_MODELS)'))]" \
+	| while read -r file; do \
+	    $(MAKE) $(DATA_DIR)/$$file; \
+	  done
 
 HF_TEST_REPO = hf-internal-testing/tokenizers-test-data
 # Fetch fixtures through the huggingface_hub CLI: it handles auth (HF_TOKEN),

--- a/tokenizers/tk-encode/examples/bench_models.json
+++ b/tokenizers/tk-encode/examples/bench_models.json
@@ -1,0 +1,6 @@
+[
+  { "name": "bert-wiki",   "file": "bert-wiki.json" },
+  { "name": "gpt-2",       "file": "gpt2-slim.json" },
+  { "name": "deepseek-v4", "file": "deepseek-v4-slim.json" },
+  { "name": "albert-v1",   "file": "albert-base-v1-tokenizer.json" }
+]

--- a/tokenizers/tk-encode/examples/bench_models.json
+++ b/tokenizers/tk-encode/examples/bench_models.json
@@ -1,6 +1,6 @@
 [
-  { "name": "bert-wiki",   "file": "bert-wiki.json" },
-  { "name": "gpt-2",       "file": "gpt2-slim.json" },
-  { "name": "deepseek-v4", "file": "deepseek-v4-slim.json" },
-  { "name": "albert-v1",   "file": "albert-base-v1-tokenizer.json" }
+  { "name": "bert-base-uncased", "file": "bert-base-uncased.json" },
+  { "name": "deepseek-v4",       "file": "deepseek-v4.json" },
+  { "name": "llama-3",           "file": "llama-3-tokenizer.json" },
+  { "name": "t5-base",           "file": "t5-base.json" }
 ]

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -1,9 +1,15 @@
 //! Comparative throughput of the reference `Tokenizer` vs the experimental
-//! `PipelineTokenizer` over every corpus in `data/fixtures/` (languages +
-//! modalities), on ~10 kB inputs — the regime where per-input overhead is
-//! amortized (see `pipeline_benchmark.rs` for the size sweep).
+//! `PipelineTokenizer`, for every model in `examples/bench_models.json` across
+//! every corpus in `data/fixtures/` (languages + modalities), on ~10 kB inputs
+//! — the regime where per-input overhead is amortized (see `pipeline_benchmark.rs`
+//! for the size sweep).
 //!
-//! Emits one JSON object per fixture on stdout, consumed by
+//! `PipelineTokenizer` is a work in progress: it only builds for tokenizers whose
+//! pre-tokenizer is Bert / Whitespace / None. Models it can't build (byte-level
+//! BPE, SentencePiece/Unigram, …) are reported as `supported: false` with their
+//! pipeline shape, rather than benched — the CI grid renders those as roadmap cards.
+//!
+//! Emits a JSON array (one object per model) on stdout, consumed by
 //! `.github/scripts/render_pipeline_bench.py` in CI.
 
 use std::convert::TryFrom;
@@ -11,10 +17,12 @@ use std::hint::black_box;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+use serde_json::{json, Value};
 use tk_encode::pipeline::PipelineTokenizer;
-use tk_encode::Tokenizer;
+use tk_encode::{ModelWrapper, Tokenizer};
 
 const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
+const MANIFEST: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/bench_models.json");
 const CHUNK_BYTES: usize = 10 * 1024;
 const MAX_CHUNKS: usize = 100;
 const REPS: usize = 5;
@@ -72,23 +80,67 @@ fn fixture_files() -> Vec<(String, PathBuf)> {
     files
 }
 
-fn main() {
-    let oracle = Tokenizer::from_file(format!("{DATA_DIR}/bert-wiki.json")).unwrap();
-    let pipeline = PipelineTokenizer::try_from(&oracle).unwrap();
+/// Local path to a manifest entry's config: `data/<file>`, else `data/<name>.json`.
+/// Both come from the test-data dataset (see the Makefile `bench-models` target).
+fn model_path(entry: &Value) -> PathBuf {
+    let name = entry["name"].as_str().unwrap();
+    let file = entry
+        .get("file")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("{name}.json"));
+    Path::new(DATA_DIR).join(file)
+}
 
-    let legacy_enc = |s: &str| oracle.encode(s, false).unwrap().len();
+fn model_kind(tok: &Tokenizer) -> &'static str {
+    match tok.get_model() {
+        ModelWrapper::BPE(_) => "BPE",
+        ModelWrapper::WordPiece(_) => "WordPiece",
+        ModelWrapper::WordLevel(_) => "WordLevel",
+        ModelWrapper::Unigram(_) => "Unigram",
+    }
+}
+
+/// A short pre-tokenizer descriptor read from the raw json — its `type`, and for
+/// a Sequence the (de-duplicated) inner types, e.g. `Split+ByteLevel`.
+fn pretok_label(path: &Path) -> String {
+    let v: Value = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or(Value::Null);
+    let pt = &v["pre_tokenizer"];
+    match pt["type"].as_str() {
+        None => "None".to_string(),
+        Some("Sequence") => {
+            let mut inner: Vec<&str> = pt["pretokenizers"]
+                .as_array()
+                .map(|a| a.iter().filter_map(|x| x["type"].as_str()).collect())
+                .unwrap_or_default();
+            inner.dedup();
+            inner.join("+")
+        }
+        Some("BertPreTokenizer") => "Bert".to_string(),
+        Some(other) => other.to_string(),
+    }
+}
+
+fn bench_model(
+    tok: &Tokenizer,
+    pipeline: &PipelineTokenizer,
+    files: &[(String, PathBuf)],
+) -> Vec<Value> {
+    let legacy_enc = |s: &str| tok.encode(s, false).unwrap().len();
     let pipeline_enc = |s: &str| pipeline.encode(s, false).unwrap().len();
 
-    println!("[");
-    let files = fixture_files();
-    for (i, (group, path)) in files.iter().enumerate() {
+    let mut rows = Vec::new();
+    for (group, path) in files {
         let name = path.file_stem().unwrap().to_str().unwrap().to_string();
         let text = std::fs::read_to_string(path).unwrap();
         let chunks = make_chunks(&text);
         let bytes: usize = chunks.iter().map(String::len).sum();
 
         let ids_match = chunks.iter().take(3).all(|c| {
-            let expected = oracle.encode(c.as_str(), false).unwrap();
+            let expected = tok.encode(c.as_str(), false).unwrap();
             let got: Vec<u32> = pipeline
                 .encode(c, false)
                 .unwrap()
@@ -107,26 +159,68 @@ fn main() {
             pipeline_s.push(time_pass(&pipeline_enc, &chunks));
         }
         let (l, p) = (median_secs(legacy_s), median_secs(pipeline_s));
+        let (legacy_mbps, pipeline_mbps) = (bytes as f64 / l / 1e6, bytes as f64 / p / 1e6);
+        eprintln!("  {name}: legacy {legacy_mbps:.1} MB/s, pipeline {pipeline_mbps:.1} MB/s");
 
-        eprintln!(
-            "{name}: legacy {:.1} MB/s, pipeline {:.1} MB/s",
-            bytes as f64 / l / 1e6,
-            bytes as f64 / p / 1e6
-        );
-        println!(
-            "{}{}",
-            serde_json::json!({
-                "fixture": name,
-                "group": group,
-                "bytes": bytes,
-                "chunks": chunks.len(),
-                "legacy_mbps": bytes as f64 / l / 1e6,
-                "pipeline_mbps": bytes as f64 / p / 1e6,
-                "speedup": l / p,
-                "ids_match": ids_match,
-            }),
-            if i + 1 < files.len() { "," } else { "" }
-        );
+        rows.push(json!({
+            "fixture": name,
+            "group": group,
+            "bytes": bytes,
+            "chunks": chunks.len(),
+            "legacy_mbps": legacy_mbps,
+            "pipeline_mbps": pipeline_mbps,
+            "speedup": l / p,
+            "ids_match": ids_match,
+        }));
     }
-    println!("]");
+    rows
+}
+
+fn main() {
+    let manifest: Vec<Value> =
+        serde_json::from_str(&std::fs::read_to_string(MANIFEST).unwrap()).unwrap();
+    let files = fixture_files();
+
+    let mut out: Vec<Value> = Vec::new();
+    for entry in &manifest {
+        let name = entry["name"].as_str().unwrap().to_string();
+        let repo = entry.get("repo").and_then(Value::as_str).unwrap_or("");
+        let path = model_path(entry);
+        eprintln!("== {name} ({repo}) ==");
+
+        let tok = match Tokenizer::from_file(&path) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("  load failed: {e}");
+                out.push(json!({
+                    "model": name, "repo": repo, "shape": "?",
+                    "supported": false, "reason": format!("load error: {e}"), "results": [],
+                }));
+                continue;
+            }
+        };
+        let shape = format!("{} · {}", model_kind(&tok), pretok_label(&path));
+
+        match PipelineTokenizer::try_from(&tok) {
+            Ok(pipeline) => {
+                let rows = bench_model(&tok, &pipeline, &files);
+                out.push(json!({
+                    "model": name, "repo": repo, "shape": shape,
+                    "supported": true, "results": rows,
+                }));
+            }
+            Err(_) => {
+                eprintln!("  unsupported by PipelineTokenizer ({shape})");
+                out.push(json!({
+                    "model": name, "repo": repo, "shape": shape,
+                    "supported": false, "results": [],
+                }));
+            }
+        }
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&Value::Array(out)).unwrap()
+    );
 }


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**1 / 4 models supported** · geomean ×1.74 across supported · 18 fixtures each — ~10 kB inputs · single thread

`09ea96dc0 · 2026-07-03 13:27 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 16 cores

> **Not yet supported:** `deepseek-v4` (BPE · Split+ByteLevel), `llama-3` (BPE · Split+ByteLevel), `t5-base` (Unigram · WhitespaceSplit+Metaspace) — roadmap cards below.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28663507286-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28663507286-bert-base-uncased-light.png" width="860">
</picture>

### Not yet supported

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28663507286-deepseek-v4-dark.png">
  <img alt="deepseek-v4 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28663507286-deepseek-v4-light.png" width="420">
</picture>
</td>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28663507286-llama-3-dark.png">
  <img alt="llama-3 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28663507286-llama-3-light.png" width="420">
</picture>
</td>
</tr>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28663507286-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28663507286-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

<details><summary>Per-fixture results</summary>

#### bert-base-uncased — WordPiece · Bert

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| cmn_Hani | lang | 3.6 | 8.5 | ×2.39 | match |
| eng_Latn | lang | 4.3 | 9.3 | ×2.19 | match |
| jpn_Jpan | lang | 4.1 | 7.4 | ×1.81 | match |
| hin_Deva | lang | 6.0 | 9.9 | ×1.64 | match |
| amh_Ethi | lang | 7.6 | 12.4 | ×1.64 | match |
| heb_Hebr | lang | 3.8 | 6.2 | ×1.63 | match |
| arb_Arab | lang | 3.8 | 6.0 | ×1.56 | match |
| ben_Beng | lang | 5.6 | 8.5 | ×1.53 | match |
| ell_Grek | lang | 3.5 | 5.2 | ×1.49 | match |
| rus_Cyrl | lang | 3.4 | 4.9 | ×1.46 | match |
| kat_Geor | lang | 5.9 | 8.4 | ×1.43 | match |
| tam_Taml | lang | 6.7 | 9.6 | ×1.43 | match |
| kor_Hang | lang | 2.3 | 3.2 | ×1.41 | match |
| tha_Thai | lang | 8.3 | 10.3 | ×1.24 | match |
| agentic-traces | modalities | 3.7 | 8.7 | ×2.37 | match |
| agentic_swe | modalities | 3.9 | 8.9 | ×2.26 | match |
| math_latex | modalities | 3.8 | 8.7 | ×2.26 | match |
| code_mixed | modalities | 3.8 | 8.3 | ×2.21 | match |

</details>
<!-- pipeline-bench:end -->

