### PR TITLE
Fix PreTokenizedInputSequence annotation and tighten encode() stubs

### DIFF
--- a/bindings/python/py_src/tokenizers/__init__.py
+++ b/bindings/python/py_src/tokenizers/__init__.py
@@ -18,7 +18,7 @@ Offsets = Tuple[int, int]
 TextInputSequence = str
 """A :obj:`str` that represents an input sequence """
 
-PreTokenizedInputSequence = Union[List[str], Tuple[str]]
+PreTokenizedInputSequence = Union[List[str], Tuple[str, ...]]
 """A pre-tokenized input sequence. Can be one of:
 
     - A :obj:`List` of :obj:`str`

--- a/bindings/python/py_src/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/__init__.pyi
@@ -3,7 +3,7 @@ Tokenizers Module
 """
 
 from collections.abc import Sequence
-from typing import Any, Final, final
+from typing import Any, Final, List, Tuple, Union, final
 
 from _typeshed import Incomplete
 
@@ -15,6 +15,10 @@ from tokenizers.processors import PostProcessor
 from tokenizers.trainers import Trainer
 
 __version__: Final[str]
+
+TextInputSequence = str
+PreTokenizedInputSequence = Union[List[str], Tuple[str, ...]]
+InputSequence = Union[TextInputSequence, PreTokenizedInputSequence]
 
 @final
 class AddedToken:
@@ -739,7 +743,7 @@ class Tokenizer:
             :obj:`List[str]`: A list of decoded strings
         """
     def async_encode(
-        self, /, sequence: Any, pair: Any | None = None, is_pretokenized: bool = False, add_special_tokens: bool = True
+        self, /, sequence: InputSequence, pair: InputSequence | None = None, is_pretokenized: bool = False, add_special_tokens: bool = True
     ) -> Any:
         """
         Asynchronously encode the given input with character offsets.
@@ -929,7 +933,7 @@ class Tokenizer:
                 Truncate direction
         """
     def encode(
-        self, /, sequence: Any, pair: Any | None = None, is_pretokenized: bool = False, add_special_tokens: bool = True
+        self, /, sequence: InputSequence, pair: InputSequence | None = None, is_pretokenized: bool = False, add_special_tokens: bool = True
     ) -> "Encoding":
         """
         Encode the given sequence and pair. This method can process raw text sequences


### PR DESCRIPTION
## What

Two type annotation issues in the Python bindings:

1. **`__init__.py` line 21**: `Tuple[str]` means a one-element tuple containing a single `str`. The correct annotation for a variable-length homogeneous tuple is `Tuple[str, ...]`.

2. **`__init__.pyi`**: The `sequence` and `pair` parameters of `encode()` and `async_encode()` are typed as `Any`, hiding that callers must pass an `InputSequence` (either a raw string or a pre-tokenized list/tuple of strings). The stubs now declare the actual constraint.

## Changes

- `bindings/python/py_src/tokenizers/__init__.py`: `Tuple[str]` → `Tuple[str, ...]`
- `bindings/python/py_src/tokenizers/__init__.pyi`:
  - Add `TextInputSequence`, `PreTokenizedInputSequence`, `InputSequence` type aliases (mirroring `__init__.py`)
  - Tighten `encode()` and `async_encode()` signatures: `sequence: Any` → `sequence: InputSequence`, `pair: Any | None` → `pair: InputSequence | None`

Closes #2088.