### PR TITLE
Plug BucketVocabStore

### DIFF
--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -727,7 +727,7 @@ impl PyWordPiece {
         let vocab = WordPiece::read_file(vocab).map_err(|e| {
             exceptions::PyException::new_err(format!("Error while reading WordPiece file: {e}"))
         })?;
-        Ok(vocab.into_iter().collect())
+        Ok(vocab.get_vocab().into_iter().collect())
     }
 
     /// Instantiate a WordPiece model from the given file
@@ -759,7 +759,7 @@ impl PyWordPiece {
         let vocab = WordPiece::read_file(vocab).map_err(|e| {
             exceptions::PyException::new_err(format!("Error while reading WordPiece file: {e}"))
         })?;
-        let vocab = vocab.into_iter().collect();
+        let vocab = vocab.get_vocab().into_iter().collect();
         Py::new(
             py,
             PyWordPiece::new(py, Some(PyVocab::Vocab(vocab)), kwargs)?,

--- a/bindings/python/src/models.rs
+++ b/bindings/python/src/models.rs
@@ -15,6 +15,7 @@ use tk::models::wordlevel::WordLevel;
 use tk::models::wordpiece::{WordPiece, WordPieceBuilder};
 use tk::models::ModelWrapper;
 use tk::tokenizer::PreTokenizedString;
+use tk::vocab_store::VocabStore;
 use tk::{Model, Token, Trainable};
 use tokenizers as tk;
 

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -42,7 +42,7 @@
 // ---------------------------------------------------------------------------
 // Inference (always available) — re-exported from `tk-encode`.
 // ---------------------------------------------------------------------------
-pub use tk_encode::{decoders, normalizers, pre_tokenizers, processors, tokenizer, utils};
+pub use tk_encode::{decoders, normalizers, pre_tokenizers, processors, tokenizer, utils, vocab_store};
 
 // Mirror the v1 top-level re-exports (`pub use tokenizer::*;` etc.).
 pub use tk_encode::tokenizer::*;

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -42,7 +42,9 @@
 // ---------------------------------------------------------------------------
 // Inference (always available) — re-exported from `tk-encode`.
 // ---------------------------------------------------------------------------
-pub use tk_encode::{decoders, normalizers, pre_tokenizers, processors, tokenizer, utils, vocab_store};
+pub use tk_encode::{
+    decoders, normalizers, pre_tokenizers, processors, tokenizer, utils, vocab_store,
+};
 
 // Mirror the v1 top-level re-exports (`pub use tokenizer::*;` etc.).
 pub use tk_encode::tokenizer::*;

--- a/tokenizers/tk-encode/src/added_vocabulary/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/added_vocabulary/bucket_vocab_store.rs
@@ -34,6 +34,7 @@ struct Entry {
 /// Example:
 ///
 /// ```
+/// use tk_encode::vocab_store::VocabStore;
 /// use tk_encode::added_vocabulary::bucket_vocab_store::BucketVocabStore;
 /// let vocab = BucketVocabStore::build(vec![
 ///     (b"a".to_vec(), 0),

--- a/tokenizers/tk-encode/src/added_vocabulary/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/added_vocabulary/bucket_vocab_store.rs
@@ -5,6 +5,8 @@ use ptr_hash::bucket_fn::Linear;
 use ptr_hash::{PtrHash, PtrHashParams};
 use std::fmt;
 
+use crate::vocab_store::{LegacyVocabStore, VocabStore};
+
 type Mphf = PtrHash<u64, Linear>;
 
 // Fixed seeds so a given vocab always hashes identically (the hasher is also stored on the struct,
@@ -79,6 +81,12 @@ impl PartialEq for BucketVocabStore {
 impl Default for BucketVocabStore {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl From<LegacyVocabStore> for BucketVocabStore {
+    fn from(value: LegacyVocabStore) -> Self {
+        Self::build(value.byte_content())
     }
 }
 

--- a/tokenizers/tk-encode/src/added_vocabulary/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/added_vocabulary/bucket_vocab_store.rs
@@ -5,7 +5,7 @@ use ptr_hash::bucket_fn::Linear;
 use ptr_hash::{PtrHash, PtrHashParams};
 use std::fmt;
 
-use crate::vocab_store::{LegacyVocabStore, VocabStore};
+use crate::vocab_store::VocabStore;
 
 type Mphf = PtrHash<u64, Linear>;
 
@@ -84,12 +84,6 @@ impl Default for BucketVocabStore {
     }
 }
 
-impl From<LegacyVocabStore> for BucketVocabStore {
-    fn from(value: LegacyVocabStore) -> Self {
-        Self::build(value.byte_content())
-    }
-}
-
 impl BucketVocabStore {
     pub fn build(tokens: Vec<(Vec<u8>, u32)>) -> Self {
         let n = tokens.len();
@@ -127,7 +121,7 @@ impl BucketVocabStore {
 
         // 4. Place each token at its MPHF slot; build the slab and the id->slot reverse table.
         let total: usize = tokens.iter().map(|(s, _)| s.len()).sum();
-        let max_id = tokens.iter().map(|(_, id)| *id).max().unwrap();
+        let max_id = tokens.iter().map(|(_, id)| *id).max();
         let mut bytes = Vec::with_capacity(total);
         let mut entries = vec![
             Entry {
@@ -137,7 +131,7 @@ impl BucketVocabStore {
             };
             n
         ];
-        let mut id_to_slot = vec![u32::MAX; max_id as usize + 1];
+        let mut id_to_slot = vec![u32::MAX; max_id.map_or(0, |m| m as usize + 1)];
         for (s, id) in &tokens {
             assert!(
                 s.len() <= u16::MAX as usize,
@@ -162,7 +156,6 @@ impl BucketVocabStore {
         }
     }
     pub fn new() -> Self {
-        // convenient to build empty edit later.
         let empty: [u64; 0] = [];
         Self {
             mphf: PtrHash::<u64, Linear>::new(&empty, PtrHashParams::default_fast()),
@@ -172,12 +165,15 @@ impl BucketVocabStore {
             id_to_slot: Box::new([]),
         }
     }
+}
+
+impl VocabStore for BucketVocabStore {
     /// This function is the equivalent of `get` on a HashaMap, it return the id
     /// corresponding to the key `q`. Since `mphf` always return a slot, we check
     /// whether the token indexed by that slot actually match the query. We don't
     /// care about collisions on query because of this!
     #[inline]
-    pub fn get_bytes(&self, q: &[u8]) -> Option<u32> {
+    fn get_bytes(&self, q: &[u8]) -> Option<u32> {
         if self.entries.is_empty() {
             return None;
         }
@@ -194,14 +190,9 @@ impl BucketVocabStore {
         }
     }
 
-    #[inline]
-    pub fn token_to_id(&self, s: &str) -> Option<u32> {
-        self.get_bytes(s.as_bytes())
-    }
-
     /// `id -> token bytes`, borrowing from the slab (no allocation).
     #[inline]
-    pub fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
         let slot = *self.id_to_slot.get(id as usize)?;
         if slot == u32::MAX {
             return None; // id is within range but absent from the vocab
@@ -211,35 +202,21 @@ impl BucketVocabStore {
         self.bytes.get(start..start + e.len as usize)
     }
 
-    #[inline]
-    pub fn id_to_token(&self, id: u32) -> Option<String> {
-        // we are not sure its a valid utf8 so if not, adds replacement char
-        self.id_to_token_bytes(id)
-            .map(|b| String::from_utf8_lossy(b).into_owned())
-    }
-
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.entries.len()
     }
 
-    pub fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
-
-    pub fn content(&self) -> Vec<(String, u32)> {
+    fn get_vocab(&self) -> Vec<(String, u32)> {
         self.entries
             .iter()
             .filter_map(|m| self.id_to_token(m.id).map(|token| (token, m.id)))
             .collect()
     }
 
-    /// Alias for `content` — kept so `Model::get_vocab` call sites resolve.
-    pub fn get_vocab(&self) -> Vec<(String, u32)> {
-        self.content()
-    }
-
-    /// convenient when we want to re-build a vocab
-    pub fn byte_content(&self) -> Vec<(Vec<u8>, u32)> {
+    fn get_vocab_bytes(&self) -> Vec<(Vec<u8>, u32)> {
         self.entries
             .iter()
             .filter_map(|m| {
@@ -312,7 +289,7 @@ mod tests {
         assert_eq!(vocab.token_to_id("anything"), None);
         assert_eq!(vocab.get_bytes(b""), None);
         assert_eq!(vocab.id_to_token(0), None);
-        assert!(vocab.content().is_empty());
+        assert!(vocab.get_vocab().is_empty());
     }
 
     #[test]
@@ -333,8 +310,8 @@ mod tests {
         let mut got = vocab.get_vocab();
         got.sort();
         assert_eq!(got, vec![("hi".to_string(), 0), ("yo".to_string(), 1)]);
-        assert_eq!(vocab.content(), vocab.get_vocab());
-        let mut bytes = vocab.byte_content();
+        assert_eq!(vocab.get_vocab(), vocab.get_vocab());
+        let mut bytes = vocab.get_vocab_bytes();
         bytes.sort();
         assert_eq!(bytes, vec![(b"hi".to_vec(), 0), (b"yo".to_vec(), 1)]);
     }

--- a/tokenizers/tk-encode/src/added_vocabulary/buckets.rs
+++ b/tokenizers/tk-encode/src/added_vocabulary/buckets.rs
@@ -1,4 +1,5 @@
 use crate::bucket_vocab_store::BucketVocabStore;
+use crate::vocab_store::VocabStore;
 
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct AddedTokenFlags {
@@ -431,11 +432,11 @@ impl Buckets {
     }
     /// All added-token byte strings + ids (e.g. to rebuild the vocab when adding tokens).
     pub fn get_vocab_bytes(&self) -> Vec<(Vec<u8>, u32)> {
-        self.vocab.byte_content()
+        self.vocab.get_vocab_bytes()
     }
     /// All added-token strings + ids.
     pub fn get_vocab(&self) -> Vec<(String, u32)> {
-        self.vocab.content()
+        self.vocab.get_vocab()
     }
     pub fn token_to_id(&self, token: &str) -> Option<u32> {
         self.vocab.token_to_id(token)

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -271,16 +271,12 @@ impl BpeBuilder {
 
         // merges.insert(pair, (rank as u32, *new_id));
 
-        let vocab = if vocab.is_empty() {
-            VocabStoreWrapper::new()
-        } else {
-            VocabStoreWrapper::build(
-                vocab
-                    .into_iter()
-                    .map(|(k, v)| (k.into_bytes(), v))
-                    .collect(),
-            )
-        };
+        let vocab = VocabStoreWrapper::build(
+            vocab
+                .into_iter()
+                .map(|(k, v)| (k.into_bytes(), v))
+                .collect(),
+        );
 
         Ok(BPE {
             vocab,

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -2,7 +2,7 @@ use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
-use crate::vocab_store::VocabStore;
+use crate::vocab_store::{VocabStore, VocabStoreWrapper};
 use ahash::AHashMap;
 use serde_json::Value;
 use std::borrow::Cow;
@@ -272,9 +272,9 @@ impl BpeBuilder {
         // merges.insert(pair, (rank as u32, *new_id));
 
         let vocab = if vocab.is_empty() {
-            VocabStore::new()
+            VocabStoreWrapper::new()
         } else {
-            VocabStore::build(
+            VocabStoreWrapper::build(
                 vocab
                     .into_iter()
                     .map(|(k, v)| (k.into_bytes(), v))
@@ -301,7 +301,7 @@ impl BpeBuilder {
 #[derive(PartialEq)]
 pub struct BPE {
     /// The vocabulary, mapping tokens <-> ids both ways.
-    pub vocab: VocabStore,
+    pub vocab: VocabStoreWrapper,
     /// Contains the mapping between Pairs and their (rank, new_id).
     pub merges: MergeMap,
     /// Contains the cache for optimizing the encoding step.

--- a/tokenizers/tk-encode/src/models/bpe/serialization.rs
+++ b/tokenizers/tk-encode/src/models/bpe/serialization.rs
@@ -1,4 +1,5 @@
 use super::{super::OrderedVocabIter, convert_merges_to_hashmap, BpeBuilder, Pair, BPE};
+use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
 use serde::{
     de::{Error, MapAccess, Visitor},

--- a/tokenizers/tk-encode/src/models/unigram/lattice.rs
+++ b/tokenizers/tk-encode/src/models/unigram/lattice.rs
@@ -227,6 +227,10 @@ impl<'a> Lattice<'a> {
         self.sentence[node.pos..node.pos + node.length].to_owned()
     }
 
+    pub fn piece_offsets(&self, node: &Node) -> (usize, usize) {
+        (node.pos, node.pos + node.length)
+    }
+
     pub fn tokens(&mut self) -> Vec<String> {
         self.viterbi()
             .iter()

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -2,9 +2,12 @@ use super::{
     lattice::Lattice,
     trie::{Trie, TrieBuilder},
 };
-use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 use crate::vocab_store::VocabStore;
+use crate::{
+    pipeline::{self, PipelineToken},
+    tokenizer::{Model, Result, Token},
+};
 use std::collections::HashMap;
 
 use std::convert::TryInto;
@@ -16,6 +19,7 @@ type Vocab = Vec<(String, f64)>;
 /// A `Unigram` model to encode sentences.
 pub struct Unigram {
     token_to_ids: VocabStore,
+    byte_fallback_map: [Option<u32>; 256],
     pub(crate) vocab: Vocab,
     cache: Cache<String, Vec<String>>,
     trie: Trie<u8>,
@@ -59,6 +63,7 @@ impl Clone for Unigram {
             byte_fallback: self.byte_fallback,
             alpha: self.alpha,
             nbest_size: self.nbest_size,
+            byte_fallback_map: self.byte_fallback_map,
         }
     }
 }
@@ -136,6 +141,12 @@ impl Unigram {
         let fuse_unk = true;
         let is_optimized = true;
 
+        let byte_fallback_map: [Option<u32>; 256] = if byte_fallback {
+            std::array::from_fn(|byte| token_to_ids.get_bytes(format!("<0x{byte:02X}>").as_bytes()))
+        } else {
+            [None; 256]
+        };
+
         Ok(Self {
             vocab,
             token_to_ids,
@@ -150,6 +161,7 @@ impl Unigram {
             byte_fallback,
             alpha: None,
             nbest_size: None,
+            byte_fallback_map,
         })
     }
 
@@ -259,130 +271,21 @@ impl Unigram {
     }
 
     fn encode_optimized(&self, sentence: &str) -> Result<Vec<String>> {
-        // https://github.com/google/sentencepiece/blob/d48247191a6d50e469ed1a4a36e877befffd1851/src/unigram_model.cc#L600
-        #[derive(Debug, Clone)]
-        struct BestPathNode {
-            /// The vocab id. (maybe UNK)
-            id: usize,
-            /// The total score of the best path ending at this node.
-            best_path_score: f64,
-            /// The starting position (in utf-8) of this node. The entire best
-            /// path can be constructed by backtracking along this link.
-            starts_at: Option<usize>,
-        }
-        impl Default for BestPathNode {
-            fn default() -> Self {
-                Self {
-                    id: 0,
-                    best_path_score: 0.0,
-                    starts_at: None,
-                }
-            }
-        }
-        let size = sentence.len();
-        let unk_score = self.min_score - K_UNK_PENALTY;
-
-        let mut best_path_ends_at = vec![BestPathNode::default(); size + 1];
-        let mut starts_at = 0;
-        while starts_at < size {
-            let best_path_score_till_here = best_path_ends_at[starts_at].best_path_score;
-            let mut has_single_node = false;
-            let mblen = sentence[starts_at..].chars().next().unwrap().len_utf8();
-            for tok_bytes in self
-                .trie
-                .common_prefix_search(sentence.bytes().skip(starts_at))
-            {
-                let key_pos = starts_at + tok_bytes.len();
-                let token: String = String::from_utf8(tok_bytes).unwrap();
-                let target_node = &mut best_path_ends_at[key_pos];
-                let length = key_pos - starts_at;
-                let id = self.token_to_ids.token_to_id(&token).unwrap();
-                let score = self.vocab.get(id as usize).unwrap().1;
-                let candidate_best_path_score = score + best_path_score_till_here;
-                if target_node.starts_at.is_none()
-                    || candidate_best_path_score > target_node.best_path_score
-                {
-                    target_node.best_path_score = candidate_best_path_score;
-                    target_node.starts_at = Some(starts_at);
-                    target_node.id = id as usize;
-                }
-                if !has_single_node && length == mblen {
-                    has_single_node = true;
-                }
-            }
-            if !has_single_node {
-                let target_node = &mut best_path_ends_at[starts_at + mblen];
-                let candidate_best_path_score = unk_score + best_path_score_till_here;
-                if target_node.starts_at.is_none()
-                    || candidate_best_path_score > target_node.best_path_score
-                {
-                    target_node.best_path_score = candidate_best_path_score;
-                    target_node.starts_at = Some(starts_at);
-                    target_node.id = self.unk_id.ok_or(UnigramError::MissingUnkId)?;
-                }
-            }
-            starts_at += mblen
-        }
-        let mut ends_at = size;
-        let mut results: Vec<String> = vec![];
-        let mut token = vec![];
-        while ends_at > 0 {
-            let node = &best_path_ends_at[ends_at];
-            let starts_at = node.starts_at.unwrap();
-            if self.fuse_unk && Some(node.id) == self.unk_id {
-                token.push(sentence[starts_at..ends_at].to_string());
-            } else {
-                if !token.is_empty() {
-                    token.reverse();
-                    results.push(token.concat());
-                    token = vec![];
-                }
-                results.push(sentence[starts_at..ends_at].to_string());
-            }
-            ends_at = starts_at;
-        }
-        if !token.is_empty() {
-            token.reverse();
-            results.push(token.concat());
-        }
-        results.reverse();
-        Ok(results)
+        let mut offsets = Vec::with_capacity(sentence.len());
+        self.encode_offsets_optimized(sentence, &mut offsets)?;
+        return Ok(offsets
+            .into_iter()
+            .map(|(start, end)| sentence[start..end].to_owned())
+            .collect());
     }
 
     fn encode_unoptimized(&self, sentence: &str) -> Result<Vec<String>> {
-        let mut lattice = Lattice::from(sentence, self.bos_id, self.eos_id);
-        self.populate_nodes(&mut lattice);
-        let path = match (self.nbest_size, self.alpha) {
-            (Some(n), Some(alpha)) if n > 0 => lattice.sample_nbest(n, alpha),
-            (_, Some(alpha)) => lattice.sample(alpha),
-            _ => lattice.viterbi(),
-        };
-        if self.fuse_unk {
-            let mut results = vec![];
-            let mut token = String::new();
-            for node in path.iter() {
-                let item = lattice.piece(&node.borrow());
-                if node.borrow().id == self.unk_id.ok_or(UnigramError::MissingUnkId)? {
-                    token.push_str(&item);
-                } else {
-                    if !token.is_empty() {
-                        results.push(token);
-                        token = String::new();
-                    }
-                    results.push(item);
-                }
-            }
-            if !token.is_empty() {
-                results.push(token);
-            }
-            Ok(results)
-        } else {
-            let results: Vec<String> = path
-                .iter()
-                .map(|node| lattice.piece(&node.borrow()))
-                .collect();
-            Ok(results)
-        }
+        let mut offsets = Vec::with_capacity(sentence.len());
+        self.encode_offsets_unoptimized(sentence, &mut offsets)?;
+        return Ok(offsets
+            .into_iter()
+            .map(|(start, end)| sentence[start..end].to_owned())
+            .collect());
     }
 
     /// Iterate of vocabulary of the model as a pair of `(token, score)`.
@@ -499,6 +402,180 @@ impl Model for Unigram {
         let string = serde_json::to_string_pretty(self)?;
         std::fs::write(&fullpath, string)?;
         Ok(vec![fullpath])
+    }
+}
+
+impl pipeline::Model for Unigram {
+    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
+        for (start, end) in self.encode_offsets(&bytes)?.into_iter() {
+            let chunk = &bytes[start..end];
+            if let Some(id) = self.token_to_ids.get_bytes(chunk) {
+                output.push(PipelineToken { id });
+            } else {
+                if self.byte_fallback {
+                    // todo: do not materialize the IDs
+                    let ids: Vec<u32> = chunk
+                        .iter()
+                        .map(|&byte| {
+                            self.byte_fallback_map[byte as usize].or(self.unk_id.map(|u| u as u32))
+                        })
+                        .collect::<Option<Vec<_>>>()
+                        .ok_or(UnigramError::MissingUnkId)?;
+                    output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                } else {
+                    let unk_id = self.unk_id.ok_or(UnigramError::MissingUnkId)?;
+                    output.push(PipelineToken { id: unk_id as u32 });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Unigram {
+    fn encode_offsets(&self, bytes: &[u8]) -> Result<Vec<(usize, usize)>> {
+        let mut offsets = Vec::with_capacity(bytes.len());
+        let string = str::from_utf8(bytes)?;
+        if self.is_optimized {
+            self.encode_offsets_optimized(string, &mut offsets)?;
+        } else {
+            self.encode_offsets_unoptimized(string, &mut offsets)?;
+        }
+        Ok(offsets)
+    }
+
+    fn encode_offsets_optimized(
+        &self,
+        sequence: &str,
+        offsets: &mut Vec<(usize, usize)>,
+    ) -> Result<()> {
+        // https://github.com/google/sentencepiece/blob/d48247191a6d50e469ed1a4a36e877befffd1851/src/unigram_model.cc#L600
+        #[derive(Debug, Clone)]
+        struct BestPathNode {
+            /// The vocab id. (maybe UNK)
+            id: usize,
+            /// The total score of the best path ending at this node.
+            best_path_score: f64,
+            /// The starting position (in utf-8) of this node. The entire best
+            /// path can be constructed by backtracking along this link.
+            starts_at: Option<usize>,
+        }
+        impl Default for BestPathNode {
+            fn default() -> Self {
+                Self {
+                    id: 0,
+                    best_path_score: 0.0,
+                    starts_at: None,
+                }
+            }
+        }
+        let size = sequence.len();
+        let unk_score = self.min_score - K_UNK_PENALTY;
+
+        let mut best_path_ends_at = vec![BestPathNode::default(); size + 1];
+        let mut starts_at = 0;
+        while starts_at < size {
+            let best_path_score_till_here = best_path_ends_at[starts_at].best_path_score;
+            let mut has_single_node = false;
+            let mblen = sequence[starts_at..].chars().next().unwrap().len_utf8();
+            for tok_bytes in self
+                .trie
+                .common_prefix_search(sequence.bytes().skip(starts_at))
+            {
+                let key_pos = starts_at + tok_bytes.len();
+                let token: String = String::from_utf8(tok_bytes).unwrap();
+                let target_node = &mut best_path_ends_at[key_pos];
+                let length = key_pos - starts_at;
+                let id = self.token_to_ids.token_to_id(&token).unwrap();
+                let score = self.vocab.get(id as usize).unwrap().1;
+                let candidate_best_path_score = score + best_path_score_till_here;
+                if target_node.starts_at.is_none()
+                    || candidate_best_path_score > target_node.best_path_score
+                {
+                    target_node.best_path_score = candidate_best_path_score;
+                    target_node.starts_at = Some(starts_at);
+                    target_node.id = id as usize;
+                }
+                if !has_single_node && length == mblen {
+                    has_single_node = true;
+                }
+            }
+            if !has_single_node {
+                let target_node = &mut best_path_ends_at[starts_at + mblen];
+                let candidate_best_path_score = unk_score + best_path_score_till_here;
+                if target_node.starts_at.is_none()
+                    || candidate_best_path_score > target_node.best_path_score
+                {
+                    target_node.best_path_score = candidate_best_path_score;
+                    target_node.starts_at = Some(starts_at);
+                    target_node.id = self.unk_id.ok_or(UnigramError::MissingUnkId)?;
+                }
+            }
+            starts_at += mblen
+        }
+        let mut ends_at = size;
+        let (mut token_start, mut token_end) = (ends_at, ends_at);
+
+        while ends_at > 0 {
+            let node = &best_path_ends_at[ends_at];
+            let starts_at = node.starts_at.unwrap();
+            if self.fuse_unk && Some(node.id) == self.unk_id {
+                token_start = starts_at;
+            } else {
+                if token_start != token_end {
+                    offsets.push((token_start, token_end));
+                }
+                offsets.push((starts_at, ends_at));
+                token_end = starts_at;
+                token_start = starts_at;
+            }
+            ends_at = starts_at;
+        }
+        if token_start != token_end {
+            offsets.push((token_start, token_end));
+        }
+        offsets.reverse();
+        Ok(())
+    }
+
+    fn encode_offsets_unoptimized(
+        &self,
+        sentence: &str,
+        offsets: &mut Vec<(usize, usize)>,
+    ) -> Result<()> {
+        let mut lattice = Lattice::from(sentence, self.bos_id, self.eos_id);
+        self.populate_nodes(&mut lattice);
+        let path = match (self.nbest_size, self.alpha) {
+            (Some(n), Some(alpha)) if n > 0 => lattice.sample_nbest(n, alpha),
+            (_, Some(alpha)) => lattice.sample(alpha),
+            _ => lattice.viterbi(),
+        };
+        if self.fuse_unk {
+            let (mut token_start, mut token_end) = (0usize, 0usize);
+            for node in path.iter() {
+                let (start, end) = lattice.piece_offsets(&node.borrow());
+                if node.borrow().id == self.unk_id.ok_or(UnigramError::MissingUnkId)? {
+                    token_end = end;
+                } else {
+                    if token_start != token_end {
+                        offsets.push((token_start, token_end));
+                    }
+                    offsets.push((start, end));
+                    token_start = end;
+                    token_end = end;
+                }
+            }
+            if token_start != token_end {
+                offsets.push((token_start, token_end));
+            }
+            Ok(())
+        } else {
+            offsets.extend(
+                path.iter()
+                    .map(|node| lattice.piece_offsets(&node.borrow())),
+            );
+            Ok(())
+        }
     }
 }
 

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -135,11 +135,7 @@ impl Unigram {
                 min_score = *score;
             }
         }
-        let token_to_ids = if pairs.is_empty() {
-            VocabStoreWrapper::new()
-        } else {
-            VocabStoreWrapper::build(pairs)
-        };
+        let token_to_ids = VocabStoreWrapper::build(pairs);
         let trie = builder.build();
         let fuse_unk = true;
         let is_optimized = true;
@@ -592,6 +588,30 @@ impl Unigram {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn pipeline_model_uses_bucket_vocab_store() {
+        let pieces = vec![
+            ("<unk>".to_string(), 0.0),
+            ("a".to_string(), -0.5),
+            ("ab".to_string(), -0.3),
+        ];
+        let model = Unigram::from(pieces, Some(0), false).unwrap();
+        assert!(matches!(model.token_to_ids, VocabStoreWrapper::Legacy(_)));
+        let id = model.token_to_id("ab");
+
+        let converted =
+            match pipeline::PipelineModel::try_from(crate::ModelWrapper::Unigram(model)).unwrap() {
+                pipeline::PipelineModel::Unigram(m) => m,
+                _ => panic!("expected a Unigram pipeline model"),
+            };
+        assert!(matches!(
+            converted.token_to_ids,
+            VocabStoreWrapper::Bucket(_)
+        ));
+        assert_eq!(converted.token_to_id("ab"), id);
+    }
 
     #[test]
     fn test_populate_nodes_unk() {

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -4,12 +4,12 @@ use super::{
 };
 use crate::vocab_store::VocabStoreWrapper;
 use crate::{
-    utils::cache::{Cache, MAX_LENGTH},
-    vocab_store::VocabStore,
-};
-use crate::{
     pipeline::{self, PipelineToken},
     tokenizer::{Model, Result, Token},
+};
+use crate::{
+    utils::cache::{Cache, MAX_LENGTH},
+    vocab_store::VocabStore,
 };
 use std::collections::HashMap;
 

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -738,4 +738,145 @@ mod tests {
         let tokens = unigram.tokenize("?é").unwrap();
         assert_eq!(tokens[0].id, 0);
     }
+
+    const INVARIANT_CORPUS: &[&str] = &[
+        "",
+        "a",
+        "x",
+        "AB",
+        "abc",
+        "abcd",
+        "abABcd",
+        "xabcabaabcdd",
+        "xyz東京",
+        "abABCcd",
+        "ababcdabcdcd",
+        "abqrcd",
+        "🙂👍🏽",
+        "e\u{301}abce\u{301}",
+        "▁ab▁",
+    ];
+
+    fn invariant_model() -> Unigram {
+        let pieces = vec![
+            ("<unk>".to_string(), 0.0),
+            ("ab".to_string(), 0.0),
+            ("cd".to_string(), -0.1),
+            ("abc".to_string(), -0.2),
+            ("a".to_string(), -0.3),
+            ("b".to_string(), -0.4),
+            ("c".to_string(), -0.5),
+            ("ABC".to_string(), -0.5),
+            ("abcdabcd".to_string(), 20.0),
+            ("q".to_string(), 20.5),
+            ("r".to_string(), 20.5),
+            ("qr".to_string(), -0.5),
+        ];
+        Unigram::from(pieces, Some(0), false).unwrap()
+    }
+
+    fn encoded_offsets(model: &Unigram, sentence: &str, optimized: bool) -> Vec<(usize, usize)> {
+        let mut offsets = vec![];
+        if optimized {
+            model
+                .encode_offsets_optimized(sentence, &mut offsets)
+                .unwrap();
+        } else {
+            model
+                .encode_offsets_unoptimized(sentence, &mut offsets)
+                .unwrap();
+        }
+        offsets
+    }
+
+    #[test]
+    fn test_offsets_partition_input() {
+        let mut model = invariant_model();
+        for fuse_unk in [true, false].iter().copied() {
+            model.set_fuse_unk(fuse_unk);
+            for sentence in INVARIANT_CORPUS {
+                for optimized in [true, false].iter().copied() {
+                    let offsets = encoded_offsets(&model, sentence, optimized);
+                    let context = format!("{sentence:?} fuse_unk={fuse_unk} optimized={optimized}");
+                    let mut pos = 0;
+                    for &(start, end) in &offsets {
+                        assert_eq!(start, pos, "gap or overlap: {context}");
+                        assert!(start < end, "empty piece: {}", context);
+                        assert!(
+                            sentence.is_char_boundary(end),
+                            "offset {} splits a char: {}",
+                            end,
+                            context
+                        );
+                        pos = end;
+                    }
+                    assert_eq!(pos, sentence.len(), "input not covered: {context}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_pieces_match_input_slices() {
+        let mut model = invariant_model();
+        for fuse_unk in [true, false].iter().copied() {
+            model.set_fuse_unk(fuse_unk);
+            for sentence in INVARIANT_CORPUS {
+                for token in model.tokenize(sentence).unwrap() {
+                    assert_eq!(
+                        token.value,
+                        &sentence[token.offsets.0..token.offsets.1],
+                        "{sentence:?} fuse_unk={fuse_unk}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_pieces_match_input_slices_byte_fallback() {
+        let pieces = vec![
+            ("<unk>".to_string(), 0.0),
+            ("a".to_string(), -0.3),
+            ("<0xC3>".to_string(), -0.01),
+            ("<0xA9>".to_string(), -0.03),
+        ];
+        let model = Unigram::from(pieces, Some(0), true).unwrap();
+        for sentence in ["aéa", "é", "🙂a"].iter().copied() {
+            for token in model.tokenize(sentence).unwrap() {
+                let is_byte_token = token.value.len() == 6
+                    && token.value.starts_with("<0x")
+                    && token.value.ends_with('>');
+                if !is_byte_token {
+                    assert_eq!(
+                        token.value,
+                        &sentence[token.offsets.0..token.offsets.1],
+                        "{sentence:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_fuse_unk_no_adjacent_unk_pieces() {
+        let model = invariant_model();
+        for sentence in INVARIANT_CORPUS {
+            for optimized in [true, false].iter().copied() {
+                let offsets = encoded_offsets(&model, sentence, optimized);
+                let in_vocab: Vec<bool> = offsets
+                    .iter()
+                    .map(|&(start, end)| model.token_to_id(&sentence[start..end]).is_some())
+                    .collect();
+                for pair in in_vocab.windows(2) {
+                    assert!(
+                        pair[0] || pair[1],
+                        "adjacent unk pieces in {:?} optimized={}",
+                        sentence,
+                        optimized
+                    );
+                }
+            }
+        }
+    }
 }

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -2,8 +2,11 @@ use super::{
     lattice::Lattice,
     trie::{Trie, TrieBuilder},
 };
-use crate::utils::cache::{Cache, MAX_LENGTH};
-use crate::vocab_store::VocabStore;
+use crate::vocab_store::VocabStoreWrapper;
+use crate::{
+    utils::cache::{Cache, MAX_LENGTH},
+    vocab_store::VocabStore,
+};
 use crate::{
     pipeline::{self, PipelineToken},
     tokenizer::{Model, Result, Token},
@@ -18,7 +21,7 @@ type Vocab = Vec<(String, f64)>;
 
 /// A `Unigram` model to encode sentences.
 pub struct Unigram {
-    token_to_ids: VocabStore,
+    token_to_ids: VocabStoreWrapper,
     byte_fallback_map: [Option<u32>; 256],
     pub(crate) vocab: Vocab,
     cache: Cache<String, Vec<String>>,
@@ -133,9 +136,9 @@ impl Unigram {
             }
         }
         let token_to_ids = if pairs.is_empty() {
-            VocabStore::new()
+            VocabStoreWrapper::new()
         } else {
-            VocabStore::build(pairs)
+            VocabStoreWrapper::build(pairs)
         };
         let trie = builder.build();
         let fuse_unk = true;
@@ -402,6 +405,13 @@ impl Model for Unigram {
         let string = serde_json::to_string_pretty(self)?;
         std::fs::write(&fullpath, string)?;
         Ok(vec![fullpath])
+    }
+}
+
+impl Unigram {
+    pub(crate) fn with_bucket_vocab(mut self) -> Self {
+        self.token_to_ids = self.token_to_ids.into_bucket();
+        self
     }
 }
 

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -273,19 +273,19 @@ impl Unigram {
     fn encode_optimized(&self, sentence: &str) -> Result<Vec<String>> {
         let mut offsets = Vec::with_capacity(sentence.len());
         self.encode_offsets_optimized(sentence, &mut offsets)?;
-        return Ok(offsets
+        Ok(offsets
             .into_iter()
             .map(|(start, end)| sentence[start..end].to_owned())
-            .collect());
+            .collect())
     }
 
     fn encode_unoptimized(&self, sentence: &str) -> Result<Vec<String>> {
         let mut offsets = Vec::with_capacity(sentence.len());
         self.encode_offsets_unoptimized(sentence, &mut offsets)?;
-        return Ok(offsets
+        Ok(offsets
             .into_iter()
             .map(|(start, end)| sentence[start..end].to_owned())
-            .collect());
+            .collect())
     }
 
     /// Iterate of vocabulary of the model as a pair of `(token, score)`.
@@ -407,7 +407,7 @@ impl Model for Unigram {
 
 impl pipeline::Model for Unigram {
     fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
-        for (start, end) in self.encode_offsets(&bytes)?.into_iter() {
+        for (start, end) in self.encode_offsets(bytes)?.into_iter() {
             let chunk = &bytes[start..end];
             if let Some(id) = self.token_to_ids.get_bytes(chunk) {
                 output.push(PipelineToken { id });

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -41,7 +41,7 @@ impl Default for WordPieceBuilder {
         Self {
             config: Config {
                 files: None,
-                vocab: VocabStoreWrapper::new(),
+                vocab: VocabStoreWrapper::build(Vec::new()),
                 unk_token: String::from("[UNK]"),
                 continuing_subword_prefix: String::from("##"),
                 max_input_chars_per_word: 100,
@@ -142,7 +142,7 @@ impl std::fmt::Debug for WordPiece {
 impl Default for WordPiece {
     fn default() -> Self {
         Self {
-            vocab: VocabStoreWrapper::new(),
+            vocab: VocabStoreWrapper::build(Vec::new()),
             unk_token: String::from("[UNK]"),
             continuing_subword_prefix: String::from("##"),
             max_input_chars_per_word: 100,
@@ -391,6 +391,26 @@ impl pipeline::Model for WordPiece {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn pipeline_model_uses_bucket_vocab_store() {
+        let model = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["[UNK]", "a", "##b"]))
+            .build()
+            .unwrap();
+        assert!(matches!(model.vocab, VocabStoreWrapper::Legacy(_)));
+        let id = model.token_to_id("##b");
+
+        let converted =
+            match pipeline::PipelineModel::try_from(crate::ModelWrapper::WordPiece(model)).unwrap()
+            {
+                pipeline::PipelineModel::WordPiece(m) => m,
+                _ => panic!("expected a WordPiece pipeline model"),
+            };
+        assert!(matches!(converted.vocab, VocabStoreWrapper::Bucket(_)));
+        assert_eq!(converted.token_to_id("##b"), id);
+    }
 
     fn make_vocab_store(tokens: &[&str]) -> VocabStoreWrapper {
         VocabStoreWrapper::build(

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -330,8 +330,10 @@ impl pipeline::Model for WordPiece {
                 .token_to_id(&self.unk_token)
                 .ok_or(Error::MissingUnkToken)?;
             output.push(PipelineToken { id: unk_id });
+            return Ok(());
         }
 
+        let word_start = output.len();
         let mut is_bad = false;
         let mut start = 0;
 
@@ -371,6 +373,7 @@ impl pipeline::Model for WordPiece {
                 .vocab
                 .token_to_id(&self.unk_token)
                 .ok_or(Error::MissingUnkToken)?;
+            output.truncate(word_start);
             output.push(PipelineToken { id: unk_id });
         }
 

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -2,8 +2,9 @@
 //! model.
 
 use crate::models::bpe::BPE;
-use crate::pipeline::{self, PipelineToken};
+use crate::pipeline;
 use crate::tokenizer::{Model, Result, Token};
+use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
 use std::collections::HashMap;
 use std::{
@@ -22,12 +23,9 @@ pub enum Error {
     MissingUnkToken,
 }
 
-type Vocab = AHashMap<String, u32>;
-type VocabR = AHashMap<u32, String>;
-
 struct Config {
     files: Option<String>,
-    vocab: Vocab,
+    vocab: VocabStore,
     unk_token: String,
     continuing_subword_prefix: String,
     max_input_chars_per_word: usize,
@@ -43,7 +41,7 @@ impl Default for WordPieceBuilder {
         Self {
             config: Config {
                 files: None,
-                vocab: AHashMap::new(),
+                vocab: VocabStore::new(),
                 unk_token: String::from("[UNK]"),
                 continuing_subword_prefix: String::from("##"),
                 max_input_chars_per_word: 100,
@@ -68,7 +66,18 @@ impl WordPieceBuilder {
     /// Set the vocab (token -> ID) mapping.
     #[must_use]
     pub fn vocab<V: Into<AHashMap<String, u32>>>(mut self, vocab: V) -> Self {
-        self.config.vocab = vocab.into();
+        let string_vocab: AHashMap<String, u32> = vocab.into();
+        self.config.vocab = VocabStore::build(
+            string_vocab
+                .into_iter()
+                .map(|(token_str, token_id)| (token_str.into_bytes(), token_id))
+                .collect(),
+        );
+        self
+    }
+
+    pub fn vocab_store(mut self, vocab_store: VocabStore) -> Self {
+        self.config.vocab = vocab_store;
         self
     }
 
@@ -99,16 +108,8 @@ impl WordPieceBuilder {
             self.config.vocab = WordPiece::read_file(&vocab)?;
         }
 
-        let vocab_r = self
-            .config
-            .vocab
-            .iter()
-            .map(|(key, val)| (*val, key.to_owned()))
-            .collect();
-
         Ok(WordPiece {
             vocab: self.config.vocab,
-            vocab_r,
             unk_token: self.config.unk_token,
             continuing_subword_prefix: self.config.continuing_subword_prefix,
             max_input_chars_per_word: self.config.max_input_chars_per_word,
@@ -119,10 +120,9 @@ impl WordPieceBuilder {
 /// A
 /// [WordPiece](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/37842.pdf)
 /// model.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq)]
 pub struct WordPiece {
-    pub vocab: Vocab,
-    pub vocab_r: VocabR,
+    pub vocab: VocabStore,
     pub unk_token: String,
     pub continuing_subword_prefix: String,
     pub max_input_chars_per_word: usize,
@@ -142,8 +142,7 @@ impl std::fmt::Debug for WordPiece {
 impl Default for WordPiece {
     fn default() -> Self {
         Self {
-            vocab: AHashMap::new(),
-            vocab_r: AHashMap::new(),
+            vocab: VocabStore::new(),
             unk_token: String::from("[UNK]"),
             continuing_subword_prefix: String::from("##"),
             max_input_chars_per_word: 100,
@@ -158,27 +157,30 @@ impl WordPiece {
     }
 
     /// Read the given files to extract the vocab
-    pub fn read_file(vocab: &str) -> Result<Vocab> {
+    pub fn read_file(vocab: &str) -> Result<VocabStore> {
         let file = File::open(vocab)?;
         let file = BufReader::new(file);
 
-        let mut vocab = AHashMap::new();
+        let mut vocab_raw: Vec<(Vec<u8>, u32)> = vec![];
         for (index, line) in file.lines().enumerate() {
             let line = line?;
-            vocab.insert(line.trim_end().to_owned(), index as u32);
+            vocab_raw.push((line.trim_end().to_owned().into_bytes(), index as u32));
         }
+
+        let vocab = VocabStore::build(vocab_raw);
 
         Ok(vocab)
     }
 
-    pub fn read_bytes(vocab: &[u8]) -> Result<Vocab> {
+    pub fn read_bytes(vocab: &[u8]) -> Result<VocabStore> {
         let file = BufReader::new(vocab);
 
-        let mut vocab = AHashMap::new();
+        let mut vocab_raw: Vec<(Vec<u8>, u32)> = vec![];
         for (index, line) in file.lines().enumerate() {
             let line = line?;
-            vocab.insert(line.trim_end().to_owned(), index as u32);
+            vocab_raw.push((line.trim_end().to_owned().into_bytes(), index as u32));
         }
+        let vocab = VocabStore::build(vocab_raw);
 
         Ok(vocab)
     }
@@ -211,7 +213,7 @@ impl WordPiece {
 
 impl Model for WordPiece {
     fn get_vocab(&self) -> HashMap<String, u32> {
-        self.vocab.clone().into_iter().collect()
+        self.vocab.get_vocab().into_iter().collect()
     }
 
     fn get_vocab_size(&self) -> usize {
@@ -220,12 +222,13 @@ impl Model for WordPiece {
 
     fn tokenize(&self, sequence: &str) -> Result<Vec<Token>> {
         let char_len = sequence.chars().count();
+
         if char_len > self.max_input_chars_per_word {
             return Ok(vec![Token {
                 value: self.unk_token.clone(),
-                id: *self
+                id: self
                     .vocab
-                    .get(&self.unk_token)
+                    .token_to_id(&self.unk_token)
                     .ok_or(Error::MissingUnkToken)?,
                 offsets: (0, sequence.len()),
             }]);
@@ -245,9 +248,9 @@ impl Model for WordPiece {
                 if start > 0 {
                     substr = Cow::Owned(format!("{}{}", self.continuing_subword_prefix, substr));
                 }
-                if self.vocab.contains_key(substr.as_ref()) {
+                if let Some(token) = self.vocab.token_to_id(substr.as_ref()) {
                     cur_str = Some(Token {
-                        id: self.vocab[substr.as_ref()],
+                        id: token,
                         value: substr.to_string(),
                         offsets: (start, end),
                     });
@@ -268,9 +271,9 @@ impl Model for WordPiece {
         if is_bad {
             Ok(vec![Token {
                 value: self.unk_token.clone(),
-                id: *self
+                id: self
                     .vocab
-                    .get(&self.unk_token)
+                    .token_to_id(&self.unk_token)
                     .ok_or(Error::MissingUnkToken)?,
                 offsets: (0, sequence.len()),
             }])
@@ -280,17 +283,17 @@ impl Model for WordPiece {
     }
 
     fn token_to_id(&self, token: &str) -> Option<u32> {
-        self.vocab.get(token).copied()
+        self.vocab.token_to_id(token)
     }
 
     fn id_to_token(&self, id: u32) -> Option<String> {
-        self.vocab_r.get(&id).cloned()
+        self.vocab.id_to_token(id)
     }
 
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>> {
         let vocab_file_name = match name {
             Some(name) => format!("{name}-vocab.txt"),
-            None => "vocab.txt".to_string(),
+            _ => "vocab.txt".to_string(),
         };
 
         // Write vocab.txt
@@ -298,8 +301,8 @@ impl Model for WordPiece {
             .iter()
             .collect();
         let mut vocab_file = File::create(&vocab_path)?;
-        let mut vocab: Vec<(&String, &u32)> = self.vocab.iter().collect();
-        vocab.sort_unstable_by_key(|k| *k.1);
+        let mut vocab: Vec<(String, u32)> = self.vocab.get_vocab().into_iter().collect();
+        vocab.sort_unstable_by_key(|(_, rank)| *rank);
         vocab_file.write_all(
             &vocab
                 .into_iter()
@@ -311,26 +314,9 @@ impl Model for WordPiece {
     }
 }
 
+
 impl pipeline::Model for WordPiece {
-    fn tokenize_bytes(
-        &self,
-        bytes: &[u8],
-        output: &mut Vec<pipeline::PipelineToken>,
-    ) -> Result<()> {
-        // todo: implement
-        // if bytes.is_empty() {
-        //     return Ok(());
-        // }
-        // // todo: maybe we can use unchecked here (unsafe)
-        // let char_len = str::from_utf8(bytes)?.chars().count();
-        // if char_len > self.max_input_chars_per_word {
-        //     let unk_id = *self
-        //         .vocab
-        //         .get(&self.unk_token)
-        //         .ok_or(Error::MissingUnkToken)?;
-        //     output.push(PipelineToken { id: unk_id });
-        //     return Ok(());
-        // }
+    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<pipeline::PipelineToken>) -> Result<()> {
         Ok(())
     }
 }
@@ -339,129 +325,285 @@ impl pipeline::Model for WordPiece {
 mod tests {
     use super::*;
 
+    fn make_vocab_store(tokens: &[&str]) -> VocabStore {
+        VocabStore::build(
+            tokens
+                .iter()
+                .enumerate()
+                .map(|(id, token)| (token.to_string().into_bytes(), id as u32))
+                .collect(),
+        )
+    }
+
+    fn model(tokens: &[&str]) -> WordPiece {
+        WordPiece::builder()
+            .vocab_store(make_vocab_store(tokens))
+            .build()
+            .unwrap()
+    }
+
+    fn tok(id: u32, value: &str, offsets: (usize, usize)) -> Token {
+        Token::new(id, value.to_string(), offsets)
+    }
+
     #[test]
     fn test_error_display() {
         assert!(format!("{}", Error::MissingUnkToken).contains("Missing [UNK] token"));
     }
 
-    const INVARIANT_CORPUS: &[&str] = &[
-        "",
-        "un",
-        "unaff",
-        "unaffable",
-        "b",
-        "ab",
-        "ba",
-        "xyz",
-        "café",
-        "日本",
-        "日本語",
-        "🙂",
-        "e\u{301}",
-    ];
-
-    fn invariant_model() -> WordPiece {
-        let vocab: Vocab = [
-            ("[UNK]", 0u32),
-            ("un", 1),
-            ("##aff", 2),
-            ("##able", 3),
-            ("日", 4),
-            ("##本", 5),
-            ("ca", 6),
-            ("##fé", 7),
-            ("a", 8),
-            ("##b", 9),
-            ("b", 10),
-        ]
-        .iter()
-        .map(|&(token, id)| (token.to_string(), id))
-        .collect();
-        WordPiece::builder().vocab(vocab).build().unwrap()
+    #[test]
+    fn whole_word_in_vocab() {
+        let wp = model(&["[UNK]", "hello"]);
+        assert_eq!(wp.tokenize("hello").unwrap(), vec![tok(1, "hello", (0, 5))]);
     }
 
     #[test]
-    fn test_offsets_partition_input() {
-        let model = invariant_model();
-        for word in INVARIANT_CORPUS {
-            let tokens = model.tokenize(word).unwrap();
-            let mut pos = 0;
-            for token in &tokens {
-                let (start, end) = token.offsets;
-                assert_eq!(start, pos, "gap or overlap in {word:?}");
-                assert!(start < end, "empty piece in {:?}", word);
-                assert!(
-                    word.is_char_boundary(end),
-                    "offset {} splits a char in {:?}",
-                    end,
-                    word
-                );
-                pos = end;
-            }
-            assert_eq!(pos, word.len(), "input not covered: {word:?}");
-        }
+    fn greedy_longest_match_splits_word() {
+        let wp = model(&["[UNK]", "un", "##aff", "##able"]);
+        assert_eq!(
+            wp.tokenize("unaffable").unwrap(),
+            vec![
+                tok(1, "un", (0, 2)),
+                tok(2, "##aff", (2, 5)),
+                tok(3, "##able", (5, 9)),
+            ]
+        );
     }
 
     #[test]
-    fn test_pieces_match_input_slices() {
-        let model = invariant_model();
-        for word in INVARIANT_CORPUS {
-            let tokens = model.tokenize(word).unwrap();
-            if tokens.len() == 1 && tokens[0].value == model.unk_token {
-                continue;
-            }
-            for token in &tokens {
-                let (start, end) = token.offsets;
-                let expected = if start == 0 {
-                    word[start..end].to_string()
-                } else {
-                    format!("{}{}", model.continuing_subword_prefix, &word[start..end])
-                };
-                assert_eq!(token.value, expected, "{word:?}");
-            }
-        }
+    fn longest_piece_wins_over_shorter_ones() {
+        let wp = model(&["[UNK]", "un", "unaff", "##aff", "##able"]);
+        assert_eq!(
+            wp.tokenize("unaffable").unwrap(),
+            vec![tok(2, "unaff", (0, 5)), tok(4, "##able", (5, 9))]
+        );
     }
 
     #[test]
-    fn test_unk_is_all_or_nothing() {
-        let model = invariant_model();
-        for word in INVARIANT_CORPUS {
-            let tokens = model.tokenize(word).unwrap();
-            if tokens.len() > 1 {
-                for token in &tokens {
-                    assert_ne!(token.value, model.unk_token, "unk fragment in {word:?}");
-                }
-            }
-        }
+    fn single_char_pieces() {
+        let wp = model(&["[UNK]", "a", "##b", "##c"]);
+        assert_eq!(
+            wp.tokenize("abc").unwrap(),
+            vec![
+                tok(1, "a", (0, 1)),
+                tok(2, "##b", (1, 2)),
+                tok(3, "##c", (2, 3)),
+            ]
+        );
     }
 
     #[test]
-    fn test_max_input_chars_gives_single_unk() {
-        let model = WordPiece::builder()
-            .vocab(invariant_model().vocab)
+    fn continuation_piece_requires_prefix() {
+        let wp = model(&["[UNK]", "un", "able"]);
+        assert_eq!(
+            wp.tokenize("unable").unwrap(),
+            vec![tok(0, "[UNK]", (0, 6))]
+        );
+    }
+
+    #[test]
+    fn prefixed_piece_never_matches_at_word_start() {
+        let wp = model(&["[UNK]", "##able"]);
+        assert_eq!(wp.tokenize("able").unwrap(), vec![tok(0, "[UNK]", (0, 4))]);
+    }
+
+    #[test]
+    fn literal_prefix_in_input_matches_prefixed_vocab_entry() {
+        let wp = model(&["[UNK]", "##able"]);
+        assert_eq!(
+            wp.tokenize("##able").unwrap(),
+            vec![tok(1, "##able", (0, 6))]
+        );
+    }
+
+    #[test]
+    fn unmatchable_suffix_collapses_whole_word_to_unk() {
+        let wp = model(&["[UNK]", "un", "##aff", "##able"]);
+        assert_eq!(
+            wp.tokenize("unaffordable").unwrap(),
+            vec![tok(0, "[UNK]", (0, 12))]
+        );
+    }
+
+    #[test]
+    fn greedy_choice_is_never_backtracked() {
+        let wp = model(&["[UNK]", "abc", "a", "##bcd"]);
+        assert_eq!(wp.tokenize("abcd").unwrap(), vec![tok(0, "[UNK]", (0, 4))]);
+    }
+
+    #[test]
+    fn unknown_first_char_is_unk() {
+        let wp = model(&["[UNK]", "a"]);
+        assert_eq!(wp.tokenize("xa").unwrap(), vec![tok(0, "[UNK]", (0, 2))]);
+    }
+
+    #[test]
+    fn unk_id_is_looked_up_in_vocab() {
+        let wp = model(&["a", "b", "[UNK]"]);
+        assert_eq!(wp.tokenize("z").unwrap(), vec![tok(2, "[UNK]", (0, 1))]);
+    }
+
+    #[test]
+    fn empty_input_yields_no_tokens() {
+        let wp = model(&["[UNK]"]);
+        assert_eq!(wp.tokenize("").unwrap(), vec![]);
+    }
+
+    #[test]
+    fn multibyte_offsets_are_byte_positions() {
+        let wp = model(&["[UNK]", "猫", "##です"]);
+        assert_eq!(
+            wp.tokenize("猫です").unwrap(),
+            vec![tok(1, "猫", (0, 3)), tok(2, "##です", (3, 9))]
+        );
+    }
+
+    #[test]
+    fn multibyte_shrinking_stays_on_char_boundaries() {
+        let wp = model(&["[UNK]", "a"]);
+        assert_eq!(wp.tokenize("a€b").unwrap(), vec![tok(0, "[UNK]", (0, 5))]);
+    }
+
+    #[test]
+    fn word_longer_than_max_chars_is_unk_even_if_in_vocab() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["[UNK]", "abcde"]))
             .max_input_chars_per_word(4)
             .build()
             .unwrap();
-        let tokens = model.tokenize("unaffable").unwrap();
-        assert_eq!(tokens.len(), 1);
-        assert_eq!(tokens[0].value, "[UNK]");
-        assert_eq!(tokens[0].offsets, (0, "unaffable".len()));
+        assert_eq!(wp.tokenize("abcde").unwrap(), vec![tok(0, "[UNK]", (0, 5))]);
     }
 
     #[test]
-    fn test_tokenize_bytes_matches_tokenize() {
-        let model = invariant_model();
-        for word in INVARIANT_CORPUS {
-            let expected: Vec<u32> = model
+    fn word_at_max_chars_is_tokenized() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["[UNK]", "abcd"]))
+            .max_input_chars_per_word(4)
+            .build()
+            .unwrap();
+        assert_eq!(wp.tokenize("abcd").unwrap(), vec![tok(1, "abcd", (0, 4))]);
+    }
+
+    #[test]
+    fn max_chars_counts_chars_not_bytes() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["[UNK]", "éééé"]))
+            .max_input_chars_per_word(4)
+            .build()
+            .unwrap();
+        assert_eq!(wp.tokenize("éééé").unwrap(), vec![tok(1, "éééé", (0, 8))]);
+    }
+
+    #[test]
+    fn missing_unk_token_is_an_error_when_needed() {
+        let wp = model(&["a"]);
+        let err = wp.tokenize("b").unwrap_err();
+        assert!(err.to_string().contains("Missing [UNK] token"));
+    }
+
+    #[test]
+    fn missing_unk_token_is_an_error_for_overlong_words() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["ab"]))
+            .max_input_chars_per_word(1)
+            .build()
+            .unwrap();
+        assert!(wp.tokenize("ab").is_err());
+    }
+
+    #[test]
+    fn missing_unk_token_is_not_an_error_when_unneeded() {
+        let wp = model(&["hello"]);
+        assert_eq!(wp.tokenize("hello").unwrap(), vec![tok(0, "hello", (0, 5))]);
+    }
+
+    #[test]
+    fn custom_unk_token() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["<unk>", "a"]))
+            .unk_token("<unk>".into())
+            .build()
+            .unwrap();
+        assert_eq!(wp.tokenize("z").unwrap(), vec![tok(0, "<unk>", (0, 1))]);
+    }
+
+    #[test]
+    fn custom_continuing_subword_prefix() {
+        let wp = WordPiece::builder()
+            .vocab_store(make_vocab_store(&["[UNK]", "foo", "@@bar"]))
+            .continuing_subword_prefix("@@".into())
+            .build()
+            .unwrap();
+        assert_eq!(
+            wp.tokenize("foobar").unwrap(),
+            vec![tok(1, "foo", (0, 3)), tok(2, "@@bar", (3, 6))]
+        );
+    }
+
+    #[test]
+    fn regular_words_tokenize_like_bert() {
+        let wp = model(&[
+            "[UNK]",
+            "the",
+            "token",
+            "##izer",
+            "##ization",
+            "un",
+            "##believ",
+            "##able",
+            "run",
+            "##ning",
+            "hugging",
+            "##face",
+            "transform",
+            "##ers",
+            "inter",
+            "##national",
+            "in",
+            "##ter",
+            "##nation",
+            "##al",
+            "##iz",
+            "##ation",
+            "fast",
+            "##er",
+            ".",
+            ",",
+        ]);
+        let cases: &[(&str, &[&str])] = &[
+            ("the", &["the"]),
+            ("tokenizer", &["token", "##izer"]),
+            ("tokenization", &["token", "##ization"]),
+            ("unbelievable", &["un", "##believ", "##able"]),
+            ("running", &["run", "##ning"]),
+            ("huggingface", &["hugging", "##face"]),
+            ("transformers", &["transform", "##ers"]),
+            (
+                "internationalization",
+                &["inter", "##national", "##ization"],
+            ),
+            ("faster", &["fast", "##er"]),
+            (".", &["."]),
+            (",", &[","]),
+            ("xylophone", &["[UNK]"]),
+        ];
+        for (word, expected) in cases {
+            let values: Vec<String> = wp
                 .tokenize(word)
                 .unwrap()
-                .iter()
-                .map(|token| token.id)
+                .into_iter()
+                .map(|t| t.value)
                 .collect();
-            let mut output = vec![];
-            pipeline::Model::tokenize_bytes(&model, word.as_bytes(), &mut output).unwrap();
-            let got: Vec<u32> = output.iter().map(|token| token.id).collect();
-            assert_eq!(expected, got, "{word:?}");
+            assert_eq!(&values, expected, "word: {word}");
         }
+
+        assert_eq!(
+            wp.tokenize("internationalization").unwrap(),
+            vec![
+                tok(14, "inter", (0, 5)),
+                tok(15, "##national", (5, 13)),
+                tok(4, "##ization", (13, 20)),
+            ]
+        );
     }
 }

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -4,7 +4,7 @@
 use crate::models::bpe::BPE;
 use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
-use crate::vocab_store::VocabStore;
+use crate::vocab_store::{VocabStore, VocabStoreWrapper};
 use ahash::AHashMap;
 use std::collections::HashMap;
 use std::{
@@ -25,7 +25,7 @@ pub enum Error {
 
 struct Config {
     files: Option<String>,
-    vocab: VocabStore,
+    vocab: VocabStoreWrapper,
     unk_token: String,
     continuing_subword_prefix: String,
     max_input_chars_per_word: usize,
@@ -41,7 +41,7 @@ impl Default for WordPieceBuilder {
         Self {
             config: Config {
                 files: None,
-                vocab: VocabStore::new(),
+                vocab: VocabStoreWrapper::new(),
                 unk_token: String::from("[UNK]"),
                 continuing_subword_prefix: String::from("##"),
                 max_input_chars_per_word: 100,
@@ -67,7 +67,7 @@ impl WordPieceBuilder {
     #[must_use]
     pub fn vocab<V: Into<AHashMap<String, u32>>>(mut self, vocab: V) -> Self {
         let string_vocab: AHashMap<String, u32> = vocab.into();
-        self.config.vocab = VocabStore::build(
+        self.config.vocab = VocabStoreWrapper::build(
             string_vocab
                 .into_iter()
                 .map(|(token_str, token_id)| (token_str.into_bytes(), token_id))
@@ -76,7 +76,7 @@ impl WordPieceBuilder {
         self
     }
 
-    pub fn vocab_store(mut self, vocab_store: VocabStore) -> Self {
+    pub fn vocab_store(mut self, vocab_store: VocabStoreWrapper) -> Self {
         self.config.vocab = vocab_store;
         self
     }
@@ -122,7 +122,7 @@ impl WordPieceBuilder {
 /// model.
 #[derive(Clone, PartialEq)]
 pub struct WordPiece {
-    pub vocab: VocabStore,
+    pub vocab: VocabStoreWrapper,
     pub unk_token: String,
     pub continuing_subword_prefix: String,
     pub max_input_chars_per_word: usize,
@@ -142,7 +142,7 @@ impl std::fmt::Debug for WordPiece {
 impl Default for WordPiece {
     fn default() -> Self {
         Self {
-            vocab: VocabStore::new(),
+            vocab: VocabStoreWrapper::new(),
             unk_token: String::from("[UNK]"),
             continuing_subword_prefix: String::from("##"),
             max_input_chars_per_word: 100,
@@ -157,7 +157,7 @@ impl WordPiece {
     }
 
     /// Read the given files to extract the vocab
-    pub fn read_file(vocab: &str) -> Result<VocabStore> {
+    pub fn read_file(vocab: &str) -> Result<VocabStoreWrapper> {
         let file = File::open(vocab)?;
         let file = BufReader::new(file);
 
@@ -167,12 +167,12 @@ impl WordPiece {
             vocab_raw.push((line.trim_end().to_owned().into_bytes(), index as u32));
         }
 
-        let vocab = VocabStore::build(vocab_raw);
+        let vocab = VocabStoreWrapper::build(vocab_raw);
 
         Ok(vocab)
     }
 
-    pub fn read_bytes(vocab: &[u8]) -> Result<VocabStore> {
+    pub fn read_bytes(vocab: &[u8]) -> Result<VocabStoreWrapper> {
         let file = BufReader::new(vocab);
 
         let mut vocab_raw: Vec<(Vec<u8>, u32)> = vec![];
@@ -180,7 +180,7 @@ impl WordPiece {
             let line = line?;
             vocab_raw.push((line.trim_end().to_owned().into_bytes(), index as u32));
         }
-        let vocab = VocabStore::build(vocab_raw);
+        let vocab = VocabStoreWrapper::build(vocab_raw);
 
         Ok(vocab)
     }
@@ -314,6 +314,13 @@ impl Model for WordPiece {
     }
 }
 
+impl WordPiece {
+    pub(crate) fn with_bucket_vocab(mut self) -> Self {
+        self.vocab = self.vocab.into_bucket();
+        self
+    }
+}
+
 impl pipeline::Model for WordPiece {
     fn tokenize_bytes(
         &self,
@@ -385,8 +392,8 @@ impl pipeline::Model for WordPiece {
 mod tests {
     use super::*;
 
-    fn make_vocab_store(tokens: &[&str]) -> VocabStore {
-        VocabStore::build(
+    fn make_vocab_store(tokens: &[&str]) -> VocabStoreWrapper {
+        VocabStoreWrapper::build(
             tokens
                 .iter()
                 .enumerate()

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -2,7 +2,7 @@
 //! model.
 
 use crate::models::bpe::BPE;
-use crate::pipeline;
+use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
@@ -314,9 +314,66 @@ impl Model for WordPiece {
     }
 }
 
-
 impl pipeline::Model for WordPiece {
-    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<pipeline::PipelineToken>) -> Result<()> {
+    fn tokenize_bytes(
+        &self,
+        bytes: &[u8],
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        let mut scratch: Vec<u8> = Vec::with_capacity(self.max_input_chars_per_word);
+        let sequence = str::from_utf8(bytes)?;
+        let char_len = sequence.chars().count();
+
+        if char_len > self.max_input_chars_per_word {
+            let unk_id = self
+                .vocab
+                .token_to_id(&self.unk_token)
+                .ok_or(Error::MissingUnkToken)?;
+            output.push(PipelineToken { id: unk_id });
+        }
+
+        let mut is_bad = false;
+        let mut start = 0;
+
+        while start < sequence.len() {
+            let mut end = sequence.len();
+            let mut candidate_token: Option<u32> = None;
+
+            while start < end {
+                scratch.clear();
+                if start > 0 {
+                    scratch.extend(self.continuing_subword_prefix.as_bytes());
+                }
+                scratch.extend(&bytes[start..end]);
+
+                if let Some(id) = self.vocab.get_bytes(&scratch) {
+                    candidate_token = Some(id);
+                    break;
+                }
+                // Step one char back
+                end -= str::from_utf8(&scratch)?
+                    .chars()
+                    .last()
+                    .map_or(1, |c| c.len_utf8());
+            }
+
+            if let Some(id) = candidate_token {
+                output.push(PipelineToken { id });
+            } else {
+                is_bad = true;
+                break;
+            }
+            start = end;
+        }
+
+        if is_bad {
+            let unk_id = self
+                .vocab
+                .token_to_id(&self.unk_token)
+                .ok_or(Error::MissingUnkToken)?;
+            output.push(PipelineToken { id: unk_id });
+        }
+
         Ok(())
     }
 }

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -2,6 +2,7 @@
 //! model.
 
 use crate::models::bpe::BPE;
+use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use ahash::AHashMap;
 use std::collections::HashMap;
@@ -310,6 +311,30 @@ impl Model for WordPiece {
     }
 }
 
+impl pipeline::Model for WordPiece {
+    fn tokenize_bytes(
+        &self,
+        bytes: &[u8],
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        // todo: implement
+        // if bytes.is_empty() {
+        //     return Ok(());
+        // }
+        // // todo: maybe we can use unchecked here (unsafe)
+        // let char_len = str::from_utf8(bytes)?.chars().count();
+        // if char_len > self.max_input_chars_per_word {
+        //     let unk_id = *self
+        //         .vocab
+        //         .get(&self.unk_token)
+        //         .ok_or(Error::MissingUnkToken)?;
+        //     output.push(PipelineToken { id: unk_id });
+        //     return Ok(());
+        // }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,5 +342,126 @@ mod tests {
     #[test]
     fn test_error_display() {
         assert!(format!("{}", Error::MissingUnkToken).contains("Missing [UNK] token"));
+    }
+
+    const INVARIANT_CORPUS: &[&str] = &[
+        "",
+        "un",
+        "unaff",
+        "unaffable",
+        "b",
+        "ab",
+        "ba",
+        "xyz",
+        "café",
+        "日本",
+        "日本語",
+        "🙂",
+        "e\u{301}",
+    ];
+
+    fn invariant_model() -> WordPiece {
+        let vocab: Vocab = [
+            ("[UNK]", 0u32),
+            ("un", 1),
+            ("##aff", 2),
+            ("##able", 3),
+            ("日", 4),
+            ("##本", 5),
+            ("ca", 6),
+            ("##fé", 7),
+            ("a", 8),
+            ("##b", 9),
+            ("b", 10),
+        ]
+        .iter()
+        .map(|&(token, id)| (token.to_string(), id))
+        .collect();
+        WordPiece::builder().vocab(vocab).build().unwrap()
+    }
+
+    #[test]
+    fn test_offsets_partition_input() {
+        let model = invariant_model();
+        for word in INVARIANT_CORPUS {
+            let tokens = model.tokenize(word).unwrap();
+            let mut pos = 0;
+            for token in &tokens {
+                let (start, end) = token.offsets;
+                assert_eq!(start, pos, "gap or overlap in {word:?}");
+                assert!(start < end, "empty piece in {:?}", word);
+                assert!(
+                    word.is_char_boundary(end),
+                    "offset {} splits a char in {:?}",
+                    end,
+                    word
+                );
+                pos = end;
+            }
+            assert_eq!(pos, word.len(), "input not covered: {word:?}");
+        }
+    }
+
+    #[test]
+    fn test_pieces_match_input_slices() {
+        let model = invariant_model();
+        for word in INVARIANT_CORPUS {
+            let tokens = model.tokenize(word).unwrap();
+            if tokens.len() == 1 && tokens[0].value == model.unk_token {
+                continue;
+            }
+            for token in &tokens {
+                let (start, end) = token.offsets;
+                let expected = if start == 0 {
+                    word[start..end].to_string()
+                } else {
+                    format!("{}{}", model.continuing_subword_prefix, &word[start..end])
+                };
+                assert_eq!(token.value, expected, "{word:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_unk_is_all_or_nothing() {
+        let model = invariant_model();
+        for word in INVARIANT_CORPUS {
+            let tokens = model.tokenize(word).unwrap();
+            if tokens.len() > 1 {
+                for token in &tokens {
+                    assert_ne!(token.value, model.unk_token, "unk fragment in {word:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_max_input_chars_gives_single_unk() {
+        let model = WordPiece::builder()
+            .vocab(invariant_model().vocab)
+            .max_input_chars_per_word(4)
+            .build()
+            .unwrap();
+        let tokens = model.tokenize("unaffable").unwrap();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].value, "[UNK]");
+        assert_eq!(tokens[0].offsets, (0, "unaffable".len()));
+    }
+
+    #[test]
+    fn test_tokenize_bytes_matches_tokenize() {
+        let model = invariant_model();
+        for word in INVARIANT_CORPUS {
+            let expected: Vec<u32> = model
+                .tokenize(word)
+                .unwrap()
+                .iter()
+                .map(|token| token.id)
+                .collect();
+            let mut output = vec![];
+            pipeline::Model::tokenize_bytes(&model, word.as_bytes(), &mut output).unwrap();
+            let got: Vec<u32> = output.iter().map(|token| token.id).collect();
+            assert_eq!(expected, got, "{word:?}");
+        }
     }
 }

--- a/tokenizers/tk-encode/src/models/wordpiece/serialization.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/serialization.rs
@@ -1,4 +1,5 @@
 use super::{super::OrderedVocabIter, WordPiece, WordPieceBuilder};
+use crate::vocab_store::VocabStore;
 use ahash::{AHashMap, AHashSet};
 use serde::{
     de::{MapAccess, Visitor},

--- a/tokenizers/tk-encode/src/models/wordpiece/serialization.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/serialization.rs
@@ -20,7 +20,13 @@ impl Serialize for WordPiece {
         model.serialize_field("max_input_chars_per_word", &self.max_input_chars_per_word)?;
 
         // Then large ones
-        let ordered_vocab = OrderedVocabIter::new(&self.vocab_r);
+        let vocab_r: AHashMap<u32, String> = self
+            .vocab
+            .get_vocab()
+            .into_iter()
+            .map(|(s, id)| (id, s))
+            .collect();
+        let ordered_vocab = OrderedVocabIter::new(&vocab_r);
         model.serialize_field("vocab", &ordered_vocab)?;
 
         model.end()

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -99,8 +99,8 @@ impl TryFrom<ModelWrapper> for PipelineModel {
     fn try_from(value: ModelWrapper) -> Result<Self> {
         match value {
             // ModelWrapper::BPE(model) => Ok(Self::BPE(model)),
-            ModelWrapper::Unigram(model) => Ok(Self::Unigram(model)),
-            ModelWrapper::WordPiece(model) => Ok(Self::WordPiece(model)),
+            ModelWrapper::Unigram(model) => Ok(Self::Unigram(model.with_bucket_vocab())),
+            ModelWrapper::WordPiece(model) => Ok(Self::WordPiece(model.with_bucket_vocab())),
             other => Err(format!("PipelineModel cannot be built from {:?}", other).into()),
         }
     }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,9 +1,11 @@
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::ops::Range;
 
 use crate::added_vocabulary::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
+use crate::models::unigram::Unigram;
+use crate::ModelWrapper;
 use crate::{
     pre_tokenizers::{
         bert::BertPreTokenizer,
@@ -14,8 +16,8 @@ use crate::{
         unicode_scripts::UnicodeScripts,
         whitespace::{Whitespace, WhitespaceSplit},
     },
-    Model, ModelWrapper, NormalizedString, Normalizer, NormalizerWrapper, PostProcessorWrapper,
-    PreTokenizerWrapper, Token, Tokenizer,
+    NormalizedString, Normalizer, NormalizerWrapper, PostProcessorWrapper, PreTokenizerWrapper,
+    Token, Tokenizer,
 };
 
 use super::{Result, SplitDelimiterBehavior};
@@ -66,6 +68,35 @@ impl PreTokenizer for PipelinePreTokenizer {
             Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, out),
             Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
             Self::WhitespaceSplit(pretok) => pretok.pre_tokenize(text, out),
+        }
+    }
+}
+
+pub enum PipelineModel {
+    Unigram(Unigram),
+    // BPE(BPE),
+}
+
+pub trait Model {
+    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()>;
+}
+
+impl Model for PipelineModel {
+    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
+        match self {
+            Self::Unigram(model) => model.tokenize_bytes(bytes, output),
+            // Self::BPE(model) => model.tokenize_bytes(bytes, output),
+        }
+    }
+}
+
+impl TryFrom<ModelWrapper> for PipelineModel {
+    type Error = super::Error;
+    fn try_from(value: ModelWrapper) -> Result<Self> {
+        match value {
+            // ModelWrapper::BPE(model) => Ok(Self::BPE(model)),
+            ModelWrapper::Unigram(model) => Ok(Self::Unigram(model)),
+            other => Err(format!("PipelineModel cannot be built from {:?}", other).into()),
         }
     }
 }
@@ -194,7 +225,7 @@ pub struct PipelineTokenizer {
     added_vocabulary: BucketAddedVocabulary,
     normalizer: Option<NormalizerWrapper>,
     pre_tokenizer: PipelinePreTokenizer,
-    model: ModelWrapper,
+    model: PipelineModel,
     _post_processor: Option<PostProcessorWrapper>,
 }
 
@@ -248,7 +279,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             added_vocabulary,
             normalizer: tok.get_normalizer().cloned(),
             pre_tokenizer,
-            model: tok.get_model().clone(),
+            model: tok.get_model().clone().try_into()?,
             _post_processor: tok.get_post_processor().cloned(),
         })
     }
@@ -298,12 +329,10 @@ impl PipelineTokenizer {
 
                                 // Tokenize each chunk
                                 for pre_token in pre_tokens.iter() {
-                                    output.extend(
-                                        self.model
-                                            .tokenize(&normalized_chunk[pre_token.range()])?
-                                            .into_iter()
-                                            .map(|Token { id, .. }| PipelineToken { id }),
-                                    );
+                                    self.model.tokenize_bytes(
+                                        &normalized_chunk[pre_token.range()].as_bytes(),
+                                        &mut output,
+                                    )?;
                                 }
                             }
                         }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -6,6 +6,7 @@ use crate::added_vocabulary::bucket_added_vocabulary::{
 };
 use crate::models::unigram::Unigram;
 use crate::ModelWrapper;
+use crate::models::wordpiece::WordPiece;
 use crate::{
     pre_tokenizers::{
         bert::BertPreTokenizer,
@@ -74,6 +75,8 @@ impl PreTokenizer for PipelinePreTokenizer {
 
 pub enum PipelineModel {
     Unigram(Unigram),
+    WordPiece(WordPiece),
+    // WordLevel(WordLevel),
     // BPE(BPE),
 }
 
@@ -84,6 +87,7 @@ pub trait Model {
 impl Model for PipelineModel {
     fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
         match self {
+            Self::WordPiece(model) => model.tokenize_bytes(bytes, output),
             Self::Unigram(model) => model.tokenize_bytes(bytes, output),
             // Self::BPE(model) => model.tokenize_bytes(bytes, output),
         }
@@ -96,6 +100,7 @@ impl TryFrom<ModelWrapper> for PipelineModel {
         match value {
             // ModelWrapper::BPE(model) => Ok(Self::BPE(model)),
             ModelWrapper::Unigram(model) => Ok(Self::Unigram(model)),
+            ModelWrapper::WordPiece(model) => Ok(Self::WordPiece(model)),
             other => Err(format!("PipelineModel cannot be built from {:?}", other).into()),
         }
     }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -5,8 +5,8 @@ use crate::added_vocabulary::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
 use crate::models::unigram::Unigram;
-use crate::ModelWrapper;
 use crate::models::wordpiece::WordPiece;
+use crate::ModelWrapper;
 use crate::{
     pre_tokenizers::{
         bert::BertPreTokenizer,
@@ -335,7 +335,7 @@ impl PipelineTokenizer {
                                 // Tokenize each chunk
                                 for pre_token in pre_tokens.iter() {
                                     self.model.tokenize_bytes(
-                                        &normalized_chunk[pre_token.range()].as_bytes(),
+                                        normalized_chunk[pre_token.range()].as_bytes(),
                                         &mut output,
                                     )?;
                                 }

--- a/tokenizers/tk-encode/src/vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab_store.rs
@@ -5,19 +5,101 @@
 
 use ahash::AHashMap;
 
+use crate::bucket_vocab_store::BucketVocabStore;
+
+#[derive(Clone, PartialEq)]
+pub enum VocabStoreWrapper {
+    Legacy(LegacyVocabStore),
+    Bucket(BucketVocabStore),
+}
+
+impl VocabStoreWrapper {
+    pub fn new() -> Self {
+        Self::Legacy(LegacyVocabStore::new())
+    }
+
+    pub fn build(tokens: Vec<(Vec<u8>, u32)>) -> Self {
+        Self::Legacy(LegacyVocabStore::build(tokens))
+    }
+}
+
+impl Default for VocabStoreWrapper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VocabStoreWrapper {
+    pub fn into_bucket(self) -> Self {
+        match self {
+            Self::Legacy(legacy) => Self::Bucket(legacy.into()),
+            bucket => bucket,
+        }
+    }
+}
+
+pub trait VocabStore {
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool;
+    fn get_bytes(&self, q: &[u8]) -> Option<u32>;
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]>;
+    fn content(&self) -> Vec<(String, u32)>;
+    fn get_vocab(&self) -> Vec<(String, u32)>;
+    fn byte_content(&self) -> Vec<(Vec<u8>, u32)>;
+
+    #[inline]
+    fn token_to_id(&self, s: &str) -> Option<u32> {
+        self.get_bytes(s.as_bytes())
+    }
+
+    #[inline]
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        self.id_to_token_bytes(id)
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+    }
+}
+
+macro_rules! delegate {
+    ($(fn $name:ident(&self $(, $arg:ident: $ty:ty)*) -> $ret:ty;)*) => {$(
+        #[inline]
+        fn $name(&self $(, $arg: $ty)*) -> $ret {
+            match self {
+                Self::Legacy(v) => v.$name($($arg),*),
+                Self::Bucket(v) => v.$name($($arg),*),
+            }
+        }
+    )*};
+}
+
+impl VocabStore for VocabStoreWrapper {
+    delegate! {
+        fn len(&self) -> usize;
+        fn is_empty(&self) -> bool;
+        fn get_bytes(&self, q: &[u8]) -> Option<u32>;
+        fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]>;
+        fn content(&self) -> Vec<(String, u32)>;
+        fn get_vocab(&self) -> Vec<(String, u32)>;
+        fn byte_content(&self) -> Vec<(Vec<u8>, u32)>;
+    }
+}
+
 #[derive(Clone, Debug, Default)]
-pub struct VocabStore {
+pub struct LegacyVocabStore {
     by_bytes: AHashMap<Vec<u8>, u32>,
     by_id: AHashMap<u32, Vec<u8>>,
 }
 
-impl PartialEq for VocabStore {
+impl PartialEq for LegacyVocabStore {
     fn eq(&self, other: &Self) -> bool {
         self.by_bytes == other.by_bytes
     }
 }
 
-impl VocabStore {
+impl LegacyVocabStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn build(tokens: Vec<(Vec<u8>, u32)>) -> Self {
         let mut by_bytes = AHashMap::with_capacity(tokens.len());
         let mut by_id = AHashMap::with_capacity(tokens.len());
@@ -27,52 +109,39 @@ impl VocabStore {
         }
         Self { by_bytes, by_id }
     }
+}
 
-    pub fn new() -> Self {
-        Self::default()
-    }
-
+impl VocabStore for LegacyVocabStore {
     #[inline]
-    pub fn get_bytes(&self, q: &[u8]) -> Option<u32> {
+    fn get_bytes(&self, q: &[u8]) -> Option<u32> {
         self.by_bytes.get(q).copied()
     }
 
     #[inline]
-    pub fn token_to_id(&self, s: &str) -> Option<u32> {
-        self.get_bytes(s.as_bytes())
-    }
-
-    #[inline]
-    pub fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
         self.by_id.get(&id).map(|b| b.as_slice())
     }
 
-    #[inline]
-    pub fn id_to_token(&self, id: u32) -> Option<String> {
-        self.id_to_token_bytes(id)
-            .map(|b| String::from_utf8_lossy(b).into_owned())
-    }
-
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.by_bytes.len()
     }
 
-    pub fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.by_bytes.is_empty()
     }
 
-    pub fn content(&self) -> Vec<(String, u32)> {
+    fn content(&self) -> Vec<(String, u32)> {
         self.by_id
             .iter()
             .map(|(id, b)| (String::from_utf8_lossy(b).into_owned(), *id))
             .collect()
     }
 
-    pub fn get_vocab(&self) -> Vec<(String, u32)> {
+    fn get_vocab(&self) -> Vec<(String, u32)> {
         self.content()
     }
 
-    pub fn byte_content(&self) -> Vec<(Vec<u8>, u32)> {
+    fn byte_content(&self) -> Vec<(Vec<u8>, u32)> {
         self.by_id.iter().map(|(id, b)| (b.clone(), *id)).collect()
     }
 }
@@ -83,7 +152,7 @@ mod tests {
 
     #[test]
     fn build_and_lookup() {
-        let vocab = VocabStore::build(vec![
+        let vocab = LegacyVocabStore::build(vec![
             (b"a".to_vec(), 0),
             (b"bb".to_vec(), 5),
             (b"ccc".to_vec(), 100),
@@ -99,7 +168,7 @@ mod tests {
 
     #[test]
     fn empty() {
-        let vocab = VocabStore::new();
+        let vocab = LegacyVocabStore::new();
         assert!(vocab.is_empty());
         assert_eq!(vocab.token_to_id("x"), None);
         assert_eq!(vocab.id_to_token(0), None);
@@ -107,9 +176,10 @@ mod tests {
 
     #[test]
     fn eq_is_content_based_order_independent() {
-        let a = VocabStore::build(vec![(b"x".to_vec(), 0), (b"y".to_vec(), 9)]);
-        let b = VocabStore::build(vec![(b"y".to_vec(), 9), (b"x".to_vec(), 0)]);
-        let c = VocabStore::build(vec![(b"x".to_vec(), 0), (b"z".to_vec(), 9)]);
+        let a = LegacyVocabStore::build(vec![(b"x".to_vec(), 0), (b"y".to_vec(), 9)]);
+        let b: LegacyVocabStore =
+            LegacyVocabStore::build(vec![(b"y".to_vec(), 9), (b"x".to_vec(), 0)]);
+        let c = LegacyVocabStore::build(vec![(b"x".to_vec(), 0), (b"z".to_vec(), 9)]);
         assert_eq!(a, b);
         assert_ne!(a, c);
     }
@@ -121,7 +191,7 @@ mod tests {
             .enumerate()
             .map(|(i, s)| (s.as_bytes().to_vec(), i as u32))
             .collect();
-        let vocab = VocabStore::build(toks.clone());
+        let vocab = LegacyVocabStore::build(toks.clone());
         let mut got = vocab.byte_content();
         got.sort();
         let mut want = toks;

--- a/tokenizers/tk-encode/src/vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab_store.rs
@@ -7,32 +7,20 @@ use ahash::AHashMap;
 
 use crate::bucket_vocab_store::BucketVocabStore;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum VocabStoreWrapper {
     Legacy(LegacyVocabStore),
     Bucket(BucketVocabStore),
 }
 
 impl VocabStoreWrapper {
-    pub fn new() -> Self {
-        Self::Legacy(LegacyVocabStore::new())
-    }
-
     pub fn build(tokens: Vec<(Vec<u8>, u32)>) -> Self {
         Self::Legacy(LegacyVocabStore::build(tokens))
     }
-}
 
-impl Default for VocabStoreWrapper {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl VocabStoreWrapper {
     pub fn into_bucket(self) -> Self {
         match self {
-            Self::Legacy(legacy) => Self::Bucket(legacy.into()),
+            Self::Legacy(legacy) => Self::Bucket(BucketVocabStore::build(legacy.get_vocab_bytes())),
             bucket => bucket,
         }
     }
@@ -43,9 +31,8 @@ pub trait VocabStore {
     fn is_empty(&self) -> bool;
     fn get_bytes(&self, q: &[u8]) -> Option<u32>;
     fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]>;
-    fn content(&self) -> Vec<(String, u32)>;
     fn get_vocab(&self) -> Vec<(String, u32)>;
-    fn byte_content(&self) -> Vec<(Vec<u8>, u32)>;
+    fn get_vocab_bytes(&self) -> Vec<(Vec<u8>, u32)>;
 
     #[inline]
     fn token_to_id(&self, s: &str) -> Option<u32> {
@@ -77,9 +64,8 @@ impl VocabStore for VocabStoreWrapper {
         fn is_empty(&self) -> bool;
         fn get_bytes(&self, q: &[u8]) -> Option<u32>;
         fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]>;
-        fn content(&self) -> Vec<(String, u32)>;
         fn get_vocab(&self) -> Vec<(String, u32)>;
-        fn byte_content(&self) -> Vec<(Vec<u8>, u32)>;
+        fn get_vocab_bytes(&self) -> Vec<(Vec<u8>, u32)>;
     }
 }
 
@@ -130,18 +116,14 @@ impl VocabStore for LegacyVocabStore {
         self.by_bytes.is_empty()
     }
 
-    fn content(&self) -> Vec<(String, u32)> {
+    fn get_vocab(&self) -> Vec<(String, u32)> {
         self.by_id
             .iter()
             .map(|(id, b)| (String::from_utf8_lossy(b).into_owned(), *id))
             .collect()
     }
 
-    fn get_vocab(&self) -> Vec<(String, u32)> {
-        self.content()
-    }
-
-    fn byte_content(&self) -> Vec<(Vec<u8>, u32)> {
+    fn get_vocab_bytes(&self) -> Vec<(Vec<u8>, u32)> {
         self.by_id.iter().map(|(id, b)| (b.clone(), *id)).collect()
     }
 }
@@ -185,6 +167,38 @@ mod tests {
     }
 
     #[test]
+    fn into_bucket_swaps_legacy_and_preserves_lookups() {
+        let wrapper = VocabStoreWrapper::build(vec![
+            (b"a".to_vec(), 0),
+            (b"bb".to_vec(), 5),
+            (b"ccc".to_vec(), 100),
+        ]);
+        assert!(matches!(wrapper, VocabStoreWrapper::Legacy(_)));
+
+        let bucket = wrapper.into_bucket();
+        assert!(matches!(bucket, VocabStoreWrapper::Bucket(_)));
+        assert_eq!(bucket.token_to_id("a"), Some(0));
+        assert_eq!(bucket.token_to_id("bb"), Some(5));
+        assert_eq!(bucket.id_to_token(100), Some("ccc".to_string()));
+        assert_eq!(bucket.token_to_id("zzz"), None);
+        assert_eq!(bucket.len(), 3);
+    }
+
+    #[test]
+    fn into_bucket_is_a_noop_on_bucket() {
+        let bucket = VocabStoreWrapper::build(vec![(b"a".to_vec(), 0)]).into_bucket();
+        assert_eq!(bucket.clone().into_bucket(), bucket);
+    }
+
+    #[test]
+    fn into_bucket_on_empty_store() {
+        let bucket = VocabStoreWrapper::build(Vec::new()).into_bucket();
+        assert!(matches!(bucket, VocabStoreWrapper::Bucket(_)));
+        assert!(bucket.is_empty());
+        assert_eq!(bucket.token_to_id("x"), None);
+    }
+
+    #[test]
     fn roundtrip_byte_content() {
         let toks: Vec<(Vec<u8>, u32)> = ["the", "\u{2581}hello", "\u{4eca}", "\n"]
             .iter()
@@ -192,7 +206,7 @@ mod tests {
             .map(|(i, s)| (s.as_bytes().to_vec(), i as u32))
             .collect();
         let vocab = LegacyVocabStore::build(toks.clone());
-        let mut got = vocab.byte_content();
+        let mut got = vocab.get_vocab_bytes();
         got.sort();
         let mut want = toks;
         want.sort();

--- a/tokenizers/tk-train/src/trainers/bpe.rs
+++ b/tokenizers/tk-train/src/trainers/bpe.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 use tk_encode::models::bpe::{Pair, WithFirstLastIterator, Word, BPE};
 use tk_encode::parallelism::*;
 use tk_encode::utils::progress::{ProgressBar, ProgressFormat, ProgressStyle};
-use tk_encode::vocab_store::VocabStore;
+use tk_encode::vocab_store::VocabStoreWrapper;
 use tk_encode::{AddedToken, Result};
 
 #[derive(Debug, Eq)]
@@ -609,7 +609,7 @@ impl BpeTrainer {
         self.finalize_progress(&progress, merges.len(), "Compute merges");
 
         // Transfer new vocab & options to model
-        model.vocab = VocabStore::build(
+        model.vocab = VocabStoreWrapper::build(
             word_to_id
                 .into_iter()
                 // we have to look up the string in id_to_word because the key in word_to_id is a hash

--- a/tokenizers/tk-train/src/trainers/wordpiece.rs
+++ b/tokenizers/tk-train/src/trainers/wordpiece.rs
@@ -175,7 +175,6 @@ impl WordPieceTrainer {
 
         // Transfer the vocab
         model.vocab = new_wordpiece.vocab;
-        model.vocab_r = new_wordpiece.vocab_r;
         // The continuing_subword_prefix is the only other option to be overridden by the trainer
         model.continuing_subword_prefix = new_wordpiece.continuing_subword_prefix;
 


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**1 / 4 models supported** · geomean ×2.09 across supported · 18 fixtures each — ~10 kB inputs · single thread

`57fc492c1 · 2026-07-06 18:14 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 8 cores

> **Not yet supported:** `deepseek-v4` (BPE · Split+ByteLevel), `llama-3` (BPE · Split+ByteLevel), `t5-base` (Unigram · WhitespaceSplit+Metaspace) — roadmap cards below.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28812941403-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28812941403-bert-base-uncased-light.png" width="860">
</picture>

### Not yet supported

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28812941403-deepseek-v4-dark.png">
  <img alt="deepseek-v4 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28812941403-deepseek-v4-light.png" width="420">
</picture>
</td>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28812941403-llama-3-dark.png">
  <img alt="llama-3 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28812941403-llama-3-light.png" width="420">
</picture>
</td>
</tr>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28812941403-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28812941403-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

<details><summary>Per-fixture results</summary>

#### bert-base-uncased — WordPiece · Bert

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| cmn_Hani | lang | 3.2 | 8.6 | ×2.70 | match |
| eng_Latn | lang | 3.9 | 10.3 | ×2.63 | match |
| jpn_Jpan | lang | 3.7 | 8.2 | ×2.20 | match |
| heb_Hebr | lang | 3.5 | 7.5 | ×2.14 | match |
| arb_Arab | lang | 3.5 | 7.2 | ×2.05 | match |
| hin_Deva | lang | 5.6 | 11.0 | ×1.98 | match |
| rus_Cyrl | lang | 3.2 | 6.3 | ×1.96 | match |
| ell_Grek | lang | 3.3 | 6.4 | ×1.96 | match |
| kor_Hang | lang | 2.2 | 4.1 | ×1.89 | match |
| ben_Beng | lang | 5.3 | 9.9 | ×1.89 | match |
| kat_Geor | lang | 5.8 | 9.7 | ×1.68 | match |
| amh_Ethi | lang | 7.1 | 11.8 | ×1.66 | match |
| tam_Taml | lang | 6.6 | 10.7 | ×1.63 | match |
| tha_Thai | lang | 8.3 | 10.2 | ×1.22 | match |
| agentic-traces | modalities | 3.4 | 9.7 | ×2.83 | match |
| math_latex | modalities | 3.6 | 9.9 | ×2.76 | match |
| agentic_swe | modalities | 3.7 | 10.0 | ×2.73 | match |
| code_mixed | modalities | 3.6 | 9.6 | ×2.70 | match |

</details>
<!-- pipeline-bench:end -->
