### PR TITLE
Feat/pipeline model

### DIFF
--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -727,7 +727,7 @@ impl PyWordPiece {
         let vocab = WordPiece::read_file(vocab).map_err(|e| {
             exceptions::PyException::new_err(format!("Error while reading WordPiece file: {e}"))
         })?;
-        Ok(vocab.into_iter().collect())
+        Ok(vocab.get_vocab().into_iter().collect())
     }
 
     /// Instantiate a WordPiece model from the given file
@@ -759,7 +759,7 @@ impl PyWordPiece {
         let vocab = WordPiece::read_file(vocab).map_err(|e| {
             exceptions::PyException::new_err(format!("Error while reading WordPiece file: {e}"))
         })?;
-        let vocab = vocab.into_iter().collect();
+        let vocab = vocab.get_vocab().into_iter().collect();
         Py::new(
             py,
             PyWordPiece::new(py, Some(PyVocab::Vocab(vocab)), kwargs)?,

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,4 +1,5 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
+use crate::pipeline;
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
@@ -669,6 +670,23 @@ impl Model for BPE {
         )?;
 
         Ok(vec![vocab_path, merges_path])
+    }
+}
+
+impl pipeline::Model for BPE {
+    fn tokenize_bytes(
+        &self,
+        bytes: &[u8],
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let sequence = str::from_utf8(bytes)?;
+        for token in self.tokenize(sequence)? {
+            output.push(pipeline::PipelineToken { id: token.id });
+        }
+        Ok(())
     }
 }
 

--- a/tokenizers/tk-encode/src/models/unigram/lattice.rs
+++ b/tokenizers/tk-encode/src/models/unigram/lattice.rs
@@ -227,6 +227,10 @@ impl<'a> Lattice<'a> {
         self.sentence[node.pos..node.pos + node.length].to_owned()
     }
 
+    pub fn piece_offsets(&self, node: &Node) -> (usize, usize) {
+        (node.pos, node.pos + node.length)
+    }
+
     pub fn tokens(&mut self) -> Vec<String> {
         self.viterbi()
             .iter()

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -2,9 +2,12 @@ use super::{
     lattice::Lattice,
     trie::{Trie, TrieBuilder},
 };
-use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 use crate::vocab_store::VocabStore;
+use crate::{
+    pipeline::{self, PipelineToken},
+    tokenizer::{Model, Result, Token},
+};
 use std::collections::HashMap;
 
 use std::convert::TryInto;
@@ -16,6 +19,7 @@ type Vocab = Vec<(String, f64)>;
 /// A `Unigram` model to encode sentences.
 pub struct Unigram {
     token_to_ids: VocabStore,
+    byte_fallback_map: [Option<u32>; 256],
     pub(crate) vocab: Vocab,
     cache: Cache<String, Vec<String>>,
     trie: Trie<u8>,
@@ -59,6 +63,7 @@ impl Clone for Unigram {
             byte_fallback: self.byte_fallback,
             alpha: self.alpha,
             nbest_size: self.nbest_size,
+            byte_fallback_map: self.byte_fallback_map,
         }
     }
 }
@@ -136,6 +141,12 @@ impl Unigram {
         let fuse_unk = true;
         let is_optimized = true;
 
+        let byte_fallback_map: [Option<u32>; 256] = if byte_fallback {
+            std::array::from_fn(|byte| token_to_ids.get_bytes(format!("<0x{byte:02X}>").as_bytes()))
+        } else {
+            [None; 256]
+        };
+
         Ok(Self {
             vocab,
             token_to_ids,
@@ -150,6 +161,7 @@ impl Unigram {
             byte_fallback,
             alpha: None,
             nbest_size: None,
+            byte_fallback_map,
         })
     }
 
@@ -259,130 +271,21 @@ impl Unigram {
     }
 
     fn encode_optimized(&self, sentence: &str) -> Result<Vec<String>> {
-        // https://github.com/google/sentencepiece/blob/d48247191a6d50e469ed1a4a36e877befffd1851/src/unigram_model.cc#L600
-        #[derive(Debug, Clone)]
-        struct BestPathNode {
-            /// The vocab id. (maybe UNK)
-            id: usize,
-            /// The total score of the best path ending at this node.
-            best_path_score: f64,
-            /// The starting position (in utf-8) of this node. The entire best
-            /// path can be constructed by backtracking along this link.
-            starts_at: Option<usize>,
-        }
-        impl Default for BestPathNode {
-            fn default() -> Self {
-                Self {
-                    id: 0,
-                    best_path_score: 0.0,
-                    starts_at: None,
-                }
-            }
-        }
-        let size = sentence.len();
-        let unk_score = self.min_score - K_UNK_PENALTY;
-
-        let mut best_path_ends_at = vec![BestPathNode::default(); size + 1];
-        let mut starts_at = 0;
-        while starts_at < size {
-            let best_path_score_till_here = best_path_ends_at[starts_at].best_path_score;
-            let mut has_single_node = false;
-            let mblen = sentence[starts_at..].chars().next().unwrap().len_utf8();
-            for tok_bytes in self
-                .trie
-                .common_prefix_search(sentence.bytes().skip(starts_at))
-            {
-                let key_pos = starts_at + tok_bytes.len();
-                let token: String = String::from_utf8(tok_bytes).unwrap();
-                let target_node = &mut best_path_ends_at[key_pos];
-                let length = key_pos - starts_at;
-                let id = self.token_to_ids.token_to_id(&token).unwrap();
-                let score = self.vocab.get(id as usize).unwrap().1;
-                let candidate_best_path_score = score + best_path_score_till_here;
-                if target_node.starts_at.is_none()
-                    || candidate_best_path_score > target_node.best_path_score
-                {
-                    target_node.best_path_score = candidate_best_path_score;
-                    target_node.starts_at = Some(starts_at);
-                    target_node.id = id as usize;
-                }
-                if !has_single_node && length == mblen {
-                    has_single_node = true;
-                }
-            }
-            if !has_single_node {
-                let target_node = &mut best_path_ends_at[starts_at + mblen];
-                let candidate_best_path_score = unk_score + best_path_score_till_here;
-                if target_node.starts_at.is_none()
-                    || candidate_best_path_score > target_node.best_path_score
-                {
-                    target_node.best_path_score = candidate_best_path_score;
-                    target_node.starts_at = Some(starts_at);
-                    target_node.id = self.unk_id.ok_or(UnigramError::MissingUnkId)?;
-                }
-            }
-            starts_at += mblen
-        }
-        let mut ends_at = size;
-        let mut results: Vec<String> = vec![];
-        let mut token = vec![];
-        while ends_at > 0 {
-            let node = &best_path_ends_at[ends_at];
-            let starts_at = node.starts_at.unwrap();
-            if self.fuse_unk && Some(node.id) == self.unk_id {
-                token.push(sentence[starts_at..ends_at].to_string());
-            } else {
-                if !token.is_empty() {
-                    token.reverse();
-                    results.push(token.concat());
-                    token = vec![];
-                }
-                results.push(sentence[starts_at..ends_at].to_string());
-            }
-            ends_at = starts_at;
-        }
-        if !token.is_empty() {
-            token.reverse();
-            results.push(token.concat());
-        }
-        results.reverse();
-        Ok(results)
+        let mut offsets = Vec::with_capacity(sentence.len());
+        self.encode_offsets_optimized(sentence, &mut offsets)?;
+        return Ok(offsets
+            .into_iter()
+            .map(|(start, end)| sentence[start..end].to_owned())
+            .collect());
     }
 
     fn encode_unoptimized(&self, sentence: &str) -> Result<Vec<String>> {
-        let mut lattice = Lattice::from(sentence, self.bos_id, self.eos_id);
-        self.populate_nodes(&mut lattice);
-        let path = match (self.nbest_size, self.alpha) {
-            (Some(n), Some(alpha)) if n > 0 => lattice.sample_nbest(n, alpha),
-            (_, Some(alpha)) => lattice.sample(alpha),
-            _ => lattice.viterbi(),
-        };
-        if self.fuse_unk {
-            let mut results = vec![];
-            let mut token = String::new();
-            for node in path.iter() {
-                let item = lattice.piece(&node.borrow());
-                if node.borrow().id == self.unk_id.ok_or(UnigramError::MissingUnkId)? {
-                    token.push_str(&item);
-                } else {
-                    if !token.is_empty() {
-                        results.push(token);
-                        token = String::new();
-                    }
-                    results.push(item);
-                }
-            }
-            if !token.is_empty() {
-                results.push(token);
-            }
-            Ok(results)
-        } else {
-            let results: Vec<String> = path
-                .iter()
-                .map(|node| lattice.piece(&node.borrow()))
-                .collect();
-            Ok(results)
-        }
+        let mut offsets = Vec::with_capacity(sentence.len());
+        self.encode_offsets_unoptimized(sentence, &mut offsets)?;
+        return Ok(offsets
+            .into_iter()
+            .map(|(start, end)| sentence[start..end].to_owned())
+            .collect());
     }
 
     /// Iterate of vocabulary of the model as a pair of `(token, score)`.
@@ -499,6 +402,180 @@ impl Model for Unigram {
         let string = serde_json::to_string_pretty(self)?;
         std::fs::write(&fullpath, string)?;
         Ok(vec![fullpath])
+    }
+}
+
+impl pipeline::Model for Unigram {
+    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
+        for (start, end) in self.encode_offsets(&bytes)?.into_iter() {
+            let chunk = &bytes[start..end];
+            if let Some(id) = self.token_to_ids.get_bytes(chunk) {
+                output.push(PipelineToken { id });
+            } else {
+                if self.byte_fallback {
+                    // todo: do not materialize the IDs
+                    let ids: Vec<u32> = chunk
+                        .iter()
+                        .map(|&byte| {
+                            self.byte_fallback_map[byte as usize].or(self.unk_id.map(|u| u as u32))
+                        })
+                        .collect::<Option<Vec<_>>>()
+                        .ok_or(UnigramError::MissingUnkId)?;
+                    output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                } else {
+                    let unk_id = self.unk_id.ok_or(UnigramError::MissingUnkId)?;
+                    output.push(PipelineToken { id: unk_id as u32 });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Unigram {
+    fn encode_offsets(&self, bytes: &[u8]) -> Result<Vec<(usize, usize)>> {
+        let mut offsets = Vec::with_capacity(bytes.len());
+        let string = str::from_utf8(bytes)?;
+        if self.is_optimized {
+            self.encode_offsets_optimized(string, &mut offsets)?;
+        } else {
+            self.encode_offsets_unoptimized(string, &mut offsets)?;
+        }
+        Ok(offsets)
+    }
+
+    fn encode_offsets_optimized(
+        &self,
+        sequence: &str,
+        offsets: &mut Vec<(usize, usize)>,
+    ) -> Result<()> {
+        // https://github.com/google/sentencepiece/blob/d48247191a6d50e469ed1a4a36e877befffd1851/src/unigram_model.cc#L600
+        #[derive(Debug, Clone)]
+        struct BestPathNode {
+            /// The vocab id. (maybe UNK)
+            id: usize,
+            /// The total score of the best path ending at this node.
+            best_path_score: f64,
+            /// The starting position (in utf-8) of this node. The entire best
+            /// path can be constructed by backtracking along this link.
+            starts_at: Option<usize>,
+        }
+        impl Default for BestPathNode {
+            fn default() -> Self {
+                Self {
+                    id: 0,
+                    best_path_score: 0.0,
+                    starts_at: None,
+                }
+            }
+        }
+        let size = sequence.len();
+        let unk_score = self.min_score - K_UNK_PENALTY;
+
+        let mut best_path_ends_at = vec![BestPathNode::default(); size + 1];
+        let mut starts_at = 0;
+        while starts_at < size {
+            let best_path_score_till_here = best_path_ends_at[starts_at].best_path_score;
+            let mut has_single_node = false;
+            let mblen = sequence[starts_at..].chars().next().unwrap().len_utf8();
+            for tok_bytes in self
+                .trie
+                .common_prefix_search(sequence.bytes().skip(starts_at))
+            {
+                let key_pos = starts_at + tok_bytes.len();
+                let token: String = String::from_utf8(tok_bytes).unwrap();
+                let target_node = &mut best_path_ends_at[key_pos];
+                let length = key_pos - starts_at;
+                let id = self.token_to_ids.token_to_id(&token).unwrap();
+                let score = self.vocab.get(id as usize).unwrap().1;
+                let candidate_best_path_score = score + best_path_score_till_here;
+                if target_node.starts_at.is_none()
+                    || candidate_best_path_score > target_node.best_path_score
+                {
+                    target_node.best_path_score = candidate_best_path_score;
+                    target_node.starts_at = Some(starts_at);
+                    target_node.id = id as usize;
+                }
+                if !has_single_node && length == mblen {
+                    has_single_node = true;
+                }
+            }
+            if !has_single_node {
+                let target_node = &mut best_path_ends_at[starts_at + mblen];
+                let candidate_best_path_score = unk_score + best_path_score_till_here;
+                if target_node.starts_at.is_none()
+                    || candidate_best_path_score > target_node.best_path_score
+                {
+                    target_node.best_path_score = candidate_best_path_score;
+                    target_node.starts_at = Some(starts_at);
+                    target_node.id = self.unk_id.ok_or(UnigramError::MissingUnkId)?;
+                }
+            }
+            starts_at += mblen
+        }
+        let mut ends_at = size;
+        let (mut token_start, mut token_end) = (ends_at, ends_at);
+
+        while ends_at > 0 {
+            let node = &best_path_ends_at[ends_at];
+            let starts_at = node.starts_at.unwrap();
+            if self.fuse_unk && Some(node.id) == self.unk_id {
+                token_start = starts_at;
+            } else {
+                if token_start != token_end {
+                    offsets.push((token_start, token_end));
+                }
+                offsets.push((starts_at, ends_at));
+                token_end = starts_at;
+                token_start = starts_at;
+            }
+            ends_at = starts_at;
+        }
+        if token_start != token_end {
+            offsets.push((token_start, token_end));
+        }
+        offsets.reverse();
+        Ok(())
+    }
+
+    fn encode_offsets_unoptimized(
+        &self,
+        sentence: &str,
+        offsets: &mut Vec<(usize, usize)>,
+    ) -> Result<()> {
+        let mut lattice = Lattice::from(sentence, self.bos_id, self.eos_id);
+        self.populate_nodes(&mut lattice);
+        let path = match (self.nbest_size, self.alpha) {
+            (Some(n), Some(alpha)) if n > 0 => lattice.sample_nbest(n, alpha),
+            (_, Some(alpha)) => lattice.sample(alpha),
+            _ => lattice.viterbi(),
+        };
+        if self.fuse_unk {
+            let (mut token_start, mut token_end) = (0usize, 0usize);
+            for node in path.iter() {
+                let (start, end) = lattice.piece_offsets(&node.borrow());
+                if node.borrow().id == self.unk_id.ok_or(UnigramError::MissingUnkId)? {
+                    token_end = end;
+                } else {
+                    if token_start != token_end {
+                        offsets.push((token_start, token_end));
+                    }
+                    offsets.push((start, end));
+                    token_start = end;
+                    token_end = end;
+                }
+            }
+            if token_start != token_end {
+                offsets.push((token_start, token_end));
+            }
+            Ok(())
+        } else {
+            offsets.extend(
+                path.iter()
+                    .map(|node| lattice.piece_offsets(&node.borrow())),
+            );
+            Ok(())
+        }
     }
 }
 

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -738,4 +738,145 @@ mod tests {
         let tokens = unigram.tokenize("?é").unwrap();
         assert_eq!(tokens[0].id, 0);
     }
+
+    const INVARIANT_CORPUS: &[&str] = &[
+        "",
+        "a",
+        "x",
+        "AB",
+        "abc",
+        "abcd",
+        "abABcd",
+        "xabcabaabcdd",
+        "xyz東京",
+        "abABCcd",
+        "ababcdabcdcd",
+        "abqrcd",
+        "🙂👍🏽",
+        "e\u{301}abce\u{301}",
+        "▁ab▁",
+    ];
+
+    fn invariant_model() -> Unigram {
+        let pieces = vec![
+            ("<unk>".to_string(), 0.0),
+            ("ab".to_string(), 0.0),
+            ("cd".to_string(), -0.1),
+            ("abc".to_string(), -0.2),
+            ("a".to_string(), -0.3),
+            ("b".to_string(), -0.4),
+            ("c".to_string(), -0.5),
+            ("ABC".to_string(), -0.5),
+            ("abcdabcd".to_string(), 20.0),
+            ("q".to_string(), 20.5),
+            ("r".to_string(), 20.5),
+            ("qr".to_string(), -0.5),
+        ];
+        Unigram::from(pieces, Some(0), false).unwrap()
+    }
+
+    fn encoded_offsets(model: &Unigram, sentence: &str, optimized: bool) -> Vec<(usize, usize)> {
+        let mut offsets = vec![];
+        if optimized {
+            model
+                .encode_offsets_optimized(sentence, &mut offsets)
+                .unwrap();
+        } else {
+            model
+                .encode_offsets_unoptimized(sentence, &mut offsets)
+                .unwrap();
+        }
+        offsets
+    }
+
+    #[test]
+    fn test_offsets_partition_input() {
+        let mut model = invariant_model();
+        for fuse_unk in [true, false].iter().copied() {
+            model.set_fuse_unk(fuse_unk);
+            for sentence in INVARIANT_CORPUS {
+                for optimized in [true, false].iter().copied() {
+                    let offsets = encoded_offsets(&model, sentence, optimized);
+                    let context = format!("{sentence:?} fuse_unk={fuse_unk} optimized={optimized}");
+                    let mut pos = 0;
+                    for &(start, end) in &offsets {
+                        assert_eq!(start, pos, "gap or overlap: {context}");
+                        assert!(start < end, "empty piece: {}", context);
+                        assert!(
+                            sentence.is_char_boundary(end),
+                            "offset {} splits a char: {}",
+                            end,
+                            context
+                        );
+                        pos = end;
+                    }
+                    assert_eq!(pos, sentence.len(), "input not covered: {context}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_pieces_match_input_slices() {
+        let mut model = invariant_model();
+        for fuse_unk in [true, false].iter().copied() {
+            model.set_fuse_unk(fuse_unk);
+            for sentence in INVARIANT_CORPUS {
+                for token in model.tokenize(sentence).unwrap() {
+                    assert_eq!(
+                        token.value,
+                        &sentence[token.offsets.0..token.offsets.1],
+                        "{sentence:?} fuse_unk={fuse_unk}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_pieces_match_input_slices_byte_fallback() {
+        let pieces = vec![
+            ("<unk>".to_string(), 0.0),
+            ("a".to_string(), -0.3),
+            ("<0xC3>".to_string(), -0.01),
+            ("<0xA9>".to_string(), -0.03),
+        ];
+        let model = Unigram::from(pieces, Some(0), true).unwrap();
+        for sentence in ["aéa", "é", "🙂a"].iter().copied() {
+            for token in model.tokenize(sentence).unwrap() {
+                let is_byte_token = token.value.len() == 6
+                    && token.value.starts_with("<0x")
+                    && token.value.ends_with('>');
+                if !is_byte_token {
+                    assert_eq!(
+                        token.value,
+                        &sentence[token.offsets.0..token.offsets.1],
+                        "{sentence:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_fuse_unk_no_adjacent_unk_pieces() {
+        let model = invariant_model();
+        for sentence in INVARIANT_CORPUS {
+            for optimized in [true, false].iter().copied() {
+                let offsets = encoded_offsets(&model, sentence, optimized);
+                let in_vocab: Vec<bool> = offsets
+                    .iter()
+                    .map(|&(start, end)| model.token_to_id(&sentence[start..end]).is_some())
+                    .collect();
+                for pair in in_vocab.windows(2) {
+                    assert!(
+                        pair[0] || pair[1],
+                        "adjacent unk pieces in {:?} optimized={}",
+                        sentence,
+                        optimized
+                    );
+                }
+            }
+        }
+    }
 }

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -273,19 +273,19 @@ impl Unigram {
     fn encode_optimized(&self, sentence: &str) -> Result<Vec<String>> {
         let mut offsets = Vec::with_capacity(sentence.len());
         self.encode_offsets_optimized(sentence, &mut offsets)?;
-        return Ok(offsets
+        Ok(offsets
             .into_iter()
             .map(|(start, end)| sentence[start..end].to_owned())
-            .collect());
+            .collect())
     }
 
     fn encode_unoptimized(&self, sentence: &str) -> Result<Vec<String>> {
         let mut offsets = Vec::with_capacity(sentence.len());
         self.encode_offsets_unoptimized(sentence, &mut offsets)?;
-        return Ok(offsets
+        Ok(offsets
             .into_iter()
             .map(|(start, end)| sentence[start..end].to_owned())
-            .collect());
+            .collect())
     }
 
     /// Iterate of vocabulary of the model as a pair of `(token, score)`.
@@ -407,7 +407,7 @@ impl Model for Unigram {
 
 impl pipeline::Model for Unigram {
     fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
-        for (start, end) in self.encode_offsets(&bytes)?.into_iter() {
+        for (start, end) in self.encode_offsets(bytes)?.into_iter() {
             let chunk = &bytes[start..end];
             if let Some(id) = self.token_to_ids.get_bytes(chunk) {
                 output.push(PipelineToken { id });

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -330,8 +330,10 @@ impl pipeline::Model for WordPiece {
                 .token_to_id(&self.unk_token)
                 .ok_or(Error::MissingUnkToken)?;
             output.push(PipelineToken { id: unk_id });
+            return Ok(());
         }
 
+        let word_start = output.len();
         let mut is_bad = false;
         let mut start = 0;
 
@@ -371,6 +373,7 @@ impl pipeline::Model for WordPiece {
                 .vocab
                 .token_to_id(&self.unk_token)
                 .ok_or(Error::MissingUnkToken)?;
+            output.truncate(word_start);
             output.push(PipelineToken { id: unk_id });
         }
 

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -2,8 +2,9 @@
 //! model.
 
 use crate::models::bpe::BPE;
-use crate::pipeline::{self, PipelineToken};
+use crate::pipeline;
 use crate::tokenizer::{Model, Result, Token};
+use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
 use std::collections::HashMap;
 use std::{
@@ -22,12 +23,9 @@ pub enum Error {
     MissingUnkToken,
 }
 
-type Vocab = AHashMap<String, u32>;
-type VocabR = AHashMap<u32, String>;
-
 struct Config {
     files: Option<String>,
-    vocab: Vocab,
+    vocab: VocabStore,
     unk_token: String,
     continuing_subword_prefix: String,
     max_input_chars_per_word: usize,
@@ -43,7 +41,7 @@ impl Default for WordPieceBuilder {
         Self {
             config: Config {
                 files: None,
-                vocab: AHashMap::new(),
+                vocab: VocabStore::new(),
                 unk_token: String::from("[UNK]"),
                 continuing_subword_prefix: String::from("##"),
                 max_input_chars_per_word: 100,
@@ -68,7 +66,18 @@ impl WordPieceBuilder {
     /// Set the vocab (token -> ID) mapping.
     #[must_use]
     pub fn vocab<V: Into<AHashMap<String, u32>>>(mut self, vocab: V) -> Self {
-        self.config.vocab = vocab.into();
+        let string_vocab: AHashMap<String, u32> = vocab.into();
+        self.config.vocab = VocabStore::build(
+            string_vocab
+                .into_iter()
+                .map(|(token_str, token_id)| (token_str.into_bytes(), token_id))
+                .collect(),
+        );
+        self
+    }
+
+    pub fn vocab_store(mut self, vocab_store: VocabStore) -> Self {
+        self.config.vocab = vocab_store;
         self
     }
 
@@ -99,16 +108,8 @@ impl WordPieceBuilder {
             self.config.vocab = WordPiece::read_file(&vocab)?;
         }
 
-        let vocab_r = self
-            .config
-            .vocab
-            .iter()
-            .map(|(key, val)| (*val, key.to_owned()))
-            .collect();
-
         Ok(WordPiece {
             vocab: self.config.vocab,
-            vocab_r,
             unk_token: self.config.unk_token,
             continuing_subword_prefix: self.config.continuing_subword_prefix,
             max_input_chars_per_word: self.config.max_input_chars_per_word,
@@ -119,10 +120,9 @@ impl WordPieceBuilder {
 /// A
 /// [WordPiece](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/37842.pdf)
 /// model.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq)]
 pub struct WordPiece {
-    pub vocab: Vocab,
-    pub vocab_r: VocabR,
+    pub vocab: VocabStore,
     pub unk_token: String,
     pub continuing_subword_prefix: String,
     pub max_input_chars_per_word: usize,
@@ -142,8 +142,7 @@ impl std::fmt::Debug for WordPiece {
 impl Default for WordPiece {
     fn default() -> Self {
         Self {
-            vocab: AHashMap::new(),
-            vocab_r: AHashMap::new(),
+            vocab: VocabStore::new(),
             unk_token: String::from("[UNK]"),
             continuing_subword_prefix: String::from("##"),
             max_input_chars_per_word: 100,
@@ -158,27 +157,30 @@ impl WordPiece {
     }
 
     /// Read the given files to extract the vocab
-    pub fn read_file(vocab: &str) -> Result<Vocab> {
+    pub fn read_file(vocab: &str) -> Result<VocabStore> {
         let file = File::open(vocab)?;
         let file = BufReader::new(file);
 
-        let mut vocab = AHashMap::new();
+        let mut vocab_raw: Vec<(Vec<u8>, u32)> = vec![];
         for (index, line) in file.lines().enumerate() {
             let line = line?;
-            vocab.insert(line.trim_end().to_owned(), index as u32);
+            vocab_raw.push((line.trim_end().to_owned().into_bytes(), index as u32));
         }
+
+        let vocab = VocabStore::build(vocab_raw);
 
         Ok(vocab)
     }
 
-    pub fn read_bytes(vocab: &[u8]) -> Result<Vocab> {
+    pub fn read_bytes(vocab: &[u8]) -> Result<VocabStore> {
         let file = BufReader::new(vocab);
 
-        let mut vocab = AHashMap::new();
+        let mut vocab_raw: Vec<(Vec<u8>, u32)> = vec![];
         for (index, line) in file.lines().enumerate() {
             let line = line?;
-            vocab.insert(line.trim_end().to_owned(), index as u32);
+            vocab_raw.push((line.trim_end().to_owned().into_bytes(), index as u32));
         }
+        let vocab = VocabStore::build(vocab_raw);
 
         Ok(vocab)
     }
@@ -211,7 +213,7 @@ impl WordPiece {
 
 impl Model for WordPiece {
     fn get_vocab(&self) -> HashMap<String, u32> {
-        self.vocab.clone().into_iter().collect()
+        self.vocab.get_vocab().into_iter().collect()
     }
 
     fn get_vocab_size(&self) -> usize {
@@ -220,12 +222,13 @@ impl Model for WordPiece {
 
     fn tokenize(&self, sequence: &str) -> Result<Vec<Token>> {
         let char_len = sequence.chars().count();
+
         if char_len > self.max_input_chars_per_word {
             return Ok(vec![Token {
                 value: self.unk_token.clone(),
-                id: *self
+                id: self
                     .vocab
-                    .get(&self.unk_token)
+                    .token_to_id(&self.unk_token)
                     .ok_or(Error::MissingUnkToken)?,
                 offsets: (0, sequence.len()),
             }]);
@@ -245,9 +248,9 @@ impl Model for WordPiece {
                 if start > 0 {
                     substr = Cow::Owned(format!("{}{}", self.continuing_subword_prefix, substr));
                 }
-                if self.vocab.contains_key(substr.as_ref()) {
+                if let Some(token) = self.vocab.token_to_id(substr.as_ref()) {
                     cur_str = Some(Token {
-                        id: self.vocab[substr.as_ref()],
+                        id: token,
                         value: substr.to_string(),
                         offsets: (start, end),
                     });
@@ -268,9 +271,9 @@ impl Model for WordPiece {
         if is_bad {
             Ok(vec![Token {
                 value: self.unk_token.clone(),
-                id: *self
+                id: self
                     .vocab
-                    .get(&self.unk_token)
+                    .token_to_id(&self.unk_token)
                     .ok_or(Error::MissingUnkToken)?,
                 offsets: (0, sequence.len()),
             }])
@@ -280,17 +283,17 @@ impl Model for WordPiece {
     }
 
     fn token_to_id(&self, token: &str) -> Option<u32> {
-        self.vocab.get(token).copied()
+        self.vocab.token_to_id(token)
     }
 
     fn id_to_token(&self, id: u32) -> Option<String> {
-        self.vocab_r.get(&id).cloned()
+        self.vocab.id_to_token(id)
     }
 
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>> {
         let vocab_file_name = match name {
             Some(name) => format!("{name}-vocab.txt"),
-            None => "vocab.txt".to_string(),
+            _ => "vocab.txt".to_string(),
         };
 
         // Write vocab.txt
@@ -298,8 +301,8 @@ impl Model for WordPiece {
             .iter()
             .collect();
         let mut vocab_file = File::create(&vocab_path)?;
-        let mut vocab: Vec<(&String, &u32)> = self.vocab.iter().collect();
-        vocab.sort_unstable_by_key(|k| *k.1);
+        let mut vocab: Vec<(String, u32)> = self.vocab.get_vocab().into_iter().collect();
+        vocab.sort_unstable_by_key(|(_, rank)| *rank);
         vocab_file.write_all(
             &vocab
                 .into_iter()
@@ -311,26 +314,9 @@ impl Model for WordPiece {
     }
 }
 
+
 impl pipeline::Model for WordPiece {
-    fn tokenize_bytes(
-        &self,
-        bytes: &[u8],
-        output: &mut Vec<pipeline::PipelineToken>,
-    ) -> Result<()> {
-        // todo: implement
-        // if bytes.is_empty() {
-        //     return Ok(());
-        // }
-        // // todo: maybe we can use unchecked here (unsafe)
-        // let char_len = str::from_utf8(bytes)?.chars().count();
-        // if char_len > self.max_input_chars_per_word {
-        //     let unk_id = *self
-        //         .vocab
-        //         .get(&self.unk_token)
-        //         .ok_or(Error::MissingUnkToken)?;
-        //     output.push(PipelineToken { id: unk_id });
-        //     return Ok(());
-        // }
+    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<pipeline::PipelineToken>) -> Result<()> {
         Ok(())
     }
 }
@@ -339,129 +325,285 @@ impl pipeline::Model for WordPiece {
 mod tests {
     use super::*;
 
+    fn make_vocab_store(tokens: &[&str]) -> VocabStore {
+        VocabStore::build(
+            tokens
+                .iter()
+                .enumerate()
+                .map(|(id, token)| (token.to_string().into_bytes(), id as u32))
+                .collect(),
+        )
+    }
+
+    fn model(tokens: &[&str]) -> WordPiece {
+        WordPiece::builder()
+            .vocab_store(make_vocab_store(tokens))
+            .build()
+            .unwrap()
+    }
+
+    fn tok(id: u32, value: &str, offsets: (usize, usize)) -> Token {
+        Token::new(id, value.to_string(), offsets)
+    }
+
     #[test]
     fn test_error_display() {
         assert!(format!("{}", Error::MissingUnkToken).contains("Missing [UNK] token"));
     }
 
-    const INVARIANT_CORPUS: &[&str] = &[
-        "",
-        "un",
-        "unaff",
-        "unaffable",
-        "b",
-        "ab",
-        "ba",
-        "xyz",
-        "café",
-        "日本",
-        "日本語",
-        "🙂",
-        "e\u{301}",
-    ];
-
-    fn invariant_model() -> WordPiece {
-        let vocab: Vocab = [
-            ("[UNK]", 0u32),
-            ("un", 1),
-            ("##aff", 2),
-            ("##able", 3),
-            ("日", 4),
-            ("##本", 5),
-            ("ca", 6),
-            ("##fé", 7),
-            ("a", 8),
-            ("##b", 9),
-            ("b", 10),
-        ]
-        .iter()
-        .map(|&(token, id)| (token.to_string(), id))
-        .collect();
-        WordPiece::builder().vocab(vocab).build().unwrap()
+    #[test]
+    fn whole_word_in_vocab() {
+        let wp = model(&["[UNK]", "hello"]);
+        assert_eq!(wp.tokenize("hello").unwrap(), vec![tok(1, "hello", (0, 5))]);
     }
 
     #[test]
-    fn test_offsets_partition_input() {
-        let model = invariant_model();
-        for word in INVARIANT_CORPUS {
-            let tokens = model.tokenize(word).unwrap();
-            let mut pos = 0;
-            for token in &tokens {
-                let (start, end) = token.offsets;
-                assert_eq!(start, pos, "gap or overlap in {word:?}");
-                assert!(start < end, "empty piece in {:?}", word);
-                assert!(
-                    word.is_char_boundary(end),
-                    "offset {} splits a char in {:?}",
-                    end,
-                    word
-                );
-                pos = end;
-            }
-            assert_eq!(pos, word.len(), "input not covered: {word:?}");
-        }
+    fn greedy_longest_match_splits_word() {
+        let wp = model(&["[UNK]", "un", "##aff", "##able"]);
+        assert_eq!(
+            wp.tokenize("unaffable").unwrap(),
+            vec![
+                tok(1, "un", (0, 2)),
+                tok(2, "##aff", (2, 5)),
+                tok(3, "##able", (5, 9)),
+            ]
+        );
     }
 
     #[test]
-    fn test_pieces_match_input_slices() {
-        let model = invariant_model();
-        for word in INVARIANT_CORPUS {
-            let tokens = model.tokenize(word).unwrap();
-            if tokens.len() == 1 && tokens[0].value == model.unk_token {
-                continue;
-            }
-            for token in &tokens {
-                let (start, end) = token.offsets;
-                let expected = if start == 0 {
-                    word[start..end].to_string()
-                } else {
-                    format!("{}{}", model.continuing_subword_prefix, &word[start..end])
-                };
-                assert_eq!(token.value, expected, "{word:?}");
-            }
-        }
+    fn longest_piece_wins_over_shorter_ones() {
+        let wp = model(&["[UNK]", "un", "unaff", "##aff", "##able"]);
+        assert_eq!(
+            wp.tokenize("unaffable").unwrap(),
+            vec![tok(2, "unaff", (0, 5)), tok(4, "##able", (5, 9))]
+        );
     }
 
     #[test]
-    fn test_unk_is_all_or_nothing() {
-        let model = invariant_model();
-        for word in INVARIANT_CORPUS {
-            let tokens = model.tokenize(word).unwrap();
-            if tokens.len() > 1 {
-                for token in &tokens {
-                    assert_ne!(token.value, model.unk_token, "unk fragment in {word:?}");
-                }
-            }
-        }
+    fn single_char_pieces() {
+        let wp = model(&["[UNK]", "a", "##b", "##c"]);
+        assert_eq!(
+            wp.tokenize("abc").unwrap(),
+            vec![
+                tok(1, "a", (0, 1)),
+                tok(2, "##b", (1, 2)),
+                tok(3, "##c", (2, 3)),
+            ]
+        );
     }
 
     #[test]
-    fn test_max_input_chars_gives_single_unk() {
-        let model = WordPiece::builder()
-            .vocab(invariant_model().vocab)
+    fn continuation_piece_requires_prefix() {
+        let wp = model(&["[UNK]", "un", "able"]);
+        assert_eq!(
+            wp.tokenize("unable").unwrap(),
+            vec![tok(0, "[UNK]", (0, 6))]
+        );
+    }
+
+    #[test]
+    fn prefixed_piece_never_matches_at_word_start() {
+        let wp = model(&["[UNK]", "##able"]);
+        assert_eq!(wp.tokenize("able").unwrap(), vec![tok(0, "[UNK]", (0, 4))]);
+    }
+
+    #[test]
+    fn literal_prefix_in_input_matches_prefixed_vocab_entry() {
+        let wp = model(&["[UNK]", "##able"]);
+        assert_eq!(
+            wp.tokenize("##able").unwrap(),
+            vec![tok(1, "##able", (0, 6))]
+        );
+    }
+
+    #[test]
+    fn unmatchable_suffix_collapses_whole_word_to_unk() {
+        let wp = model(&["[UNK]", "un", "##aff", "##able"]);
+        assert_eq!(
+            wp.tokenize("unaffordable").unwrap(),
+            vec![tok(0, "[UNK]", (0, 12))]
+        );
+    }
+
+    #[test]
+    fn greedy_choice_is_never_backtracked() {
+        let wp = model(&["[UNK]", "abc", "a", "##bcd"]);
+        assert_eq!(wp.tokenize("abcd").unwrap(), vec![tok(0, "[UNK]", (0, 4))]);
+    }
+
+    #[test]
+    fn unknown_first_char_is_unk() {
+        let wp = model(&["[UNK]", "a"]);
+        assert_eq!(wp.tokenize("xa").unwrap(), vec![tok(0, "[UNK]", (0, 2))]);
+    }
+
+    #[test]
+    fn unk_id_is_looked_up_in_vocab() {
+        let wp = model(&["a", "b", "[UNK]"]);
+        assert_eq!(wp.tokenize("z").unwrap(), vec![tok(2, "[UNK]", (0, 1))]);
+    }
+
+    #[test]
+    fn empty_input_yields_no_tokens() {
+        let wp = model(&["[UNK]"]);
+        assert_eq!(wp.tokenize("").unwrap(), vec![]);
+    }
+
+    #[test]
+    fn multibyte_offsets_are_byte_positions() {
+        let wp = model(&["[UNK]", "猫", "##です"]);
+        assert_eq!(
+            wp.tokenize("猫です").unwrap(),
+            vec![tok(1, "猫", (0, 3)), tok(2, "##です", (3, 9))]
+        );
+    }
+
+    #[test]
+    fn multibyte_shrinking_stays_on_char_boundaries() {
+        let wp = model(&["[UNK]", "a"]);
+        assert_eq!(wp.tokenize("a€b").unwrap(), vec![tok(0, "[UNK]", (0, 5))]);
+    }
+
+    #[test]
+    fn word_longer_than_max_chars_is_unk_even_if_in_vocab() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["[UNK]", "abcde"]))
             .max_input_chars_per_word(4)
             .build()
             .unwrap();
-        let tokens = model.tokenize("unaffable").unwrap();
-        assert_eq!(tokens.len(), 1);
-        assert_eq!(tokens[0].value, "[UNK]");
-        assert_eq!(tokens[0].offsets, (0, "unaffable".len()));
+        assert_eq!(wp.tokenize("abcde").unwrap(), vec![tok(0, "[UNK]", (0, 5))]);
     }
 
     #[test]
-    fn test_tokenize_bytes_matches_tokenize() {
-        let model = invariant_model();
-        for word in INVARIANT_CORPUS {
-            let expected: Vec<u32> = model
+    fn word_at_max_chars_is_tokenized() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["[UNK]", "abcd"]))
+            .max_input_chars_per_word(4)
+            .build()
+            .unwrap();
+        assert_eq!(wp.tokenize("abcd").unwrap(), vec![tok(1, "abcd", (0, 4))]);
+    }
+
+    #[test]
+    fn max_chars_counts_chars_not_bytes() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["[UNK]", "éééé"]))
+            .max_input_chars_per_word(4)
+            .build()
+            .unwrap();
+        assert_eq!(wp.tokenize("éééé").unwrap(), vec![tok(1, "éééé", (0, 8))]);
+    }
+
+    #[test]
+    fn missing_unk_token_is_an_error_when_needed() {
+        let wp = model(&["a"]);
+        let err = wp.tokenize("b").unwrap_err();
+        assert!(err.to_string().contains("Missing [UNK] token"));
+    }
+
+    #[test]
+    fn missing_unk_token_is_an_error_for_overlong_words() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["ab"]))
+            .max_input_chars_per_word(1)
+            .build()
+            .unwrap();
+        assert!(wp.tokenize("ab").is_err());
+    }
+
+    #[test]
+    fn missing_unk_token_is_not_an_error_when_unneeded() {
+        let wp = model(&["hello"]);
+        assert_eq!(wp.tokenize("hello").unwrap(), vec![tok(0, "hello", (0, 5))]);
+    }
+
+    #[test]
+    fn custom_unk_token() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["<unk>", "a"]))
+            .unk_token("<unk>".into())
+            .build()
+            .unwrap();
+        assert_eq!(wp.tokenize("z").unwrap(), vec![tok(0, "<unk>", (0, 1))]);
+    }
+
+    #[test]
+    fn custom_continuing_subword_prefix() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["[UNK]", "foo", "@@bar"]))
+            .continuing_subword_prefix("@@".into())
+            .build()
+            .unwrap();
+        assert_eq!(
+            wp.tokenize("foobar").unwrap(),
+            vec![tok(1, "foo", (0, 3)), tok(2, "@@bar", (3, 6))]
+        );
+    }
+
+    #[test]
+    fn regular_words_tokenize_like_bert() {
+        let wp = model(&[
+            "[UNK]",
+            "the",
+            "token",
+            "##izer",
+            "##ization",
+            "un",
+            "##believ",
+            "##able",
+            "run",
+            "##ning",
+            "hugging",
+            "##face",
+            "transform",
+            "##ers",
+            "inter",
+            "##national",
+            "in",
+            "##ter",
+            "##nation",
+            "##al",
+            "##iz",
+            "##ation",
+            "fast",
+            "##er",
+            ".",
+            ",",
+        ]);
+        let cases: &[(&str, &[&str])] = &[
+            ("the", &["the"]),
+            ("tokenizer", &["token", "##izer"]),
+            ("tokenization", &["token", "##ization"]),
+            ("unbelievable", &["un", "##believ", "##able"]),
+            ("running", &["run", "##ning"]),
+            ("huggingface", &["hugging", "##face"]),
+            ("transformers", &["transform", "##ers"]),
+            (
+                "internationalization",
+                &["inter", "##national", "##ization"],
+            ),
+            ("faster", &["fast", "##er"]),
+            (".", &["."]),
+            (",", &[","]),
+            ("xylophone", &["[UNK]"]),
+        ];
+        for (word, expected) in cases {
+            let values: Vec<String> = wp
                 .tokenize(word)
                 .unwrap()
-                .iter()
-                .map(|token| token.id)
+                .into_iter()
+                .map(|t| t.value)
                 .collect();
-            let mut output = vec![];
-            pipeline::Model::tokenize_bytes(&model, word.as_bytes(), &mut output).unwrap();
-            let got: Vec<u32> = output.iter().map(|token| token.id).collect();
-            assert_eq!(expected, got, "{word:?}");
+            assert_eq!(&values, expected, "word: {word}");
         }
+
+        assert_eq!(
+            wp.tokenize("internationalization").unwrap(),
+            vec![
+                tok(14, "inter", (0, 5)),
+                tok(15, "##national", (5, 13)),
+                tok(4, "##ization", (13, 20)),
+            ]
+        );
     }
 }

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -2,7 +2,7 @@
 //! model.
 
 use crate::models::bpe::BPE;
-use crate::pipeline;
+use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
@@ -314,9 +314,66 @@ impl Model for WordPiece {
     }
 }
 
-
 impl pipeline::Model for WordPiece {
-    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<pipeline::PipelineToken>) -> Result<()> {
+    fn tokenize_bytes(
+        &self,
+        bytes: &[u8],
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        let mut scratch: Vec<u8> = Vec::with_capacity(self.max_input_chars_per_word);
+        let sequence = str::from_utf8(bytes)?;
+        let char_len = sequence.chars().count();
+
+        if char_len > self.max_input_chars_per_word {
+            let unk_id = self
+                .vocab
+                .token_to_id(&self.unk_token)
+                .ok_or(Error::MissingUnkToken)?;
+            output.push(PipelineToken { id: unk_id });
+        }
+
+        let mut is_bad = false;
+        let mut start = 0;
+
+        while start < sequence.len() {
+            let mut end = sequence.len();
+            let mut candidate_token: Option<u32> = None;
+
+            while start < end {
+                scratch.clear();
+                if start > 0 {
+                    scratch.extend(self.continuing_subword_prefix.as_bytes());
+                }
+                scratch.extend(&bytes[start..end]);
+
+                if let Some(id) = self.vocab.get_bytes(&scratch) {
+                    candidate_token = Some(id);
+                    break;
+                }
+                // Step one char back
+                end -= str::from_utf8(&scratch)?
+                    .chars()
+                    .last()
+                    .map_or(1, |c| c.len_utf8());
+            }
+
+            if let Some(id) = candidate_token {
+                output.push(PipelineToken { id });
+            } else {
+                is_bad = true;
+                break;
+            }
+            start = end;
+        }
+
+        if is_bad {
+            let unk_id = self
+                .vocab
+                .token_to_id(&self.unk_token)
+                .ok_or(Error::MissingUnkToken)?;
+            output.push(PipelineToken { id: unk_id });
+        }
+
         Ok(())
     }
 }

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -2,6 +2,7 @@
 //! model.
 
 use crate::models::bpe::BPE;
+use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use ahash::AHashMap;
 use std::collections::HashMap;
@@ -310,6 +311,30 @@ impl Model for WordPiece {
     }
 }
 
+impl pipeline::Model for WordPiece {
+    fn tokenize_bytes(
+        &self,
+        bytes: &[u8],
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        // todo: implement
+        // if bytes.is_empty() {
+        //     return Ok(());
+        // }
+        // // todo: maybe we can use unchecked here (unsafe)
+        // let char_len = str::from_utf8(bytes)?.chars().count();
+        // if char_len > self.max_input_chars_per_word {
+        //     let unk_id = *self
+        //         .vocab
+        //         .get(&self.unk_token)
+        //         .ok_or(Error::MissingUnkToken)?;
+        //     output.push(PipelineToken { id: unk_id });
+        //     return Ok(());
+        // }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,5 +342,126 @@ mod tests {
     #[test]
     fn test_error_display() {
         assert!(format!("{}", Error::MissingUnkToken).contains("Missing [UNK] token"));
+    }
+
+    const INVARIANT_CORPUS: &[&str] = &[
+        "",
+        "un",
+        "unaff",
+        "unaffable",
+        "b",
+        "ab",
+        "ba",
+        "xyz",
+        "café",
+        "日本",
+        "日本語",
+        "🙂",
+        "e\u{301}",
+    ];
+
+    fn invariant_model() -> WordPiece {
+        let vocab: Vocab = [
+            ("[UNK]", 0u32),
+            ("un", 1),
+            ("##aff", 2),
+            ("##able", 3),
+            ("日", 4),
+            ("##本", 5),
+            ("ca", 6),
+            ("##fé", 7),
+            ("a", 8),
+            ("##b", 9),
+            ("b", 10),
+        ]
+        .iter()
+        .map(|&(token, id)| (token.to_string(), id))
+        .collect();
+        WordPiece::builder().vocab(vocab).build().unwrap()
+    }
+
+    #[test]
+    fn test_offsets_partition_input() {
+        let model = invariant_model();
+        for word in INVARIANT_CORPUS {
+            let tokens = model.tokenize(word).unwrap();
+            let mut pos = 0;
+            for token in &tokens {
+                let (start, end) = token.offsets;
+                assert_eq!(start, pos, "gap or overlap in {word:?}");
+                assert!(start < end, "empty piece in {:?}", word);
+                assert!(
+                    word.is_char_boundary(end),
+                    "offset {} splits a char in {:?}",
+                    end,
+                    word
+                );
+                pos = end;
+            }
+            assert_eq!(pos, word.len(), "input not covered: {word:?}");
+        }
+    }
+
+    #[test]
+    fn test_pieces_match_input_slices() {
+        let model = invariant_model();
+        for word in INVARIANT_CORPUS {
+            let tokens = model.tokenize(word).unwrap();
+            if tokens.len() == 1 && tokens[0].value == model.unk_token {
+                continue;
+            }
+            for token in &tokens {
+                let (start, end) = token.offsets;
+                let expected = if start == 0 {
+                    word[start..end].to_string()
+                } else {
+                    format!("{}{}", model.continuing_subword_prefix, &word[start..end])
+                };
+                assert_eq!(token.value, expected, "{word:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_unk_is_all_or_nothing() {
+        let model = invariant_model();
+        for word in INVARIANT_CORPUS {
+            let tokens = model.tokenize(word).unwrap();
+            if tokens.len() > 1 {
+                for token in &tokens {
+                    assert_ne!(token.value, model.unk_token, "unk fragment in {word:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_max_input_chars_gives_single_unk() {
+        let model = WordPiece::builder()
+            .vocab(invariant_model().vocab)
+            .max_input_chars_per_word(4)
+            .build()
+            .unwrap();
+        let tokens = model.tokenize("unaffable").unwrap();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].value, "[UNK]");
+        assert_eq!(tokens[0].offsets, (0, "unaffable".len()));
+    }
+
+    #[test]
+    fn test_tokenize_bytes_matches_tokenize() {
+        let model = invariant_model();
+        for word in INVARIANT_CORPUS {
+            let expected: Vec<u32> = model
+                .tokenize(word)
+                .unwrap()
+                .iter()
+                .map(|token| token.id)
+                .collect();
+            let mut output = vec![];
+            pipeline::Model::tokenize_bytes(&model, word.as_bytes(), &mut output).unwrap();
+            let got: Vec<u32> = output.iter().map(|token| token.id).collect();
+            assert_eq!(expected, got, "{word:?}");
+        }
     }
 }

--- a/tokenizers/tk-encode/src/models/wordpiece/serialization.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/serialization.rs
@@ -20,7 +20,13 @@ impl Serialize for WordPiece {
         model.serialize_field("max_input_chars_per_word", &self.max_input_chars_per_word)?;
 
         // Then large ones
-        let ordered_vocab = OrderedVocabIter::new(&self.vocab_r);
+        let vocab_r: AHashMap<u32, String> = self
+            .vocab
+            .get_vocab()
+            .into_iter()
+            .map(|(s, id)| (id, s))
+            .collect();
+        let ordered_vocab = OrderedVocabIter::new(&vocab_r);
         model.serialize_field("vocab", &ordered_vocab)?;
 
         model.end()

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -7,6 +7,7 @@ use crate::added_vocabulary::bucket_added_vocabulary::{
 };
 use crate::models::unigram::Unigram;
 use crate::{ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer};
+use crate::models::wordpiece::WordPiece;
 use crate::{
     normalizers::NormalizerWrapper,
     pre_tokenizers::{
@@ -78,6 +79,8 @@ impl PreTokenizer for PipelinePreTokenizer {
 
 pub enum PipelineModel {
     Unigram(Unigram),
+    WordPiece(WordPiece),
+    // WordLevel(WordLevel),
     // BPE(BPE),
 }
 
@@ -88,6 +91,7 @@ pub trait Model {
 impl Model for PipelineModel {
     fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
         match self {
+            Self::WordPiece(model) => model.tokenize_bytes(bytes, output),
             Self::Unigram(model) => model.tokenize_bytes(bytes, output),
             // Self::BPE(model) => model.tokenize_bytes(bytes, output),
         }
@@ -100,6 +104,7 @@ impl TryFrom<ModelWrapper> for PipelineModel {
         match value {
             // ModelWrapper::BPE(model) => Ok(Self::BPE(model)),
             ModelWrapper::Unigram(model) => Ok(Self::Unigram(model)),
+            ModelWrapper::WordPiece(model) => Ok(Self::WordPiece(model)),
             other => Err(format!("PipelineModel cannot be built from {:?}", other).into()),
         }
     }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -339,7 +339,7 @@ impl PipelineTokenizer {
                                 // Tokenize each chunk
                                 for pre_token in pre_tokens.iter() {
                                     self.model.tokenize_bytes(
-                                        &normalized_chunk[pre_token.range()].as_bytes(),
+                                        normalized_chunk[pre_token.range()].as_bytes(),
                                         &mut output,
                                     )?;
                                 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,9 +1,12 @@
+use std::borrow::Cow;
+use std::convert::{TryFrom, TryInto};
 use std::ops::Range;
-use std::{borrow::Cow, convert::TryFrom};
 
 use crate::added_vocabulary::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
+use crate::models::unigram::Unigram;
+use crate::{ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer};
 use crate::{
     normalizers::NormalizerWrapper,
     pre_tokenizers::{
@@ -15,7 +18,6 @@ use crate::{
         unicode_scripts::UnicodeScripts,
         whitespace::{Whitespace, WhitespaceSplit},
     },
-    Model, ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer,
 };
 
 use super::{Result, SplitDelimiterBehavior};
@@ -70,6 +72,35 @@ impl PreTokenizer for PipelinePreTokenizer {
             Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, out),
             Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
             Self::WhitespaceSplit(pretok) => pretok.pre_tokenize(text, out),
+        }
+    }
+}
+
+pub enum PipelineModel {
+    Unigram(Unigram),
+    // BPE(BPE),
+}
+
+pub trait Model {
+    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()>;
+}
+
+impl Model for PipelineModel {
+    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
+        match self {
+            Self::Unigram(model) => model.tokenize_bytes(bytes, output),
+            // Self::BPE(model) => model.tokenize_bytes(bytes, output),
+        }
+    }
+}
+
+impl TryFrom<ModelWrapper> for PipelineModel {
+    type Error = super::Error;
+    fn try_from(value: ModelWrapper) -> Result<Self> {
+        match value {
+            // ModelWrapper::BPE(model) => Ok(Self::BPE(model)),
+            ModelWrapper::Unigram(model) => Ok(Self::Unigram(model)),
+            other => Err(format!("PipelineModel cannot be built from {:?}", other).into()),
         }
     }
 }
@@ -198,7 +229,7 @@ pub struct PipelineTokenizer {
     added_vocabulary: BucketAddedVocabulary,
     normalizer: Option<NormalizerWrapper>,
     pre_tokenizer: PipelinePreTokenizer,
-    model: ModelWrapper,
+    model: PipelineModel,
     _post_processor: Option<PostProcessorWrapper>,
 }
 
@@ -252,7 +283,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             added_vocabulary,
             normalizer: tok.get_normalizer().cloned(),
             pre_tokenizer,
-            model: tok.get_model().clone(),
+            model: tok.get_model().clone().try_into()?,
             _post_processor: tok.get_post_processor().cloned(),
         })
     }
@@ -302,12 +333,10 @@ impl PipelineTokenizer {
 
                                 // Tokenize each chunk
                                 for pre_token in pre_tokens.iter() {
-                                    output.extend(
-                                        self.model
-                                            .tokenize(&normalized_chunk[pre_token.range()])?
-                                            .into_iter()
-                                            .map(|Token { id, .. }| PipelineToken { id }),
-                                    );
+                                    self.model.tokenize_bytes(
+                                        &normalized_chunk[pre_token.range()].as_bytes(),
+                                        &mut output,
+                                    )?;
                                 }
                             }
                         }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 use crate::added_vocabulary::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
+use crate::models::bpe::BPE;
 use crate::models::unigram::Unigram;
 use crate::{ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer};
 use crate::models::wordpiece::WordPiece;
@@ -80,8 +81,8 @@ impl PreTokenizer for PipelinePreTokenizer {
 pub enum PipelineModel {
     Unigram(Unigram),
     WordPiece(WordPiece),
+    BPE(BPE),
     // WordLevel(WordLevel),
-    // BPE(BPE),
 }
 
 pub trait Model {
@@ -93,7 +94,7 @@ impl Model for PipelineModel {
         match self {
             Self::WordPiece(model) => model.tokenize_bytes(bytes, output),
             Self::Unigram(model) => model.tokenize_bytes(bytes, output),
-            // Self::BPE(model) => model.tokenize_bytes(bytes, output),
+            Self::BPE(model) => model.tokenize_bytes(bytes, output),
         }
     }
 }
@@ -102,7 +103,7 @@ impl TryFrom<ModelWrapper> for PipelineModel {
     type Error = super::Error;
     fn try_from(value: ModelWrapper) -> Result<Self> {
         match value {
-            // ModelWrapper::BPE(model) => Ok(Self::BPE(model)),
+            ModelWrapper::BPE(model) => Ok(Self::BPE(model)),
             ModelWrapper::Unigram(model) => Ok(Self::Unigram(model)),
             ModelWrapper::WordPiece(model) => Ok(Self::WordPiece(model)),
             other => Err(format!("PipelineModel cannot be built from {:?}", other).into()),

--- a/tokenizers/tk-train/src/trainers/wordpiece.rs
+++ b/tokenizers/tk-train/src/trainers/wordpiece.rs
@@ -175,7 +175,6 @@ impl WordPieceTrainer {
 
         // Transfer the vocab
         model.vocab = new_wordpiece.vocab;
-        model.vocab_r = new_wordpiece.vocab_r;
         // The continuing_subword_prefix is the only other option to be overridden by the trainer
         model.continuing_subword_prefix = new_wordpiece.continuing_subword_prefix;
 


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**1 / 4 models supported** · geomean ×3.33 across supported · 18 fixtures each — ~10 kB inputs · single thread

`65b8e537b · 2026-07-07 12:17 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

> **Not yet supported:** `deepseek-v4` (BPE · Split+ByteLevel), `llama-3` (BPE · Split+ByteLevel), `t5-base` (Unigram · WhitespaceSplit+Metaspace) — roadmap cards below.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28865343973-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28865343973-bert-base-uncased-light.png" width="860">
</picture>

### Not yet supported

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28865343973-deepseek-v4-dark.png">
  <img alt="deepseek-v4 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28865343973-deepseek-v4-light.png" width="420">
</picture>
</td>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28865343973-llama-3-dark.png">
  <img alt="llama-3 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28865343973-llama-3-light.png" width="420">
</picture>
</td>
</tr>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28865343973-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28865343973-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

<details><summary>Per-fixture results</summary>

#### bert-base-uncased — WordPiece · Bert

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| cmn_Hani | lang | 3.5 | 15.1 | ×4.36 | match |
| eng_Latn | lang | 4.1 | 17.2 | ×4.18 | match |
| jpn_Jpan | lang | 4.0 | 14.9 | ×3.73 | match |
| arb_Arab | lang | 3.8 | 12.7 | ×3.32 | match |
| ben_Beng | lang | 5.6 | 18.4 | ×3.31 | match |
| ell_Grek | lang | 3.5 | 11.3 | ×3.23 | match |
| rus_Cyrl | lang | 3.4 | 10.6 | ×3.16 | match |
| hin_Deva | lang | 6.0 | 18.7 | ×3.12 | match |
| heb_Hebr | lang | 3.8 | 11.6 | ×3.03 | match |
| tam_Taml | lang | 6.6 | 19.7 | ×2.97 | match |
| kor_Hang | lang | 2.3 | 6.4 | ×2.85 | match |
| amh_Ethi | lang | 7.4 | 20.4 | ×2.76 | match |
| kat_Geor | lang | 5.8 | 14.8 | ×2.54 | match |
| tha_Thai | lang | 8.2 | 13.4 | ×1.64 | match |
| agentic-traces | modalities | 3.6 | 16.0 | ×4.50 | match |
| math_latex | modalities | 3.7 | 16.3 | ×4.42 | match |
| agentic_swe | modalities | 3.8 | 16.7 | ×4.37 | match |
| code_mixed | modalities | 3.7 | 15.8 | ×4.30 | match |

</details>
<!-- pipeline-bench:end -->



