### PR TITLE
ci: bench against latest release, measure memory consumption and executable size

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -1,31 +1,40 @@
 #!/usr/bin/env python3
-"""Render the multi-model fixture_bench JSON as full-size per-model charts +
-a markdown report for a PR description.
+"""Render the fixture_bench JSON as full-size charts + a markdown report for a
+PR description.
 
-Input: JSON array from `cargo run --release -p tk-encode --example fixture_bench`,
-one object per model:
-    {model, shape, supported, [reason], results: [{fixture, group,
-     legacy_mbps, pipeline_mbps, speedup, ids_match,
-     stage_ns_per_byte: {added_split, normalize, pre_tokenize, model, total}}, ...]}
+Input: JSON object from `cargo run --release -p tk-encode --features
+tk-encode/bench-baseline --example fixture_bench`:
 
-The report leads with a single overview chart — one row per manifest model:
-its workload `desc`, geomean ×speedup bar and a min–max whisker across
-fixtures (no cross-model aggregate: the models exercise different execution
-modes, so averaging them means nothing). Everything else is collapsed into
-per-model <details> blocks.
+    {baseline: {crate, version},
+     models: [{model, shape, desc, supported, [reason],
+               memory: {baseline|pipeline:
+                        {load_bytes, encode_bytes, peak_bytes} | null} | null,
+               results: [{fixture, group, bytes, chunks,
+                          mbps: {baseline, pipeline},
+                          ids_match, ids_match_baseline,
+                          stage_ns_per_byte: {added_split, normalize,
+                                              pre_tokenize, model, total}}]}]}
 
-Each supported model gets two full-size charts inside its block:
-  1. a diverging bar chart (log2 around ×1.0): per-fixture ×speedup + the
-     `MB/s: Tokenizer → Pipeline` throughput column, with group headers,
-     slower/faster hints, ticks and an inline "⚠ ids differ" flag;
-  2. a stacked stage-decomposition chart (ns/byte, lower is better — the
-     opposite direction from the speedup chart, hence the explicit hint and
-     the reference tick): where the pipeline spends its own encode time per
-     fixture — added-token split + normalize + pre-tokenize + model — with a
-     tick at the reference Tokenizer's total ns/byte on each row, so bar vs
-     tick reads the same way as the ×speedup column.
-Unsupported models (standalone ByteLevel, Unigram/Metaspace, …) get a compact
-"not supported" card. Charts are rendered full-size so readers can zoom.
+Two series: `baseline` — the latest released tokenizers crate, the bar to beat
+(the in-tree Tokenizer is on its way out, so it isn't benched; it only serves
+as the id oracle behind `ids_match`) — drawn gray as context, and `pipeline` —
+the experimental PipelineTokenizer, blue. The report leads with three
+always-visible charts:
+
+  1. throughput overview — per model, geomean ×speedup of the pipeline against
+     the release (×1.0 = release), with a min–max whisker across fixtures (no
+     cross-model aggregate: the models exercise different execution modes, so
+     averaging them means nothing);
+  2. memory overview — per model, resident-set delta after load plus the encode
+     pass, one stacked bar per implementation, tick = peak RSS;
+  3. binary size — stripped minimal encode binary per implementation (workflow
+     measurement, via --binary-sizes).
+
+Everything else is collapsed into per-model <details> blocks: a per-fixture
+×speedup chart, the pipeline stage decomposition (ablation-ladder view with a
+release-total tick per row), and the numbers table. Models the pipeline can't
+build yet render as compact "not supported" roadmap cards. Charts are rendered
+full-size so readers can zoom.
 """
 import argparse
 import json
@@ -41,22 +50,27 @@ INK = {
     "light": {
         "surface": "#fcfcfb", "card": "#ffffff", "primary": "#0b0b0b",
         "secondary": "#52514e", "muted": "#898781", "grid": "#e1e0d9",
-        "border": "#e1e0d9", "baseline": "#c3c2b7",
-        "faster": "#2a78d6", "slower": "#e34948", "critical": "#d03b3b",
+        "border": "#e1e0d9", "baseline": "#c3c2b7", "critical": "#d03b3b",
     },
     "dark": {
         "surface": "#1a1a19", "card": "#212120", "primary": "#ffffff",
         "secondary": "#c3c2b7", "muted": "#898781", "grid": "#2c2c2a",
-        "border": "#33332f", "baseline": "#4a4a46",
-        "faster": "#3987e5", "slower": "#e66767", "critical": "#e66767",
+        "border": "#33332f", "baseline": "#4a4a46", "critical": "#e66767",
     },
 }
+# Series identity: the release baseline is context-gray on purpose — in the
+# speedup charts it *is* the ×1.0 axis, in memory/binary-size it's the
+# reference bar the pipeline is read against.
+SERIES_INK = {
+    "light": {"baseline": "#898781", "pipeline": "#2a78d6"},
+    "dark": {"baseline": "#898781", "pipeline": "#3987e5"},
+}
 FONT = "-apple-system,'Segoe UI',Helvetica,Arial,sans-serif"
-GUTTER, PLOT_W, PAD_R, COL_W, ROW_H, BAR_H = 150, 540, 110, 150, 26, 16
+GUTTER, PLOT_W, PAD_R, COL_W, ROW_H, BAR_H = 190, 540, 110, 150, 26, 16
 CHART_W = GUTTER + PLOT_W + PAD_R + COL_W
-# Overview chart: wider gutter (model name + desc), same total width.
+# Overview charts: wider gutter (model name + desc), same total width.
 OV_GUTTER, OV_PLOT = 250, 440
-TICKS = [0.5, 0.67, 0.75, 0.8, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0, 5.0]
+TICKS = [0.5, 0.67, 0.75, 0.8, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0, 5.0, 7.0, 10.0]
 GROUPS = [("lang", "Languages"), ("modalities", "Modalities")]
 CARD_W, CARD_H = 470, 150
 
@@ -82,6 +96,14 @@ def geomean(values):
     return math.exp(sum(math.log(v) for v in values) / len(values))
 
 
+def fnum(v, spec="{:.1f}"):
+    return spec.format(v) if v is not None else "—"
+
+
+def chain(vals, spec="{:.1f}"):
+    return " → ".join(fnum(v, spec) for v in vals)
+
+
 def text_on(hex_color):
     """Black or white label, whichever reads on `hex_color` (relative luminance)."""
     r, g, b = (int(hex_color[i:i + 2], 16) / 255 for i in (1, 3, 5))
@@ -99,21 +121,45 @@ def bar_path(x0, x1, y, h, r):
             f"V{y + h - r:.1f} q0,{r:.1f} {r:.1f},{r:.1f} H{right:.1f} Z")
 
 
+def hbar(x0, x1, y, h, color):
+    if abs(x1 - x0) < 1.5:
+        return f'<rect x="{min(x0, x1):.1f}" y="{y:.1f}" width="1.5" height="{h}" fill="{color}"/>'
+    return f'<path d="{bar_path(x0, x1, y, h, 4)}" fill="{color}"/>'
+
+
+def speedup(row):
+    b, p = row["mbps"]["baseline"], row["mbps"]["pipeline"]
+    return p / b if b and p else None
+
+
+def model_speedups(model):
+    return [v for v in (speedup(r) for r in model["results"]) if v]
+
+
 def scale(models):
-    """Shared log2 x-range across every supported fixture speedup, so charts
-    for different models are directly comparable."""
-    vals = [r["speedup"] for m in models if m["supported"] for r in m["results"]]
+    """Shared log2 x-range across every plotted speedup, so charts for
+    different models are directly comparable."""
+    vals = [v for m in models for v in model_speedups(m)]
     if not vals:
         return 0.75, 1.5
     return min(0.75, min(vals) / 1.08), max(1.5, max(vals) * 1.08)
 
 
-def thin_ticks(ticks, x, min_px=26):
-    """Drop axis ticks that would collide at the current scale (e.g. ×0.75 and
-    ×0.8 once a big speedup stretches the log range). ×1.0 always survives."""
-    kept = [t for t in ticks if t == 1.0]
+def nice_ticks(vmax):
+    """Round ticks for a 0-anchored linear axis: a 1/2/2.5/5×10^k step chosen
+    so ~5 ticks fit, never exceeding vmax."""
+    raw = vmax / 5
+    mag = 10 ** math.floor(math.log10(raw))
+    step = next(s * mag for s in (1, 2, 2.5, 5, 10) if s * mag >= raw)
+    return [i * step for i in range(int(vmax / step) + 1)]
+
+
+def thin_ticks(ticks, x, min_px=26, keep=None):
+    """Drop axis ticks that would collide at the current scale. `keep` (e.g. the
+    ×1.0 baseline) always survives."""
+    kept = [t for t in ticks if t == keep]
     for t in ticks:
-        if t != 1.0 and all(abs(x(t) - x(k)) >= min_px for k in kept):
+        if t != keep and all(abs(x(t) - x(k)) >= min_px for k in kept):
             kept.append(t)
     return sorted(kept)
 
@@ -126,21 +172,227 @@ def footer_text(ink, height, meta, subtitle_base=""):
             f'style="font-variant-numeric:tabular-nums">{escape(" · ".join(parts))}</text>')
 
 
-def chart_svg(model, mode, subtitle_base, meta, lo, hi):
-    """Full-size per-fixture speedup chart for a supported model."""
-    ink = INK[mode]
+def legend_row(ink, sink, y, entries):
+    """Bottom legend: [(kind, key, label)] with kind ∈ swatch|tick|dot; `key` is
+    a series key into `sink` or a raw color."""
+    parts, lx = [], GUTTER
+    for kind, key, label in entries:
+        color = sink.get(key, key)
+        if kind == "swatch":
+            parts.append(f'<rect x="{lx}" y="{y - 9}" width="11" height="11" rx="2" fill="{color}"/>')
+        elif kind == "dot":
+            parts.append(f'<circle cx="{lx + 5.5}" cy="{y - 3.5}" r="5" fill="{color}" '
+                         f'stroke="{ink["surface"]}" stroke-width="2"/>')
+        else:
+            parts.append(f'<line x1="{lx + 5}" y1="{y - 10}" x2="{lx + 5}" y2="{y + 2}" '
+                         f'stroke="{color}" stroke-width="1.5"/>')
+        parts.append(f'<text x="{lx + 16}" y="{y}" fill="{ink["secondary"]}" '
+                     f'font-size="11.5">{escape(label)}</text>')
+        lx += 16 + 8 + len(label) * 6.6 + 18
+    return "".join(parts)
+
+
+def svg_doc(ink, height, title, subtitle, body, meta, subtitle_base=""):
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{CHART_W}" height="{height}"
+  viewBox="0 0 {CHART_W} {height}" font-family="{FONT}">
+<rect width="{CHART_W}" height="{height}" fill="{ink["surface"]}"/>
+<text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="700">{escape(title)}</text>
+<text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
+{body}
+{footer_text(ink, height, meta, subtitle_base)}
+</svg>'''
+
+
+def speedup_axis(ink, x, ticks, top, bottom):
+    grid = []
+    for t in ticks:
+        strong = t == 1.0
+        grid.append(f'<line x1="{x(t):.1f}" y1="{top - 6}" x2="{x(t):.1f}" y2="{bottom - 4}" '
+                    f'stroke="{ink["baseline"] if strong else ink["grid"]}" stroke-width="1"/>')
+        grid.append(f'<text x="{x(t):.1f}" y="{bottom + 10}" fill="{ink["muted"]}" font-size="11" '
+                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">×{t:g}</text>')
+    hints = (f'<text x="{x(1.0) - 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+             f'text-anchor="end">← slower</text>'
+             f'<text x="{x(1.0) + 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+             f'text-anchor="start">faster →</text>')
+    return "".join(grid) + hints
+
+
+def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label):
+    """The headline chart: a row per manifest model — name + workload desc,
+    geomean ×speedup of the pipeline vs the release (×1.0) with a min–max
+    whisker across fixtures. No cross-model aggregate on purpose: the models
+    exercise different execution modes. Unsupported models appear as muted
+    status rows so the overview is the complete state of the world."""
+    ink, sink = INK[mode], SERIES_INK[mode]
+
+    def x(v):
+        return OV_GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * OV_PLOT
+
+    ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x, min_px=34, keep=1.0)
+
+    top, row_h = 74, 40
+    col_x = CHART_W - 16
+    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+            f'text-anchor="end">fixtures · ids</text>']
+    y = top
+    for m in models:
+        cy = y + row_h / 2
+        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy - 3:.1f}" fill="{ink["primary"]}" '
+                    f'font-size="12.5" font-weight="600" text-anchor="end">{escape(m["model"])}</text>')
+        desc = m.get("desc") or m["shape"]
+        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 11:.1f}" fill="{ink["muted"]}" '
+                    f'font-size="10.5" text-anchor="end">{escape(desc)}</text>')
+        vals = model_speedups(m)
+        if vals:
+            g, mn, mx = geomean(vals), min(vals), max(vals)
+            body.append(hbar(x(1.0), x(g), cy - 7, 14, sink["pipeline"]))
+            body.append(f'<line x1="{x(mn):.1f}" y1="{cy:.1f}" x2="{x(mx):.1f}" y2="{cy:.1f}" '
+                        f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
+            for v in (mn, mx):
+                body.append(f'<line x1="{x(v):.1f}" y1="{cy - 4:.1f}" x2="{x(v):.1f}" y2="{cy + 4:.1f}" '
+                            f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
+            anchor, lx = (("start", max(x(mx), x(1.0)) + 8) if g >= 1
+                          else ("end", min(x(mn), x(1.0)) - 8))
+            if anchor == "end" and lx - 40 < OV_GUTTER + 4:
+                anchor, lx = "start", max(x(mx), x(1.0)) + 8
+            body.append(f'<text x="{lx:.1f}" y="{cy + 4:.1f}" fill="{ink["primary"]}" font-size="12" '
+                        f'font-weight="600" text-anchor="{anchor}" '
+                        f'style="font-variant-numeric:tabular-nums">×{g:.2f}</text>')
+            bad = sum(1 for r in m["results"] if r["ids_match"] is False)
+            right, fill = ((f"⚠ {bad} differ", ink["critical"]) if bad
+                           else (f'{len(m["results"])} · ids ok', ink["secondary"]))
+            body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{fill}" font-size="12" '
+                        f'text-anchor="end" style="font-variant-numeric:tabular-nums">{right}</text>')
+        elif m["results"]:
+            body.append(f'<text x="{x(1.0) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["muted"]}" '
+                        f'font-size="11.5" font-style="italic">benched, but {escape(baseline_label)} '
+                        f'can’t load this model — no comparison</text>')
+        else:
+            pretok = m["shape"].split("·")[-1].strip()
+            why = (m.get("reason") or f"no {pretok} pre-tokenizer")
+            body.append(f'<text x="{x(1.0) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["muted"]}" '
+                        f'font-size="11.5" font-style="italic">not supported — {escape(why)}</text>')
+            body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{ink["muted"]}" font-size="12" '
+                        f'text-anchor="end">—</text>')
+        y += row_h
+
+    axis = speedup_axis(ink, x, ticks, top, y + 4)
+    y += 30
+    legend = legend_row(ink, sink, y, [
+        ("swatch", "pipeline", "PipelineTokenizer"),
+        ("tick", ink["baseline"], f"×1.0 = {baseline_label}"),
+    ])
+    height = y + 34
+    subtitle = (f"geomean ×speedup per model vs {baseline_label} · "
+                f"whisker: min–max across fixtures · {subtitle_base}")
+    return svg_doc(ink, height, "PipelineTokenizer vs latest release — encode throughput",
+                   subtitle, axis + "".join(body) + legend, meta)
+
+
+def memory_svg(models, mode, meta, baseline_label):
+    """Per model: resident-set delta of each implementation — load footprint plus
+    the encode-pass delta as stacked segments, peak RSS as a tick."""
+    ink, sink = INK[mode], SERIES_INK[mode]
+    models = [m for m in models if isinstance(m.get("memory"), dict)]
+
+    def mem(m, impl):
+        d = m["memory"].get(impl)
+        if not isinstance(d, dict):
+            return None
+        return {k: max(0, d[k]) / 1e6 if d.get(k) is not None else None
+                for k in ("load_bytes", "encode_bytes", "peak_bytes")}
+
+    vals = []
+    for m in models:
+        for impl in ("baseline", "pipeline"):
+            d = mem(m, impl)
+            if d:
+                vals.append((d["load_bytes"] or 0) + (d["encode_bytes"] or 0))
+                if d["peak_bytes"]:
+                    vals.append(d["peak_bytes"])
+    if not vals:
+        return svg_doc(ink, 120, "Memory footprint", "no data", "", meta)
+    max_mb = max(vals) * 1.05
+    plot_w = CHART_W - OV_GUTTER - PAD_R - COL_W
+
+    def x(v):
+        return OV_GUTTER + v / max_mb * plot_w
+
+    top, bar_h, row_h = 78, 12, 2 * (12 + 3) + 16
+    col_x = CHART_W - 16
+    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+            f'text-anchor="end">MB: {escape(baseline_label)} → Pipeline</text>',
+            f'<text x="{OV_GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
+            f'smaller is better · solid: after load · translucent: encode-pass delta</text>']
+    y = top
+    for m in models:
+        cy = y + row_h / 2
+        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 4:.1f}" fill="{ink["primary"]}" '
+                    f'font-size="12.5" font-weight="600" text-anchor="end">{escape(m["model"])}</text>')
+        totals = []
+        by = y + 8
+        for impl in ("baseline", "pipeline"):
+            d = mem(m, impl)
+            if not d:
+                totals.append(None)
+                by += bar_h + 3
+                continue
+            load, enc = d["load_bytes"] or 0, d["encode_bytes"] or 0
+            totals.append(load + enc)
+            body.append(f'<rect x="{x(0):.1f}" y="{by:.1f}" width="{max(1.5, x(load) - x(0)):.1f}" '
+                        f'height="{bar_h}" rx="2" fill="{sink[impl]}"/>')
+            if x(enc) - x(0) > 2:
+                body.append(f'<rect x="{x(load) + 2:.1f}" y="{by:.1f}" '
+                            f'width="{max(1.5, x(enc) - x(0) - 2):.1f}" height="{bar_h}" rx="2" '
+                            f'fill="{sink[impl]}" fill-opacity="0.45"/>')
+            if d["peak_bytes"]:
+                px = x(d["peak_bytes"])
+                body.append(f'<line x1="{px:.1f}" y1="{by - 2:.1f}" x2="{px:.1f}" '
+                            f'y2="{by + bar_h + 2:.1f}" stroke="{ink["primary"]}" stroke-width="1.5"/>')
+            by += bar_h + 3
+        body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{ink["secondary"]}" font-size="12" '
+                    f'text-anchor="end" style="font-variant-numeric:tabular-nums">'
+                    f'{chain(totals, "{:.0f}")}</text>')
+        y += row_h
+
+    grid = []
+    ticks = nice_ticks(max_mb)
+    for tv in ticks:
+        unit = " MB" if tv == ticks[-1] else ""
+        grid.append(f'<line x1="{x(tv):.1f}" y1="{top - 6}" x2="{x(tv):.1f}" y2="{y - 4}" '
+                    f'stroke="{ink["grid"]}" stroke-width="1"/>')
+        grid.append(f'<text x="{x(tv):.1f}" y="{y + 10}" fill="{ink["muted"]}" font-size="11" '
+                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{unit}</text>')
+    y += 30
+    legend = legend_row(ink, sink, y, [
+        ("swatch", "baseline", baseline_label),
+        ("swatch", "pipeline", "PipelineTokenizer"),
+        ("tick", ink["primary"], "peak RSS (VmHWM)"),
+    ])
+    height = y + 34
+    subtitle = "resident-set delta per implementation, one process each · load + encode pass"
+    return svg_doc(ink, height, "Memory footprint",
+                   subtitle, "".join(grid) + "".join(body) + legend, meta)
+
+
+def chart_svg(model, mode, subtitle_base, meta, lo, hi, baseline_label):
+    """Full-size per-fixture chart: the pipeline's ×speedup vs the release, with
+    the `MB/s: release → Pipeline` throughput column."""
+    ink, sink = INK[mode], SERIES_INK[mode]
     rows = model["results"]
 
     def x(v):
         return GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * PLOT_W
 
-    ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x)
+    ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x, min_px=34, keep=1.0)
 
     top = 74
     col_x = GUTTER + PLOT_W + PAD_R + COL_W - 16
     body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-            f'text-anchor="end">MB/s: Tokenizer → Pipeline</text>']
+            f'text-anchor="end">MB/s: {escape(baseline_label)} → Pipeline</text>']
     y = top
+    baseline_id_note = False
     for key, title in GROUPS:
         # stable order (alphabetical by fixture) so a fixture keeps its row across
         # runs and lines up with the stage-decomposition chart — not sorted by the
@@ -153,76 +405,80 @@ def chart_svg(model, mode, subtitle_base, meta, lo, hi):
                     f'font-weight="600" letter-spacing="1.2" text-anchor="end" dx="-10">{title.upper()}</text>')
         y += 22
         for r in group_rows:
-            v, x0, x1 = r["speedup"], x(1.0), x(r["speedup"])
-            if abs(math.log2(v)) < math.log2(1.02):  # within noise of the baseline
-                color = ink["muted"]
-            else:
-                color = ink["faster"] if v >= 1 else ink["slower"]
-            by = y + (ROW_H - BAR_H) / 2
+            label = r["fixture"]
+            if r.get("ids_match_baseline") is False:
+                label += " †"
+                baseline_id_note = True
             body.append(f'<text x="{GUTTER - 10}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
-                        f'font-size="12.5" text-anchor="end">{escape(r["fixture"])}</text>')
-            if abs(x1 - x0) < 1.5:
-                body.append(f'<rect x="{min(x0, x1):.1f}" y="{by}" width="1.5" height="{BAR_H}" fill="{color}"/>')
-            else:
-                body.append(f'<path d="{bar_path(x0, x1, by, BAR_H, 4)}" fill="{color}"/>')
-            label = f"×{v:.2f}"
-            anchor, lx = ("start", max(x0, x1) + 6) if v >= 1 else ("end", min(x0, x1) - 6)
-            if not r["ids_match"]:
-                label += "  ⚠ ids differ"
-            fill = ink["primary"] if r["ids_match"] else ink["critical"]
-            body.append(f'<text x="{lx:.1f}" y="{y + ROW_H / 2 + 4}" fill="{fill}" font-size="12" '
-                        f'font-weight="600" text-anchor="{anchor}" '
-                        f'style="font-variant-numeric:tabular-nums">{label}</text>')
+                        f'font-size="12.5" text-anchor="end">{escape(label)}</text>')
+            v = speedup(r)
+            by = y + (ROW_H - BAR_H) / 2
+            if v:
+                body.append(hbar(x(1.0), x(v), by, BAR_H, sink["pipeline"]))
+                txt = f"×{v:.2f}"
+                fill = ink["primary"]
+                if r["ids_match"] is False:
+                    txt += "  ⚠ ids differ"
+                    fill = ink["critical"]
+                anchor, lx = ("start", max(x(1.0), x(v)) + 6) if v >= 1 else ("end", min(x(1.0), x(v)) - 6)
+                # a long label left of a slow bar would run into the fixture
+                # names — flip it to the empty space right of the ×1.0 axis
+                if anchor == "end" and lx - len(txt) * 6.7 < GUTTER + 4:
+                    anchor, lx = "start", x(1.0) + 6
+                body.append(f'<text x="{lx:.1f}" y="{y + ROW_H / 2 + 4}" fill="{fill}" '
+                            f'font-size="12" font-weight="600" text-anchor="{anchor}" '
+                            f'style="font-variant-numeric:tabular-nums">{txt}</text>')
+            mb = r["mbps"]
             body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
                         f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
-                        f'{r["legacy_mbps"]:.1f} → {r["pipeline_mbps"]:.1f}</text>')
+                        f'{chain([mb.get("baseline"), mb.get("pipeline")])}</text>')
             y += ROW_H
         y += 10
 
+    axis = speedup_axis(ink, x, ticks, top, y)
+    y += 26
+    legend = legend_row(ink, sink, y, [
+        ("swatch", "pipeline", "PipelineTokenizer"),
+        ("tick", ink["baseline"], f"×1.0 = {baseline_label}"),
+    ])
     height = y + 44
-    grid = []
-    for t in ticks:
-        strong = t == 1.0
-        grid.append(f'<line x1="{x(t):.1f}" y1="{top - 6}" x2="{x(t):.1f}" y2="{y - 6}" '
-                    f'stroke="{ink["baseline"] if strong else ink["grid"]}" stroke-width="1"/>')
-        grid.append(f'<text x="{x(t):.1f}" y="{y + 12}" fill="{ink["muted"]}" font-size="11" '
-                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">×{t:g}</text>')
-    hints = (f'<text x="{x(1.0) - 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-             f'text-anchor="end">← slower</text>'
-             f'<text x="{x(1.0) + 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-             f'text-anchor="start">faster →</text>')
 
-    g = geomean([r["speedup"] for r in rows])
-    subtitle = f'{model["shape"]} · geomean ×{g:.2f}'
-    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{CHART_W}" height="{height}"
-  viewBox="0 0 {CHART_W} {height}" font-family="{FONT}">
-<rect width="{CHART_W}" height="{height}" fill="{ink["surface"]}"/>
-<text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="700">{escape(model["model"])} — Pipeline vs Tokenizer encode throughput</text>
-<text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
-{"".join(grid)}
-{hints}
-{"".join(body)}
-{footer_text(ink, height, meta, subtitle_base)}
-</svg>'''
+    parts = [model["shape"]]
+    vals = model_speedups(model)
+    if vals:
+        parts.append(f"geomean ×{geomean(vals):.2f} vs {baseline_label}")
+    else:
+        parts.append(f"{baseline_label} can’t load this model — no comparison")
+    if baseline_id_note:
+        parts.append(f"† ids differ from {baseline_label}")
+    return svg_doc(ink, height, f'{model["model"]} — PipelineTokenizer encode throughput',
+                   " · ".join(parts), axis + "".join(body) + legend, meta, subtitle_base)
 
 
 def has_stages(model):
     return any("stage_ns_per_byte" in r for r in model["results"])
 
 
-def ref_ns_per_byte(row):
-    """The reference Tokenizer's whole-encode cost in the stage chart's unit
-    (MB/s → ns/byte), so it can be drawn as a tick on the pipeline's stacked bar."""
-    return 1000.0 / row["legacy_mbps"]
+def baseline_ns_per_byte(row):
+    """The release's whole-encode cost in the stage chart's unit (MB/s →
+    ns/byte), so it can be drawn as a tick on the pipeline's stacked bar."""
+    v = row["mbps"]["baseline"]
+    return 1000.0 / v if v else None
 
 
 def stage_scale(models):
-    """Shared linear ns/byte range across every supported fixture's total — and the
-    reference Tokenizer's total, so the reference ticks always land on-plot — keeping
-    the stacked stage bars comparable across models."""
-    vals = [v for m in models if m["supported"]
-            for r in m["results"] if "stage_ns_per_byte" in r
-            for v in (r["stage_ns_per_byte"]["total"], ref_ns_per_byte(r))]
+    """Shared linear ns/byte range across every fixture's total — and the
+    release ticks, so they always land on-plot — keeping the stacked stage
+    bars comparable across models."""
+    vals = []
+    for m in models:
+        for r in m["results"]:
+            if "stage_ns_per_byte" not in r:
+                continue
+            vals.append(r["stage_ns_per_byte"]["total"])
+            ref = baseline_ns_per_byte(r)
+            if ref:
+                vals.append(ref)
     vals = [v for v in vals if v > 0]
     return max(vals) * 1.05 if vals else 1.0
 
@@ -244,10 +500,11 @@ def stage_mix(rows):
     return sorted(((label[k], acc[k] / n) for k in acc), key=lambda kv: -kv[1])
 
 
-def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
-    """Per-fixture stacked decomposition of the *pipeline's* own encode time
-    (ns/byte): normalize + split + model + other. Shows where the pipeline spends
-    its time and — via the right column — how that maps onto the ×speedup headline."""
+def stage_chart_svg(model, mode, subtitle_base, meta, max_total, baseline_label):
+    """Per-fixture stacked decomposition of the pipeline's own encode time
+    (ns/byte). Shows where the pipeline spends its time; the tick puts the
+    release's whole-encode cost on the same scale, so bar vs tick reads the
+    same way as the ×speedup chart."""
     ink = INK[mode]
     sink = STAGE_INK[mode]
     rows = [r for r in model["results"] if "stage_ns_per_byte" in r]
@@ -262,7 +519,7 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
     body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
             f'text-anchor="end">ns/byte · ×speedup</text>',
             f'<text x="{GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
-            f'time per byte — shorter is faster · tick = Tokenizer total</text>']
+            f'time per byte — shorter is faster · tick = {escape(baseline_label)} total</text>']
     y = top
     for key, title in GROUPS:
         group_rows = sorted((r for r in rows if r["group"] == key),
@@ -292,59 +549,49 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total):
                                     f'text-anchor="middle" style="font-variant-numeric:tabular-nums">'
                                     f'{txt}</text>')
                 cursor += seg
-            # reference Tokenizer total on the same scale: bar shorter than the
-            # tick ⇔ pipeline faster ⇔ ×speedup ≥ 1
-            rx = GUTTER + w(ref_ns_per_byte(r))
-            body.append(f'<line x1="{rx:.1f}" y1="{by - 3}" x2="{rx:.1f}" y2="{by + BAR_H + 3}" '
-                        f'stroke="{ink["primary"]}" stroke-width="1.5"/>')
+            # the release's total on the same scale: bar shorter than the tick
+            # ⇔ pipeline faster ⇔ ×speedup ≥ 1
+            ref = baseline_ns_per_byte(r)
+            if ref:
+                rx = GUTTER + w(ref)
+                body.append(f'<line x1="{rx:.1f}" y1="{by - 3}" x2="{rx:.1f}" y2="{by + BAR_H + 3}" '
+                            f'stroke="{ink["primary"]}" stroke-width="1.5"/>')
+            vs = speedup(r)
             body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
                         f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
-                        f'{s["total"]:.1f} · ×{r["speedup"]:.2f}</text>')
+                        f'{s["total"]:.1f} · {fnum(vs, "×{:.2f}")}</text>')
             y += ROW_H
         y += 10
 
-    # x-axis: 4 evenly spaced ns/byte gridlines + ticks
+    # x-axis: round ns/byte gridlines + ticks, unit on the last one
     grid = []
-    for i in range(5):
-        tv = max_total * i / 4
+    axis_ticks = nice_ticks(max_total)
+    for tv in axis_ticks:
+        unit = " ns/B" if tv == axis_ticks[-1] else ""
         gx = GUTTER + w(tv)
         grid.append(f'<line x1="{gx:.1f}" y1="{top - 6}" x2="{gx:.1f}" y2="{y - 6}" '
                     f'stroke="{ink["grid"]}" stroke-width="1"/>')
         grid.append(f'<text x="{gx:.1f}" y="{y + 12}" fill="{ink["muted"]}" font-size="11" '
-                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:.0f}</text>')
+                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{unit}</text>')
 
-    # legend row: the stage colors + the reference-tick glyph
+    # legend row: the stage colors + the release-tick glyph
     y += 26
-    legend = []
-    lx = GUTTER
-    for skey, lbl in STAGES:
-        legend.append(f'<rect x="{lx}" y="{y - 9}" width="11" height="11" rx="2" fill="{sink[skey]}"/>')
-        legend.append(f'<text x="{lx + 16}" y="{y}" fill="{ink["secondary"]}" font-size="11.5">{lbl}</text>')
-        lx += 16 + 8 + len(lbl) * 7 + 18
-    legend.append(f'<line x1="{lx + 5}" y1="{y - 10}" x2="{lx + 5}" y2="{y + 2}" '
-                  f'stroke="{ink["primary"]}" stroke-width="1.5"/>')
-    legend.append(f'<text x="{lx + 16}" y="{y}" fill="{ink["secondary"]}" font-size="11.5">'
-                  f'Tokenizer total (reference)</text>')
+    entries = [("swatch", k, lbl) for k, lbl in STAGES]
+    entries.append(("tick", ink["primary"], f"{baseline_label} total"))
+    legend = legend_row(ink, sink, y, entries)
     height = y + 34
 
     mix = stage_mix(rows)
     mix_txt = " · ".join(f"{lbl} {100 * frac:.0f}%" for lbl, frac in mix)
     subtitle = f'{model["shape"]} · stage mix: {mix_txt}'
-    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{CHART_W}" height="{height}"
-  viewBox="0 0 {CHART_W} {height}" font-family="{FONT}">
-<rect width="{CHART_W}" height="{height}" fill="{ink["surface"]}"/>
-<text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="700">{escape(model["model"])} — Pipeline encode stage decomposition</text>
-<text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
-{"".join(grid)}
-{"".join(body)}
-{"".join(legend)}
-{footer_text(ink, height, meta, subtitle_base)}
-</svg>'''
+    return svg_doc(ink, height, f'{model["model"]} — Pipeline encode stage decomposition',
+                   subtitle, "".join(grid) + "".join(body) + legend, meta, subtitle_base)
 
 
 def card_svg(model, mode):
-    """Compact 'not supported' card for a model the pipeline can't build.
-    Plain single-chunk text only: cairosvg mis-centers text-anchor with tspans."""
+    """Compact roadmap card for a model the pipeline can't bench yet (or that
+    failed to load). Plain single-chunk text only: cairosvg mis-centers
+    text-anchor with tspans."""
     ink = INK[mode]
     pretok = model["shape"].split("·")[-1].strip()
     why = model.get("reason") or f"PipelineTokenizer has no {pretok} pre-tokenizer"
@@ -366,90 +613,6 @@ def card_svg(model, mode):
          f'text-anchor="middle">{escape(why)}</text>',
          "</svg>"]
     return "".join(b)
-
-
-def overview_svg(models, mode, subtitle_base, meta, lo, hi):
-    """The one always-visible chart: a row per manifest model — name + workload
-    desc, geomean ×speedup bar with a min–max whisker across fixtures — on the
-    same log2 axis as the per-model charts. No cross-model aggregate on purpose:
-    the models exercise different execution modes. Unsupported models appear as
-    muted status rows so the overview is the complete state of the world."""
-    ink = INK[mode]
-
-    def x(v):
-        return OV_GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * OV_PLOT
-
-    ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x)
-
-    top = 74
-    row_h = 40
-    col_x = CHART_W - 16
-    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-            f'text-anchor="end">fixtures · ids</text>']
-    y = top
-    for m in models:
-        cy = y + row_h / 2
-        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy - 3:.1f}" fill="{ink["primary"]}" '
-                    f'font-size="12.5" font-weight="600" text-anchor="end">{escape(m["model"])}</text>')
-        desc = m.get("desc") or m["shape"]
-        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 11:.1f}" fill="{ink["muted"]}" '
-                    f'font-size="10.5" text-anchor="end">{escape(desc)}</text>')
-        if m["supported"]:
-            vals = [r["speedup"] for r in m["results"]]
-            g, mn, mx = geomean(vals), min(vals), max(vals)
-            if abs(math.log2(g)) < math.log2(1.02):  # within noise of the baseline
-                color = ink["muted"]
-            else:
-                color = ink["faster"] if g >= 1 else ink["slower"]
-            body.append(f'<path d="{bar_path(x(1.0), x(g), cy - 7, 14, 4)}" fill="{color}"/>')
-            body.append(f'<line x1="{x(mn):.1f}" y1="{cy:.1f}" x2="{x(mx):.1f}" y2="{cy:.1f}" '
-                        f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
-            for v in (mn, mx):
-                body.append(f'<line x1="{x(v):.1f}" y1="{cy - 4:.1f}" x2="{x(v):.1f}" y2="{cy + 4:.1f}" '
-                            f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
-            anchor, lx = (("start", max(x(mx), x(1.0)) + 8) if g >= 1
-                          else ("end", min(x(mn), x(1.0)) - 8))
-            body.append(f'<text x="{lx:.1f}" y="{cy + 4:.1f}" fill="{ink["primary"]}" font-size="12" '
-                        f'font-weight="600" text-anchor="{anchor}" '
-                        f'style="font-variant-numeric:tabular-nums">×{g:.2f}</text>')
-            bad = sum(not r["ids_match"] for r in m["results"])
-            right, fill = ((f"⚠ {bad} differ", ink["critical"]) if bad
-                           else (f'{len(m["results"])} · ids ok', ink["secondary"]))
-            body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{fill}" font-size="12" '
-                        f'text-anchor="end" style="font-variant-numeric:tabular-nums">{right}</text>')
-        else:
-            pretok = m["shape"].split("·")[-1].strip()
-            body.append(f'<text x="{x(1.0) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["muted"]}" '
-                        f'font-size="11.5" font-style="italic">not supported — '
-                        f'no {escape(pretok)} pre-tokenizer</text>')
-            body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{ink["muted"]}" font-size="12" '
-                        f'text-anchor="end">—</text>')
-        y += row_h
-
-    grid = []
-    for t in ticks:
-        strong = t == 1.0
-        grid.append(f'<line x1="{x(t):.1f}" y1="{top - 6}" x2="{x(t):.1f}" y2="{y - 2}" '
-                    f'stroke="{ink["baseline"] if strong else ink["grid"]}" stroke-width="1"/>')
-        grid.append(f'<text x="{x(t):.1f}" y="{y + 14}" fill="{ink["muted"]}" font-size="11" '
-                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">×{t:g}</text>')
-    hints = (f'<text x="{x(1.0) - 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-             f'text-anchor="end">← slower</text>'
-             f'<text x="{x(1.0) + 8:.1f}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-             f'text-anchor="start">faster →</text>')
-
-    height = y + 46
-    subtitle = f'geomean ×speedup per model · whisker: min–max across fixtures · {subtitle_base}'
-    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{CHART_W}" height="{height}"
-  viewBox="0 0 {CHART_W} {height}" font-family="{FONT}">
-<rect width="{CHART_W}" height="{height}" fill="{ink["surface"]}"/>
-<text x="16" y="26" fill="{ink["primary"]}" font-size="15" font-weight="700">PipelineTokenizer vs Tokenizer — encode throughput by model</text>
-<text x="16" y="44" fill="{ink["secondary"]}" font-size="12">{escape(subtitle)}</text>
-{"".join(grid)}
-{hints}
-{"".join(body)}
-{footer_text(ink, height, meta)}
-</svg>'''
 
 
 def detect_hardware():
@@ -481,49 +644,144 @@ def picture(base, run_id, slug, alt, width):
         "</picture>"])
 
 
-def render_markdown(models, subtitle_base, meta, base, run_id):
-    """Overview chart inline; everything per-model — charts and the per-fixture
+def mem_line(model, baseline_label):
+    mem = model.get("memory")
+    if not isinstance(mem, dict):
+        return None
+    def part(impl, label):
+        d = mem.get(impl)
+        if not isinstance(d, dict):
+            return f"{label} —"
+        cell = lambda k: ("—" if d.get(k) is None else f"{max(0, d[k]) / 1e6:.0f}")
+        return f"{label} {cell('load_bytes')}+{cell('encode_bytes')} (peak {cell('peak_bytes')})"
+    return ("**Memory** (RSS MB, load+encode): "
+            + " · ".join(part(i, l) for i, l in
+                         (("baseline", baseline_label), ("pipeline", "Pipeline"))))
+
+
+def binsize_svg(sizes, mode, meta, baseline_label):
+    """Stripped size of a minimal release-built encode program (load a
+    tokenizer.json, encode one string) linking each implementation — what the
+    library adds to a shipped binary. Bars are 0-anchored on a linear MB axis."""
+    ink, sink = INK[mode], SERIES_INK[mode]
+    rows = [("baseline", baseline_label), ("pipeline", "PipelineTokenizer")]
+    present = [sizes.get(k) for k, _ in rows if sizes.get(k)]
+    if not present:
+        return None
+    max_mb = max(present) / 1e6 * 1.15
+    plot_w = CHART_W - OV_GUTTER - PAD_R - COL_W
+    base = sizes.get("baseline")
+
+    def x(v):
+        return OV_GUTTER + v / max_mb * plot_w
+
+    top, bar_h, row_h = 74, 16, 30
+    col_x = CHART_W - 16
+    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+            f'text-anchor="end">MB: {escape(baseline_label)} → Pipeline</text>',
+            f'<text x="{OV_GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
+            f'smaller is better</text>']
+    y = top
+    for key, label in rows:
+        v = sizes.get(key)
+        cy = y + row_h / 2
+        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 4:.1f}" fill="{ink["primary"]}" '
+                    f'font-size="12.5" font-weight="600" text-anchor="end">{escape(label)}</text>')
+        if v:
+            mb = v / 1e6
+            body.append(hbar(x(0), x(mb), cy - bar_h / 2, bar_h, sink[key]))
+            txt = f"{mb:.2f} MB"
+            if base and key != "baseline":
+                txt += f"  ({(v / base - 1) * 100:+.0f}% vs {baseline_label})"
+            body.append(f'<text x="{x(mb) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["primary"]}" '
+                        f'font-size="12" font-weight="600" '
+                        f'style="font-variant-numeric:tabular-nums">{escape(txt)}</text>')
+        else:
+            body.append(f'<text x="{x(0) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["muted"]}" '
+                        f'font-size="11.5" font-style="italic">not measured</text>')
+        y += row_h
+
+    grid = []
+    ticks = nice_ticks(max_mb)
+    for tv in ticks:
+        unit = " MB" if tv == ticks[-1] else ""
+        grid.append(f'<line x1="{x(tv):.1f}" y1="{top - 6}" x2="{x(tv):.1f}" y2="{y - 4}" '
+                    f'stroke="{ink["grid"]}" stroke-width="1"/>')
+        grid.append(f'<text x="{x(tv):.1f}" y="{y + 10}" fill="{ink["muted"]}" font-size="11" '
+                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{unit}</text>')
+    height = y + 44
+    subtitle = ("stripped release build of a minimal encode program "
+                "(load a tokenizer.json + encode one string)")
+    return svg_doc(ink, height, "Binary size",
+                   subtitle, "".join(grid) + "".join(body), meta)
+
+
+def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
+    """Overview charts inline; everything per-model — charts and the per-fixture
     table — inside one <details> block per model, so the PR description stays a
     single screen. No cross-model aggregate number anywhere: the models exercise
     different execution modes, so only per-model geomeans are meaningful."""
-    supported = [m for m in models if m["supported"]]
-    unsupported = [m for m in models if not m["supported"]]
+    models = data["models"]
+    baseline_label = f'v{data["baseline"]["version"]}'
+    benched = [m for m in models if m["results"]]
+    unsupported = [m for m in models if not m["results"]]
     mismatches = [f"{m['model']}/{r['fixture']}"
-                  for m in supported for r in m["results"] if not r["ids_match"]]
+                  for m in benched for r in m["results"] if r["ids_match"] is False]
+    base_mismatch = sorted({m["model"] for m in benched
+                            for r in m["results"] if r.get("ids_match_baseline") is False})
 
     md = ["## PipelineTokenizer benchmark", "",
-          f"**{len(supported)} / {len(models)} models supported** — {subtitle_base}", "",
+          f"**{len(benched)} / {len(models)} models supported** — PipelineTokenizer vs "
+          f"`tokenizers` {baseline_label} (latest release) · {subtitle_base}", "",
           f"`{meta[0]}` · {meta[1]}", "",
-          picture(base, run_id, "overview", "Per-model encode throughput summary", 860), ""]
+          picture(base, run_id, "overview", "Per-model encode throughput vs latest release", 860), "",
+          picture(base, run_id, "memory", "Per-model memory footprint", 860), ""]
+    if sizes:
+        md += [picture(base, run_id, "binsize", "Minimal encode binary size", 860), ""]
 
     if mismatches:
-        md += [f"> ⚠️ **Token ids diverge from the reference on: {', '.join(mismatches)}** "
-               f"— speedups there are meaningless until fixed.", ""]
+        md += [f"> ⚠️ **Pipeline token ids diverge from this tree's Tokenizer on: "
+               f"{', '.join(mismatches)}** — speedups there are meaningless until fixed.", ""]
+    if base_mismatch:
+        md += [f"> ℹ️ Token ids differ from {baseline_label} on: {', '.join(base_mismatch)} "
+               f"(† in the per-model charts) — expected when this branch fixes encode bugs, "
+               f"but worth a look.", ""]
 
-    for m in supported:
-        g = geomean([r["speedup"] for r in m["results"]])
+    for m in benched:
         slug = slugify(m["model"])
         desc = m.get("desc") or m["shape"]
-        flag = " · ⚠ ids differ" if any(not r["ids_match"] for r in m["results"]) else ""
+        vals = model_speedups(m)
+        summary = (f"×{geomean(vals):.2f} vs {baseline_label}" if vals
+                   else f"{baseline_label} can't load — no comparison")
+        flag = " · ⚠ ids differ" if any(r["ids_match"] is False for r in m["results"]) else ""
         md += [f"<details><summary><b>{escape(m['model'])}</b> — {escape(desc)} · "
-               f"geomean ×{g:.2f}{flag}</summary>", ""]
+               f"{summary}{flag}</summary>", ""]
         md += [picture(base, run_id, slug, f"{m['model']} speedup", 860), ""]
         if has_stages(m):
             md += [picture(base, run_id, f"{slug}-stages",
                            f"{m['model']} stage decomposition", 860), ""]
-        md += ["| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup "
-               "| added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |",
-               "|---|---|---:|---:|---:|---:|---:|---:|---:|:--|"]
+        ml = mem_line(m, baseline_label)
+        if ml:
+            md += [ml, ""]
+        md += [f"| Fixture | Group | {baseline_label} MB/s | Pipeline MB/s | Speedup | Ids |",
+               "|---|---|---:|---:|---:|:--|"]
         for r in sorted(m["results"], key=lambda r: (r["group"], r["fixture"])):
-            ids = "match" if r["ids_match"] else "⚠️ differ"
-            s = r.get("stage_ns_per_byte", {})
-            cells = " ".join(f"| {s[k]:.2f}" if k in s else "| —"
-                             for k in ("added_split", "normalize", "pre_tokenize", "model"))
-            md.append(f"| {r['fixture']} | {r['group']} | {r['legacy_mbps']:.1f} "
-                      f"| {r['pipeline_mbps']:.1f} | ×{r['speedup']:.2f} {cells} | {ids} |")
+            mb = r["mbps"]
+            flags = []
+            if r["ids_match"] is False:
+                flags.append("⚠️ ≠ tree")
+            if r.get("ids_match_baseline") is False:
+                flags.append(f"≠ {baseline_label}")
+            ids = " · ".join(flags) if flags else "match"
+            md.append(
+                f"| {r['fixture']} | {r['group']} "
+                f"| {fnum(mb.get('baseline'))} | {fnum(mb.get('pipeline'))} "
+                f"| {fnum(speedup(r), '×{:.2f}')} "
+                f"| {ids} |")
         md += ["", "</details>", ""]
 
-    # Unsupported models: roadmap cards, collapsed — they're status, not results.
+    # Unsupported / failed-to-load models: roadmap cards, collapsed — they're
+    # status, not results.
     if unsupported:
         names = ", ".join(f"<code>{escape(m['model'])}</code>" for m in unsupported)
         md += [f"<details><summary><b>Not yet supported:</b> {names}</summary>", "", "<table>"]
@@ -546,6 +804,8 @@ def main():
     ap.add_argument("--revision", default="")
     ap.add_argument("--img-base", default="", help="base URL for uploaded PNGs")
     ap.add_argument("--run-id", default="local")
+    ap.add_argument("--binary-sizes", default="",
+                    help="JSON file {stub, baseline, pipeline} of stripped binary bytes")
     args = ap.parse_args()
 
     rev = args.revision
@@ -558,34 +818,43 @@ def main():
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     meta = (f"{rev[:9]} · {stamp}", detect_hardware())
 
-    models = json.loads(Path(args.results).read_text())
-    lo, hi = scale(models)
-    max_total = stage_scale(models)
+    data = json.loads(Path(args.results).read_text())
+    models = data["models"]
+    baseline_label = f'v{data["baseline"]["version"]}'
+    sizes = json.loads(Path(args.binary_sizes).read_text()) if args.binary_sizes else None
+    benched = [m for m in models if m["results"]]
+    lo, hi = scale(benched)
+    max_total = stage_scale(benched)
     out = Path(args.out_dir)
     for mode in ("light", "dark"):
         (out / f"pipeline_bench_overview_{mode}.svg").write_text(
-            overview_svg(models, mode, args.subtitle, meta, lo, hi))
+            overview_svg(models, mode, args.subtitle, meta, lo, hi, baseline_label))
+        (out / f"pipeline_bench_memory_{mode}.svg").write_text(
+            memory_svg(models, mode, meta, baseline_label))
+        if sizes:
+            svg = binsize_svg(sizes, mode, meta, baseline_label)
+            if svg:
+                (out / f"pipeline_bench_binsize_{mode}.svg").write_text(svg)
     for m in models:
         slug = slugify(m["model"])
         for mode in ("light", "dark"):
-            svg = (chart_svg(m, mode, args.subtitle, meta, lo, hi)
-                   if m["supported"] else card_svg(m, mode))
+            svg = (chart_svg(m, mode, args.subtitle, meta, lo, hi, baseline_label)
+                   if m["results"] else card_svg(m, mode))
             (out / f"pipeline_bench_{slug}_{mode}.svg").write_text(svg)
-            if m["supported"] and has_stages(m):
+            if has_stages(m):
                 (out / f"pipeline_bench_{slug}-stages_{mode}.svg").write_text(
-                    stage_chart_svg(m, mode, args.subtitle, meta, max_total))
+                    stage_chart_svg(m, mode, args.subtitle, meta, max_total, baseline_label))
 
     (out / "pipeline_bench.md").write_text(
-        render_markdown(models, args.subtitle, meta, args.img_base, args.run_id))
+        render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes))
 
-    supported = [m for m in models if m["supported"]]
     # per-model geomeans only — a cross-model aggregate would average unrelated
     # execution modes (normalizer-heavy vs split-heavy vs model-bounded)
     per_model = " · ".join(
-        f"{m['model']} x{geomean([r['speedup'] for r in m['results']]):.3f}"
-        for m in supported)
-    print(f"{len(supported)}/{len(models)} supported"
-          + (f" · {per_model}" if per_model else ""))
+        f"{m['model']} x{geomean(model_speedups(m)):.3f}"
+        for m in benched if model_speedups(m))
+    print(f"{len(benched)}/{len(models)} supported"
+          + (f" · vs {baseline_label}: {per_model}" if per_model else ""))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -6,7 +6,7 @@ Input: JSON object from `cargo run --release -p tk-encode --features
 tk-encode/bench-baseline --example fixture_bench`:
 
     {baseline: {crate, version},
-     models: [{model, shape, desc, supported, [reason],
+     models: [{model, shape, desc, [reason],
                memory: {baseline|pipeline:
                         {load_bytes, encode_bytes, peak_bytes} | null} | null,
                results: [{fixture, group, bytes, chunks,
@@ -645,9 +645,7 @@ def picture(base, run_id, slug, alt, width):
 
 
 def mem_line(model, baseline_label):
-    mem = model.get("memory")
-    if not isinstance(mem, dict):
-        return None
+    mem = model["memory"]
     def part(impl, label):
         d = mem.get(impl)
         if not isinstance(d, dict):
@@ -665,40 +663,28 @@ def binsize_svg(sizes, mode, meta, baseline_label):
     library adds to a shipped binary. Bars are 0-anchored on a linear MB axis."""
     ink, sink = INK[mode], SERIES_INK[mode]
     rows = [("baseline", baseline_label), ("pipeline", "PipelineTokenizer")]
-    present = [sizes.get(k) for k, _ in rows if sizes.get(k)]
-    if not present:
-        return None
-    max_mb = max(present) / 1e6 * 1.15
+    max_mb = max(sizes.values()) / 1e6 * 1.15
     plot_w = CHART_W - OV_GUTTER - PAD_R - COL_W
-    base = sizes.get("baseline")
 
     def x(v):
         return OV_GUTTER + v / max_mb * plot_w
 
     top, bar_h, row_h = 74, 16, 30
-    col_x = CHART_W - 16
-    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-            f'text-anchor="end">MB: {escape(baseline_label)} → Pipeline</text>',
-            f'<text x="{OV_GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
+    body = [f'<text x="{OV_GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
             f'smaller is better</text>']
     y = top
     for key, label in rows:
-        v = sizes.get(key)
+        mb = sizes[key] / 1e6
         cy = y + row_h / 2
         body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 4:.1f}" fill="{ink["primary"]}" '
                     f'font-size="12.5" font-weight="600" text-anchor="end">{escape(label)}</text>')
-        if v:
-            mb = v / 1e6
-            body.append(hbar(x(0), x(mb), cy - bar_h / 2, bar_h, sink[key]))
-            txt = f"{mb:.2f} MB"
-            if base and key != "baseline":
-                txt += f"  ({(v / base - 1) * 100:+.0f}% vs {baseline_label})"
-            body.append(f'<text x="{x(mb) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["primary"]}" '
-                        f'font-size="12" font-weight="600" '
-                        f'style="font-variant-numeric:tabular-nums">{escape(txt)}</text>')
-        else:
-            body.append(f'<text x="{x(0) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["muted"]}" '
-                        f'font-size="11.5" font-style="italic">not measured</text>')
+        body.append(hbar(x(0), x(mb), cy - bar_h / 2, bar_h, sink[key]))
+        txt = f"{mb:.2f} MB"
+        if key != "baseline":
+            txt += f"  ({(sizes[key] / sizes['baseline'] - 1) * 100:+.0f}% vs {baseline_label})"
+        body.append(f'<text x="{x(mb) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["primary"]}" '
+                    f'font-size="12" font-weight="600" '
+                    f'style="font-variant-numeric:tabular-nums">{escape(txt)}</text>')
         y += row_h
 
     grid = []
@@ -760,9 +746,7 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
         if has_stages(m):
             md += [picture(base, run_id, f"{slug}-stages",
                            f"{m['model']} stage decomposition", 860), ""]
-        ml = mem_line(m, baseline_label)
-        if ml:
-            md += [ml, ""]
+        md += [mem_line(m, baseline_label), ""]
         md += [f"| Fixture | Group | {baseline_label} MB/s | Pipeline MB/s | Speedup | Ids |",
                "|---|---|---:|---:|---:|:--|"]
         for r in sorted(m["results"], key=lambda r: (r["group"], r["fixture"])):
@@ -805,7 +789,7 @@ def main():
     ap.add_argument("--img-base", default="", help="base URL for uploaded PNGs")
     ap.add_argument("--run-id", default="local")
     ap.add_argument("--binary-sizes", default="",
-                    help="JSON file {stub, baseline, pipeline} of stripped binary bytes")
+                    help="JSON file {baseline, pipeline} of stripped binary bytes")
     args = ap.parse_args()
 
     rev = args.revision
@@ -832,9 +816,8 @@ def main():
         (out / f"pipeline_bench_memory_{mode}.svg").write_text(
             memory_svg(models, mode, meta, baseline_label))
         if sizes:
-            svg = binsize_svg(sizes, mode, meta, baseline_label)
-            if svg:
-                (out / f"pipeline_bench_binsize_{mode}.svg").write_text(svg)
+            (out / f"pipeline_bench_binsize_{mode}.svg").write_text(
+                binsize_svg(sizes, mode, meta, baseline_label))
     for m in models:
         slug = slugify(m["model"])
         for mode in ("light", "dark"):

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -1,8 +1,14 @@
 name: Pipeline Benchmark
 
-# Comparative benchmark: reference `Tokenizer` vs experimental
-# `PipelineTokenizer`, for every model in tk-encode/examples/bench_models.json
-# across every corpus in data/fixtures/ on ~10 kB inputs
+# Comparative benchmark: the experimental `PipelineTokenizer` vs the latest
+# *released* tokenizers crate (the baseline to beat — the in-tree legacy
+# `Tokenizer` is being phased out, so it is only the id-correctness oracle,
+# never a benched series), for every model in
+# tk-encode/examples/bench_models.json across every corpus in data/fixtures/.
+# Measures throughput (~10 kB inputs), short-prompt encode latency
+# (time-to-first-token), per-implementation memory footprint (RSS), and
+# stripped minimal-binary size. The release dep is behind tk-encode's
+# `bench-baseline` feature, so production builds never pull it.
 # Triggers:
 #   • push to feat/train_encode_split → benches and updates PR #2119's description.
 #   • add the "run-pipeline-bench" label to any PR → benches that PR and updates
@@ -52,7 +58,7 @@ env:
 
 jobs:
   pipeline-bench:
-    name: Tokenizer vs PipelineTokenizer
+    name: PipelineTokenizer vs latest release
     # push / dispatch always run; a labeled PR runs only for our label.
     if: github.event_name != 'pull_request' || github.event.label.name == 'run-pipeline-bench'
     # Same dedicated runner group as benchmarks.yml — shared 2-vCPU runners
@@ -88,8 +94,27 @@ jobs:
 
       - name: Run comparative benchmark
         run: |
-          cargo run --release -p tk-encode --example fixture_bench > pipeline_bench.json
+          cargo run --release -p tk-encode --features tk-encode/bench-baseline \
+            --example fixture_bench > pipeline_bench.json
           cat pipeline_bench.json
+
+      # Stripped size of a minimal encode program linking each implementation —
+      # the "how much does this library add to my binary" number.
+      - name: Measure binary sizes
+        run: |
+          cargo build --release -p tk-encode --features tk-encode/bench-baseline \
+            --example binsize_baseline --example binsize_pipeline
+          printf '{' > binary_sizes.json
+          sep=''
+          for key in baseline pipeline; do
+            bin="target/release/examples/binsize_$key"
+            "$bin" data/gpt2.json "The quick brown fox jumps 123."   # binary actually works
+            strip -o "$bin.stripped" "$bin"
+            printf '%s"%s": %s' "$sep" "$key" "$(stat -c %s "$bin.stripped")" >> binary_sizes.json
+            sep=', '
+          done
+          printf '}\n' >> binary_sizes.json
+          cat binary_sizes.json
 
       - name: Render report
         run: |
@@ -99,7 +124,8 @@ jobs:
             --subtitle "~10 kB inputs · single thread" \
             --revision "${{ github.event.pull_request.head.sha || github.sha }}" \
             --img-base "$base_url" \
-            --run-id "${{ github.run_id }}"
+            --run-id "${{ github.run_id }}" \
+            --binary-sizes binary_sizes.json
           uvx --with cairosvg python -c "
           import cairosvg, glob
           for f in glob.glob('pipeline_bench_*.svg'):
@@ -155,13 +181,15 @@ jobs:
           gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/run-pipeline-bench" \
             -X DELETE || true
 
+      # Pipeline ids must match this tree's Tokenizer. Baseline id mismatches
+      # (ids_match_baseline) are report-only: a branch may fix encode bugs.
       - name: Fail on id mismatches
         run: |
           python3 -c "
           import json, sys
-          models = json.load(open('pipeline_bench.json'))
+          models = json.load(open('pipeline_bench.json'))['models']
           bad = [f\"{m['model']}/{r['fixture']}\" for m in models
-                 if m['supported'] for r in m['results'] if not r['ids_match']]
+                 for r in m['results'] if r.get('ids_match') is False]
           sys.exit(f'ids diverge on: {bad}' if bad else 0)
           "
 
@@ -172,6 +200,7 @@ jobs:
           name: pipeline-bench
           path: |
             tokenizers/pipeline_bench.json
+            tokenizers/binary_sizes.json
             tokenizers/pipeline_bench.md
             tokenizers/pipeline_bench_*.svg
             tokenizers/pipeline_bench_*.png

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -5,10 +5,9 @@ name: Pipeline Benchmark
 # `Tokenizer` is being phased out, so it is only the id-correctness oracle,
 # never a benched series), for every model in
 # tk-encode/examples/bench_models.json across every corpus in data/fixtures/.
-# Measures throughput (~10 kB inputs), short-prompt encode latency
-# (time-to-first-token), per-implementation memory footprint (RSS), and
-# stripped minimal-binary size. The release dep is behind tk-encode's
-# `bench-baseline` feature, so production builds never pull it.
+# Measures throughput (~10 kB inputs), per-implementation memory footprint
+# (RSS), and stripped minimal-binary size. The release dep is behind
+# tk-encode's `bench-baseline` feature, so production builds never pull it.
 # Triggers:
 #   • push to feat/train_encode_split → benches and updates PR #2119's description.
 #   • add the "run-pipeline-bench" label to any PR → benches that PR and updates

--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -497,6 +497,12 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
+name = "daachorse"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99251f238b74cd219a86fe6ea9328308ebb223fcbb5b8eb5aa400b847a41dded"
@@ -2306,7 +2312,7 @@ dependencies = [
  "assert_approx_eq",
  "compact_str",
  "criterion 0.6.0",
- "daachorse",
+ "daachorse 3.0.2",
  "dary_heap",
  "derive_builder",
  "fancy-regex",
@@ -2332,6 +2338,7 @@ dependencies = [
  "spm_precompiled",
  "tempfile",
  "thiserror 2.0.18",
+ "tokenizers 0.23.1",
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",
@@ -2360,6 +2367,40 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tk-encode",
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
+dependencies = [
+ "ahash",
+ "compact_str",
+ "daachorse 1.0.1",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "indicatif 0.18.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
 ]
 
 [[package]]

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -61,6 +61,9 @@ ptr_hash = { version = "1.1.0" }
 memchr = "2.8.2"
 unicode-normalization = "0.1.25"
 yada = "0.7.0"
+# Latest released tokenizers, used as the comparison baseline by the CI benchmark
+# (examples gated on `bench-baseline`). Optional so production builds never pull it.
+tokenizers-release = { package = "tokenizers", version = "=0.23.1", optional = true }
 
 [features]
 # TODO: onig is C (Oniguruma, archived upstream). We're moving to the pure-Rust
@@ -71,6 +74,7 @@ progressbar = ["indicatif"]
 http = ["hf-hub"]
 unstable_wasm = ["fancy-regex", "getrandom/wasm_js"]
 rustls-tls = ["hf-hub?/rustls-tls"]
+bench-baseline = ["dep:tokenizers-release"]
 
 [dev-dependencies]
 criterion = "0.6"
@@ -82,3 +86,11 @@ tracing-subscriber = "0.3.18"
 [[bench]]
 name = "pipeline_benchmark"
 harness = false
+
+[[example]]
+name = "fixture_bench"
+required-features = ["bench-baseline"]
+
+[[example]]
+name = "binsize_baseline"
+required-features = ["bench-baseline"]

--- a/tokenizers/tk-encode/examples/binsize_baseline.rs
+++ b/tokenizers/tk-encode/examples/binsize_baseline.rs
@@ -1,0 +1,17 @@
+//! Minimal encode program measured by CI for binary size: the latest released
+//! `tokenizers` crate (the comparison baseline). Structurally identical to
+//! `binsize_pipeline.rs`.
+
+use tokenizers_release::Tokenizer;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: binsize_baseline <tokenizer.json> <text>");
+    let text = args
+        .next()
+        .expect("usage: binsize_baseline <tokenizer.json> <text>");
+    let tok = Tokenizer::from_file(path).unwrap();
+    println!("{}", tok.encode(text.as_str(), false).unwrap().len());
+}

--- a/tokenizers/tk-encode/examples/binsize_pipeline.rs
+++ b/tokenizers/tk-encode/examples/binsize_pipeline.rs
@@ -1,0 +1,22 @@
+//! Minimal encode program measured by CI for binary size: the `PipelineTokenizer`
+//! encode path (which still links the `Tokenizer` build path — a pipeline is
+//! built from one). Kept structurally identical to `binsize_baseline.rs` so the
+//! stripped sizes compare like for like.
+
+use std::convert::TryFrom;
+
+use tk_encode::pipeline::PipelineTokenizer;
+use tk_encode::Tokenizer;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: binsize_pipeline <tokenizer.json> <text>");
+    let text = args
+        .next()
+        .expect("usage: binsize_pipeline <tokenizer.json> <text>");
+    let tok = Tokenizer::from_file(path).unwrap();
+    let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
+    println!("{}", pipeline.encode(text.as_str(), false).unwrap().len());
+}

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -13,15 +13,14 @@
 //! serves as the id-correctness oracle (`ids_match`, which CI fails on).
 //! `ids_match_baseline` — pipeline vs the released crate — is report-only,
 //! since a branch may intentionally fix encode behavior. Models the pipeline
-//! can't build yet are reported as `supported: false` with their pipeline shape
-//! rather than benched — the CI grid renders those as roadmap cards. Each
-//! manifest entry carries a `desc`: a one-line label of the workload archetype
-//! the model exercises, passed through to the report.
+//! can't build yet are reported with empty `results` (plus the failure
+//! `reason`) and their pipeline shape rather than benched — the CI grid
+//! renders those as roadmap cards. Each manifest entry carries a `desc`: a
+//! one-line label of the workload archetype the model exercises, passed
+//! through to the report.
 //!
 //! Emits one JSON object (`{baseline, models}`) on stdout, consumed by
-//! `.github/scripts/render_pipeline_bench.py` in CI. For local iteration the
-//! data dir, manifest and rep count can be overridden with the
-//! `FIXTURE_BENCH_DATA` / `FIXTURE_BENCH_MANIFEST` / `FIXTURE_BENCH_REPS` env vars.
+//! `.github/scripts/render_pipeline_bench.py` in CI.
 
 use std::convert::TryFrom;
 use std::hint::black_box;
@@ -63,22 +62,6 @@ const ADDED_NORMALIZED: &[&str] = &[
     "wuzzlefang",
     "crungledorf",
 ];
-
-fn data_dir() -> PathBuf {
-    std::env::var_os("FIXTURE_BENCH_DATA").map_or_else(|| PathBuf::from(DATA_DIR), PathBuf::from)
-}
-
-fn manifest_path() -> PathBuf {
-    std::env::var_os("FIXTURE_BENCH_MANIFEST")
-        .map_or_else(|| PathBuf::from(MANIFEST), PathBuf::from)
-}
-
-fn reps() -> usize {
-    std::env::var("FIXTURE_BENCH_REPS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(REPS)
-}
 
 /// Inject the benchmark's added tokens into `tok` before the pipeline is built from it,
 /// so both the oracle and the pipeline see them (and stay id-for-id identical).
@@ -163,8 +146,8 @@ fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) 
         }
     };
     run(); // warm-up
-    let mut samples = Vec::with_capacity(reps());
-    for _ in 0..reps() {
+    let mut samples = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
         let start = Instant::now();
         run();
         samples.push(start.elapsed().as_secs_f64());
@@ -175,7 +158,7 @@ fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) 
 fn fixture_files() -> Vec<(String, PathBuf)> {
     let mut files = Vec::new();
     for group in ["lang", "modalities"] {
-        let dir = data_dir().join("fixtures").join(group);
+        let dir = Path::new(DATA_DIR).join("fixtures").join(group);
         let mut entries: Vec<_> = std::fs::read_dir(&dir)
             .unwrap_or_else(|e| panic!("{}: {e} — run `make fixtures` first", dir.display()))
             .map(|e| e.unwrap().path())
@@ -198,7 +181,7 @@ fn model_path(entry: &Value) -> PathBuf {
         .and_then(Value::as_str)
         .map(str::to_string)
         .unwrap_or_else(|| format!("{name}.json"));
-    data_dir().join(file)
+    Path::new(DATA_DIR).join(file)
 }
 
 fn model_kind(tok: &Tokenizer) -> &'static str {
@@ -346,8 +329,6 @@ fn measure_memory(model: &Path, baseline_ok: bool) -> Value {
     Value::Object(out)
 }
 
-type EncodeFn<'a> = Box<dyn Fn(&str) -> usize + 'a>;
-
 fn bench_model(
     baseline: Option<&BaselineTokenizer>,
     oracle: &Tokenizer,
@@ -355,8 +336,7 @@ fn bench_model(
     files: &[(String, PathBuf)],
 ) -> Vec<Value> {
     let pipe_enc = |s: &str| pipeline.encode(s, false).unwrap().len();
-    let base_enc: Option<EncodeFn> =
-        baseline.map(|b| Box::new(move |s: &str| b.encode(s, false).unwrap().len()) as EncodeFn);
+    let base_enc = baseline.map(|b| move |s: &str| b.encode(s, false).unwrap().len());
 
     let mut rows = Vec::new();
     for (group, path) in files {
@@ -392,7 +372,7 @@ fn bench_model(
         }
         time_pass(&pipe_enc, &chunks);
         let (mut base_s, mut pipe_s) = (Vec::new(), Vec::new());
-        for _ in 0..reps() {
+        for _ in 0..REPS {
             if let Some(be) = &base_enc {
                 base_s.push(time_pass(be, &chunks));
             }
@@ -459,7 +439,7 @@ fn main() {
     }
 
     let manifest: Vec<Value> =
-        serde_json::from_str(&std::fs::read_to_string(manifest_path()).unwrap()).unwrap();
+        serde_json::from_str(&std::fs::read_to_string(MANIFEST).unwrap()).unwrap();
     let files = fixture_files();
 
     let mut models: Vec<Value> = Vec::new();
@@ -476,7 +456,7 @@ fn main() {
                 eprintln!("  load failed: {e}");
                 models.push(json!({
                     "model": name, "repo": repo, "desc": desc, "shape": "?",
-                    "supported": false, "reason": format!("load error: {e}"),
+                    "reason": format!("load error: {e}"),
                     "results": [], "memory": Value::Null,
                 }));
                 continue;
@@ -498,7 +478,7 @@ fn main() {
                     eprintln!("  pipeline builds but can't encode yet ({shape}): {e}");
                     models.push(json!({
                         "model": name, "repo": repo, "desc": desc, "shape": shape,
-                        "supported": false, "reason": format!("{e}"),
+                        "reason": format!("{e}"),
                         "results": [], "memory": Value::Null,
                     }));
                     continue;
@@ -508,7 +488,7 @@ fn main() {
                 eprintln!("  unsupported by PipelineTokenizer ({shape})");
                 models.push(json!({
                     "model": name, "repo": repo, "desc": desc, "shape": shape,
-                    "supported": false, "results": [], "memory": Value::Null,
+                    "results": [], "memory": Value::Null,
                 }));
                 continue;
             }
@@ -538,7 +518,6 @@ fn main() {
 
         models.push(json!({
             "model": name, "repo": repo, "desc": desc, "shape": shape,
-            "supported": true,
             "results": rows, "memory": memory,
         }));
     }

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -1,32 +1,50 @@
-//! Comparative throughput of the reference `Tokenizer` vs the experimental
-//! `PipelineTokenizer`, for every model in `examples/bench_models.json` across
-//! every corpus in `data/fixtures/` (languages + modalities), on ~10 kB inputs
-//! — the regime where per-input overhead is amortized (see `pipeline_benchmark.rs`
-//! for the size sweep).
+//! Comparative benchmark of the experimental `PipelineTokenizer` against the
+//! latest *released* `tokenizers` crate (the bar to beat — the in-tree legacy
+//! `Tokenizer` is on its way out, so the release is the reference), for every
+//! model in `examples/bench_models.json` across every corpus in `data/fixtures/`.
 //!
-//! `PipelineTokenizer` is a work in progress: models it can't build yet (standalone
-//! ByteLevel pre-tokenizer, Metaspace/Unigram, …) are reported as `supported: false`
-//! with their pipeline shape, rather than benched — the CI grid renders those as
-//! roadmap cards. Each manifest entry carries a `desc`: a one-line label of the
-//! workload archetype the model exercises, passed through to the report.
+//! Per fixture it measures throughput on ~10 kB inputs (the regime where
+//! per-input overhead is amortized — see `pipeline_benchmark.rs` for the size
+//! sweep). Per model it also measures resident-set deltas by re-spawning itself
+//! as `--memory <impl> <model.json>` children — one implementation per process,
+//! so allocator page reuse across implementations can't blur the attribution.
 //!
-//! Emits a JSON array (one object per model) on stdout, consumed by
-//! `.github/scripts/render_pipeline_bench.py` in CI.
+//! The in-tree `Tokenizer` is *not* benched: it only builds the pipeline and
+//! serves as the id-correctness oracle (`ids_match`, which CI fails on).
+//! `ids_match_baseline` — pipeline vs the released crate — is report-only,
+//! since a branch may intentionally fix encode behavior. Models the pipeline
+//! can't build yet are reported as `supported: false` with their pipeline shape
+//! rather than benched — the CI grid renders those as roadmap cards. Each
+//! manifest entry carries a `desc`: a one-line label of the workload archetype
+//! the model exercises, passed through to the report.
+//!
+//! Emits one JSON object (`{baseline, models}`) on stdout, consumed by
+//! `.github/scripts/render_pipeline_bench.py` in CI. For local iteration the
+//! data dir, manifest and rep count can be overridden with the
+//! `FIXTURE_BENCH_DATA` / `FIXTURE_BENCH_MANIFEST` / `FIXTURE_BENCH_REPS` env vars.
 
 use std::convert::TryFrom;
 use std::hint::black_box;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Instant;
 
 use serde_json::{json, Value};
 use tk_encode::pipeline::PipelineTokenizer;
 use tk_encode::{AddedToken, ModelWrapper, Tokenizer};
+use tokenizers_release::{AddedToken as BaselineAddedToken, Tokenizer as BaselineTokenizer};
 
 const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
 const MANIFEST: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/bench_models.json");
+// Keep in sync with the `tokenizers-release` pin in Cargo.toml.
+const BASELINE_VERSION: &str = "0.23.1";
 const CHUNK_BYTES: usize = 10 * 1024;
 const MAX_CHUNKS: usize = 100;
 const REPS: usize = 5;
+const PROBE: &str = "The quick brown fox jumps 123.";
+// Chunks per fixture for the memory children's encode pass: enough to warm the
+// lazy structures and grow the output buffers, small enough to stay cheap.
+const MEM_CHUNKS_PER_FIXTURE: usize = 2;
 
 // Added tokens injected into every loaded tokenizer so the `added_*` fixtures exercise
 // the added-token split for whichever model is benched — no bespoke tokenizer config.
@@ -46,8 +64,24 @@ const ADDED_NORMALIZED: &[&str] = &[
     "crungledorf",
 ];
 
+fn data_dir() -> PathBuf {
+    std::env::var_os("FIXTURE_BENCH_DATA").map_or_else(|| PathBuf::from(DATA_DIR), PathBuf::from)
+}
+
+fn manifest_path() -> PathBuf {
+    std::env::var_os("FIXTURE_BENCH_MANIFEST")
+        .map_or_else(|| PathBuf::from(MANIFEST), PathBuf::from)
+}
+
+fn reps() -> usize {
+    std::env::var("FIXTURE_BENCH_REPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(REPS)
+}
+
 /// Inject the benchmark's added tokens into `tok` before the pipeline is built from it,
-/// so both the reference and the pipeline see them (and stay id-for-id identical).
+/// so both the oracle and the pipeline see them (and stay id-for-id identical).
 fn inject_added_tokens(tok: &mut Tokenizer) {
     let special = ADDED_SPECIAL
         .iter()
@@ -55,6 +89,18 @@ fn inject_added_tokens(tok: &mut Tokenizer) {
     let normalized = ADDED_NORMALIZED
         .iter()
         .map(|s| AddedToken::from(*s, false).normalized(true));
+    let _ = tok.add_special_tokens(special);
+    let _ = tok.add_tokens(normalized);
+}
+
+/// Same injection through the released crate's `AddedToken`.
+fn inject_added_tokens_baseline(tok: &mut BaselineTokenizer) {
+    let special = ADDED_SPECIAL
+        .iter()
+        .map(|s| BaselineAddedToken::from(*s, true).normalized(false));
+    let normalized = ADDED_NORMALIZED
+        .iter()
+        .map(|s| BaselineAddedToken::from(*s, false).normalized(true));
     let _ = tok.add_special_tokens(special);
     let _ = tok.add_tokens(normalized);
 }
@@ -117,8 +163,8 @@ fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) 
         }
     };
     run(); // warm-up
-    let mut samples = Vec::with_capacity(REPS);
-    for _ in 0..REPS {
+    let mut samples = Vec::with_capacity(reps());
+    for _ in 0..reps() {
         let start = Instant::now();
         run();
         samples.push(start.elapsed().as_secs_f64());
@@ -129,7 +175,7 @@ fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) 
 fn fixture_files() -> Vec<(String, PathBuf)> {
     let mut files = Vec::new();
     for group in ["lang", "modalities"] {
-        let dir = Path::new(DATA_DIR).join("fixtures").join(group);
+        let dir = data_dir().join("fixtures").join(group);
         let mut entries: Vec<_> = std::fs::read_dir(&dir)
             .unwrap_or_else(|e| panic!("{}: {e} — run `make fixtures` first", dir.display()))
             .map(|e| e.unwrap().path())
@@ -152,7 +198,7 @@ fn model_path(entry: &Value) -> PathBuf {
         .and_then(Value::as_str)
         .map(str::to_string)
         .unwrap_or_else(|| format!("{name}.json"));
-    Path::new(DATA_DIR).join(file)
+    data_dir().join(file)
 }
 
 fn model_kind(tok: &Tokenizer) -> &'static str {
@@ -187,13 +233,130 @@ fn pretok_label(path: &Path) -> String {
     }
 }
 
+/// Resident set size in bytes. Exact on Linux (`/proc`); on macOS a `ps`
+/// fallback good enough for local iteration — CI runs on Linux.
+fn rss_now() -> Option<i64> {
+    if cfg!(target_os = "linux") {
+        proc_status_bytes("VmRSS:")
+    } else {
+        let out = Command::new("ps")
+            .args(["-o", "rss=", "-p"])
+            .arg(std::process::id().to_string())
+            .output()
+            .ok()?;
+        let kb: i64 = String::from_utf8(out.stdout).ok()?.trim().parse().ok()?;
+        Some(kb * 1024)
+    }
+}
+
+/// Peak resident set (VmHWM) in bytes — Linux only, `None` elsewhere.
+fn rss_peak() -> Option<i64> {
+    proc_status_bytes("VmHWM:")
+}
+
+fn proc_status_bytes(key: &str) -> Option<i64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    let kb: i64 = status
+        .lines()
+        .find(|l| l.starts_with(key))?
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()?;
+    Some(kb * 1024)
+}
+
+/// `--memory <impl> <model.json>` child entry: load one implementation, encode a
+/// capped pass over the fixtures, print `{load_bytes, encode_bytes, peak_bytes}`.
+/// One implementation per process so the deltas attribute cleanly.
+fn memory_child(which: &str, model: &Path) {
+    let mut chunks: Vec<String> = Vec::new();
+    for (_, path) in &fixture_files() {
+        let text = std::fs::read_to_string(path).unwrap();
+        chunks.extend(make_chunks(&text).into_iter().take(MEM_CHUNKS_PER_FIXTURE));
+    }
+
+    let rss0 = rss_now().unwrap_or(0);
+    let mut n = 0usize;
+    let (after_load, after_encode) = match which {
+        "baseline" => {
+            let mut tok = BaselineTokenizer::from_file(model).unwrap();
+            inject_added_tokens_baseline(&mut tok);
+            let after_load = rss_now().unwrap_or(0);
+            for c in &chunks {
+                n += tok.encode(c.as_str(), false).unwrap().len();
+            }
+            (after_load, rss_now().unwrap_or(0))
+        }
+        "pipeline" => {
+            let mut tok = Tokenizer::from_file(model).unwrap();
+            inject_added_tokens(&mut tok);
+            let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
+            // Count only the pipeline's own structures; the transient source
+            // Tokenizer still shows in peak_bytes, which is honest — building a
+            // pipeline currently requires one.
+            drop(tok);
+            let after_load = rss_now().unwrap_or(0);
+            for c in &chunks {
+                n += pipeline.encode(c, false).unwrap().len();
+            }
+            (after_load, rss_now().unwrap_or(0))
+        }
+        other => panic!("unknown impl {:?}", other),
+    };
+    black_box(n);
+
+    println!(
+        "{}",
+        json!({
+            "load_bytes": after_load - rss0,
+            "encode_bytes": after_encode - after_load,
+            "peak_bytes": rss_peak().map(|p| p - rss0),
+        })
+    );
+}
+
+/// Re-run this binary once per available implementation to get per-impl memory
+/// numbers that a shared address space couldn't provide.
+fn measure_memory(model: &Path, baseline_ok: bool) -> Value {
+    let exe = std::env::current_exe().unwrap();
+    let mut out = serde_json::Map::new();
+    for (key, ok) in [("baseline", baseline_ok), ("pipeline", true)] {
+        if !ok {
+            out.insert(key.into(), Value::Null);
+            continue;
+        }
+        let res = Command::new(&exe)
+            .arg("--memory")
+            .arg(key)
+            .arg(model)
+            .output()
+            .expect("failed to spawn memory child");
+        if !res.status.success() {
+            eprintln!(
+                "  memory child {key} failed: {}",
+                String::from_utf8_lossy(&res.stderr)
+            );
+            out.insert(key.into(), Value::Null);
+            continue;
+        }
+        let parsed: Value = serde_json::from_slice(&res.stdout).unwrap_or(Value::Null);
+        out.insert(key.into(), parsed);
+    }
+    Value::Object(out)
+}
+
+type EncodeFn<'a> = Box<dyn Fn(&str) -> usize + 'a>;
+
 fn bench_model(
-    tok: &Tokenizer,
+    baseline: Option<&BaselineTokenizer>,
+    oracle: &Tokenizer,
     pipeline: &PipelineTokenizer,
     files: &[(String, PathBuf)],
 ) -> Vec<Value> {
-    let legacy_enc = |s: &str| tok.encode(s, false).unwrap().len();
-    let pipeline_enc = |s: &str| pipeline.encode(s, false).unwrap().len();
+    let pipe_enc = |s: &str| pipeline.encode(s, false).unwrap().len();
+    let base_enc: Option<EncodeFn> =
+        baseline.map(|b| Box::new(move |s: &str| b.encode(s, false).unwrap().len()) as EncodeFn);
 
     let mut rows = Vec::new();
     for (group, path) in files {
@@ -202,28 +365,48 @@ fn bench_model(
         let chunks = make_chunks(&text);
         let bytes: usize = chunks.iter().map(String::len).sum();
 
-        let ids_match = chunks.iter().take(3).all(|c| {
-            let expected = tok.encode(c.as_str(), false).unwrap();
-            let got: Vec<u32> = pipeline
+        let pipe_ids = |c: &String| -> Vec<u32> {
+            pipeline
                 .encode(c, false)
                 .unwrap()
                 .iter()
                 .map(|t| t.id)
-                .collect();
-            expected.get_ids() == got
+                .collect()
+        };
+        // The correctness gate CI fails on: pipeline vs this tree's Tokenizer.
+        let ids_match = chunks
+            .iter()
+            .take(3)
+            .all(|c| oracle.encode(c.as_str(), false).unwrap().get_ids() == pipe_ids(c));
+        // Report-only: pipeline vs the released crate (a branch may fix encode bugs).
+        let ids_match_baseline = baseline.map(|b| {
+            chunks
+                .iter()
+                .take(3)
+                .all(|c| b.encode(c.as_str(), false).unwrap().get_ids() == pipe_ids(c))
         });
 
-        // interleave impls so frequency/thermal drift hits both equally
-        time_pass(&legacy_enc, &chunks);
-        time_pass(&pipeline_enc, &chunks);
-        let (mut legacy_s, mut pipeline_s) = (Vec::new(), Vec::new());
-        for _ in 0..REPS {
-            legacy_s.push(time_pass(&legacy_enc, &chunks));
-            pipeline_s.push(time_pass(&pipeline_enc, &chunks));
+        // interleave both impls so frequency/thermal drift hits them equally
+        if let Some(be) = &base_enc {
+            time_pass(be, &chunks);
         }
-        let (l, p) = (median_secs(legacy_s), median_secs(pipeline_s));
-        let (legacy_mbps, pipeline_mbps) = (bytes as f64 / l / 1e6, bytes as f64 / p / 1e6);
-        eprintln!("  {name}: legacy {legacy_mbps:.1} MB/s, pipeline {pipeline_mbps:.1} MB/s");
+        time_pass(&pipe_enc, &chunks);
+        let (mut base_s, mut pipe_s) = (Vec::new(), Vec::new());
+        for _ in 0..reps() {
+            if let Some(be) = &base_enc {
+                base_s.push(time_pass(be, &chunks));
+            }
+            pipe_s.push(time_pass(&pipe_enc, &chunks));
+        }
+        let mbps = |secs: f64| bytes as f64 / secs / 1e6;
+        let base_mbps = (!base_s.is_empty()).then(|| mbps(median_secs(base_s)));
+        let pipe_mbps = mbps(median_secs(pipe_s));
+
+        let fmt = |v: Option<f64>| v.map_or("—".into(), |v| format!("{v:.1}"));
+        eprintln!(
+            "  {name}: baseline {} MB/s, pipeline {pipe_mbps:.1} MB/s",
+            fmt(base_mbps)
+        );
 
         // Staged decomposition of the pipeline's own encode via the ablation ladder:
         // time each cumulative stage level, then subtract to isolate each stage's cost
@@ -253,11 +436,9 @@ fn bench_model(
             "group": group,
             "bytes": bytes,
             "chunks": chunks.len(),
-            "legacy_mbps": legacy_mbps,
-            "pipeline_mbps": pipeline_mbps,
-            "speedup": l / p,
+            "mbps": { "baseline": base_mbps, "pipeline": pipe_mbps },
             "ids_match": ids_match,
-            // pipeline-only stage decomposition (ns/byte); the four stages sum to total.
+            "ids_match_baseline": ids_match_baseline,
             "stage_ns_per_byte": {
                 "added_split": ns_added,
                 "normalize": ns_norm,
@@ -271,11 +452,17 @@ fn bench_model(
 }
 
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.get(1).map(String::as_str) == Some("--memory") {
+        memory_child(&args[2], Path::new(&args[3]));
+        return;
+    }
+
     let manifest: Vec<Value> =
-        serde_json::from_str(&std::fs::read_to_string(MANIFEST).unwrap()).unwrap();
+        serde_json::from_str(&std::fs::read_to_string(manifest_path()).unwrap()).unwrap();
     let files = fixture_files();
 
-    let mut out: Vec<Value> = Vec::new();
+    let mut models: Vec<Value> = Vec::new();
     for entry in &manifest {
         let name = entry["name"].as_str().unwrap().to_string();
         let repo = entry.get("repo").and_then(Value::as_str).unwrap_or("");
@@ -287,9 +474,10 @@ fn main() {
             Ok(t) => t,
             Err(e) => {
                 eprintln!("  load failed: {e}");
-                out.push(json!({
+                models.push(json!({
                     "model": name, "repo": repo, "desc": desc, "shape": "?",
-                    "supported": false, "reason": format!("load error: {e}"), "results": [],
+                    "supported": false, "reason": format!("load error: {e}"),
+                    "results": [], "memory": Value::Null,
                 }));
                 continue;
             }
@@ -299,39 +487,65 @@ fn main() {
         inject_added_tokens(&mut tok);
         let shape = format!("{} · {}", model_kind(&tok), pretok_label(&path));
 
-        match PipelineTokenizer::try_from(&tok) {
-            // A model can satisfy the pipeline's *build* constraints yet still fail at
-            // *encode* time — e.g. a Sequence containing ByteLevel, which rewrites bytes
-            // and has no range-based impl. Probe once and downgrade to "unsupported"
-            // (with the reason) instead of panicking partway through the bench.
-            Ok(pipeline) => match pipeline.encode("The quick brown fox jumps 123.", false) {
-                Ok(_) => {
-                    let rows = bench_model(&tok, &pipeline, &files);
-                    out.push(json!({
-                        "model": name, "repo": repo, "desc": desc, "shape": shape,
-                        "supported": true, "results": rows,
-                    }));
-                }
+        // A model can satisfy the pipeline's *build* constraints yet still fail at
+        // *encode* time — e.g. a Sequence containing ByteLevel, which rewrites bytes
+        // and has no range-based impl. Probe once and downgrade to "unsupported"
+        // (with the reason) instead of panicking partway through the bench.
+        let pipeline = match PipelineTokenizer::try_from(&tok) {
+            Ok(p) => match p.encode(PROBE, false) {
+                Ok(_) => p,
                 Err(e) => {
-                    eprintln!("  builds but can't encode yet ({shape}): {e}");
-                    out.push(json!({
+                    eprintln!("  pipeline builds but can't encode yet ({shape}): {e}");
+                    models.push(json!({
                         "model": name, "repo": repo, "desc": desc, "shape": shape,
-                        "supported": false, "reason": format!("{e}"), "results": [],
+                        "supported": false, "reason": format!("{e}"),
+                        "results": [], "memory": Value::Null,
                     }));
+                    continue;
                 }
             },
             Err(_) => {
                 eprintln!("  unsupported by PipelineTokenizer ({shape})");
-                out.push(json!({
+                models.push(json!({
                     "model": name, "repo": repo, "desc": desc, "shape": shape,
-                    "supported": false, "results": [],
+                    "supported": false, "results": [], "memory": Value::Null,
                 }));
+                continue;
             }
-        }
+        };
+
+        // The released crate may not load (or encode) a config that needs
+        // features newer than the release — bench without it rather than fail.
+        let baseline = match BaselineTokenizer::from_file(&path) {
+            Ok(mut b) => {
+                inject_added_tokens_baseline(&mut b);
+                match b.encode(PROBE, false) {
+                    Ok(_) => Some(b),
+                    Err(e) => {
+                        eprintln!("  baseline v{BASELINE_VERSION} loads but can't encode: {e}");
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("  baseline v{BASELINE_VERSION} can't load this config: {e}");
+                None
+            }
+        };
+
+        let rows = bench_model(baseline.as_ref(), &tok, &pipeline, &files);
+        let memory = measure_memory(&path, baseline.is_some());
+
+        models.push(json!({
+            "model": name, "repo": repo, "desc": desc, "shape": shape,
+            "supported": true,
+            "results": rows, "memory": memory,
+        }));
     }
 
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&Value::Array(out)).unwrap()
-    );
+    let out = json!({
+        "baseline": { "crate": "tokenizers", "version": BASELINE_VERSION },
+        "models": models,
+    });
+    println!("{}", serde_json::to_string_pretty(&out).unwrap());
 }


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**5 / 6 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · single thread

`f41341f18 · 2026-07-09 18:57 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 16 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-overview-dark.png">
  <img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-overview-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-memory-dark.png">
  <img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-memory-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-binsize-dark.png">
  <img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-binsize-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.28 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-bert-base-uncased-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 2+0 (peak 6) · Pipeline 5+0 (peak 6)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| amh_Ethi | lang | 7.2 | 21.7 | ×3.02 | match |
| arb_Arab | lang | 3.5 | 14.9 | ×4.29 | match |
| ben_Beng | lang | 5.2 | 22.0 | ×4.25 | match |
| cmn_Hani | lang | 3.2 | 14.4 | ×4.53 | match |
| ell_Grek | lang | 3.2 | 14.0 | ×4.34 | match |
| eng_Latn | lang | 3.8 | 16.1 | ×4.19 | match |
| heb_Hebr | lang | 3.5 | 13.1 | ×3.74 | match |
| hin_Deva | lang | 5.6 | 20.3 | ×3.64 | match |
| jpn_Jpan | lang | 3.7 | 17.3 | ×4.67 | match |
| kat_Geor | lang | 5.7 | 18.5 | ×3.27 | match |
| kor_Hang | lang | 2.1 | 9.3 | ×4.38 | match |
| rus_Cyrl | lang | 3.1 | 13.8 | ×4.40 | match |
| tam_Taml | lang | 6.4 | 24.5 | ×3.81 | match |
| tha_Thai | lang | 8.2 | 21.9 | ×2.68 | match |
| added_normalized_dense | modalities | 6.2 | 21.8 | ×3.54 | match |
| added_normalized_sparse | modalities | 4.8 | 19.2 | ×3.97 | match |
| added_special_dense | modalities | 4.8 | 50.6 | ×10.58 | match |
| added_special_sparse | modalities | 3.7 | 22.9 | ×6.19 | match |
| agentic-traces | modalities | 3.3 | 15.3 | ×4.64 | match |
| agentic_swe | modalities | 3.6 | 16.1 | ×4.54 | match |
| code_mixed | modalities | 3.4 | 15.9 | ×4.66 | match |
| math_latex | modalities | 3.4 | 15.6 | ×4.55 | match |

</details>

<details><summary><b>deepseek-v4</b> — split-heavy byte-level BPE, 3 chained regexes · ×2.66 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-deepseek-v4-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 51+0 (peak 58) · Pipeline 84+0 (peak 84)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| amh_Ethi | lang | 3.7 | 14.3 | ×3.84 | match |
| arb_Arab | lang | 3.6 | 9.2 | ×2.59 | match |
| ben_Beng | lang | 4.4 | 11.1 | ×2.54 | match |
| cmn_Hani | lang | 3.2 | 8.1 | ×2.51 | match |
| ell_Grek | lang | 3.7 | 9.9 | ×2.70 | match |
| eng_Latn | lang | 2.6 | 6.5 | ×2.50 | match |
| heb_Hebr | lang | 3.0 | 8.0 | ×2.67 | match |
| hin_Deva | lang | 4.1 | 12.1 | ×2.97 | match |
| jpn_Jpan | lang | 3.7 | 8.8 | ×2.42 | match |
| kat_Geor | lang | 4.4 | 11.6 | ×2.65 | match |
| kor_Hang | lang | 3.2 | 9.9 | ×3.14 | match |
| rus_Cyrl | lang | 3.4 | 8.7 | ×2.54 | match |
| tam_Taml | lang | 4.7 | 11.3 | ×2.40 | match |
| tha_Thai | lang | 5.4 | 10.7 | ×1.99 | match |
| added_normalized_dense | modalities | 3.5 | 12.0 | ×3.45 | match |
| added_normalized_sparse | modalities | 3.5 | 10.1 | ×2.92 | match |
| added_special_dense | modalities | 2.9 | 7.1 | ×2.44 | match |
| added_special_sparse | modalities | 3.1 | 7.4 | ×2.38 | match |
| agentic-traces | modalities | 2.4 | 6.3 | ×2.69 | match |
| agentic_swe | modalities | 2.3 | 5.7 | ×2.51 | match |
| code_mixed | modalities | 2.6 | 6.9 | ×2.68 | match |
| math_latex | modalities | 2.4 | 6.2 | ×2.58 | match |

</details>

<details><summary><b>gpt2</b> — standalone ByteLevel pre-tokenizer · ×7.91 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-gpt2-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 17+1 (peak 18) · Pipeline 21+0 (peak 21)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 42.0 | ×10.91 | match |
| arb_Arab | lang | 3.1 | 22.5 | ×7.32 | match |
| ben_Beng | lang | 2.2 | 28.9 | ×13.38 | match |
| cmn_Hani | lang | 3.2 | 24.5 | ×7.75 | match |
| ell_Grek | lang | 3.1 | 25.1 | ×7.99 | match |
| eng_Latn | lang | 2.7 | 11.8 | ×4.32 | match |
| heb_Hebr | lang | 3.1 | 24.6 | ×7.85 | match |
| hin_Deva | lang | 2.6 | 26.4 | ×10.21 | match |
| jpn_Jpan | lang | 3.5 | 19.7 | ×5.62 | match |
| kat_Geor | lang | 3.6 | 53.9 | ×15.03 | match |
| kor_Hang | lang | 3.0 | 32.6 | ×10.95 | match |
| rus_Cyrl | lang | 3.3 | 24.1 | ×7.19 | match |
| tam_Taml | lang | 2.2 | 35.5 | ×16.35 | match |
| tha_Thai | lang | 2.9 | 29.2 | ×10.11 | match |
| added_normalized_dense | modalities | 3.6 | 22.7 | ×6.34 | match |
| added_normalized_sparse | modalities | 3.4 | 18.7 | ×5.53 | match |
| added_special_dense | modalities | 3.5 | 32.0 | ×9.15 | match |
| added_special_sparse | modalities | 3.3 | 19.0 | ×5.77 | match |
| agentic-traces | modalities | 2.4 | 13.0 | ×5.46 | match |
| agentic_swe | modalities | 2.4 | 17.5 | ×7.26 | match |
| code_mixed | modalities | 2.4 | 15.5 | ×6.46 | match |
| math_latex | modalities | 2.6 | 12.4 | ×4.80 | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.04 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-llama-2-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 15+0 (peak 15) · Pipeline 14+0 (peak 14)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 29.3 | ×6.94 | match |
| arb_Arab | lang | 8.8 | 32.3 | ×3.66 | match |
| ben_Beng | lang | 9.6 | 52.2 | ×5.44 | match |
| cmn_Hani | lang | 8.1 | 62.4 | ×7.69 | match |
| ell_Grek | lang | 8.7 | 36.5 | ×4.21 | match |
| eng_Latn | lang | 3.9 | 5.7 | ×1.44 | match |
| heb_Hebr | lang | 8.5 | 35.9 | ×4.24 | match |
| hin_Deva | lang | 10.5 | 44.9 | ×4.27 | match |
| jpn_Jpan | lang | 11.4 | 78.3 | ×6.85 | match |
| kat_Geor | lang | 12.4 | 56.8 | ×4.57 | match |
| kor_Hang | lang | 6.3 | 33.5 | ×5.31 | match |
| rus_Cyrl | lang | 7.9 | 14.5 | ×1.82 | match |
| tam_Taml | lang | 11.1 | 59.5 | ×5.38 | match |
| tha_Thai | lang | 13.7 | 72.5 | ×5.29 | match |
| added_normalized_dense | modalities | 5.1 | 8.4 | ×1.65 | match |
| added_normalized_sparse | modalities | 4.7 | 6.9 | ×1.48 | match |
| added_special_dense | modalities | 4.4 | 11.4 | ×2.61 | match |
| added_special_sparse | modalities | 6.4 | 7.8 | ×1.20 | match |
| agentic-traces | modalities | 4.3 | 6.5 | ×1.50 | match |
| agentic_swe | modalities | 3.9 | 6.1 | ×1.59 | match |
| code_mixed | modalities | 4.1 | 6.3 | ×1.54 | match |
| math_latex | modalities | 4.2 | 6.3 | ×1.48 | match |

</details>

<details><summary><b>llama-3</b> — split-heavy byte-level BPE, single regex · ×4.06 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-llama-3-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 128+0 (peak 189) · Pipeline 129+0 (peak 189)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Ids |
|---|---|---:|---:|---:|:--|
| amh_Ethi | lang | 3.1 | 21.9 | ×7.02 | match |
| arb_Arab | lang | 3.7 | 11.9 | ×3.22 | match |
| ben_Beng | lang | 2.8 | 13.5 | ×4.90 | match |
| cmn_Hani | lang | 3.9 | 13.0 | ×3.34 | match |
| ell_Grek | lang | 3.9 | 12.7 | ×3.24 | match |
| eng_Latn | lang | 3.4 | 13.6 | ×3.96 | match |
| heb_Hebr | lang | 3.2 | 15.0 | ×4.75 | match |
| hin_Deva | lang | 3.7 | 16.8 | ×4.58 | match |
| jpn_Jpan | lang | 4.3 | 13.0 | ×3.03 | match |
| kat_Geor | lang | 3.8 | 23.8 | ×6.26 | match |
| kor_Hang | lang | 3.4 | 12.4 | ×3.64 | match |
| rus_Cyrl | lang | 3.8 | 11.9 | ×3.14 | match |
| tam_Taml | lang | 2.8 | 13.6 | ×4.88 | match |
| tha_Thai | lang | 4.2 | 13.5 | ×3.19 | match |
| added_normalized_dense | modalities | 3.7 | 16.8 | ×4.58 | match |
| added_normalized_sparse | modalities | 3.9 | 18.4 | ×4.67 | match |
| added_special_dense | modalities | 3.5 | 12.6 | ×3.62 | match |
| added_special_sparse | modalities | 3.8 | 15.2 | ×4.01 | match |
| agentic-traces | modalities | 3.1 | 12.4 | ×3.99 | match |
| agentic_swe | modalities | 3.2 | 11.0 | ×3.45 | match |
| code_mixed | modalities | 3.3 | 13.0 | ×3.89 | match |
| math_latex | modalities | 3.1 | 13.0 | ×4.24 | match |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29042161989-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
