### PR TITLE
experiment: reduce normalizer alloc further

### DIFF
--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -2333,6 +2333,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -2524,6 +2525,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -58,6 +58,7 @@ dary_heap = { version = "0.3.6", features = ["serde"] }
 compact_str = { version = "0.9", features = ["serde"] }
 ptr_hash = { version = "1.1.0" }
 memchr = "2.8.2"
+unicode-normalization = "0.1.25"
 
 [features]
 default = ["progressbar", "onig"]

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -1,4 +1,7 @@
-use crate::tokenizer::{NormalizedString, Normalizer, Result};
+use crate::{
+    pipeline,
+    tokenizer::{NormalizedString, Normalizer, Result},
+};
 
 use serde::{Deserialize, Serialize};
 use unicode_categories::UnicodeCategories;
@@ -133,5 +136,28 @@ impl Normalizer for BertNormalizer {
         }
 
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for BertNormalizer {
+    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
+        let input = input.into();
+       // todo
+       input
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pipeline_bert_matches_legacy() {
+        let n = BertNormalizer::default();
+        for input in &["Héllo World", "中文字", "  spaced  ", "abc", "", "\tTab\n"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     pipeline,
     tokenizer::{NormalizedString, Normalizer, Result},
@@ -5,6 +7,7 @@ use crate::{
 
 use serde::{Deserialize, Serialize};
 use unicode_categories::UnicodeCategories;
+use unicode_normalization::{is_nfd_quick, IsNormalized, UnicodeNormalization};
 
 /// Checks whether a character is whitespace
 fn is_whitespace(c: char) -> bool {
@@ -25,6 +28,12 @@ fn is_control(c: char) -> bool {
         // cf. https://unicode.org/reports/tr44/ (Table 12)
         _ => c.is_other(),
     }
+}
+
+/// Whether lowercasing `c` leaves it unchanged (a single, identical char)
+fn lowercases_to_self(c: char) -> bool {
+    let mut it = c.to_lowercase();
+    matches!((it.next(), it.next()), (Some(first), None) if first == c)
 }
 
 /// Checks whether a character is chinese
@@ -117,6 +126,23 @@ impl BertNormalizer {
     fn do_lowercase(&self, normalized: &mut NormalizedString) {
         normalized.lowercase();
     }
+
+    fn is_noop(&self, input: &str, strip_accents: bool) -> bool {
+        if strip_accents && !matches!(is_nfd_quick(input.chars()), IsNormalized::Yes) {
+            return false;
+        }
+        let changes = |c: char| {
+            (self.clean_text
+                && (c as usize == 0
+                    || c as usize == 0xfffd
+                    || is_control(c)
+                    || (is_whitespace(c) && c != ' ')))
+                || (self.handle_chinese_chars && is_chinese_char(c))
+                || (strip_accents && c.is_mark_nonspacing())
+                || (self.lowercase && !lowercases_to_self(c))
+        };
+        !input.chars().any(changes)
+    }
 }
 
 impl Normalizer for BertNormalizer {
@@ -140,10 +166,46 @@ impl Normalizer for BertNormalizer {
 }
 
 impl pipeline::Normalizer for BertNormalizer {
-    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
-        let input = input.into();
-       // todo
-       input
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let strip_accents = self.strip_accents.unwrap_or(self.lowercase);
+
+        if self.is_noop(input, strip_accents) {
+           return input.into()
+        }
+
+        let cleaned: String = input
+            .chars()
+            .filter(|&c| {
+                !(self.clean_text && (c as usize == 0 || c as usize == 0xfffd || is_control(c)))
+            })
+            .flat_map(|c| {
+                let c = if self.clean_text && is_whitespace(c) {
+                    ' '
+                } else {
+                    c
+                };
+                if self.handle_chinese_chars && is_chinese_char(c) {
+                    [Some(' '), Some(c), Some(' ')]
+                } else {
+                    [Some(c), None, None]
+                }
+            })
+            .flatten()
+            .collect();
+
+        let stripped = if strip_accents {
+            cleaned.nfd().filter(|c| !c.is_mark_nonspacing()).collect()
+        } else {
+            cleaned
+        };
+
+        let lowered = if self.lowercase {
+            stripped.chars().flat_map(char::to_lowercase).collect()
+        } else {
+            stripped
+        };
+
+        Cow::Owned(lowered)
     }
 }
 
@@ -151,13 +213,67 @@ impl pipeline::Normalizer for BertNormalizer {
 mod tests {
     use super::*;
 
+    const INPUTS: &[&str] = &[
+        "Héllo World",
+        "中文字",
+        "a中b文c",
+        "  spaced  ",
+        "abc",
+        "",
+        "\tTab\n\r",
+        "MiXeD Café",
+        "e\u{0301}",           // already-NFD combining acute
+        "\u{fb01}ligature",    // NFKC ligature (unchanged by NFD)
+        "null\0here",
+        "repl\u{fffd}char",
+        "ctrl\u{0007}char",
+        "ǅ",                   // titlecase, lowercases to multi-mapping
+        "İstanbul",            // dotted capital I: lowercases to 2 chars
+        "straße",
+    ];
+
     #[test]
     fn pipeline_bert_matches_legacy() {
+        for &clean_text in &[true, false] {
+            for &handle_chinese_chars in &[true, false] {
+                for &strip_accents in &[None, Some(true), Some(false)] {
+                    for &lowercase in &[true, false] {
+                        let n = BertNormalizer::new(
+                            clean_text,
+                            handle_chinese_chars,
+                            strip_accents,
+                            lowercase,
+                        );
+                        for input in INPUTS {
+                            let mut ns = NormalizedString::from(*input);
+                            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+                            assert_eq!(
+                                ns.get(),
+                                &*pipeline::Normalizer::normalize(&n, input),
+                                "config={n:?} input={input:?}",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn pipeline_bert_borrows_when_noop() {
         let n = BertNormalizer::default();
-        for input in &["Héllo World", "中文字", "  spaced  ", "abc", "", "\tTab\n"] {
-            let mut ns = NormalizedString::from(*input);
-            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        for input in &["hello world", "already lowercase ascii", ""] {
+            assert!(matches!(
+                pipeline::Normalizer::normalize(&n, input),
+                Cow::Borrowed(_)
+            ));
+        }
+        // Anything that must change is owned.
+        for input in &["Héllo", "中", "\tx", "ABC"] {
+            assert!(matches!(
+                pipeline::Normalizer::normalize(&n, input),
+                Cow::Owned(_)
+            ));
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 
 use crate::{
     pipeline,

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -5,6 +5,7 @@ use crate::{
     tokenizer::{NormalizedString, Normalizer, Result},
 };
 
+use itertools::Either;
 use serde::{Deserialize, Serialize};
 use unicode_categories::UnicodeCategories;
 use unicode_normalization::{is_nfd_quick, IsNormalized, UnicodeNormalization};
@@ -166,14 +167,15 @@ impl Normalizer for BertNormalizer {
 }
 
 impl pipeline::Normalizer for BertNormalizer {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
         let strip_accents = self.strip_accents.unwrap_or(self.lowercase);
 
         if self.is_noop(input, strip_accents) {
-            return input.into();
+            return input;
         }
+        scratch.clear();
 
-        let cleaned: String = input
+        let cleaned = input
             .chars()
             .filter(|&c| {
                 !(self.clean_text && (c as usize == 0 || c as usize == 0xfffd || is_control(c)))
@@ -190,22 +192,20 @@ impl pipeline::Normalizer for BertNormalizer {
                     [Some(c), None, None]
                 }
             })
-            .flatten()
-            .collect();
+            .flatten();
 
         let stripped = if strip_accents {
-            cleaned.nfd().filter(|c| !c.is_mark_nonspacing()).collect()
+            Either::Left(cleaned.nfd().filter(|c| !c.is_mark_nonspacing()))
         } else {
-            cleaned
+            Either::Right(cleaned)
         };
-
-        let lowered = if self.lowercase {
-            stripped.chars().flat_map(char::to_lowercase).collect()
+        let lowerecased = if self.lowercase {
+            Either::Left(stripped.flat_map(char::to_lowercase))
         } else {
-            stripped
+            Either::Right(stripped)
         };
-
-        Cow::Owned(lowered)
+        scratch.extend(lowerecased);
+        scratch
     }
 }
 
@@ -247,33 +247,16 @@ mod tests {
                         for input in INPUTS {
                             let mut ns = NormalizedString::from(*input);
                             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+                            let mut scratch = String::new();
                             assert_eq!(
                                 ns.get(),
-                                &*pipeline::Normalizer::normalize(&n, input),
+                                &*pipeline::Normalizer::normalize(&n, input, &mut scratch),
                                 "config={n:?} input={input:?}",
                             );
                         }
                     }
                 }
             }
-        }
-    }
-
-    #[test]
-    fn pipeline_bert_borrows_when_noop() {
-        let n = BertNormalizer::default();
-        for input in &["hello world", "already lowercase ascii", ""] {
-            assert!(matches!(
-                pipeline::Normalizer::normalize(&n, input),
-                Cow::Borrowed(_)
-            ));
-        }
-        // Anything that must change is owned.
-        for input in &["Héllo", "中", "\tx", "ABC"] {
-            assert!(matches!(
-                pipeline::Normalizer::normalize(&n, input),
-                Cow::Owned(_)
-            ));
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -170,7 +170,7 @@ impl pipeline::Normalizer for BertNormalizer {
         let strip_accents = self.strip_accents.unwrap_or(self.lowercase);
 
         if self.is_noop(input, strip_accents) {
-           return input.into()
+            return input.into();
         }
 
         let cleaned: String = input
@@ -222,13 +222,13 @@ mod tests {
         "",
         "\tTab\n\r",
         "MiXeD Café",
-        "e\u{0301}",           // already-NFD combining acute
-        "\u{fb01}ligature",    // NFKC ligature (unchanged by NFD)
+        "e\u{0301}",        // already-NFD combining acute
+        "\u{fb01}ligature", // NFKC ligature (unchanged by NFD)
         "null\0here",
         "repl\u{fffd}char",
         "ctrl\u{0007}char",
-        "ǅ",                   // titlecase, lowercases to multi-mapping
-        "İstanbul",            // dotted capital I: lowercases to 2 chars
+        "ǅ",        // titlecase, lowercases to multi-mapping
+        "İstanbul", // dotted capital I: lowercases to 2 chars
         "straße",
     ];
 

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -174,7 +174,7 @@ impl pipeline::Normalizer for BertNormalizer {
         }
         scratch.clear();
 
-        let cleaned = input
+        let cleaned: String = input
             .chars()
             .filter(|&c| {
                 !(self.clean_text && (c as usize == 0 || c as usize == 0xfffd || is_control(c)))
@@ -191,12 +191,13 @@ impl pipeline::Normalizer for BertNormalizer {
                     [Some(c), None, None]
                 }
             })
-            .flatten();
+            .flatten()
+            .collect();
 
         let stripped = if strip_accents {
             Either::Left(cleaned.nfd().filter(|c| !c.is_mark_nonspacing()))
         } else {
-            Either::Right(cleaned)
+            Either::Right(cleaned.chars())
         };
         let lowerecased = if self.lowercase {
             Either::Left(stripped.flat_map(char::to_lowercase))

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -1,4 +1,3 @@
-
 use crate::{
     pipeline,
     tokenizer::{NormalizedString, Normalizer, Result},

--- a/tokenizers/tk-encode/src/normalizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/normalizers/byte_level.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::byte_level::{byte_level_transform, BYTES_CHAR_LOOKUP};
 use crate::utils::macro_rules_attribute;
@@ -31,5 +34,31 @@ impl Normalizer for ByteLevel {
             normalized.transform(byte_level_transform(s), 0);
         }
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for ByteLevel {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let table = &*BYTES_CHAR_LOOKUP;
+        let mut out = String::with_capacity(input.len());
+        for &b in input.as_bytes() {
+            out.push(table[b as usize]);
+        }
+        Cow::Owned(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pipeline_byte_level_matches_legacy() {
+        let n = ByteLevel::new();
+        for input in &["Hello world", "Hello 我今天", "abc", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/normalizers/byte_level.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::byte_level::{byte_level_transform, BYTES_CHAR_LOOKUP};
@@ -38,13 +36,14 @@ impl Normalizer for ByteLevel {
 }
 
 impl pipeline::Normalizer for ByteLevel {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
         let table = &*BYTES_CHAR_LOOKUP;
-        let mut out = String::with_capacity(input.len());
+        scratch.clear();
+        scratch.reserve(input.len());
         for &b in input.as_bytes() {
-            out.push(table[b as usize]);
+            scratch.push(table[b as usize]);
         }
-        Cow::Owned(out)
+        scratch
     }
 }
 
@@ -55,10 +54,11 @@ mod tests {
     #[test]
     fn pipeline_byte_level_matches_legacy() {
         let n = ByteLevel::new();
+        let mut scratch = String::new();
         for input in &["Hello world", "Hello 我今天", "abc", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/normalizers/byte_level.rs
@@ -58,7 +58,10 @@ mod tests {
         for input in &["Hello world", "Hello 我今天", "abc", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
+            assert_eq!(
+                ns.get(),
+                pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/mod.rs
+++ b/tokenizers/tk-encode/src/normalizers/mod.rs
@@ -16,7 +16,7 @@ pub use crate::normalizers::unicode::{Nmt, NFC, NFD, NFKC, NFKD};
 pub use crate::normalizers::utils::{Lowercase, Sequence};
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::{NormalizedString, Normalizer};
+use crate::{NormalizedString, Normalizer, pipeline};
 
 /// Wrapper for known Normalizers.
 #[derive(Clone, Debug, Serialize)]
@@ -216,6 +216,27 @@ impl_enum_from!(Precompiled, NormalizerWrapper, Precompiled);
 impl_enum_from!(Replace, NormalizerWrapper, Replace);
 impl_enum_from!(Prepend, NormalizerWrapper, Prepend);
 impl_enum_from!(ByteLevel, NormalizerWrapper, ByteLevel);
+
+impl pipeline::Normalizer for NormalizerWrapper {
+    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
+        match self {
+            Self::BertNormalizer(bn) => pipeline::Normalizer::normalize(bn, input),
+            Self::StripNormalizer(sn) => pipeline::Normalizer::normalize(sn, input),
+            Self::StripAccents(sn) => pipeline::Normalizer::normalize(sn, input),
+            Self::NFC(nfc) => pipeline::Normalizer::normalize(nfc, input),
+            Self::NFD(nfd) => pipeline::Normalizer::normalize(nfd, input),
+            Self::NFKC(nfkc) => pipeline::Normalizer::normalize(nfkc, input),
+            Self::NFKD(nfkd) => pipeline::Normalizer::normalize(nfkd, input),
+            Self::Sequence(sequence) => pipeline::Normalizer::normalize(sequence, input),
+            Self::Lowercase(lc) => pipeline::Normalizer::normalize(lc, input),
+            Self::Nmt(nmt) => pipeline::Normalizer::normalize(nmt, input),
+            Self::Precompiled(pc) => pipeline::Normalizer::normalize(pc, input),
+            Self::Replace(rp) => pipeline::Normalizer::normalize(rp, input),
+            Self::Prepend(pp) => pipeline::Normalizer::normalize(pp, input),
+            Self::ByteLevel(bl) => pipeline::Normalizer::normalize(bl, input),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/normalizers/mod.rs
+++ b/tokenizers/tk-encode/src/normalizers/mod.rs
@@ -233,7 +233,7 @@ impl pipeline::Normalizer for NormalizerWrapper {
             Self::Replace(rp) => pipeline::Normalizer::normalize(rp, input, scratch),
             Self::Prepend(pp) => pipeline::Normalizer::normalize(pp, input, scratch),
             Self::ByteLevel(bl) => pipeline::Normalizer::normalize(bl, input, scratch),
-            Self::Precompiled(_) => &input,
+            Self::Precompiled(_) => input,
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/mod.rs
+++ b/tokenizers/tk-encode/src/normalizers/mod.rs
@@ -16,7 +16,7 @@ pub use crate::normalizers::unicode::{Nmt, NFC, NFD, NFKC, NFKD};
 pub use crate::normalizers::utils::{Lowercase, Sequence};
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::{NormalizedString, Normalizer, pipeline};
+use crate::{pipeline, NormalizedString, Normalizer};
 
 /// Wrapper for known Normalizers.
 #[derive(Clone, Debug, Serialize)]

--- a/tokenizers/tk-encode/src/normalizers/mod.rs
+++ b/tokenizers/tk-encode/src/normalizers/mod.rs
@@ -218,22 +218,22 @@ impl_enum_from!(Prepend, NormalizerWrapper, Prepend);
 impl_enum_from!(ByteLevel, NormalizerWrapper, ByteLevel);
 
 impl pipeline::Normalizer for NormalizerWrapper {
-    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
         match self {
-            Self::BertNormalizer(bn) => pipeline::Normalizer::normalize(bn, input),
-            Self::StripNormalizer(sn) => pipeline::Normalizer::normalize(sn, input),
-            Self::StripAccents(sn) => pipeline::Normalizer::normalize(sn, input),
-            Self::NFC(nfc) => pipeline::Normalizer::normalize(nfc, input),
-            Self::NFD(nfd) => pipeline::Normalizer::normalize(nfd, input),
-            Self::NFKC(nfkc) => pipeline::Normalizer::normalize(nfkc, input),
-            Self::NFKD(nfkd) => pipeline::Normalizer::normalize(nfkd, input),
-            Self::Sequence(sequence) => pipeline::Normalizer::normalize(sequence, input),
-            Self::Lowercase(lc) => pipeline::Normalizer::normalize(lc, input),
-            Self::Nmt(nmt) => pipeline::Normalizer::normalize(nmt, input),
-            Self::Precompiled(pc) => pipeline::Normalizer::normalize(pc, input),
-            Self::Replace(rp) => pipeline::Normalizer::normalize(rp, input),
-            Self::Prepend(pp) => pipeline::Normalizer::normalize(pp, input),
-            Self::ByteLevel(bl) => pipeline::Normalizer::normalize(bl, input),
+            Self::BertNormalizer(bn) => pipeline::Normalizer::normalize(bn, input, scratch),
+            Self::StripNormalizer(sn) => pipeline::Normalizer::normalize(sn, input, scratch),
+            Self::StripAccents(sn) => pipeline::Normalizer::normalize(sn, input, scratch),
+            Self::NFC(nfc) => pipeline::Normalizer::normalize(nfc, input, scratch),
+            Self::NFD(nfd) => pipeline::Normalizer::normalize(nfd, input, scratch),
+            Self::NFKC(nfkc) => pipeline::Normalizer::normalize(nfkc, input, scratch),
+            Self::NFKD(nfkd) => pipeline::Normalizer::normalize(nfkd, input, scratch),
+            Self::Sequence(sequence) => pipeline::Normalizer::normalize(sequence, input, scratch),
+            Self::Lowercase(lc) => pipeline::Normalizer::normalize(lc, input, scratch),
+            Self::Nmt(nmt) => pipeline::Normalizer::normalize(nmt, input, scratch),
+            Self::Replace(rp) => pipeline::Normalizer::normalize(rp, input, scratch),
+            Self::Prepend(pp) => pipeline::Normalizer::normalize(pp, input, scratch),
+            Self::ByteLevel(bl) => pipeline::Normalizer::normalize(bl, input, scratch),
+            Self::Precompiled(_) => &input,
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/precompiled.rs
+++ b/tokenizers/tk-encode/src/normalizers/precompiled.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 pub use spm_precompiled::Precompiled;
 use std::cmp::Ordering;
@@ -65,6 +68,13 @@ impl Normalizer for Precompiled {
             normalized.transform(transformations, 0);
         }
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for Precompiled {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        // todo
+        input.into()
     }
 }
 

--- a/tokenizers/tk-encode/src/normalizers/precompiled.rs
+++ b/tokenizers/tk-encode/src/normalizers/precompiled.rs
@@ -1,4 +1,3 @@
-use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 pub use spm_precompiled::Precompiled;
 use std::cmp::Ordering;
@@ -68,7 +67,6 @@ impl Normalizer for Precompiled {
         Ok(())
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/normalizers/precompiled.rs
+++ b/tokenizers/tk-encode/src/normalizers/precompiled.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 pub use spm_precompiled::Precompiled;
@@ -71,12 +69,6 @@ impl Normalizer for Precompiled {
     }
 }
 
-impl pipeline::Normalizer for Precompiled {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        // todo
-        input.into()
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/normalizers/prepend.rs
+++ b/tokenizers/tk-encode/src/normalizers/prepend.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use serde::{Deserialize, Serialize};
 
@@ -20,6 +23,15 @@ impl Normalizer for Prepend {
             normalized.prepend(&self.prepend);
         }
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for Prepend {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if input.is_empty() {
+            return Cow::Borrowed(input);
+        }
+        Cow::Owned(format!("{prepend}{input}", prepend = &self.prepend))
     }
 }
 
@@ -58,5 +70,15 @@ mod tests {
             n.alignments_original(),
             vec![(0, 4), (4, 5), (5, 6), (6, 7), (7, 8)]
         );
+    }
+
+    #[test]
+    fn pipeline_prepend_matches_legacy() {
+        let n = Prepend::new("▁".to_string());
+        for input in &["Hello", "world", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/prepend.rs
+++ b/tokenizers/tk-encode/src/normalizers/prepend.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use serde::{Deserialize, Serialize};
@@ -27,11 +25,14 @@ impl Normalizer for Prepend {
 }
 
 impl pipeline::Normalizer for Prepend {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
         if input.is_empty() {
-            return Cow::Borrowed(input);
+            return input;
         }
-        Cow::Owned(format!("{prepend}{input}", prepend = &self.prepend))
+        scratch.clear();
+        scratch.push_str(&self.prepend);
+        scratch.push_str(input);
+        scratch
     }
 }
 
@@ -75,10 +76,11 @@ mod tests {
     #[test]
     fn pipeline_prepend_matches_legacy() {
         let n = Prepend::new("▁".to_string());
+        let mut scratch = String::new();
         for input in &["Hello", "world", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/prepend.rs
+++ b/tokenizers/tk-encode/src/normalizers/prepend.rs
@@ -80,7 +80,10 @@ mod tests {
         for input in &["Hello", "world", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
+            assert_eq!(
+                ns.get(),
+                pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::pattern::Pattern;
 use crate::tokenizer::Decoder;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
@@ -85,6 +88,24 @@ impl Normalizer for Replace {
     }
 }
 
+impl pipeline::Normalizer for Replace {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let parts = (&self.regex).find_matches(&input).unwrap();
+
+        if parts.iter().any(|(_, is_match)| *is_match) {
+            let replaced: String = parts.into_iter().map(|((start, end), is_match)| {
+                if is_match {
+                    &self.content
+                } else {
+                    &input[start..end]
+                }
+            }).collect();
+            return Cow::Owned(replaced)
+        }
+        input.into()
+    }
+}
+
 impl Decoder for Replace {
     fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
         tokens
@@ -155,5 +176,22 @@ mod tests {
             replace.decode_chain(original).unwrap(),
             vec!["hello", " hello"]
         );
+    }
+
+    #[test]
+    fn pipeline_replace_matches_legacy() {
+        let n = Replace::new("''", "\"").unwrap();
+        for input in &["This is a ''test''", "no quotes", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+
+        let n = Replace::new(ReplacePattern::Regex(r"\s+".into()), " ").unwrap();
+        for input in &["a   b   c", "single", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -1,4 +1,3 @@
-
 use crate::pipeline;
 use crate::tokenizer::pattern::Pattern;
 use crate::tokenizer::Decoder;

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 
 use crate::pipeline;
 use crate::tokenizer::pattern::Pattern;
@@ -103,7 +102,7 @@ impl pipeline::Normalizer for Replace {
             }));
             return scratch;
         }
-        input.into()
+        input
     }
 }
 

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -89,21 +89,19 @@ impl Normalizer for Replace {
 }
 
 impl pipeline::Normalizer for Replace {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
         let parts = (&self.regex).find_matches(input).unwrap();
 
         if parts.iter().any(|(_, is_match)| *is_match) {
-            let replaced: String = parts
-                .into_iter()
-                .map(|((start, end), is_match)| {
-                    if is_match {
-                        &self.content
-                    } else {
-                        &input[start..end]
-                    }
-                })
-                .collect();
-            return Cow::Owned(replaced);
+            scratch.clear();
+            scratch.extend(parts.into_iter().map(|((start, end), is_match)| {
+                if is_match {
+                    &self.content
+                } else {
+                    &input[start..end]
+                }
+            }));
+            return scratch;
         }
         input.into()
     }
@@ -187,14 +185,22 @@ mod tests {
         for input in &["This is a ''test''", "no quotes", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            let mut scratch = String::new();
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
 
         let n = Replace::new(ReplacePattern::Regex(r"\s+".into()), " ").unwrap();
         for input in &["a   b   c", "single", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            let mut scratch = String::new();
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -90,17 +90,20 @@ impl Normalizer for Replace {
 
 impl pipeline::Normalizer for Replace {
     fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        let parts = (&self.regex).find_matches(&input).unwrap();
+        let parts = (&self.regex).find_matches(input).unwrap();
 
         if parts.iter().any(|(_, is_match)| *is_match) {
-            let replaced: String = parts.into_iter().map(|((start, end), is_match)| {
-                if is_match {
-                    &self.content
-                } else {
-                    &input[start..end]
-                }
-            }).collect();
-            return Cow::Owned(replaced)
+            let replaced: String = parts
+                .into_iter()
+                .map(|((start, end), is_match)| {
+                    if is_match {
+                        &self.content
+                    } else {
+                        &input[start..end]
+                    }
+                })
+                .collect();
+            return Cow::Owned(replaced);
         }
         input.into()
     }

--- a/tokenizers/tk-encode/src/normalizers/strip.rs
+++ b/tokenizers/tk-encode/src/normalizers/strip.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
 use serde::{Deserialize, Serialize};
@@ -40,6 +43,18 @@ impl Normalizer for Strip {
     }
 }
 
+impl pipeline::Normalizer for Strip {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let s = if self.strip_left {
+            input.trim_start()
+        } else {
+            input
+        };
+        let s = if self.strip_right { s.trim_end() } else { s };
+        Cow::Borrowed(s)
+    }
+}
+
 // This normalizer removes combining marks from a normalized string
 // It's different from unidecode as it does not attempt to modify
 // non ascii languages.
@@ -52,6 +67,16 @@ impl Normalizer for StripAccents {
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
         normalized.filter(|c| !is_combining_mark(c));
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for StripAccents {
+    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
+        if input.chars().any(is_combining_mark) {
+            Cow::Owned(input.chars().filter(|&c| !is_combining_mark(c)).collect())
+        } else {
+            Cow::Borrowed(input)
+        }
     }
 }
 
@@ -153,5 +178,27 @@ mod tests {
                 (1, 2)
             ]
         );
+    }
+
+    #[test]
+    fn pipeline_strip_accents_matches_legacy() {
+        let n = StripAccents;
+        for input in &["café", "abc", "", "å ç ñ", "     hello"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_strip_matches_legacy() {
+        for (strip_left, strip_right) in [(true, true), (true, false), (false, true)] {
+            let n = Strip::new(strip_left, strip_right);
+            for input in &["  hello  ", "hello", "", "   ", "\t hi \n"] {
+                let mut ns = NormalizedString::from(*input);
+                Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+                assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            }
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/strip.rs
+++ b/tokenizers/tk-encode/src/normalizers/strip.rs
@@ -190,7 +190,10 @@ mod tests {
         for input in &["café", "abc", "", "å ç ñ", "     hello"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
+            assert_eq!(
+                ns.get(),
+                pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 
@@ -202,7 +205,10 @@ mod tests {
             for input in &["  hello  ", "hello", "", "   ", "\t hi \n"] {
                 let mut ns = NormalizedString::from(*input);
                 Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-                assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
+                assert_eq!(
+                    ns.get(),
+                    pipeline::Normalizer::normalize(&n, input, &mut scratch)
+                );
             }
         }
     }

--- a/tokenizers/tk-encode/src/normalizers/strip.rs
+++ b/tokenizers/tk-encode/src/normalizers/strip.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
@@ -44,14 +42,17 @@ impl Normalizer for Strip {
 }
 
 impl pipeline::Normalizer for Strip {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, _scratch: &'a mut String) -> &'a str {
         let s = if self.strip_left {
             input.trim_start()
         } else {
             input
         };
-        let s = if self.strip_right { s.trim_end() } else { s };
-        Cow::Borrowed(s)
+        if self.strip_right {
+            s.trim_end()
+        } else {
+            s
+        }
     }
 }
 
@@ -71,11 +72,13 @@ impl Normalizer for StripAccents {
 }
 
 impl pipeline::Normalizer for StripAccents {
-    fn normalize<'a>(&self, input: &'a str) -> std::borrow::Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
         if input.chars().any(is_combining_mark) {
-            Cow::Owned(input.chars().filter(|&c| !is_combining_mark(c)).collect())
+            scratch.clear();
+            scratch.extend(input.chars().filter(|&c| !is_combining_mark(c)));
+            scratch
         } else {
-            Cow::Borrowed(input)
+            input
         }
     }
 }
@@ -183,21 +186,23 @@ mod tests {
     #[test]
     fn pipeline_strip_accents_matches_legacy() {
         let n = StripAccents;
+        let mut scratch = String::new();
         for input in &["café", "abc", "", "å ç ñ", "     hello"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
         }
     }
 
     #[test]
     fn pipeline_strip_matches_legacy() {
+        let mut scratch = String::new();
         for (strip_left, strip_right) in [(true, true), (true, false), (false, true)] {
             let n = Strip::new(strip_left, strip_right);
             for input in &["  hello  ", "hello", "", "   ", "\t hi \n"] {
                 let mut ns = NormalizedString::from(*input);
                 Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-                assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+                assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
             }
         }
     }

--- a/tokenizers/tk-encode/src/normalizers/unicode.rs
+++ b/tokenizers/tk-encode/src/normalizers/unicode.rs
@@ -1,5 +1,12 @@
+use std::borrow::Cow;
+
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
+
+use unicode_normalization::{
+    is_nfc_quick, is_nfd_quick, is_nfkc_quick, is_nfkd_quick, IsNormalized, UnicodeNormalization,
+};
 
 #[derive(Default, Copy, Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -8,6 +15,15 @@ impl Normalizer for NFD {
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
         normalized.nfd();
         Ok(())
+    }
+}
+impl pipeline::Normalizer for NFD {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if let IsNormalized::Yes = is_nfd_quick(input.chars()) {
+            input.into()
+        } else {
+            Cow::Owned(input.nfd().collect())
+        }
     }
 }
 
@@ -20,6 +36,15 @@ impl Normalizer for NFKD {
         Ok(())
     }
 }
+impl pipeline::Normalizer for NFKD {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if let IsNormalized::Yes = is_nfkd_quick(input.chars()) {
+            input.into()
+        } else {
+            Cow::Owned(input.nfkd().collect())
+        }
+    }
+}
 
 #[derive(Default, Copy, Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -30,6 +55,15 @@ impl Normalizer for NFC {
         Ok(())
     }
 }
+impl pipeline::Normalizer for NFC {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if let IsNormalized::Yes = is_nfc_quick(input.chars()) {
+            input.into()
+        } else {
+            Cow::Owned(input.nfc().collect())
+        }
+    }
+}
 
 #[derive(Default, Copy, Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -38,6 +72,15 @@ impl Normalizer for NFKC {
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
         normalized.nfkc();
         Ok(())
+    }
+}
+impl pipeline::Normalizer for NFKC {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if let IsNormalized::Yes = is_nfkc_quick(input.chars()) {
+            input.into()
+        } else {
+            Cow::Owned(input.nfkc().collect())
+        }
     }
 }
 
@@ -81,6 +124,40 @@ impl Normalizer for Nmt {
         Ok(())
     }
 }
+impl pipeline::Normalizer for Nmt {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let normalized: String = input
+            .chars()
+            .filter(|&c| {
+                !matches!(
+                    c as u32,
+                    0x0001..=0x0008 |
+                    0x000B |
+                    0x000E..=0x001F |
+                    0x007F |
+                    0x008F |
+                    0x009F
+                )
+            })
+            // Other code points considered as whitespace.
+            .map(|c| match c as u32 {
+                0x0009 => ' ',
+                0x000A => ' ',
+                0x000C => ' ',
+                0x000D => ' ',
+                0x1680 => ' ',
+                0x200B..=0x200F => ' ',
+                0x2028 => ' ',
+                0x2029 => ' ',
+                0x2581 => ' ',
+                0xFEFF => ' ',
+                0xFFFD => ' ',
+                _ => c,
+            })
+            .collect();
+        Cow::Owned(normalized)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -99,5 +176,55 @@ mod tests {
         );
 
         assert_eq!(n.alignments_original(), vec![(0, 2), (0, 2), (0, 2)]);
+    }
+
+    #[test]
+    fn pipeline_nfd_matches_legacy() {
+        let n = NFD;
+        for input in &["é", "café", "abc", "", "Å"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_nfkd_matches_legacy() {
+        let n = NFKD;
+        for input in &["\u{fb01}", "²", "café", "abc", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_nfc_matches_legacy() {
+        let n = NFC;
+        for input in &["e\u{0301}", "abc", "", "cafe\u{0301}"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_nfkc_matches_legacy() {
+        let n = NFKC;
+        for input in &["\u{fb01}", "²", "e\u{0301}", "abc", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_nmt_matches_legacy() {
+        let n = Nmt;
+        for input in &["a\tb", "x\u{200b}y", "abc", "", "\u{feff}hi", "c\u{0007}d"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/unicode.rs
+++ b/tokenizers/tk-encode/src/normalizers/unicode.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
@@ -18,11 +16,13 @@ impl Normalizer for NFD {
     }
 }
 impl pipeline::Normalizer for NFD {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
         if let IsNormalized::Yes = is_nfd_quick(input.chars()) {
-            input.into()
+            input
         } else {
-            Cow::Owned(input.nfd().collect())
+            scratch.clear();
+            scratch.extend(input.nfd());
+            scratch
         }
     }
 }
@@ -37,11 +37,13 @@ impl Normalizer for NFKD {
     }
 }
 impl pipeline::Normalizer for NFKD {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
         if let IsNormalized::Yes = is_nfkd_quick(input.chars()) {
-            input.into()
+            input
         } else {
-            Cow::Owned(input.nfkd().collect())
+            scratch.clear();
+            scratch.extend(input.nfkd());
+            scratch
         }
     }
 }
@@ -56,11 +58,13 @@ impl Normalizer for NFC {
     }
 }
 impl pipeline::Normalizer for NFC {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
         if let IsNormalized::Yes = is_nfc_quick(input.chars()) {
-            input.into()
+            input
         } else {
-            Cow::Owned(input.nfc().collect())
+            scratch.clear();
+            scratch.extend(input.nfc());
+            scratch
         }
     }
 }
@@ -75,11 +79,13 @@ impl Normalizer for NFKC {
     }
 }
 impl pipeline::Normalizer for NFKC {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
         if let IsNormalized::Yes = is_nfkc_quick(input.chars()) {
-            input.into()
+            input
         } else {
-            Cow::Owned(input.nfkc().collect())
+            scratch.clear();
+            scratch.extend(input.nfkc());
+            scratch
         }
     }
 }
@@ -125,37 +131,39 @@ impl Normalizer for Nmt {
     }
 }
 impl pipeline::Normalizer for Nmt {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        let normalized: String = input
-            .chars()
-            .filter(|&c| {
-                !matches!(
-                    c as u32,
-                    0x0001..=0x0008 |
-                    0x000B |
-                    0x000E..=0x001F |
-                    0x007F |
-                    0x008F |
-                    0x009F
-                )
-            })
-            // Other code points considered as whitespace.
-            .map(|c| match c as u32 {
-                0x0009 => ' ',
-                0x000A => ' ',
-                0x000C => ' ',
-                0x000D => ' ',
-                0x1680 => ' ',
-                0x200B..=0x200F => ' ',
-                0x2028 => ' ',
-                0x2029 => ' ',
-                0x2581 => ' ',
-                0xFEFF => ' ',
-                0xFFFD => ' ',
-                _ => c,
-            })
-            .collect();
-        Cow::Owned(normalized)
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
+        scratch.clear();
+        scratch.extend(
+            input
+                .chars()
+                .filter(|&c| {
+                    !matches!(
+                        c as u32,
+                        0x0001..=0x0008 |
+                        0x000B |
+                        0x000E..=0x001F |
+                        0x007F |
+                        0x008F |
+                        0x009F
+                    )
+                })
+                // Other code points considered as whitespace.
+                .map(|c| match c as u32 {
+                    0x0009 => ' ',
+                    0x000A => ' ',
+                    0x000C => ' ',
+                    0x000D => ' ',
+                    0x1680 => ' ',
+                    0x200B..=0x200F => ' ',
+                    0x2028 => ' ',
+                    0x2029 => ' ',
+                    0x2581 => ' ',
+                    0xFEFF => ' ',
+                    0xFFFD => ' ',
+                    _ => c,
+                }),
+        );
+        scratch
     }
 }
 
@@ -181,50 +189,55 @@ mod tests {
     #[test]
     fn pipeline_nfd_matches_legacy() {
         let n = NFD;
+        let mut scratch = String::new();
         for input in &["é", "café", "abc", "", "Å"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
         }
     }
 
     #[test]
     fn pipeline_nfkd_matches_legacy() {
         let n = NFKD;
+        let mut scratch = String::new();
         for input in &["\u{fb01}", "²", "café", "abc", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
         }
     }
 
     #[test]
     fn pipeline_nfc_matches_legacy() {
         let n = NFC;
+        let mut scratch = String::new();
         for input in &["e\u{0301}", "abc", "", "cafe\u{0301}"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
         }
     }
 
     #[test]
     fn pipeline_nfkc_matches_legacy() {
         let n = NFKC;
+        let mut scratch = String::new();
         for input in &["\u{fb01}", "²", "e\u{0301}", "abc", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
         }
     }
 
     #[test]
     fn pipeline_nmt_matches_legacy() {
         let n = Nmt;
+        let mut scratch = String::new();
         for input in &["a\tb", "x\u{200b}y", "abc", "", "\u{feff}hi", "c\u{0007}d"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/unicode.rs
+++ b/tokenizers/tk-encode/src/normalizers/unicode.rs
@@ -193,7 +193,10 @@ mod tests {
         for input in &["é", "café", "abc", "", "Å"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
+            assert_eq!(
+                ns.get(),
+                pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 
@@ -204,7 +207,10 @@ mod tests {
         for input in &["\u{fb01}", "²", "café", "abc", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
+            assert_eq!(
+                ns.get(),
+                pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 
@@ -215,7 +221,10 @@ mod tests {
         for input in &["e\u{0301}", "abc", "", "cafe\u{0301}"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
+            assert_eq!(
+                ns.get(),
+                pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 
@@ -226,7 +235,10 @@ mod tests {
         for input in &["\u{fb01}", "²", "e\u{0301}", "abc", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
+            assert_eq!(
+                ns.get(),
+                pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 
@@ -237,7 +249,10 @@ mod tests {
         for input in &["a\tb", "x\u{200b}y", "abc", "", "\u{feff}hi", "c\u{0007}d"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), pipeline::Normalizer::normalize(&n, input, &mut scratch));
+            assert_eq!(
+                ns.get(),
+                pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/utils.rs
+++ b/tokenizers/tk-encode/src/normalizers/utils.rs
@@ -1,6 +1,9 @@
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 use crate::normalizers::NormalizerWrapper;
+use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
 
@@ -48,6 +51,26 @@ impl Normalizer for Sequence {
     }
 }
 
+impl pipeline::Normalizer for Sequence {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let mut cow: Cow<'a, str> = Cow::Borrowed(input);
+        for normalizer in &self.normalizers {
+            cow = match cow {
+                // Still borrowing `input` ('a): chain directly so an all-no-op
+                // sequence stays zero-alloc and returns a borrow of `input`.
+                Cow::Borrowed(s) => pipeline::Normalizer::normalize(normalizer, s),
+                // Owned locally: the next step may borrow from it, so materialize
+                // its result before the local `String` is dropped.
+                Cow::Owned(s) => match pipeline::Normalizer::normalize(normalizer, &s) {
+                    Cow::Borrowed(b) => Cow::Owned(b.to_owned()),
+                    Cow::Owned(o) => Cow::Owned(o),
+                },
+            };
+        }
+        cow
+    }
+}
+
 /// Lowercases the input
 #[derive(Copy, Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -56,5 +79,37 @@ impl Normalizer for Lowercase {
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
         normalized.lowercase();
         Ok(())
+    }
+}
+
+impl pipeline::Normalizer for Lowercase {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        Cow::Owned(input.to_lowercase())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::normalizers::{StripAccents, NFD};
+
+    #[test]
+    fn pipeline_lowercase_matches_legacy() {
+        let n = Lowercase;
+        for input in &["HELLO", "Hello World", "abc", "", "ÀÉ"] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
+    }
+
+    #[test]
+    fn pipeline_sequence_matches_legacy() {
+        let n = Sequence::new(vec![NFD.into(), StripAccents.into(), Lowercase.into()]);
+        for input in &["Café", "HÉLLO", "abc", ""] {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+        }
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/utils.rs
+++ b/tokenizers/tk-encode/src/normalizers/utils.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use serde::{Deserialize, Serialize};
 
 use crate::normalizers::NormalizerWrapper;
@@ -52,23 +50,41 @@ impl Normalizer for Sequence {
 }
 
 impl pipeline::Normalizer for Sequence {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        let mut cow: Cow<'a, str> = Cow::Borrowed(input);
-        for normalizer in &self.normalizers {
-            cow = match cow {
-                // Still borrowing `input` ('a): chain directly so an all-no-op
-                // sequence stays zero-alloc and returns a borrow of `input`.
-                Cow::Borrowed(s) => pipeline::Normalizer::normalize(normalizer, s),
-                // Owned locally: the next step may borrow from it, so materialize
-                // its result before the local `String` is dropped.
-                Cow::Owned(s) => match pipeline::Normalizer::normalize(normalizer, &s) {
-                    Cow::Borrowed(b) => Cow::Owned(b.to_owned()),
-                    Cow::Owned(o) => Cow::Owned(o),
-                },
-            };
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
+        let Some((first_normalizer, rest)) = self.normalizers.split_first() else {
+            return input;
+        };
+
+        // A normalizer can't read and write the same buffer, so chaining needs two.
+        // `scratch` is one; `spare` is the alternate.
+        let mut spare = String::new();
+        normalize_into(first_normalizer, input, scratch);
+        for normalizer in rest {
+            normalize_into(normalizer, scratch, &mut spare);
+            std::mem::swap(scratch, &mut spare);
         }
-        cow
+        scratch
     }
+}
+
+/// Run `n` on `src`, leaving its full output in `dst` (cleared first). A
+/// normalizer may hand back a borrow of `src` rather than writing (input left
+/// unchanged, or a trimmed sub-slice); we copy that in so the result always
+/// lives in `dst`.
+fn normalize_into(n: &NormalizerWrapper, src: &str, dst: &mut String) {
+    dst.clear();
+    // The result's lifetime is tied to the `&mut dst` reborrow, so grab its
+    // address/len and drop the borrow before touching `dst` again.
+    let (out_ptr, out_len) = {
+        let out = pipeline::Normalizer::normalize(n, src, dst);
+        (out.as_ptr() as usize, out.len())
+    };
+    if out_ptr == dst.as_ptr() as usize {
+        return; // `n` wrote straight into `dst`
+    }
+    // Otherwise `out` borrows `src`; copy that slice in.
+    let start = out_ptr - src.as_ptr() as usize;
+    dst.push_str(&src[start..start + out_len]);
 }
 
 /// Lowercases the input
@@ -83,8 +99,10 @@ impl Normalizer for Lowercase {
 }
 
 impl pipeline::Normalizer for Lowercase {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        Cow::Owned(input.to_lowercase())
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str {
+        scratch.clear();
+        scratch.extend(input.chars().flat_map(char::to_lowercase));
+        scratch
     }
 }
 
@@ -99,7 +117,11 @@ mod tests {
         for input in &["HELLO", "Hello World", "abc", "", "ÀÉ"] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            let mut scratch = String::new();
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 
@@ -109,7 +131,11 @@ mod tests {
         for input in &["Café", "HÉLLO", "abc", ""] {
             let mut ns = NormalizedString::from(*input);
             Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(ns.get(), &*pipeline::Normalizer::normalize(&n, input));
+            let mut scratch = String::new();
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(&n, input, &mut scratch)
+            );
         }
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,5 +1,5 @@
+use std::convert::TryFrom;
 use std::ops::Range;
-use std::{borrow::Cow, convert::TryFrom};
 
 use crate::added_vocabulary::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
@@ -27,7 +27,7 @@ impl Split {
 }
 
 pub trait Normalizer {
-    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str>;
+    fn normalize<'a>(&self, input: &'a str, scratch: &'a mut String) -> &'a str;
 }
 
 /// Range-based pre-tokenization: yields spans into the input rather than owned
@@ -222,6 +222,10 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
         )?;
         added_vocabulary.set_encode_special_tokens(legacy_av.get_encode_special_tokens());
 
+        let normalizer = tok.get_normalizer().cloned();
+        if let Some(NormalizerWrapper::Precompiled(_)) = normalizer {
+            return Err("Precompile Normalizer is not supported for the PipelineTokenizer".into());
+        }
         Ok(Self {
             added_vocabulary,
             normalizer: tok.get_normalizer().cloned(),
@@ -246,6 +250,7 @@ impl PipelineTokenizer {
     pub fn encode(&self, input: &str, _add_special_tokens: bool) -> Result<Vec<PipelineToken>> {
         let mut output: Vec<PipelineToken> = vec![];
         let mut pre_tokens: Vec<Split> = vec![];
+        let mut normalized_scratch: String = String::with_capacity(4096);
 
         // First, we extract all special tokens from the non-normalized input
         for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
@@ -255,7 +260,7 @@ impl PipelineTokenizer {
                 }
                 Segment::Text(chunk) => {
                     let normalized: &str = if let Some(normalizer) = &self.normalizer {
-                        &normalizer.normalize(chunk)
+                        normalizer.normalize(chunk, &mut normalized_scratch)
                     } else {
                         chunk
                     };

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,13 +1,13 @@
-use std::convert::TryFrom;
 use std::ops::Range;
+use std::{borrow::Cow, convert::TryFrom};
 
 use crate::added_vocabulary::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
 use crate::{
+    normalizers::NormalizerWrapper,
     pre_tokenizers::{bert::BertPreTokenizer, whitespace::Whitespace},
-    Model, ModelWrapper, NormalizedString, Normalizer, NormalizerWrapper, PostProcessorWrapper,
-    PreTokenizerWrapper, Token, Tokenizer,
+    Model, ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer,
 };
 
 use super::Result;
@@ -24,6 +24,10 @@ impl Split {
     pub fn range(self) -> Range<usize> {
         self.start as usize..self.end as usize
     }
+}
+
+pub trait Normalizer {
+    fn normalize<'a>(&self, input: &'a str) -> Cow<'a, str>;
 }
 
 /// Range-based pre-tokenization: yields spans into the input rather than owned
@@ -250,15 +254,15 @@ impl PipelineTokenizer {
                     output.push(PipelineToken { id: token });
                 }
                 Segment::Text(chunk) => {
-                    // Normalize the text segment
-                    let mut normalized: NormalizedString = chunk.into();
-                    if let Some(normalizer) = &self.normalizer {
-                        normalizer.normalize(&mut normalized)?;
-                    }
+                    let normalized: &str = if let Some(normalizer) = &self.normalizer {
+                        &normalizer.normalize(chunk)
+                    } else {
+                        chunk
+                    };
 
                     // Extract special tokens from the normalized input
                     for segment in
-                        SpecialSegmentIterator::new(normalized.get(), &self.added_vocabulary, true)
+                        SpecialSegmentIterator::new(normalized, &self.added_vocabulary, true)
                     {
                         match segment {
                             Segment::SpecialToken(token) => {


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**1 / 4 models supported** · geomean ×2.65 across supported · 18 fixtures each — ~10 kB inputs · single thread

`15bef594a · 2026-07-03 16:19 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

> **Not yet supported:** `deepseek-v4` (BPE · Split+ByteLevel), `llama-3` (BPE · Split+ByteLevel), `t5-base` (Unigram · WhitespaceSplit+Metaspace) — roadmap cards below.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28672163328-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28672163328-bert-base-uncased-light.png" width="860">
</picture>

### Not yet supported

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28672163328-deepseek-v4-dark.png">
  <img alt="deepseek-v4 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28672163328-deepseek-v4-light.png" width="420">
</picture>
</td>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28672163328-llama-3-dark.png">
  <img alt="llama-3 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28672163328-llama-3-light.png" width="420">
</picture>
</td>
</tr>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28672163328-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28672163328-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

<details><summary>Per-fixture results</summary>

#### bert-base-uncased — WordPiece · Bert

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| cmn_Hani | lang | 3.5 | 14.1 | ×4.04 | match |
| eng_Latn | lang | 4.2 | 16.6 | ×3.99 | match |
| amh_Ethi | lang | 7.5 | 21.3 | ×2.84 | match |
| jpn_Jpan | lang | 4.0 | 11.1 | ×2.81 | match |
| hin_Deva | lang | 5.9 | 14.8 | ×2.50 | match |
| ben_Beng | lang | 5.5 | 12.7 | ×2.31 | match |
| tam_Taml | lang | 6.6 | 15.0 | ×2.27 | match |
| arb_Arab | lang | 3.8 | 8.4 | ×2.23 | match |
| heb_Hebr | lang | 3.8 | 8.1 | ×2.16 | match |
| ell_Grek | lang | 3.4 | 7.1 | ×2.07 | match |
| kat_Geor | lang | 5.8 | 11.2 | ×1.94 | match |
| rus_Cyrl | lang | 3.3 | 6.4 | ×1.93 | match |
| kor_Hang | lang | 2.2 | 4.0 | ×1.78 | match |
| tha_Thai | lang | 8.2 | 13.9 | ×1.70 | match |
| agentic-traces | modalities | 3.6 | 14.6 | ×4.05 | match |
| math_latex | modalities | 3.8 | 14.9 | ×3.97 | match |
| agentic_swe | modalities | 3.9 | 14.8 | ×3.85 | match |
| code_mixed | modalities | 3.7 | 13.3 | ×3.60 | match |

</details>
<!-- pipeline-bench:end -->

