### PR TITLE
no alloc model, follow-ups

### DIFF
--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -59,6 +59,7 @@ ptr_hash = { version = "2.0.1", default-features = false }
 memchr = "2.8.2"
 unicode-normalization = "0.1.25"
 yada = "0.7.0"
+
 # Latest released tokenizers, used as the comparison baseline by the CI benchmark
 # (examples gated on `bench-baseline`). Optional so production builds never pull it.
 tokenizers-release = { package = "tokenizers", version = "=0.23.1", optional = true }

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -34,7 +34,7 @@ use logos::Logos;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rayon::ThreadPoolBuilder;
 use serde_json::{json, Value};
-use tk_encode::pipeline::PipelineTokenizer;
+use tk_encode::pipeline::{Model, PipelineTokenizer};
 use tk_encode::{AddedToken, ModelWrapper, Tokenizer};
 use tokenizers_release::{AddedToken as BaselineAddedToken, Tokenizer as BaselineTokenizer};
 
@@ -204,10 +204,11 @@ fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
 fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) -> f64 {
     let mut out = Vec::new();
     let mut pre_tokens = Vec::new();
+    let mut scratch = pipeline.get_model().init_scratch();
     let mut run = || {
         for chunk in chunks {
             out.clear();
-            let _ = pipeline.encode_generic::<STAGE>(chunk, &mut out, &mut pre_tokens);
+            let _ = pipeline.encode_generic::<STAGE>(chunk, &mut pre_tokens, &mut scratch, &mut out, );
             black_box(&out);
             black_box(&pre_tokens);
         }

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -208,7 +208,8 @@ fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) 
     let mut run = || {
         for chunk in chunks {
             out.clear();
-            let _ = pipeline.encode_generic::<STAGE>(chunk, &mut pre_tokens, &mut scratch, &mut out, );
+            let _ =
+                pipeline.encode_generic::<STAGE>(chunk, &mut pre_tokens, &mut scratch, &mut out);
             black_box(&out);
             black_box(&pre_tokens);
         }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -683,7 +683,6 @@ pub struct PipelineBPE {
     vocab: VocabStore,
     merges: MergeMap,
     ignore_merges: bool,
-    // cache_capacity: Option<usize>,
 }
 
 enum Atoms {
@@ -762,7 +761,6 @@ impl PipelineBPE {
             ignore_merges,
             merges,
             vocab,
-            // cache_capacity: model.cache.map(|cache| cache.capacity),
         })
     }
 
@@ -837,35 +835,26 @@ impl pipeline::Model for PipelineBPE {
                 return Ok(());
             }
         }
+
+        // TODO: persistent cache mapping &str -> &[u32]
+
         let BpeScratch {
             merge_queue,
             skip,
             word,
-            // word_cache,
         } = scratch;
 
-        // if let Some(cache) = word_cache {
-        //     if let Some(cached) = cache.get(sequence) {
-        //         output.extend(cached.iter().map(|&id| PipelineToken { id }));
-        //         return Ok(());
-        //     }
-        // }
         self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
-        // if let Some(cache) = word_cache {
-        //     cache.insert(sequence.to_string(), word.get_chars());
-        // }
 
         Ok(())
     }
 
     fn init_scratch(&self) -> Self::Scratch {
         Self::Scratch {
-            // 256 is an arbitrary size
-            merge_queue: QuaternaryHeap::with_capacity(256),
-            skip: Vec::with_capacity(256),
+            merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
-            // word_cache: self.cache_capacity.map(AHashMap::with_capacity),
+            skip: Vec::new(),
         }
     }
 }
@@ -874,7 +863,6 @@ pub struct BpeScratch {
     pub(crate) merge_queue: QuaternaryHeap<Merge>,
     pub(crate) skip: Vec<Merge>,
     pub(crate) word: Word,
-    // word_cache: Option<AHashMap<String, Vec<u32>>>,
 }
 impl ModelScratch for BpeScratch {}
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -853,8 +853,7 @@ impl pipeline::Model for PipelineBPE {
         self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         if let Some(cache) = word_cache {
-            let tokens = word.get_chars();
-            cache.insert(sequence.to_string(), tokens);
+            cache.insert(sequence.to_string(), word.get_chars());
         }
 
         Ok(())

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -683,7 +683,7 @@ pub struct PipelineBPE {
     vocab: VocabStore,
     merges: MergeMap,
     ignore_merges: bool,
-    cache_capacity: Option<usize>,
+    // cache_capacity: Option<usize>,
 }
 
 enum Atoms {
@@ -762,7 +762,7 @@ impl PipelineBPE {
             ignore_merges,
             merges,
             vocab,
-            cache_capacity: model.cache.map(|cache| cache.capacity),
+            // cache_capacity: model.cache.map(|cache| cache.capacity),
         })
     }
 
@@ -841,20 +841,20 @@ impl pipeline::Model for PipelineBPE {
             merge_queue,
             skip,
             word,
-            word_cache,
+            // word_cache,
         } = scratch;
 
-        if let Some(cache) = word_cache {
-            if let Some(cached) = cache.get(sequence) {
-                output.extend(cached.iter().map(|&id| PipelineToken { id }));
-                return Ok(());
-            }
-        }
+        // if let Some(cache) = word_cache {
+        //     if let Some(cached) = cache.get(sequence) {
+        //         output.extend(cached.iter().map(|&id| PipelineToken { id }));
+        //         return Ok(());
+        //     }
+        // }
         self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
-        if let Some(cache) = word_cache {
-            cache.insert(sequence.to_string(), word.get_chars());
-        }
+        // if let Some(cache) = word_cache {
+        //     cache.insert(sequence.to_string(), word.get_chars());
+        // }
 
         Ok(())
     }
@@ -865,7 +865,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(256),
             skip: Vec::with_capacity(256),
             word: Word::with_capacity(64),
-            word_cache: self.cache_capacity.map(AHashMap::with_capacity),
+            // word_cache: self.cache_capacity.map(AHashMap::with_capacity),
         }
     }
 }
@@ -874,7 +874,7 @@ pub struct BpeScratch {
     pub(crate) merge_queue: QuaternaryHeap<Merge>,
     pub(crate) skip: Vec<Merge>,
     pub(crate) word: Word,
-    word_cache: Option<AHashMap<String, Vec<u32>>>,
+    // word_cache: Option<AHashMap<String, Vec<u32>>>,
 }
 impl ModelScratch for BpeScratch {}
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1347,7 +1347,9 @@ mod tests {
 
     mod pipeline_bpe {
         use super::*;
-        use crate::utils::byte_level::BYTES_CHAR_LOOKUP;
+        use crate::{
+            pipeline::Model as PipelineModel, utils::byte_level::BYTES_CHAR_LOOKUP, Model,
+        };
 
         const HELLO_VOCAB: &[(&str, u32)] = &[
             ("h", 0),
@@ -1376,7 +1378,8 @@ mod tests {
 
         fn pipeline_ids(model: &PipelineBPE, sequence: &str) -> Vec<u32> {
             let mut out = Vec::new();
-            pipeline::Model::tokenize_pipeline(model, sequence, &mut out).unwrap();
+            let mut scratch = model.init_scratch();
+            pipeline::Model::tokenize_pipeline(model, sequence, &mut scratch, &mut out).unwrap();
             out.iter().map(|t| t.id).collect()
         }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,4 +1,5 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
+use crate::models::bpe::Merge;
 use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
@@ -6,6 +7,7 @@ use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
 use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
+use dary_heap::QuaternaryHeap;
 use serde_json::Value;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -548,7 +550,9 @@ impl BPE {
             word.add(unk_id, unk_len);
         }
 
-        word.merge_all(&self.merges, self.dropout);
+        let mut queue = QuaternaryHeap::with_capacity(word.len_symbols());
+        let mut skip = Vec::with_capacity(queue.len());
+        word.merge_all(&self.merges, self.dropout, &mut queue, &mut skip);
 
         Ok(word)
     }
@@ -760,22 +764,24 @@ impl PipelineBPE {
         })
     }
 
-    fn merge_word(&self, sequence: &str) -> Word {
-        let mut word = match &self.atoms {
+    fn merge_word<'a>(&self, sequence: &str, scratch: &'a mut BpeScratch) -> &'a Word {
+        let BpeScratch {
+            merge_queue,
+            skip,
+            word,
+        } = scratch;
+        word.clear();
+        match &self.atoms {
             Atoms::Bytes { byte_to_id } => {
-                let mut word = Word::with_capacity(sequence.len());
                 for &b in sequence.as_bytes() {
                     word.add(byte_to_id[b as usize], 1);
                 }
-                word
             }
             Atoms::Chars {
                 byte_fallback,
                 unk_token,
                 fuse_unk,
             } => {
-                let mut word = Word::with_capacity(sequence.len());
-
                 for char_str in sequence
                     .char_indices()
                     .map(|(i, c)| &sequence[i..i + c.len_utf8()])
@@ -803,20 +809,20 @@ impl PipelineBPE {
                         }
                     }
                 }
-                word
             }
         };
-        word.merge_all(&self.merges, None);
+        word.merge_all(&self.merges, None, merge_queue, skip);
         word
     }
 }
 
 impl pipeline::Model for PipelineBPE {
     type Scratch = BpeScratch;
+
     fn tokenize_pipeline(
         &self,
         sequence: &str,
-        _scratch: &mut Self::Scratch,
+        scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
         if sequence.is_empty() {
@@ -831,17 +837,26 @@ impl pipeline::Model for PipelineBPE {
         }
 
         // todo: use thread-local cache
-        let word = self.merge_word(sequence);
+        let word = self.merge_word(sequence, scratch);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         Ok(())
     }
 
     fn init_scratch(&self) -> Self::Scratch {
-        Self::Scratch {}
+        Self::Scratch {
+            // 256 is an arbitrary size
+            merge_queue: QuaternaryHeap::with_capacity(256),
+            skip: Vec::with_capacity(256),
+            word: Word::with_capacity(64),
+        }
     }
 }
 
-pub struct BpeScratch {}
+pub struct BpeScratch {
+    pub(crate) merge_queue: QuaternaryHeap<Merge>,
+    pub(crate) skip: Vec<Merge>,
+    pub(crate) word: Word,
+}
 impl ModelScratch for BpeScratch {}
 
 #[cfg(test)]

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,5 +1,5 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
-use crate::pipeline::{self, PipelineToken};
+use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
@@ -812,7 +812,13 @@ impl PipelineBPE {
 }
 
 impl pipeline::Model for PipelineBPE {
-    fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()> {
+    type Scratch = BpeScratch;
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        _scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
         if sequence.is_empty() {
             return Ok(());
         }
@@ -829,7 +835,14 @@ impl pipeline::Model for PipelineBPE {
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         Ok(())
     }
+
+    fn init_scratch(&self) -> Self::Scratch {
+        Self::Scratch {}
+    }
 }
+
+pub struct BpeScratch {}
+impl ModelScratch for BpeScratch {}
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -866,9 +866,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(256),
             skip: Vec::with_capacity(256),
             word: Word::with_capacity(64),
-            word_cache: self
-                .cache_capacity
-                .map(AHashMap::with_capacity),
+            word_cache: self.cache_capacity.map(AHashMap::with_capacity),
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -683,6 +683,7 @@ pub struct PipelineBPE {
     vocab: VocabStore,
     merges: MergeMap,
     ignore_merges: bool,
+    cache_capacity: Option<usize>,
 }
 
 enum Atoms {
@@ -761,15 +762,17 @@ impl PipelineBPE {
             ignore_merges,
             merges,
             vocab,
+            cache_capacity: model.cache.map(|cache| cache.capacity),
         })
     }
 
-    fn merge_word<'a>(&self, sequence: &str, scratch: &'a mut BpeScratch) -> &'a Word {
-        let BpeScratch {
-            merge_queue,
-            skip,
-            word,
-        } = scratch;
+    fn merge_word(
+        &self,
+        sequence: &str,
+        merge_queue: &mut QuaternaryHeap<Merge>,
+        skip: &mut Vec<Merge>,
+        word: &mut Word,
+    ) {
         word.clear();
         match &self.atoms {
             Atoms::Bytes { byte_to_id } => {
@@ -812,7 +815,6 @@ impl PipelineBPE {
             }
         };
         word.merge_all(&self.merges, None, merge_queue, skip);
-        word
     }
 }
 
@@ -835,10 +837,26 @@ impl pipeline::Model for PipelineBPE {
                 return Ok(());
             }
         }
+        let BpeScratch {
+            merge_queue,
+            skip,
+            word,
+            word_cache,
+        } = scratch;
 
-        // todo: use thread-local cache
-        let word = self.merge_word(sequence, scratch);
+        if let Some(cache) = word_cache {
+            if let Some(cached) = cache.get(sequence) {
+                output.extend(cached.iter().map(|&id| PipelineToken { id }));
+                return Ok(());
+            }
+        }
+        self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+        if let Some(cache) = word_cache {
+            let tokens = word.get_chars();
+            cache.insert(sequence.to_string(), tokens);
+        }
+
         Ok(())
     }
 
@@ -848,6 +866,9 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(256),
             skip: Vec::with_capacity(256),
             word: Word::with_capacity(64),
+            word_cache: self
+                .cache_capacity
+                .map(AHashMap::with_capacity),
         }
     }
 }
@@ -856,6 +877,7 @@ pub struct BpeScratch {
     pub(crate) merge_queue: QuaternaryHeap<Merge>,
     pub(crate) skip: Vec<Merge>,
     pub(crate) word: Word,
+    word_cache: Option<AHashMap<String, Vec<u32>>>,
 }
 impl ModelScratch for BpeScratch {}
 

--- a/tokenizers/tk-encode/src/models/bpe/word.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word.rs
@@ -1,3 +1,4 @@
+
 use super::Pair;
 use ahash::AHashMap;
 use dary_heap::QuaternaryHeap;
@@ -5,7 +6,7 @@ use rand::{rng, Rng};
 use std::cmp::Ordering;
 
 #[derive(Debug, Eq)]
-struct Merge {
+pub struct Merge {
     pos: usize,
     rank: u32,
     new_id: u32,
@@ -93,6 +94,14 @@ impl Word {
         }
     }
 
+    pub fn clear(&mut self) {
+        self.symbols.clear();
+    }
+
+    pub fn len_symbols(&self) -> usize {
+        self.symbols.len()
+    }
+
     pub fn add(&mut self, c: u32, byte_len: usize) {
         let (prev, next) = {
             let len = self.symbols.len() as isize;
@@ -167,9 +176,15 @@ impl Word {
         changes
     }
 
-    pub fn merge_all(&mut self, merges: &AHashMap<Pair, (u32, u32)>, dropout: Option<f32>) {
-        let mut queue = QuaternaryHeap::with_capacity(self.symbols.len());
-        let mut skip = Vec::with_capacity(queue.len());
+    pub fn merge_all(
+        &mut self,
+        merges: &AHashMap<Pair, (u32, u32)>,
+        dropout: Option<f32>,
+        queue: &mut QuaternaryHeap<Merge>,
+        skip: &mut Vec<Merge>,
+    ) {
+        queue.clear();
+        skip.clear();
 
         queue.extend(
             self.symbols

--- a/tokenizers/tk-encode/src/models/bpe/word.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word.rs
@@ -272,7 +272,7 @@ impl Word {
     }
 
     pub fn get_chars(&self) -> Vec<u32> {
-        self.symbols.iter().map(|s| s.c).collect()
+        self.get_chars_iter().collect()
     }
 
     pub fn get_chars_iter(&self) -> impl Iterator<Item = u32> + '_ {

--- a/tokenizers/tk-encode/src/models/bpe/word.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word.rs
@@ -1,4 +1,3 @@
-
 use super::Pair;
 use ahash::AHashMap;
 use dary_heap::QuaternaryHeap;

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -505,10 +505,21 @@ impl Model for Unigram {
     }
 }
 
+pub struct UnigramScratch {}
+
+impl pipeline::ModelScratch for UnigramScratch {}
+
 impl pipeline::Model for Unigram {
+    type Scratch = UnigramScratch;
+
+    fn init_scratch(&self) -> Self::Scratch {
+        Self::Scratch {}
+    }
+
     fn tokenize_pipeline(
         &self,
         sequence: &str,
+        _scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
         let str_tokens = self.encode(sequence)?;

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -213,7 +213,7 @@ impl ModelScratch for WordLevelScratch {}
 impl pipeline::Model for WordLevel {
     type Scratch = WordLevelScratch;
     fn init_scratch(&self) -> Self::Scratch {
-        ()
+        
     }
     fn tokenize_pipeline(
         &self,

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -212,9 +212,7 @@ impl ModelScratch for WordLevelScratch {}
 
 impl pipeline::Model for WordLevel {
     type Scratch = WordLevelScratch;
-    fn init_scratch(&self) -> Self::Scratch {
-        
-    }
+    fn init_scratch(&self) -> Self::Scratch {}
     fn tokenize_pipeline(
         &self,
         sequence: &str,

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -1,5 +1,5 @@
 use super::OrderedVocabIter;
-use crate::pipeline::{self, PipelineToken};
+use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use ahash::AHashMap;
 use serde_json::Value;
@@ -207,10 +207,18 @@ impl Model for WordLevel {
     }
 }
 
+type WordLevelScratch = ();
+impl ModelScratch for WordLevelScratch {}
+
 impl pipeline::Model for WordLevel {
+    type Scratch = WordLevelScratch;
+    fn init_scratch(&self) -> Self::Scratch {
+        ()
+    }
     fn tokenize_pipeline(
         &self,
         sequence: &str,
+        _scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
         if let Some(&id) = self.vocab.get(sequence) {

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -2,7 +2,7 @@
 //! model.
 
 use crate::models::bpe::BPE;
-use crate::pipeline::{self, PipelineModelScratch, PipelineToken};
+use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use ahash::AHashMap;
 use std::collections::HashMap;
@@ -359,7 +359,7 @@ impl pipeline::Model for PipelineWordPiece {
 
     fn init_scratch(&self) -> Self::Scratch {
         Self::Scratch {
-            candidate_str: String::with_capacity(self.max_input_chars_per_word)
+            candidate_str: String::with_capacity(self.max_input_chars_per_word),
         }
     }
 

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -2,7 +2,7 @@
 //! model.
 
 use crate::models::bpe::BPE;
-use crate::pipeline::{self, PipelineToken};
+use crate::pipeline::{self, PipelineModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use ahash::AHashMap;
 use std::collections::HashMap;
@@ -314,6 +314,13 @@ impl Model for WordPiece {
     }
 }
 
+pub struct WordPieceScratch {
+    candidate_str: String,
+}
+
+impl pipeline::ModelScratch for WordPieceScratch {}
+
+
 pub struct PipelineWordPiece {
     vocab_trie: yada::DoubleArray<Vec<u8>>,
     unk_token: Option<u32>,
@@ -348,13 +355,22 @@ impl TryFrom<WordPiece> for PipelineWordPiece {
 }
 
 impl pipeline::Model for PipelineWordPiece {
+        type Scratch = WordPieceScratch;
+
+    fn init_scratch(&self) -> Self::Scratch {
+        Self::Scratch {
+            candidate_str: String::with_capacity(self.max_input_chars_per_word)
+        }
+    }
+
     fn tokenize_pipeline(
         &self,
         sequence: &str,
+        scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
         let checkpoint = output.len();
-        let mut candidate = String::with_capacity(self.max_input_chars_per_word);
+        let candidate = &mut scratch.candidate_str;
 
         let char_len = sequence.chars().count();
         if char_len > self.max_input_chars_per_word {

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -353,8 +353,8 @@ impl pipeline::Model for PipelineWordPiece {
         sequence: &str,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
+        let checkpoint = output.len();
         let mut candidate = String::with_capacity(self.max_input_chars_per_word);
-        let mut candidate_tokens = Vec::with_capacity(sequence.len());
 
         let char_len = sequence.chars().count();
         if char_len > self.max_input_chars_per_word {
@@ -385,13 +385,13 @@ impl pipeline::Model for PipelineWordPiece {
                 .last()
             else {
                 let unk_id = self.unk_token.ok_or(Error::MissingUnkToken)?;
+                output.truncate(checkpoint);
                 output.push(PipelineToken { id: unk_id });
                 return Ok(());
             };
-            candidate_tokens.push(PipelineToken { id: token_id });
+            output.push(PipelineToken { id: token_id });
             start += match_len - prefix_len;
         }
-        output.extend_from_slice(&candidate_tokens);
         Ok(())
     }
 }

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -320,7 +320,6 @@ pub struct WordPieceScratch {
 
 impl pipeline::ModelScratch for WordPieceScratch {}
 
-
 pub struct PipelineWordPiece {
     vocab_trie: yada::DoubleArray<Vec<u8>>,
     unk_token: Option<u32>,
@@ -355,7 +354,7 @@ impl TryFrom<WordPiece> for PipelineWordPiece {
 }
 
 impl pipeline::Model for PipelineWordPiece {
-        type Scratch = WordPieceScratch;
+    type Scratch = WordPieceScratch;
 
     fn init_scratch(&self) -> Self::Scratch {
         Self::Scratch {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -748,7 +748,7 @@ impl Model for PipelineModel {
             (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
                 model.tokenize_pipeline(sequence, scratch, output)
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -387,6 +387,10 @@ impl PipelineTokenizer {
     pub const STAGE_SPLIT: u8 = 2;
     pub const STAGE_MODEL: u8 = 3;
 
+    pub fn get_model(&self) -> &PipelineModel {
+        &self.model
+    }
+
     /// Encode `input` into token ids.
     ///
     /// Special tokens are matched in two passes:
@@ -744,6 +748,7 @@ impl Model for PipelineModel {
             (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
                 model.tokenize_pipeline(sequence, scratch, output)
             }
+            _ => unreachable!()
         }
     }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -720,6 +720,7 @@ mod tests {
     use crate::models::wordpiece::WordPiece;
     use crate::pre_tokenizers::byte_level::ByteLevel;
     use crate::pre_tokenizers::sequence::Sequence;
+    use crate::models::wordpiece::WordPiece;
 
     struct FixedMatcher(Vec<((usize, usize), u32)>);
     impl PipelinePatternMatcher for FixedMatcher {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -4,10 +4,10 @@ use std::{borrow::Cow, convert::TryFrom};
 
 use atomsplit::classify::classify;
 
-use crate::models::bpe::PipelineBPE;
-use crate::models::unigram::Unigram;
+use crate::models::bpe::{BpeScratch, PipelineBPE};
+use crate::models::unigram::{Unigram, UnigramScratch};
 use crate::models::wordlevel::WordLevel;
-use crate::models::wordpiece::PipelineWordPiece;
+use crate::models::wordpiece::{PipelineWordPiece, WordPieceScratch};
 use crate::utils::byte_level::GPT2_REGEX_STR;
 use crate::vocab::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
@@ -400,7 +400,14 @@ impl PipelineTokenizer {
     pub fn encode(&self, input: &str, _add_special_tokens: bool) -> Result<Vec<PipelineToken>> {
         let mut output = Vec::new();
         let mut pre_tokens = Vec::new();
-        self.encode_generic::<{ Self::STAGE_MODEL }>(input, &mut output, &mut pre_tokens)?;
+        let mut scratch = self.model.init_scratch();
+
+        self.encode_generic::<{ Self::STAGE_MODEL }>(
+            input,
+            &mut pre_tokens,
+            &mut scratch,
+            &mut output,
+        )?;
         Ok(output)
     }
 
@@ -421,8 +428,9 @@ impl PipelineTokenizer {
     pub fn encode_generic<const STAGE: u8>(
         &self,
         input: &str,
-        output: &mut Vec<PipelineToken>,
         pre_tokens: &mut Vec<Span>,
+        scratch: &mut PipelineModelScratch,
+        output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
         // First, we extract all special tokens from the non-normalized input
         for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
@@ -459,6 +467,7 @@ impl PipelineTokenizer {
                                         for pre_token in pre_tokens.iter() {
                                             self.model.tokenize_pipeline(
                                                 &normalized_chunk[pre_token.range()],
+                                                scratch,
                                                 output,
                                             )?;
                                         }
@@ -687,8 +696,19 @@ pub fn split_matches(
     }
 }
 
+pub trait ModelScratch {}
+
 pub trait Model {
-    fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()>;
+    type Scratch: ModelScratch;
+
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()>;
+
+    fn init_scratch(&self) -> Self::Scratch;
 }
 
 #[allow(
@@ -703,15 +723,48 @@ pub enum PipelineModel {
 }
 
 impl Model for PipelineModel {
-    fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()> {
+    type Scratch = PipelineModelScratch;
+
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        match (self, scratch) {
+            (Self::BPE(model), PipelineModelScratch::BPE(scratch)) => {
+                model.tokenize_pipeline(sequence, scratch, output)
+            }
+            (Self::Unigram(model), PipelineModelScratch::Unigram(scratch)) => {
+                model.tokenize_pipeline(sequence, scratch, output)
+            }
+            (Self::WordLevel(model), PipelineModelScratch::WordLevel(scratch)) => {
+                model.tokenize_pipeline(sequence, scratch, output)
+            }
+            (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
+                model.tokenize_pipeline(sequence, scratch, output)
+            }
+        }
+    }
+
+    fn init_scratch(&self) -> Self::Scratch {
         match self {
-            Self::BPE(model) => model.tokenize_pipeline(sequence, output),
-            Self::Unigram(model) => model.tokenize_pipeline(sequence, output),
-            Self::WordLevel(model) => model.tokenize_pipeline(sequence, output),
-            Self::WordPiece(model) => model.tokenize_pipeline(sequence, output),
+            Self::BPE(bpe) => PipelineModelScratch::BPE(bpe.init_scratch()),
+            Self::WordLevel(_) => Self::Scratch::WordLevel(()),
+            Self::WordPiece(wordpiece) => Self::Scratch::WordPiece(wordpiece.init_scratch()),
+            Self::Unigram(unigram) => Self::Scratch::Unigram(unigram.init_scratch()),
         }
     }
 }
+
+pub enum PipelineModelScratch {
+    BPE(BpeScratch),
+    WordLevel(()),
+    WordPiece(WordPieceScratch),
+    Unigram(UnigramScratch),
+}
+
+impl ModelScratch for PipelineModelScratch {}
 
 #[cfg(test)]
 mod tests {
@@ -720,7 +773,6 @@ mod tests {
     use crate::models::wordpiece::WordPiece;
     use crate::pre_tokenizers::byte_level::ByteLevel;
     use crate::pre_tokenizers::sequence::Sequence;
-    use crate::models::wordpiece::WordPiece;
 
     struct FixedMatcher(Vec<((usize, usize), u32)>);
     impl PipelinePatternMatcher for FixedMatcher {


### PR DESCRIPTION
# TL;DR

0-alloc in the encode hot path for WordPiece and BPE

Pre-allocs a "scratch" struct, model-specific, with the necessary heap buffers. The encode loop uses those buffers instead of allocating its own.

## Caveat

- WordLevel does not allocate, the scratch struct is `()`
- Unigram scratch buffer is not implemented (the struct is a dummy struct)
- The scratch struct is currently allocated at every call to `.encode()`; does not benefit encoding a bunch of short sequences. We should make it persist with the model instance so it can be reused across sentences. 


<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**5 / 6 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · single thread

`051260184 · 2026-07-10 16:45 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 8 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-overview-dark.png">
  <img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-overview-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-memory-dark.png">
  <img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-memory-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-binsize-dark.png">
  <img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-binsize-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×5.40 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-bert-base-uncased-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 2+0 (peak 6) · Pipeline 6+0 (peak 7)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 6.8 | 24.5 | ×3.63 | 3% (1.2) | 68% (27.2) | 23% (9.5) | 6% (2.4) | match |
| arb_Arab | lang | 3.4 | 19.9 | ×5.94 | 2% (1.2) | 56% (27.7) | 27% (13.3) | 15% (7.7) | match |
| ben_Beng | lang | 5.1 | 28.7 | ×5.65 | 3% (1.2) | 56% (19.2) | 26% (8.8) | 15% (5.1) | match |
| cmn_Hani | lang | 3.0 | 17.4 | ×5.87 | 2% (1.2) | 65% (37.2) | 19% (11.0) | 14% (8.1) | match |
| ell_Grek | lang | 3.2 | 19.2 | ×6.02 | 2% (1.2) | 56% (28.9) | 26% (13.3) | 17% (8.6) | match |
| eng_Latn | lang | 3.7 | 18.4 | ×4.99 | 5% (2.7) | 73% (39.0) | 6% (3.3) | 16% (8.8) | match |
| heb_Hebr | lang | 3.4 | 16.7 | ×4.91 | 2% (1.2) | 64% (37.8) | 22% (13.2) | 12% (7.3) | match |
| hin_Deva | lang | 5.5 | 24.5 | ×4.48 | 3% (1.2) | 66% (27.0) | 19% (7.8) | 12% (4.7) | match |
| jpn_Jpan | lang | 3.6 | 23.4 | ×6.49 | 3% (1.2) | 55% (23.3) | 26% (10.8) | 17% (7.1) | match |
| kat_Geor | lang | 5.6 | 23.8 | ×4.25 | 3% (1.2) | 63% (26.2) | 24% (10.0) | 10% (4.0) | match |
| kor_Hang | lang | 2.1 | 14.2 | ×6.69 | 2% (1.2) | 50% (35.1) | 31% (21.5) | 18% (12.4) | match |
| rus_Cyrl | lang | 3.1 | 19.0 | ×6.22 | 2% (1.2) | 53% (27.7) | 26% (13.5) | 20% (10.3) | match |
| tam_Taml | lang | 6.4 | 31.4 | ×4.91 | 4% (1.2) | 59% (18.6) | 26% (8.3) | 11% (3.4) | match |
| tha_Thai | lang | 7.9 | 28.0 | ×3.55 | 3% (1.2) | 71% (25.0) | 22% (7.7) | 4% (1.5) | match |
| added_normalized_dense | modalities | 5.8 | 22.1 | ×3.78 | 3% (1.4) | 92% (40.8) | 3% (1.4) | 2% (1.0) | match |
| added_normalized_sparse | modalities | 4.7 | 20.1 | ×4.31 | 4% (1.9) | 82% (40.2) | 5% (2.3) | 9% (4.4) | match |
| added_special_dense | modalities | 4.6 | 52.2 | ×11.40 | 29% (5.2) | 50% (9.1) | 13% (2.3) | 8% (1.4) | match |
| added_special_sparse | modalities | 3.6 | 24.4 | ×6.81 | 9% (3.7) | 70% (28.1) | 7% (2.9) | 13% (5.2) | match |
| agentic-traces | modalities | 3.2 | 18.3 | ×5.73 | 5% (2.5) | 72% (38.8) | 7% (3.7) | 17% (9.0) | match |
| agentic_swe | modalities | 3.4 | 19.7 | ×5.75 | 4% (2.0) | 78% (39.4) | 5% (2.3) | 13% (6.7) | match |
| code_mixed | modalities | 3.3 | 19.2 | ×5.81 | 4% (2.2) | 75% (38.8) | 6% (3.3) | 14% (7.5) | match |
| math_latex | modalities | 3.3 | 18.5 | ×5.68 | 5% (2.6) | 72% (38.9) | 7% (3.5) | 16% (8.8) | match |

</details>

<details><summary><b>deepseek-v4</b> — split-heavy byte-level BPE, 3 chained regexes · ×2.99 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-deepseek-v4-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 51+0 (peak 58) · Pipeline 84+0 (peak 84)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 12.7 | ×3.57 | 1% (0.7) | 0% (0.0) | 83% (45.0) | 16% (8.5) | match |
| arb_Arab | lang | 3.4 | 8.9 | ×2.63 | 1% (0.6) | 0% (0.0) | 86% (52.2) | 13% (7.7) | match |
| ben_Beng | lang | 4.2 | 11.6 | ×2.75 | 1% (0.6) | 0% (0.0) | 89% (38.2) | 10% (4.1) | match |
| cmn_Hani | lang | 3.1 | 7.0 | ×2.25 | 1% (0.8) | 0% (0.0) | 89% (68.1) | 10% (7.8) | match |
| ell_Grek | lang | 3.6 | 9.8 | ×2.71 | 1% (0.6) | 0% (0.0) | 88% (50.5) | 11% (6.2) | match |
| eng_Latn | lang | 2.4 | 6.6 | ×2.70 | 3% (2.2) | 0% (0.0) | 84% (71.0) | 13% (11.0) | match |
| heb_Hebr | lang | 2.7 | 7.8 | ×2.88 | 1% (0.6) | 0% (0.0) | 85% (53.9) | 14% (9.2) | match |
| hin_Deva | lang | 3.8 | 13.0 | ×3.45 | 1% (0.6) | 0% (0.0) | 88% (39.0) | 11% (4.9) | match |
| jpn_Jpan | lang | 3.4 | 8.0 | ×2.36 | 1% (0.7) | 0% (0.0) | 88% (58.8) | 11% (7.6) | match |
| kat_Geor | lang | 4.1 | 11.5 | ×2.83 | 2% (0.6) | 0% (0.0) | 86% (34.0) | 12% (4.9) | match |
| kor_Hang | lang | 2.7 | 8.5 | ×3.14 | 1% (0.6) | 0% (0.0) | 81% (54.2) | 18% (12.2) | match |
| rus_Cyrl | lang | 3.1 | 8.2 | ×2.65 | 1% (0.6) | 0% (0.0) | 86% (50.1) | 12% (7.2) | match |
| tam_Taml | lang | 4.5 | 11.5 | ×2.57 | 2% (0.6) | 1% (0.2) | 87% (32.9) | 11% (4.2) | match |
| tha_Thai | lang | 5.0 | 10.2 | ×2.06 | 2% (0.6) | 0% (0.0) | 89% (27.9) | 9% (2.9) | match |
| added_normalized_dense | modalities | 3.3 | 18.9 | ×5.66 | 2% (0.7) | 0% (0.0) | 93% (44.7) | 5% (2.5) | match |
| added_normalized_sparse | modalities | 3.3 | 16.1 | ×4.82 | 2% (1.4) | 0% (0.0) | 91% (51.4) | 6% (3.6) | match |
| added_special_dense | modalities | 2.8 | 7.6 | ×2.75 | 5% (6.7) | 0% (0.4) | 91% (111.1) | 4% (4.3) | match |
| added_special_sparse | modalities | 3.0 | 9.9 | ×3.35 | 4% (4.1) | 0% (0.1) | 90% (82.9) | 5% (4.7) | match |
| agentic-traces | modalities | 2.1 | 6.5 | ×3.01 | 2% (1.9) | 0% (0.0) | 89% (85.5) | 9% (8.4) | match |
| agentic_swe | modalities | 2.3 | 6.9 | ×3.00 | 1% (1.4) | 0% (0.0) | 88% (103.8) | 11% (12.9) | match |
| code_mixed | modalities | 2.5 | 8.0 | ×3.22 | 2% (1.7) | 0% (0.0) | 92% (83.5) | 6% (5.4) | match |
| math_latex | modalities | 2.1 | 6.4 | ×3.11 | 2% (2.1) | 0% (0.0) | 85% (84.0) | 12% (12.3) | match |

</details>

<details><summary><b>gpt2</b> — standalone ByteLevel pre-tokenizer · ×9.53 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-gpt2-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 17+1 (peak 18) · Pipeline 20+0 (peak 20)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 30.5 | ×8.41 | 5% (0.7) | 0% (0.0) | 50% (6.1) | 45% (5.4) | match |
| arb_Arab | lang | 3.0 | 20.2 | ×6.82 | 4% (0.6) | 0% (0.0) | 45% (7.4) | 51% (8.3) | match |
| ben_Beng | lang | 2.0 | 34.0 | ×17.29 | 3% (0.6) | 0% (0.0) | 59% (11.3) | 38% (7.4) | match |
| cmn_Hani | lang | 3.0 | 20.3 | ×6.81 | 4% (0.6) | 0% (0.0) | 41% (5.6) | 54% (7.4) | match |
| ell_Grek | lang | 2.9 | 22.7 | ×7.76 | 5% (0.6) | 0% (0.0) | 52% (6.7) | 44% (5.7) | match |
| eng_Latn | lang | 2.6 | 12.5 | ×4.80 | 10% (2.1) | 0% (0.0) | 53% (11.0) | 37% (7.5) | match |
| heb_Hebr | lang | 2.8 | 19.8 | ×7.08 | 4% (0.6) | 0% (0.0) | 46% (7.5) | 51% (8.3) | match |
| hin_Deva | lang | 2.3 | 33.0 | ×14.07 | 3% (0.6) | 0% (0.0) | 59% (11.3) | 38% (7.2) | match |
| jpn_Jpan | lang | 3.2 | 17.1 | ×5.34 | 6% (0.6) | 0% (0.0) | 45% (4.9) | 49% (5.4) | match |
| kat_Geor | lang | 3.3 | 37.6 | ×11.36 | 6% (0.6) | 0% (0.0) | 48% (4.8) | 46% (4.6) | match |
| kor_Hang | lang | 2.7 | 22.2 | ×8.37 | 3% (0.6) | 0% (0.0) | 44% (7.7) | 53% (9.3) | match |
| rus_Cyrl | lang | 3.1 | 20.4 | ×6.67 | 5% (0.6) | 0% (0.0) | 51% (6.5) | 44% (5.7) | match |
| tam_Taml | lang | 2.0 | 39.7 | ×19.65 | 3% (0.6) | 0% (0.0) | 61% (11.5) | 36% (6.7) | match |
| tha_Thai | lang | 2.7 | 25.1 | ×9.34 | 4% (0.6) | 0% (0.0) | 51% (7.4) | 44% (6.4) | match |
| added_normalized_dense | modalities | 3.5 | 67.5 | ×19.34 | 9% (0.9) | 0% (0.0) | 64% (6.5) | 28% (2.9) | match |
| added_normalized_sparse | modalities | 3.3 | 56.7 | ×17.21 | 11% (1.5) | 0% (0.0) | 62% (8.2) | 28% (3.7) | match |
| added_special_dense | modalities | 3.4 | 46.1 | ×13.73 | 29% (5.0) | 0% (0.0) | 54% (9.6) | 17% (3.0) | match |
| added_special_sparse | modalities | 3.1 | 43.5 | ×13.87 | 19% (3.4) | 0% (0.0) | 59% (10.7) | 22% (4.0) | match |
| agentic-traces | modalities | 2.1 | 14.2 | ×6.85 | 8% (1.9) | 0% (0.0) | 55% (13.4) | 37% (9.0) | match |
| agentic_swe | modalities | 2.2 | 20.8 | ×9.42 | 6% (1.3) | 0% (0.0) | 60% (12.7) | 33% (7.0) | match |
| code_mixed | modalities | 2.3 | 20.3 | ×8.86 | 8% (1.6) | 0% (0.0) | 61% (13.1) | 31% (6.7) | match |
| math_latex | modalities | 2.3 | 14.2 | ×6.09 | 9% (2.0) | 0% (0.0) | 55% (12.4) | 36% (8.2) | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×2.87 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-llama-2-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 14+0 (peak 14) · Pipeline 15+0 (peak 15)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 24.9 | ×6.10 | 0% (0.0) | 126% (22.3) | 0% (0.0) | 0% (0.0) | match |
| arb_Arab | lang | 8.8 | 26.2 | ×3.00 | 0% (0.0) | 128% (21.2) | 0% (0.0) | 0% (0.0) | match |
| ben_Beng | lang | 9.2 | 46.3 | ×5.03 | 0% (0.0) | 101% (11.4) | 0% (0.0) | 3% (0.3) | match |
| cmn_Hani | lang | 7.9 | 55.4 | ×7.04 | 2% (0.1) | 102% (3.3) | 0% (0.0) | 0% (0.0) | match |
| ell_Grek | lang | 8.3 | 27.3 | ×3.31 | 0% (0.0) | 115% (24.3) | 0% (0.0) | 3% (0.6) | match |
| eng_Latn | lang | 3.9 | 5.3 | ×1.38 | 0% (0.1) | 99% (28.6) | 5% (1.5) | 0% (0.0) | match |
| heb_Hebr | lang | 8.5 | 33.2 | ×3.92 | 0% (0.0) | 93% (16.8) | 5% (0.9) | 2% (0.4) | match |
| hin_Deva | lang | 10.5 | 35.4 | ×3.37 | 0% (0.0) | 125% (18.1) | 0% (0.0) | 0% (0.0) | match |
| jpn_Jpan | lang | 11.0 | 71.2 | ×6.50 | 2% (0.0) | 89% (2.7) | 1% (0.0) | 9% (0.3) | match |
| kat_Geor | lang | 11.9 | 53.7 | ×4.51 | 0% (0.0) | 91% (9.2) | 4% (0.4) | 5% (0.5) | match |
| kor_Hang | lang | 6.0 | 30.8 | ×5.16 | 0% (0.1) | 93% (16.3) | 3% (0.6) | 3% (0.5) | match |
| rus_Cyrl | lang | 7.4 | 13.7 | ×1.85 | 0% (0.0) | 92% (13.5) | 5% (0.8) | 2% (0.4) | match |
| tam_Taml | lang | 10.4 | 55.9 | ×5.38 | 0% (0.0) | 90% (8.5) | 4% (0.4) | 5% (0.5) | match |
| tha_Thai | lang | 12.9 | 61.8 | ×4.81 | 1% (0.0) | 107% (5.6) | 0% (0.0) | 7% (0.4) | match |
| added_normalized_dense | modalities | 4.6 | 7.5 | ×1.65 | 0% (0.1) | 91% (18.2) | 4% (0.9) | 4% (0.8) | match |
| added_normalized_sparse | modalities | 4.3 | 6.3 | ×1.49 | 0% (0.1) | 93% (25.5) | 5% (1.3) | 2% (0.7) | match |
| added_special_dense | modalities | 4.1 | 12.2 | ×3.01 | 9% (5.2) | 72% (43.8) | 2% (1.1) | 17% (10.3) | match |
| added_special_sparse | modalities | 6.1 | 7.5 | ×1.25 | 5% (2.2) | 87% (40.8) | 3% (1.6) | 5% (2.5) | match |
| agentic-traces | modalities | 4.0 | 6.0 | ×1.49 | 0% (0.1) | 96% (28.1) | 0% (0.0) | 9% (2.5) | match |
| agentic_swe | modalities | 3.8 | 5.6 | ×1.47 | 0% (0.0) | 99% (51.6) | 0% (0.0) | 5% (2.5) | match |
| code_mixed | modalities | 3.9 | 5.8 | ×1.47 | 0% (0.0) | 113% (39.8) | 0% (0.0) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 5.7 | ×1.43 | 0% (0.1) | 100% (28.4) | 0% (0.0) | 6% (1.6) | match |

</details>

<details><summary><b>llama-3</b> — split-heavy byte-level BPE, single regex · ×4.44 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-llama-3-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 128+0 (peak 189) · Pipeline 129+0 (peak 189)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 2.5 | 16.8 | ×6.68 | 2% (0.7) | 0% (0.0) | 75% (29.0) | 23% (9.0) | match |
| arb_Arab | lang | 3.3 | 11.0 | ×3.29 | 1% (0.6) | 0% (0.0) | 77% (33.9) | 21% (9.3) | match |
| ben_Beng | lang | 2.6 | 14.9 | ×5.67 | 1% (0.6) | 0% (0.0) | 86% (43.9) | 13% (6.7) | match |
| cmn_Hani | lang | 3.6 | 11.2 | ×3.11 | 2% (0.6) | 0% (0.0) | 72% (20.8) | 26% (7.4) | match |
| ell_Grek | lang | 3.5 | 11.8 | ×3.36 | 2% (0.6) | 0% (0.0) | 78% (30.3) | 21% (8.0) | match |
| eng_Latn | lang | 2.9 | 13.7 | ×4.77 | 4% (2.1) | 0% (0.0) | 78% (47.2) | 19% (11.4) | match |
| heb_Hebr | lang | 2.7 | 13.3 | ×4.85 | 1% (0.6) | 0% (0.0) | 75% (33.5) | 23% (10.4) | match |
| hin_Deva | lang | 3.2 | 15.5 | ×4.81 | 1% (0.6) | 0% (0.0) | 90% (51.8) | 9% (5.2) | match |
| jpn_Jpan | lang | 4.0 | 11.7 | ×2.92 | 2% (0.6) | 0% (0.0) | 76% (19.7) | 22% (5.6) | match |
| kat_Geor | lang | 3.0 | 21.1 | ×7.09 | 2% (0.6) | 0% (0.0) | 76% (18.6) | 21% (5.2) | match |
| kor_Hang | lang | 3.3 | 10.4 | ×3.14 | 1% (0.6) | 0% (0.0) | 72% (34.1) | 27% (12.6) | match |
| rus_Cyrl | lang | 3.4 | 10.6 | ×3.10 | 2% (0.6) | 0% (0.0) | 77% (28.9) | 21% (8.0) | match |
| tam_Taml | lang | 2.5 | 14.9 | ×5.93 | 1% (0.6) | 0% (0.0) | 87% (47.6) | 12% (6.7) | match |
| tha_Thai | lang | 4.0 | 12.3 | ×3.08 | 2% (0.7) | 0% (0.0) | 79% (30.0) | 20% (7.5) | match |
| added_normalized_dense | modalities | 3.6 | 29.5 | ×8.29 | 3% (0.8) | 0% (0.0) | 88% (25.8) | 9% (2.7) | match |
| added_normalized_sparse | modalities | 3.7 | 22.5 | ×6.06 | 4% (1.4) | 0% (0.1) | 89% (34.2) | 7% (2.9) | match |
| added_special_dense | modalities | 2.9 | 11.7 | ×4.00 | 6% (5.1) | 0% (0.0) | 90% (72.3) | 3% (2.5) | match |
| added_special_sparse | modalities | 3.3 | 14.3 | ×4.38 | 5% (3.4) | 0% (0.0) | 90% (58.7) | 5% (3.5) | match |
| agentic-traces | modalities | 2.5 | 10.9 | ×4.35 | 3% (1.9) | 0% (0.1) | 83% (58.4) | 14% (9.6) | match |
| agentic_swe | modalities | 2.6 | 11.7 | ×4.59 | 2% (1.3) | 0% (0.0) | 86% (59.8) | 12% (8.0) | match |
| code_mixed | modalities | 2.8 | 12.1 | ×4.30 | 3% (1.7) | 0% (0.0) | 86% (57.3) | 11% (7.5) | match |
| math_latex | modalities | 2.7 | 11.4 | ×4.26 | 3% (2.0) | 0% (0.0) | 82% (55.5) | 15% (10.4) | match |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29108011577-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->





