### PR TITLE
Do not panic when deserializing an invalid Precompiled normalizer

### DIFF
--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -137,10 +137,9 @@ impl<'de> Deserialize<'de> for NormalizerWrapper {
                     ),
                     EnumType::Precompiled => NormalizerWrapper::Precompiled(
                         serde_json::from_str(
-                            &serde_json::to_string(&values).expect("Can reserialize precompiled"),
+                            &serde_json::to_string(&values).map_err(serde::de::Error::custom)?,
                         )
-                        // .map_err(serde::de::Error::custom)
-                        .expect("Precompiled"),
+                        .map_err(serde::de::Error::custom)?,
                     ),
                     EnumType::Replace => NormalizerWrapper::Replace(
                         serde_json::from_value(values).map_err(serde::de::Error::custom)?,
@@ -220,6 +219,16 @@ impl_enum_from!(ByteLevel, NormalizerWrapper, ByteLevel);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn invalid_precompiled_charsmap_is_rejected() {
+        // A crafted config with an invalid `precompiled_charsmap` used to
+        // `.expect()` and panic; like every other normalizer it must now
+        // surface a serde error.
+        let json = r#"{"type":"Precompiled","precompiled_charsmap":"!!!not-base64!!!"}"#;
+        assert!(serde_json::from_str::<NormalizerWrapper>(json).is_err());
+    }
+
     #[test]
     fn post_processor_deserialization_no_type() {
         let json = r#"{"strip_left":false, "strip_right":true}"#;


### PR DESCRIPTION
## What

Every arm of the tagged `NormalizerWrapper` deserializer routes parse failures through `.map_err(serde::de::Error::custom)?`, so an invalid `tokenizer.json` returns a clean serde error — **except** `Precompiled`:

```rust
EnumType::Precompiled => NormalizerWrapper::Precompiled(
    serde_json::from_str(
        &serde_json::to_string(&values).expect("Can reserialize precompiled"),
    )
    // .map_err(serde::de::Error::custom)
    .expect("Precompiled"),
),
```

A crafted `{"type":"Precompiled","precompiled_charsmap":"<invalid>"}` makes the inner `from_str` return `Err`, and `.expect("Precompiled")` turns that into a **panic while loading the tokenizer**, unlike every other normalizer. The commented-out `// .map_err(serde::de::Error::custom)` on the very next line shows the graceful path was intended.

## Fix

Route both fallible steps through `map_err(serde::de::Error::custom)?`, matching all the sibling arms:

```rust
EnumType::Precompiled => NormalizerWrapper::Precompiled(
    serde_json::from_str(
        &serde_json::to_string(&values).map_err(serde::de::Error::custom)?,
    )
    .map_err(serde::de::Error::custom)?,
),
```

## Tests

Adds `invalid_precompiled_charsmap_is_rejected`: a crafted `precompiled_charsmap` now returns `Err` instead of panicking. Full lib suite green (202); `cargo fmt`/`clippy` clean.

cc @ArthurZucker @McPatate