### PR TITLE
Harden tokenizer deserialization against panics on crafted configs

### DIFF
--- a/tokenizers/src/decoders/strip.rs
+++ b/tokenizers/src/decoders/strip.rs
@@ -42,7 +42,10 @@ impl Decoder for Strip {
                 }
 
                 let mut stop_cut = chars.len();
-                for i in 0..self.stop {
+                // Bound the loop by the token length: `self.stop` comes from the
+                // config unvalidated, so without this `chars.len() - i - 1` would
+                // underflow (and panic / index out of bounds) on short tokens.
+                for i in 0..self.stop.min(chars.len()) {
                     let index = chars.len() - i - 1;
                     if chars[index] == self.content {
                         stop_cut = index;
@@ -52,6 +55,10 @@ impl Decoder for Strip {
                     }
                 }
 
+                // `start_cut` and `stop_cut` can cross when a token is made
+                // entirely of `content` characters; clamp so the range is never
+                // reversed, which would panic when slicing.
+                let stop_cut = stop_cut.max(start_cut);
                 let new_token: String = chars[start_cut..stop_cut].iter().collect();
                 new_token
             })
@@ -76,5 +83,18 @@ mod tests {
             .decode_chain(vec!["Hey".into(), " friend!".into()])
             .unwrap();
         assert_eq!(res, vec!["He", " friend!"]);
+    }
+
+    #[test]
+    fn does_not_panic_on_crafted_config() {
+        // `start`/`stop` come from the config unvalidated. A token made entirely
+        // of `content` chars used to slice a reversed range and panic.
+        let decoder = Strip::new('H', 2, 2);
+        assert_eq!(decoder.decode_chain(vec!["HH".into()]).unwrap(), vec![""]);
+
+        // Empty (and short) tokens used to underflow `chars.len() - i - 1`.
+        let decoder = Strip::new('H', 0, 1);
+        assert_eq!(decoder.decode_chain(vec!["".into()]).unwrap(), vec![""]);
+        assert_eq!(decoder.decode_chain(vec!["H".into()]).unwrap(), vec![""]);
     }
 }

--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -261,10 +261,23 @@ impl BpeBuilder {
                 let b_id = vocab
                     .get(&b)
                     .ok_or_else(|| Error::MergeTokenOutOfVocabulary(b.to_owned()))?;
+                // The `continuing_subword_prefix` is stripped from the right token
+                // before the pair is concatenated. A crafted merge list (e.g. loaded
+                // from an untrusted tokenizer.json) may pair a right token shorter
+                // than the prefix, or two tokens whose concatenation is longer than
+                // any vocabulary entry. In both cases the merged token cannot exist
+                // in the vocabulary, so report it as out-of-vocab rather than
+                // indexing past the scratch buffer (which is only `max_len` long).
+                let b_tail = b
+                    .as_bytes()
+                    .get(prefix_len..)
+                    .ok_or_else(|| Error::MergeTokenOutOfVocabulary(format!("{a}{b}")))?;
+                let merge_len = a.len() + b_tail.len();
+                if merge_len > buffer.len() {
+                    return Err(Error::MergeTokenOutOfVocabulary(format!("{a}{b}")).into());
+                }
                 buffer[0..a.len()].copy_from_slice(a.as_bytes());
-                let b_len = b.len() - prefix_len;
-                let merge_len = a.len() + b_len;
-                buffer[a.len()..merge_len].copy_from_slice(&b.as_bytes()[prefix_len..]);
+                buffer[a.len()..merge_len].copy_from_slice(b_tail);
                 // SAFETY: buffer contains a concatenation of two valid UTF-8 strings, so it is itself valid UTF-8, even considering prefix_len
                 let new_token = unsafe { from_utf8_unchecked(&buffer[..merge_len]) };
                 let new_id = vocab
@@ -1167,5 +1180,42 @@ mod tests {
                 }
             ]
         )
+    }
+
+    // A crafted merge list (e.g. from an untrusted tokenizer.json) whose merged
+    // token is longer than any vocabulary entry must not panic on the scratch
+    // buffer; the builder should return a graceful error instead.
+    #[test]
+    fn merge_concat_longer_than_vocab_does_not_panic() {
+        let vocab: Vocab = [("a".into(), 0u32), ("b".into(), 1u32)]
+            .iter()
+            .cloned()
+            .collect();
+        // "a" + "b" = "ab" is not in the vocab and is longer than max_len (1).
+        let res = BpeBuilder::default()
+            .vocab_and_merges(vocab, vec![("a".to_string(), "b".to_string())])
+            .build();
+        assert!(
+            matches!(
+                res.as_ref().map_err(|e| e.to_string()),
+                Err(msg) if msg.contains("out of vocabulary")
+            ),
+            "expected MergeTokenOutOfVocabulary, got {res:?}"
+        );
+    }
+
+    // A right merge token shorter than `continuing_subword_prefix` used to
+    // underflow `b.len() - prefix_len`; it must now error gracefully.
+    #[test]
+    fn merge_right_token_shorter_than_prefix_does_not_panic() {
+        let vocab: Vocab = [("ab".into(), 0u32), ("x".into(), 1u32)]
+            .iter()
+            .cloned()
+            .collect();
+        let res = BpeBuilder::default()
+            .continuing_subword_prefix("##".into())
+            .vocab_and_merges(vocab, vec![("ab".to_string(), "x".to_string())])
+            .build();
+        assert!(res.is_err(), "expected an error, got {res:?}");
     }
 }

--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -137,10 +137,9 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                     ),
                     EnumType::Precompiled => NormalizerWrapper::Precompiled(
                         serde_json::from_str(
-                            &serde_json::to_string(&values).expect("Can reserialize precompiled"),
+                            &serde_json::to_string(&values).map_err(serde::de::Error::custom)?,
                         )
-                        // .map_err(serde::de::Error::custom)
-                        .expect("Precompiled"),
+                        .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Replace => NormalizerWrapper::Replace(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,
@@ -220,6 +219,16 @@ impl_enum_from!(ByteLevel, NormalizerWrapper, ByteLevel);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn invalid_precompiled_charsmap_is_rejected() {
+        // A crafted config with an invalid `precompiled_charsmap` used to
+        // `.expect()` and panic; like every other normalizer it must now
+        // surface a serde error.
+        let json = r#"{"type":"Precompiled","precompiled_charsmap":"!!!not-base64!!!"}"#;
+        assert!(serde_json::from_str::<NormalizerWrapper>(json).is_err());
+    }
+
     #[test]
     fn post_processor_deserialization_no_type() {
         let json = r#"{"strip_left":false, "strip_right":true}"#;

--- a/tokenizers/src/pre_tokenizers/fixed_length.rs
+++ b/tokenizers/src/pre_tokenizers/fixed_length.rs
@@ -23,6 +23,12 @@ fn default_length() -> usize {
 
 impl PreTokenizer for FixedLength {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
+        // `length` is deserialized straight from the config with no validation;
+        // a value of 0 would panic in `<[_]>::chunks` ("chunk size must be
+        // non-zero"). Reject it with a clear error instead.
+        if self.length == 0 {
+            return Err("FixedLength pre-tokenizer length must be greater than 0".into());
+        }
         pretokenized.split(|_, normalized| {
             let text = normalized.get();
             if text.is_empty() {
@@ -118,5 +124,14 @@ mod tests {
                 ("d", (15, 16)),
             ]
         );
+    }
+
+    #[test]
+    fn zero_length_is_rejected() {
+        // `length` is deserialized without validation; a value of 0 used to
+        // panic in `chunks`. It must now return an error on non-empty input.
+        let pretok = FixedLength { length: 0 };
+        let mut pretokenized = PreTokenizedString::from("hello");
+        assert!(pretok.pre_tokenize(&mut pretokenized).is_err());
     }
 }

--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -334,7 +334,7 @@ impl From<AHashMap<String, SpecialToken>> for Tokens {
 /// ```
 ///
 #[derive(Debug, Clone, PartialEq, Builder, Serialize, Deserialize, Eq)]
-#[serde(tag = "type", from = "TemplateProcessingDeserializer")]
+#[serde(tag = "type", try_from = "TemplateProcessingDeserializer")]
 #[builder(build_fn(validate = "Self::validate"))]
 pub struct TemplateProcessing {
     #[builder(try_setter, default = "\"$0\".try_into().unwrap()")]
@@ -425,17 +425,21 @@ struct TemplateProcessingDeserializer {
     pair: Template,
     special_tokens: Tokens,
 }
-impl From<TemplateProcessingDeserializer> for TemplateProcessing {
-    fn from(t: TemplateProcessingDeserializer) -> Self {
-        let added_single = count_added(&t.single, Some(&t.special_tokens));
-        let added_pair = count_added(&t.pair, Some(&t.special_tokens));
-        Self {
-            single: t.single,
-            pair: t.pair,
-            added_single,
-            added_pair,
-            special_tokens: t.special_tokens,
-        }
+impl TryFrom<TemplateProcessingDeserializer> for TemplateProcessing {
+    type Error = String;
+
+    // Build through the builder so `validate` runs: this rejects a template that
+    // references a special token missing from `special_tokens` (or a `pair`
+    // template that doesn't use both sequences). Constructing directly bypassed
+    // that check, so such a deserialized processor panicked at
+    // `self.special_tokens.0[id]` during `apply_template`.
+    fn try_from(t: TemplateProcessingDeserializer) -> std::result::Result<Self, Self::Error> {
+        TemplateProcessingBuilder::default()
+            .single(t.single)
+            .pair(t.pair)
+            .special_tokens(t.special_tokens)
+            .build()
+            .map_err(|e| e.to_string())
     }
 }
 
@@ -883,6 +887,26 @@ mod tests {
         let err_a = Err("Missing SpecialToken(s) with id(s) `[SEP], [CLS]`".into());
         let err_b = Err("Missing SpecialToken(s) with id(s) `[CLS], [SEP]`".into());
         assert!(processor == err_a || processor == err_b);
+    }
+
+    #[test]
+    fn deserialize_missing_special_tokens_is_rejected() {
+        // Deserialization used to bypass `validate`, so a template referencing a
+        // special token absent from `special_tokens` deserialized fine and then
+        // panicked at `self.special_tokens.0[id]` during `apply_template`. It must
+        // now be rejected at deserialization time instead.
+        let template_s = "{\
+            \"type\":\"TemplateProcessing\",\
+            \"single\":[\
+                {\"SpecialToken\":{\"id\":\"[CLS]\",\"type_id\":0}},\
+                {\"Sequence\":{\"id\":\"A\",\"type_id\":0}}\
+            ],\
+            \"pair\":[\
+                {\"Sequence\":{\"id\":\"A\",\"type_id\":0}},\
+                {\"Sequence\":{\"id\":\"B\",\"type_id\":1}}\
+            ],\
+            \"special_tokens\":{}}";
+        assert!(serde_json::from_str::<TemplateProcessing>(template_s).is_err());
     }
 
     #[test]

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -303,7 +303,13 @@ impl Encoding {
 
     /// Truncate the current `Encoding`.
     ///
-    /// Panics if `stride >= max_len`
+    /// `stride` is the overlap kept between successive overflow windows. If it is
+    /// `>= max_len` it is clamped to `max_len - 1` (the maximum meaningful
+    /// overlap), which also avoids underflowing `max_len - stride`. This is
+    /// reachable from a deserialized tokenizer whose truncation params were not
+    /// validated by [`with_truncation`], so it must not panic. The primary
+    /// (first) truncated encoding is independent of `stride`; only the overflow
+    /// windows are affected.
     pub fn truncate(&mut self, max_len: usize, stride: usize, direction: TruncationDirection) {
         let encoding_len = self.ids.len();
         if max_len >= encoding_len {
@@ -316,7 +322,8 @@ impl Encoding {
             return;
         }
 
-        assert!(stride < max_len, "`stride` must be strictly less than `max_len={}` (note that `max_len` may be shorter than the max length of the original model, as it subtracts the number of special characters", max_len);
+        // max_len >= 1 here (the max_len == 0 case returned above).
+        let stride = stride.min(max_len - 1);
 
         // When truncating, we lose the `sequence_ranges` information.
         self.sequence_ranges.clear();
@@ -646,6 +653,30 @@ mod tests {
                 ..Default::default()
             }
         );
+    }
+
+    #[test]
+    fn truncate_stride_ge_max_len_does_not_panic() {
+        // Reachable from a deserialized tokenizer whose truncation `stride` was
+        // not validated (unlike the `with_truncation` setter). truncate must clamp
+        // instead of panicking on the former `assert(stride < max_len)`.
+        let mut a = Encoding {
+            ids: vec![1, 2, 3],
+            type_ids: vec![0, 0, 0],
+            tokens: vec![
+                String::from("Hello"),
+                String::from("World"),
+                String::from("!"),
+            ],
+            words: vec![Some(0), Some(1), Some(2)],
+            offsets: vec![(0, 5), (6, 11), (11, 12)],
+            special_tokens_mask: vec![0, 0, 0],
+            attention_mask: vec![1, 1, 1],
+            ..Default::default()
+        };
+        a.truncate(2, 5, TruncationDirection::Right); // stride 5 >= max_len 2
+                                                      // The primary (first) truncated encoding is independent of `stride`.
+        assert_eq!(a.get_ids(), &[1, 2]);
     }
 
     #[test]


### PR DESCRIPTION
## What

A `tokenizer.json` is untrusted input, but several components deserialized from one bypass the validation their builders enforce, so a crafted config **panics at load or encode/decode time** instead of returning an error. This PR fixes six such panics (each with a regression test); they share the theme "deserialization skips a check the code later relies on."

| Component | Crafted input | Was | Now |
|-----------|--------------|-----|-----|
| `Encoding::truncate` | `stride >= max_length` via deserialized truncation params | panic (`assert`) | clamped, no panic |
| `TemplateProcessing` | template references a special token absent from `special_tokens` | panic at encode (`HashMap` index) | `Err` at load (routes through `validate`) |
| BPE builder | merge pair whose concatenation exceeds the longest vocab token | OOB panic on scratch buffer | `MergeTokenOutOfVocabulary` |
| `Strip` decoder | crafted `start`/`stop` (e.g. token all `content` chars) | underflow / reversed-range slice panic | clamped, no panic |
| `FixedLength` pre-tokenizer | `length = 0` | `chunks(0)` panic | `Err` |
| `Precompiled` normalizer | invalid `precompiled_charsmap` | `.expect()` panic | serde `Err` (matches every sibling arm) |

## Why one PR

All six are the same class of bug (untrusted-config → panic) and several are one-line fixes; grouping them keeps the review to a single coherent security-hardening pass rather than six fragments.

## Tests

Each fix has a regression test; full lib suite green (208 passed). `cargo fmt` / `cargo clippy --lib -- -D warnings` clean.

cc @SBrandeis @McPatate @ArthurZucker