### PR TITLE
Feat/no alloc model

### DIFF
--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -2,9 +2,12 @@ use super::{
     lattice::Lattice,
     trie::{Trie, TrieBuilder},
 };
-use crate::tokenizer::{Model, Result, Token};
 use crate::utils::cache::{Cache, MAX_LENGTH};
 use crate::vocab_store::VocabStore;
+use crate::{
+    pipeline::{self, PipelineToken},
+    tokenizer::{Model, Result, Token},
+};
 use std::collections::HashMap;
 
 use std::convert::TryInto;
@@ -499,6 +502,43 @@ impl Model for Unigram {
         let string = serde_json::to_string_pretty(self)?;
         std::fs::write(&fullpath, string)?;
         Ok(vec![fullpath])
+    }
+}
+
+impl pipeline::Model for Unigram {
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        let str_tokens = self.encode(sequence)?;
+
+        for string in str_tokens {
+            match self.token_to_ids.token_to_id(&string) {
+                Some(id) => {
+                    output.push(PipelineToken { id });
+                }
+                None => {
+                    if self.byte_fallback {
+                        let byte_token_ids: Option<Vec<_>> = string
+                            .bytes()
+                            .map(|byte| {
+                                let byte_string = format!("<0x{byte:02X}>");
+                                self.token_to_ids.token_to_id(&byte_string)
+                            })
+                            .collect();
+                        if let Some(token_ids) = byte_token_ids {
+                            output.extend(token_ids.iter().map(|&id| PipelineToken { id }));
+                            continue;
+                        }
+                    }
+                    output.push(PipelineToken {
+                        id: self.unk_id.ok_or(UnigramError::MissingUnkId)? as u32,
+                    });
+                }
+            };
+        }
+        Ok(())
     }
 }
 

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -1,4 +1,5 @@
 use super::OrderedVocabIter;
+use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use ahash::AHashMap;
 use serde_json::Value;
@@ -203,6 +204,23 @@ impl Model for WordLevel {
         vocab_file.write_all(serialized.as_bytes())?;
 
         Ok(vec![vocab_path])
+    }
+}
+
+impl pipeline::Model for WordLevel {
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        if let Some(&id) = self.vocab.get(sequence) {
+            output.push(PipelineToken { id })
+        } else if let Some(&unk_id) = self.vocab.get(&self.unk_token) {
+            output.push(PipelineToken { id: unk_id });
+        } else {
+            return Err(Box::new(Error::MissingUnkToken));
+        }
+        Ok(())
     }
 }
 

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -318,6 +318,7 @@ impl pipeline::Model for WordPiece {
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
         let mut candidate = String::with_capacity(self.max_input_chars_per_word);
+        let mut candidate_tokens = Vec::with_capacity(sequence.len());
 
         let char_len = sequence.chars().count();
         if char_len > self.max_input_chars_per_word {
@@ -326,42 +327,45 @@ impl pipeline::Model for WordPiece {
                 .get(&self.unk_token)
                 .ok_or(Error::MissingUnkToken)?;
             output.push(PipelineToken { id: unk_id });
+            return Ok(());
         }
 
-        let mut is_good = false;
+        let mut is_bad = false;
         let mut start = 0;
 
         while start < sequence.len() {
-            candidate.clear();
             let mut end = sequence.len();
 
             while start < end {
+                candidate.clear();
+
                 if start > 0 {
                     candidate.push_str(&self.continuing_subword_prefix);
                 }
                 candidate.push_str(&sequence[start..end]);
 
                 if let Some(&id) = self.vocab.get(&candidate) {
-                    output.push(PipelineToken { id });
-                    is_good = true;
+                    candidate_tokens.push(PipelineToken { id });
                     break;
                 }
                 end -= candidate.chars().last().map_or(1, |c| c.len_utf8());
             }
 
-            if !is_good {
+            if end <= start {
+                is_bad = true;
                 break;
             }
-
             start = end;
         }
 
-        if !is_good {
+        if is_bad {
             let unk_id = *self
                 .vocab
                 .get(&self.unk_token)
                 .ok_or(Error::MissingUnkToken)?;
             output.push(PipelineToken { id: unk_id });
+        } else {
+            output.extend_from_slice(&candidate_tokens);
         }
         Ok(())
     }

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -330,43 +330,36 @@ impl pipeline::Model for WordPiece {
             return Ok(());
         }
 
-        let mut is_bad = false;
         let mut start = 0;
 
         while start < sequence.len() {
-            let mut end = sequence.len();
-
-            while start < end {
-                candidate.clear();
-
-                if start > 0 {
-                    candidate.push_str(&self.continuing_subword_prefix);
-                }
-                candidate.push_str(&sequence[start..end]);
-
-                if let Some(&id) = self.vocab.get(&candidate) {
-                    candidate_tokens.push(PipelineToken { id });
-                    break;
-                }
-                end -= candidate.chars().last().map_or(1, |c| c.len_utf8());
+            candidate.clear();
+            if start > 0 {
+                candidate.push_str(&self.continuing_subword_prefix);
             }
+            candidate.push_str(&sequence[start..]);
 
-            if end <= start {
-                is_bad = true;
-                break;
-            }
+            let prefix_len = candidate.len() - (sequence.len() - start);
+            let matched = sequence[start..]
+                .char_indices()
+                .rev()
+                .find_map(|(idx, character)| {
+                    let end = start + idx + character.len_utf8();
+                    candidate.truncate(prefix_len + (end - start));
+                    self.vocab.get(&candidate).map(|&id| (end, id))
+                });
+            let Some((end, token_id)) = matched else {
+                let unk_id = *self
+                    .vocab
+                    .get(&self.unk_token)
+                    .ok_or(Error::MissingUnkToken)?;
+                output.push(PipelineToken { id: unk_id });
+                return Ok(());
+            };
+            candidate_tokens.push(PipelineToken { id: token_id });
             start = end;
         }
-
-        if is_bad {
-            let unk_id = *self
-                .vocab
-                .get(&self.unk_token)
-                .ok_or(Error::MissingUnkToken)?;
-            output.push(PipelineToken { id: unk_id });
-        } else {
-            output.extend_from_slice(&candidate_tokens);
-        }
+        output.extend_from_slice(&candidate_tokens);
         Ok(())
     }
 }

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -2,6 +2,7 @@
 //! model.
 
 use crate::models::bpe::BPE;
+use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use ahash::AHashMap;
 use std::collections::HashMap;
@@ -307,6 +308,62 @@ impl Model for WordPiece {
         )?;
 
         Ok(vec![vocab_path])
+    }
+}
+
+impl pipeline::Model for WordPiece {
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        let mut candidate = String::with_capacity(self.max_input_chars_per_word);
+
+        let char_len = sequence.chars().count();
+        if char_len > self.max_input_chars_per_word {
+            let unk_id = *self
+                .vocab
+                .get(&self.unk_token)
+                .ok_or(Error::MissingUnkToken)?;
+            output.push(PipelineToken { id: unk_id });
+        }
+
+        let mut is_good = false;
+        let mut start = 0;
+
+        while start < sequence.len() {
+            candidate.clear();
+            let mut end = sequence.len();
+
+            while start < end {
+                if start > 0 {
+                    candidate.push_str(&self.continuing_subword_prefix);
+                }
+                candidate.push_str(&sequence[start..end]);
+
+                if let Some(&id) = self.vocab.get(&candidate) {
+                    output.push(PipelineToken { id });
+                    is_good = true;
+                    break;
+                }
+                end -= candidate.chars().last().map_or(1, |c| c.len_utf8());
+            }
+
+            if !is_good {
+                break;
+            }
+
+            start = end;
+        }
+
+        if !is_good {
+            let unk_id = *self
+                .vocab
+                .get(&self.unk_token)
+                .ok_or(Error::MissingUnkToken)?;
+            output.push(PipelineToken { id: unk_id });
+        }
+        Ok(())
     }
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -691,14 +691,12 @@ pub enum PipelineModel {
 
 impl Model for PipelineModel {
     fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()> {
-        let tokens = match self {
+       match self {
             Self::BPE(model) => return model.tokenize_pipeline(sequence, output),
-            Self::Unigram(model) => model.tokenize(sequence),
-            Self::WordLevel(model) => model.tokenize(sequence),
-            Self::WordPiece(model) => model.tokenize(sequence),
-        }?;
-        output.extend(tokens.iter().map(|&Token { id, .. }| PipelineToken { id }));
-        Ok(())
+            Self::Unigram(model) => model.tokenize_pipeline(sequence, output),
+            Self::WordLevel(model) => model.tokenize_pipeline(sequence, output),
+            Self::WordPiece(model) => model.tokenize_pipeline(sequence, output),
+        }
     }
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -25,8 +25,7 @@ use crate::{
         unicode_scripts::UnicodeScripts,
         whitespace::{Whitespace, WhitespaceSplit},
     },
-    Model as LegacyModelTrait, ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token,
-    Tokenizer,
+    ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer,
 };
 
 use super::{Result, SplitDelimiterBehavior};

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -691,8 +691,8 @@ pub enum PipelineModel {
 
 impl Model for PipelineModel {
     fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()> {
-       match self {
-            Self::BPE(model) => return model.tokenize_pipeline(sequence, output),
+        match self {
+            Self::BPE(model) => model.tokenize_pipeline(sequence, output),
             Self::Unigram(model) => model.tokenize_pipeline(sequence, output),
             Self::WordLevel(model) => model.tokenize_pipeline(sequence, output),
             Self::WordPiece(model) => model.tokenize_pipeline(sequence, output),


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**5 / 6 models supported** — ~10 kB inputs · single thread

`60c04292e · 2026-07-09 14:25 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 96 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-overview-dark.png">
  <img alt="Per-model encode throughput summary" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-overview-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · geomean ×4.10</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-bert-base-uncased-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.5 | 21.9 | ×2.93 | 1.22 | 27.47 | 9.20 | 7.69 | match |
| arb_Arab | lang | 3.7 | 15.0 | ×4.00 | 1.16 | 28.17 | 12.72 | 23.94 | match |
| ben_Beng | lang | 5.5 | 22.1 | ×4.03 | 1.16 | 19.57 | 8.40 | 15.51 | match |
| cmn_Hani | lang | 3.5 | 14.5 | ×4.21 | 1.18 | 37.58 | 10.93 | 17.91 | match |
| ell_Grek | lang | 3.4 | 13.9 | ×4.04 | 1.17 | 29.27 | 14.30 | 26.27 | match |
| eng_Latn | lang | 4.2 | 16.5 | ×3.96 | 2.50 | 38.66 | 3.63 | 14.09 | match |
| heb_Hebr | lang | 3.8 | 13.1 | ×3.49 | 1.17 | 38.11 | 12.86 | 23.16 | match |
| hin_Deva | lang | 5.9 | 20.3 | ×3.46 | 1.16 | 27.40 | 7.44 | 12.40 | match |
| jpn_Jpan | lang | 4.0 | 17.5 | ×4.41 | 1.17 | 23.30 | 10.87 | 20.51 | match |
| kat_Geor | lang | 5.8 | 18.7 | ×3.23 | 1.16 | 26.54 | 9.66 | 15.43 | match |
| kor_Hang | lang | 2.2 | 9.4 | ×4.19 | 1.18 | 34.93 | 21.48 | 47.58 | match |
| rus_Cyrl | lang | 3.3 | 13.7 | ×4.12 | 1.17 | 28.16 | 12.96 | 29.71 | match |
| tam_Taml | lang | 6.6 | 24.7 | ×3.73 | 1.16 | 19.04 | 7.80 | 11.72 | match |
| tha_Thai | lang | 8.2 | 22.0 | ×2.68 | 1.17 | 25.42 | 7.23 | 11.03 | match |
| added_normalized_dense | modalities | 6.3 | 21.8 | ×3.49 | 1.30 | 40.57 | 1.45 | 1.58 | match |
| added_normalized_sparse | modalities | 4.9 | 19.3 | ×3.91 | 1.90 | 40.04 | 2.45 | 6.49 | match |
| added_special_dense | modalities | 4.9 | 50.1 | ×10.20 | 5.15 | 9.24 | 2.41 | 2.22 | match |
| added_special_sparse | modalities | 3.8 | 23.0 | ×6.13 | 3.52 | 28.17 | 3.10 | 7.67 | match |
| agentic-traces | modalities | 3.5 | 15.4 | ×4.42 | 2.35 | 38.52 | 4.08 | 19.13 | match |
| agentic_swe | modalities | 3.7 | 16.3 | ×4.36 | 1.89 | 38.71 | 3.03 | 17.09 | match |
| code_mixed | modalities | 3.6 | 15.9 | ×4.44 | 2.13 | 38.57 | 3.66 | 17.56 | match |
| math_latex | modalities | 3.6 | 15.6 | ×4.31 | 2.44 | 38.62 | 3.54 | 18.47 | match |

</details>

<details><summary><b>deepseek-v4</b> — split-heavy byte-level BPE, 3 chained regexes · geomean ×2.68</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-deepseek-v4-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.4 | 14.1 | ×4.12 | 0.68 | 0.00 | 44.13 | 24.60 | match |
| arb_Arab | lang | 3.4 | 9.3 | ×2.73 | 0.60 | 0.00 | 49.34 | 58.01 | match |
| ben_Beng | lang | 4.4 | 11.0 | ×2.53 | 0.59 | 0.00 | 36.96 | 51.56 | match |
| cmn_Hani | lang | 3.3 | 7.9 | ×2.42 | 0.76 | 0.00 | 66.32 | 55.07 | match |
| ell_Grek | lang | 3.6 | 10.0 | ×2.77 | 0.60 | 0.00 | 47.57 | 52.39 | match |
| eng_Latn | lang | 2.6 | 6.5 | ×2.50 | 1.97 | 0.00 | 72.05 | 75.68 | match |
| heb_Hebr | lang | 3.2 | 8.0 | ×2.52 | 0.60 | 0.00 | 52.49 | 69.85 | match |
| hin_Deva | lang | 4.2 | 11.9 | ×2.82 | 0.60 | 0.00 | 39.81 | 41.39 | match |
| jpn_Jpan | lang | 3.7 | 8.8 | ×2.39 | 0.66 | 0.00 | 58.18 | 52.09 | match |
| kat_Geor | lang | 4.3 | 11.6 | ×2.68 | 0.59 | 0.00 | 33.20 | 51.28 | match |
| kor_Hang | lang | 3.2 | 10.0 | ×3.14 | 0.61 | 0.00 | 51.54 | 49.00 | match |
| rus_Cyrl | lang | 3.5 | 8.7 | ×2.51 | 0.60 | 0.00 | 48.74 | 65.98 | match |
| tam_Taml | lang | 4.6 | 11.5 | ×2.49 | 0.59 | 0.00 | 32.03 | 54.53 | match |
| tha_Thai | lang | 5.3 | 10.6 | ×2.02 | 0.60 | 0.00 | 27.58 | 65.66 | match |
| added_normalized_dense | modalities | 3.5 | 11.9 | ×3.38 | 0.73 | 0.00 | 42.44 | 44.93 | match |
| added_normalized_sparse | modalities | 3.4 | 10.2 | ×2.96 | 1.30 | 0.00 | 49.17 | 47.98 | match |
| added_special_dense | modalities | 2.9 | 7.2 | ×2.52 | 6.73 | 0.62 | 108.75 | 23.58 | match |
| added_special_sparse | modalities | 3.1 | 7.5 | ×2.44 | 3.89 | 0.27 | 80.98 | 48.38 | match |
| agentic-traces | modalities | 2.3 | 6.2 | ×2.71 | 1.78 | 0.00 | 88.58 | 66.66 | match |
| agentic_swe | modalities | 2.3 | 5.8 | ×2.58 | 1.29 | 0.00 | 101.07 | 72.21 | match |
| code_mixed | modalities | 2.5 | 6.7 | ×2.71 | 1.56 | 0.00 | 81.63 | 61.83 | match |
| math_latex | modalities | 2.4 | 6.2 | ×2.63 | 1.87 | 0.00 | 86.03 | 85.50 | match |

</details>

<details><summary><b>gpt2</b> — standalone ByteLevel pre-tokenizer · geomean ×8.00</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-gpt2-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.7 | 40.2 | ×10.74 | 0.66 | 0.00 | 6.24 | 17.08 | match |
| arb_Arab | lang | 3.0 | 22.1 | ×7.33 | 0.60 | 0.00 | 7.65 | 35.83 | match |
| ben_Beng | lang | 2.3 | 28.3 | ×12.51 | 0.59 | 0.00 | 12.42 | 22.17 | match |
| cmn_Hani | lang | 3.1 | 24.5 | ×7.95 | 0.61 | 0.00 | 5.68 | 33.90 | match |
| ell_Grek | lang | 3.1 | 24.5 | ×7.93 | 0.61 | 0.00 | 6.89 | 32.22 | match |
| eng_Latn | lang | 2.6 | 11.7 | ×4.45 | 1.98 | 0.00 | 11.09 | 70.35 | match |
| heb_Hebr | lang | 2.9 | 24.6 | ×8.37 | 0.59 | 0.01 | 8.18 | 30.92 | match |
| hin_Deva | lang | 2.5 | 26.3 | ×10.58 | 0.60 | 0.00 | 12.42 | 25.05 | match |
| jpn_Jpan | lang | 3.4 | 19.6 | ×5.77 | 0.61 | 0.00 | 5.08 | 44.39 | match |
| kat_Geor | lang | 3.6 | 52.9 | ×14.80 | 0.60 | 0.00 | 4.85 | 12.52 | match |
| kor_Hang | lang | 2.8 | 32.4 | ×11.38 | 0.61 | 0.00 | 7.83 | 21.39 | match |
| rus_Cyrl | lang | 3.2 | 24.8 | ×7.67 | 0.60 | 0.00 | 6.84 | 32.77 | match |
| tam_Taml | lang | 2.2 | 35.6 | ×16.45 | 0.59 | 0.00 | 11.57 | 16.03 | match |
| tha_Thai | lang | 2.8 | 29.0 | ×10.22 | 0.61 | 0.00 | 7.58 | 25.68 | match |
| added_normalized_dense | modalities | 3.5 | 22.7 | ×6.49 | 0.72 | 0.00 | 6.65 | 34.84 | match |
| added_normalized_sparse | modalities | 3.3 | 18.8 | ×5.68 | 1.27 | 0.00 | 8.36 | 43.20 | match |
| added_special_dense | modalities | 3.5 | 32.3 | ×9.12 | 5.20 | 0.18 | 9.54 | 14.27 | match |
| added_special_sparse | modalities | 3.3 | 19.0 | ×5.77 | 3.15 | 0.11 | 10.92 | 36.40 | match |
| agentic-traces | modalities | 2.4 | 13.1 | ×5.45 | 1.77 | 0.00 | 13.41 | 60.00 | match |
| agentic_swe | modalities | 2.5 | 17.8 | ×7.19 | 1.28 | 0.00 | 12.69 | 41.14 | match |
| code_mixed | modalities | 2.4 | 15.6 | ×6.50 | 1.55 | 0.00 | 13.13 | 48.43 | match |
| math_latex | modalities | 2.5 | 12.4 | ×4.89 | 1.87 | 0.00 | 12.37 | 65.23 | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · geomean ×3.06</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-llama-2-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 32.5 | ×7.51 | 0.04 | 12.55 | 0.01 | 18.59 | match |
| arb_Arab | lang | 9.0 | 32.9 | ×3.67 | 0.03 | 14.46 | 0.00 | 16.50 | match |
| ben_Beng | lang | 9.7 | 53.7 | ×5.53 | 0.04 | 9.85 | 0.03 | 9.08 | match |
| cmn_Hani | lang | 8.1 | 61.9 | ×7.69 | 0.05 | 2.82 | 0.00 | 12.71 | match |
| ell_Grek | lang | 8.9 | 37.5 | ×4.20 | 0.03 | 13.57 | 0.05 | 13.61 | match |
| eng_Latn | lang | 4.1 | 6.0 | ×1.46 | 0.06 | 25.71 | 0.00 | 141.35 | match |
| heb_Hebr | lang | 8.8 | 36.9 | ×4.20 | 0.03 | 15.05 | 0.03 | 12.43 | match |
| hin_Deva | lang | 10.7 | 47.2 | ×4.42 | 0.03 | 12.58 | 0.00 | 9.14 | match |
| jpn_Jpan | lang | 11.3 | 78.8 | ×6.96 | 0.05 | 2.57 | 0.01 | 9.49 | match |
| kat_Geor | lang | 12.7 | 59.8 | ×4.72 | 0.05 | 8.35 | 0.00 | 8.54 | match |
| kor_Hang | lang | 6.4 | 34.3 | ×5.35 | 0.05 | 14.47 | 0.00 | 15.17 | match |
| rus_Cyrl | lang | 7.9 | 14.5 | ×1.84 | 0.03 | 12.10 | 0.00 | 56.66 | match |
| tam_Taml | lang | 11.0 | 62.1 | ×5.67 | 0.03 | 7.72 | 0.00 | 8.52 | match |
| tha_Thai | lang | 13.6 | 72.3 | ×5.30 | 0.03 | 4.27 | 0.00 | 9.37 | match |
| added_normalized_dense | modalities | 5.3 | 8.6 | ×1.64 | 0.08 | 16.24 | 0.07 | 103.01 | match |
| added_normalized_sparse | modalities | 4.8 | 7.1 | ×1.49 | 0.07 | 22.97 | 0.00 | 119.33 | match |
| added_special_dense | modalities | 4.7 | 11.6 | ×2.47 | 5.40 | 42.12 | 1.26 | 30.45 | match |
| added_special_sparse | modalities | 6.4 | 7.8 | ×1.21 | 2.28 | 42.10 | 0.56 | 79.99 | match |
| agentic-traces | modalities | 4.2 | 6.5 | ×1.54 | 0.11 | 28.91 | 0.00 | 123.11 | match |
| agentic_swe | modalities | 3.9 | 5.9 | ×1.50 | 0.03 | 53.07 | 0.00 | 111.09 | match |
| code_mixed | modalities | 4.1 | 6.1 | ×1.50 | 0.03 | 41.27 | 0.00 | 118.17 | match |
| math_latex | modalities | 4.3 | 6.2 | ×1.45 | 0.06 | 28.81 | 0.00 | 129.27 | match |

</details>

<details><summary><b>llama-3</b> — split-heavy byte-level BPE, single regex · geomean ×3.98</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-llama-3-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.0 | 22.7 | ×7.46 | 0.65 | 0.00 | 27.02 | 16.66 | match |
| arb_Arab | lang | 3.5 | 12.0 | ×3.43 | 0.59 | 0.01 | 30.88 | 51.82 | match |
| ben_Beng | lang | 2.7 | 13.2 | ×4.95 | 0.59 | 0.00 | 45.24 | 31.00 | match |
| cmn_Hani | lang | 3.9 | 12.7 | ×3.23 | 0.61 | 0.00 | 22.12 | 52.94 | match |
| ell_Grek | lang | 3.9 | 12.8 | ×3.32 | 0.60 | 0.00 | 29.65 | 44.81 | match |
| eng_Latn | lang | 3.6 | 14.7 | ×4.12 | 1.98 | 0.00 | 46.82 | 13.73 | match |
| heb_Hebr | lang | 3.2 | 14.8 | ×4.66 | 0.59 | 0.00 | 32.56 | 31.51 | match |
| hin_Deva | lang | 3.8 | 16.7 | ×4.40 | 0.60 | 0.00 | 50.11 | 5.61 | match |
| jpn_Jpan | lang | 4.4 | 12.9 | ×2.92 | 0.62 | 0.00 | 18.78 | 56.17 | match |
| kat_Geor | lang | 3.7 | 22.9 | ×6.16 | 0.59 | 0.00 | 19.46 | 22.31 | match |
| kor_Hang | lang | 3.4 | 12.2 | ×3.61 | 0.61 | 0.00 | 32.47 | 44.81 | match |
| rus_Cyrl | lang | 4.0 | 11.9 | ×2.94 | 0.60 | 0.00 | 27.86 | 52.45 | match |
| tam_Taml | lang | 3.0 | 13.7 | ×4.60 | 0.59 | 0.00 | 45.78 | 23.36 | match |
| tha_Thai | lang | 4.5 | 13.7 | ×3.07 | 0.61 | 0.00 | 29.15 | 41.45 | match |
| added_normalized_dense | modalities | 3.8 | 16.4 | ×4.31 | 0.73 | 0.00 | 25.42 | 31.58 | match |
| added_normalized_sparse | modalities | 4.1 | 18.1 | ×4.45 | 1.27 | 0.00 | 33.36 | 16.91 | match |
| added_special_dense | modalities | 3.6 | 12.6 | ×3.48 | 5.13 | 0.27 | 69.85 | 0.36 | match |
| added_special_sparse | modalities | 4.0 | 15.1 | ×3.75 | 3.24 | 0.02 | 55.88 | 3.25 | match |
| agentic-traces | modalities | 3.1 | 12.1 | ×3.90 | 1.78 | 0.00 | 56.30 | 19.25 | match |
| agentic_swe | modalities | 3.3 | 10.8 | ×3.32 | 1.27 | 0.00 | 58.51 | 26.91 | match |
| code_mixed | modalities | 3.5 | 13.3 | ×3.84 | 1.55 | 0.00 | 55.78 | 12.48 | match |
| math_latex | modalities | 3.3 | 13.6 | ×4.13 | 1.86 | 0.02 | 51.47 | 20.07 | match |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29024896738-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->



