### PR TITLE
experiment: icu_normalizer as a dependency

### DIFF
--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -1020,6 +1020,9 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
@@ -2312,6 +2315,7 @@ dependencies = [
  "fancy-regex",
  "getrandom 0.3.4",
  "hf-hub",
+ "icu_normalizer",
  "indicatif 0.18.4",
  "itertools 0.14.0",
  "log",
@@ -2605,6 +2609,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -3058,6 +3068,12 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"

--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -1020,9 +1020,6 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
@@ -2338,7 +2335,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
- "unicode-normalization",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -2532,15 +2528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-normalization-alignments"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,12 +2596,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -3068,12 +3049,6 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -59,8 +59,9 @@ dary_heap = { version = "0.3.6", features = ["serde"] }
 compact_str = { version = "0.9", features = ["serde"] }
 ptr_hash = { version = "1.1.0" }
 memchr = "2.8.2"
-unicode-normalization = "0.1.25"
-icu_normalizer = "2.2.0"
+icu_normalizer = { version = "2.2.0", default-features = false, features = [
+  "compiled_data",
+] }
 
 [features]
 # TODO: onig is C (Oniguruma, archived upstream). We're moving to the pure-Rust

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -60,6 +60,7 @@ compact_str = { version = "0.9", features = ["serde"] }
 ptr_hash = { version = "1.1.0" }
 memchr = "2.8.2"
 unicode-normalization = "0.1.25"
+icu_normalizer = "2.2.0"
 
 [features]
 # TODO: onig is C (Oniguruma, archived upstream). We're moving to the pure-Rust

--- a/tokenizers/tk-encode/src/normalizers/bert.rs
+++ b/tokenizers/tk-encode/src/normalizers/bert.rs
@@ -5,11 +5,11 @@ use crate::{
     tokenizer::{NormalizedString, Normalizer, Result},
 };
 
+use super::icu::ICU_NFD;
 use super::utils::lowercases_to_self;
 
 use serde::{Deserialize, Serialize};
 use unicode_categories::UnicodeCategories;
-use unicode_normalization::{is_nfd_quick, IsNormalized, UnicodeNormalization};
 
 /// Checks whether a character is whitespace
 fn is_whitespace(c: char) -> bool {
@@ -138,7 +138,7 @@ impl BertNormalizer {
     }
 
     fn is_noop(&self, input: &str, strip_accents: bool) -> bool {
-        if strip_accents && !matches!(is_nfd_quick(input.chars()), IsNormalized::Yes) {
+        if strip_accents && !ICU_NFD.is_normalized(input) {
             return false;
         }
         let changes = |c: char| {
@@ -196,18 +196,22 @@ impl pipeline::Normalizer for BertNormalizer {
             })
             .flatten();
 
-        // `.nfd()` changes the iterator's type, so the stage toggles can't be
+        // NFD changes the iterator's type, so the stage toggles can't be
         // plain `if`s mid-chain: each config combination gets its own
         // statically-typed chain, all funneled into one pre-sized String.
         let mut normalized = String::with_capacity(input.len());
         match (strip_accents, self.lowercase) {
             (true, true) => normalized.extend(
-                cleaned
-                    .nfd()
+                ICU_NFD
+                    .normalize_iter(cleaned)
                     .filter(|c| !c.is_mark_nonspacing())
                     .flat_map(char::to_lowercase),
             ),
-            (true, false) => normalized.extend(cleaned.nfd().filter(|c| !c.is_mark_nonspacing())),
+            (true, false) => normalized.extend(
+                ICU_NFD
+                    .normalize_iter(cleaned)
+                    .filter(|c| !c.is_mark_nonspacing()),
+            ),
             (false, true) => normalized.extend(cleaned.flat_map(char::to_lowercase)),
             (false, false) => normalized.extend(cleaned),
         }

--- a/tokenizers/tk-encode/src/normalizers/icu.rs
+++ b/tokenizers/tk-encode/src/normalizers/icu.rs
@@ -1,0 +1,10 @@
+use icu_normalizer::{ComposingNormalizerBorrowed, DecomposingNormalizerBorrowed};
+
+pub(crate) static ICU_NFC: ComposingNormalizerBorrowed<'static> =
+    ComposingNormalizerBorrowed::new_nfc();
+pub(crate) static ICU_NFKC: ComposingNormalizerBorrowed<'static> =
+    ComposingNormalizerBorrowed::new_nfkc();
+pub(crate) static ICU_NFD: DecomposingNormalizerBorrowed<'static> =
+    DecomposingNormalizerBorrowed::new_nfd();
+pub(crate) static ICU_NFKD: DecomposingNormalizerBorrowed<'static> =
+    DecomposingNormalizerBorrowed::new_nfkd();

--- a/tokenizers/tk-encode/src/normalizers/mod.rs
+++ b/tokenizers/tk-encode/src/normalizers/mod.rs
@@ -1,5 +1,6 @@
 pub mod bert;
 pub mod byte_level;
+pub(crate) mod icu;
 pub mod precompiled;
 pub mod prepend;
 pub mod replace;

--- a/tokenizers/tk-encode/src/normalizers/unicode.rs
+++ b/tokenizers/tk-encode/src/normalizers/unicode.rs
@@ -4,9 +4,7 @@ use crate::pipeline;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::macro_rules_attribute;
 
-use unicode_normalization::{
-    is_nfc_quick, is_nfd_quick, is_nfkc_quick, is_nfkd_quick, IsNormalized, UnicodeNormalization,
-};
+use super::icu::{ICU_NFC, ICU_NFD, ICU_NFKC, ICU_NFKD};
 
 #[derive(Default, Copy, Clone, Debug)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -19,11 +17,7 @@ impl Normalizer for NFD {
 }
 impl pipeline::Normalizer for NFD {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
-        if let IsNormalized::Yes = is_nfd_quick(input.chars()) {
-            Ok(input.into())
-        } else {
-            Ok(Cow::Owned(input.nfd().collect()))
-        }
+        Ok(ICU_NFD.normalize(input))
     }
 }
 
@@ -38,11 +32,7 @@ impl Normalizer for NFKD {
 }
 impl pipeline::Normalizer for NFKD {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
-        if let IsNormalized::Yes = is_nfkd_quick(input.chars()) {
-            Ok(input.into())
-        } else {
-            Ok(Cow::Owned(input.nfkd().collect()))
-        }
+        Ok(ICU_NFKD.normalize(input))
     }
 }
 
@@ -57,11 +47,7 @@ impl Normalizer for NFC {
 }
 impl pipeline::Normalizer for NFC {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
-        if let IsNormalized::Yes = is_nfc_quick(input.chars()) {
-            Ok(input.into())
-        } else {
-            Ok(Cow::Owned(input.nfc().collect()))
-        }
+        Ok(ICU_NFC.normalize(input))
     }
 }
 
@@ -76,11 +62,7 @@ impl Normalizer for NFKC {
 }
 impl pipeline::Normalizer for NFKC {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
-        if let IsNormalized::Yes = is_nfkc_quick(input.chars()) {
-            Ok(input.into())
-        } else {
-            Ok(Cow::Owned(input.nfkc().collect()))
-        }
+        Ok(ICU_NFKC.normalize(input))
     }
 }
 


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**5 / 6 models supported** — ~10 kB inputs · single thread

`0d5123ab9 · 2026-07-09 17:06 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 8 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-overview-dark.png">
  <img alt="Per-model encode throughput summary" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-overview-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · geomean ×4.29</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-bert-base-uncased-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.5 | 24.5 | ×3.29 | 1.23 | 21.71 | 9.52 | 7.22 | match |
| arb_Arab | lang | 3.8 | 15.0 | ×3.96 | 1.16 | 26.33 | 13.29 | 24.23 | match |
| ben_Beng | lang | 5.5 | 22.4 | ×4.06 | 1.16 | 18.47 | 9.02 | 15.16 | match |
| cmn_Hani | lang | 3.4 | 16.6 | ×4.81 | 1.18 | 29.10 | 10.94 | 18.11 | match |
| ell_Grek | lang | 3.5 | 14.3 | ×4.15 | 1.17 | 27.12 | 13.38 | 27.20 | match |
| eng_Latn | lang | 4.2 | 17.4 | ×4.17 | 2.54 | 35.54 | 3.43 | 13.92 | match |
| heb_Hebr | lang | 3.8 | 14.7 | ×3.92 | 1.16 | 29.61 | 13.31 | 23.25 | match |
| hin_Deva | lang | 5.9 | 23.1 | ×3.89 | 1.17 | 21.09 | 7.90 | 12.24 | match |
| jpn_Jpan | lang | 3.9 | 17.9 | ×4.56 | 1.17 | 21.50 | 10.80 | 20.75 | match |
| kat_Geor | lang | 5.8 | 21.1 | ×3.62 | 1.16 | 20.60 | 9.77 | 14.85 | match |
| kor_Hang | lang | 2.3 | 9.6 | ×4.27 | 1.17 | 33.11 | 21.46 | 47.02 | match |
| rus_Cyrl | lang | 3.3 | 14.0 | ×4.21 | 1.17 | 26.39 | 13.53 | 28.77 | match |
| tam_Taml | lang | 6.7 | 25.2 | ×3.78 | 1.15 | 17.75 | 8.31 | 11.44 | match |
| tha_Thai | lang | 8.1 | 24.6 | ×3.03 | 1.22 | 19.49 | 7.79 | 10.96 | match |
| added_normalized_dense | modalities | 6.3 | 23.3 | ×3.72 | 1.36 | 37.13 | 1.18 | 2.25 | match |
| added_normalized_sparse | modalities | 4.9 | 20.4 | ×4.14 | 1.96 | 36.99 | 2.08 | 7.03 | match |
| added_special_dense | modalities | 4.9 | 44.3 | ×9.10 | 5.35 | 11.24 | 2.12 | 8.97 | match |
| added_special_sparse | modalities | 3.8 | 23.1 | ×6.11 | 3.61 | 28.46 | 2.17 | 7.77 | match |
| agentic-traces | modalities | 3.6 | 16.2 | ×4.56 | 2.47 | 35.27 | 3.91 | 17.94 | match |
| agentic_swe | modalities | 3.8 | 17.4 | ×4.54 | 2.03 | 35.39 | 2.72 | 16.33 | match |
| code_mixed | modalities | 3.6 | 17.0 | ×4.66 | 2.20 | 35.38 | 3.54 | 17.20 | match |
| math_latex | modalities | 3.7 | 16.4 | ×4.40 | 2.44 | 35.47 | 3.66 | 17.25 | match |

</details>

<details><summary><b>deepseek-v4</b> — split-heavy byte-level BPE, 3 chained regexes · geomean ×2.62</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-deepseek-v4-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 14.5 | ×3.70 | 0.70 | 0.00 | 43.01 | 24.95 | match |
| arb_Arab | lang | 3.5 | 9.4 | ×2.67 | 0.59 | 0.00 | 50.55 | 55.00 | match |
| ben_Beng | lang | 4.4 | 11.2 | ×2.53 | 0.60 | 0.00 | 36.79 | 51.72 | match |
| cmn_Hani | lang | 3.2 | 7.8 | ×2.47 | 0.76 | 0.00 | 66.76 | 53.35 | match |
| ell_Grek | lang | 3.7 | 10.0 | ×2.73 | 0.60 | 0.01 | 48.39 | 50.94 | match |
| eng_Latn | lang | 2.7 | 6.7 | ×2.47 | 2.03 | 0.01 | 70.12 | 74.40 | match |
| heb_Hebr | lang | 3.2 | 8.0 | ×2.49 | 0.61 | 0.00 | 52.02 | 72.23 | match |
| hin_Deva | lang | 4.3 | 12.1 | ×2.82 | 0.60 | 0.00 | 39.69 | 40.53 | match |
| jpn_Jpan | lang | 3.8 | 8.9 | ×2.37 | 0.67 | 0.00 | 56.91 | 54.20 | match |
| kat_Geor | lang | 4.4 | 11.5 | ×2.61 | 0.59 | 0.00 | 33.38 | 52.56 | match |
| kor_Hang | lang | 3.3 | 9.9 | ×2.97 | 0.61 | 0.00 | 53.63 | 44.91 | match |
| rus_Cyrl | lang | 3.6 | 8.9 | ×2.43 | 0.60 | 0.00 | 48.18 | 65.69 | match |
| tam_Taml | lang | 4.7 | 11.4 | ×2.43 | 0.60 | 0.00 | 33.15 | 53.94 | match |
| tha_Thai | lang | 5.4 | 10.8 | ×1.99 | 0.61 | 0.01 | 27.24 | 64.07 | match |
| added_normalized_dense | modalities | 3.7 | 12.1 | ×3.28 | 0.75 | 0.00 | 42.09 | 39.77 | match |
| added_normalized_sparse | modalities | 3.5 | 10.1 | ×2.92 | 1.33 | 0.00 | 48.92 | 46.44 | match |
| added_special_dense | modalities | 2.9 | 7.2 | ×2.46 | 6.75 | 0.66 | 107.75 | 23.59 | match |
| added_special_sparse | modalities | 3.2 | 7.4 | ×2.33 | 3.95 | 0.25 | 85.13 | 42.26 | match |
| agentic-traces | modalities | 2.4 | 6.3 | ×2.63 | 1.81 | 0.00 | 87.26 | 64.74 | match |
| agentic_swe | modalities | 2.4 | 5.9 | ×2.48 | 1.29 | 0.01 | 105.70 | 67.46 | match |
| code_mixed | modalities | 2.6 | 7.1 | ×2.74 | 1.55 | 0.00 | 78.74 | 60.09 | match |
| math_latex | modalities | 2.4 | 6.3 | ×2.61 | 1.90 | 0.06 | 82.80 | 73.68 | match |

</details>

<details><summary><b>gpt2</b> — standalone ByteLevel pre-tokenizer · geomean ×8.01</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-gpt2-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 37.4 | ×9.89 | 0.66 | 0.00 | 6.23 | 18.92 | match |
| arb_Arab | lang | 3.0 | 22.5 | ×7.55 | 0.60 | 0.00 | 7.35 | 35.52 | match |
| ben_Beng | lang | 2.3 | 29.0 | ×12.79 | 0.60 | 0.00 | 11.43 | 22.52 | match |
| cmn_Hani | lang | 3.1 | 24.6 | ×7.81 | 0.61 | 0.00 | 5.69 | 33.16 | match |
| ell_Grek | lang | 3.1 | 26.1 | ×8.36 | 0.60 | 0.00 | 6.71 | 29.97 | match |
| eng_Latn | lang | 2.8 | 11.9 | ×4.33 | 1.98 | 0.01 | 10.66 | 69.58 | match |
| heb_Hebr | lang | 3.0 | 25.0 | ×8.41 | 0.60 | 0.00 | 7.61 | 31.12 | match |
| hin_Deva | lang | 2.5 | 26.9 | ×10.60 | 0.60 | 0.00 | 11.40 | 24.41 | match |
| jpn_Jpan | lang | 3.5 | 19.6 | ×5.60 | 0.60 | 0.00 | 5.04 | 44.40 | match |
| kat_Geor | lang | 3.6 | 54.1 | ×15.15 | 0.59 | 0.00 | 4.75 | 12.38 | match |
| kor_Hang | lang | 2.8 | 32.4 | ×11.56 | 0.62 | 0.00 | 7.48 | 22.04 | match |
| rus_Cyrl | lang | 3.2 | 23.9 | ×7.41 | 0.60 | 0.00 | 6.52 | 33.85 | match |
| tam_Taml | lang | 2.1 | 34.9 | ×16.37 | 0.60 | 0.00 | 12.10 | 15.36 | match |
| tha_Thai | lang | 2.8 | 29.0 | ×10.41 | 0.65 | 0.00 | 8.01 | 24.76 | match |
| added_normalized_dense | modalities | 3.5 | 22.9 | ×6.57 | 0.87 | 0.00 | 6.44 | 41.19 | match |
| added_normalized_sparse | modalities | 3.3 | 18.7 | ×5.71 | 1.41 | 0.00 | 8.00 | 42.44 | match |
| added_special_dense | modalities | 3.6 | 32.7 | ×8.98 | 5.21 | 0.15 | 8.92 | 15.76 | match |
| added_special_sparse | modalities | 3.3 | 19.3 | ×5.89 | 3.32 | 0.01 | 10.53 | 36.44 | match |
| agentic-traces | modalities | 2.4 | 13.1 | ×5.48 | 1.82 | 0.01 | 13.39 | 59.59 | match |
| agentic_swe | modalities | 2.4 | 17.8 | ×7.33 | 1.29 | 0.00 | 12.62 | 40.72 | match |
| code_mixed | modalities | 2.4 | 15.7 | ×6.60 | 1.56 | 0.00 | 12.85 | 48.24 | match |
| math_latex | modalities | 2.6 | 12.5 | ×4.85 | 1.86 | 0.04 | 12.16 | 64.43 | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · geomean ×2.97</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-llama-2-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 30.3 | ×7.04 | 0.04 | 14.72 | 0.00 | 18.64 | match |
| arb_Arab | lang | 9.1 | 31.6 | ×3.49 | 0.03 | 17.13 | 0.00 | 15.47 | match |
| ben_Beng | lang | 9.7 | 50.9 | ×5.26 | 0.04 | 11.51 | 0.00 | 8.70 | match |
| cmn_Hani | lang | 8.1 | 63.2 | ×7.81 | 0.05 | 3.00 | 0.00 | 12.20 | match |
| ell_Grek | lang | 9.0 | 35.5 | ×3.96 | 0.03 | 16.11 | 0.00 | 12.78 | match |
| eng_Latn | lang | 4.1 | 5.7 | ×1.39 | 0.06 | 30.66 | 0.00 | 144.87 | match |
| heb_Hebr | lang | 8.8 | 34.0 | ×3.87 | 0.05 | 17.70 | 0.00 | 12.42 | match |
| hin_Deva | lang | 10.6 | 43.4 | ×4.08 | 0.03 | 14.78 | 0.00 | 8.96 | match |
| jpn_Jpan | lang | 11.2 | 77.6 | ×6.93 | 0.05 | 2.73 | 0.00 | 9.46 | match |
| kat_Geor | lang | 12.6 | 56.5 | ×4.48 | 0.05 | 9.75 | 0.00 | 8.10 | match |
| kor_Hang | lang | 6.5 | 32.7 | ×5.05 | 0.06 | 17.00 | 0.00 | 14.34 | match |
| rus_Cyrl | lang | 8.0 | 14.3 | ×1.79 | 0.03 | 14.30 | 0.00 | 56.13 | match |
| tam_Taml | lang | 11.1 | 60.0 | ×5.42 | 0.03 | 8.91 | 0.00 | 8.28 | match |
| tha_Thai | lang | 14.0 | 73.4 | ×5.26 | 0.03 | 4.74 | 0.00 | 8.94 | match |
| added_normalized_dense | modalities | 5.2 | 8.3 | ×1.59 | 0.07 | 19.30 | 0.00 | 105.18 | match |
| added_normalized_sparse | modalities | 4.6 | 6.6 | ×1.44 | 0.07 | 27.20 | 0.00 | 122.03 | match |
| added_special_dense | modalities | 4.5 | 12.4 | ×2.73 | 5.32 | 44.03 | 0.73 | 29.67 | match |
| added_special_sparse | modalities | 6.5 | 7.9 | ×1.22 | 2.28 | 42.76 | 0.00 | 80.72 | match |
| agentic-traces | modalities | 4.2 | 6.3 | ×1.49 | 0.25 | 29.09 | 0.00 | 127.91 | match |
| agentic_swe | modalities | 3.9 | 5.8 | ×1.48 | 0.09 | 53.15 | 0.00 | 118.06 | match |
| code_mixed | modalities | 4.0 | 5.9 | ×1.46 | 0.04 | 41.64 | 0.00 | 125.02 | match |
| math_latex | modalities | 4.2 | 6.0 | ×1.44 | 0.07 | 29.22 | 0.00 | 135.16 | match |

</details>

<details><summary><b>llama-3</b> — split-heavy byte-level BPE, single regex · geomean ×3.97</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-llama-3-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.0 | 22.5 | ×7.38 | 0.67 | 0.00 | 27.32 | 15.15 | match |
| arb_Arab | lang | 3.7 | 12.1 | ×3.29 | 0.60 | 0.00 | 31.13 | 51.09 | match |
| ben_Beng | lang | 2.9 | 13.1 | ×4.50 | 0.63 | 0.00 | 45.15 | 30.62 | match |
| cmn_Hani | lang | 4.2 | 13.2 | ×3.15 | 0.61 | 0.00 | 20.11 | 53.33 | match |
| ell_Grek | lang | 4.0 | 13.0 | ×3.22 | 0.60 | 0.00 | 29.48 | 44.68 | match |
| eng_Latn | lang | 3.7 | 14.8 | ×4.02 | 1.97 | 0.02 | 46.93 | 14.37 | match |
| heb_Hebr | lang | 3.2 | 14.4 | ×4.48 | 0.59 | 0.00 | 35.90 | 29.60 | match |
| hin_Deva | lang | 3.9 | 16.5 | ×4.28 | 0.60 | 0.01 | 50.35 | 13.06 | match |
| jpn_Jpan | lang | 4.7 | 13.2 | ×2.83 | 0.60 | 0.00 | 19.35 | 53.88 | match |
| kat_Geor | lang | 3.9 | 23.6 | ×6.10 | 0.60 | 0.00 | 17.94 | 21.86 | match |
| kor_Hang | lang | 3.5 | 12.7 | ×3.61 | 0.61 | 0.00 | 30.98 | 46.66 | match |
| rus_Cyrl | lang | 4.0 | 12.0 | ×3.04 | 0.60 | 0.00 | 27.08 | 53.14 | match |
| tam_Taml | lang | 2.8 | 14.0 | ×4.95 | 0.61 | 0.03 | 44.31 | 27.48 | match |
| tha_Thai | lang | 4.5 | 13.9 | ×3.11 | 0.61 | 0.00 | 28.23 | 42.83 | match |
| added_normalized_dense | modalities | 4.0 | 17.0 | ×4.19 | 0.76 | 0.00 | 23.47 | 34.94 | match |
| added_normalized_sparse | modalities | 4.2 | 18.9 | ×4.54 | 1.30 | 0.00 | 31.15 | 21.44 | match |
| added_special_dense | modalities | 3.6 | 13.1 | ×3.64 | 5.12 | 0.30 | 66.66 | 5.00 | match |
| added_special_sparse | modalities | 4.0 | 15.8 | ×3.93 | 3.39 | 0.00 | 53.28 | 7.07 | match |
| agentic-traces | modalities | 3.2 | 12.8 | ×4.05 | 1.77 | 0.00 | 53.31 | 22.11 | match |
| agentic_swe | modalities | 3.3 | 11.3 | ×3.43 | 1.29 | 0.00 | 55.22 | 31.70 | match |
| code_mixed | modalities | 3.5 | 13.4 | ×3.85 | 1.53 | 0.04 | 55.56 | 13.61 | match |
| math_latex | modalities | 3.2 | 12.9 | ×4.03 | 1.90 | 0.00 | 54.20 | 15.58 | match |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29035474644-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
