### PR TITLE
ci: nit updates to the bench workflow

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -8,15 +8,23 @@ one object per model:
      legacy_mbps, pipeline_mbps, speedup, ids_match,
      stage_ns_per_byte: {added_split, normalize, pre_tokenize, model, total}}, ...]}
 
-Each supported model gets two full-size charts:
+The report leads with a single overview chart — one row per manifest model:
+its workload `desc`, geomean ×speedup bar and a min–max whisker across
+fixtures (no cross-model aggregate: the models exercise different execution
+modes, so averaging them means nothing). Everything else is collapsed into
+per-model <details> blocks.
+
+Each supported model gets two full-size charts inside its block:
   1. a diverging bar chart (log2 around ×1.0): per-fixture ×speedup + the
      `MB/s: Tokenizer → Pipeline` throughput column, with group headers,
      slower/faster hints, ticks and an inline "⚠ ids differ" flag;
-  2. a stacked stage-decomposition chart (ns/byte): where the pipeline spends
-     its own encode time per fixture — added-token split + normalize +
-     pre-tokenize + model (the two distinct splitting costs kept separate),
-     with each fixture's ×speedup alongside.
-Unsupported models (byte-level BPE, Unigram/Metaspace, …) get a compact
+  2. a stacked stage-decomposition chart (ns/byte, lower is better — the
+     opposite direction from the speedup chart, hence the explicit hint and
+     the reference tick): where the pipeline spends its own encode time per
+     fixture — added-token split + normalize + pre-tokenize + model — with a
+     tick at the reference Tokenizer's total ns/byte on each row, so bar vs
+     tick reads the same way as the ×speedup column.
+Unsupported models (standalone ByteLevel, Unigram/Metaspace, …) get a compact
 "not supported" card. Charts are rendered full-size so readers can zoom.
 """
 import argparse
@@ -46,6 +54,8 @@ INK = {
 FONT = "-apple-system,'Segoe UI',Helvetica,Arial,sans-serif"
 GUTTER, PLOT_W, PAD_R, COL_W, ROW_H, BAR_H = 150, 540, 110, 150, 26, 16
 CHART_W = GUTTER + PLOT_W + PAD_R + COL_W
+# Overview chart: wider gutter (model name + desc), same total width.
+OV_GUTTER, OV_PLOT = 250, 440
 TICKS = [0.5, 0.67, 0.75, 0.8, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0, 5.0]
 GROUPS = [("lang", "Languages"), ("modalities", "Modalities")]
 CARD_W, CARD_H = 470, 150
@@ -98,14 +108,33 @@ def scale(models):
     return min(0.75, min(vals) / 1.08), max(1.5, max(vals) * 1.08)
 
 
+def thin_ticks(ticks, x, min_px=26):
+    """Drop axis ticks that would collide at the current scale (e.g. ×0.75 and
+    ×0.8 once a big speedup stretches the log range). ×1.0 always survives."""
+    kept = [t for t in ticks if t == 1.0]
+    for t in ticks:
+        if t != 1.0 and all(abs(x(t) - x(k)) >= min_px for k in kept):
+            kept.append(t)
+    return sorted(kept)
+
+
+def footer_text(ink, height, meta, subtitle_base=""):
+    """Run metadata as a single muted footer line. Kept out of the header so a
+    long shape/desc subtitle can never collide with the hardware string."""
+    parts = [meta[0], meta[1]] + ([subtitle_base] if subtitle_base else [])
+    return (f'<text x="16" y="{height - 12}" fill="{ink["muted"]}" font-size="10.5" '
+            f'style="font-variant-numeric:tabular-nums">{escape(" · ".join(parts))}</text>')
+
+
 def chart_svg(model, mode, subtitle_base, meta, lo, hi):
     """Full-size per-fixture speedup chart for a supported model."""
     ink = INK[mode]
     rows = model["results"]
-    ticks = [t for t in TICKS if lo <= t <= hi]
 
     def x(v):
         return GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * PLOT_W
+
+    ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x)
 
     top = 74
     col_x = GUTTER + PLOT_W + PAD_R + COL_W - 16
@@ -150,7 +179,7 @@ def chart_svg(model, mode, subtitle_base, meta, lo, hi):
             y += ROW_H
         y += 10
 
-    height = y + 34
+    height = y + 44
     grid = []
     for t in ticks:
         strong = t == 1.0
@@ -164,18 +193,16 @@ def chart_svg(model, mode, subtitle_base, meta, lo, hi):
              f'text-anchor="start">faster →</text>')
 
     g = geomean([r["speedup"] for r in rows])
-    subtitle = f'{model["shape"]} · geomean ×{g:.2f} · {subtitle_base}'
+    subtitle = f'{model["shape"]} · geomean ×{g:.2f}'
     return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{CHART_W}" height="{height}"
   viewBox="0 0 {CHART_W} {height}" font-family="{FONT}">
 <rect width="{CHART_W}" height="{height}" fill="{ink["surface"]}"/>
 <text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="700">{escape(model["model"])} — Pipeline vs Tokenizer encode throughput</text>
 <text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
-<text x="{CHART_W - 16}" y="26" fill="{ink["muted"]}" font-size="11" text-anchor="end"
-  style="font-variant-numeric:tabular-nums">{escape(meta[0])}</text>
-<text x="{CHART_W - 16}" y="44" fill="{ink["muted"]}" font-size="11" text-anchor="end">{escape(meta[1])}</text>
 {"".join(grid)}
 {hints}
 {"".join(body)}
+{footer_text(ink, height, meta, subtitle_base)}
 </svg>'''
 
 
@@ -183,11 +210,19 @@ def has_stages(model):
     return any("stage_ns_per_byte" in r for r in model["results"])
 
 
+def ref_ns_per_byte(row):
+    """The reference Tokenizer's whole-encode cost in the stage chart's unit
+    (MB/s → ns/byte), so it can be drawn as a tick on the pipeline's stacked bar."""
+    return 1000.0 / row["legacy_mbps"]
+
+
 def stage_scale(models):
-    """Shared linear ns/byte range across every supported fixture's total, so the
-    stacked stage bars are comparable across models."""
-    vals = [r["stage_ns_per_byte"]["total"] for m in models if m["supported"]
-            for r in m["results"] if "stage_ns_per_byte" in r]
+    """Shared linear ns/byte range across every supported fixture's total — and the
+    reference Tokenizer's total, so the reference ticks always land on-plot — keeping
+    the stacked stage bars comparable across models."""
+    vals = [v for m in models if m["supported"]
+            for r in m["results"] if "stage_ns_per_byte" in r
+            for v in (r["stage_ns_per_byte"]["total"], ref_ns_per_byte(r))]
     vals = [v for v in vals if v > 0]
     return max(vals) * 1.05 if vals else 1.0
 
@@ -222,8 +257,12 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
 
     top = 84
     col_x = GUTTER + PLOT_W + PAD_R + COL_W - 16
+    # Unlike the speedup chart above it, bars here grow with *time*: call the
+    # direction out explicitly so the two charts can't be read the same way.
     body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-            f'text-anchor="end">ns/byte · ×speedup</text>']
+            f'text-anchor="end">ns/byte · ×speedup</text>',
+            f'<text x="{GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
+            f'time per byte — shorter is faster · tick = Tokenizer total</text>']
     y = top
     for key, title in GROUPS:
         group_rows = sorted((r for r in rows if r["group"] == key),
@@ -253,6 +292,11 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
                                     f'text-anchor="middle" style="font-variant-numeric:tabular-nums">'
                                     f'{txt}</text>')
                 cursor += seg
+            # reference Tokenizer total on the same scale: bar shorter than the
+            # tick ⇔ pipeline faster ⇔ ×speedup ≥ 1
+            rx = GUTTER + w(ref_ns_per_byte(r))
+            body.append(f'<line x1="{rx:.1f}" y1="{by - 3}" x2="{rx:.1f}" y2="{by + BAR_H + 3}" '
+                        f'stroke="{ink["primary"]}" stroke-width="1.5"/>')
             body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
                         f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
                         f'{s["total"]:.1f} · ×{r["speedup"]:.2f}</text>')
@@ -269,7 +313,7 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
         grid.append(f'<text x="{gx:.1f}" y="{y + 12}" fill="{ink["muted"]}" font-size="11" '
                     f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:.0f}</text>')
 
-    # legend row
+    # legend row: the stage colors + the reference-tick glyph
     y += 26
     legend = []
     lx = GUTTER
@@ -277,12 +321,12 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
         legend.append(f'<rect x="{lx}" y="{y - 9}" width="11" height="11" rx="2" fill="{sink[skey]}"/>')
         legend.append(f'<text x="{lx + 16}" y="{y}" fill="{ink["secondary"]}" font-size="11.5">{lbl}</text>')
         lx += 16 + 8 + len(lbl) * 7 + 18
-    height = y + 18
+    legend.append(f'<line x1="{lx + 5}" y1="{y - 10}" x2="{lx + 5}" y2="{y + 2}" '
+                  f'stroke="{ink["primary"]}" stroke-width="1.5"/>')
+    legend.append(f'<text x="{lx + 16}" y="{y}" fill="{ink["secondary"]}" font-size="11.5">'
+                  f'Tokenizer total (reference)</text>')
+    height = y + 34
 
-    # Keep this subtitle short: the stage-mix string is long, and `subtitle_base`
-    # (the "~10 kB inputs · single thread" run context) already rides in the markdown
-    # header and the speedup chart above — appending it here collides with the
-    # right-aligned hardware line.
     mix = stage_mix(rows)
     mix_txt = " · ".join(f"{lbl} {100 * frac:.0f}%" for lbl, frac in mix)
     subtitle = f'{model["shape"]} · stage mix: {mix_txt}'
@@ -291,19 +335,19 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
 <rect width="{CHART_W}" height="{height}" fill="{ink["surface"]}"/>
 <text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="700">{escape(model["model"])} — Pipeline encode stage decomposition</text>
 <text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
-<text x="{CHART_W - 16}" y="26" fill="{ink["muted"]}" font-size="11" text-anchor="end"
-  style="font-variant-numeric:tabular-nums">{escape(meta[0])}</text>
-<text x="{CHART_W - 16}" y="44" fill="{ink["muted"]}" font-size="11" text-anchor="end">{escape(meta[1])}</text>
 {"".join(grid)}
 {"".join(body)}
 {"".join(legend)}
+{footer_text(ink, height, meta, subtitle_base)}
 </svg>'''
 
 
 def card_svg(model, mode):
-    """Compact 'not supported' card for a model the pipeline can't build."""
+    """Compact 'not supported' card for a model the pipeline can't build.
+    Plain single-chunk text only: cairosvg mis-centers text-anchor with tspans."""
     ink = INK[mode]
     pretok = model["shape"].split("·")[-1].strip()
+    why = model.get("reason") or f"PipelineTokenizer has no {pretok} pre-tokenizer"
     header = 54
     b = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{CARD_W}" height="{CARD_H}" '
          f'viewBox="0 0 {CARD_W} {CARD_H}" font-family="{FONT}">',
@@ -319,9 +363,93 @@ def card_svg(model, mode):
          f'<text x="{CARD_W / 2}" y="{(CARD_H + header) / 2 - 2}" fill="{ink["secondary"]}" font-size="12.5" '
          f'font-weight="600" text-anchor="middle">Not benchmarked yet</text>',
          f'<text x="{CARD_W / 2}" y="{(CARD_H + header) / 2 + 16}" fill="{ink["muted"]}" font-size="11.5" '
-         f'text-anchor="middle">PipelineTokenizer has no <tspan font-weight="600">{escape(pretok)}</tspan> pre-tokenizer</text>',
+         f'text-anchor="middle">{escape(why)}</text>',
          "</svg>"]
     return "".join(b)
+
+
+def overview_svg(models, mode, subtitle_base, meta, lo, hi):
+    """The one always-visible chart: a row per manifest model — name + workload
+    desc, geomean ×speedup bar with a min–max whisker across fixtures — on the
+    same log2 axis as the per-model charts. No cross-model aggregate on purpose:
+    the models exercise different execution modes. Unsupported models appear as
+    muted status rows so the overview is the complete state of the world."""
+    ink = INK[mode]
+
+    def x(v):
+        return OV_GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * OV_PLOT
+
+    ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x)
+
+    top = 74
+    row_h = 40
+    col_x = CHART_W - 16
+    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+            f'text-anchor="end">fixtures · ids</text>']
+    y = top
+    for m in models:
+        cy = y + row_h / 2
+        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy - 3:.1f}" fill="{ink["primary"]}" '
+                    f'font-size="12.5" font-weight="600" text-anchor="end">{escape(m["model"])}</text>')
+        desc = m.get("desc") or m["shape"]
+        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 11:.1f}" fill="{ink["muted"]}" '
+                    f'font-size="10.5" text-anchor="end">{escape(desc)}</text>')
+        if m["supported"]:
+            vals = [r["speedup"] for r in m["results"]]
+            g, mn, mx = geomean(vals), min(vals), max(vals)
+            if abs(math.log2(g)) < math.log2(1.02):  # within noise of the baseline
+                color = ink["muted"]
+            else:
+                color = ink["faster"] if g >= 1 else ink["slower"]
+            body.append(f'<path d="{bar_path(x(1.0), x(g), cy - 7, 14, 4)}" fill="{color}"/>')
+            body.append(f'<line x1="{x(mn):.1f}" y1="{cy:.1f}" x2="{x(mx):.1f}" y2="{cy:.1f}" '
+                        f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
+            for v in (mn, mx):
+                body.append(f'<line x1="{x(v):.1f}" y1="{cy - 4:.1f}" x2="{x(v):.1f}" y2="{cy + 4:.1f}" '
+                            f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
+            anchor, lx = (("start", max(x(mx), x(1.0)) + 8) if g >= 1
+                          else ("end", min(x(mn), x(1.0)) - 8))
+            body.append(f'<text x="{lx:.1f}" y="{cy + 4:.1f}" fill="{ink["primary"]}" font-size="12" '
+                        f'font-weight="600" text-anchor="{anchor}" '
+                        f'style="font-variant-numeric:tabular-nums">×{g:.2f}</text>')
+            bad = sum(not r["ids_match"] for r in m["results"])
+            right, fill = ((f"⚠ {bad} differ", ink["critical"]) if bad
+                           else (f'{len(m["results"])} · ids ok', ink["secondary"]))
+            body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{fill}" font-size="12" '
+                        f'text-anchor="end" style="font-variant-numeric:tabular-nums">{right}</text>')
+        else:
+            pretok = m["shape"].split("·")[-1].strip()
+            body.append(f'<text x="{x(1.0) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["muted"]}" '
+                        f'font-size="11.5" font-style="italic">not supported — '
+                        f'no {escape(pretok)} pre-tokenizer</text>')
+            body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{ink["muted"]}" font-size="12" '
+                        f'text-anchor="end">—</text>')
+        y += row_h
+
+    grid = []
+    for t in ticks:
+        strong = t == 1.0
+        grid.append(f'<line x1="{x(t):.1f}" y1="{top - 6}" x2="{x(t):.1f}" y2="{y - 2}" '
+                    f'stroke="{ink["baseline"] if strong else ink["grid"]}" stroke-width="1"/>')
+        grid.append(f'<text x="{x(t):.1f}" y="{y + 14}" fill="{ink["muted"]}" font-size="11" '
+                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">×{t:g}</text>')
+    hints = (f'<text x="{x(1.0) - 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+             f'text-anchor="end">← slower</text>'
+             f'<text x="{x(1.0) + 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+             f'text-anchor="start">faster →</text>')
+
+    height = y + 46
+    subtitle = f'geomean ×speedup per model · whisker: min–max across fixtures · {subtitle_base}'
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{CHART_W}" height="{height}"
+  viewBox="0 0 {CHART_W} {height}" font-family="{FONT}">
+<rect width="{CHART_W}" height="{height}" fill="{ink["surface"]}"/>
+<text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="700">PipelineTokenizer vs Tokenizer — encode throughput by model</text>
+<text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
+{"".join(grid)}
+{hints}
+{"".join(body)}
+{footer_text(ink, height, meta)}
+</svg>'''
 
 
 def detect_hardware():
@@ -354,44 +482,51 @@ def picture(base, run_id, slug, alt, width):
 
 
 def render_markdown(models, subtitle_base, meta, base, run_id):
+    """Overview chart inline; everything per-model — charts and the per-fixture
+    table — inside one <details> block per model, so the PR description stays a
+    single screen. No cross-model aggregate number anywhere: the models exercise
+    different execution modes, so only per-model geomeans are meaningful."""
     supported = [m for m in models if m["supported"]]
     unsupported = [m for m in models if not m["supported"]]
     mismatches = [f"{m['model']}/{r['fixture']}"
                   for m in supported for r in m["results"] if not r["ids_match"]]
 
-    md = ["## PipelineTokenizer benchmark", ""]
-    head = f"**{len(supported)} / {len(models)} models supported**"
-    if supported:
-        g = geomean([r["speedup"] for m in supported for r in m["results"]])
-        nfix = len(supported[0]["results"])
-        head += f" · geomean ×{g:.2f} across supported · {nfix} fixtures each"
-    md += [f"{head} — {subtitle_base}", "", f"`{meta[0]}` · {meta[1]}", ""]
+    md = ["## PipelineTokenizer benchmark", "",
+          f"**{len(supported)} / {len(models)} models supported** — {subtitle_base}", "",
+          f"`{meta[0]}` · {meta[1]}", "",
+          picture(base, run_id, "overview", "Per-model encode throughput summary", 860), ""]
 
-    staged_rows = [r for m in supported for r in m["results"] if "stage_ns_per_byte" in r]
-    if staged_rows:
-        mix = ", ".join(f"{lbl} {100 * frac:.0f}%" for lbl, frac in stage_mix(staged_rows))
-        md += [f"Pipeline stage mix (mean share of encode time): {mix}. "
-               f"Per-model decomposition charts below.", ""]
-
-    if unsupported:
-        items = ", ".join(f"`{m['model']}` ({m['shape']})" for m in unsupported)
-        md += [f"> **Not yet supported:** {items} — roadmap cards below.", ""]
     if mismatches:
         md += [f"> ⚠️ **Token ids diverge from the reference on: {', '.join(mismatches)}** "
                f"— speedups there are meaningless until fixed.", ""]
 
-    # Supported models: speedup chart + stage-decomposition chart each
-    # (readable inline, click to zoom).
     for m in supported:
+        g = geomean([r["speedup"] for r in m["results"]])
         slug = slugify(m["model"])
+        desc = m.get("desc") or m["shape"]
+        flag = " · ⚠ ids differ" if any(not r["ids_match"] for r in m["results"]) else ""
+        md += [f"<details><summary><b>{escape(m['model'])}</b> — {escape(desc)} · "
+               f"geomean ×{g:.2f}{flag}</summary>", ""]
         md += [picture(base, run_id, slug, f"{m['model']} speedup", 860), ""]
         if has_stages(m):
             md += [picture(base, run_id, f"{slug}-stages",
                            f"{m['model']} stage decomposition", 860), ""]
+        md += ["| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup "
+               "| added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |",
+               "|---|---|---:|---:|---:|---:|---:|---:|---:|:--|"]
+        for r in sorted(m["results"], key=lambda r: (r["group"], r["fixture"])):
+            ids = "match" if r["ids_match"] else "⚠️ differ"
+            s = r.get("stage_ns_per_byte", {})
+            cells = " ".join(f"| {s[k]:.2f}" if k in s else "| —"
+                             for k in ("added_split", "normalize", "pre_tokenize", "model"))
+            md.append(f"| {r['fixture']} | {r['group']} | {r['legacy_mbps']:.1f} "
+                      f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} {cells} | {ids} |")
+        md += ["", "</details>", ""]
 
-    # Unsupported models: compact roadmap cards, two per row.
+    # Unsupported models: roadmap cards, collapsed — they're status, not results.
     if unsupported:
-        md += ["### Not yet supported", "", "<table>"]
+        names = ", ".join(f"<code>{escape(m['model'])}</code>" for m in unsupported)
+        md += [f"<details><summary><b>Not yet supported:</b> {names}</summary>", "", "<table>"]
         for i in range(0, len(unsupported), 2):
             md.append("<tr>")
             for m in unsupported[i:i + 2]:
@@ -399,24 +534,7 @@ def render_markdown(models, subtitle_base, meta, base, run_id):
                        picture(base, run_id, slugify(m["model"]), f"{m['model']} not supported", 420),
                        "</td>"]
             md.append("</tr>")
-        md += ["</table>", ""]
-
-    if supported:
-        md += ["<details><summary>Per-fixture results</summary>", ""]
-        for m in supported:
-            md += [f"#### {m['model']} — {m['shape']}", "",
-                   "| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup "
-                   "| added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |",
-                   "|---|---|---:|---:|---:|---:|---:|---:|---:|:--|"]
-            for r in sorted(m["results"], key=lambda r: (r["group"], r["fixture"])):
-                ids = "match" if r["ids_match"] else "⚠️ differ"
-                s = r.get("stage_ns_per_byte", {})
-                cells = " ".join(f"| {s[k]:.2f}" if k in s else "| —"
-                                 for k in ("added_split", "normalize", "pre_tokenize", "model"))
-                md.append(f"| {r['fixture']} | {r['group']} | {r['legacy_mbps']:.1f} "
-                          f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} {cells} | {ids} |")
-            md.append("")
-        md += ["</details>", ""]
+        md += ["</table>", "", "</details>", ""]
     return "\n".join(md)
 
 
@@ -444,6 +562,9 @@ def main():
     lo, hi = scale(models)
     max_total = stage_scale(models)
     out = Path(args.out_dir)
+    for mode in ("light", "dark"):
+        (out / f"pipeline_bench_overview_{mode}.svg").write_text(
+            overview_svg(models, mode, args.subtitle, meta, lo, hi))
     for m in models:
         slug = slugify(m["model"])
         for mode in ("light", "dark"):
@@ -458,8 +579,13 @@ def main():
         render_markdown(models, args.subtitle, meta, args.img_base, args.run_id))
 
     supported = [m for m in models if m["supported"]]
-    g = geomean([r["speedup"] for m in supported for r in m["results"]]) if supported else 0
-    print(f"{len(supported)}/{len(models)} supported, geomean x{g:.3f}")
+    # per-model geomeans only — a cross-model aggregate would average unrelated
+    # execution modes (normalizer-heavy vs split-heavy vs model-bounded)
+    per_model = " · ".join(
+        f"{m['model']} x{geomean([r['speedup'] for r in m['results']]):.3f}"
+        for m in supported)
+    print(f"{len(supported)}/{len(models)} supported"
+          + (f" · {per_model}" if per_model else ""))
 
 
 if __name__ == "__main__":

--- a/tokenizers/tk-encode/examples/bench_models.json
+++ b/tokenizers/tk-encode/examples/bench_models.json
@@ -1,6 +1,8 @@
 [
-  { "name": "bert-base-uncased", "file": "bert-base-uncased.json" },
-  { "name": "deepseek-v4",       "file": "deepseek-v4.json" },
-  { "name": "llama-3",           "file": "llama-3-tokenizer.json" },
-  { "name": "t5-base",           "file": "t5-base.json" }
+  { "name": "bert-base-uncased", "file": "bert-base-uncased.json", "desc": "normalizer-heavy WordPiece" },
+  { "name": "deepseek-v4",       "file": "deepseek-v4.json",       "desc": "split-heavy byte-level BPE, 3 chained regexes" },
+  { "name": "gpt2",              "file": "gpt2.json",              "desc": "standalone ByteLevel pre-tokenizer" },
+  { "name": "llama-2",           "file": "llama-2.json",           "desc": "model-bounded BPE, no pre-tokenizer" },
+  { "name": "llama-3",           "file": "llama-3-tokenizer.json", "desc": "split-heavy byte-level BPE, single regex" },
+  { "name": "t5-base",           "file": "t5-base.json",           "desc": "Unigram + Metaspace" }
 ]

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -36,8 +36,14 @@ const REPS: usize = 5;
 // `added_*` fixtures are built from exactly these strings (see the dataset FIXTURES.md).
 const ADDED_SPECIAL: &[&str] = &["<|xs0|>", "<|xs1|>", "<|xs2|>", "<|xs3|>", "<|xs4|>"];
 const ADDED_NORMALIZED: &[&str] = &[
-    "widgetron", "flibberjast", "zorptastic", "quibblenaut", "snorlaxian", "blorptronic",
-    "wuzzlefang", "crungledorf",
+    "widgetron",
+    "flibberjast",
+    "zorptastic",
+    "quibblenaut",
+    "snorlaxian",
+    "blorptronic",
+    "wuzzlefang",
+    "crungledorf",
 ];
 
 /// Inject the benchmark's added tokens into `tok` before the pipeline is built from it,

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -4,10 +4,11 @@
 //! — the regime where per-input overhead is amortized (see `pipeline_benchmark.rs`
 //! for the size sweep).
 //!
-//! `PipelineTokenizer` is a work in progress: it only builds for tokenizers whose
-//! pre-tokenizer is Bert / Whitespace / None. Models it can't build (byte-level
-//! BPE, SentencePiece/Unigram, …) are reported as `supported: false` with their
-//! pipeline shape, rather than benched — the CI grid renders those as roadmap cards.
+//! `PipelineTokenizer` is a work in progress: models it can't build yet (standalone
+//! ByteLevel pre-tokenizer, Metaspace/Unigram, …) are reported as `supported: false`
+//! with their pipeline shape, rather than benched — the CI grid renders those as
+//! roadmap cards. Each manifest entry carries a `desc`: a one-line label of the
+//! workload archetype the model exercises, passed through to the report.
 //!
 //! Emits a JSON array (one object per model) on stdout, consumed by
 //! `.github/scripts/render_pipeline_bench.py` in CI.
@@ -272,6 +273,7 @@ fn main() {
     for entry in &manifest {
         let name = entry["name"].as_str().unwrap().to_string();
         let repo = entry.get("repo").and_then(Value::as_str).unwrap_or("");
+        let desc = entry.get("desc").and_then(Value::as_str).unwrap_or("");
         let path = model_path(entry);
         eprintln!("== {name} ({repo}) ==");
 
@@ -280,7 +282,7 @@ fn main() {
             Err(e) => {
                 eprintln!("  load failed: {e}");
                 out.push(json!({
-                    "model": name, "repo": repo, "shape": "?",
+                    "model": name, "repo": repo, "desc": desc, "shape": "?",
                     "supported": false, "reason": format!("load error: {e}"), "results": [],
                 }));
                 continue;
@@ -300,14 +302,14 @@ fn main() {
                 Ok(_) => {
                     let rows = bench_model(&tok, &pipeline, &files);
                     out.push(json!({
-                        "model": name, "repo": repo, "shape": shape,
+                        "model": name, "repo": repo, "desc": desc, "shape": shape,
                         "supported": true, "results": rows,
                     }));
                 }
                 Err(e) => {
                     eprintln!("  builds but can't encode yet ({shape}): {e}");
                     out.push(json!({
-                        "model": name, "repo": repo, "shape": shape,
+                        "model": name, "repo": repo, "desc": desc, "shape": shape,
                         "supported": false, "reason": format!("{e}"), "results": [],
                     }));
                 }
@@ -315,7 +317,7 @@ fn main() {
             Err(_) => {
                 eprintln!("  unsupported by PipelineTokenizer ({shape})");
                 out.push(json!({
-                    "model": name, "repo": repo, "shape": shape,
+                    "model": name, "repo": repo, "desc": desc, "shape": shape,
                     "supported": false, "results": [],
                 }));
             }


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**2 / 6 models supported** — ~10 kB inputs · single thread

`3efb4ac86 · 2026-07-08 17:06 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-overview-dark.png">
  <img alt="Per-model encode throughput summary" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-overview-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · geomean ×2.90</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-bert-base-uncased-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.4 | 20.2 | ×2.73 | 1.23 | 28.19 | 9.27 | 10.14 | match |
| arb_Arab | lang | 3.8 | 8.3 | ×2.20 | 1.16 | 27.62 | 13.42 | 77.63 | match |
| ben_Beng | lang | 5.5 | 12.6 | ×2.29 | 1.15 | 19.35 | 8.81 | 49.85 | match |
| cmn_Hani | lang | 3.5 | 13.8 | ×3.98 | 1.18 | 37.61 | 10.95 | 22.26 | match |
| ell_Grek | lang | 3.5 | 7.1 | ×2.04 | 1.17 | 28.91 | 13.46 | 97.30 | match |
| eng_Latn | lang | 4.1 | 14.7 | ×3.59 | 2.54 | 39.35 | 3.76 | 19.91 | match |
| heb_Hebr | lang | 3.7 | 8.0 | ×2.15 | 1.16 | 37.85 | 13.48 | 71.37 | match |
| hin_Deva | lang | 5.9 | 14.5 | ×2.47 | 1.17 | 27.27 | 7.73 | 32.11 | match |
| jpn_Jpan | lang | 4.0 | 11.0 | ×2.78 | 1.17 | 23.47 | 10.81 | 55.03 | match |
| kat_Geor | lang | 5.8 | 11.0 | ×1.90 | 1.17 | 27.36 | 9.68 | 52.36 | match |
| kor_Hang | lang | 2.3 | 4.0 | ×1.79 | 1.18 | 35.68 | 21.55 | 187.51 | match |
| rus_Cyrl | lang | 3.3 | 6.4 | ×1.94 | 1.16 | 27.53 | 13.67 | 112.76 | match |
| tam_Taml | lang | 6.6 | 14.7 | ×2.23 | 1.15 | 19.04 | 8.22 | 39.07 | match |
| tha_Thai | lang | 8.2 | 13.5 | ×1.65 | 1.17 | 25.97 | 7.65 | 38.75 | match |
| added_normalized_dense | modalities | 6.2 | 21.2 | ×3.41 | 1.31 | 41.48 | 1.05 | 2.61 | match |
| added_normalized_sparse | modalities | 4.9 | 17.9 | ×3.62 | 1.83 | 40.60 | 2.65 | 10.14 | match |
| added_special_dense | modalities | 4.9 | 47.5 | ×9.66 | 5.13 | 9.28 | 1.90 | 3.87 | match |
| added_special_sparse | modalities | 3.8 | 21.0 | ×5.55 | 3.56 | 28.29 | 2.72 | 12.31 | match |
| agentic-traces | modalities | 3.5 | 13.0 | ×3.67 | 2.32 | 39.13 | 4.02 | 30.50 | match |
| agentic_swe | modalities | 3.8 | 13.3 | ×3.53 | 1.88 | 39.35 | 3.02 | 29.74 | match |
| code_mixed | modalities | 3.6 | 12.0 | ×3.31 | 2.15 | 39.27 | 3.77 | 37.00 | match |
| math_latex | modalities | 3.7 | 13.4 | ×3.62 | 2.47 | 39.24 | 3.67 | 28.25 | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · geomean ×1.62</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-llama-2-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 6.5 | ×1.54 | 0.04 | 14.46 | 0.00 | 141.08 | match |
| arb_Arab | lang | 8.9 | 16.0 | ×1.80 | 0.03 | 16.73 | 0.00 | 46.92 | match |
| ben_Beng | lang | 9.7 | 17.3 | ×1.78 | 0.04 | 10.49 | 0.00 | 48.45 | match |
| cmn_Hani | lang | 7.9 | 13.0 | ×1.65 | 0.06 | 3.14 | 0.00 | 73.18 | match |
| ell_Grek | lang | 8.8 | 16.2 | ×1.84 | 0.03 | 15.01 | 0.90 | 44.31 | match |
| eng_Latn | lang | 4.1 | 4.9 | ×1.19 | 0.05 | 30.33 | 0.00 | 175.62 | match |
| heb_Hebr | lang | 8.7 | 16.5 | ×1.89 | 0.03 | 15.05 | 1.09 | 43.00 | match |
| hin_Deva | lang | 10.4 | 19.1 | ×1.82 | 0.03 | 14.13 | 0.66 | 36.80 | match |
| jpn_Jpan | lang | 11.0 | 20.5 | ×1.86 | 0.05 | 2.69 | 0.00 | 45.65 | match |
| kat_Geor | lang | 12.4 | 24.2 | ×1.95 | 0.04 | 9.12 | 0.40 | 30.85 | match |
| kor_Hang | lang | 6.3 | 10.3 | ×1.62 | 0.06 | 16.60 | 0.00 | 81.57 | match |
| rus_Cyrl | lang | 7.9 | 9.6 | ×1.23 | 0.03 | 13.98 | 0.00 | 90.06 | match |
| tam_Taml | lang | 10.8 | 19.8 | ×1.83 | 0.03 | 8.52 | 0.36 | 41.02 | match |
| tha_Thai | lang | 13.4 | 25.6 | ×1.91 | 0.03 | 5.04 | 0.00 | 33.82 | match |
| added_normalized_dense | modalities | 5.2 | 6.7 | ×1.29 | 0.02 | 18.50 | 0.52 | 126.24 | match |
| added_normalized_sparse | modalities | 4.8 | 5.9 | ×1.22 | 0.07 | 26.89 | 0.00 | 147.10 | match |
| added_special_dense | modalities | 4.7 | 15.5 | ×3.28 | 5.11 | 42.55 | 1.68 | 13.64 | match |
| added_special_sparse | modalities | 6.6 | 15.5 | ×2.34 | 2.14 | 41.85 | 0.00 | 19.59 | match |
| agentic-traces | modalities | 4.3 | 5.1 | ×1.21 | 0.12 | 28.50 | 0.00 | 166.77 | match |
| agentic_swe | modalities | 3.9 | 5.0 | ×1.26 | 0.07 | 52.44 | 0.00 | 154.31 | match |
| code_mixed | modalities | 4.1 | 5.0 | ×1.23 | 0.03 | 40.77 | 0.00 | 164.01 | match |
| math_latex | modalities | 4.2 | 5.0 | ×1.20 | 0.06 | 28.51 | 0.00 | 173.34 | match |

</details>

<details><summary><b>Not yet supported:</b> <code>deepseek-v4</code>, <code>gpt2</code>, <code>llama-3</code>, <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-deepseek-v4-dark.png">
  <img alt="deepseek-v4 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-deepseek-v4-light.png" width="420">
</picture>
</td>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-gpt2-dark.png">
  <img alt="gpt2 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-gpt2-light.png" width="420">
</picture>
</td>
</tr>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-llama-3-dark.png">
  <img alt="llama-3 not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-llama-3-light.png" width="420">
</picture>
</td>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-28960949367-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
