### PR TITLE
dirty: thread-cache

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/mod.rs
+++ b/tokenizers/tk-encode/src/models/bpe/mod.rs
@@ -32,6 +32,12 @@ pub enum Error {
     /// Dropout not between 0 and 1.
     #[error("Dropout should be between 0 and 1, inclusive")]
     InvalidDropout,
+    /// When byte_fallback is enabled but the fallback code is not in the vocab
+    #[error("Byte fallback `<{0:#04X}>` not found in the vocabulary")]
+    ByteFallbackOutOfVocabulary(u8),
+    /// When BPE operating with byte_level the byte atom is not in the vocab
+    #[error("Byte atom `{0:#04X}` not found in the vocabulary")]
+    ByteAtomOutOfVocabulary(u8),
 }
 
 /// Provides access to the `FirstLastIterator` to any Iterator

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,7 +1,7 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
-use crate::utils::byte_level::transform_vocab;
+use crate::utils::byte_level::{self};
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
 use crate::vocab_store::VocabStore;
@@ -709,23 +709,22 @@ impl PipelineBPE {
             return Err("BPE models with dropout not supported yet".into());
         }
         let BPE {
-            mut vocab,
+            vocab,
             merges,
             ignore_merges,
             byte_fallback,
             ..
         } = model;
 
-        let atoms = if with_byte_level {
-            vocab = transform_vocab(vocab);
-
-            Atoms::Bytes {
-                byte_to_id: std::array::from_fn(|byte| {
-                    vocab
-                        .get_bytes(&[byte as u8])
-                        .expect("all bytes must be present in the vocab")
-                }),
+        let (vocab, atoms) = if with_byte_level {
+            let vocab = byte_level::transform_vocab(vocab);
+            let mut byte_to_id = [0u32; 256];
+            for b in 0u8..=255 {
+                byte_to_id[b as usize] = vocab
+                    .get_bytes(&[b])
+                    .ok_or(Error::ByteAtomOutOfVocabulary(b))?;
             }
+            (vocab, Atoms::Bytes { byte_to_id })
         } else {
             let unk_token = if let Some(unk_str) = model.unk_token {
                 let token_id = vocab
@@ -735,22 +734,26 @@ impl PipelineBPE {
             } else {
                 None
             };
-            let byte_fallback = if byte_fallback {
-                Some(std::array::from_fn(|idx| {
-                    let idx = idx as u8;
-                    let code = format!("<{idx:#04X}>");
-                    vocab
+            let fallback_lookup = if byte_fallback {
+                let mut fallback_lookup = [0u32; 256];
+                for b in 0u8..=255 {
+                    let code = format!("<{b:#04X}>");
+                    fallback_lookup[b as usize] = vocab
                         .token_to_id(&code)
-                        .expect("all byte fallback codes must be present in the vocab")
-                }))
+                        .ok_or(Error::ByteFallbackOutOfVocabulary(b))?;
+                }
+                Some(fallback_lookup)
             } else {
                 None
             };
-            Atoms::Chars {
-                fuse_unk: model.fuse_unk,
-                unk_token,
-                byte_fallback,
-            }
+            (
+                vocab,
+                Atoms::Chars {
+                    fuse_unk: model.fuse_unk,
+                    unk_token,
+                    byte_fallback: fallback_lookup,
+                },
+            )
         };
         Ok(Self {
             atoms,

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,6 +1,6 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
+use crate::pipeline;
 use crate::tokenizer::{Model, Result, Token};
-use crate::utils::byte_level::transform_vocab;
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
 use crate::vocab_store::VocabStore;
@@ -294,16 +294,10 @@ impl BpeBuilder {
             fuse_unk: self.config.fuse_unk,
             byte_fallback: self.config.byte_fallback,
             ignore_merges: self.config.ignore_merges,
-            vocab_space: BPEVocabSpace::Unicode,
         })
     }
 }
 
-#[derive(PartialEq, Clone, Copy)]
-enum BPEVocabSpace {
-    Unicode,
-    Bytes,
-}
 
 /// A [Byte Pair Encoding](https://www.aclweb.org/anthology/P16-1162/) model.
 #[derive(PartialEq)]
@@ -330,8 +324,6 @@ pub struct BPE {
     pub byte_fallback: bool,
     /// Whether or not to direct output words if they are part of the vocab.
     pub ignore_merges: bool,
-
-    vocab_space: BPEVocabSpace,
 }
 
 impl std::fmt::Debug for BPE {
@@ -372,7 +364,6 @@ impl Clone for BPE {
             fuse_unk: self.fuse_unk,
             byte_fallback: self.byte_fallback,
             ignore_merges: self.ignore_merges,
-            vocab_space: self.vocab_space,
         }
     }
 }
@@ -476,16 +467,6 @@ impl BPE {
     }
 
     fn merge_word(&self, w: &str) -> Result<Word> {
-        if let BPEVocabSpace::Bytes = self.vocab_space {
-            let mut word = Word::with_capacity(w.len());
-            for &byte in w.as_bytes() {
-                let token_id = self.vocab.get_bytes(&[byte]).unwrap();
-                word.add(token_id, 1);
-            }
-            word.merge_all(&self.merges, self.dropout);
-            return Ok(word);
-        }
-
         let mut indices = w.char_indices().map(|(idx, _)| idx).peekable();
         let mut word = Word::with_capacity(w.len());
         let mut unk: Option<(u32, usize)> = None;
@@ -582,15 +563,6 @@ impl BPE {
 
     fn tokenize_with_cache(&self, sequence: &str) -> Result<Vec<Token>> {
         if self.ignore_merges {
-            if let BPEVocabSpace::Bytes = self.vocab_space {
-                if let Some(id) = self.vocab.get_bytes(sequence.as_bytes()) {
-                    return Ok(vec![Token::new(
-                        id,
-                        sequence.to_string(),
-                        (0, sequence.len()),
-                    )]);
-                }
-            }
             if let Some(id) = self.vocab.token_to_id(sequence) {
                 return Ok(vec![Token::new(
                     id,
@@ -702,11 +674,20 @@ impl Model for BPE {
     }
 }
 
-impl BPE {
-    pub(crate) fn transform_vocab(&mut self) {
-        // todo: get rid of clone
-        self.vocab = transform_vocab(self.vocab.clone());
-        self.vocab_space = BPEVocabSpace::Bytes;
+
+pub struct PipelineBPE {
+
+}
+
+impl pipeline::Model for PipelineBPE {
+    fn tokenize_bytes(&self, _bytes: &[u8], _output: &mut Vec<pipeline::PipelineToken>) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl  PipelineBPE {
+    pub fn from_bpe(_model: BPE, _with_byte_level: bool) -> Result<Self> {
+        Ok(Self {})
     }
 }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,5 +1,6 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::tokenizer::{Model, Result, Token};
+use crate::utils::byte_level::transform_vocab;
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
 use crate::vocab_store::VocabStore;
@@ -293,8 +294,15 @@ impl BpeBuilder {
             fuse_unk: self.config.fuse_unk,
             byte_fallback: self.config.byte_fallback,
             ignore_merges: self.config.ignore_merges,
+            vocab_space: BPEVocabSpace::Unicode,
         })
     }
+}
+
+#[derive(PartialEq, Clone, Copy)]
+enum BPEVocabSpace {
+    Unicode,
+    Bytes,
 }
 
 /// A [Byte Pair Encoding](https://www.aclweb.org/anthology/P16-1162/) model.
@@ -322,6 +330,8 @@ pub struct BPE {
     pub byte_fallback: bool,
     /// Whether or not to direct output words if they are part of the vocab.
     pub ignore_merges: bool,
+
+    vocab_space: BPEVocabSpace,
 }
 
 impl std::fmt::Debug for BPE {
@@ -362,6 +372,7 @@ impl Clone for BPE {
             fuse_unk: self.fuse_unk,
             byte_fallback: self.byte_fallback,
             ignore_merges: self.ignore_merges,
+            vocab_space: self.vocab_space,
         }
     }
 }
@@ -465,6 +476,16 @@ impl BPE {
     }
 
     fn merge_word(&self, w: &str) -> Result<Word> {
+        if let BPEVocabSpace::Bytes = self.vocab_space {
+            let mut word = Word::with_capacity(w.len());
+            for &byte in w.as_bytes() {
+                let token_id = self.vocab.get_bytes(&[byte]).unwrap();
+                word.add(token_id, 1);
+            }
+            word.merge_all(&self.merges, self.dropout);
+            return Ok(word);
+        }
+
         let mut indices = w.char_indices().map(|(idx, _)| idx).peekable();
         let mut word = Word::with_capacity(w.len());
         let mut unk: Option<(u32, usize)> = None;
@@ -561,6 +582,15 @@ impl BPE {
 
     fn tokenize_with_cache(&self, sequence: &str) -> Result<Vec<Token>> {
         if self.ignore_merges {
+            if let BPEVocabSpace::Bytes = self.vocab_space {
+                if let Some(id) = self.vocab.get_bytes(sequence.as_bytes()) {
+                    return Ok(vec![Token::new(
+                        id,
+                        sequence.to_string(),
+                        (0, sequence.len()),
+                    )]);
+                }
+            }
             if let Some(id) = self.vocab.token_to_id(sequence) {
                 return Ok(vec![Token::new(
                     id,
@@ -669,6 +699,14 @@ impl Model for BPE {
         )?;
 
         Ok(vec![vocab_path, merges_path])
+    }
+}
+
+impl BPE {
+    pub(crate) fn transform_vocab(&mut self) {
+        // todo: get rid of clone
+        self.vocab = transform_vocab(self.vocab.clone());
+        self.vocab_space = BPEVocabSpace::Bytes;
     }
 }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -674,11 +674,39 @@ impl Model for BPE {
     }
 }
 
+static PIPELINE_NEXT_CACHE_ID: AtomicU64 = AtomicU64::new(0);
+
+thread_local! {
+    #[allow(clippy::type_complexity)]
+    static PIPELINE_BPE_LOCAL_CACHE: RefCell<AHashMap<u64, AHashMap<Vec<u8>, Vec<u32>>>> =
+        RefCell::new(AHashMap::new());
+}
+
+#[derive(Debug)]
+pub(crate) struct PipelineBpeCache {
+    id: AtomicU64,
+    pub capacity: usize,
+}
+
+impl PipelineBpeCache {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            id: AtomicU64::new(PIPELINE_NEXT_CACHE_ID.fetch_add(1, Ordering::Relaxed)),
+            capacity,
+        }
+    }
+
+    pub(crate) fn id(&self) -> u64 {
+        self.id.load(Ordering::Relaxed)
+    }
+}
+
 pub struct PipelineBPE {
     atoms: Atoms,
     vocab: VocabStore,
     merges: MergeMap,
     ignore_merges: bool,
+    cache: Option<PipelineBpeCache>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -760,6 +788,7 @@ impl PipelineBPE {
             ignore_merges,
             merges,
             vocab,
+            cache: model.cache.map(|c| PipelineBpeCache::new(c.capacity)),
         })
     }
 
@@ -824,9 +853,29 @@ impl pipeline::Model for PipelineBPE {
             }
         }
 
-        // todo: use thread-local cache
-        let word = self.merge_word(sequence)?;
-        output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+        if let Some(cache) = self.cache.as_ref() {
+            let cache_id = cache.id();
+            PIPELINE_BPE_LOCAL_CACHE.with(|cell| {
+                let mut by_bpe = cell.borrow_mut();
+                let local = by_bpe.entry(cache_id).or_default();
+                if let Some(hit) = local.get(sequence.as_bytes()) {
+                    output.extend(hit.iter().map(|&id| PipelineToken { id }));
+                    return Result::Ok(());
+                }
+                let word = self.merge_word(sequence)?;
+                let tokens: Vec<_> = word.get_chars_iter().collect();
+                output.extend(tokens.iter().map(|&id| PipelineToken { id }));
+                if sequence.len() < MAX_LENGTH && local.len() < cache.capacity {
+                    local.insert(sequence.to_owned().into_bytes(), tokens);
+                }
+                Ok(())
+            })?;
+        } else {
+            // Cache disabled (capacity 0): fall back to the uncached path.
+            let word = self.merge_word(sequence)?;
+            output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+        };
+
         Ok(())
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,6 +1,7 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
-use crate::pipeline;
+use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
+use crate::utils::byte_level::transform_vocab;
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
 use crate::vocab_store::VocabStore;
@@ -297,7 +298,6 @@ impl BpeBuilder {
         })
     }
 }
-
 
 /// A [Byte Pair Encoding](https://www.aclweb.org/anthology/P16-1162/) model.
 #[derive(PartialEq)]
@@ -674,20 +674,157 @@ impl Model for BPE {
     }
 }
 
-
 pub struct PipelineBPE {
-
+    atoms: Atoms,
+    vocab: VocabStore,
+    merges: MergeMap,
+    ignore_merges: bool,
 }
 
-impl pipeline::Model for PipelineBPE {
-    fn tokenize_bytes(&self, _bytes: &[u8], _output: &mut Vec<pipeline::PipelineToken>) -> Result<()> {
-        Ok(())
+#[derive(Debug, Clone, Copy)]
+struct UnkToken {
+    id: u32,
+}
+
+enum Atoms {
+    Bytes {
+        byte_to_id: [u32; 256],
+    },
+    Chars {
+        byte_fallback: Option<[u32; 256]>,
+        unk_token: Option<UnkToken>,
+        fuse_unk: bool,
+    },
+}
+
+impl PipelineBPE {
+    pub fn from_bpe(model: BPE, with_byte_level: bool) -> Result<Self> {
+        if matches!(&model.continuing_subword_prefix, Some(prefix) if !prefix.is_empty()) {
+            return Err("BPE models with continuing_subword_prefix are not supported yet".into());
+        }
+        if matches!(&model.end_of_word_suffix, Some(suffix) if !suffix.is_empty()) {
+            return Err("BPE models with end_of_word_suffix are not supported yet".into());
+        }
+        if matches!(&model.dropout, Some(dropout) if *dropout > 0.0) {
+            return Err("BPE models with dropout not supported yet".into());
+        }
+        let BPE {
+            mut vocab,
+            merges,
+            ignore_merges,
+            byte_fallback,
+            ..
+        } = model;
+
+        let atoms = if with_byte_level {
+            vocab = transform_vocab(vocab);
+
+            Atoms::Bytes {
+                byte_to_id: std::array::from_fn(|byte| {
+                    vocab
+                        .get_bytes(&[byte as u8])
+                        .expect("all bytes must be present in the vocab")
+                }),
+            }
+        } else {
+            let unk_token = if let Some(unk_str) = model.unk_token {
+                let token_id = vocab
+                    .token_to_id(&unk_str)
+                    .ok_or_else(|| Error::UnkTokenOutOfVocabulary(unk_str.clone()))?;
+                Some(UnkToken { id: token_id })
+            } else {
+                None
+            };
+            let byte_fallback = if byte_fallback {
+                Some(std::array::from_fn(|idx| {
+                    let idx = idx as u8;
+                    let code = format!("<{idx:#04X}>");
+                    vocab
+                        .token_to_id(&code)
+                        .expect("all byte fallback codes must be present in the vocab")
+                }))
+            } else {
+                None
+            };
+            Atoms::Chars {
+                fuse_unk: model.fuse_unk,
+                unk_token,
+                byte_fallback,
+            }
+        };
+        Ok(Self {
+            atoms,
+            ignore_merges,
+            merges,
+            vocab,
+        })
+    }
+
+    fn merge_word(&self, sequence: &str) -> Result<Word> {
+        let mut scratch = [0u8; 4];
+        let mut word = match self.atoms {
+            Atoms::Bytes { byte_to_id } => {
+                let mut word = Word::with_capacity(sequence.len());
+                for &b in sequence.as_bytes() {
+                    word.add(byte_to_id[b as usize], 1);
+                }
+                word
+            }
+            Atoms::Chars {
+                byte_fallback,
+                unk_token,
+                fuse_unk,
+            } => {
+                let mut word = Word::with_capacity(sequence.chars().count());
+                for c in sequence.chars() {
+                    let char_str = c.encode_utf8(&mut scratch);
+                    if let Some(char_id) = self.vocab.token_to_id(char_str) {
+                        word.add(char_id, c.len_utf8());
+                    } else {
+                        if let Some(fallback_lookup) = byte_fallback {
+                            for &b in char_str.as_bytes() {
+                                word.add(fallback_lookup[b as usize], 1);
+                            }
+                            continue;
+                        }
+                        if let Some(UnkToken { id: unk_id }) = unk_token {
+                            if fuse_unk {
+                                if let Some(last) = word.last_mut() {
+                                    if last.id() == unk_id {
+                                        last.add_len(c.len_utf8());
+                                        continue;
+                                    }
+                                }
+                            }
+                            word.add(unk_id, c.len_utf8());
+                        }
+                    }
+                }
+                word
+            }
+        };
+        word.merge_all(&self.merges, None);
+        Ok(word)
     }
 }
 
-impl  PipelineBPE {
-    pub fn from_bpe(_model: BPE, _with_byte_level: bool) -> Result<Self> {
-        Ok(Self {})
+impl pipeline::Model for PipelineBPE {
+    fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()> {
+        if sequence.is_empty() {
+            return Ok(());
+        }
+
+        if self.ignore_merges {
+            if let Some(id) = self.vocab.get_bytes(sequence.as_bytes()) {
+                output.push(PipelineToken { id });
+                return Ok(());
+            }
+        }
+
+        // todo: use thread-local cache
+        let word = self.merge_word(sequence)?;
+        output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+        Ok(())
     }
 }
 
@@ -1190,5 +1327,317 @@ mod tests {
                 }
             ]
         )
+    }
+
+    mod pipeline_bpe {
+        use super::*;
+        use crate::utils::byte_level::BYTES_CHAR_LOOKUP;
+
+        const HELLO_VOCAB: &[(&str, u32)] = &[
+            ("h", 0),
+            ("e", 1),
+            ("l", 2),
+            ("o", 3),
+            ("he", 4),
+            ("hel", 5),
+            ("hell", 6),
+            ("hello", 7),
+        ];
+        const HELLO_MERGES: &[(&str, &str)] =
+            &[("h", "e"), ("he", "l"), ("hel", "l"), ("hell", "o")];
+
+        fn v(pairs: &[(&str, u32)]) -> Vocab {
+            pairs.iter().map(|&(s, i)| (s.into(), i)).collect()
+        }
+
+        fn m(pairs: &[(&str, &str)]) -> Merges {
+            pairs.iter().map(|&(a, b)| (a.into(), b.into())).collect()
+        }
+
+        fn hello_builder() -> BpeBuilder {
+            BpeBuilder::default().vocab_and_merges(v(HELLO_VOCAB), m(HELLO_MERGES))
+        }
+
+        fn pipeline_ids(model: &PipelineBPE, sequence: &str) -> Vec<u32> {
+            let mut out = Vec::new();
+            pipeline::Model::tokenize_pipeline(model, sequence, &mut out).unwrap();
+            out.iter().map(|t| t.id).collect()
+        }
+
+        fn reference_ids(model: &BPE, sequence: &str) -> Vec<u32> {
+            model
+                .tokenize(sequence)
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect()
+        }
+
+        #[test]
+        fn applies_merges() {
+            let bpe = hello_builder().build().unwrap();
+            let reference = bpe.clone();
+            let pipeline = PipelineBPE::from_bpe(bpe, false).unwrap();
+            for (input, want) in [
+                ("hello", vec![7]),
+                ("hell", vec![6]),
+                ("helo", vec![5, 3]),
+                ("oleh", vec![3, 2, 1, 0]),
+            ] {
+                assert_eq!(pipeline_ids(&pipeline, input), want, "{input:?}");
+                assert_eq!(
+                    pipeline_ids(&pipeline, input),
+                    reference_ids(&reference, input),
+                    "{input:?} vs reference"
+                );
+            }
+        }
+
+        #[test]
+        fn empty_input_yields_no_tokens() {
+            let pipeline = PipelineBPE::from_bpe(hello_builder().build().unwrap(), false).unwrap();
+            assert!(pipeline_ids(&pipeline, "").is_empty());
+        }
+
+        #[test]
+        fn unknown_char_without_unk_is_dropped() {
+            let bpe = hello_builder().build().unwrap();
+            let reference = bpe.clone();
+            let pipeline = PipelineBPE::from_bpe(bpe, false).unwrap();
+            // 'x' vanishes, making 'h' and 'e' adjacent, so the (h,e) merge
+            // applies — mirrors the reference model.
+            assert_eq!(pipeline_ids(&pipeline, "hxe"), vec![4]);
+            assert_eq!(
+                pipeline_ids(&pipeline, "hxe"),
+                reference_ids(&reference, "hxe")
+            );
+        }
+
+        #[test]
+        fn unk_replaces_unknown_chars() {
+            let mut vocab = v(HELLO_VOCAB);
+            vocab.insert("<unk>".into(), 8);
+            let bpe = BpeBuilder::default()
+                .vocab_and_merges(vocab, m(HELLO_MERGES))
+                .unk_token("<unk>".into())
+                .build()
+                .unwrap();
+            let reference = bpe.clone();
+            let pipeline = PipelineBPE::from_bpe(bpe, false).unwrap();
+            for (input, want) in [
+                ("hxe", vec![0, 8, 1]),
+                ("xh", vec![8, 0]),
+                ("hxxe", vec![0, 8, 8, 1]),
+                ("xx", vec![8, 8]),
+            ] {
+                assert_eq!(pipeline_ids(&pipeline, input), want, "{input:?}");
+                assert_eq!(
+                    pipeline_ids(&pipeline, input),
+                    reference_ids(&reference, input),
+                    "{input:?} vs reference"
+                );
+            }
+        }
+
+        #[test]
+        fn fused_unk_collapses_runs() {
+            let mut vocab = v(HELLO_VOCAB);
+            vocab.insert("<unk>".into(), 8);
+            let bpe = BpeBuilder::default()
+                .vocab_and_merges(vocab, m(HELLO_MERGES))
+                .unk_token("<unk>".into())
+                .fuse_unk(true)
+                .build()
+                .unwrap();
+            let reference = bpe.clone();
+            let pipeline = PipelineBPE::from_bpe(bpe, false).unwrap();
+            for (input, want) in [
+                ("hxxe", vec![0, 8, 1]),
+                ("xxh", vec![8, 0]),
+                ("xxxx", vec![8]),
+                ("xhx", vec![8, 0, 8]),
+            ] {
+                assert_eq!(pipeline_ids(&pipeline, input), want, "{input:?}");
+                assert_eq!(
+                    pipeline_ids(&pipeline, input),
+                    reference_ids(&reference, input),
+                    "{input:?} vs reference"
+                );
+            }
+        }
+
+        fn byte_fallback_vocab() -> Vocab {
+            let mut vocab = v(&[("h", 300), ("e", 301), ("<unk>", 400)]);
+            vocab.extend((0..=255u8).map(|b| (format!("<0x{b:02X}>"), u32::from(b))));
+            vocab
+        }
+
+        #[test]
+        fn byte_fallback_encodes_missing_chars_as_byte_tokens() {
+            let bpe = BpeBuilder::default()
+                .vocab_and_merges(byte_fallback_vocab(), vec![])
+                .byte_fallback(true)
+                .build()
+                .unwrap();
+            let reference = bpe.clone();
+            let pipeline = PipelineBPE::from_bpe(bpe, false).unwrap();
+            // 'é' is not in the vocab: falls back to its UTF-8 bytes C3 A9
+            assert_eq!(pipeline_ids(&pipeline, "hé"), vec![300, 0xC3, 0xA9]);
+            assert_eq!(pipeline_ids(&pipeline, "🤗"), vec![0xF0, 0x9F, 0xA4, 0x97]);
+            for input in ["hé", "🤗", "he"] {
+                assert_eq!(
+                    pipeline_ids(&pipeline, input),
+                    reference_ids(&reference, input),
+                    "{input:?} vs reference"
+                );
+            }
+        }
+
+        #[test]
+        fn byte_fallback_wins_over_unk() {
+            let bpe = BpeBuilder::default()
+                .vocab_and_merges(byte_fallback_vocab(), vec![])
+                .byte_fallback(true)
+                .unk_token("<unk>".into())
+                .build()
+                .unwrap();
+            let reference = bpe.clone();
+            let pipeline = PipelineBPE::from_bpe(bpe, false).unwrap();
+            assert_eq!(pipeline_ids(&pipeline, "é"), vec![0xC3, 0xA9]);
+            assert_eq!(pipeline_ids(&pipeline, "é"), reference_ids(&reference, "é"));
+        }
+
+        #[test]
+        fn ignore_merges_prefers_whole_word() {
+            let bpe = hello_builder().ignore_merges(true).build().unwrap();
+            let reference = bpe.clone();
+            let pipeline = PipelineBPE::from_bpe(bpe, false).unwrap();
+            // direct vocab hit bypasses the merge loop; a miss falls through to it
+            assert_eq!(pipeline_ids(&pipeline, "hello"), vec![7]);
+            assert_eq!(pipeline_ids(&pipeline, "helo"), vec![5, 3]);
+            for input in ["hello", "helo"] {
+                assert_eq!(
+                    pipeline_ids(&pipeline, input),
+                    reference_ids(&reference, input),
+                    "{input:?} vs reference"
+                );
+            }
+        }
+
+        #[test]
+        fn rejects_unsupported_configs() {
+            // no merges: BpeBuilder::build underflows on merges whose right token
+            // is shorter than continuing_subword_prefix (pre-existing, unrelated)
+            let build = |f: fn(BpeBuilder) -> BpeBuilder| {
+                f(BpeBuilder::default().vocab_and_merges(v(HELLO_VOCAB), vec![]))
+                    .build()
+                    .unwrap()
+            };
+            assert!(PipelineBPE::from_bpe(
+                build(|b| b.continuing_subword_prefix("##".into())),
+                false
+            )
+            .is_err());
+            assert!(
+                PipelineBPE::from_bpe(build(|b| b.end_of_word_suffix("</w>".into())), false)
+                    .is_err()
+            );
+            assert!(PipelineBPE::from_bpe(build(|b| b.dropout(0.5)), false).is_err());
+            // no-op values must not be rejected: gpt2's tokenizer.json serializes
+            // prefix/suffix as "" and the reference treats dropout 0.0 as disabled
+            assert!(PipelineBPE::from_bpe(
+                build(|b| {
+                    b.continuing_subword_prefix(String::new())
+                        .end_of_word_suffix(String::new())
+                        .dropout(0.0)
+                }),
+                false
+            )
+            .is_ok());
+        }
+
+        #[test]
+        fn rejects_unk_token_missing_from_vocab() {
+            let bpe = hello_builder().unk_token("<unk>".into()).build().unwrap();
+            assert!(PipelineBPE::from_bpe(bpe, false).is_err());
+        }
+
+        #[test]
+        fn byte_fallback_with_missing_codes_errors() {
+            // Incomplete <0xNN> coverage must be a build error, not a panic.
+            let bpe = hello_builder().byte_fallback(true).build().unwrap();
+            assert!(PipelineBPE::from_bpe(bpe, false).is_err());
+        }
+
+        fn projected(s: &str) -> String {
+            s.bytes().map(|b| BYTES_CHAR_LOOKUP[b as usize]).collect()
+        }
+
+        /// A gpt2-shaped miniature: the 256 projected single-byte tokens
+        /// (id == byte value) plus `extra` tokens and merges, given in raw
+        /// space and projected here — like a real byte-level tokenizer.json,
+        /// whose vocab is stored in the projected alphabet.
+        fn byte_level_bpe(
+            extra: &[(&str, u32)],
+            merges: &[(&str, &str)],
+            ignore_merges: bool,
+        ) -> BPE {
+            let mut vocab: Vocab = (0..=255u8)
+                .map(|b| (BYTES_CHAR_LOOKUP[b as usize].to_string(), u32::from(b)))
+                .collect();
+            vocab.extend(extra.iter().map(|&(s, i)| (projected(s), i)));
+            let merges: Merges = merges
+                .iter()
+                .map(|&(a, b)| (projected(a), projected(b)))
+                .collect();
+            BpeBuilder::default()
+                .vocab_and_merges(vocab, merges)
+                .ignore_merges(ignore_merges)
+                .build()
+                .unwrap()
+        }
+
+        #[test]
+        fn byte_level_merges_raw_bytes() {
+            let bpe = byte_level_bpe(
+                &[("he", 300), (" he", 301)],
+                &[("h", "e"), (" ", "he")],
+                false,
+            );
+            let reference = bpe.clone();
+            let pipeline = PipelineBPE::from_bpe(bpe, true).unwrap();
+            assert_eq!(pipeline_ids(&pipeline, " he"), vec![301]);
+            // single bytes hit the un-projected single-byte tokens (id == byte value)
+            assert_eq!(pipeline_ids(&pipeline, "é"), vec![0xC3, 0xA9]);
+            // the end-to-end invariant: raw input through the pipeline must equal
+            // projected input through the reference model
+            for input in [" he", "é", "\x00\x7f", "hé llo"] {
+                assert_eq!(
+                    pipeline_ids(&pipeline, input),
+                    reference_ids(&reference, &projected(input)),
+                    "{input:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn byte_level_ignore_merges_whole_word() {
+            let bpe = byte_level_bpe(&[(" hello", 300)], &[], true);
+            let pipeline = PipelineBPE::from_bpe(bpe, true).unwrap();
+            assert_eq!(pipeline_ids(&pipeline, " hello"), vec![300]);
+            // not in vocab → falls through to single-byte atoms
+            assert_eq!(
+                pipeline_ids(&pipeline, "zz"),
+                vec![u32::from(b'z'), u32::from(b'z')]
+            );
+        }
+
+        #[test]
+        fn byte_level_requires_full_byte_coverage() {
+            // An ASCII-only vocab covers no control/high bytes: building the
+            // byte-level pipeline must be a build error, not a panic.
+            let bpe = hello_builder().build().unwrap();
+            assert!(PipelineBPE::from_bpe(bpe, true).is_err());
+        }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word.rs
@@ -36,7 +36,7 @@ impl Ord for Merge {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct Symbol {
+pub(crate) struct Symbol {
     c: u32,
     prev: isize,
     next: isize,
@@ -50,6 +50,14 @@ impl Symbol {
         self.c = new_c;
         self.len += other.len;
         self.next = other.next;
+    }
+
+    pub fn id(&self) -> u32 {
+        self.c
+    }
+
+    pub fn add_len(&mut self, rhs: usize) {
+        self.len += rhs;
     }
 }
 
@@ -265,6 +273,10 @@ impl Word {
             pos = new_pos;
             offset
         })
+    }
+
+    pub(crate) fn last_mut(&mut self) -> Option<&mut Symbol> {
+        self.symbols.last_mut()
     }
 }
 

--- a/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
@@ -10,12 +10,12 @@ use crate::tokenizer::{
 };
 use crate::utils::macro_rules_attribute;
 
+pub(crate) const GPT2_REGEX_STR: &'static str =
+    r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+";
+
 /// Regex that matches exactly one token.
 /// See https://github.com/openai/gpt-2/blob/master/src/encoder.py#L98
-static RE: LazyLock<SysRegex> = LazyLock::new(|| {
-    SysRegex::new(r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+")
-        .unwrap()
-});
+static RE: LazyLock<SysRegex> = LazyLock::new(|| SysRegex::new(GPT2_REGEX_STR).unwrap());
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// Provides all the necessary steps to handle the BPE tokenization at the byte-level. Takes care

--- a/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
@@ -529,6 +529,84 @@ mod tests {
         );
     }
 
+    /// Splits from the pipeline conversion of `byte_level`, with the raw text of each
+    /// range transformed to the byte-level alphabet so it's comparable with the legacy
+    /// oracle's output strings.
+    fn pipeline_splits(byte_level: ByteLevel, text: &str) -> Vec<(String, (usize, usize))> {
+        use std::convert::TryFrom;
+        let converted = crate::pipeline::PipelinePreTokenizer::try_from(
+            crate::PreTokenizerWrapper::ByteLevel(byte_level),
+        )
+        .unwrap();
+        let mut out = Vec::new();
+        crate::pipeline::PreTokenizer::pre_tokenize(&converted, text, &mut out).unwrap();
+        out.iter()
+            .map(|s| {
+                let transformed = text[s.range()]
+                    .bytes()
+                    .map(|b| BYTES_CHAR_LOOKUP[b as usize])
+                    .collect();
+                (transformed, (s.start as usize, s.end as usize))
+            })
+            .collect()
+    }
+
+    fn legacy_splits(byte_level: ByteLevel, text: &str) -> Vec<(String, (usize, usize))> {
+        let mut pre = PreTokenizedString::from(text);
+        byte_level.pre_tokenize(&mut pre).unwrap();
+        pre.get_splits(OffsetReferential::Original, OffsetType::Byte)
+            .into_iter()
+            .map(|(s, o, _)| (s.to_string(), o))
+            .collect()
+    }
+
+    #[test]
+    fn pipeline_conversion_matches_legacy_splits() {
+        let byte_level = ByteLevel::default().add_prefix_space(false);
+        for text in [
+            "Hello my friend, how is your day going?",
+            "Hello there\nHello there",
+            "Hello there       dear",
+            " leading space",
+            "trailing space   ",
+            "i⭢j",
+            "中文 text 123, mixed! 🤗 emoji",
+            "I'm can't we've they'll it's",
+            "tabs\tand\r\nnewlines",
+            "café über naïve",
+            "!!!???...",
+            "single",
+        ] {
+            assert_eq!(
+                pipeline_splits(byte_level, text),
+                legacy_splits(byte_level, text),
+                "diverged on {text:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn pipeline_conversion_no_regex_is_identity_split() {
+        let byte_level = ByteLevel::default().add_prefix_space(false).use_regex(false);
+        let text = "Hello my friend, how is your day going?";
+        assert_eq!(
+            pipeline_splits(byte_level, text),
+            legacy_splits(byte_level, text),
+        );
+    }
+
+    #[test]
+    fn pipeline_conversion_rejects_add_prefix_space() {
+        // The range-based pipeline can't prepend text; converting must fail loudly
+        // rather than silently produce different splits than the legacy path.
+        use std::convert::TryFrom;
+        let byte_level = ByteLevel::default().add_prefix_space(true);
+        assert!(crate::pipeline::PipelinePreTokenizer::try_from(
+            crate::PreTokenizerWrapper::ByteLevel(byte_level)
+        )
+        .is_err());
+    }
+
     #[test]
     fn deserialization() {
         // Before use_regex

--- a/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
@@ -10,7 +10,7 @@ use crate::tokenizer::{
 };
 use crate::utils::macro_rules_attribute;
 
-pub(crate) const GPT2_REGEX_STR: &'static str =
+pub(crate) const GPT2_REGEX_STR: &str =
     r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+";
 
 /// Regex that matches exactly one token.
@@ -587,7 +587,9 @@ mod tests {
 
     #[test]
     fn pipeline_conversion_no_regex_is_identity_split() {
-        let byte_level = ByteLevel::default().add_prefix_space(false).use_regex(false);
+        let byte_level = ByteLevel::default()
+            .add_prefix_space(false)
+            .use_regex(false);
         let text = "Hello my friend, how is your day going?";
         assert_eq!(
             pipeline_splits(byte_level, text),

--- a/tokenizers/tk-encode/src/pre_tokenizers/mod.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/mod.rs
@@ -61,30 +61,6 @@ impl PreTokenizer for PreTokenizerWrapper {
     }
 }
 
-impl crate::pipeline::PreTokenizer for PreTokenizerWrapper {
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<crate::pipeline::Split>) -> crate::Result<()> {
-        use crate::pipeline::PreTokenizer as PipePreTok;
-        match self {
-            Self::BertPreTokenizer(p) => PipePreTok::pre_tokenize(p, text, out),
-            Self::Delimiter(p) => PipePreTok::pre_tokenize(p, text, out),
-            Self::Digits(p) => PipePreTok::pre_tokenize(p, text, out),
-            Self::FixedLength(p) => PipePreTok::pre_tokenize(p, text, out),
-            Self::Punctuation(p) => PipePreTok::pre_tokenize(p, text, out),
-            Self::Sequence(p) => PipePreTok::pre_tokenize(p, text, out),
-            Self::Split(p) => PipePreTok::pre_tokenize(p, text, out),
-            Self::UnicodeScripts(p) => PipePreTok::pre_tokenize(p, text, out),
-            Self::Whitespace(p) => PipePreTok::pre_tokenize(p, text, out),
-            Self::WhitespaceSplit(p) => PipePreTok::pre_tokenize(p, text, out),
-            Self::ByteLevel(_) => {
-                Err("ByteLevel has no range-based pipeline impl (it rewrites bytes)".into())
-            }
-            Self::Metaspace(_) => {
-                Err("Metaspace has no range-based pipeline impl (it rewrites bytes)".into())
-            }
-        }
-    }
-}
-
 impl<'de> Deserialize<'de> for PreTokenizerWrapper {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where

--- a/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
@@ -137,6 +137,7 @@ impl pipeline::PreTokenizer for PipelineSequence {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use crate::pre_tokenizers::byte_level::ByteLevel;
     use crate::pre_tokenizers::digits::Digits;

--- a/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
@@ -1,4 +1,6 @@
-use crate::pipeline;
+use std::convert::{TryFrom, TryInto};
+
+use crate::pipeline::{self, PipelinePreTokenizer};
 use crate::pre_tokenizers::PreTokenizerWrapper;
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result};
 use crate::utils::macro_rules_attribute;
@@ -46,7 +48,52 @@ impl PreTokenizer for Sequence {
     }
 }
 
-impl pipeline::PreTokenizer for Sequence {
+#[derive(Clone, Debug, PartialEq)]
+pub struct PipelineSequence {
+    pre_tokenizers: Vec<PipelinePreTokenizer>,
+}
+
+impl PipelineSequence {
+    pub fn new(pre_tokenizers: Vec<PipelinePreTokenizer>) -> Self {
+        Self { pre_tokenizers }
+    }
+}
+
+impl AsRef<[PipelinePreTokenizer]> for PipelineSequence {
+    fn as_ref(&self) -> &[PipelinePreTokenizer] {
+        &self.pre_tokenizers
+    }
+}
+
+impl AsMut<[PipelinePreTokenizer]> for PipelineSequence {
+    fn as_mut(&mut self) -> &mut [PipelinePreTokenizer] {
+        &mut self.pre_tokenizers
+    }
+}
+
+impl IntoIterator for PipelineSequence {
+    type Item = PipelinePreTokenizer;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.pre_tokenizers.into_iter()
+    }
+}
+
+impl TryFrom<Sequence> for PipelineSequence {
+    type Error = crate::Error;
+    fn try_from(value: Sequence) -> Result<Self> {
+        Ok(Self {
+            pre_tokenizers: value
+                .pretokenizers
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+}
+
+impl pipeline::PreTokenizer for PipelineSequence {
     /// Runs each child in turn, where every child subdivides the spans produced
     /// so far. A child sees only the text of a span (`&text[span]`) and returns
     /// offsets relative to it, which we rebase to absolute mirroring how the
@@ -65,7 +112,7 @@ impl pipeline::PreTokenizer for Sequence {
         });
         let mut next: Vec<pipeline::Split> = Vec::with_capacity(cap);
 
-        for child in &self.pretokenizers {
+        for child in &self.pre_tokenizers {
             next.clear();
             for span in &current {
                 let base = span.start;
@@ -98,7 +145,7 @@ mod tests {
     use crate::{OffsetReferential, OffsetType};
 
     /// Run the pipeline path and return `(piece, (start, end))` for each split.
-    fn pipeline_pretokenize(seq: &Sequence, text: &str) -> Vec<(String, (usize, usize))> {
+    fn pipeline_pretokenize(seq: &PipelineSequence, text: &str) -> Vec<(String, (usize, usize))> {
         let mut out = Vec::new();
         crate::pipeline::PreTokenizer::pre_tokenize(seq, text, &mut out).unwrap();
         out.iter()
@@ -128,8 +175,12 @@ mod tests {
             PreTokenizerWrapper::WhitespaceSplit(WhitespaceSplit),
             PreTokenizerWrapper::Punctuation(Punctuation::default()),
         ]);
+        let pipe_seq = seq
+            .clone()
+            .try_into()
+            .expect("Failed to convert Sequence to PipelineSequence");
         assert_eq!(
-            pipeline_pretokenize(&seq, "Hey friend!     How are you?!?"),
+            pipeline_pretokenize(&pipe_seq, "Hey friend!     How are you?!?"),
             [
                 ("Hey", (0, 3)),
                 ("friend", (4, 10)),
@@ -179,9 +230,13 @@ mod tests {
         ];
         for (ci, cfg) in configs.into_iter().enumerate() {
             let seq = Sequence::new(cfg);
+            let pipe_seq = seq
+                .clone()
+                .try_into()
+                .expect("Failed to convert Sequence to PipelineSequence");
             for text in texts {
                 assert_eq!(
-                    pipeline_pretokenize(&seq, text),
+                    pipeline_pretokenize(&pipe_seq, text),
                     legacy_pretokenize(&seq, text),
                     "config #{ci} diverged on {text:?}",
                 );
@@ -195,18 +250,94 @@ mod tests {
             PreTokenizerWrapper::WhitespaceSplit(WhitespaceSplit),
             PreTokenizerWrapper::Punctuation(Punctuation::default()),
         ]);
-        assert!(pipeline_pretokenize(&seq, "").is_empty());
+        let pipe_seq = seq
+            .clone()
+            .try_into()
+            .expect("Failed to convert Sequence to PipelineSequence");
+
+        assert!(pipeline_pretokenize(&pipe_seq, "").is_empty());
+    }
+
+    #[test]
+    fn pipeline_matches_legacy_oracle_byte_level() {
+        // The Llama-3 / DeepSeek archetype: Sequence[Split(regex), ByteLevel(use_regex=false)].
+        // Pipeline ranges must match the legacy oracle's Original-referential offsets, and the
+        // byte-level transform of each range must match the legacy split string.
+        use crate::pre_tokenizers::byte_level::GPT2_REGEX_STR;
+        use crate::pre_tokenizers::split::{Split, SplitPattern};
+        use crate::utils::byte_level::BYTES_CHAR_LOOKUP;
+        use crate::SplitDelimiterBehavior;
+
+        let seq = Sequence::new(vec![
+            PreTokenizerWrapper::Split(
+                Split::new(
+                    SplitPattern::Regex(GPT2_REGEX_STR.to_owned()),
+                    SplitDelimiterBehavior::Isolated,
+                    false,
+                )
+                .unwrap(),
+            ),
+            PreTokenizerWrapper::ByteLevel(ByteLevel::new(false, true, false)),
+        ]);
+        let pipe_seq: PipelineSequence = seq
+            .clone()
+            .try_into()
+            .expect("Failed to convert Sequence to PipelineSequence");
+        for text in [
+            "Hello there\nHello there",
+            "中文 text 123, mixed! 🤗",
+            "I'm sure it's fine   ",
+        ] {
+            let mut out = Vec::new();
+            crate::pipeline::PreTokenizer::pre_tokenize(&pipe_seq, text, &mut out).unwrap();
+            let pipeline: Vec<(String, (usize, usize))> = out
+                .iter()
+                .map(|s| {
+                    let transformed = text[s.range()]
+                        .bytes()
+                        .map(|b| BYTES_CHAR_LOOKUP[b as usize])
+                        .collect();
+                    (transformed, (s.start as usize, s.end as usize))
+                })
+                .collect();
+            assert_eq!(
+                pipeline,
+                legacy_pretokenize(&seq, text),
+                "diverged on {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn deserialized_sequence_matches_legacy_oracle() {
+        // Real tokenizers are loaded via serde, not `Sequence::new` — the pipeline
+        // path must behave identically for a deserialized Sequence.
+        let seq: Sequence = serde_json::from_str(
+            r#"{"type":"Sequence","pretokenizers":[{"type":"WhitespaceSplit"}]}"#,
+        )
+        .unwrap();
+        let pipe_seq = seq
+            .clone()
+            .try_into()
+            .expect("Failed to convert Sequence to PipelineSequence");
+
+        let text = "Hey friend!     How are you?!?";
+        assert_eq!(
+            pipeline_pretokenize(&pipe_seq, text),
+            legacy_pretokenize(&seq, text),
+        );
     }
 
     #[test]
     fn pipeline_unsupported_child_errors() {
-        // A byte-rewriting child has no range-based form → the whole Sequence errors.
+        // Metaspace has no range-based form. Constructing the Sequence must still work
+        // (the legacy path supports it) — only the pipeline conversion should fail.
+        use std::convert::TryFrom;
         let seq = Sequence::new(vec![
             PreTokenizerWrapper::WhitespaceSplit(WhitespaceSplit),
-            PreTokenizerWrapper::ByteLevel(ByteLevel::default()),
+            PreTokenizerWrapper::Metaspace(crate::pre_tokenizers::metaspace::Metaspace::default()),
         ]);
-        let mut out = Vec::new();
-        assert!(crate::pipeline::PreTokenizer::pre_tokenize(&seq, "hi there", &mut out).is_err());
+        assert!(PipelinePreTokenizer::try_from(PreTokenizerWrapper::Sequence(seq)).is_err());
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -130,9 +130,7 @@ impl TryFrom<PreTokenizerWrapper> for PipelinePreTokenizer {
             }
             PreTokenizerWrapper::Sequence(p) => Ok(PipelinePreTokenizer::Sequence(p.try_into()?)),
             other => {
-                Err(
-                    format!("PipelineTokenizer does not support PreTokenizer: {other:?}").into(),
-                )
+                Err(format!("PipelineTokenizer does not support PreTokenizer: {other:?}").into())
             }
         }
     }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -6,7 +6,7 @@ use crate::added_vocabulary::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
 use crate::decoders::byte_level::GPT2_REGEX_STR;
-use crate::models::bpe::BPE;
+use crate::models::bpe::PipelineBPE;
 use crate::models::unigram::Unigram;
 use crate::models::wordlevel::WordLevel;
 use crate::models::wordpiece::WordPiece;
@@ -299,20 +299,30 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
         )?;
         added_vocabulary.set_encode_special_tokens(legacy_av.get_encode_special_tokens());
 
-        let mut model = tok.get_model().clone().try_into()?;
-        if let PipelineModel::BPE(bpe) = &mut model {
-            let has_byte_level = match tok.get_pre_tokenizer() {
-                Some(PreTokenizerWrapper::ByteLevel(_)) => true,
-                Some(PreTokenizerWrapper::Sequence(seq)) => seq
-                    .as_ref()
-                    .iter()
-                    .any(|wrapper| matches!(wrapper, PreTokenizerWrapper::ByteLevel(_))),
-                _ => false,
-            };
-            if has_byte_level {
-                bpe.transform_vocab();
+        let with_byte_level = {
+            if let Some(pt) = tok.get_pre_tokenizer() {
+                if let PreTokenizerWrapper::ByteLevel(_) = pt {
+                    true
+                } else if let PreTokenizerWrapper::Sequence(seq) = pt {
+                    seq.as_ref()
+                        .iter()
+                        .any(|p| matches!(p, PreTokenizerWrapper::ByteLevel(_)))
+                } else {
+                    false
+                }
+            } else {
+                false
             }
-        }
+        };
+
+        let model = match tok.get_model().clone() {
+            ModelWrapper::BPE(model) => {
+                PipelineModel::BPE(PipelineBPE::from_bpe(model, with_byte_level)?)
+            }
+            ModelWrapper::Unigram(model) => PipelineModel::Unigram(model),
+            ModelWrapper::WordLevel(model) => PipelineModel::WordLevel(model),
+            ModelWrapper::WordPiece(model) => PipelineModel::WordPiece(model),
+        };
 
         Ok(Self {
             added_vocabulary,
@@ -639,7 +649,7 @@ pub trait Model {
 }
 
 pub enum PipelineModel {
-    BPE(BPE),
+    BPE(PipelineBPE),
     Unigram(Unigram),
     WordLevel(WordLevel),
     WordPiece(WordPiece),
@@ -647,28 +657,18 @@ pub enum PipelineModel {
 
 impl Model for PipelineModel {
     fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
+        if let PipelineModel::BPE(model) = self {
+            return model.tokenize_bytes(bytes, output);
+        }
         let sequence = str::from_utf8(bytes)?;
         let tokens = match self {
-            Self::BPE(model) => model.tokenize(sequence),
             Self::Unigram(model) => model.tokenize(sequence),
             Self::WordLevel(model) => model.tokenize(sequence),
             Self::WordPiece(model) => model.tokenize(sequence),
+            Self::BPE(_) => unreachable!(),
         }?;
         output.extend(tokens.iter().map(|&Token { id, .. }| PipelineToken { id }));
         Ok(())
-    }
-}
-
-impl TryFrom<ModelWrapper> for PipelineModel {
-    type Error = crate::Error;
-
-    fn try_from(value: ModelWrapper) -> std::prelude::v1::Result<Self, Self::Error> {
-        Ok(match value {
-            ModelWrapper::BPE(model) => Self::BPE(model),
-            ModelWrapper::Unigram(model) => Self::Unigram(model),
-            ModelWrapper::WordLevel(model) => Self::WordLevel(model),
-            ModelWrapper::WordPiece(model) => Self::WordPiece(model),
-        })
     }
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -414,8 +414,8 @@ impl PipelineTokenizer {
                                     if STAGE >= Self::STAGE_MODEL {
                                         // Tokenize each chunk
                                         for pre_token in pre_tokens.iter() {
-                                            self.model.tokenize_bytes(
-                                                normalized_chunk[pre_token.range()].as_bytes(),
+                                            self.model.tokenize_pipeline(
+                                                &normalized_chunk[pre_token.range()],
                                                 output,
                                             )?;
                                         }
@@ -645,7 +645,7 @@ pub fn split_matches(
 }
 
 pub trait Model {
-    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()>;
+    fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()>;
 }
 
 pub enum PipelineModel {
@@ -656,16 +656,15 @@ pub enum PipelineModel {
 }
 
 impl Model for PipelineModel {
-    fn tokenize_bytes(&self, bytes: &[u8], output: &mut Vec<PipelineToken>) -> Result<()> {
+    fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()> {
         if let PipelineModel::BPE(model) = self {
-            return model.tokenize_bytes(bytes, output);
+            return model.tokenize_pipeline(sequence, output);
         }
-        let sequence = str::from_utf8(bytes)?;
         let tokens = match self {
+            Self::BPE(_) => unreachable!(),
             Self::Unigram(model) => model.tokenize(sequence),
             Self::WordLevel(model) => model.tokenize(sequence),
             Self::WordPiece(model) => model.tokenize(sequence),
-            Self::BPE(_) => unreachable!(),
         }?;
         output.extend(tokens.iter().map(|&Token { id, .. }| PipelineToken { id }));
         Ok(())

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -648,6 +648,10 @@ pub trait Model {
     fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()>;
 }
 
+#[allow(
+    clippy::large_enum_variant,
+    reason = "PipelineBPE holds a 1kB byte -> id lookup table"
+)]
 pub enum PipelineModel {
     BPE(PipelineBPE),
     Unigram(Unigram),

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -5,6 +5,7 @@ use std::{borrow::Cow, convert::TryFrom};
 use crate::added_vocabulary::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
+use crate::decoders::byte_level::GPT2_REGEX_STR;
 use crate::models::bpe::BPE;
 use crate::models::unigram::Unigram;
 use crate::models::wordlevel::WordLevel;

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -9,6 +9,9 @@ use crate::models::bpe::BPE;
 use crate::models::unigram::Unigram;
 use crate::models::wordlevel::WordLevel;
 use crate::models::wordpiece::WordPiece;
+use crate::pre_tokenizers::sequence::PipelineSequence;
+use crate::pre_tokenizers::split::SplitPattern;
+use crate::SplitDelimiterBehavior::Isolated;
 use crate::{
     normalizers::NormalizerWrapper,
     pre_tokenizers::{
@@ -17,7 +20,6 @@ use crate::{
         digits::Digits,
         fixed_length::FixedLength,
         punctuation::Punctuation,
-        sequence::Sequence,
         split::Split as SplitPretok,
         unicode_scripts::UnicodeScripts,
         whitespace::{Whitespace, WhitespaceSplit},
@@ -55,13 +57,14 @@ pub trait PreTokenizer {
 
 /// The pre-tokenizers a [`PipelineTokenizer`] can run.
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PipelinePreTokenizer {
     Bert(BertPreTokenizer),
     Delimiter(CharDelimiterSplit),
     Digits(Digits),
     FixedLength(FixedLength),
     Punctuation(Punctuation),
-    Sequence(Sequence),
+    Sequence(PipelineSequence),
     Split(SplitPretok),
     UnicodeScripts(UnicodeScripts),
     Whitespace(Whitespace),
@@ -89,6 +92,47 @@ impl PreTokenizer for PipelinePreTokenizer {
             Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, out),
             Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
             Self::WhitespaceSplit(pretok) => pretok.pre_tokenize(text, out),
+        }
+    }
+}
+
+impl TryFrom<PreTokenizerWrapper> for PipelinePreTokenizer {
+    type Error = crate::Error;
+
+    fn try_from(value: PreTokenizerWrapper) -> Result<Self> {
+        match value {
+            PreTokenizerWrapper::BertPreTokenizer(p) => Ok(PipelinePreTokenizer::Bert(p)),
+            PreTokenizerWrapper::Delimiter(p) => Ok(PipelinePreTokenizer::Delimiter(p)),
+            PreTokenizerWrapper::Digits(p) => Ok(PipelinePreTokenizer::Digits(p)),
+            PreTokenizerWrapper::FixedLength(p) => Ok(PipelinePreTokenizer::FixedLength(p)),
+            PreTokenizerWrapper::Punctuation(p) => Ok(PipelinePreTokenizer::Punctuation(p)),
+            PreTokenizerWrapper::Split(p) => Ok(PipelinePreTokenizer::Split(p.clone())),
+            PreTokenizerWrapper::UnicodeScripts(p) => Ok(PipelinePreTokenizer::UnicodeScripts(p)),
+            PreTokenizerWrapper::Whitespace(p) => Ok(PipelinePreTokenizer::Whitespace(p.clone())),
+            PreTokenizerWrapper::WhitespaceSplit(p) => Ok(PipelinePreTokenizer::WhitespaceSplit(p)),
+            PreTokenizerWrapper::ByteLevel(byte_level) => {
+                if byte_level.add_prefix_space {
+                    return Err(
+                        "ByteLevel add_prefix_space=true is not supported by the pipeline yet"
+                            .into(),
+                    );
+                }
+                if byte_level.use_regex {
+                    Ok(PipelinePreTokenizer::Split(SplitPretok::new(
+                        SplitPattern::Regex(GPT2_REGEX_STR.to_owned()),
+                        Isolated,
+                        false,
+                    )?))
+                } else {
+                    Ok(PipelinePreTokenizer::None)
+                }
+            }
+            PreTokenizerWrapper::Sequence(p) => Ok(PipelinePreTokenizer::Sequence(p.try_into()?)),
+            other => {
+                Err(
+                    format!("PipelineTokenizer does not support PreTokenizer: {other:?}").into(),
+                )
+            }
         }
     }
 }
@@ -231,25 +275,12 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
     /// Adding them in id order preserves ids (tokens present in the model reuse their model id, the
     /// rest keep their dense order), so the pipeline emits the same ids as the reference tokenizer.
     fn try_from(tok: &Tokenizer) -> Result<Self> {
-        let pre_tokenizer = match tok.get_pre_tokenizer() {
-            None => PipelinePreTokenizer::None,
-            Some(PreTokenizerWrapper::BertPreTokenizer(p)) => PipelinePreTokenizer::Bert(*p),
-            Some(PreTokenizerWrapper::Delimiter(p)) => PipelinePreTokenizer::Delimiter(*p),
-            Some(PreTokenizerWrapper::Digits(p)) => PipelinePreTokenizer::Digits(p.clone()),
-            Some(PreTokenizerWrapper::FixedLength(p)) => PipelinePreTokenizer::FixedLength(*p),
-            Some(PreTokenizerWrapper::Punctuation(p)) => PipelinePreTokenizer::Punctuation(*p),
-            Some(PreTokenizerWrapper::Sequence(p)) => PipelinePreTokenizer::Sequence(p.clone()),
-            Some(PreTokenizerWrapper::Split(p)) => PipelinePreTokenizer::Split(p.clone()),
-            Some(PreTokenizerWrapper::UnicodeScripts(p)) => PipelinePreTokenizer::UnicodeScripts(*p),
-            Some(PreTokenizerWrapper::Whitespace(p)) => PipelinePreTokenizer::Whitespace(p.clone()),
-            Some(PreTokenizerWrapper::WhitespaceSplit(p)) => PipelinePreTokenizer::WhitespaceSplit(*p),
-            Some(other) => {
-                return Err(format!(
-                    "PipelineTokenizer only supports Bert/Whitespace/None pre-tokenizers, got: {other:?}"
-                )
-                .into())
-            }
-        };
+        let pre_tokenizer: PipelinePreTokenizer = tok
+            .get_pre_tokenizer()
+            .cloned()
+            .map(TryInto::try_into)
+            .transpose()?
+            .unwrap_or(PipelinePreTokenizer::None);
 
         let legacy_av = tok.get_added_vocabulary();
         let mut added_tokens: Vec<_> = legacy_av.get_added_tokens_decoder().iter().collect();

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -303,9 +303,10 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
         if let PipelineModel::BPE(bpe) = &mut model {
             let has_byte_level = match tok.get_pre_tokenizer() {
                 Some(PreTokenizerWrapper::ByteLevel(_)) => true,
-                Some(PreTokenizerWrapper::Sequence(seq)) => {
-                    seq.as_ref().iter().any(|wrapper| matches!(wrapper, PreTokenizerWrapper::ByteLevel(_)))
-                },
+                Some(PreTokenizerWrapper::Sequence(seq)) => seq
+                    .as_ref()
+                    .iter()
+                    .any(|wrapper| matches!(wrapper, PreTokenizerWrapper::ByteLevel(_))),
                 _ => false,
             };
             if has_byte_level {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -299,7 +299,19 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
         )?;
         added_vocabulary.set_encode_special_tokens(legacy_av.get_encode_special_tokens());
 
-        let model = tok.get_model().clone().try_into()?;
+        let mut model = tok.get_model().clone().try_into()?;
+        if let PipelineModel::BPE(bpe) = &mut model {
+            let has_byte_level = match tok.get_pre_tokenizer() {
+                Some(PreTokenizerWrapper::ByteLevel(_)) => true,
+                Some(PreTokenizerWrapper::Sequence(seq)) => {
+                    seq.as_ref().iter().any(|wrapper| matches!(wrapper, PreTokenizerWrapper::ByteLevel(_)))
+                },
+                _ => false,
+            };
+            if has_byte_level {
+                bpe.transform_vocab();
+            }
+        }
 
         Ok(Self {
             added_vocabulary,

--- a/tokenizers/tk-encode/src/utils/byte_level.rs
+++ b/tokenizers/tk-encode/src/utils/byte_level.rs
@@ -1,6 +1,6 @@
-use std::sync::LazyLock;
-
+use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
+use std::sync::LazyLock;
 
 /// Maps each byte to its GPT-2 byte-level unicode character, indexed by the byte value.
 ///
@@ -74,6 +74,22 @@ fn make_byte_char_lookup() -> [char; 256] {
     }
 
     lookup
+}
+
+fn reverse_lookup(c: char) -> Vec<u8> {
+    CHAR_BYTES_LOOKUP
+        .get(&c)
+        .map_or_else(|| c.to_string().into_bytes(), |b| vec![*b])
+}
+
+pub(crate) fn transform_vocab(vocab: VocabStore) -> VocabStore {
+    VocabStore::build(
+        vocab
+            .content()
+            .into_iter()
+            .map(|(string, token_id)| (string.chars().flat_map(reverse_lookup).collect(), token_id))
+            .collect(),
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**3 / 4 models supported** · geomean ×3.03 across supported · 22 fixtures each — ~10 kB inputs · single thread

`89a5fe763 · 2026-07-08 16:08 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

Pipeline stage mix (mean share of encode time): model 45%, pre-tokenize 38%, normalize 14%, added-token 2%. Per-model decomposition charts below.

> **Not yet supported:** `t5-base` (Unigram · WhitespaceSplit+Metaspace) — roadmap cards below.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-bert-base-uncased-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-deepseek-v4-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-llama-3-stages-light.png" width="860">
</picture>

### Not yet supported

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28957134184-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

<details><summary>Per-fixture results</summary>

#### bert-base-uncased — WordPiece · Bert

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.4 | 20.9 | ×2.81 | 1.22 | 27.83 | 9.01 | 9.54 | match |
| arb_Arab | lang | 3.8 | 8.4 | ×2.21 | 1.17 | 27.67 | 13.27 | 77.37 | match |
| ben_Beng | lang | 5.6 | 12.7 | ×2.28 | 1.16 | 19.38 | 8.74 | 49.06 | match |
| cmn_Hani | lang | 3.5 | 14.2 | ×4.06 | 1.17 | 37.79 | 10.88 | 21.15 | match |
| ell_Grek | lang | 3.5 | 7.1 | ×2.05 | 1.16 | 28.78 | 13.52 | 96.65 | match |
| eng_Latn | lang | 4.2 | 15.1 | ×3.61 | 2.54 | 39.73 | 3.43 | 19.96 | match |
| heb_Hebr | lang | 3.8 | 8.1 | ×2.14 | 1.17 | 37.80 | 13.29 | 70.76 | match |
| hin_Deva | lang | 6.0 | 14.7 | ×2.47 | 1.16 | 27.12 | 7.82 | 31.47 | match |
| jpn_Jpan | lang | 4.0 | 11.2 | ×2.82 | 1.17 | 23.43 | 10.78 | 52.47 | match |
| kat_Geor | lang | 5.8 | 11.2 | ×1.92 | 1.16 | 26.62 | 9.30 | 51.21 | match |
| kor_Hang | lang | 2.3 | 4.1 | ×1.81 | 1.19 | 35.33 | 21.35 | 185.65 | match |
| rus_Cyrl | lang | 3.3 | 6.4 | ×1.93 | 1.16 | 27.58 | 13.62 | 112.23 | match |
| tam_Taml | lang | 6.6 | 15.0 | ×2.25 | 1.15 | 18.82 | 8.20 | 37.84 | match |
| tha_Thai | lang | 8.2 | 14.0 | ×1.70 | 1.17 | 25.24 | 7.37 | 36.06 | match |
| added_normalized_dense | modalities | 6.2 | 21.2 | ×3.41 | 1.31 | 41.79 | 1.10 | 4.23 | match |
| added_normalized_sparse | modalities | 4.9 | 18.0 | ×3.65 | 1.93 | 41.02 | 2.32 | 10.99 | match |
| added_special_dense | modalities | 4.9 | 48.2 | ×9.88 | 5.12 | 9.31 | 2.26 | 3.39 | match |
| added_special_sparse | modalities | 3.8 | 21.4 | ×5.69 | 3.70 | 28.31 | 2.83 | 11.55 | match |
| agentic-traces | modalities | 3.6 | 13.4 | ×3.77 | 2.33 | 39.55 | 3.87 | 29.66 | match |
| agentic_swe | modalities | 3.8 | 13.7 | ×3.59 | 1.87 | 39.65 | 3.08 | 29.08 | match |
| code_mixed | modalities | 3.7 | 12.4 | ×3.37 | 2.13 | 39.60 | 3.44 | 36.84 | match |
| math_latex | modalities | 3.7 | 13.7 | ×3.69 | 2.46 | 39.64 | 3.51 | 27.67 | match |

#### deepseek-v4 — BPE · Split+ByteLevel

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 16.2 | ×4.05 | 0.66 | 0.00 | 42.93 | 16.10 | match |
| arb_Arab | lang | 3.5 | 8.8 | ×2.50 | 0.59 | 0.00 | 51.20 | 60.06 | match |
| ben_Beng | lang | 4.4 | 10.6 | ×2.43 | 0.59 | 0.00 | 36.32 | 57.93 | match |
| cmn_Hani | lang | 3.3 | 7.8 | ×2.37 | 0.76 | 0.00 | 63.87 | 61.89 | match |
| ell_Grek | lang | 3.7 | 9.5 | ×2.58 | 0.60 | 0.00 | 47.26 | 58.05 | match |
| eng_Latn | lang | 2.8 | 7.3 | ×2.61 | 1.99 | 0.00 | 67.77 | 68.23 | match |
| heb_Hebr | lang | 3.2 | 7.7 | ×2.39 | 0.61 | 0.00 | 51.06 | 79.53 | match |
| hin_Deva | lang | 4.2 | 11.6 | ×2.74 | 0.60 | 0.00 | 39.44 | 44.70 | match |
| jpn_Jpan | lang | 3.8 | 8.7 | ×2.32 | 0.66 | 0.00 | 55.75 | 56.13 | match |
| kat_Geor | lang | 4.5 | 11.2 | ×2.49 | 0.59 | 0.00 | 33.15 | 55.51 | match |
| kor_Hang | lang | 3.3 | 9.4 | ×2.80 | 0.61 | 0.00 | 53.13 | 50.11 | match |
| rus_Cyrl | lang | 3.5 | 8.6 | ×2.46 | 0.60 | 0.00 | 47.27 | 68.86 | match |
| tam_Taml | lang | 4.6 | 11.2 | ×2.44 | 0.59 | 0.00 | 32.63 | 54.99 | match |
| tha_Thai | lang | 5.5 | 10.7 | ×1.94 | 0.61 | 0.00 | 27.77 | 64.32 | match |
| added_normalized_dense | modalities | 4.0 | 11.5 | ×2.90 | 0.73 | 0.00 | 44.01 | 42.28 | match |
| added_normalized_sparse | modalities | 3.8 | 10.5 | ×2.77 | 1.33 | 0.00 | 49.47 | 45.33 | match |
| added_special_dense | modalities | 3.2 | 7.3 | ×2.28 | 6.73 | 0.26 | 112.29 | 10.89 | match |
| added_special_sparse | modalities | 3.0 | 7.9 | ×2.63 | 4.00 | 0.06 | 80.65 | 42.12 | match |
| agentic-traces | modalities | 2.5 | 6.1 | ×2.46 | 1.79 | 0.00 | 93.68 | 63.11 | match |
| agentic_swe | modalities | 2.5 | 5.7 | ×2.31 | 1.29 | 0.01 | 107.81 | 79.12 | match |
| code_mixed | modalities | 2.6 | 6.8 | ×2.62 | 1.54 | 0.00 | 78.54 | 63.64 | match |
| math_latex | modalities | 2.5 | 6.5 | ×2.62 | 1.90 | 0.00 | 82.57 | 68.92 | match |

#### llama-3 — BPE · Split+ByteLevel

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.5 | 23.1 | ×6.54 | 0.66 | 0.00 | 28.99 | 10.84 | match |
| arb_Arab | lang | 3.7 | 11.4 | ×3.05 | 0.59 | 0.00 | 33.41 | 52.10 | match |
| ben_Beng | lang | 2.9 | 12.0 | ×4.17 | 0.60 | 0.00 | 45.13 | 38.18 | match |
| cmn_Hani | lang | 4.1 | 12.5 | ×3.09 | 0.61 | 0.00 | 20.22 | 57.89 | match |
| ell_Grek | lang | 4.0 | 12.6 | ×3.17 | 0.60 | 0.00 | 29.55 | 47.34 | match |
| eng_Latn | lang | 3.4 | 14.2 | ×4.19 | 2.06 | 0.02 | 46.49 | 17.00 | match |
| heb_Hebr | lang | 3.3 | 13.6 | ×4.09 | 0.63 | 0.00 | 32.36 | 38.12 | match |
| hin_Deva | lang | 4.1 | 16.5 | ×4.02 | 0.60 | 0.00 | 50.01 | 6.59 | match |
| jpn_Jpan | lang | 4.6 | 12.8 | ×2.80 | 0.60 | 0.00 | 18.95 | 56.84 | match |
| kat_Geor | lang | 4.0 | 22.6 | ×5.60 | 0.59 | 0.00 | 18.30 | 24.00 | match |
| kor_Hang | lang | 3.1 | 11.4 | ×3.62 | 0.61 | 0.00 | 33.88 | 54.19 | match |
| rus_Cyrl | lang | 4.0 | 11.7 | ×2.90 | 0.60 | 0.00 | 26.77 | 57.02 | match |
| tam_Taml | lang | 3.2 | 12.4 | ×3.87 | 0.60 | 0.00 | 46.14 | 30.77 | match |
| tha_Thai | lang | 4.4 | 12.8 | ×2.90 | 0.61 | 0.00 | 29.81 | 45.41 | match |
| added_normalized_dense | modalities | 4.1 | 15.4 | ×3.74 | 0.74 | 0.00 | 25.85 | 36.51 | match |
| added_normalized_sparse | modalities | 4.2 | 17.3 | ×4.11 | 1.30 | 0.00 | 34.26 | 19.81 | match |
| added_special_dense | modalities | 4.0 | 12.5 | ×3.15 | 5.23 | 0.15 | 70.71 | 1.34 | match |
| added_special_sparse | modalities | 4.2 | 15.1 | ×3.62 | 3.32 | 0.00 | 56.26 | 4.22 | match |
| agentic-traces | modalities | 3.1 | 12.4 | ×3.98 | 1.83 | 0.00 | 53.05 | 26.47 | match |
| agentic_swe | modalities | 3.4 | 10.7 | ×3.10 | 1.28 | 0.00 | 58.22 | 27.98 | match |
| code_mixed | modalities | 3.6 | 13.7 | ×3.81 | 1.56 | 0.00 | 52.83 | 18.66 | match |
| math_latex | modalities | 3.3 | 12.8 | ×3.92 | 1.96 | 0.00 | 53.78 | 16.77 | match |

</details>
<!-- pipeline-bench:end -->

