### PR TITLE
Improve single thread performance of de-tokenization

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -851,6 +851,23 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
                        "</td>"]
             md.append("</tr>")
         md += ["</table>", "", "</details>", ""]
+
+    # Decode throughput: legacy `Tokenizer::decode` for every model that reports
+    # it (the pipeline has no decode), so byte-level BPE is covered here too.
+    decode_models = [m for m in models if m.get("decode_results")]
+    if decode_models:
+        md += ["<details><summary><b>Decode throughput (Tokenizer)</b></summary>", "",
+               "Single-thread `Tokenizer::decode`, MB/s over decoded output bytes.", ""]
+        for m in decode_models:
+            rows = m["decode_results"]
+            g = geomean([r["decode_mbps"] for r in rows]) if rows else 0.0
+            md += [f"#### {escape(m['model'])} — {escape(m.get('shape', '?'))} · "
+                   f"geomean {g:.1f} MB/s", "",
+                   "| Fixture | Group | Decode MB/s |", "|---|---|---:|"]
+            for r in sorted(rows, key=lambda r: (r["group"], -r["decode_mbps"])):
+                md.append(f"| {r['fixture']} | {r['group']} | {r['decode_mbps']:.1f} |")
+            md.append("")
+        md += ["</details>", ""]
     return "\n".join(md)
 
 

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -189,6 +189,51 @@ fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
     start.elapsed().as_secs_f64()
 }
 
+fn time_decode(decode: &dyn Fn(&[u32]) -> usize, id_chunks: &[Vec<u32>]) -> f64 {
+    let start = Instant::now();
+    let mut n = 0usize;
+    for ids in id_chunks {
+        n += decode(ids);
+    }
+    black_box(n);
+    start.elapsed().as_secs_f64()
+}
+
+/// Legacy-`Tokenizer` decode throughput per fixture. Decode is a `Tokenizer`
+/// capability (the `PipelineTokenizer` has none), so this runs for every model
+/// regardless of pipeline support — including byte-level BPE, where the fused
+/// decode path matters most. Throughput is measured over decoded output bytes.
+fn bench_decode(tok: &Tokenizer, fixtures: &[Fixture]) -> Vec<Value> {
+    let decode = |ids: &[u32]| tok.decode(ids, false).map(|s| s.len()).unwrap_or(0);
+
+    let mut rows = Vec::new();
+    for f in fixtures {
+        // Pre-encode each chunk to ids once; only decode is timed.
+        let id_chunks: Vec<Vec<u32>> = f
+            .chunks
+            .iter()
+            .map(|c| tok.encode(c.as_str(), false).unwrap().get_ids().to_vec())
+            .collect();
+        let out_bytes: usize = id_chunks.iter().map(|ids| decode(ids)).sum();
+
+        time_decode(&decode, &id_chunks); // warm-up
+        let mut samples = Vec::with_capacity(REPS);
+        for _ in 0..REPS {
+            samples.push(time_decode(&decode, &id_chunks));
+        }
+        let decode_mbps = out_bytes as f64 / median_secs(samples) / 1e6;
+        eprintln!("  {}: decode {decode_mbps:.1} MB/s", f.name);
+
+        rows.push(json!({
+            "fixture": f.name,
+            "group": f.group,
+            "out_bytes": out_bytes,
+            "decode_mbps": decode_mbps,
+        }));
+    }
+    rows
+}
+
 /// Median ns/byte of a warmed-up `run` over `len` bytes (`run` returns a value that's
 /// `black_box`'d so the work isn't optimized away).
 fn timed_ns(len: usize, mut run: impl FnMut() -> usize) -> f64 {
@@ -901,7 +946,7 @@ fn main() {
                 models.push(json!({
                     "model": name, "desc": desc, "shape": "?",
                     "reason": format!("load error: {e}"),
-                    "results": [], "memory": Value::Null,
+                    "results": [], "memory": Value::Null, "decode_results": [],
                 }));
                 continue;
             }
@@ -910,6 +955,9 @@ fn main() {
         // something to match, before any pipeline is derived from `tok`.
         inject_added_tokens(&mut tok);
         let shape = format!("{} · {}", model_kind(&tok), pretok_label(&path));
+
+        // Decode is a legacy-`Tokenizer` capability; measure it for every model.
+        let decode_rows = bench_decode(&tok, &fixtures);
 
         // A model can satisfy the pipeline's *build* constraints yet still fail at
         // *encode* time — e.g. a Sequence containing ByteLevel, which rewrites bytes
@@ -923,7 +971,7 @@ fn main() {
                     models.push(json!({
                         "model": name, "desc": desc, "shape": shape,
                         "reason": format!("{e}"),
-                        "results": [], "memory": Value::Null,
+                        "results": [], "memory": Value::Null, "decode_results": decode_rows,
                     }));
                     continue;
                 }
@@ -932,7 +980,7 @@ fn main() {
                 eprintln!("  unsupported by PipelineTokenizer ({shape})");
                 models.push(json!({
                     "model": name, "desc": desc, "shape": shape,
-                    "results": [], "memory": Value::Null,
+                    "results": [], "memory": Value::Null, "decode_results": decode_rows,
                 }));
                 continue;
             }
@@ -974,6 +1022,7 @@ fn main() {
         models.push(json!({
             "model": name, "desc": desc, "shape": shape,
             "results": rows, "memory": memory, "threads": threads,
+            "decode_results": decode_rows,
         }));
     }
 

--- a/tokenizers/tk-encode/src/decoders/mod.rs
+++ b/tokenizers/tk-encode/src/decoders/mod.rs
@@ -164,6 +164,13 @@ impl Decoder for DecoderWrapper {
             Self::Fuse(bf) => bf.decode_chain(tokens),
         }
     }
+
+    fn decode_fused_bytes(&self, tokens: &[&[u8]]) -> Option<Result<String>> {
+        match self {
+            Self::ByteLevel(bl) => bl.decode_fused_bytes(tokens),
+            _ => None,
+        }
+    }
 }
 
 impl_enum_from!(BPEDecoder, DecoderWrapper, BPE);

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -624,6 +624,10 @@ impl Model for BPE {
         self.vocab.id_to_token(id)
     }
 
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+        self.vocab.id_to_token_bytes(id)
+    }
+
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>> {
         let vocab_r: VocabR = self
             .vocab

--- a/tokenizers/tk-encode/src/models/mod.rs
+++ b/tokenizers/tk-encode/src/models/mod.rs
@@ -170,6 +170,13 @@ impl Model for ModelWrapper {
         }
     }
 
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+        match self {
+            Self::BPE(t) => t.id_to_token_bytes(id),
+            _ => None,
+        }
+    }
+
     fn get_vocab(&self) -> HashMap<String, u32> {
         match self {
             Self::WordLevel(t) => t.get_vocab(),

--- a/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
@@ -112,8 +112,16 @@ impl Decoder for ByteLevel {
             .flat_map(|t| {
                 t.chars()
                     .try_fold(vec![], |mut acc, c| {
-                        CHAR_BYTES_LOOKUP.get(&c).map(|b| {
-                            acc.push(*b);
+                        {
+                            let idx = c as usize;
+                            if idx < 512 {
+                                CHAR_BYTES_LOOKUP[idx]
+                            } else {
+                                None
+                            }
+                        }
+                        .map(|b| {
+                            acc.push(b);
                             acc
                         })
                     })

--- a/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
@@ -130,6 +130,38 @@ impl Decoder for ByteLevel {
             .collect::<Vec<u8>>();
         Ok(vec![String::from_utf8_lossy(&toks).to_string()])
     }
+
+    fn decode_fused_bytes(&self, tokens: &[&[u8]]) -> Option<Result<String>> {
+        let total: usize = tokens.iter().map(|t| t.len()).sum();
+        let mut toks = Vec::with_capacity(total);
+        for t in tokens {
+            // Each `t` is a token's UTF-8 bytes. Map every char to its byte via
+            // the CHAR_BYTES_LOOKUP array; if any char is not a byte-level char,
+            // fall back to the raw token bytes for that token — identical to
+            // `decode_chain`, but without a `String` allocation per token.
+            let start = toks.len();
+            let mut all_mapped = true;
+            match std::str::from_utf8(t) {
+                Ok(s) => {
+                    for c in s.chars() {
+                        match CHAR_BYTES_LOOKUP.get(c as usize).copied().flatten() {
+                            Some(b) => toks.push(b),
+                            None => {
+                                all_mapped = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(_) => all_mapped = false,
+            }
+            if !all_mapped {
+                toks.truncate(start);
+                toks.extend_from_slice(t);
+            }
+        }
+        Some(Ok(String::from_utf8_lossy(&toks).to_string()))
+    }
 }
 
 /// As a `PostProcessor`, `ByteLevel` is in charge of trimming the offsets if necessary.

--- a/tokenizers/tk-encode/src/tokenizer/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/mod.rs
@@ -74,6 +74,12 @@ pub trait Model {
     fn token_to_id(&self, token: &str) -> Option<u32>;
     /// Find the string token associated to an ID
     fn id_to_token(&self, id: u32) -> Option<String>;
+    /// Borrow a token's raw bytes from the model's vocab store (zero-copy), or
+    /// `None` if the ID is unknown or the model exposes no byte view. Enables
+    /// the fused decode fast path without a `String` allocation per token.
+    fn id_to_token_bytes(&self, _id: u32) -> Option<&[u8]> {
+        None
+    }
     /// Retrieve the entire vocabulary mapping (token -> ID)
     fn get_vocab(&self) -> HashMap<String, u32>;
     /// Retrieve the size of the vocabulary
@@ -182,6 +188,15 @@ pub trait Decoder {
         Ok(results.join(""))
     }
     fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>>;
+
+    /// Fast path: decode directly from borrowed per-token byte slices, avoiding
+    /// a `String` allocation per token. The output must be identical to
+    /// `self.decode(tokens)` for the same tokens. Returns `None` when the
+    /// decoder does not support this path (the default), so the caller falls
+    /// back to the `decode_chain` route.
+    fn decode_fused_bytes(&self, _tokens: &[&[u8]]) -> Option<Result<String>> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -921,6 +936,10 @@ where
 
     /// Decode the given ids, back to a String
     pub fn decode(&self, ids: &[u32], skip_special_tokens: bool) -> Result<String> {
+        if let Some(result) = self.decode_fused(ids, skip_special_tokens) {
+            return result;
+        }
+
         let tokens = ids
             .iter()
             .filter_map(|id| {
@@ -938,6 +957,42 @@ where
         } else {
             Ok(tokens.join(" "))
         }
+    }
+
+    /// Fused decode fast path: borrow each token's bytes from the model's vocab
+    /// store (zero-copy) and let the decoder concatenate + transform them in a
+    /// single pass, instead of allocating a `String` per token and a
+    /// `Vec<String>`.
+    ///
+    /// Returns `None` (so `decode` uses the regular path) when there is no
+    /// decoder, when the decoder does not support the fused byte path, when any
+    /// input ID is an added/special token (the regular path handles the
+    /// `skip_special_tokens` filtering and added-token content), or when a
+    /// token has no byte view in the model.
+    fn decode_fused(&self, ids: &[u32], skip_special_tokens: bool) -> Option<Result<String>> {
+        let _ = skip_special_tokens;
+        let decoder = self.decoder.as_ref()?;
+
+        // The fast path only reconstructs model tokens. If any id is an
+        // added/special token, defer to the regular decoder path, which applies
+        // skip_special_tokens and writes added-token content.
+        let added = self.added_vocabulary.get_added_tokens_decoder();
+        let check_added = !added.is_empty();
+
+        // Borrow each token's bytes from the model. `id_to_token_bytes` returns
+        // None for models with no byte view (e.g. Unigram/WordPiece), so those
+        // bail here without materializing the whole vector. `decode_fused_bytes`
+        // then returns None for any decoder that can't use it, falling back to
+        // the regular decoder path.
+        let mut token_bytes: Vec<&[u8]> = Vec::with_capacity(ids.len());
+        for &id in ids {
+            if check_added && added.contains_key(&id) {
+                return None;
+            }
+            token_bytes.push(self.model.id_to_token_bytes(id)?);
+        }
+
+        decoder.decode_fused_bytes(&token_bytes)
     }
 
     /// Decode the given ids, back to a String

--- a/tokenizers/tk-encode/src/utils/byte_level.rs
+++ b/tokenizers/tk-encode/src/utils/byte_level.rs
@@ -1,5 +1,4 @@
 use crate::vocab::bucket_vocab_store::BucketVocabStore;
-use ahash::AHashMap;
 use std::sync::LazyLock;
 
 // The GPT-2 pre-tokenize regex is the canonical spec in atomsplit (single source of truth); re-export
@@ -19,12 +18,19 @@ pub(crate) use atomsplit::regexes::GPT2 as GPT2_REGEX_STR;
 pub static BYTES_CHAR_LOOKUP: LazyLock<[char; 256]> = LazyLock::new(make_byte_char_lookup);
 /// Inverse of [`BYTES_CHAR_LOOKUP`]: maps each byte-level unicode character back to its byte.
 ///
-/// Used when decoding byte-level tokens back into raw bytes. Because [`BYTES_CHAR_LOOKUP`] is
-/// a bijection over all 256 bytes, this map has exactly 256 entries with no collisions.
-pub static CHAR_BYTES_LOOKUP: LazyLock<AHashMap<char, u8>> = LazyLock::new(|| {
-    (0..=255u8)
-        .map(|byte| (BYTES_CHAR_LOOKUP[byte as usize], byte))
-        .collect()
+/// O(1) array lookup indexed by the character's codepoint (no hashing). Byte-level chars
+/// live in `0..324` (see [`BYTES_CHAR_LOOKUP`]), so a 512-entry table covers all of them.
+/// `None` marks a codepoint that is not a byte-level character. Used when decoding byte-level
+/// tokens back into raw bytes.
+pub static CHAR_BYTES_LOOKUP: LazyLock<[Option<u8>; 512]> = LazyLock::new(|| {
+    let mut table = [None; 512];
+    for byte in 0..=255u8 {
+        let idx = BYTES_CHAR_LOOKUP[byte as usize] as usize;
+        if idx < 512 {
+            table[idx] = Some(byte);
+        }
+    }
+    table
 });
 
 /// Expands a UTF-8 string into its GPT-2 byte-level character sequence, paired with the
@@ -82,8 +88,10 @@ fn make_byte_char_lookup() -> [char; 256] {
 
 fn reverse_lookup(c: char) -> Vec<u8> {
     CHAR_BYTES_LOOKUP
-        .get(&c)
-        .map_or_else(|| c.to_string().into_bytes(), |b| vec![*b])
+        .get(c as usize)
+        .copied()
+        .flatten()
+        .map_or_else(|| c.to_string().into_bytes(), |b| vec![b])
 }
 
 pub(crate) fn transform_vocab(vocab: BucketVocabStore) -> BucketVocabStore {


### PR DESCRIPTION
Brings de-tokenization single thread performance up on arm64 and x86_64.

2 patches:
- byte-level: O(1) array for char->byte decode lookup
- decode: fused single-buffer fast path over the VocabStore byte slab

Perf (single-thread decode, one pinned core, baseline -> this series):
```
byte-level decode      llama3-en (English)   llama3-ja (CJK)
Nvidia Vera            40.8 -> 64.5 MiB/s    41.1 -> 181 MiB/s   (1.6x / 4.4x)
Intel Granite Rapids   29.7 -> 44.6 MiB/s    35.6 -> 125 MiB/s   (1.5x / 3.5x)
AMD Turin              46.1 -> 66.2 MiB/s    51.1 -> 180 MiB/s   (1.4x / 3.5x)
```