### PR TITLE
feat: other data structure for WordPiece (yada)

### DIFF
--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -2338,6 +2338,7 @@ dependencies = [
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
+ "yada",
 ]
 
 [[package]]
@@ -3079,6 +3080,12 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yada"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c3bb06259642a57b4ea1bf2a8260f7d94b7b78a096c46f193318918d925f61"
 
 [[package]]
 name = "yoke"

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -60,6 +60,7 @@ compact_str = { version = "0.9", features = ["serde"] }
 ptr_hash = { version = "1.1.0" }
 memchr = "2.8.2"
 unicode-normalization = "0.1.25"
+yada = "0.7.0"
 
 [features]
 # TODO: onig is C (Oniguruma, archived upstream). We're moving to the pure-Rust

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -6,6 +6,8 @@ use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use ahash::AHashMap;
 use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::ops::Deref;
 use std::{
     borrow::Cow,
     fs::File,
@@ -13,6 +15,8 @@ use std::{
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
 };
+use yada::builder::DoubleArrayBuilder;
+use yada::DoubleArray;
 
 mod serialization;
 
@@ -311,7 +315,41 @@ impl Model for WordPiece {
     }
 }
 
-impl pipeline::Model for WordPiece {
+pub struct PipelineWordPiece {
+    vocab_trie: yada::DoubleArray<Vec<u8>>,
+    unk_token: Option<u32>,
+    continuing_subword_prefix: String,
+    max_input_chars_per_word: usize,
+}
+
+impl TryFrom<WordPiece> for PipelineWordPiece {
+    type Error = crate::Error;
+    fn try_from(value: WordPiece) -> Result<Self> {
+        let WordPiece {
+            vocab,
+            unk_token,
+            continuing_subword_prefix,
+            max_input_chars_per_word,
+            ..
+        } = value;
+        let unk_token = vocab.get(&unk_token).copied();
+
+        let keyset: Vec<_> = vocab
+            .into_iter()
+            .map(|(string, token_id)| (string.into_bytes(), token_id))
+            .collect();
+        let vocab_trie = DoubleArray::new(DoubleArrayBuilder::build(&keyset)?)?;
+
+        Ok(Self {
+            continuing_subword_prefix,
+            max_input_chars_per_word,
+            unk_token,
+            vocab_trie,
+        })
+    }
+}
+
+impl pipeline::Model for PipelineWordPiece {
     fn tokenize_pipeline(
         &self,
         sequence: &str,
@@ -322,10 +360,7 @@ impl pipeline::Model for WordPiece {
 
         let char_len = sequence.chars().count();
         if char_len > self.max_input_chars_per_word {
-            let unk_id = *self
-                .vocab
-                .get(&self.unk_token)
-                .ok_or(Error::MissingUnkToken)?;
+            let unk_id = self.unk_token.ok_or(Error::MissingUnkToken)?;
             output.push(PipelineToken { id: unk_id });
             return Ok(());
         }
@@ -339,25 +374,15 @@ impl pipeline::Model for WordPiece {
             }
             candidate.push_str(&sequence[start..]);
 
-            let prefix_len = candidate.len() - (sequence.len() - start);
-            let matched = sequence[start..]
-                .char_indices()
-                .rev()
-                .find_map(|(idx, character)| {
-                    let end = start + idx + character.len_utf8();
-                    candidate.truncate(prefix_len + (end - start));
-                    self.vocab.get(&candidate).map(|&id| (end, id))
-                });
-            let Some((end, token_id)) = matched else {
-                let unk_id = *self
-                    .vocab
-                    .get(&self.unk_token)
-                    .ok_or(Error::MissingUnkToken)?;
+            let Some((token_id, prefix_len)) =
+                self.vocab_trie.common_prefix_search(&candidate).last()
+            else {
+                let unk_id = self.unk_token.ok_or(Error::MissingUnkToken)?;
                 output.push(PipelineToken { id: unk_id });
                 return Ok(());
             };
             candidate_tokens.push(PipelineToken { id: token_id });
-            start = end;
+            start = start + prefix_len;
         }
         output.extend_from_slice(&candidate_tokens);
         Ok(())

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -7,7 +7,6 @@ use crate::tokenizer::{Model, Result, Token};
 use ahash::AHashMap;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::ops::Deref;
 use std::{
     borrow::Cow,
     fs::File,
@@ -334,10 +333,9 @@ impl TryFrom<WordPiece> for PipelineWordPiece {
         } = value;
         let unk_token = vocab.get(&unk_token).copied();
 
-        let keyset: Vec<_> = vocab
-            .into_iter()
-            .map(|(string, token_id)| (string.into_bytes(), token_id))
-            .collect();
+        // yada requires the keyset sorted by key bytes.
+        let mut keyset: Vec<_> = vocab.into_iter().collect();
+        keyset.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
         let vocab_trie = DoubleArray::new(DoubleArrayBuilder::build(&keyset)?)?;
 
         Ok(Self {
@@ -369,20 +367,29 @@ impl pipeline::Model for PipelineWordPiece {
 
         while start < sequence.len() {
             candidate.clear();
-            if start > 0 {
+            let prefix_len = if start > 0 {
                 candidate.push_str(&self.continuing_subword_prefix);
-            }
+                self.continuing_subword_prefix.len()
+            } else {
+                0
+            };
             candidate.push_str(&sequence[start..]);
 
-            let Some((token_id, prefix_len)) =
-                self.vocab_trie.common_prefix_search(&candidate).last()
+            // Matches must extend past the continuing-subword prefix: the
+            // prefix alone (or a fragment of it) is not a valid subword here,
+            // even if it happens to be in the vocab.
+            let Some((token_id, match_len)) = self
+                .vocab_trie
+                .common_prefix_search(&candidate)
+                .filter(|(_, len)| *len > prefix_len)
+                .last()
             else {
                 let unk_id = self.unk_token.ok_or(Error::MissingUnkToken)?;
                 output.push(PipelineToken { id: unk_id });
                 return Ok(());
             };
             candidate_tokens.push(PipelineToken { id: token_id });
-            start = start + prefix_len;
+            start += match_len - prefix_len;
         }
         output.extend_from_slice(&candidate_tokens);
         Ok(())

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -8,7 +8,7 @@ use crate::added_vocabulary::bucket_added_vocabulary::{
 use crate::models::bpe::PipelineBPE;
 use crate::models::unigram::Unigram;
 use crate::models::wordlevel::WordLevel;
-use crate::models::wordpiece::WordPiece;
+use crate::models::wordpiece::{PipelineWordPiece, WordPiece};
 use crate::pre_tokenizers::sequence::PipelineSequence;
 use crate::pre_tokenizers::split::SplitPattern;
 use crate::utils::byte_level::GPT2_REGEX_STR;
@@ -350,7 +350,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             }
             ModelWrapper::Unigram(model) => PipelineModel::Unigram(model),
             ModelWrapper::WordLevel(model) => PipelineModel::WordLevel(model),
-            ModelWrapper::WordPiece(model) => PipelineModel::WordPiece(model),
+            ModelWrapper::WordPiece(model) => PipelineModel::WordPiece(model.try_into()?),
         };
 
         Ok(Self {
@@ -685,7 +685,7 @@ pub enum PipelineModel {
     BPE(PipelineBPE),
     Unigram(Unigram),
     WordLevel(WordLevel),
-    WordPiece(WordPiece),
+    WordPiece(PipelineWordPiece),
 }
 
 impl Model for PipelineModel {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -8,7 +8,7 @@ use crate::added_vocabulary::bucket_added_vocabulary::{
 use crate::models::bpe::PipelineBPE;
 use crate::models::unigram::Unigram;
 use crate::models::wordlevel::WordLevel;
-use crate::models::wordpiece::{PipelineWordPiece, WordPiece};
+use crate::models::wordpiece::PipelineWordPiece;
 use crate::pre_tokenizers::sequence::PipelineSequence;
 use crate::pre_tokenizers::split::SplitPattern;
 use crate::utils::byte_level::GPT2_REGEX_STR;
@@ -705,6 +705,7 @@ mod tests {
     use crate::models::bpe::BPE;
     use crate::pre_tokenizers::byte_level::ByteLevel;
     use crate::pre_tokenizers::sequence::Sequence;
+    use crate::models::wordpiece::WordPiece;
 
     struct FixedMatcher(Vec<((usize, usize), u32)>);
     impl PipelinePatternMatcher for FixedMatcher {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -703,9 +703,9 @@ impl Model for PipelineModel {
 mod tests {
     use super::*;
     use crate::models::bpe::BPE;
+    use crate::models::wordpiece::WordPiece;
     use crate::pre_tokenizers::byte_level::ByteLevel;
     use crate::pre_tokenizers::sequence::Sequence;
-    use crate::models::wordpiece::WordPiece;
 
     struct FixedMatcher(Vec<((usize, usize), u32)>);
     impl PipelinePatternMatcher for FixedMatcher {


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**5 / 6 models supported** — ~10 kB inputs · single thread

`d2b7c7d79 · 2026-07-10 12:59 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 16 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-overview-dark.png">
  <img alt="Per-model encode throughput summary" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-overview-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · geomean ×4.94</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-bert-base-uncased-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.0 | 23.5 | ×3.37 | 1.22 | 27.67 | 9.23 | 4.22 | match |
| arb_Arab | lang | 3.5 | 18.8 | ×5.39 | 1.17 | 27.58 | 13.35 | 10.81 | match |
| ben_Beng | lang | 5.2 | 27.1 | ×5.21 | 1.15 | 19.32 | 8.78 | 7.41 | match |
| cmn_Hani | lang | 3.2 | 15.5 | ×4.93 | 1.18 | 37.78 | 10.93 | 14.13 | match |
| ell_Grek | lang | 3.2 | 18.1 | ×5.61 | 1.17 | 28.71 | 13.56 | 11.49 | match |
| eng_Latn | lang | 3.8 | 17.3 | ×4.55 | 2.64 | 39.16 | 3.38 | 12.20 | match |
| heb_Hebr | lang | 3.5 | 15.8 | ×4.51 | 1.16 | 37.91 | 13.23 | 10.59 | match |
| hin_Deva | lang | 5.6 | 23.0 | ×4.12 | 1.16 | 27.20 | 7.72 | 6.97 | match |
| jpn_Jpan | lang | 3.7 | 21.3 | ×5.75 | 1.17 | 23.42 | 10.83 | 11.00 | match |
| kat_Geor | lang | 5.6 | 22.8 | ×4.04 | 1.16 | 26.33 | 9.61 | 6.18 | match |
| kor_Hang | lang | 2.1 | 13.3 | ×6.27 | 1.18 | 35.09 | 21.54 | 16.83 | match |
| rus_Cyrl | lang | 3.2 | 18.1 | ×5.75 | 1.17 | 27.56 | 13.66 | 12.32 | match |
| tam_Taml | lang | 6.5 | 30.0 | ×4.63 | 1.16 | 18.79 | 8.19 | 4.84 | match |
| tha_Thai | lang | 8.1 | 27.4 | ×3.40 | 1.17 | 25.30 | 7.63 | 1.78 | match |
| added_normalized_dense | modalities | 6.1 | 21.8 | ×3.58 | 1.31 | 41.01 | 1.20 | 1.59 | match |
| added_normalized_sparse | modalities | 4.8 | 19.4 | ×4.04 | 1.92 | 40.42 | 2.30 | 6.27 | match |
| added_special_dense | modalities | 4.7 | 50.7 | ×10.67 | 5.35 | 9.32 | 2.07 | 2.11 | match |
| added_special_sparse | modalities | 3.7 | 23.1 | ×6.24 | 3.66 | 28.60 | 2.85 | 7.26 | match |
| agentic-traces | modalities | 3.3 | 16.7 | ×5.03 | 2.46 | 38.90 | 3.90 | 14.25 | match |
| agentic_swe | modalities | 3.5 | 17.9 | ×5.04 | 1.93 | 39.01 | 2.89 | 11.81 | match |
| code_mixed | modalities | 3.4 | 17.5 | ×5.08 | 2.24 | 39.03 | 3.96 | 12.08 | match |
| math_latex | modalities | 3.4 | 17.0 | ×4.96 | 2.58 | 39.10 | 3.69 | 13.28 | match |

</details>

<details><summary><b>deepseek-v4</b> — split-heavy byte-level BPE, 3 chained regexes · geomean ×2.59</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-deepseek-v4-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 13.7 | ×3.84 | 0.66 | 0.00 | 46.90 | 23.67 | match |
| arb_Arab | lang | 3.4 | 9.1 | ×2.65 | 0.60 | 0.00 | 52.41 | 54.23 | match |
| ben_Beng | lang | 4.4 | 10.8 | ×2.48 | 0.59 | 0.00 | 38.34 | 51.58 | match |
| cmn_Hani | lang | 3.2 | 7.7 | ×2.45 | 0.81 | 0.00 | 67.90 | 59.56 | match |
| ell_Grek | lang | 3.6 | 9.5 | ×2.66 | 0.61 | 0.00 | 50.60 | 52.54 | match |
| eng_Latn | lang | 2.7 | 6.4 | ×2.40 | 2.10 | 0.09 | 78.48 | 69.58 | match |
| heb_Hebr | lang | 3.2 | 7.9 | ×2.46 | 0.60 | 0.00 | 54.39 | 70.42 | match |
| hin_Deva | lang | 4.3 | 11.9 | ×2.78 | 0.60 | 0.00 | 40.50 | 43.54 | match |
| jpn_Jpan | lang | 3.8 | 8.8 | ×2.34 | 0.67 | 0.00 | 57.92 | 55.01 | match |
| kat_Geor | lang | 4.4 | 11.3 | ×2.56 | 0.59 | 0.00 | 34.59 | 52.74 | match |
| kor_Hang | lang | 3.3 | 9.7 | ×2.94 | 0.61 | 0.00 | 54.94 | 45.46 | match |
| rus_Cyrl | lang | 3.6 | 8.7 | ×2.45 | 0.60 | 0.00 | 49.15 | 65.02 | match |
| tam_Taml | lang | 4.8 | 11.3 | ×2.38 | 0.59 | 0.00 | 33.42 | 53.10 | match |
| tha_Thai | lang | 5.4 | 10.6 | ×1.95 | 0.61 | 0.00 | 29.17 | 64.19 | match |
| added_normalized_dense | modalities | 3.7 | 11.8 | ×3.17 | 0.75 | 0.00 | 44.68 | 36.56 | match |
| added_normalized_sparse | modalities | 3.6 | 10.1 | ×2.83 | 1.33 | 0.00 | 50.24 | 45.40 | match |
| added_special_dense | modalities | 3.0 | 7.2 | ×2.41 | 6.86 | 0.54 | 110.43 | 22.46 | match |
| added_special_sparse | modalities | 3.2 | 7.5 | ×2.36 | 3.98 | 0.21 | 82.67 | 46.42 | match |
| agentic-traces | modalities | 2.4 | 6.2 | ×2.60 | 1.88 | 0.00 | 89.11 | 79.42 | match |
| agentic_swe | modalities | 2.3 | 5.6 | ×2.42 | 1.35 | 0.02 | 107.81 | 64.44 | match |
| code_mixed | modalities | 2.6 | 6.9 | ×2.66 | 1.64 | 0.00 | 79.85 | 60.57 | match |
| math_latex | modalities | 2.4 | 6.2 | ×2.60 | 1.99 | 0.00 | 86.05 | 69.57 | match |

</details>

<details><summary><b>gpt2</b> — standalone ByteLevel pre-tokenizer · geomean ×8.01</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-gpt2-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 41.7 | ×11.02 | 0.66 | 0.00 | 6.06 | 16.35 | match |
| arb_Arab | lang | 3.1 | 22.3 | ×7.28 | 0.60 | 0.00 | 7.51 | 36.59 | match |
| ben_Beng | lang | 2.3 | 29.7 | ×12.66 | 0.59 | 0.00 | 11.33 | 21.64 | match |
| cmn_Hani | lang | 3.2 | 24.8 | ×7.78 | 0.61 | 0.00 | 6.01 | 32.84 | match |
| ell_Grek | lang | 3.1 | 25.4 | ×8.07 | 0.60 | 0.00 | 6.64 | 31.28 | match |
| eng_Latn | lang | 2.7 | 11.8 | ×4.34 | 2.06 | 0.05 | 11.48 | 69.75 | match |
| heb_Hebr | lang | 3.1 | 25.8 | ×8.40 | 0.60 | 0.00 | 7.41 | 30.43 | match |
| hin_Deva | lang | 2.6 | 26.4 | ×10.12 | 0.60 | 0.00 | 11.04 | 25.96 | match |
| jpn_Jpan | lang | 3.5 | 19.5 | ×5.58 | 0.60 | 0.00 | 5.12 | 44.63 | match |
| kat_Geor | lang | 3.5 | 54.5 | ×15.37 | 0.60 | 0.00 | 4.76 | 12.26 | match |
| kor_Hang | lang | 2.9 | 31.9 | ×11.16 | 0.61 | 0.00 | 7.50 | 22.47 | match |
| rus_Cyrl | lang | 3.3 | 24.5 | ×7.50 | 0.60 | 0.00 | 6.44 | 32.98 | match |
| tam_Taml | lang | 2.2 | 35.9 | ×16.37 | 0.60 | 0.00 | 11.31 | 15.32 | match |
| tha_Thai | lang | 2.8 | 28.9 | ×10.15 | 0.61 | 0.00 | 7.37 | 25.57 | match |
| added_normalized_dense | modalities | 3.5 | 22.7 | ×6.42 | 0.78 | 0.00 | 6.42 | 35.67 | match |
| added_normalized_sparse | modalities | 3.3 | 18.5 | ×5.55 | 1.34 | 0.00 | 8.11 | 42.85 | match |
| added_special_dense | modalities | 3.7 | 33.1 | ×9.01 | 5.02 | 0.38 | 8.91 | 14.93 | match |
| added_special_sparse | modalities | 3.3 | 19.2 | ×5.75 | 3.53 | 0.00 | 10.57 | 36.23 | match |
| agentic-traces | modalities | 2.3 | 13.0 | ×5.61 | 1.90 | 0.00 | 13.34 | 61.12 | match |
| agentic_swe | modalities | 2.3 | 17.5 | ×7.58 | 1.36 | 0.00 | 12.50 | 41.57 | match |
| code_mixed | modalities | 2.3 | 15.6 | ×6.79 | 1.63 | 0.01 | 12.87 | 48.77 | match |
| math_latex | modalities | 2.5 | 12.4 | ×5.02 | 2.05 | 0.00 | 12.17 | 64.88 | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · geomean ×3.00</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-llama-2-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 29.7 | ×7.02 | 0.04 | 14.59 | 0.28 | 19.01 | match |
| arb_Arab | lang | 8.9 | 30.7 | ×3.47 | 0.03 | 16.91 | 0.30 | 15.56 | match |
| ben_Beng | lang | 9.5 | 49.8 | ×5.24 | 0.04 | 11.41 | 0.01 | 8.81 | match |
| cmn_Hani | lang | 7.8 | 61.5 | ×7.86 | 0.06 | 3.01 | 0.00 | 12.50 | match |
| ell_Grek | lang | 8.6 | 32.7 | ×3.80 | 0.03 | 18.27 | 0.00 | 11.74 | match |
| eng_Latn | lang | 4.1 | 5.7 | ×1.40 | 0.05 | 30.44 | 0.00 | 144.75 | match |
| heb_Hebr | lang | 8.6 | 33.5 | ×3.89 | 0.03 | 17.64 | 0.04 | 12.37 | match |
| hin_Deva | lang | 10.4 | 42.6 | ×4.08 | 0.03 | 14.73 | 0.03 | 9.04 | match |
| jpn_Jpan | lang | 10.8 | 76.6 | ×7.07 | 0.05 | 2.73 | 0.00 | 9.79 | match |
| kat_Geor | lang | 12.4 | 56.4 | ×4.55 | 0.05 | 9.57 | 0.16 | 8.23 | match |
| kor_Hang | lang | 6.3 | 31.8 | ×5.06 | 0.06 | 17.14 | 0.00 | 14.37 | match |
| rus_Cyrl | lang | 7.5 | 14.1 | ×1.87 | 0.04 | 14.34 | 0.00 | 56.69 | match |
| tam_Taml | lang | 10.8 | 59.1 | ×5.45 | 0.03 | 8.82 | 0.11 | 8.26 | match |
| tha_Thai | lang | 13.4 | 70.2 | ×5.25 | 0.03 | 4.76 | 0.00 | 9.40 | match |
| added_normalized_dense | modalities | 5.0 | 8.2 | ×1.63 | 0.07 | 19.10 | 0.00 | 104.55 | match |
| added_normalized_sparse | modalities | 4.5 | 6.7 | ×1.48 | 0.07 | 27.89 | 0.00 | 122.07 | match |
| added_special_dense | modalities | 4.6 | 12.2 | ×2.67 | 5.30 | 45.28 | 1.07 | 27.62 | match |
| added_special_sparse | modalities | 6.0 | 7.8 | ×1.29 | 2.19 | 41.61 | 0.32 | 79.97 | match |
| agentic-traces | modalities | 4.1 | 6.3 | ×1.55 | 0.26 | 27.39 | 0.09 | 127.41 | match |
| agentic_swe | modalities | 3.9 | 5.8 | ×1.50 | 0.09 | 50.14 | 0.14 | 121.51 | match |
| code_mixed | modalities | 3.9 | 5.8 | ×1.50 | 0.03 | 39.32 | 0.00 | 127.76 | match |
| math_latex | modalities | 4.1 | 6.1 | ×1.49 | 0.07 | 26.04 | 0.00 | 137.39 | match |

</details>

<details><summary><b>llama-3</b> — split-heavy byte-level BPE, single regex · geomean ×4.05</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-llama-3-stages-light.png" width="860">
</picture>

| Fixture | Group | Tokenizer MB/s | Pipeline MB/s | Speedup | added ns/B | norm ns/B | pre-tok ns/B | model ns/B | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.0 | 22.6 | ×7.47 | 0.67 | 0.00 | 27.71 | 15.20 | match |
| arb_Arab | lang | 3.6 | 11.9 | ×3.26 | 0.60 | 0.00 | 32.49 | 50.84 | match |
| ben_Beng | lang | 2.7 | 13.0 | ×4.82 | 0.59 | 0.00 | 46.16 | 30.91 | match |
| cmn_Hani | lang | 3.8 | 12.8 | ×3.35 | 0.61 | 0.00 | 20.38 | 55.60 | match |
| ell_Grek | lang | 3.8 | 12.9 | ×3.40 | 0.60 | 0.00 | 29.96 | 45.07 | match |
| eng_Latn | lang | 3.4 | 14.3 | ×4.19 | 2.08 | 0.04 | 47.49 | 15.17 | match |
| heb_Hebr | lang | 2.9 | 15.1 | ×5.14 | 0.60 | 0.00 | 29.43 | 34.92 | match |
| hin_Deva | lang | 3.7 | 16.6 | ×4.50 | 0.60 | 0.00 | 50.63 | 6.22 | match |
| jpn_Jpan | lang | 4.3 | 12.9 | ×2.98 | 0.60 | 0.00 | 18.30 | 56.30 | match |
| kat_Geor | lang | 3.7 | 23.2 | ×6.28 | 0.60 | 0.00 | 17.83 | 24.24 | match |
| kor_Hang | lang | 3.3 | 12.5 | ×3.74 | 0.61 | 0.00 | 31.99 | 47.59 | match |
| rus_Cyrl | lang | 4.0 | 12.1 | ×3.05 | 0.60 | 0.00 | 27.74 | 53.86 | match |
| tam_Taml | lang | 2.8 | 13.7 | ×4.97 | 0.60 | 0.00 | 45.27 | 28.18 | match |
| tha_Thai | lang | 4.3 | 13.3 | ×3.07 | 0.60 | 0.00 | 29.72 | 42.43 | match |
| added_normalized_dense | modalities | 3.7 | 16.2 | ×4.42 | 0.76 | 0.00 | 25.45 | 32.24 | match |
| added_normalized_sparse | modalities | 4.1 | 17.9 | ×4.43 | 1.34 | 0.00 | 33.77 | 17.48 | match |
| added_special_dense | modalities | 3.5 | 12.7 | ×3.60 | 5.28 | 0.41 | 68.77 | 2.75 | match |
| added_special_sparse | modalities | 4.0 | 15.1 | ×3.75 | 3.35 | 0.07 | 55.52 | 4.19 | match |
| agentic-traces | modalities | 3.1 | 12.0 | ×3.83 | 1.86 | 0.00 | 58.19 | 19.06 | match |
| agentic_swe | modalities | 3.2 | 10.7 | ×3.35 | 1.35 | 0.00 | 61.19 | 29.96 | match |
| code_mixed | modalities | 3.3 | 13.0 | ×3.91 | 1.63 | 0.02 | 56.28 | 14.68 | match |
| math_latex | modalities | 3.1 | 12.6 | ×4.04 | 1.98 | 0.00 | 54.34 | 17.38 | match |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29094044569-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
