### PR TITLE
feat: T5 support (ai-generated)

### DIFF
--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -4,8 +4,8 @@
 //! — the regime where per-input overhead is amortized (see `pipeline_benchmark.rs`
 //! for the size sweep).
 //!
-//! `PipelineTokenizer` is a work in progress: models it can't build yet (standalone
-//! ByteLevel pre-tokenizer, Metaspace/Unigram, …) are reported as `supported: false`
+//! `PipelineTokenizer` is a work in progress: models it can't build yet (e.g.
+//! Metaspace with `prepend_scheme=first`) are reported as `supported: false`
 //! with their pipeline shape, rather than benched — the CI grid renders those as
 //! roadmap cards. Each manifest entry carries a `desc`: a one-line label of the
 //! workload archetype the model exercises, passed through to the report.
@@ -101,19 +101,29 @@ fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
 /// successive levels and subtracting gives each stage's marginal cost (the ablation
 /// ladder), no profiler and no per-segment instrumentation.
 ///
-/// Both caller-owned buffers are reused across chunks and `black_box`'d each iteration:
-/// `output` anchors the special-scan/normalize/model work, `pre_tokens` anchors the
-/// split stage, so under fat LTO no dead partial stage gets optimized away. The
-/// `black_box` lives here, in the bench — never in the library.
+/// The caller-owned buffers are reused across chunks and `black_box`'d each iteration:
+/// `output` anchors the special-scan/normalize/model work, `pre_tokens` and the
+/// Metaspace rewrite buffer anchor the split stage, so under fat LTO no dead partial
+/// stage gets optimized away. The `black_box` lives here, in the bench — never in the
+/// library.
 fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) -> f64 {
     let mut out = Vec::new();
     let mut pre_tokens = Vec::new();
+    let mut rewrite_buf = String::new();
+    let mut rewritten = Vec::new();
     let mut run = || {
         for chunk in chunks {
             out.clear();
-            let _ = pipeline.encode_generic::<STAGE>(chunk, &mut out, &mut pre_tokens);
+            let _ = pipeline.encode_generic::<STAGE>(
+                chunk,
+                &mut out,
+                &mut pre_tokens,
+                &mut rewrite_buf,
+                &mut rewritten,
+            );
             black_box(&out);
             black_box(&pre_tokens);
+            black_box(&rewrite_buf);
         }
     };
     run(); // warm-up

--- a/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
@@ -1,3 +1,4 @@
+use crate::pipeline;
 use crate::tokenizer::{Decoder, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use serde::{de, Deserialize, Deserializer, Serialize};
 
@@ -144,6 +145,57 @@ impl PreTokenizer for Metaspace {
                 Ok(vec![normalized])
             }
         })
+    }
+}
+
+impl Metaspace {
+    /// Pipeline-side form of [`PreTokenizer::pre_tokenize`], for one pre-token
+    /// `piece`. Metaspace edits text (space → replacement, prepend), which the
+    /// range-based [`pipeline::PreTokenizer`] cannot express, so the rewritten
+    /// text is appended to the caller's `scratch` and the emitted
+    /// [`pipeline::Split`]s are ranges into `scratch`.
+    ///
+    /// A single pass replaces, prepends, and splits at once: every replacement
+    /// char landing in `scratch` starts a new split, which is exactly
+    /// `SplitDelimiterBehavior::MergedWithNext` on the rewritten text.
+    ///
+    /// `PrependScheme::First` is unsupported (rejected at pipeline build): it
+    /// depends on the piece's offset in the original input, which the pipeline
+    /// does not track.
+    pub(crate) fn rewrite(
+        &self,
+        piece: &str,
+        scratch: &mut String,
+        out: &mut Vec<pipeline::Split>,
+    ) {
+        let base = scratch.len() as u32;
+        if self.prepend_scheme == PrependScheme::Always
+            && !piece.starts_with([' ', self.replacement])
+        {
+            scratch.push(self.replacement);
+        }
+        let mut split_start = base;
+        for ch in piece.chars() {
+            let ch = if ch == ' ' { self.replacement } else { ch };
+            if self.split && ch == self.replacement {
+                let pos = scratch.len() as u32;
+                if pos > split_start {
+                    out.push(pipeline::Split {
+                        start: split_start,
+                        end: pos,
+                    });
+                }
+                split_start = pos;
+            }
+            scratch.push(ch);
+        }
+        let end = scratch.len() as u32;
+        if end > split_start {
+            out.push(pipeline::Split {
+                start: split_start,
+                end,
+            });
+        }
     }
 }
 
@@ -353,6 +405,66 @@ mod tests {
             ]
         );
     }
+    fn rewrite_pieces(pretok: &Metaspace, pieces: &[&str]) -> Vec<String> {
+        let mut scratch = String::new();
+        let mut out = Vec::new();
+        for piece in pieces {
+            pretok.rewrite(piece, &mut scratch, &mut out);
+        }
+        out.iter().map(|s| scratch[s.range()].to_string()).collect()
+    }
+
+    /// Classic-path splits (Normalized referential) — the oracle for `rewrite`.
+    fn legacy_pieces(pretok: &Metaspace, text: &str) -> Vec<String> {
+        let mut pretokenized = PreTokenizedString::from(text);
+        pretok.pre_tokenize(&mut pretokenized).unwrap();
+        pretokenized
+            .get_splits(OffsetReferential::Normalized, OffsetType::Byte)
+            .into_iter()
+            .map(|(s, _, _)| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn rewrite_matches_legacy() {
+        let texts = [
+            "Hey friend!",
+            "Hey   friend!",
+            " Hey",
+            "▁already marked",
+            "how▁are you",
+            "no-spaces",
+            "中文 text 123",
+            "   ",
+        ];
+        for (scheme, split) in [
+            (PrependScheme::Always, true),
+            (PrependScheme::Always, false),
+            (PrependScheme::Never, true),
+            (PrependScheme::Never, false),
+        ] {
+            let pretok = Metaspace::new('▁', scheme, split);
+            for text in texts {
+                assert_eq!(
+                    rewrite_pieces(&pretok, &[text]),
+                    legacy_pieces(&pretok, text),
+                    "{scheme:?} split={split} diverged on {text:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rewrite_prepends_per_piece() {
+        // T5's shape: WhitespaceSplit runs first, so Metaspace sees one piece
+        // per word and its only effect is the per-piece prepend.
+        let pretok = Metaspace::new('▁', PrependScheme::Always, true);
+        assert_eq!(
+            rewrite_pieces(&pretok, &["Hey", "friend!"]),
+            vec!["▁Hey", "▁friend!"],
+        );
+    }
+
     #[test]
     fn decode() {
         let decoder = Metaspace::new('▁', PrependScheme::Always, true);

--- a/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
@@ -310,8 +310,9 @@ mod tests {
 
     #[test]
     fn pipeline_unsupported_child_errors() {
-        // Metaspace has no range-based form. Constructing the Sequence must still work
-        // (the legacy path supports it) — only the pipeline conversion should fail.
+        // Metaspace has no range-based form: `PipelineTokenizer` peels a *trailing*
+        // Metaspace off into its rewrite stage before this conversion runs, so the
+        // raw enum conversion itself must still reject it.
         use std::convert::TryFrom;
         let seq = Sequence::new(vec![
             PreTokenizerWrapper::WhitespaceSplit(WhitespaceSplit),

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -9,7 +9,8 @@ use crate::models::bpe::PipelineBPE;
 use crate::models::unigram::Unigram;
 use crate::models::wordlevel::WordLevel;
 use crate::models::wordpiece::WordPiece;
-use crate::pre_tokenizers::sequence::PipelineSequence;
+use crate::pre_tokenizers::metaspace::{Metaspace, PrependScheme};
+use crate::pre_tokenizers::sequence::{PipelineSequence, Sequence};
 use crate::pre_tokenizers::split::SplitPattern;
 use crate::utils::byte_level::GPT2_REGEX_STR;
 use crate::SplitDelimiterBehavior::Isolated;
@@ -260,8 +261,57 @@ pub struct PipelineTokenizer {
     added_vocabulary: BucketAddedVocabulary,
     normalizer: Option<NormalizerWrapper>,
     pre_tokenizer: PipelinePreTokenizer,
+    /// Trailing `Metaspace`, run as a rewrite stage after `pre_tokenizer`: it
+    /// edits text (space → replacement, prepend), which the range-based
+    /// pre-tokenizers cannot express, so its output lives in a scratch buffer.
+    rewriter: Option<Metaspace>,
     model: PipelineModel,
     _post_processor: Option<PostProcessorWrapper>,
+}
+
+/// Splits the tokenizer's pre-tokenizer into its range-based part and the
+/// trailing [`Metaspace`] rewriter, if any. Metaspace must come last: a
+/// pre-tokenizer after it would have to see the rewritten text, which stays
+/// out of band in the scratch buffer.
+fn peel_metaspace(
+    pretok: Option<PreTokenizerWrapper>,
+) -> Result<(Option<PreTokenizerWrapper>, Option<Metaspace>)> {
+    fn validate(metaspace: Metaspace) -> Result<Metaspace> {
+        if metaspace.prepend_scheme == PrependScheme::First {
+            return Err(
+                "Metaspace prepend_scheme=first is not supported by the pipeline yet".into(),
+            );
+        }
+        Ok(metaspace)
+    }
+
+    match pretok {
+        Some(PreTokenizerWrapper::Metaspace(metaspace)) => Ok((None, Some(validate(metaspace)?))),
+        Some(PreTokenizerWrapper::Sequence(seq)) => {
+            let mut children: Vec<PreTokenizerWrapper> = seq.into_iter().collect();
+            match children
+                .iter()
+                .position(|p| matches!(p, PreTokenizerWrapper::Metaspace(_)))
+            {
+                None => Ok((
+                    Some(PreTokenizerWrapper::Sequence(Sequence::new(children))),
+                    None,
+                )),
+                Some(pos) if pos + 1 == children.len() => {
+                    let Some(PreTokenizerWrapper::Metaspace(metaspace)) = children.pop() else {
+                        unreachable!()
+                    };
+                    let rest = (!children.is_empty())
+                        .then(|| PreTokenizerWrapper::Sequence(Sequence::new(children)));
+                    Ok((rest, Some(validate(metaspace)?)))
+                }
+                Some(_) => Err(
+                    "Metaspace pre tokenizer must be the last pre tokenizer in the Sequence".into(),
+                ),
+            }
+        }
+        other => Ok((other, None)),
+    }
 }
 
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
@@ -274,9 +324,8 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
     /// Adding them in id order preserves ids (tokens present in the model reuse their model id, the
     /// rest keep their dense order), so the pipeline emits the same ids as the reference tokenizer.
     fn try_from(tok: &Tokenizer) -> Result<Self> {
-        let pre_tokenizer: PipelinePreTokenizer = tok
-            .get_pre_tokenizer()
-            .cloned()
+        let (range_pretok, rewriter) = peel_metaspace(tok.get_pre_tokenizer().cloned())?;
+        let pre_tokenizer: PipelinePreTokenizer = range_pretok
             .map(TryInto::try_into)
             .transpose()?
             .unwrap_or(PipelinePreTokenizer::None);
@@ -358,6 +407,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             added_vocabulary,
             normalizer: tok.get_normalizer().cloned(),
             pre_tokenizer,
+            rewriter,
             model,
             _post_processor: tok.get_post_processor().cloned(),
         })
@@ -387,7 +437,15 @@ impl PipelineTokenizer {
     pub fn encode(&self, input: &str, _add_special_tokens: bool) -> Result<Vec<PipelineToken>> {
         let mut output = Vec::new();
         let mut pre_tokens = Vec::new();
-        self.encode_generic::<{ Self::STAGE_MODEL }>(input, &mut output, &mut pre_tokens)?;
+        let mut rewrite_buf = String::new();
+        let mut rewritten = Vec::new();
+        self.encode_generic::<{ Self::STAGE_MODEL }>(
+            input,
+            &mut output,
+            &mut pre_tokens,
+            &mut rewrite_buf,
+            &mut rewritten,
+        )?;
         Ok(output)
     }
 
@@ -401,15 +459,18 @@ impl PipelineTokenizer {
     ///
     /// [`STAGE_MODEL`]: Self::STAGE_MODEL
     ///
-    /// `output` and the `pre_tokens` scratch are caller-owned so a benchmark can reuse
-    /// them across calls and observe both buffers to anchor the ablation levels — the
-    /// library itself stays free of any `black_box`/timing artifact.
+    /// `output` and the scratch buffers (`pre_tokens`, plus `rewrite_buf`/`rewritten`
+    /// for the Metaspace rewriter) are caller-owned so a benchmark can reuse them
+    /// across calls and observe them to anchor the ablation levels — the library
+    /// itself stays free of any `black_box`/timing artifact.
     #[doc(hidden)] // public only so `examples/fixture_bench.rs` can drive partial stages
     pub fn encode_generic<const STAGE: u8>(
         &self,
         input: &str,
         output: &mut Vec<PipelineToken>,
         pre_tokens: &mut Vec<Split>,
+        rewrite_buf: &mut String,
+        rewritten: &mut Vec<Split>,
     ) -> Result<()> {
         // First, we extract all special tokens from the non-normalized input
         for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
@@ -441,11 +502,27 @@ impl PipelineTokenizer {
                                     pre_tokens.clear();
                                     self.pre_tokenizer
                                         .pre_tokenize(normalized_chunk, pre_tokens)?;
+                                    let model_text: &str = match &self.rewriter {
+                                        Some(metaspace) => {
+                                            rewrite_buf.clear();
+                                            rewritten.clear();
+                                            for pre_token in pre_tokens.iter() {
+                                                metaspace.rewrite(
+                                                    &normalized_chunk[pre_token.range()],
+                                                    rewrite_buf,
+                                                    rewritten,
+                                                );
+                                            }
+                                            std::mem::swap(pre_tokens, rewritten);
+                                            rewrite_buf.as_str()
+                                        }
+                                        None => normalized_chunk,
+                                    };
                                     if STAGE >= Self::STAGE_MODEL {
                                         // Tokenize each chunk
                                         for pre_token in pre_tokens.iter() {
                                             self.model.tokenize_pipeline(
-                                                &normalized_chunk[pre_token.range()],
+                                                &model_text[pre_token.range()],
                                                 output,
                                             )?;
                                         }
@@ -784,5 +861,38 @@ mod tests {
         tok.with_pre_tokenizer(Some(ByteLevel::new(false, true, true)));
         let err = conversion_error(&tok);
         assert!(err.contains("not supported with model"), "{}", err);
+    }
+
+    #[test]
+    fn conversion_rejects_metaspace_not_last_in_sequence() {
+        let mut tok = Tokenizer::new(BPE::default());
+        tok.with_pre_tokenizer(Some(Sequence::new(vec![
+            PreTokenizerWrapper::Metaspace(Metaspace::default()),
+            PreTokenizerWrapper::WhitespaceSplit(WhitespaceSplit),
+        ])));
+        let err = conversion_error(&tok);
+        assert!(err.contains("must be the last"), "{}", err);
+    }
+
+    #[test]
+    fn conversion_rejects_metaspace_prepend_scheme_first() {
+        let mut tok = Tokenizer::new(BPE::default());
+        tok.with_pre_tokenizer(Some(Metaspace::new('▁', PrependScheme::First, true)));
+        let err = conversion_error(&tok);
+        assert!(err.contains("prepend_scheme=first"), "{}", err);
+    }
+
+    #[test]
+    fn conversion_peels_trailing_metaspace() {
+        // Bare Metaspace and the T5 shape (Sequence ending in Metaspace) both build.
+        let mut tok = Tokenizer::new(BPE::default());
+        tok.with_pre_tokenizer(Some(Metaspace::default()));
+        assert!(PipelineTokenizer::try_from(&tok).is_ok());
+
+        tok.with_pre_tokenizer(Some(Sequence::new(vec![
+            PreTokenizerWrapper::WhitespaceSplit(WhitespaceSplit),
+            PreTokenizerWrapper::Metaspace(Metaspace::default()),
+        ])));
+        assert!(PipelineTokenizer::try_from(&tok).is_ok());
     }
 }

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -1,17 +1,18 @@
 //! The experimental `PipelineTokenizer` must produce exactly the same token
 //! ids as the reference `Tokenizer` (the oracle). Exercised over the bert-wiki
-//! tokenizer (`Whitespace` pre-tokenizer + `WordPiece`) on an English and a
-//! Japanese corpus, with lines packed into ~1 kB and ~10 kB documents. The
-//! oracle is called with `add_special_tokens = false` because the pipeline
-//! does not apply the post-processor yet.
+//! tokenizer (`Whitespace` pre-tokenizer + `WordPiece`) and the t5-base
+//! tokenizer (`WhitespaceSplit` + `Metaspace` rewriter + `Unigram`) on an
+//! English and a Japanese corpus, with lines packed into ~1 kB and ~10 kB
+//! documents. The oracle is called with `add_special_tokens = false` because
+//! the pipeline does not apply the post-processor yet.
 
 use std::convert::TryFrom;
 
 use tk_encode::pipeline::PipelineTokenizer;
 use tk_encode::Tokenizer;
 
-fn load(corpus: &str) -> (Tokenizer, PipelineTokenizer, String) {
-    let oracle = Tokenizer::from_file("../data/bert-wiki.json").unwrap();
+fn load(tokenizer: &str, corpus: &str) -> (Tokenizer, PipelineTokenizer, String) {
+    let oracle = Tokenizer::from_file(tokenizer).unwrap();
     let pipeline = PipelineTokenizer::try_from(&oracle).unwrap();
     let text = std::fs::read_to_string(corpus).unwrap();
     (oracle, pipeline, text)
@@ -36,8 +37,8 @@ fn make_chunks(text: &str, target_bytes: usize) -> Vec<String> {
     chunks
 }
 
-fn check_chunks(corpus: &str, target_bytes: usize) {
-    let (oracle, pipeline, text) = load(corpus);
+fn check_chunks(tokenizer: &str, corpus: &str, target_bytes: usize) {
+    let (oracle, pipeline, text) = load(tokenizer, corpus);
     for chunk in make_chunks(&text, target_bytes) {
         let expected = oracle.encode(chunk.as_str(), false).unwrap();
         let got: Vec<u32> = pipeline
@@ -56,16 +57,16 @@ fn check_chunks(corpus: &str, target_bytes: usize) {
 }
 
 macro_rules! corpus_tests {
-    ($($name:ident => $file:literal),* $(,)?) => {
+    ($($name:ident => ($tokenizer:literal, $corpus:literal)),* $(,)?) => {
         $(
             mod $name {
                 #[test]
                 fn chunks_1kb() {
-                    super::check_chunks($file, 1024);
+                    super::check_chunks($tokenizer, $corpus, 1024);
                 }
                 #[test]
                 fn chunks_10kb() {
-                    super::check_chunks($file, 10 * 1024);
+                    super::check_chunks($tokenizer, $corpus, 10 * 1024);
                 }
             }
         )*
@@ -73,6 +74,8 @@ macro_rules! corpus_tests {
 }
 
 corpus_tests! {
-    big => "../data/big.txt",
-    wagahai => "../data/unigram_wagahaiwa_nekodearu.txt",
+    bert_wiki_big => ("../data/bert-wiki.json", "../data/big.txt"),
+    bert_wiki_wagahai => ("../data/bert-wiki.json", "../data/unigram_wagahaiwa_nekodearu.txt"),
+    t5_big => ("../data/t5-base.json", "../data/big.txt"),
+    t5_wagahai => ("../data/t5-base.json", "../data/unigram_wagahaiwa_nekodearu.txt"),
 }


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**6 / 6 models supported** — ~10 kB inputs · single thread

`6563b30c0 · 2026-07-09 16:09 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-overview-dark.png">
  <img alt="Per-model encode throughput summary" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-overview-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · geomean ×2.95</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-bert-base-uncased-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.5 | 21.1 | ×2.82 | 1.31 | 27.07 | 10.15 | 8.71 | match |
| arb_Arab | lang | 3.8 | 8.5 | ×2.23 | 1.16 | 27.51 | 13.70 | 75.09 | match |
| ben_Beng | lang | 5.5 | 12.8 | ×2.32 | 1.16 | 19.13 | 8.95 | 48.14 | match |
| cmn_Hani | lang | 3.5 | 14.0 | ×4.03 | 1.17 | 37.63 | 11.00 | 20.89 | match |
| ell_Grek | lang | 3.5 | 7.2 | ×2.06 | 1.24 | 28.69 | 13.86 | 94.69 | match |
| eng_Latn | lang | 4.2 | 15.3 | ×3.68 | 2.82 | 38.68 | 3.37 | 18.39 | match |
| heb_Hebr | lang | 3.8 | 8.2 | ×2.17 | 1.22 | 37.51 | 13.60 | 68.81 | match |
| hin_Deva | lang | 5.9 | 14.9 | ×2.52 | 1.20 | 27.00 | 7.95 | 30.11 | match |
| jpn_Jpan | lang | 4.0 | 11.4 | ×2.88 | 1.19 | 23.49 | 10.97 | 52.61 | match |
| kat_Geor | lang | 5.8 | 11.3 | ×1.94 | 1.16 | 26.56 | 10.33 | 50.49 | match |
| kor_Hang | lang | 2.3 | 4.1 | ×1.81 | 1.18 | 35.03 | 21.88 | 183.00 | match |
| rus_Cyrl | lang | 3.3 | 6.4 | ×1.95 | 1.18 | 27.75 | 13.55 | 109.42 | match |
| tam_Taml | lang | 6.7 | 15.1 | ×2.27 | 1.19 | 18.58 | 8.48 | 37.61 | match |
| tha_Thai | lang | 8.3 | 13.9 | ×1.68 | 1.17 | 25.02 | 8.56 | 36.81 | match |
| added_normalized_dense | modalities | 6.3 | 21.6 | ×3.45 | 1.62 | 40.27 | 1.44 | 2.01 | match |
| added_normalized_sparse | modalities | 5.0 | 18.4 | ×3.71 | 1.98 | 39.92 | 2.36 | 9.15 | match |
| added_special_dense | modalities | 5.0 | 47.4 | ×9.55 | 5.24 | 9.19 | 2.20 | 3.38 | match |
| added_special_sparse | modalities | 3.8 | 21.3 | ×5.62 | 3.81 | 27.88 | 3.17 | 11.13 | match |
| agentic-traces | modalities | 3.6 | 13.5 | ×3.80 | 2.48 | 38.40 | 4.55 | 27.82 | match |
| agentic_swe | modalities | 3.8 | 13.9 | ×3.67 | 1.95 | 38.61 | 3.08 | 26.86 | match |
| code_mixed | modalities | 3.6 | 12.4 | ×3.42 | 2.23 | 38.48 | 3.56 | 35.42 | match |
| math_latex | modalities | 3.7 | 13.9 | ×3.76 | 2.65 | 38.47 | 3.78 | 25.35 | match |

</details>

<details><summary><b>deepseek-v4</b> — split-heavy byte-level BPE, 3 chained regexes · geomean ×2.61</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-deepseek-v4-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 14.3 | ×3.78 | 0.66 | 0.00 | 43.71 | 25.15 | match |
| arb_Arab | lang | 3.5 | 8.7 | ×2.46 | 0.63 | 0.02 | 49.85 | 55.51 | match |
| ben_Beng | lang | 4.4 | 11.1 | ×2.53 | 0.59 | 0.00 | 36.66 | 52.08 | match |
| cmn_Hani | lang | 3.3 | 8.0 | ×2.42 | 0.84 | 0.00 | 66.65 | 56.10 | match |
| ell_Grek | lang | 3.6 | 9.6 | ×2.65 | 0.69 | 0.00 | 52.63 | 51.63 | match |
| eng_Latn | lang | 2.6 | 6.6 | ×2.50 | 2.07 | 0.01 | 70.97 | 76.65 | match |
| heb_Hebr | lang | 3.2 | 7.9 | ×2.48 | 0.65 | 0.01 | 53.52 | 72.15 | match |
| hin_Deva | lang | 4.2 | 11.8 | ×2.80 | 0.60 | 0.00 | 39.76 | 43.22 | match |
| jpn_Jpan | lang | 3.8 | 8.8 | ×2.35 | 0.68 | 0.00 | 59.18 | 53.39 | match |
| kat_Geor | lang | 4.4 | 11.7 | ×2.64 | 0.59 | 0.00 | 32.84 | 51.46 | match |
| kor_Hang | lang | 3.3 | 9.8 | ×3.00 | 0.61 | 0.00 | 53.74 | 47.24 | match |
| rus_Cyrl | lang | 3.6 | 8.8 | ×2.43 | 0.60 | 0.00 | 49.74 | 65.05 | match |
| tam_Taml | lang | 4.8 | 11.6 | ×2.43 | 0.59 | 0.00 | 32.52 | 52.88 | match |
| tha_Thai | lang | 5.5 | 10.8 | ×1.98 | 0.61 | 0.00 | 27.26 | 64.40 | match |
| added_normalized_dense | modalities | 3.7 | 12.1 | ×3.25 | 0.75 | 0.00 | 42.22 | 37.88 | match |
| added_normalized_sparse | modalities | 3.5 | 10.2 | ×2.90 | 1.36 | 0.00 | 49.14 | 46.39 | match |
| added_special_dense | modalities | 2.9 | 7.2 | ×2.49 | 6.72 | 0.37 | 109.68 | 19.74 | match |
| added_special_sparse | modalities | 3.1 | 7.6 | ×2.43 | 3.98 | 0.21 | 80.61 | 43.59 | match |
| agentic-traces | modalities | 2.4 | 6.3 | ×2.67 | 1.90 | 0.06 | 87.25 | 69.17 | match |
| agentic_swe | modalities | 2.3 | 5.8 | ×2.45 | 1.36 | 0.01 | 106.43 | 66.31 | match |
| code_mixed | modalities | 2.6 | 6.9 | ×2.70 | 1.66 | 0.02 | 78.65 | 63.35 | match |
| math_latex | modalities | 2.4 | 6.2 | ×2.56 | 1.99 | 0.03 | 84.79 | 72.43 | match |

</details>

<details><summary><b>gpt2</b> — standalone ByteLevel pre-tokenizer · geomean ×7.96</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-gpt2-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.7 | 38.6 | ×10.35 | 0.74 | 0.00 | 6.13 | 18.06 | match |
| arb_Arab | lang | 3.0 | 22.4 | ×7.40 | 0.66 | 0.00 | 7.32 | 36.21 | match |
| ben_Beng | lang | 2.3 | 28.8 | ×12.71 | 0.60 | 0.00 | 11.40 | 22.49 | match |
| cmn_Hani | lang | 3.1 | 24.4 | ×7.82 | 0.73 | 0.00 | 5.70 | 33.81 | match |
| ell_Grek | lang | 3.0 | 23.6 | ×7.77 | 0.61 | 0.00 | 6.80 | 34.25 | match |
| eng_Latn | lang | 2.7 | 11.8 | ×4.31 | 2.14 | 0.17 | 10.56 | 70.50 | match |
| heb_Hebr | lang | 3.0 | 25.2 | ×8.44 | 0.66 | 0.00 | 7.46 | 30.92 | match |
| hin_Deva | lang | 2.6 | 26.2 | ×10.29 | 0.60 | 0.00 | 11.31 | 25.81 | match |
| jpn_Jpan | lang | 3.5 | 19.5 | ×5.54 | 0.61 | 0.00 | 5.07 | 44.58 | match |
| kat_Geor | lang | 3.6 | 55.3 | ×15.45 | 0.60 | 0.00 | 4.78 | 11.99 | match |
| kor_Hang | lang | 2.8 | 33.1 | ×11.68 | 0.72 | 0.00 | 7.76 | 20.96 | match |
| rus_Cyrl | lang | 3.2 | 24.0 | ×7.45 | 0.60 | 0.00 | 6.51 | 33.73 | match |
| tam_Taml | lang | 2.2 | 35.0 | ×16.22 | 0.63 | 0.00 | 11.52 | 15.67 | match |
| tha_Thai | lang | 2.8 | 29.4 | ×10.40 | 0.61 | 0.00 | 7.54 | 24.91 | match |
| added_normalized_dense | modalities | 3.5 | 22.3 | ×6.38 | 0.77 | 0.00 | 6.47 | 36.89 | match |
| added_normalized_sparse | modalities | 3.3 | 18.3 | ×5.54 | 1.32 | 0.00 | 8.11 | 43.89 | match |
| added_special_dense | modalities | 3.7 | 31.9 | ×8.70 | 5.04 | 0.11 | 8.88 | 15.44 | match |
| added_special_sparse | modalities | 3.3 | 18.7 | ×5.71 | 3.25 | 0.06 | 10.37 | 37.28 | match |
| agentic-traces | modalities | 2.4 | 12.9 | ×5.48 | 1.87 | 0.02 | 13.17 | 60.97 | match |
| agentic_swe | modalities | 2.4 | 17.5 | ×7.23 | 1.36 | 0.02 | 12.55 | 42.23 | match |
| code_mixed | modalities | 2.3 | 15.2 | ×6.74 | 1.65 | 0.13 | 12.78 | 49.67 | match |
| math_latex | modalities | 2.4 | 12.1 | ×5.05 | 2.18 | 0.00 | 12.09 | 66.98 | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · geomean ×3.01</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-llama-2-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 29.3 | ×6.98 | 0.04 | 14.32 | 0.96 | 18.88 | match |
| arb_Arab | lang | 8.8 | 30.4 | ×3.47 | 0.03 | 16.55 | 1.22 | 15.30 | match |
| ben_Beng | lang | 9.5 | 49.2 | ×5.20 | 0.04 | 11.31 | 0.76 | 8.24 | match |
| cmn_Hani | lang | 7.8 | 61.4 | ×7.88 | 0.06 | 2.84 | 0.09 | 12.78 | match |
| ell_Grek | lang | 8.7 | 34.2 | ×3.93 | 0.03 | 15.79 | 1.19 | 12.35 | match |
| eng_Latn | lang | 3.9 | 5.7 | ×1.45 | 0.05 | 29.44 | 2.64 | 142.54 | match |
| heb_Hebr | lang | 8.5 | 33.6 | ×3.93 | 0.03 | 17.67 | 0.87 | 11.32 | match |
| hin_Deva | lang | 10.5 | 44.4 | ×4.21 | 0.03 | 12.86 | 1.18 | 8.51 | match |
| jpn_Jpan | lang | 10.9 | 76.5 | ×7.01 | 0.05 | 2.70 | 0.06 | 9.57 | match |
| kat_Geor | lang | 12.4 | 55.4 | ×4.46 | 0.04 | 9.49 | 0.63 | 7.90 | match |
| kor_Hang | lang | 6.4 | 31.7 | ×4.97 | 0.06 | 16.50 | 1.29 | 13.82 | match |
| rus_Cyrl | lang | 7.8 | 14.1 | ×1.81 | 0.03 | 13.84 | 1.02 | 55.61 | match |
| tam_Taml | lang | 10.9 | 58.9 | ×5.42 | 0.03 | 8.67 | 0.61 | 7.62 | match |
| tha_Thai | lang | 13.3 | 69.8 | ×5.25 | 0.03 | 4.69 | 0.22 | 9.20 | match |
| added_normalized_dense | modalities | 5.1 | 8.3 | ×1.62 | 0.07 | 18.41 | 1.30 | 103.04 | match |
| added_normalized_sparse | modalities | 4.7 | 6.8 | ×1.44 | 0.07 | 26.30 | 2.09 | 118.88 | match |
| added_special_dense | modalities | 4.7 | 12.3 | ×2.63 | 5.04 | 42.72 | 2.90 | 29.43 | match |
| added_special_sparse | modalities | 6.3 | 7.8 | ×1.24 | 2.14 | 41.77 | 0.00 | 82.51 | match |
| agentic-traces | modalities | 4.2 | 6.5 | ×1.57 | 0.11 | 28.67 | 0.00 | 125.52 | match |
| agentic_swe | modalities | 3.8 | 6.0 | ×1.57 | 0.09 | 51.64 | 0.00 | 119.75 | match |
| code_mixed | modalities | 3.9 | 6.2 | ×1.59 | 0.03 | 40.38 | 0.00 | 122.61 | match |
| math_latex | modalities | 4.1 | 6.1 | ×1.50 | 0.07 | 29.29 | 1.06 | 135.57 | match |

</details>

<details><summary><b>llama-3</b> — split-heavy byte-level BPE, single regex · geomean ×4.10</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-llama-3-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 2.9 | 21.9 | ×7.54 | 0.75 | 0.00 | 27.57 | 16.63 | match |
| arb_Arab | lang | 3.4 | 11.6 | ×3.45 | 0.66 | 0.00 | 31.43 | 56.11 | match |
| ben_Beng | lang | 2.6 | 13.2 | ×5.11 | 0.59 | 0.00 | 45.53 | 29.29 | match |
| cmn_Hani | lang | 4.0 | 13.0 | ×3.26 | 0.61 | 0.00 | 19.96 | 54.49 | match |
| ell_Grek | lang | 3.9 | 13.3 | ×3.37 | 0.60 | 0.00 | 28.04 | 45.09 | match |
| eng_Latn | lang | 3.6 | 15.3 | ×4.28 | 2.11 | 0.00 | 43.71 | 17.71 | match |
| heb_Hebr | lang | 3.1 | 15.0 | ×4.92 | 0.60 | 0.00 | 30.95 | 33.98 | match |
| hin_Deva | lang | 3.8 | 17.4 | ×4.60 | 0.60 | 0.00 | 47.64 | 8.40 | match |
| jpn_Jpan | lang | 4.4 | 12.9 | ×2.92 | 0.64 | 0.00 | 19.67 | 55.98 | match |
| kat_Geor | lang | 3.7 | 23.7 | ×6.34 | 0.67 | 0.00 | 17.69 | 22.35 | match |
| kor_Hang | lang | 3.5 | 12.3 | ×3.54 | 0.61 | 0.00 | 32.96 | 46.62 | match |
| rus_Cyrl | lang | 4.1 | 12.2 | ×2.98 | 0.59 | 0.00 | 26.97 | 52.99 | match |
| tam_Taml | lang | 2.7 | 14.0 | ×5.11 | 0.62 | 0.02 | 44.22 | 26.55 | match |
| tha_Thai | lang | 4.4 | 13.8 | ×3.12 | 0.62 | 0.00 | 28.20 | 42.43 | match |
| added_normalized_dense | modalities | 3.7 | 17.1 | ×4.59 | 0.74 | 0.00 | 23.18 | 33.08 | match |
| added_normalized_sparse | modalities | 4.1 | 19.1 | ×4.70 | 1.50 | 0.00 | 31.08 | 19.30 | match |
| added_special_dense | modalities | 3.6 | 13.0 | ×3.61 | 5.17 | 0.03 | 68.02 | 2.67 | match |
| added_special_sparse | modalities | 4.0 | 15.8 | ×3.95 | 3.31 | 0.07 | 53.01 | 5.73 | match |
| agentic-traces | modalities | 3.2 | 12.8 | ×4.00 | 1.97 | 0.00 | 52.55 | 20.56 | match |
| agentic_swe | modalities | 3.3 | 11.1 | ×3.39 | 1.46 | 0.00 | 57.05 | 30.29 | match |
| code_mixed | modalities | 3.4 | 13.4 | ×3.95 | 1.66 | 0.00 | 54.79 | 16.75 | match |
| math_latex | modalities | 3.1 | 12.8 | ×4.15 | 2.01 | 0.00 | 53.95 | 20.15 | match |

</details>

<details><summary><b>t5-base</b> — Unigram + Metaspace · geomean ×2.15</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-t5-base-dark.png">
  <img alt="t5-base speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-t5-base-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-t5-base-stages-dark.png">
  <img alt="t5-base stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29031876445-t5-base-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 6.2 | 17.9 | ×2.88 | 0.66 | 16.34 | 4.18 | 31.88 | match |
| arb_Arab | lang | 4.4 | 10.7 | ×2.42 | 0.60 | 22.54 | 5.13 | 64.07 | match |
| ben_Beng | lang | 6.5 | 15.0 | ×2.31 | 0.59 | 20.56 | 3.60 | 40.50 | match |
| cmn_Hani | lang | 9.5 | 15.8 | ×1.66 | 0.70 | 14.71 | 3.21 | 43.45 | match |
| ell_Grek | lang | 4.6 | 11.0 | ×2.41 | 0.60 | 23.01 | 5.10 | 61.46 | match |
| eng_Latn | lang | 2.4 | 4.7 | ×1.91 | 2.11 | 34.67 | 6.72 | 167.17 | match |
| heb_Hebr | lang | 4.3 | 11.3 | ×2.60 | 0.60 | 19.35 | 5.23 | 61.89 | match |
| hin_Deva | lang | 5.6 | 14.2 | ×2.53 | 0.60 | 20.10 | 4.20 | 44.59 | match |
| jpn_Jpan | lang | 10.0 | 16.2 | ×1.62 | 0.61 | 17.44 | 3.61 | 38.92 | match |
| kat_Geor | lang | 7.2 | 16.0 | ×2.22 | 0.60 | 15.73 | 3.36 | 40.98 | match |
| kor_Hang | lang | 4.7 | 12.0 | ×2.56 | 0.74 | 19.96 | 4.80 | 55.77 | match |
| rus_Cyrl | lang | 3.6 | 7.4 | ×2.02 | 0.60 | 22.96 | 4.84 | 106.50 | match |
| tam_Taml | lang | 7.6 | 16.5 | ×2.17 | 0.60 | 15.80 | 3.18 | 39.47 | match |
| tha_Thai | lang | 9.9 | 17.2 | ×1.75 | 0.61 | 16.48 | 2.58 | 36.80 | match |
| added_normalized_dense | modalities | 2.9 | 5.2 | ×1.80 | 0.76 | 33.96 | 4.03 | 149.97 | match |
| added_normalized_sparse | modalities | 2.9 | 5.7 | ×1.96 | 1.30 | 33.98 | 5.63 | 132.14 | match |
| added_special_dense | modalities | 6.4 | 21.3 | ×3.33 | 5.04 | 10.78 | 5.23 | 24.17 | match |
| added_special_sparse | modalities | 3.6 | 8.5 | ×2.35 | 3.36 | 25.03 | 7.04 | 80.30 | match |
| agentic-traces | modalities | 2.5 | 4.7 | ×1.86 | 1.91 | 34.54 | 5.95 | 166.21 | match |
| agentic_swe | modalities | 3.3 | 6.0 | ×1.81 | 1.35 | 33.81 | 4.21 | 124.02 | match |
| code_mixed | modalities | 3.0 | 5.6 | ×1.88 | 1.64 | 34.50 | 5.21 | 134.61 | match |
| math_latex | modalities | 2.4 | 4.8 | ×1.97 | 2.05 | 34.65 | 6.74 | 159.40 | match |

</details>
<!-- pipeline-bench:end -->
