### PR TITLE
Map prepended text to a zero-width span to avoid overlapping offsets (#1775)

### DIFF
--- a/tokenizers/src/normalizers/prepend.rs
+++ b/tokenizers/src/normalizers/prepend.rs
@@ -41,10 +41,12 @@ mod tests {
             NormalizedString::new(
                 original.to_string(),
                 normalized.to_string(),
+                // The prepended "▁" (3 bytes) maps to a zero-width span at the
+                // start; the original characters keep their own offsets.
                 vec![
-                    (0, 1),
-                    (0, 1),
-                    (0, 1),
+                    (0, 0),
+                    (0, 0),
+                    (0, 0),
                     (0, 1),
                     (1, 2),
                     (2, 3),
@@ -56,7 +58,7 @@ mod tests {
         );
         assert_eq!(
             n.alignments_original(),
-            vec![(0, 4), (4, 5), (5, 6), (6, 7), (7, 8)]
+            vec![(3, 4), (4, 5), (5, 6), (6, 7), (7, 8)]
         );
     }
 }

--- a/tokenizers/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/src/pre_tokenizers/byte_level.rs
@@ -141,7 +141,16 @@ impl PreTokenizer for ByteLevel {
                         .map(|(i, b)| (BYTES_CHAR[b], isize::from(i > 0))),
                 );
             }
-            normalized.transform(transformations, 0);
+            // Remap every normalized byte to its byte-level char over the full
+            // normalized range (not the original range) so bytes that map to a
+            // zero-width original span -- e.g. a prepended prefix space/marker --
+            // are still covered; addressing them via the original range would
+            // exclude them and desync the transformation offsets.
+            normalized.transform_range(
+                crate::tokenizer::normalizer::Range::Normalized(..),
+                transformations,
+                0,
+            );
             Ok(())
         })
     }

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -501,14 +501,17 @@ impl NormalizedString {
 
     /// Prepend the given string to ourself
     pub fn prepend(&mut self, s: &str) -> &mut Self {
-        if let Some(next) = self.normalized.chars().next() {
-            let transformations = s
-                .chars()
-                .enumerate()
-                .map(|(i, c)| (c, isize::from(i != 0)))
-                .chain(std::iter::once((next, 1)));
-
-            self.transform_range(Range::Normalized(0..next.len_utf8()), transformations, 0);
+        if !s.is_empty() {
+            // The prepended text has no counterpart in the original input, so it
+            // must map to a zero-width span at the start of the original string.
+            // Inserting it as new characters at an empty range does exactly that
+            // and leaves the existing characters' alignments untouched. Borrowing
+            // the first original character's offsets instead (the previous
+            // behaviour) produced overlapping token offsets for multi-byte
+            // scripts once the model split the prepended marker off, e.g. CJK
+            // tokens with `▁` under the Metaspace pre-tokenizer. See #1775.
+            let transformations = s.chars().map(|c| (c, 1isize));
+            self.transform_range(Range::Normalized(0..0), transformations, 0);
         }
         self
     }
@@ -1374,13 +1377,16 @@ mod tests {
         let mut n = NormalizedString::from("there");
         n.prepend("Hey ");
         assert_eq!(&n.normalized, "Hey there");
+        // The prepended "Hey " has no source in the original input, so it maps to
+        // a zero-width span at the start; the original characters keep their own
+        // offsets (rather than the first one being shared with the prefix).
         assert_eq!(
             n.alignments,
             vec![
-                (0, 1),
-                (0, 1),
-                (0, 1),
-                (0, 1),
+                (0, 0),
+                (0, 0),
+                (0, 0),
+                (0, 0),
                 (0, 1),
                 (1, 2),
                 (2, 3),
@@ -1388,7 +1394,35 @@ mod tests {
                 (4, 5)
             ]
         );
-        assert_eq!(n.convert_offsets(Range::Normalized(0..4)), Some(0..1));
+        assert_eq!(n.convert_offsets(Range::Normalized(0..4)), Some(0..0));
+    }
+
+    #[test]
+    fn prepend_multibyte_no_overlap() {
+        // Regression for #1775: when the prepended metaspace-style marker is a
+        // multi-byte character and the following original characters are also
+        // multi-byte (e.g. CJK), the prefix must not borrow the first original
+        // character's bytes, which previously produced overlapping offsets.
+        let mut n = NormalizedString::from("中文");
+        n.prepend("\u{2581}"); // ▁, 3 bytes
+        assert_eq!(&n.normalized, "\u{2581}中文");
+        // alignments hold one entry per normalized byte. ▁ -> zero-width (0,0);
+        // 中 -> original bytes (0,3); 文 -> (3,6). Crucially ▁ does not share 中's
+        // (0,3) span, so token offsets no longer overlap.
+        assert_eq!(
+            n.alignments,
+            vec![
+                (0, 0),
+                (0, 0),
+                (0, 0),
+                (0, 3),
+                (0, 3),
+                (0, 3),
+                (3, 6),
+                (3, 6),
+                (3, 6),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`char_to_token()` can point to the wrong token for tokenizers that use a Metaspace-style prefix (e.g. `DebertaV2TokenizerFast`, `XLMRobertaTokenizerFast`), because token **offsets overlap** on multi-byte scripts. Reported in #1775.

Root cause is in `NormalizedString::prepend`. It mapped the prepended text — which has no counterpart in the original input — onto the **first original character's byte range**. That is invisible while the prefix stays glued to the following text, but once the model splits the prepended marker into its own token it surfaces. For `"中文"` under Metaspace (xlm-roberta), the tokens are `["▁", "中文"]` and the offsets were:

```
▁    (0, 3)   ← borrows 中's bytes
中文  (0, 6)   ← overlaps
```

so `char_to_token(0)` resolves to `▁` instead of `中文`. Reproduces on Chinese and Japanese samples; Latin/Cyrillic/Korean don't split the `▁word` unit, so they never exposed it.

## Fix

Prepended text has no source in the original string, so it should map to a **zero-width span at the start**. `prepend` now inserts the text as new characters at an empty range, leaving the existing characters' offsets untouched:

```
▁    (0, 0)   ← zero-width, synthetic
中文  (0, 6)   ← no overlap
```

`ByteLevel`'s byte-level remap is updated to transform over the full **normalized** range instead of the original range, so the now-zero-width prefix byte (e.g. the prefix space from `add_prefix_space`) is still covered — otherwise it would be excluded and desync the transformation offsets.

## Tests

- New `prepend_multibyte_no_overlap` regression test (the exact CJK + `▁` case).
- Updated the `prepend` and `Prepend`-normalizer alignment expectations to the corrected zero-width behaviour.
- Full suite green (`cargo test`, with `make test` data), including all `byte_level`, `added_tokens`, and `normalizer` tests. `cargo fmt` / `cargo clippy` clean.

Every prepend caller in the tree (Metaspace, ByteLevel's leading space, the `Prepend` normalizer) prepends synthetic text, so zero-width alignment is correct for all of them.
