### PR TITLE
llama2 (BPE no pretok) support

### DIFF
--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -6,11 +6,17 @@ dir_guard=@mkdir -p $(@D)
 
 SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2-merges.txt $(DATA_DIR)/bert-base-uncased-vocab.txt $(DATA_DIR)/big.txt $(DATA_DIR)/small.txt $(DATA_DIR)/albert-base-v1-tokenizer.json  $(DATA_DIR)/llama-3-tokenizer.json
 BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/fixtures/modalities/agentic-traces.txt
-TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/fixtures/modalities/agentic-traces.txt
+TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/fixtures/modalities/agentic-traces.txt $(ORACLE_RESOURCES)
 
 FIXTURE_LANGS = amh_Ethi arb_Arab ben_Beng cmn_Hani ell_Grek eng_Latn heb_Hebr hin_Deva jpn_Jpan kat_Geor kor_Hang rus_Cyrl tam_Taml tha_Thai
 FIXTURE_MODALITIES = agentic_swe agentic-traces code_mixed math_latex
 FIXTURES_RESOURCES = $(FIXTURE_LANGS:%=$(DATA_DIR)/fixtures/lang/%.txt) $(FIXTURE_MODALITIES:%=$(DATA_DIR)/fixtures/modalities/%.txt)
+
+# Tokenizer configs + language fixtures exercised by the multilingual oracle
+# (tk-encode/tests/pipeline_oracle.rs): two configs × a subset of languages.
+ORACLE_LANGS = eng_Latn rus_Cyrl arb_Arab cmn_Hani jpn_Jpan hin_Deva kor_Hang tha_Thai
+ORACLE_RESOURCES = $(DATA_DIR)/bert-base-uncased.json $(DATA_DIR)/fixtures/models/llama-2-7b-chat-hf.json \
+	$(ORACLE_LANGS:%=$(DATA_DIR)/fixtures/lang/%.txt)
 
 # Models benched by tk-encode/examples/fixture_bench.rs; the manifest is the
 # single source of truth (Rust reads it too).

--- a/tokenizers/tk-encode/examples/bench_models.json
+++ b/tokenizers/tk-encode/examples/bench_models.json
@@ -1,6 +1,6 @@
 [
   { "name": "bert-base-uncased", "file": "bert-base-uncased.json" },
   { "name": "deepseek-v4",       "file": "deepseek-v4.json" },
-  { "name": "llama-3",           "file": "llama-3-tokenizer.json" },
+  { "name": "llama-2",           "file": "fixtures/models/llama-2-7b-chat-hf.json" },
   { "name": "t5-base",           "file": "t5-base.json" }
 ]

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,9 +1,11 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
+use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
 use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
+use rayon::result;
 use serde_json::Value;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -669,6 +671,65 @@ impl Model for BPE {
         )?;
 
         Ok(vec![vocab_path, merges_path])
+    }
+}
+
+impl pipeline::Model for BPE {
+    fn tokenize_bytes(
+        &self,
+        bytes: &[u8],
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        let sequence = str::from_utf8(bytes)?;
+        self.encode_ids(sequence, output)
+    }
+}
+
+impl BPE {
+    fn push_word_ids(&self, word: &Word, out: &mut Vec<PipelineToken>) {
+        out.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+    }
+    fn encode_ids(&self, sequence: &str, out: &mut Vec<PipelineToken>) -> Result<()> {
+        if sequence.is_empty() {
+            return Ok(());
+        }
+
+        if self.dropout.is_none() || self.dropout == Some(0.0) {
+            self.encode_ids_cached(sequence, out)
+        } else {
+            let word = self.merge_word(sequence)?;
+            self.push_word_ids(&word, out);
+            Ok(())
+        }
+    }
+    fn encode_ids_cached(&self, sequence: &str, out: &mut Vec<PipelineToken>) -> Result<()> {
+        if self.ignore_merges {
+            if let Some(id) = self.vocab.token_to_id(sequence) {
+                out.push(PipelineToken { id });
+                return Ok(());
+            }
+        }
+        let Some(cache) = self.cache.as_ref() else {
+            // Cache disabled (capacity 0): fall back to the uncached path.
+            let word = self.merge_word(sequence)?;
+            self.push_word_ids(&word, out);
+            return Ok(());
+        };
+        let cache_id = cache.id();
+        BPE_LOCAL_CACHE.with(|cell| {
+            let mut by_bpe = cell.borrow_mut();
+            let local = by_bpe.entry(cache_id).or_default();
+            if let Some(hit) = local.get(sequence) {
+                self.push_word_ids(&hit, out);
+                return Ok(());
+            }
+            let word = self.merge_word(sequence)?;
+            self.push_word_ids(&word, out);
+            if sequence.len() < MAX_LENGTH && local.len() < cache.capacity {
+                local.insert(sequence.to_owned(), word);
+            }
+            Ok(())
+        })
     }
 }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -5,7 +5,6 @@ use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
 use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
-use rayon::result;
 use serde_json::Value;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -720,7 +719,7 @@ impl BPE {
             let mut by_bpe = cell.borrow_mut();
             let local = by_bpe.entry(cache_id).or_default();
             if let Some(hit) = local.get(sequence) {
-                self.push_word_ids(&hit, out);
+                self.push_word_ids(hit, out);
                 return Ok(());
             }
             let word = self.merge_word(sequence)?;
@@ -1136,6 +1135,82 @@ mod tests {
             .unwrap();
         let tokens = bpe.tokenize("\n").unwrap();
         assert_eq!(tokens, vec![Token::new(1u32, "<0x0A>".into(), (0, 1)),]);
+    }
+
+    /// Ids from the encode-only pipeline fast path (`pipeline::Model::tokenize_bytes`).
+    fn pipeline_ids(bpe: &BPE, s: &str) -> Vec<u32> {
+        use crate::pipeline::Model as _;
+        let mut out = Vec::new();
+        bpe.tokenize_bytes(s.as_bytes(), &mut out).unwrap();
+        out.into_iter().map(|t| t.id).collect()
+    }
+
+    /// Ids from the reference `Model::tokenize`.
+    fn reference_ids(bpe: &BPE, s: &str) -> Vec<u32> {
+        bpe.tokenize(s).unwrap().iter().map(|t| t.id).collect()
+    }
+
+    #[test]
+    fn test_byte_fallback_tokenize_bytes() {
+        // One covered byte + unk fallback; the fast path must match `tokenize`.
+        let vocab: Vocab = [("<unk>".into(), 0), ("<0x61>".into(), 1)]
+            .iter()
+            .cloned()
+            .collect();
+        let bpe = BpeBuilder::default()
+            .vocab_and_merges(vocab, vec![])
+            .unk_token("<unk>".to_string())
+            .byte_fallback(true)
+            .build()
+            .unwrap();
+        assert_eq!(pipeline_ids(&bpe, "a"), vec![1]); // 'a' -> <0x61>
+        assert_eq!(pipeline_ids(&bpe, "c"), vec![0]); // 'c' uncovered -> <unk>
+        assert_eq!(pipeline_ids(&bpe, "a"), reference_ids(&bpe, "a"));
+        assert_eq!(pipeline_ids(&bpe, "c"), reference_ids(&bpe, "c"));
+
+        // Full byte vocab (<0xNN> -> id N): every char decomposes to its raw
+        // UTF-8 bytes, exercising multi-byte code points through byte fallback.
+        let mut vocab: Vocab = (0u32..=255).map(|b| (format!("<{b:#04X}>"), b)).collect();
+        vocab.insert("<unk>".into(), 256);
+        let bpe = BpeBuilder::default()
+            .vocab_and_merges(vocab, vec![])
+            .unk_token("<unk>".to_string())
+            .byte_fallback(true)
+            .build()
+            .unwrap();
+        for s in ["é", "🦀", "日本語", "a\nz", "café"] {
+            let expected: Vec<u32> = s.bytes().map(u32::from).collect();
+            assert_eq!(pipeline_ids(&bpe, s), expected, "byte ids for {s:?}");
+            assert_eq!(
+                pipeline_ids(&bpe, s),
+                reference_ids(&bpe, s),
+                "fast vs ref {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_byte_fallback_fuse_unk_tokenize_bytes() {
+        // Only 'a' is byte-representable; uncovered chars hit the fused-unk path.
+        let vocab: Vocab = [("<unk>".into(), 0), ("<0x61>".into(), 1)]
+            .iter()
+            .cloned()
+            .collect();
+        let bpe = BpeBuilder::default()
+            .vocab_and_merges(vocab, vec![])
+            .unk_token("<unk>".to_string())
+            .byte_fallback(true)
+            .fuse_unk(true)
+            .build()
+            .unwrap();
+        for s in ["a", "c", "cc", "aca", "acca"] {
+            assert_eq!(
+                pipeline_ids(&bpe, s),
+                reference_ids(&bpe, s),
+                "fast vs ref {s:?}"
+            );
+        }
+        assert_eq!(pipeline_ids(&bpe, "cc"), vec![0]); // adjacent unks fuse to one <unk>
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -72,7 +72,10 @@ pub enum PipelinePreTokenizer {
 impl PreTokenizer for PipelinePreTokenizer {
     fn pre_tokenize(&self, text: &str, out: &mut Vec<Split>) -> Result<()> {
         match self {
-            Self::None => Ok(()),
+            Self::None => {
+                out.push(Split { start: 0, end: text.len() as u32 });
+                Ok(())
+            },
             Self::Bert(pretok) => pretok.pre_tokenize(text, out),
             Self::Delimiter(pretok) => pretok.pre_tokenize(text, out),
             Self::Digits(pretok) => pretok.pre_tokenize(text, out),

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -73,9 +73,12 @@ impl PreTokenizer for PipelinePreTokenizer {
     fn pre_tokenize(&self, text: &str, out: &mut Vec<Split>) -> Result<()> {
         match self {
             Self::None => {
-                out.push(Split { start: 0, end: text.len() as u32 });
+                out.push(Split {
+                    start: 0,
+                    end: text.len() as u32,
+                });
                 Ok(())
-            },
+            }
             Self::Bert(pretok) => pretok.pre_tokenize(text, out),
             Self::Delimiter(pretok) => pretok.pre_tokenize(text, out),
             Self::Digits(pretok) => pretok.pre_tokenize(text, out),
@@ -323,7 +326,7 @@ impl PipelineTokenizer {
                                 // Tokenize each chunk
                                 for pre_token in pre_tokens.iter() {
                                     self.model.tokenize_bytes(
-                                        &normalized_chunk[pre_token.range()].as_bytes(),
+                                        normalized_chunk[pre_token.range()].as_bytes(),
                                         &mut output,
                                     )?;
                                 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -566,12 +566,16 @@ pub enum PipelineModel {
 
 impl Model for PipelineModel {
     fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
+        if let Self::BPE(model) = self {
+            return model.tokenize_bytes(bytes, output);
+        }
         let sequence = str::from_utf8(bytes)?;
         let tokens = match self {
-            Self::BPE(model) => model.tokenize(sequence),
             Self::Unigram(model) => model.tokenize(sequence),
             Self::WordLevel(model) => model.tokenize(sequence),
             Self::WordPiece(model) => model.tokenize(sequence),
+            // safety: handled above
+            Self::BPE(_) => unreachable!(),
         }?;
         output.extend(tokens.iter().map(|&Token { id, .. }| PipelineToken { id }));
         Ok(())

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -116,5 +116,5 @@ mod bert_base_uncased {
 }
 
 mod llama2 {
-    lang_fixtures!("../data/llama-2-7b-chat-hf.json");
+    lang_fixtures!("../data/fixtures/models/llama-2-7b-chat-hf.json");
 }

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -1,20 +1,40 @@
 //! The experimental `PipelineTokenizer` must produce exactly the same token
-//! ids as the reference `Tokenizer` (the oracle). Exercised over the bert-wiki
-//! tokenizer (`Whitespace` pre-tokenizer + `WordPiece`) on an English and a
-//! Japanese corpus, with lines packed into ~1 kB and ~10 kB documents. The
-//! oracle is called with `add_special_tokens = false` because the pipeline
-//! does not apply the post-processor yet.
+//! ids as the reference `Tokenizer` (the oracle). Exercised over two tokenizer
+//! configs — `bert-base-uncased` (`BertNormalizer` + `BertPreTokenizer` +
+//! `WordPiece`) and `llama-2` (SentencePiece-style: `Prepend`/`Replace`
+//! normalizer, *no* pre-tokenizer, byte-fallback `BPE`) — against a ~1 MB
+//! fraction of several language fixtures, with lines packed into ~1 kB and
+//! ~10 kB documents. The oracle is called with `add_special_tokens = false`
+//! because the pipeline does not apply the post-processor yet.
 
 use std::convert::TryFrom;
 
 use tk_encode::pipeline::PipelineTokenizer;
 use tk_encode::Tokenizer;
 
-fn load(corpus: &str) -> (Tokenizer, PipelineTokenizer, String) {
-    let oracle = Tokenizer::from_file("../data/bert-wiki.json").unwrap();
+/// Cap each language fixture to a ~1 MB, line-bounded prefix so the oracle
+/// stays affordable while still exercising real multilingual text.
+const FRACTION_BYTES: usize = 1024 * 1024;
+
+fn load_tokenizers(config: &str) -> (Tokenizer, PipelineTokenizer) {
+    let oracle = Tokenizer::from_file(config).unwrap();
     let pipeline = PipelineTokenizer::try_from(&oracle).unwrap();
+    (oracle, pipeline)
+}
+
+/// Read `corpus`, keeping whole lines until adding the next would exceed
+/// `max_bytes`. Whole lines keep the prefix valid UTF-8.
+fn load_fraction(corpus: &str, max_bytes: usize) -> String {
     let text = std::fs::read_to_string(corpus).unwrap();
-    (oracle, pipeline, text)
+    let mut out = String::new();
+    for line in text.lines() {
+        if !out.is_empty() && out.len() + line.len() + 1 > max_bytes {
+            break;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
 }
 
 fn make_chunks(text: &str, target_bytes: usize) -> Vec<String> {
@@ -36,8 +56,9 @@ fn make_chunks(text: &str, target_bytes: usize) -> Vec<String> {
     chunks
 }
 
-fn check_chunks(corpus: &str, target_bytes: usize) {
-    let (oracle, pipeline, text) = load(corpus);
+fn check_chunks(config: &str, corpus: &str, target_bytes: usize) {
+    let (oracle, pipeline) = load_tokenizers(config);
+    let text = load_fraction(corpus, FRACTION_BYTES);
     for chunk in make_chunks(&text, target_bytes) {
         let expected = oracle.encode(chunk.as_str(), false).unwrap();
         let got: Vec<u32> = pipeline
@@ -55,24 +76,45 @@ fn check_chunks(corpus: &str, target_bytes: usize) {
     }
 }
 
+/// One `chunks_1kb` / `chunks_10kb` case per corpus, all against a single
+/// tokenizer `$config`. Invoke inside a `mod <tokenizer> { .. }` so cases nest
+/// as `<tokenizer>::<corpus>`.
 macro_rules! corpus_tests {
-    ($($name:ident => $file:literal),* $(,)?) => {
+    ($config:literal; $($corpus:ident => $corpus_path:literal),* $(,)?) => {
         $(
-            mod $name {
+            mod $corpus {
                 #[test]
                 fn chunks_1kb() {
-                    super::check_chunks($file, 1024);
+                    crate::check_chunks($config, $corpus_path, 1024);
                 }
                 #[test]
                 fn chunks_10kb() {
-                    super::check_chunks($file, 10 * 1024);
+                    crate::check_chunks($config, $corpus_path, 10 * 1024);
                 }
             }
         )*
     };
 }
 
-corpus_tests! {
-    big => "../data/big.txt",
-    wagahai => "../data/unigram_wagahaiwa_nekodearu.txt",
+macro_rules! lang_fixtures {
+    ($config:literal) => {
+        corpus_tests! { $config;
+            eng_latn => "../data/fixtures/lang/eng_Latn.txt",
+            rus_cyrl => "../data/fixtures/lang/rus_Cyrl.txt",
+            arb_arab => "../data/fixtures/lang/arb_Arab.txt",
+            cmn_hani => "../data/fixtures/lang/cmn_Hani.txt",
+            jpn_jpan => "../data/fixtures/lang/jpn_Jpan.txt",
+            hin_deva => "../data/fixtures/lang/hin_Deva.txt",
+            kor_hang => "../data/fixtures/lang/kor_Hang.txt",
+            tha_thai => "../data/fixtures/lang/tha_Thai.txt",
+        }
+    };
+}
+
+mod bert_base_uncased {
+    lang_fixtures!("../data/bert-base-uncased.json");
+}
+
+mod llama2 {
+    lang_fixtures!("../data/llama-2-7b-chat-hf.json");
 }


### PR DESCRIPTION
# TL;DR

All the necessary changes to run benches on llama2 (BPE model, no pretokenization)

+ Updates to the tests and benches


<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**2 / 4 models supported** · geomean ×2.47 across supported · 18 fixtures each — ~10 kB inputs · single thread

`695dbcc13 · 2026-07-07 17:08 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 16 cores

> **Not yet supported:** `deepseek-v4` (BPE · Split+ByteLevel), `t5-base` (Unigram · WhitespaceSplit+Metaspace) — roadmap cards below.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28884419890-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28884419890-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28884419890-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28884419890-llama-2-light.png" width="860">
</picture>

### Not yet supported

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28884419890-deepseek-v4-dark.png">
  <img alt="deepseek-v4 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28884419890-deepseek-v4-light.png" width="420">
</picture>
</td>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28884419890-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28884419890-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

<details><summary>Per-fixture results</summary>

#### bert-base-uncased — WordPiece · Bert

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| cmn_Hani | lang | 3.5 | 13.8 | ×3.97 | match |
| eng_Latn | lang | 4.1 | 14.9 | ×3.64 | match |
| jpn_Jpan | lang | 4.0 | 11.1 | ×2.79 | match |
| amh_Ethi | lang | 7.4 | 20.4 | ×2.77 | match |
| hin_Deva | lang | 5.9 | 14.7 | ×2.47 | match |
| ben_Beng | lang | 5.5 | 12.6 | ×2.28 | match |
| tam_Taml | lang | 6.6 | 14.9 | ×2.25 | match |
| arb_Arab | lang | 3.8 | 8.3 | ×2.19 | match |
| heb_Hebr | lang | 3.8 | 8.0 | ×2.13 | match |
| ell_Grek | lang | 3.4 | 7.0 | ×2.04 | match |
| rus_Cyrl | lang | 3.3 | 6.4 | ×1.92 | match |
| kat_Geor | lang | 5.8 | 11.0 | ×1.90 | match |
| kor_Hang | lang | 2.2 | 4.0 | ×1.78 | match |
| tha_Thai | lang | 8.3 | 13.9 | ×1.67 | match |
| agentic-traces | modalities | 3.5 | 13.1 | ×3.72 | match |
| math_latex | modalities | 3.8 | 13.7 | ×3.65 | match |
| agentic_swe | modalities | 3.8 | 13.4 | ×3.57 | match |
| code_mixed | modalities | 3.6 | 12.2 | ×3.33 | match |

#### llama-2 — BPE · None

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| tha_Thai | lang | 14.3 | 52.0 | ×3.64 | match |
| kat_Geor | lang | 13.4 | 47.5 | ×3.55 | match |
| jpn_Jpan | lang | 11.9 | 41.9 | ×3.52 | match |
| ell_Grek | lang | 9.3 | 30.8 | ×3.31 | match |
| heb_Hebr | lang | 9.1 | 29.7 | ×3.27 | match |
| tam_Taml | lang | 11.7 | 37.5 | ×3.21 | match |
| hin_Deva | lang | 11.0 | 34.7 | ×3.15 | match |
| arb_Arab | lang | 9.5 | 28.3 | ×2.97 | match |
| ben_Beng | lang | 10.2 | 29.7 | ×2.91 | match |
| cmn_Hani | lang | 8.3 | 23.6 | ×2.86 | match |
| kor_Hang | lang | 6.7 | 16.9 | ×2.51 | match |
| amh_Ethi | lang | 4.4 | 9.7 | ×2.21 | match |
| rus_Cyrl | lang | 8.3 | 13.6 | ×1.64 | match |
| eng_Latn | lang | 4.1 | 5.6 | ×1.38 | match |
| agentic-traces | modalities | 4.4 | 6.2 | ×1.41 | match |
| code_mixed | modalities | 4.1 | 5.6 | ×1.39 | match |
| math_latex | modalities | 4.3 | 5.9 | ×1.38 | match |
| agentic_swe | modalities | 4.0 | 5.5 | ×1.36 | match |

</details>
<!-- pipeline-bench:end -->


