### PR TITLE
feat(bench): per-stage decomposition for the pipeline benchmark

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -5,11 +5,16 @@ a markdown report for a PR description.
 Input: JSON array from `cargo run --release -p tk-encode --example fixture_bench`,
 one object per model:
     {model, shape, supported, [reason], results: [{fixture, group,
-     legacy_mbps, pipeline_mbps, speedup, ids_match}, ...]}
+     legacy_mbps, pipeline_mbps, speedup, ids_match,
+     stage_ns_per_byte: {normalize, pre_tokenize, model, other, total}}, ...]}
 
-Each supported model gets a full-size diverging bar chart (log2 around ×1.0):
-per-fixture ×speedup + the `MB/s: Tokenizer → Pipeline` throughput column, with
-group headers, slower/faster hints, ticks and an inline "⚠ ids differ" flag.
+Each supported model gets two full-size charts:
+  1. a diverging bar chart (log2 around ×1.0): per-fixture ×speedup + the
+     `MB/s: Tokenizer → Pipeline` throughput column, with group headers,
+     slower/faster hints, ticks and an inline "⚠ ids differ" flag;
+  2. a stacked stage-decomposition chart (ns/byte): where the pipeline spends
+     its own encode time — normalize + split + model + other — per fixture,
+     with each fixture's ×speedup alongside.
 Unsupported models (byte-level BPE, Unigram/Metaspace, …) get a compact
 "not supported" card. Charts are rendered full-size so readers can zoom.
 """
@@ -43,6 +48,17 @@ CHART_W = GUTTER + PLOT_W + PAD_R + COL_W
 TICKS = [0.5, 0.67, 0.75, 0.8, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0, 5.0]
 GROUPS = [("lang", "Languages"), ("modalities", "Modalities")]
 CARD_W, CARD_H = 470, 150
+
+# Pipeline encode stages, in execution order, keyed to `stage_ns_per_byte` in the
+# fixture_bench JSON. "other" is the untimed remainder (special-token scan + glue).
+STAGES = [("normalize", "normalize"), ("pre_tokenize", "split"),
+          ("model", "model"), ("other", "other")]
+STAGE_INK = {
+    "light": {"normalize": "#2a9d8f", "pre_tokenize": "#e0952b",
+              "model": "#2a78d6", "other": "#c3c2b7"},
+    "dark": {"normalize": "#3fb8a8", "pre_tokenize": "#f0b45a",
+             "model": "#3987e5", "other": "#54544e"},
+}
 
 
 def slugify(name):
@@ -151,6 +167,115 @@ def chart_svg(model, mode, subtitle_base, meta, lo, hi):
 </svg>'''
 
 
+def has_stages(model):
+    return any("stage_ns_per_byte" in r for r in model["results"])
+
+
+def stage_scale(models):
+    """Shared linear ns/byte range across every supported fixture's total, so the
+    stacked stage bars are comparable across models."""
+    vals = [r["stage_ns_per_byte"]["total"] for m in models if m["supported"]
+            for r in m["results"] if "stage_ns_per_byte" in r]
+    vals = [v for v in vals if v > 0]
+    return max(vals) * 1.05 if vals else 1.0
+
+
+def stage_mix(rows):
+    """Mean per-stage share of total, as a list of (label, fraction), largest first."""
+    acc = {k: 0.0 for k, _ in STAGES}
+    n = 0
+    for r in rows:
+        s = r.get("stage_ns_per_byte")
+        if not s or not s["total"]:
+            continue
+        n += 1
+        for k, _ in STAGES:
+            acc[k] += s.get(k, 0.0) / s["total"]
+    if not n:
+        return []
+    label = dict(STAGES)
+    return sorted(((label[k], acc[k] / n) for k in acc), key=lambda kv: -kv[1])
+
+
+def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
+    """Per-fixture stacked decomposition of the *pipeline's* own encode time
+    (ns/byte): normalize + split + model + other. Shows where the pipeline spends
+    its time and — via the right column — how that maps onto the ×speedup headline."""
+    ink = INK[mode]
+    sink = STAGE_INK[mode]
+    rows = [r for r in model["results"] if "stage_ns_per_byte" in r]
+
+    def w(v):  # ns/byte -> px width on the shared scale
+        return (v / max_total) * PLOT_W if max_total else 0.0
+
+    top = 84
+    col_x = GUTTER + PLOT_W + PAD_R + COL_W - 16
+    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+            f'text-anchor="end">ns/byte · ×speedup</text>']
+    y = top
+    for key, title in GROUPS:
+        group_rows = sorted((r for r in rows if r["group"] == key),
+                            key=lambda r: -r["stage_ns_per_byte"]["total"])
+        if not group_rows:
+            continue
+        body.append(f'<text x="{GUTTER}" y="{y + 12}" fill="{ink["secondary"]}" font-size="11" '
+                    f'font-weight="600" letter-spacing="1.2" text-anchor="end" dx="-10">{title.upper()}</text>')
+        y += 22
+        for r in group_rows:
+            s = r["stage_ns_per_byte"]
+            by = y + (ROW_H - BAR_H) / 2
+            body.append(f'<text x="{GUTTER - 10}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
+                        f'font-size="12.5" text-anchor="end">{escape(r["fixture"])}</text>')
+            cursor = float(GUTTER)
+            for skey, _ in STAGES:
+                seg = w(s.get(skey, 0.0))
+                if seg > 0.4:
+                    body.append(f'<rect x="{cursor:.1f}" y="{by}" width="{seg:.1f}" '
+                                f'height="{BAR_H}" fill="{sink[skey]}"/>')
+                cursor += seg
+            body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
+                        f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
+                        f'{s["total"]:.1f} · ×{r["speedup"]:.2f}</text>')
+            y += ROW_H
+        y += 10
+
+    # x-axis: 4 evenly spaced ns/byte gridlines + ticks
+    grid = []
+    for i in range(5):
+        tv = max_total * i / 4
+        gx = GUTTER + w(tv)
+        grid.append(f'<line x1="{gx:.1f}" y1="{top - 6}" x2="{gx:.1f}" y2="{y - 6}" '
+                    f'stroke="{ink["grid"]}" stroke-width="1"/>')
+        grid.append(f'<text x="{gx:.1f}" y="{y + 12}" fill="{ink["muted"]}" font-size="11" '
+                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:.0f}</text>')
+
+    # legend row
+    y += 26
+    legend = []
+    lx = GUTTER
+    for skey, lbl in STAGES:
+        legend.append(f'<rect x="{lx}" y="{y - 9}" width="11" height="11" rx="2" fill="{sink[skey]}"/>')
+        legend.append(f'<text x="{lx + 16}" y="{y}" fill="{ink["secondary"]}" font-size="11.5">{lbl}</text>')
+        lx += 16 + 8 + len(lbl) * 7 + 18
+    height = y + 18
+
+    mix = stage_mix(rows)
+    mix_txt = " · ".join(f"{lbl} {100 * frac:.0f}%" for lbl, frac in mix)
+    subtitle = f'{model["shape"]} · stage mix: {mix_txt} · {subtitle_base}'
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{CHART_W}" height="{height}"
+  viewBox="0 0 {CHART_W} {height}" font-family="{FONT}">
+<rect width="{CHART_W}" height="{height}" fill="{ink["surface"]}"/>
+<text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="700">{escape(model["model"])} — Pipeline encode stage decomposition</text>
+<text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
+<text x="{CHART_W - 16}" y="26" fill="{ink["muted"]}" font-size="11" text-anchor="end"
+  style="font-variant-numeric:tabular-nums">{escape(meta[0])}</text>
+<text x="{CHART_W - 16}" y="44" fill="{ink["muted"]}" font-size="11" text-anchor="end">{escape(meta[1])}</text>
+{"".join(grid)}
+{"".join(body)}
+{"".join(legend)}
+</svg>'''
+
+
 def card_svg(model, mode):
     """Compact 'not supported' card for a model the pipeline can't build."""
     ink = INK[mode]
@@ -218,6 +343,12 @@ def render_markdown(models, subtitle_base, meta, base, run_id):
         head += f" · geomean ×{g:.2f} across supported · {nfix} fixtures each"
     md += [f"{head} — {subtitle_base}", "", f"`{meta[0]}` · {meta[1]}", ""]
 
+    staged_rows = [r for m in supported for r in m["results"] if "stage_ns_per_byte" in r]
+    if staged_rows:
+        mix = ", ".join(f"{lbl} {100 * frac:.0f}%" for lbl, frac in stage_mix(staged_rows))
+        md += [f"Pipeline stage mix (mean share of encode time): {mix}. "
+               f"Per-model decomposition charts below.", ""]
+
     if unsupported:
         items = ", ".join(f"`{m['model']}` ({m['shape']})" for m in unsupported)
         md += [f"> **Not yet supported:** {items} — roadmap cards below.", ""]
@@ -225,9 +356,14 @@ def render_markdown(models, subtitle_base, meta, base, run_id):
         md += [f"> ⚠️ **Token ids diverge from the reference on: {', '.join(mismatches)}** "
                f"— speedups there are meaningless until fixed.", ""]
 
-    # Supported models: full-size chart each (readable inline, click to zoom).
+    # Supported models: speedup chart + stage-decomposition chart each
+    # (readable inline, click to zoom).
     for m in supported:
-        md += [picture(base, run_id, slugify(m["model"]), f"{m['model']} speedup", 860), ""]
+        slug = slugify(m["model"])
+        md += [picture(base, run_id, slug, f"{m['model']} speedup", 860), ""]
+        if has_stages(m):
+            md += [picture(base, run_id, f"{slug}-stages",
+                           f"{m['model']} stage decomposition", 860), ""]
 
     # Unsupported models: compact roadmap cards, two per row.
     if unsupported:
@@ -245,12 +381,16 @@ def render_markdown(models, subtitle_base, meta, base, run_id):
         md += ["<details><summary>Per-fixture results</summary>", ""]
         for m in supported:
             md += [f"#### {m['model']} — {m['shape']}", "",
-                   "| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | Ids |",
-                   "|---|---|---:|---:|---:|:--|"]
+                   "| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup "
+                   "| norm ns/B | split ns/B | model ns/B | other ns/B | Ids |",
+                   "|---|---|---:|---:|---:|---:|---:|---:|---:|:--|"]
             for r in sorted(m["results"], key=lambda r: (r["group"], -r["speedup"])):
                 ids = "match" if r["ids_match"] else "⚠️ differ"
+                s = r.get("stage_ns_per_byte", {})
+                cells = " ".join(f"| {s[k]:.2f}" if k in s else "| —"
+                                 for k in ("normalize", "pre_tokenize", "model", "other"))
                 md.append(f"| {r['fixture']} | {r['group']} | {r['legacy_mbps']:.1f} "
-                          f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} | {ids} |")
+                          f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} {cells} | {ids} |")
             md.append("")
         md += ["</details>", ""]
     return "\n".join(md)
@@ -278,6 +418,7 @@ def main():
 
     models = json.loads(Path(args.results).read_text())
     lo, hi = scale(models)
+    max_total = stage_scale(models)
     out = Path(args.out_dir)
     for m in models:
         slug = slugify(m["model"])
@@ -285,6 +426,9 @@ def main():
             svg = (chart_svg(m, mode, args.subtitle, meta, lo, hi)
                    if m["supported"] else card_svg(m, mode))
             (out / f"pipeline_bench_{slug}_{mode}.svg").write_text(svg)
+            if m["supported"] and has_stages(m):
+                (out / f"pipeline_bench_{slug}-stages_{mode}.svg").write_text(
+                    stage_chart_svg(m, mode, args.subtitle, meta, max_total))
 
     (out / "pipeline_bench.md").write_text(
         render_markdown(models, args.subtitle, meta, args.img_base, args.run_id))

--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -113,8 +113,11 @@ def chart_svg(model, mode, subtitle_base, meta, lo, hi):
             f'text-anchor="end">MB/s: Tokenizer → Pipeline</text>']
     y = top
     for key, title in GROUPS:
+        # stable order (alphabetical by fixture) so a fixture keeps its row across
+        # runs and lines up with the stage-decomposition chart — not sorted by the
+        # (run-varying) speedup.
         group_rows = sorted((r for r in rows if r["group"] == key),
-                            key=lambda r: -r["speedup"])
+                            key=lambda r: r["fixture"])
         if not group_rows:
             continue
         body.append(f'<text x="{GUTTER}" y="{y + 12}" fill="{ink["secondary"]}" font-size="11" '
@@ -224,7 +227,7 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
     y = top
     for key, title in GROUPS:
         group_rows = sorted((r for r in rows if r["group"] == key),
-                            key=lambda r: -r["stage_ns_per_byte"]["total"])
+                            key=lambda r: r["fixture"])  # stable order, matches speedup chart
         if not group_rows:
             continue
         body.append(f'<text x="{GUTTER}" y="{y + 12}" fill="{ink["secondary"]}" font-size="11" '
@@ -405,7 +408,7 @@ def render_markdown(models, subtitle_base, meta, base, run_id):
                    "| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup "
                    "| added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |",
                    "|---|---|---:|---:|---:|---:|---:|---:|---:|:--|"]
-            for r in sorted(m["results"], key=lambda r: (r["group"], -r["speedup"])):
+            for r in sorted(m["results"], key=lambda r: (r["group"], r["fixture"])):
                 ids = "match" if r["ids_match"] else "⚠️ differ"
                 s = r.get("stage_ns_per_byte", {})
                 cells = " ".join(f"| {s[k]:.2f}" if k in s else "| —"

--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -6,14 +6,15 @@ Input: JSON array from `cargo run --release -p tk-encode --example fixture_bench
 one object per model:
     {model, shape, supported, [reason], results: [{fixture, group,
      legacy_mbps, pipeline_mbps, speedup, ids_match,
-     stage_ns_per_byte: {normalize, pre_tokenize, model, other, total}}, ...]}
+     stage_ns_per_byte: {added_split, normalize, pre_tokenize, model, total}}, ...]}
 
 Each supported model gets two full-size charts:
   1. a diverging bar chart (log2 around ×1.0): per-fixture ×speedup + the
      `MB/s: Tokenizer → Pipeline` throughput column, with group headers,
      slower/faster hints, ticks and an inline "⚠ ids differ" flag;
   2. a stacked stage-decomposition chart (ns/byte): where the pipeline spends
-     its own encode time — normalize + split + model + other — per fixture,
+     its own encode time per fixture — added-token split + normalize +
+     pre-tokenize + model (the two distinct splitting costs kept separate),
      with each fixture's ×speedup alongside.
 Unsupported models (byte-level BPE, Unigram/Metaspace, …) get a compact
 "not supported" card. Charts are rendered full-size so readers can zoom.
@@ -50,14 +51,16 @@ GROUPS = [("lang", "Languages"), ("modalities", "Modalities")]
 CARD_W, CARD_H = 470, 150
 
 # Pipeline encode stages, in execution order, keyed to `stage_ns_per_byte` in the
-# fixture_bench JSON. "other" is the untimed remainder (special-token scan + glue).
-STAGES = [("normalize", "normalize"), ("pre_tokenize", "split"),
-          ("model", "model"), ("other", "other")]
+# fixture_bench JSON. `added_split` = the added/special-token scan (AddedVocabulary),
+# `pre_tokenize` = the pre-tokenizer split — two distinct splitting costs. The four
+# stages sum to the whole-encode total.
+STAGES = [("added_split", "added-token"), ("normalize", "normalize"),
+          ("pre_tokenize", "pre-tokenize"), ("model", "model")]
 STAGE_INK = {
-    "light": {"normalize": "#2a9d8f", "pre_tokenize": "#e0952b",
-              "model": "#2a78d6", "other": "#c3c2b7"},
-    "dark": {"normalize": "#3fb8a8", "pre_tokenize": "#f0b45a",
-             "model": "#3987e5", "other": "#54544e"},
+    "light": {"added_split": "#7a5ea8", "normalize": "#2a9d8f",
+              "pre_tokenize": "#e0952b", "model": "#2a78d6"},
+    "dark": {"added_split": "#a48ad4", "normalize": "#3fb8a8",
+             "pre_tokenize": "#f0b45a", "model": "#3987e5"},
 }
 
 
@@ -400,13 +403,13 @@ def render_markdown(models, subtitle_base, meta, base, run_id):
         for m in supported:
             md += [f"#### {m['model']} — {m['shape']}", "",
                    "| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup "
-                   "| norm ns/B | split ns/B | model ns/B | other ns/B | Ids |",
+                   "| added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |",
                    "|---|---|---:|---:|---:|---:|---:|---:|---:|:--|"]
             for r in sorted(m["results"], key=lambda r: (r["group"], -r["speedup"])):
                 ids = "match" if r["ids_match"] else "⚠️ differ"
                 s = r.get("stage_ns_per_byte", {})
                 cells = " ".join(f"| {s[k]:.2f}" if k in s else "| —"
-                                 for k in ("normalize", "pre_tokenize", "model", "other"))
+                                 for k in ("added_split", "normalize", "pre_tokenize", "model"))
                 md.append(f"| {r['fixture']} | {r['group']} | {r['legacy_mbps']:.1f} "
                           f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} {cells} | {ids} |")
             md.append("")

--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -69,6 +69,12 @@ def geomean(values):
     return math.exp(sum(math.log(v) for v in values) / len(values))
 
 
+def text_on(hex_color):
+    """Black or white label, whichever reads on `hex_color` (relative luminance)."""
+    r, g, b = (int(hex_color[i:i + 2], 16) / 255 for i in (1, 3, 5))
+    return "#111111" if 0.2126 * r + 0.7152 * g + 0.0722 * b > 0.6 else "#ffffff"
+
+
 def bar_path(x0, x1, y, h, r):
     # square at the baseline (x0), rounded at the data end (x1)
     left, right = min(x0, x1), max(x0, x1)
@@ -228,10 +234,18 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
                         f'font-size="12.5" text-anchor="end">{escape(r["fixture"])}</text>')
             cursor = float(GUTTER)
             for skey, _ in STAGES:
-                seg = w(s.get(skey, 0.0))
+                val = s.get(skey, 0.0)
+                seg = w(val)
                 if seg > 0.4:
                     body.append(f'<rect x="{cursor:.1f}" y="{by}" width="{seg:.1f}" '
                                 f'height="{BAR_H}" fill="{sink[skey]}"/>')
+                    # ns/byte inside the slice when it's wide enough to read
+                    if seg >= 24:
+                        txt = f"{val:.0f}" if val >= 9.5 else f"{val:.1f}"
+                        body.append(f'<text x="{cursor + seg / 2:.1f}" y="{y + ROW_H / 2 + 4}" '
+                                    f'fill="{text_on(sink[skey])}" font-size="10.5" '
+                                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">'
+                                    f'{txt}</text>')
                 cursor += seg
             body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
                         f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
@@ -259,9 +273,13 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
         lx += 16 + 8 + len(lbl) * 7 + 18
     height = y + 18
 
+    # Keep this subtitle short: the stage-mix string is long, and `subtitle_base`
+    # (the "~10 kB inputs · single thread" run context) already rides in the markdown
+    # header and the speedup chart above — appending it here collides with the
+    # right-aligned hardware line.
     mix = stage_mix(rows)
     mix_txt = " · ".join(f"{lbl} {100 * frac:.0f}%" for lbl, frac in mix)
-    subtitle = f'{model["shape"]} · stage mix: {mix_txt} · {subtitle_base}'
+    subtitle = f'{model["shape"]} · stage mix: {mix_txt}'
     return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{CHART_W}" height="{height}"
   viewBox="0 0 {CHART_W} {height}" font-family="{FONT}">
 <rect width="{CHART_W}" height="{height}" fill="{ink["surface"]}"/>

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -9,7 +9,7 @@ BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram_wagahaiwa_nekodear
 TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/fixtures/modalities/agentic-traces.txt
 
 FIXTURE_LANGS = amh_Ethi arb_Arab ben_Beng cmn_Hani ell_Grek eng_Latn heb_Hebr hin_Deva jpn_Jpan kat_Geor kor_Hang rus_Cyrl tam_Taml tha_Thai
-FIXTURE_MODALITIES = agentic_swe agentic-traces code_mixed math_latex
+FIXTURE_MODALITIES = agentic_swe agentic-traces code_mixed math_latex added_special_sparse added_special_dense added_normalized_sparse added_normalized_dense
 FIXTURES_RESOURCES = $(FIXTURE_LANGS:%=$(DATA_DIR)/fixtures/lang/%.txt) $(FIXTURE_MODALITIES:%=$(DATA_DIR)/fixtures/modalities/%.txt)
 
 # Models benched by tk-encode/examples/fixture_bench.rs; the manifest is the

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -241,13 +241,26 @@ fn main() {
         let shape = format!("{} · {}", model_kind(&tok), pretok_label(&path));
 
         match PipelineTokenizer::try_from(&tok) {
-            Ok(pipeline) => {
-                let rows = bench_model(&tok, &pipeline, &files);
-                out.push(json!({
-                    "model": name, "repo": repo, "shape": shape,
-                    "supported": true, "results": rows,
-                }));
-            }
+            // A model can satisfy the pipeline's *build* constraints yet still fail at
+            // *encode* time — e.g. a Sequence containing ByteLevel, which rewrites bytes
+            // and has no range-based impl. Probe once and downgrade to "unsupported"
+            // (with the reason) instead of panicking partway through the bench.
+            Ok(pipeline) => match pipeline.encode("The quick brown fox jumps 123.", false) {
+                Ok(_) => {
+                    let rows = bench_model(&tok, &pipeline, &files);
+                    out.push(json!({
+                        "model": name, "repo": repo, "shape": shape,
+                        "supported": true, "results": rows,
+                    }));
+                }
+                Err(e) => {
+                    eprintln!("  builds but can't encode yet ({shape}): {e}");
+                    out.push(json!({
+                        "model": name, "repo": repo, "shape": shape,
+                        "supported": false, "reason": format!("{e}"), "results": [],
+                    }));
+                }
+            },
             Err(_) => {
                 eprintln!("  unsupported by PipelineTokenizer ({shape})");
                 out.push(json!({

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -67,24 +67,28 @@ fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
 /// `PipelineTokenizer::encode_generic::<STAGE>`. `STAGE` is a const generic, so each
 /// level is a branchless specialization with the later stages compiled out — timing
 /// successive levels and subtracting gives each stage's marginal cost (the ablation
-/// ladder), no profiler and no per-segment instrumentation. The output buffer is reused
-/// across chunks; `black_box` keeps the optimizer from eliding the (empty-at-low-stages)
-/// result.
+/// ladder), no profiler and no per-segment instrumentation.
+///
+/// Both caller-owned buffers are reused across chunks and `black_box`'d each iteration:
+/// `output` anchors the special-scan/normalize/model work, `pre_tokens` anchors the
+/// split stage, so under fat LTO no dead partial stage gets optimized away. The
+/// `black_box` lives here, in the bench — never in the library.
 fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) -> f64 {
     let mut out = Vec::new();
-    for chunk in chunks {
-        out.clear();
-        let _ = pipeline.encode_generic::<STAGE>(chunk, &mut out); // warm-up
-        black_box(&out);
-    }
+    let mut pre_tokens = Vec::new();
+    let mut run = || {
+        for chunk in chunks {
+            out.clear();
+            let _ = pipeline.encode_generic::<STAGE>(chunk, &mut out, &mut pre_tokens);
+            black_box(&out);
+            black_box(&pre_tokens);
+        }
+    };
+    run(); // warm-up
     let mut samples = Vec::with_capacity(REPS);
     for _ in 0..REPS {
         let start = Instant::now();
-        for chunk in chunks {
-            out.clear();
-            let _ = pipeline.encode_generic::<STAGE>(chunk, &mut out);
-            black_box(&out);
-        }
+        run();
         samples.push(start.elapsed().as_secs_f64());
     }
     median_secs(samples)

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -63,25 +63,28 @@ fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
     start.elapsed().as_secs_f64()
 }
 
-/// Median wall-time (seconds) of one pass over `chunks` through `PipelineTokenizer::
-/// encode_upto::<STAGE>`. `STAGE` is a const generic, so each level is a branchless
-/// specialization with the later stages compiled out — timing successive levels and
-/// subtracting gives each stage's marginal cost (the ablation ladder), no profiler
-/// and no per-segment instrumentation.
+/// Median wall-time (seconds) of one pass over `chunks` through the shared encode core
+/// `PipelineTokenizer::encode_generic::<STAGE>`. `STAGE` is a const generic, so each
+/// level is a branchless specialization with the later stages compiled out — timing
+/// successive levels and subtracting gives each stage's marginal cost (the ablation
+/// ladder), no profiler and no per-segment instrumentation. The output buffer is reused
+/// across chunks; `black_box` keeps the optimizer from eliding the (empty-at-low-stages)
+/// result.
 fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) -> f64 {
-    let mut warm = 0usize;
+    let mut out = Vec::new();
     for chunk in chunks {
-        warm += pipeline.encode_upto::<STAGE>(chunk);
+        out.clear();
+        let _ = pipeline.encode_generic::<STAGE>(chunk, &mut out); // warm-up
+        black_box(&out);
     }
-    black_box(warm);
     let mut samples = Vec::with_capacity(REPS);
     for _ in 0..REPS {
         let start = Instant::now();
-        let mut acc = 0usize;
         for chunk in chunks {
-            acc += pipeline.encode_upto::<STAGE>(chunk);
+            out.clear();
+            let _ = pipeline.encode_generic::<STAGE>(chunk, &mut out);
+            black_box(&out);
         }
-        black_box(acc);
         samples.push(start.elapsed().as_secs_f64());
     }
     median_secs(samples)

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -19,13 +19,38 @@ use std::time::Instant;
 
 use serde_json::{json, Value};
 use tk_encode::pipeline::PipelineTokenizer;
-use tk_encode::{ModelWrapper, Tokenizer};
+use tk_encode::{AddedToken, ModelWrapper, Tokenizer};
 
 const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
 const MANIFEST: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/bench_models.json");
 const CHUNK_BYTES: usize = 10 * 1024;
 const MAX_CHUNKS: usize = 100;
 const REPS: usize = 5;
+
+// Added tokens injected into every loaded tokenizer so the `added_*` fixtures exercise
+// the added-token split for whichever model is benched — no bespoke tokenizer config.
+// `ADDED_SPECIAL` (normalized:false) is matched on the raw pass; `ADDED_NORMALIZED`
+// (normalized:true) on the normalized pass. The strings are distinctive markers that do
+// not occur in the language/modality corpora, so they leave those results untouched. The
+// `added_*` fixtures are built from exactly these strings (see the dataset FIXTURES.md).
+const ADDED_SPECIAL: &[&str] = &["<|xs0|>", "<|xs1|>", "<|xs2|>", "<|xs3|>", "<|xs4|>"];
+const ADDED_NORMALIZED: &[&str] = &[
+    "widgetron", "flibberjast", "zorptastic", "quibblenaut", "snorlaxian", "blorptronic",
+    "wuzzlefang", "crungledorf",
+];
+
+/// Inject the benchmark's added tokens into `tok` before the pipeline is built from it,
+/// so both the reference and the pipeline see them (and stay id-for-id identical).
+fn inject_added_tokens(tok: &mut Tokenizer) {
+    let special = ADDED_SPECIAL
+        .iter()
+        .map(|s| AddedToken::from(*s, true).normalized(false));
+    let normalized = ADDED_NORMALIZED
+        .iter()
+        .map(|s| AddedToken::from(*s, false).normalized(true));
+    let _ = tok.add_special_tokens(special);
+    let _ = tok.add_tokens(normalized);
+}
 
 fn make_chunks(text: &str) -> Vec<String> {
     let mut chunks = Vec::new();
@@ -250,7 +275,7 @@ fn main() {
         let path = model_path(entry);
         eprintln!("== {name} ({repo}) ==");
 
-        let tok = match Tokenizer::from_file(&path) {
+        let mut tok = match Tokenizer::from_file(&path) {
             Ok(t) => t,
             Err(e) => {
                 eprintln!("  load failed: {e}");
@@ -261,6 +286,9 @@ fn main() {
                 continue;
             }
         };
+        // Give every model the benchmark's added tokens so the `added_*` fixtures have
+        // something to match, before the pipeline is derived from `tok`.
+        inject_added_tokens(&mut tok);
         let shape = format!("{} · {}", model_kind(&tok), pretok_label(&path));
 
         match PipelineTokenizer::try_from(&tok) {

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -201,15 +201,19 @@ fn bench_model(
         let t_norm = stage_secs::<{ PipelineTokenizer::STAGE_NORMALIZE }>(pipeline, &chunks);
         let t_split = stage_secs::<{ PipelineTokenizer::STAGE_SPLIT }>(pipeline, &chunks);
         let t_model = stage_secs::<{ PipelineTokenizer::STAGE_MODEL }>(pipeline, &chunks);
+        // Two distinct "split" costs are separated here: `added_split` is the
+        // added/special-token scan (the SpecialSegmentIterator over the AddedVocabulary,
+        // captured by the FRAME level), `pre_tokenize` is the pre-tokenizer split. All
+        // four stages sum exactly to `total`.
         let nspb = |secs: f64| secs * 1e9 / bytes as f64;
-        let (ns_norm, ns_split, ns_model, ns_other) = (
+        let (ns_added, ns_norm, ns_split, ns_model) = (
+            nspb(t_frame.max(0.0)),
             nspb((t_norm - t_frame).max(0.0)),
             nspb((t_split - t_norm).max(0.0)),
             nspb((t_model - t_split).max(0.0)),
-            nspb(t_frame.max(0.0)),
         );
         eprintln!(
-            "    stages ns/byte: norm {ns_norm:.2}, split {ns_split:.2}, model {ns_model:.2}, other {ns_other:.2}"
+            "    stages ns/byte: added-split {ns_added:.2}, norm {ns_norm:.2}, pre-split {ns_split:.2}, model {ns_model:.2}"
         );
 
         rows.push(json!({
@@ -221,12 +225,12 @@ fn bench_model(
             "pipeline_mbps": pipeline_mbps,
             "speedup": l / p,
             "ids_match": ids_match,
-            // pipeline-only stage decomposition (ns/byte); stages + other ≈ total.
+            // pipeline-only stage decomposition (ns/byte); the four stages sum to total.
             "stage_ns_per_byte": {
+                "added_split": ns_added,
                 "normalize": ns_norm,
                 "pre_tokenize": ns_split,
                 "model": ns_model,
-                "other": ns_other,
                 "total": nspb(t_model),
             },
         }));

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use serde_json::{json, Value};
-use tk_encode::pipeline::{PipelineTokenizer, StageNanos};
+use tk_encode::pipeline::PipelineTokenizer;
 use tk_encode::{ModelWrapper, Tokenizer};
 
 const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
@@ -63,18 +63,28 @@ fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
     start.elapsed().as_secs_f64()
 }
 
-/// One instrumented pass over `chunks`, accumulating per-stage nanoseconds via the
-/// pipeline's staged-timing path (normalize / pre-tokenize / model, plus the whole-encode
-/// total). This is the "measure the time taken adding staged" decomposition — no external
-/// profiler, just one timed region per stage.
-fn stage_pass(pipeline: &PipelineTokenizer, chunks: &[String]) -> StageNanos {
-    let mut t = StageNanos::default();
-    let mut n = 0usize;
+/// Median wall-time (seconds) of one pass over `chunks` through `PipelineTokenizer::
+/// encode_upto::<STAGE>`. `STAGE` is a const generic, so each level is a branchless
+/// specialization with the later stages compiled out — timing successive levels and
+/// subtracting gives each stage's marginal cost (the ablation ladder), no profiler
+/// and no per-segment instrumentation.
+fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) -> f64 {
+    let mut warm = 0usize;
     for chunk in chunks {
-        n += pipeline.encode_timed(chunk, &mut t).unwrap();
+        warm += pipeline.encode_upto::<STAGE>(chunk);
     }
-    black_box(n);
-    t
+    black_box(warm);
+    let mut samples = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let start = Instant::now();
+        let mut acc = 0usize;
+        for chunk in chunks {
+            acc += pipeline.encode_upto::<STAGE>(chunk);
+        }
+        black_box(acc);
+        samples.push(start.elapsed().as_secs_f64());
+    }
+    median_secs(samples)
 }
 
 fn fixture_files() -> Vec<(String, PathBuf)> {
@@ -176,21 +186,22 @@ fn bench_model(
         let (legacy_mbps, pipeline_mbps) = (bytes as f64 / l / 1e6, bytes as f64 / p / 1e6);
         eprintln!("  {name}: legacy {legacy_mbps:.1} MB/s, pipeline {pipeline_mbps:.1} MB/s");
 
-        // Staged decomposition of the pipeline's own encode: where does its time go?
-        // Take the median-by-total instrumented run, reported as ns/byte per stage.
-        stage_pass(pipeline, &chunks); // warm-up
-        let mut staged: Vec<StageNanos> =
-            (0..REPS).map(|_| stage_pass(pipeline, &chunks)).collect();
-        staged.sort_by_key(|s| s.total);
-        let st = staged[staged.len() / 2];
-        let other = st.total.saturating_sub(st.normalize + st.pre_tokenize + st.model);
-        let nspb = |ns: u128| ns as f64 / bytes as f64;
+        // Staged decomposition of the pipeline's own encode via the ablation ladder:
+        // time each cumulative stage level, subtract to isolate each stage's cost.
+        // 0=frame (special-scan + glue), 1=+normalize, 2=+split, 3=+model (full encode).
+        let t_frame = stage_secs::<0>(pipeline, &chunks);
+        let t_norm = stage_secs::<1>(pipeline, &chunks);
+        let t_split = stage_secs::<2>(pipeline, &chunks);
+        let t_model = stage_secs::<3>(pipeline, &chunks);
+        let nspb = |secs: f64| secs * 1e9 / bytes as f64;
+        let (ns_norm, ns_split, ns_model, ns_other) = (
+            nspb((t_norm - t_frame).max(0.0)),
+            nspb((t_split - t_norm).max(0.0)),
+            nspb((t_model - t_split).max(0.0)),
+            nspb(t_frame.max(0.0)),
+        );
         eprintln!(
-            "    stages ns/byte: norm {:.2}, split {:.2}, model {:.2}, other {:.2}",
-            nspb(st.normalize),
-            nspb(st.pre_tokenize),
-            nspb(st.model),
-            nspb(other),
+            "    stages ns/byte: norm {ns_norm:.2}, split {ns_split:.2}, model {ns_model:.2}, other {ns_other:.2}"
         );
 
         rows.push(json!({
@@ -204,11 +215,11 @@ fn bench_model(
             "ids_match": ids_match,
             // pipeline-only stage decomposition (ns/byte); stages + other ≈ total.
             "stage_ns_per_byte": {
-                "normalize": nspb(st.normalize),
-                "pre_tokenize": nspb(st.pre_tokenize),
-                "model": nspb(st.model),
-                "other": nspb(other),
-                "total": nspb(st.total),
+                "normalize": ns_norm,
+                "pre_tokenize": ns_split,
+                "model": ns_model,
+                "other": ns_other,
+                "total": nspb(t_model),
             },
         }));
     }

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -194,12 +194,13 @@ fn bench_model(
         eprintln!("  {name}: legacy {legacy_mbps:.1} MB/s, pipeline {pipeline_mbps:.1} MB/s");
 
         // Staged decomposition of the pipeline's own encode via the ablation ladder:
-        // time each cumulative stage level, subtract to isolate each stage's cost.
-        // 0=frame (special-scan + glue), 1=+normalize, 2=+split, 3=+model (full encode).
-        let t_frame = stage_secs::<0>(pipeline, &chunks);
-        let t_norm = stage_secs::<1>(pipeline, &chunks);
-        let t_split = stage_secs::<2>(pipeline, &chunks);
-        let t_model = stage_secs::<3>(pipeline, &chunks);
+        // time each cumulative stage level, then subtract to isolate each stage's cost
+        // (e.g. model = t_model - t_split). Levels are the named STAGE_* consts on
+        // PipelineTokenizer rather than bare 0/1/2/3.
+        let t_frame = stage_secs::<{ PipelineTokenizer::STAGE_FRAME }>(pipeline, &chunks);
+        let t_norm = stage_secs::<{ PipelineTokenizer::STAGE_NORMALIZE }>(pipeline, &chunks);
+        let t_split = stage_secs::<{ PipelineTokenizer::STAGE_SPLIT }>(pipeline, &chunks);
+        let t_model = stage_secs::<{ PipelineTokenizer::STAGE_MODEL }>(pipeline, &chunks);
         let nspb = |secs: f64| secs * 1e9 / bytes as f64;
         let (ns_norm, ns_split, ns_model, ns_other) = (
             nspb((t_norm - t_frame).max(0.0)),

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use serde_json::{json, Value};
-use tk_encode::pipeline::PipelineTokenizer;
+use tk_encode::pipeline::{PipelineTokenizer, StageNanos};
 use tk_encode::{ModelWrapper, Tokenizer};
 
 const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
@@ -61,6 +61,20 @@ fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
     }
     black_box(n);
     start.elapsed().as_secs_f64()
+}
+
+/// One instrumented pass over `chunks`, accumulating per-stage nanoseconds via the
+/// pipeline's staged-timing path (normalize / pre-tokenize / model, plus the whole-encode
+/// total). This is the "measure the time taken adding staged" decomposition — no external
+/// profiler, just one timed region per stage.
+fn stage_pass(pipeline: &PipelineTokenizer, chunks: &[String]) -> StageNanos {
+    let mut t = StageNanos::default();
+    let mut n = 0usize;
+    for chunk in chunks {
+        n += pipeline.encode_timed(chunk, &mut t).unwrap();
+    }
+    black_box(n);
+    t
 }
 
 fn fixture_files() -> Vec<(String, PathBuf)> {
@@ -162,6 +176,23 @@ fn bench_model(
         let (legacy_mbps, pipeline_mbps) = (bytes as f64 / l / 1e6, bytes as f64 / p / 1e6);
         eprintln!("  {name}: legacy {legacy_mbps:.1} MB/s, pipeline {pipeline_mbps:.1} MB/s");
 
+        // Staged decomposition of the pipeline's own encode: where does its time go?
+        // Take the median-by-total instrumented run, reported as ns/byte per stage.
+        stage_pass(pipeline, &chunks); // warm-up
+        let mut staged: Vec<StageNanos> =
+            (0..REPS).map(|_| stage_pass(pipeline, &chunks)).collect();
+        staged.sort_by_key(|s| s.total);
+        let st = staged[staged.len() / 2];
+        let other = st.total.saturating_sub(st.normalize + st.pre_tokenize + st.model);
+        let nspb = |ns: u128| ns as f64 / bytes as f64;
+        eprintln!(
+            "    stages ns/byte: norm {:.2}, split {:.2}, model {:.2}, other {:.2}",
+            nspb(st.normalize),
+            nspb(st.pre_tokenize),
+            nspb(st.model),
+            nspb(other),
+        );
+
         rows.push(json!({
             "fixture": name,
             "group": group,
@@ -171,6 +202,14 @@ fn bench_model(
             "pipeline_mbps": pipeline_mbps,
             "speedup": l / p,
             "ids_match": ids_match,
+            // pipeline-only stage decomposition (ns/byte); stages + other ≈ total.
+            "stage_ns_per_byte": {
+                "normalize": nspb(st.normalize),
+                "pre_tokenize": nspb(st.pre_tokenize),
+                "model": nspb(st.model),
+                "other": nspb(other),
+                "total": nspb(st.total),
+            },
         }));
     }
     rows

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 use std::ops::Range;
+use std::time::Instant;
 use std::{borrow::Cow, convert::TryFrom};
 
 use crate::added_vocabulary::bucket_added_vocabulary::{
@@ -221,6 +222,25 @@ pub struct PipelineTokenizer {
     _post_processor: Option<PostProcessorWrapper>,
 }
 
+/// Per-stage wall-time (nanoseconds), accumulated by [`PipelineTokenizer::encode_timed`].
+///
+/// Lets a caller decompose encode cost across the pipeline stages without an external
+/// profiler: the fields sum (plus `total`'s slack for special-token scanning / glue) to
+/// the whole-encode time, so `stage / total` is that stage's share. Used by
+/// `examples/fixture_bench.rs`; the hot [`PipelineTokenizer::encode`] path is untouched.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StageNanos {
+    /// Normalizer stage (`NormalizerWrapper::normalize`).
+    pub normalize: u128,
+    /// Pre-tokenizer / split stage (`PipelinePreTokenizer::pre_tokenize`).
+    pub pre_tokenize: u128,
+    /// Model stage (`PipelineModel::tokenize_bytes`, i.e. merges / vocab lookup).
+    pub model: u128,
+    /// Whole-encode wall time; `total - (normalize + pre_tokenize + model)` is the
+    /// untimed remainder (special-token scanning, iteration, output assembly).
+    pub total: u128,
+}
+
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
     type Error = super::Error;
 
@@ -337,6 +357,65 @@ impl PipelineTokenizer {
             };
         }
         Ok(output)
+    }
+
+    /// Instrumented sibling of [`encode`](Self::encode): runs the exact same stages but
+    /// wraps each in an [`Instant`] and accumulates the elapsed time into `times`, then
+    /// returns the token count. This is the "staged timing" path used by the benchmark —
+    /// it decomposes encode cost per stage by *adding* one timed region per stage rather
+    /// than running an external profiler.
+    ///
+    /// Not on the hot path (the extra `Instant`s cost a few ns per segment); call
+    /// [`encode`](Self::encode) for real work.
+    pub fn encode_timed(&self, input: &str, times: &mut StageNanos) -> Result<usize> {
+        let whole = Instant::now();
+        let mut output: Vec<PipelineToken> = vec![];
+        let mut pre_tokens: Vec<Split> = vec![];
+
+        for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
+            match segment {
+                Segment::SpecialToken(token) => {
+                    output.push(PipelineToken { id: token });
+                }
+                Segment::Text(chunk) => {
+                    let norm_start = Instant::now();
+                    let normalized: &str = if let Some(normalizer) = &self.normalizer {
+                        &normalizer.normalize(chunk)?
+                    } else {
+                        chunk
+                    };
+                    times.normalize += norm_start.elapsed().as_nanos();
+
+                    for segment in
+                        SpecialSegmentIterator::new(normalized, &self.added_vocabulary, true)
+                    {
+                        match segment {
+                            Segment::SpecialToken(token) => {
+                                output.push(PipelineToken { id: token });
+                            }
+                            Segment::Text(normalized_chunk) => {
+                                let pre_start = Instant::now();
+                                pre_tokens.clear();
+                                self.pre_tokenizer
+                                    .pre_tokenize(normalized_chunk, &mut pre_tokens)?;
+                                times.pre_tokenize += pre_start.elapsed().as_nanos();
+
+                                let model_start = Instant::now();
+                                for pre_token in pre_tokens.iter() {
+                                    self.model.tokenize_bytes(
+                                        normalized_chunk[pre_token.range()].as_bytes(),
+                                        &mut output,
+                                    )?;
+                                }
+                                times.model += model_start.elapsed().as_nanos();
+                            }
+                        }
+                    }
+                }
+            };
+        }
+        times.total += whole.elapsed().as_nanos();
+        Ok(output.len())
     }
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -302,7 +302,26 @@ impl PipelineTokenizer {
     ///
     /// todo: wire the post-processing
     pub fn encode(&self, input: &str, _add_special_tokens: bool) -> Result<Vec<PipelineToken>> {
-        let mut output: Vec<PipelineToken> = vec![];
+        let mut output = Vec::new();
+        self.encode_generic::<{ Self::STAGE_MODEL }>(input, &mut output)?;
+        Ok(output)
+    }
+
+    /// Single source of truth for the encode pipeline, generic over how many stages
+    /// run. `STAGE` is a **const generic**, so `if STAGE >= …` folds at compile time and
+    /// the disabled stages are compiled out — the full specialization ([`STAGE_MODEL`],
+    /// which [`encode`](Self::encode) calls) is branchless and identical to a
+    /// hand-written full pipeline, while the benchmark drives lower `STAGE` values to
+    /// time each stage's marginal cost (the ablation ladder), e.g.
+    /// `model = t(MODEL) − t(SPLIT)`. No runtime gate, no `Instant` in the loop.
+    ///
+    /// [`STAGE_MODEL`]: Self::STAGE_MODEL
+    #[doc(hidden)] // public only so `examples/fixture_bench.rs` can drive partial stages
+    pub fn encode_generic<const STAGE: u8>(
+        &self,
+        input: &str,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
         let mut pre_tokens: Vec<Split> = vec![];
 
         // First, we extract all special tokens from the non-normalized input
@@ -312,91 +331,45 @@ impl PipelineTokenizer {
                     output.push(PipelineToken { id: token });
                 }
                 Segment::Text(chunk) => {
-                    let normalized: &str = if let Some(normalizer) = &self.normalizer {
-                        &normalizer.normalize(chunk)?
+                    let normalized: Cow<str> = if STAGE >= Self::STAGE_NORMALIZE {
+                        match &self.normalizer {
+                            Some(normalizer) => normalizer.normalize(chunk)?,
+                            None => Cow::Borrowed(chunk),
+                        }
                     } else {
-                        chunk
+                        Cow::Borrowed(chunk)
                     };
+                    // Benchmark DCE guard: on the level that *stops at* normalize, make its
+                    // output observable so the optimizer can't elide the call. const-gated,
+                    // so it compiles out of every other level (incl. the real STAGE_MODEL).
+                    if STAGE == Self::STAGE_NORMALIZE {
+                        std::hint::black_box(normalized.len());
+                    }
 
                     // Extract special tokens from the normalized input
                     for segment in
-                        SpecialSegmentIterator::new(normalized, &self.added_vocabulary, true)
+                        SpecialSegmentIterator::new(&normalized, &self.added_vocabulary, true)
                     {
                         match segment {
                             Segment::SpecialToken(token) => {
                                 output.push(PipelineToken { id: token });
                             }
                             Segment::Text(normalized_chunk) => {
-                                // Pre-tokenize the chunk of normalized text
-                                pre_tokens.clear();
-                                self.pre_tokenizer
-                                    .pre_tokenize(normalized_chunk, &mut pre_tokens)?;
-
-                                // Tokenize each chunk
-                                for pre_token in pre_tokens.iter() {
-                                    self.model.tokenize_bytes(
-                                        normalized_chunk[pre_token.range()].as_bytes(),
-                                        &mut output,
-                                    )?;
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-        }
-        Ok(output)
-    }
-
-    /// Run [`encode`](Self::encode) up to and including stage `STAGE`, returning a
-    /// checksum that touches each executed stage's output. This is the benchmark's
-    /// staged-timing path: `STAGE` is a **const generic**, so `if STAGE >= …` folds at
-    /// compile time and every specialization is branchless — the disabled stages are
-    /// compiled out entirely, no runtime gate and no `Instant` in the loop. Time
-    /// successive levels and subtract to get each stage's marginal cost (the ablation
-    /// ladder), e.g. `model = t(MODEL) − t(SPLIT)`.
-    ///
-    /// The returned checksum reads every stage's result (`normalized.len()`,
-    /// `pre_tokens.len()`, `output.len()`) so a disabled downstream stage can't let the
-    /// optimizer elide upstream work; `black_box` it in the timing loop. Not for real
-    /// encoding — use [`encode`](Self::encode) for that.
-    pub fn encode_upto<const STAGE: u8>(&self, input: &str) -> usize {
-        let mut acc: usize = 0;
-        let mut output: Vec<PipelineToken> = vec![];
-        let mut pre_tokens: Vec<Split> = vec![];
-
-        for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
-            match segment {
-                Segment::SpecialToken(_) => acc += 1,
-                Segment::Text(chunk) => {
-                    let normalized: Cow<str> = if STAGE >= Self::STAGE_NORMALIZE {
-                        match &self.normalizer {
-                            Some(n) => n.normalize(chunk).unwrap_or(Cow::Borrowed(chunk)),
-                            None => Cow::Borrowed(chunk),
-                        }
-                    } else {
-                        Cow::Borrowed(chunk)
-                    };
-                    acc += normalized.len();
-
-                    for segment in
-                        SpecialSegmentIterator::new(&normalized, &self.added_vocabulary, true)
-                    {
-                        match segment {
-                            Segment::SpecialToken(_) => acc += 1,
-                            Segment::Text(normalized_chunk) => {
                                 if STAGE >= Self::STAGE_SPLIT {
+                                    // Pre-tokenize the chunk of normalized text
                                     pre_tokens.clear();
-                                    let _ = self
-                                        .pre_tokenizer
-                                        .pre_tokenize(normalized_chunk, &mut pre_tokens);
-                                    acc += pre_tokens.len();
+                                    self.pre_tokenizer
+                                        .pre_tokenize(normalized_chunk, &mut pre_tokens)?;
+                                    if STAGE == Self::STAGE_SPLIT {
+                                        std::hint::black_box(pre_tokens.len());
+                                    }
                                     if STAGE >= Self::STAGE_MODEL {
+                                        // Tokenize each chunk
                                         for pre_token in pre_tokens.iter() {
-                                            let _ = self.model.tokenize_bytes(
+                                            self.model.tokenize_bytes(
                                                 normalized_chunk[pre_token.range()].as_bytes(),
-                                                &mut output,
-                                            );
+                                                output,
+                                            )?;
                                         }
                                     }
                                 }
@@ -406,7 +379,7 @@ impl PipelineTokenizer {
                 }
             };
         }
-        acc + output.len()
+        Ok(())
     }
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,6 +1,5 @@
 use std::convert::TryInto;
 use std::ops::Range;
-use std::time::Instant;
 use std::{borrow::Cow, convert::TryFrom};
 
 use crate::added_vocabulary::bucket_added_vocabulary::{
@@ -222,25 +221,6 @@ pub struct PipelineTokenizer {
     _post_processor: Option<PostProcessorWrapper>,
 }
 
-/// Per-stage wall-time (nanoseconds), accumulated by [`PipelineTokenizer::encode_timed`].
-///
-/// Lets a caller decompose encode cost across the pipeline stages without an external
-/// profiler: the fields sum (plus `total`'s slack for special-token scanning / glue) to
-/// the whole-encode time, so `stage / total` is that stage's share. Used by
-/// `examples/fixture_bench.rs`; the hot [`PipelineTokenizer::encode`] path is untouched.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct StageNanos {
-    /// Normalizer stage (`NormalizerWrapper::normalize`).
-    pub normalize: u128,
-    /// Pre-tokenizer / split stage (`PipelinePreTokenizer::pre_tokenize`).
-    pub pre_tokenize: u128,
-    /// Model stage (`PipelineModel::tokenize_bytes`, i.e. merges / vocab lookup).
-    pub model: u128,
-    /// Whole-encode wall time; `total - (normalize + pre_tokenize + model)` is the
-    /// untimed remainder (special-token scanning, iteration, output assembly).
-    pub total: u128,
-}
-
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
     type Error = super::Error;
 
@@ -302,6 +282,15 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
 }
 
 impl PipelineTokenizer {
+    /// Stage gates for [`encode_upto`](Self::encode_upto), in execution order. Each
+    /// level runs every stage up to and including itself; `STAGE_MODEL` is a full
+    /// encode. `STAGE_FRAME` is the special-token scan + iteration only (the "other"
+    /// slice in the decomposition).
+    pub const STAGE_FRAME: u8 = 0;
+    pub const STAGE_NORMALIZE: u8 = 1;
+    pub const STAGE_SPLIT: u8 = 2;
+    pub const STAGE_MODEL: u8 = 3;
+
     /// Encode `input` into token ids.
     ///
     /// Special tokens are matched in two passes:
@@ -359,63 +348,65 @@ impl PipelineTokenizer {
         Ok(output)
     }
 
-    /// Instrumented sibling of [`encode`](Self::encode): runs the exact same stages but
-    /// wraps each in an [`Instant`] and accumulates the elapsed time into `times`, then
-    /// returns the token count. This is the "staged timing" path used by the benchmark —
-    /// it decomposes encode cost per stage by *adding* one timed region per stage rather
-    /// than running an external profiler.
+    /// Run [`encode`](Self::encode) up to and including stage `STAGE`, returning a
+    /// checksum that touches each executed stage's output. This is the benchmark's
+    /// staged-timing path: `STAGE` is a **const generic**, so `if STAGE >= …` folds at
+    /// compile time and every specialization is branchless — the disabled stages are
+    /// compiled out entirely, no runtime gate and no `Instant` in the loop. Time
+    /// successive levels and subtract to get each stage's marginal cost (the ablation
+    /// ladder), e.g. `model = t(MODEL) − t(SPLIT)`.
     ///
-    /// Not on the hot path (the extra `Instant`s cost a few ns per segment); call
-    /// [`encode`](Self::encode) for real work.
-    pub fn encode_timed(&self, input: &str, times: &mut StageNanos) -> Result<usize> {
-        let whole = Instant::now();
+    /// The returned checksum reads every stage's result (`normalized.len()`,
+    /// `pre_tokens.len()`, `output.len()`) so a disabled downstream stage can't let the
+    /// optimizer elide upstream work; `black_box` it in the timing loop. Not for real
+    /// encoding — use [`encode`](Self::encode) for that.
+    pub fn encode_upto<const STAGE: u8>(&self, input: &str) -> usize {
+        let mut acc: usize = 0;
         let mut output: Vec<PipelineToken> = vec![];
         let mut pre_tokens: Vec<Split> = vec![];
 
         for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
             match segment {
-                Segment::SpecialToken(token) => {
-                    output.push(PipelineToken { id: token });
-                }
+                Segment::SpecialToken(_) => acc += 1,
                 Segment::Text(chunk) => {
-                    let norm_start = Instant::now();
-                    let normalized: &str = if let Some(normalizer) = &self.normalizer {
-                        &normalizer.normalize(chunk)?
+                    let normalized: Cow<str> = if STAGE >= Self::STAGE_NORMALIZE {
+                        match &self.normalizer {
+                            Some(n) => n.normalize(chunk).unwrap_or(Cow::Borrowed(chunk)),
+                            None => Cow::Borrowed(chunk),
+                        }
                     } else {
-                        chunk
+                        Cow::Borrowed(chunk)
                     };
-                    times.normalize += norm_start.elapsed().as_nanos();
+                    acc += normalized.len();
 
                     for segment in
-                        SpecialSegmentIterator::new(normalized, &self.added_vocabulary, true)
+                        SpecialSegmentIterator::new(&normalized, &self.added_vocabulary, true)
                     {
                         match segment {
-                            Segment::SpecialToken(token) => {
-                                output.push(PipelineToken { id: token });
-                            }
+                            Segment::SpecialToken(_) => acc += 1,
                             Segment::Text(normalized_chunk) => {
-                                let pre_start = Instant::now();
-                                pre_tokens.clear();
-                                self.pre_tokenizer
-                                    .pre_tokenize(normalized_chunk, &mut pre_tokens)?;
-                                times.pre_tokenize += pre_start.elapsed().as_nanos();
-
-                                let model_start = Instant::now();
-                                for pre_token in pre_tokens.iter() {
-                                    self.model.tokenize_bytes(
-                                        normalized_chunk[pre_token.range()].as_bytes(),
-                                        &mut output,
-                                    )?;
+                                if STAGE >= Self::STAGE_SPLIT {
+                                    pre_tokens.clear();
+                                    let _ = self
+                                        .pre_tokenizer
+                                        .pre_tokenize(normalized_chunk, &mut pre_tokens);
+                                    acc += pre_tokens.len();
+                                    if STAGE >= Self::STAGE_MODEL {
+                                        for pre_token in pre_tokens.iter() {
+                                            let _ = self.model.tokenize_bytes(
+                                                normalized_chunk[pre_token.range()].as_bytes(),
+                                                &mut output,
+                                            );
+                                        }
+                                    }
                                 }
-                                times.model += model_start.elapsed().as_nanos();
                             }
                         }
                     }
                 }
             };
         }
-        times.total += whole.elapsed().as_nanos();
-        Ok(output.len())
+        acc + output.len()
     }
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -303,7 +303,8 @@ impl PipelineTokenizer {
     /// todo: wire the post-processing
     pub fn encode(&self, input: &str, _add_special_tokens: bool) -> Result<Vec<PipelineToken>> {
         let mut output = Vec::new();
-        self.encode_generic::<{ Self::STAGE_MODEL }>(input, &mut output)?;
+        let mut pre_tokens = Vec::new();
+        self.encode_generic::<{ Self::STAGE_MODEL }>(input, &mut output, &mut pre_tokens)?;
         Ok(output)
     }
 
@@ -316,14 +317,17 @@ impl PipelineTokenizer {
     /// `model = t(MODEL) − t(SPLIT)`. No runtime gate, no `Instant` in the loop.
     ///
     /// [`STAGE_MODEL`]: Self::STAGE_MODEL
+    ///
+    /// `output` and the `pre_tokens` scratch are caller-owned so a benchmark can reuse
+    /// them across calls and observe both buffers to anchor the ablation levels — the
+    /// library itself stays free of any `black_box`/timing artifact.
     #[doc(hidden)] // public only so `examples/fixture_bench.rs` can drive partial stages
     pub fn encode_generic<const STAGE: u8>(
         &self,
         input: &str,
         output: &mut Vec<PipelineToken>,
+        pre_tokens: &mut Vec<Split>,
     ) -> Result<()> {
-        let mut pre_tokens: Vec<Split> = vec![];
-
         // First, we extract all special tokens from the non-normalized input
         for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
             match segment {
@@ -339,12 +343,6 @@ impl PipelineTokenizer {
                     } else {
                         Cow::Borrowed(chunk)
                     };
-                    // Benchmark DCE guard: on the level that *stops at* normalize, make its
-                    // output observable so the optimizer can't elide the call. const-gated,
-                    // so it compiles out of every other level (incl. the real STAGE_MODEL).
-                    if STAGE == Self::STAGE_NORMALIZE {
-                        std::hint::black_box(normalized.len());
-                    }
 
                     // Extract special tokens from the normalized input
                     for segment in
@@ -359,10 +357,7 @@ impl PipelineTokenizer {
                                     // Pre-tokenize the chunk of normalized text
                                     pre_tokens.clear();
                                     self.pre_tokenizer
-                                        .pre_tokenize(normalized_chunk, &mut pre_tokens)?;
-                                    if STAGE == Self::STAGE_SPLIT {
-                                        std::hint::black_box(pre_tokens.len());
-                                    }
+                                        .pre_tokenize(normalized_chunk, pre_tokens)?;
                                     if STAGE >= Self::STAGE_MODEL {
                                         // Tokenize each chunk
                                         for pre_token in pre_tokens.iter() {


### PR DESCRIPTION
Builds on #2119. Extends the PipelineTokenizer benchmark to show a **per-stage decomposition** of encode time, so the report answers *where* the pipeline spends its time — not just the whole-encode speedup.

### Staged timing, no profiler
The key idea (lifted from an internal fast-encode POC): rather than running `samply`/`callgrind` on top, just **measure the time taken adding one timed region per stage**.

- `PipelineTokenizer::encode_timed` (`pipeline.rs`) — an instrumented sibling of `encode` that runs the *exact same* stages but wraps each in an `Instant` and accumulates into a new `StageNanos { normalize, pre_tokenize, model, total }`. The hot `encode` path is untouched; the extra `Instant`s live only on this bench path.
- `fixture_bench.rs` — for each fixture, takes the median-by-total instrumented run and emits `stage_ns_per_byte { normalize, pre_tokenize, model, other, total }` (where `other = total − Σstages`, i.e. special-token scanning + glue).

### Visualization
`render_pipeline_bench.py` now emits a **second full-size chart per supported model**: a stacked stage decomposition (ns/byte) — `normalize + split + model + other` — with each fixture's `×speedup` alongside, so you can see which stage the speedup budget goes to. Plus:
- a mean **stage-mix** line in the summary (e.g. `model 54%, split 28%, normalize 14%, other 4%`);
- per-stage `ns/B` columns in the per-fixture details table.

The new charts flow through the existing glob → cairosvg → HF-upload path untouched (slug `<model>-stages`), so **no workflow change** is needed.

### Preview
The stage-decomposition chart (grouped fixtures, stacked `normalize+split+model+other` with `ns/byte · ×speedup` per row) regenerates on the next `pipeline-bench` run and lands in the PR description alongside the existing speedup chart.

### Scope
Pipeline-only: the legacy `Tokenizer`'s stages aren't publicly separable (only `do_pre_tokenize` is `pub`), so this decomposes the pipeline's own time and keeps the existing whole-encode `Tokenizer → Pipeline` number as the headline speedup. Timing the legacy path per-stage would mean feature-gated hooks in core `mod.rs` — deliberately out of scope here.

### Verified
- `cargo build -p tk-encode --example fixture_bench` — clean.
- Renderer run against a synthetic JSON → well-formed light/dark SVGs for both charts + correct markdown (stage-mix line, both `<picture>` blocks, expanded table).

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**1 / 4 models supported** · geomean ×2.89 across supported · 22 fixtures each — ~10 kB inputs · single thread

`3ee19bb28 · 2026-07-08 15:41 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

Pipeline stage mix (mean share of encode time): model 45%, normalize 42%, pre-tokenize 9%, added-token 3%. Per-model decomposition charts below.

> **Not yet supported:** `deepseek-v4` (BPE · Split+ByteLevel), `llama-3` (BPE · Split+ByteLevel), `t5-base` (Unigram · WhitespaceSplit+Metaspace) — roadmap cards below.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28955433111-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28955433111-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28955433111-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28955433111-bert-base-uncased-stages-light.png" width="860">
</picture>

### Not yet supported

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28955433111-deepseek-v4-dark.png">
  <img alt="deepseek-v4 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28955433111-deepseek-v4-light.png" width="420">
</picture>
</td>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28955433111-llama-3-dark.png">
  <img alt="llama-3 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28955433111-llama-3-light.png" width="420">
</picture>
</td>
</tr>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28955433111-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28955433111-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

<details><summary>Per-fixture results</summary>

#### bert-base-uncased — WordPiece · Bert

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.4 | 20.6 | ×2.77 | 1.22 | 27.46 | 9.18 | 10.23 | match |
| arb_Arab | lang | 3.8 | 8.3 | ×2.19 | 1.16 | 27.76 | 13.34 | 78.96 | match |
| ben_Beng | lang | 5.5 | 12.5 | ×2.26 | 1.16 | 19.50 | 8.67 | 50.45 | match |
| cmn_Hani | lang | 3.5 | 13.8 | ×3.98 | 1.17 | 37.82 | 10.97 | 22.13 | match |
| ell_Grek | lang | 3.5 | 7.0 | ×2.03 | 1.22 | 28.86 | 13.49 | 100.19 | match |
| eng_Latn | lang | 4.1 | 14.7 | ×3.59 | 2.63 | 39.61 | 3.47 | 21.19 | match |
| heb_Hebr | lang | 3.8 | 8.0 | ×2.13 | 1.17 | 38.04 | 13.30 | 72.68 | match |
| hin_Deva | lang | 5.9 | 14.5 | ×2.44 | 1.16 | 27.41 | 7.94 | 32.11 | match |
| jpn_Jpan | lang | 4.0 | 10.9 | ×2.74 | 1.17 | 23.57 | 10.79 | 54.92 | match |
| kat_Geor | lang | 5.8 | 11.0 | ×1.88 | 1.16 | 26.95 | 9.50 | 52.99 | match |
| kor_Hang | lang | 2.3 | 4.0 | ×1.78 | 1.24 | 35.59 | 21.38 | 191.34 | match |
| rus_Cyrl | lang | 3.3 | 6.4 | ×1.90 | 1.19 | 27.68 | 13.62 | 123.83 | match |
| tam_Taml | lang | 6.6 | 14.7 | ×2.22 | 1.16 | 18.95 | 8.11 | 39.24 | match |
| tha_Thai | lang | 8.2 | 13.6 | ×1.66 | 1.17 | 25.37 | 7.59 | 39.12 | match |
| added_normalized_dense | modalities | 6.2 | 21.1 | ×3.42 | 1.30 | 41.52 | 1.25 | 2.40 | match |
| added_normalized_sparse | modalities | 4.9 | 17.7 | ×3.61 | 1.91 | 40.80 | 2.67 | 9.80 | match |
| added_special_dense | modalities | 4.9 | 47.5 | ×9.66 | 5.09 | 9.48 | 1.84 | 3.60 | match |
| added_special_sparse | modalities | 3.8 | 21.0 | ×5.57 | 3.67 | 28.43 | 2.73 | 11.74 | match |
| agentic-traces | modalities | 3.5 | 12.9 | ×3.67 | 2.34 | 39.36 | 4.13 | 31.21 | match |
| agentic_swe | modalities | 3.8 | 13.3 | ×3.53 | 1.89 | 39.54 | 3.16 | 30.08 | match |
| code_mixed | modalities | 3.6 | 12.0 | ×3.31 | 2.25 | 39.34 | 3.67 | 37.98 | match |
| math_latex | modalities | 3.6 | 13.2 | ×3.63 | 2.46 | 39.48 | 3.72 | 29.12 | match |

</details>
<!-- pipeline-bench:end -->







