### PR TITLE
Validate TemplateProcessing on deserialization (fix panic on crafted tokenizer.json)

### DIFF
--- a/tokenizers/src/processors/template.rs
+++ b/tokenizers/src/processors/template.rs
@@ -334,7 +334,7 @@ impl From<AHashMap<String, SpecialToken>> for Tokens {
 /// ```
 ///
 #[derive(Debug, Clone, PartialEq, Builder, Serialize, Deserialize, Eq)]
-#[serde(tag = "type", from = "TemplateProcessingDeserializer")]
+#[serde(tag = "type", try_from = "TemplateProcessingDeserializer")]
 #[builder(build_fn(validate = "Self::validate"))]
 pub struct TemplateProcessing {
     #[builder(try_setter, default = "\"$0\".try_into().unwrap()")]
@@ -425,17 +425,21 @@ struct TemplateProcessingDeserializer {
     pair: Template,
     special_tokens: Tokens,
 }
-impl From<TemplateProcessingDeserializer> for TemplateProcessing {
-    fn from(t: TemplateProcessingDeserializer) -> Self {
-        let added_single = count_added(&t.single, Some(&t.special_tokens));
-        let added_pair = count_added(&t.pair, Some(&t.special_tokens));
-        Self {
-            single: t.single,
-            pair: t.pair,
-            added_single,
-            added_pair,
-            special_tokens: t.special_tokens,
-        }
+impl TryFrom<TemplateProcessingDeserializer> for TemplateProcessing {
+    type Error = String;
+
+    // Build through the builder so `validate` runs: this rejects a template that
+    // references a special token missing from `special_tokens` (or a `pair`
+    // template that doesn't use both sequences). Constructing directly bypassed
+    // that check, so such a deserialized processor panicked at
+    // `self.special_tokens.0[id]` during `apply_template`.
+    fn try_from(t: TemplateProcessingDeserializer) -> std::result::Result<Self, Self::Error> {
+        TemplateProcessingBuilder::default()
+            .single(t.single)
+            .pair(t.pair)
+            .special_tokens(t.special_tokens)
+            .build()
+            .map_err(|e| e.to_string())
     }
 }
 
@@ -883,6 +887,26 @@ mod tests {
         let err_a = Err("Missing SpecialToken(s) with id(s) `[SEP], [CLS]`".into());
         let err_b = Err("Missing SpecialToken(s) with id(s) `[CLS], [SEP]`".into());
         assert!(processor == err_a || processor == err_b);
+    }
+
+    #[test]
+    fn deserialize_missing_special_tokens_is_rejected() {
+        // Deserialization used to bypass `validate`, so a template referencing a
+        // special token absent from `special_tokens` deserialized fine and then
+        // panicked at `self.special_tokens.0[id]` during `apply_template`. It must
+        // now be rejected at deserialization time instead.
+        let template_s = "{\
+            \"type\":\"TemplateProcessing\",\
+            \"single\":[\
+                {\"SpecialToken\":{\"id\":\"[CLS]\",\"type_id\":0}},\
+                {\"Sequence\":{\"id\":\"A\",\"type_id\":0}}\
+            ],\
+            \"pair\":[\
+                {\"Sequence\":{\"id\":\"A\",\"type_id\":0}},\
+                {\"Sequence\":{\"id\":\"B\",\"type_id\":1}}\
+            ],\
+            \"special_tokens\":{}}";
+        assert!(serde_json::from_str::<TemplateProcessing>(template_s).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What

`TemplateProcessing` deserialized from a `tokenizer.json` skips the builder's validation. serde routes through `From<TemplateProcessingDeserializer>`, which builds the struct directly without verifying that every special token referenced by the `single`/`pair` templates actually appears in `special_tokens`.

That invariant is not optional — `apply_template` indexes the special-tokens map directly:

```rust
// processors/template.rs
let tok = &self.special_tokens.0[id]; // We already checked existence above
```

The "already checked" only holds on the programmatic path (`TemplateProcessingBuilder::build` → `validate`). On the deserialization path it does not, so a crafted config whose template references a token missing from `special_tokens` loads fine and then **panics at encode time** on the missing map key.

## Repro

A `tokenizer.json` post-processor like:

```json
{
  "type": "TemplateProcessing",
  "single": [{ "SpecialToken": { "id": "[CLS]", "type_id": 0 } }],
  "pair": [],
  "special_tokens": {}
}
```

deserializes without error, then panics inside `apply_template` on the first `encode`.

## Fix

Switch the serde bridge from `from` to `try_from` and route through `TemplateProcessingBuilder`, so the same `validate` that guards the programmatic path also guards deserialization. Invalid configs now return a clean `Err` at load time instead of panicking later.

```rust
#[serde(tag = "type", try_from = "TemplateProcessingDeserializer")]

impl TryFrom<TemplateProcessingDeserializer> for TemplateProcessing {
    type Error = String;
    fn try_from(t: TemplateProcessingDeserializer) -> Result<Self, Self::Error> {
        TemplateProcessingBuilder::default()
            .single(t.single)
            .pair(t.pair)
            .special_tokens(t.special_tokens)
            .build()
            .map_err(|e| e.to_string())
    }
}
```

## Tests

Added `deserialize_missing_special_tokens_is_rejected`: a template referencing `[CLS]` with empty `special_tokens` now returns `Err` from `serde_json::from_str` instead of panicking on encode. Existing `template_processing_serde` (valid round-trip) and `missing_special_tokens` still pass. Full `tokenizers` lib suite green (203 passed); `cargo fmt`/`clippy` clean on the changed file.

cc @ArthurZucker @McPatate