### PR TITLE
Remove unreachable convert_offsets empty 0..0 branch

### DIFF
--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -174,14 +174,6 @@ impl NormalizedString {
             return None;
         }
 
-        // If we target 0..0 on an empty string, we want to expand to the entire equivalent
-        if original && self.original.is_empty() && target == (0..0) {
-            return Some(0..len_normalized);
-        }
-        if !original && self.normalized.is_empty() && target == (0..0) {
-            return Some(0..len_original);
-        }
-
         if original {
             let (mut start, mut end) = (None, None);
             self.alignments


### PR DESCRIPTION
## Summary
- Remove two unreachable `if` blocks in `NormalizedString::convert_offsets`
- Empty ranges (including `0..0`) already return via `if target.start == target.end`
- Dead since initial byte-offset refactor (`66fef2b9`, 2020); behavior unchanged

## Test plan
- [x] `cd tokenizers && cargo test --lib range_conversion`
- [x] `cd tokenizers && cargo test --lib tokenizer::normalizer::tests`
- [x] `cargo fmt -- --check` and `cargo clippy --lib -- -D warnings`