### PR TITLE
bench(pipeline): per-stage split cost as share% (+ ns), readable regardless of baseline

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -31,10 +31,12 @@ always-visible charts:
      measurement, via --binary-sizes).
 
 Everything else is collapsed into per-model <details> blocks: a per-fixture
-×speedup chart, the pipeline stage decomposition (ablation-ladder view with a
-release-total tick per row), and the numbers table. Models the pipeline can't
-build yet render as compact "not supported" roadmap cards. Charts are rendered
-full-size so readers can zoom.
+×speedup chart, the pipeline stage decomposition (100%-normalized per fixture —
+each stage as its share of that fixture's own encode time, labelled `share% ·
+ns/B`, so the mix reads regardless of how slow the release baseline is; total
+ns/B and ×speedup stay in the right column), and the numbers table (which carries
+the same per-stage `share% (ns/B)` columns). Models the pipeline can't build yet
+render as compact "not supported" roadmap cards. Charts are full-size for zoom.
 """
 import argparse
 import json
@@ -459,30 +461,6 @@ def has_stages(model):
     return any("stage_ns_per_byte" in r for r in model["results"])
 
 
-def baseline_ns_per_byte(row):
-    """The release's whole-encode cost in the stage chart's unit (MB/s →
-    ns/byte), so it can be drawn as a tick on the pipeline's stacked bar."""
-    v = row["mbps"]["baseline"]
-    return 1000.0 / v if v else None
-
-
-def stage_scale(models):
-    """Shared linear ns/byte range across every fixture's total — and the
-    release ticks, so they always land on-plot — keeping the stacked stage
-    bars comparable across models."""
-    vals = []
-    for m in models:
-        for r in m["results"]:
-            if "stage_ns_per_byte" not in r:
-                continue
-            vals.append(r["stage_ns_per_byte"]["total"])
-            ref = baseline_ns_per_byte(r)
-            if ref:
-                vals.append(ref)
-    vals = [v for v in vals if v > 0]
-    return max(vals) * 1.05 if vals else 1.0
-
-
 def stage_mix(rows):
     """Mean per-stage share of total, as a list of (label, fraction), largest first."""
     acc = {k: 0.0 for k, _ in STAGES}
@@ -500,26 +478,31 @@ def stage_mix(rows):
     return sorted(((label[k], acc[k] / n) for k in acc), key=lambda kv: -kv[1])
 
 
-def stage_chart_svg(model, mode, subtitle_base, meta, max_total, baseline_label):
-    """Per-fixture stacked decomposition of the pipeline's own encode time
-    (ns/byte). Shows where the pipeline spends its time; the tick puts the
-    release's whole-encode cost on the same scale, so bar vs tick reads the
-    same way as the ×speedup chart."""
+def stage_cell(s, key):
+    """One stage's cost as `share% (ns/B)` for the per-fixture table, else `—`."""
+    if not s or not s.get("total") or key not in s:
+        return "—"
+    val, total = s[key], s["total"]
+    return f"{100 * val / total:.0f}% ({val:.1f})"
+
+
+def stage_chart_svg(model, mode, subtitle_base, meta, baseline_label):
+    """Per-fixture breakdown of where the pipeline spends its OWN encode time, as a
+    100%-normalized stacked bar: each stage is its share of THAT fixture's total,
+    labelled `share% · ns/B`. Normalizing per row (instead of a shared ns/byte scale
+    anchored to the slow release) keeps the mix readable no matter the absolute cost;
+    the right column keeps the total ns/byte and the ×speedup vs the release, so
+    neither the magnitude nor the comparison is lost."""
     ink = INK[mode]
     sink = STAGE_INK[mode]
     rows = [r for r in model["results"] if "stage_ns_per_byte" in r]
 
-    def w(v):  # ns/byte -> px width on the shared scale
-        return (v / max_total) * PLOT_W if max_total else 0.0
-
     top = 84
     col_x = GUTTER + PLOT_W + PAD_R + COL_W - 16
-    # Unlike the speedup chart above it, bars here grow with *time*: call the
-    # direction out explicitly so the two charts can't be read the same way.
     body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-            f'text-anchor="end">ns/byte · ×speedup</text>',
+            f'text-anchor="end">total ns/B · ×speedup</text>',
             f'<text x="{GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
-            f'time per byte — shorter is faster · tick = {escape(baseline_label)} total</text>']
+            f'share of pipeline encode time (each bar = 100%) · label = share% · ns/B</text>']
     y = top
     for key, title in GROUPS:
         group_rows = sorted((r for r in rows if r["group"] == key),
@@ -531,31 +514,29 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total, baseline_label)
         y += 22
         for r in group_rows:
             s = r["stage_ns_per_byte"]
+            total = s["total"] or 1.0
             by = y + (ROW_H - BAR_H) / 2
             body.append(f'<text x="{GUTTER - 10}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
                         f'font-size="12.5" text-anchor="end">{escape(r["fixture"])}</text>')
             cursor = float(GUTTER)
             for skey, _ in STAGES:
                 val = s.get(skey, 0.0)
-                seg = w(val)
+                frac = val / total
+                seg = frac * PLOT_W  # each bar fills PLOT_W (100% of this fixture's total)
                 if seg > 0.4:
                     body.append(f'<rect x="{cursor:.1f}" y="{by}" width="{seg:.1f}" '
                                 f'height="{BAR_H}" fill="{sink[skey]}"/>')
-                    # ns/byte inside the slice when it's wide enough to read
-                    if seg >= 24:
-                        txt = f"{val:.0f}" if val >= 9.5 else f"{val:.1f}"
+                    # share% (plus ns/B when the slice is wide enough for both)
+                    if seg >= 22:
+                        pct = f"{100 * frac:.0f}%"
+                        ns = f"{val:.0f}" if val >= 9.5 else f"{val:.1f}"
+                        txt = f"{pct} · {ns}" if seg >= 62 else pct
                         body.append(f'<text x="{cursor + seg / 2:.1f}" y="{y + ROW_H / 2 + 4}" '
                                     f'fill="{text_on(sink[skey])}" font-size="10.5" '
                                     f'text-anchor="middle" style="font-variant-numeric:tabular-nums">'
                                     f'{txt}</text>')
                 cursor += seg
-            # the release's total on the same scale: bar shorter than the tick
-            # ⇔ pipeline faster ⇔ ×speedup ≥ 1
-            ref = baseline_ns_per_byte(r)
-            if ref:
-                rx = GUTTER + w(ref)
-                body.append(f'<line x1="{rx:.1f}" y1="{by - 3}" x2="{rx:.1f}" y2="{by + BAR_H + 3}" '
-                            f'stroke="{ink["primary"]}" stroke-width="1.5"/>')
+            # magnitude + comparison kept in the right column (the % bar drops both)
             vs = speedup(r)
             body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
                         f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
@@ -563,28 +544,25 @@ def stage_chart_svg(model, mode, subtitle_base, meta, max_total, baseline_label)
             y += ROW_H
         y += 10
 
-    # x-axis: round ns/byte gridlines + ticks, unit on the last one
+    # x-axis: fixed 0–100% gridlines
     grid = []
-    axis_ticks = nice_ticks(max_total)
-    for tv in axis_ticks:
-        unit = " ns/B" if tv == axis_ticks[-1] else ""
-        gx = GUTTER + w(tv)
+    for pct in (0, 25, 50, 75, 100):
+        gx = GUTTER + pct / 100 * PLOT_W
         grid.append(f'<line x1="{gx:.1f}" y1="{top - 6}" x2="{gx:.1f}" y2="{y - 6}" '
                     f'stroke="{ink["grid"]}" stroke-width="1"/>')
         grid.append(f'<text x="{gx:.1f}" y="{y + 12}" fill="{ink["muted"]}" font-size="11" '
-                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{unit}</text>')
+                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">'
+                    f'{pct}{"%" if pct == 100 else ""}</text>')
 
-    # legend row: the stage colors + the release-tick glyph
+    # legend row: the stage colors
     y += 26
-    entries = [("swatch", k, lbl) for k, lbl in STAGES]
-    entries.append(("tick", ink["primary"], f"{baseline_label} total"))
-    legend = legend_row(ink, sink, y, entries)
+    legend = legend_row(ink, sink, y, [("swatch", k, lbl) for k, lbl in STAGES])
     height = y + 34
 
     mix = stage_mix(rows)
     mix_txt = " · ".join(f"{lbl} {100 * frac:.0f}%" for lbl, frac in mix)
     subtitle = f'{model["shape"]} · stage mix: {mix_txt}'
-    return svg_doc(ink, height, f'{model["model"]} — Pipeline encode stage decomposition',
+    return svg_doc(ink, height, f'{model["model"]} — Pipeline encode stage mix',
                    subtitle, "".join(grid) + "".join(body) + legend, meta, subtitle_base)
 
 
@@ -747,8 +725,12 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
             md += [picture(base, run_id, f"{slug}-stages",
                            f"{m['model']} stage decomposition", 860), ""]
         md += [mem_line(m, baseline_label), ""]
-        md += [f"| Fixture | Group | {baseline_label} MB/s | Pipeline MB/s | Speedup | Ids |",
-               "|---|---|---:|---:|---:|:--|"]
+        # Per-stage columns show each split's share of the pipeline's own encode time
+        # with the ns/byte alongside — `share% (ns/B)` — so the split cost is readable
+        # as text regardless of how slow the release baseline is.
+        md += [f"| Fixture | Group | {baseline_label} MB/s | Pipeline MB/s | Speedup "
+               "| added-token | normalize | pre-tokenize | model | Ids |",
+               "|---|---|---:|---:|---:|---:|---:|---:|---:|:--|"]
         for r in sorted(m["results"], key=lambda r: (r["group"], r["fixture"])):
             mb = r["mbps"]
             flags = []
@@ -757,11 +739,14 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
             if r.get("ids_match_baseline") is False:
                 flags.append(f"≠ {baseline_label}")
             ids = " · ".join(flags) if flags else "match"
+            s = r.get("stage_ns_per_byte")
+            stages = " ".join(f"| {stage_cell(s, k)}"
+                              for k in ("added_split", "normalize", "pre_tokenize", "model"))
             md.append(
                 f"| {r['fixture']} | {r['group']} "
                 f"| {fnum(mb.get('baseline'))} | {fnum(mb.get('pipeline'))} "
                 f"| {fnum(speedup(r), '×{:.2f}')} "
-                f"| {ids} |")
+                f"{stages} | {ids} |")
         md += ["", "</details>", ""]
 
     # Unsupported / failed-to-load models: roadmap cards, collapsed — they're
@@ -808,7 +793,6 @@ def main():
     sizes = json.loads(Path(args.binary_sizes).read_text()) if args.binary_sizes else None
     benched = [m for m in models if m["results"]]
     lo, hi = scale(benched)
-    max_total = stage_scale(benched)
     out = Path(args.out_dir)
     for mode in ("light", "dark"):
         (out / f"pipeline_bench_overview_{mode}.svg").write_text(
@@ -826,7 +810,7 @@ def main():
             (out / f"pipeline_bench_{slug}_{mode}.svg").write_text(svg)
             if has_stages(m):
                 (out / f"pipeline_bench_{slug}-stages_{mode}.svg").write_text(
-                    stage_chart_svg(m, mode, args.subtitle, meta, max_total, baseline_label))
+                    stage_chart_svg(m, mode, args.subtitle, meta, baseline_label))
 
     (out / "pipeline_bench.md").write_text(
         render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes))


### PR DESCRIPTION
## Problem

The pipeline bench's **stage-decomposition chart** was unreadable. It scaled every fixture's stacked bar to a *shared ns/byte range that included the release's whole-encode tick* (`1000 / baseline_mbps`). The released tokenizer is slow, so that tick is a large ns/byte value that **dominated the scale and crushed the pipeline's own stage breakdown into a sliver** — you couldn't see where the pipeline actually spends its time (normalize vs pre-tokenize vs model).

## Fix

Make the stage chart a **100%-normalized** bar: each stage is its **share of that fixture's own pipeline total**, labelled **`share% · ns/B`**. The mix is now readable no matter the absolute cost, and nothing is lost — the right column keeps **`total ns/B · ×speedup`** so magnitude and the release comparison are still there. The x-axis is a fixed 0–100%.

Dropped the now-moot machinery: the shared absolute scale (`stage_scale`), the release tick (`baseline_ns_per_byte`), and the `max_total` plumbing.

## Also

Restored **per-stage columns to the numbers table** as `share% (ns/B)` — `added-token / normalize / pre-tokenize / model` — so the split cost is legible as text too, e.g. `56% (39.1)` for normalize.

## Notes
- Render-only change (`.github/scripts/render_pipeline_bench.py`); the `fixture_bench` JSON already carries per-stage ns + total, so the share is computed in the renderer.
- Verified: syntax check, no dangling references to the removed helpers, and the chart + table cells render on a sample (normalize `56% (39.1)`, model `21% (13.1)`).

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**5 / 6 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · single thread

`cc07890a3 · 2026-07-10 15:33 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 16 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-overview-dark.png">
  <img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-overview-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-memory-dark.png">
  <img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-memory-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-binsize-dark.png">
  <img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-binsize-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.96 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-bert-base-uncased-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 1+0 (peak 6) · Pipeline 7+0 (peak 7)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.1 | 23.6 | ×3.34 | 3% (1.2) | 64% (27.2) | 22% (9.3) | 11% (4.6) | match |
| arb_Arab | lang | 3.4 | 18.8 | ×5.45 | 2% (1.2) | 52% (27.7) | 25% (13.4) | 21% (11.3) | match |
| ben_Beng | lang | 5.2 | 27.1 | ×5.22 | 3% (1.2) | 52% (19.3) | 24% (8.8) | 21% (7.7) | match |
| cmn_Hani | lang | 3.1 | 15.4 | ×4.95 | 2% (1.2) | 58% (37.6) | 17% (11.0) | 23% (15.0) | match |
| ell_Grek | lang | 3.2 | 18.1 | ×5.61 | 2% (1.2) | 52% (28.8) | 25% (13.6) | 21% (11.7) | match |
| eng_Latn | lang | 3.8 | 17.4 | ×4.60 | 4% (2.5) | 66% (39.1) | 6% (3.5) | 24% (14.1) | match |
| heb_Hebr | lang | 3.5 | 15.8 | ×4.57 | 2% (1.2) | 60% (37.6) | 21% (13.4) | 17% (11.0) | match |
| hin_Deva | lang | 5.5 | 23.0 | ×4.15 | 3% (1.2) | 63% (27.2) | 18% (7.8) | 17% (7.2) | match |
| jpn_Jpan | lang | 3.6 | 21.3 | ×5.86 | 3% (1.2) | 50% (23.3) | 23% (10.8) | 24% (11.3) | match |
| kat_Geor | lang | 5.7 | 22.8 | ×4.04 | 3% (1.2) | 60% (26.3) | 22% (9.8) | 14% (6.3) | match |
| kor_Hang | lang | 2.2 | 13.4 | ×6.20 | 2% (1.2) | 47% (35.0) | 29% (21.6) | 23% (16.9) | match |
| rus_Cyrl | lang | 3.1 | 18.1 | ×5.76 | 2% (1.2) | 50% (27.6) | 25% (13.7) | 23% (12.7) | match |
| tam_Taml | lang | 6.5 | 30.1 | ×4.65 | 3% (1.2) | 56% (18.8) | 25% (8.2) | 15% (5.2) | match |
| tha_Thai | lang | 8.0 | 27.5 | ×3.42 | 3% (1.2) | 70% (25.2) | 21% (7.6) | 6% (2.2) | match |
| added_normalized_dense | modalities | 6.0 | 21.8 | ×3.62 | 3% (1.3) | 86% (40.8) | 3% (1.4) | 8% (3.7) | match |
| added_normalized_sparse | modalities | 4.8 | 19.4 | ×4.05 | 4% (1.9) | 76% (40.3) | 5% (2.7) | 15% (8.2) | match |
| added_special_dense | modalities | 4.7 | 51.1 | ×10.82 | 27% (5.1) | 49% (9.4) | 11% (2.1) | 13% (2.4) | match |
| added_special_sparse | modalities | 3.7 | 23.2 | ×6.29 | 8% (3.7) | 65% (28.0) | 7% (3.2) | 19% (8.4) | match |
| agentic-traces | modalities | 3.3 | 16.7 | ×5.05 | 4% (2.3) | 63% (38.8) | 7% (4.2) | 26% (16.3) | match |
| agentic_swe | modalities | 3.5 | 17.9 | ×5.07 | 3% (1.9) | 68% (38.9) | 5% (3.1) | 24% (13.7) | match |
| code_mixed | modalities | 3.4 | 17.4 | ×5.15 | 4% (2.2) | 66% (38.8) | 6% (3.7) | 24% (14.1) | match |
| math_latex | modalities | 3.4 | 17.0 | ×4.97 | 4% (2.5) | 64% (38.9) | 6% (3.7) | 26% (15.5) | match |

</details>

<details><summary><b>deepseek-v4</b> — split-heavy byte-level BPE, 3 chained regexes · ×2.53 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-deepseek-v4-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 51+0 (peak 58) · Pipeline 84+0 (peak 84)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 13.9 | ×3.58 | 1% (0.7) | 0% (0.0) | 64% (45.6) | 35% (25.2) | match |
| arb_Arab | lang | 3.7 | 9.1 | ×2.47 | 1% (0.6) | 0% (0.0) | 49% (53.2) | 51% (55.6) | match |
| ben_Beng | lang | 4.5 | 11.0 | ×2.43 | 1% (0.6) | 0% (0.0) | 42% (38.8) | 57% (52.0) | match |
| cmn_Hani | lang | 3.4 | 7.9 | ×2.34 | 1% (0.8) | 0% (0.0) | 52% (66.2) | 47% (60.2) | match |
| ell_Grek | lang | 3.7 | 9.7 | ×2.62 | 1% (0.6) | 0% (0.0) | 49% (50.7) | 51% (52.7) | match |
| eng_Latn | lang | 2.7 | 6.6 | ×2.45 | 1% (2.0) | 0% (0.0) | 49% (73.6) | 50% (75.7) | match |
| heb_Hebr | lang | 3.2 | 7.8 | ×2.46 | 0% (0.6) | 0% (0.0) | 42% (54.5) | 57% (74.3) | match |
| hin_Deva | lang | 4.2 | 11.7 | ×2.79 | 1% (0.6) | 0% (0.0) | 50% (42.0) | 50% (41.8) | match |
| jpn_Jpan | lang | 3.8 | 8.8 | ×2.30 | 1% (0.7) | 0% (0.0) | 53% (60.8) | 46% (52.5) | match |
| kat_Geor | lang | 4.5 | 11.3 | ×2.53 | 1% (0.6) | 0% (0.0) | 40% (35.6) | 59% (53.0) | match |
| kor_Hang | lang | 3.3 | 9.6 | ×2.90 | 1% (0.6) | 0% (0.0) | 54% (56.0) | 46% (47.3) | match |
| rus_Cyrl | lang | 3.6 | 8.8 | ×2.46 | 1% (0.6) | 0% (0.0) | 43% (49.6) | 57% (65.6) | match |
| tam_Taml | lang | 4.8 | 11.4 | ×2.39 | 1% (0.6) | 0% (0.0) | 39% (33.8) | 61% (53.0) | match |
| tha_Thai | lang | 5.5 | 10.6 | ×1.93 | 1% (0.6) | 0% (0.0) | 31% (28.8) | 69% (65.0) | match |
| added_normalized_dense | modalities | 4.0 | 11.7 | ×2.95 | 1% (0.7) | 0% (0.0) | 54% (45.9) | 45% (37.9) | match |
| added_normalized_sparse | modalities | 3.6 | 9.8 | ×2.75 | 1% (1.4) | 0% (0.0) | 53% (53.8) | 46% (46.1) | match |
| added_special_dense | modalities | 2.9 | 6.9 | ×2.37 | 5% (6.8) | 0% (0.5) | 83% (116.0) | 12% (17.2) | match |
| added_special_sparse | modalities | 3.2 | 7.4 | ×2.32 | 3% (4.0) | 0% (0.1) | 65% (86.9) | 32% (42.7) | match |
| agentic-traces | modalities | 2.4 | 5.8 | ×2.42 | 1% (1.8) | 0% (0.0) | 66% (110.2) | 33% (54.1) | match |
| agentic_swe | modalities | 2.3 | 5.7 | ×2.41 | 1% (1.4) | 0% (0.0) | 62% (109.3) | 37% (64.8) | match |
| code_mixed | modalities | 2.6 | 7.1 | ×2.70 | 1% (1.6) | 0% (0.0) | 54% (76.3) | 45% (63.3) | match |
| math_latex | modalities | 2.4 | 6.1 | ×2.51 | 1% (1.9) | 0% (0.0) | 53% (87.0) | 46% (75.5) | match |

</details>

<details><summary><b>gpt2</b> — standalone ByteLevel pre-tokenizer · ×7.78 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-gpt2-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 17+1 (peak 18) · Pipeline 20+0 (peak 20)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 39.9 | ×10.22 | 3% (0.7) | 0% (0.0) | 26% (6.2) | 72% (17.4) | match |
| arb_Arab | lang | 3.1 | 22.0 | ×7.02 | 1% (0.6) | 0% (0.0) | 16% (7.3) | 83% (37.8) | match |
| ben_Beng | lang | 2.2 | 29.4 | ×13.33 | 2% (0.6) | 0% (0.0) | 34% (11.4) | 65% (22.0) | match |
| cmn_Hani | lang | 3.3 | 24.6 | ×7.49 | 2% (0.6) | 0% (0.0) | 14% (5.5) | 85% (33.7) | match |
| ell_Grek | lang | 3.2 | 25.0 | ×7.72 | 2% (0.6) | 0% (0.0) | 17% (6.7) | 81% (31.9) | match |
| eng_Latn | lang | 2.8 | 11.9 | ×4.26 | 2% (2.0) | 0% (0.0) | 13% (10.7) | 85% (69.9) | match |
| heb_Hebr | lang | 3.2 | 25.2 | ×7.84 | 2% (0.6) | 0% (0.0) | 19% (7.5) | 79% (30.8) | match |
| hin_Deva | lang | 2.6 | 26.7 | ×10.24 | 2% (0.6) | 0% (0.0) | 31% (11.3) | 68% (25.0) | match |
| jpn_Jpan | lang | 3.6 | 20.0 | ×5.49 | 1% (0.6) | 0% (0.0) | 10% (4.9) | 89% (43.6) | match |
| kat_Geor | lang | 3.7 | 57.3 | ×15.55 | 4% (0.6) | 0% (0.0) | 28% (4.8) | 68% (11.4) | match |
| kor_Hang | lang | 3.0 | 32.1 | ×10.62 | 2% (0.6) | 0% (0.0) | 25% (7.5) | 73% (22.4) | match |
| rus_Cyrl | lang | 3.4 | 23.9 | ×7.09 | 1% (0.6) | 0% (0.0) | 16% (6.5) | 83% (34.0) | match |
| tam_Taml | lang | 2.2 | 34.6 | ×15.79 | 2% (0.6) | 0% (0.0) | 40% (11.5) | 58% (16.7) | match |
| tha_Thai | lang | 2.9 | 27.7 | ×9.50 | 2% (0.6) | 0% (0.0) | 21% (7.4) | 77% (27.4) | match |
| added_normalized_dense | modalities | 3.6 | 22.6 | ×6.25 | 2% (0.7) | 0% (0.0) | 16% (6.6) | 83% (35.2) | match |
| added_normalized_sparse | modalities | 3.4 | 18.6 | ×5.47 | 3% (1.4) | 0% (0.0) | 16% (8.4) | 81% (42.5) | match |
| added_special_dense | modalities | 3.5 | 31.9 | ×9.04 | 17% (5.1) | 0% (0.1) | 32% (9.4) | 50% (14.6) | match |
| added_special_sparse | modalities | 3.3 | 19.0 | ×5.77 | 7% (3.3) | 0% (0.1) | 21% (10.5) | 72% (36.2) | match |
| agentic-traces | modalities | 2.4 | 13.1 | ×5.45 | 2% (1.8) | 0% (0.0) | 18% (13.3) | 80% (60.3) | match |
| agentic_swe | modalities | 2.4 | 17.7 | ×7.27 | 2% (1.3) | 0% (0.0) | 23% (12.6) | 75% (41.3) | match |
| code_mixed | modalities | 2.4 | 15.7 | ×6.49 | 2% (1.6) | 0% (0.0) | 21% (13.1) | 77% (48.7) | match |
| math_latex | modalities | 2.6 | 12.5 | ×4.83 | 2% (1.9) | 0% (0.0) | 16% (12.3) | 82% (65.2) | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×2.81 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-llama-2-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 14+0 (peak 14) · Pipeline 15+0 (peak 15)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 26.2 | ×6.27 | 0% (0.0) | 54% (20.8) | 0% (0.1) | 45% (17.4) | match |
| arb_Arab | lang | 8.6 | 26.5 | ×3.10 | 0% (0.0) | 59% (22.6) | 2% (0.9) | 38% (14.6) | match |
| ben_Beng | lang | 9.2 | 41.5 | ×4.49 | 0% (0.0) | 66% (16.0) | 0% (0.0) | 34% (8.1) | match |
| cmn_Hani | lang | 8.2 | 60.5 | ×7.38 | 0% (0.1) | 22% (3.5) | 0% (0.0) | 77% (12.1) | match |
| ell_Grek | lang | 8.5 | 28.7 | ×3.39 | 0% (0.0) | 64% (22.1) | 1% (0.4) | 35% (12.0) | match |
| eng_Latn | lang | 4.0 | 5.6 | ×1.39 | 0% (0.1) | 24% (43.3) | 0% (0.0) | 76% (135.4) | match |
| heb_Hebr | lang | 8.3 | 27.9 | ×3.34 | 0% (0.0) | 69% (24.7) | 1% (0.5) | 30% (10.8) | match |
| hin_Deva | lang | 10.2 | 35.4 | ×3.46 | 0% (0.0) | 71% (19.9) | 0% (0.0) | 29% (8.2) | match |
| jpn_Jpan | lang | 11.4 | 76.4 | ×6.69 | 0% (0.0) | 25% (3.1) | 0% (0.0) | 75% (9.2) | match |
| kat_Geor | lang | 12.0 | 48.8 | ×4.05 | 0% (0.0) | 62% (12.6) | 1% (0.2) | 37% (7.6) | match |
| kor_Hang | lang | 6.2 | 26.7 | ×4.29 | 0% (0.1) | 62% (23.0) | 4% (1.4) | 34% (12.7) | match |
| rus_Cyrl | lang | 7.9 | 13.4 | ×1.70 | 0% (0.0) | 25% (18.3) | 1% (0.5) | 74% (55.1) | match |
| tam_Taml | lang | 10.4 | 49.4 | ×4.74 | 0% (0.0) | 59% (11.8) | 2% (0.4) | 39% (7.9) | match |
| tha_Thai | lang | 13.6 | 71.2 | ×5.23 | 0% (0.0) | 36% (4.8) | 0% (0.0) | 64% (8.7) | match |
| added_normalized_dense | modalities | 4.9 | 8.2 | ×1.67 | 0% (0.1) | 21% (26.4) | 1% (1.8) | 77% (95.0) | match |
| added_normalized_sparse | modalities | 4.5 | 6.5 | ×1.46 | 0% (0.1) | 24% (37.3) | 0% (0.6) | 75% (115.2) | match |
| added_special_dense | modalities | 4.5 | 12.0 | ×2.69 | 6% (5.1) | 60% (48.2) | 1% (0.8) | 32% (25.8) | match |
| added_special_sparse | modalities | 6.5 | 7.8 | ×1.21 | 2% (2.1) | 33% (41.1) | 0% (0.6) | 65% (82.3) | match |
| agentic-traces | modalities | 4.3 | 6.6 | ×1.53 | 0% (0.1) | 18% (27.1) | 0% (0.2) | 82% (124.4) | match |
| agentic_swe | modalities | 4.0 | 6.1 | ×1.54 | 0% (0.0) | 30% (49.4) | 0% (0.0) | 70% (115.9) | match |
| code_mixed | modalities | 4.1 | 6.3 | ×1.53 | 0% (0.0) | 24% (38.5) | 0% (0.0) | 76% (122.6) | match |
| math_latex | modalities | 4.3 | 6.3 | ×1.47 | 0% (0.1) | 17% (27.0) | 0% (0.0) | 83% (132.6) | match |

</details>

<details><summary><b>llama-3</b> — split-heavy byte-level BPE, single regex · ×4.03 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-llama-3-stages-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 128+0 (peak 189) · Pipeline 129+0 (peak 189)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.1 | 21.9 | ×7.02 | 1% (0.7) | 0% (0.0) | 63% (28.8) | 35% (16.0) | match |
| arb_Arab | lang | 3.6 | 11.7 | ×3.25 | 1% (0.6) | 0% (0.0) | 40% (33.9) | 59% (49.9) | match |
| ben_Beng | lang | 2.8 | 13.4 | ×4.86 | 1% (0.6) | 0% (0.0) | 60% (44.5) | 39% (28.9) | match |
| cmn_Hani | lang | 4.0 | 13.0 | ×3.29 | 1% (0.6) | 0% (0.0) | 28% (21.0) | 71% (53.6) | match |
| ell_Grek | lang | 3.9 | 12.9 | ×3.34 | 1% (0.6) | 0% (0.0) | 39% (30.1) | 61% (47.2) | match |
| eng_Latn | lang | 3.4 | 14.5 | ×4.23 | 3% (2.1) | 0% (0.0) | 67% (47.5) | 30% (21.1) | match |
| heb_Hebr | lang | 3.2 | 14.8 | ×4.67 | 1% (0.6) | 0% (0.0) | 48% (33.5) | 51% (35.2) | match |
| hin_Deva | lang | 3.6 | 16.4 | ×4.51 | 1% (0.6) | 0% (0.0) | 85% (52.0) | 14% (8.3) | match |
| jpn_Jpan | lang | 4.3 | 13.0 | ×3.00 | 1% (0.6) | 0% (0.0) | 26% (19.3) | 74% (55.5) | match |
| kat_Geor | lang | 3.8 | 23.4 | ×6.22 | 1% (0.6) | 0% (0.0) | 43% (18.5) | 55% (23.5) | match |
| kor_Hang | lang | 3.4 | 12.2 | ×3.54 | 1% (0.6) | 0% (0.0) | 42% (33.5) | 58% (46.6) | match |
| rus_Cyrl | lang | 3.9 | 11.9 | ×3.09 | 1% (0.6) | 0% (0.0) | 34% (28.4) | 65% (54.1) | match |
| tam_Taml | lang | 2.8 | 13.4 | ×4.82 | 1% (0.6) | 0% (0.0) | 65% (48.2) | 35% (25.7) | match |
| tha_Thai | lang | 4.2 | 13.5 | ×3.18 | 1% (0.7) | 0% (0.0) | 41% (30.3) | 58% (42.6) | match |
| added_normalized_dense | modalities | 3.7 | 16.2 | ×4.38 | 1% (0.7) | 0% (0.0) | 44% (26.7) | 55% (33.3) | match |
| added_normalized_sparse | modalities | 4.0 | 17.6 | ×4.37 | 2% (1.4) | 0% (0.0) | 64% (35.8) | 34% (19.1) | match |
| added_special_dense | modalities | 3.4 | 12.3 | ×3.61 | 6% (5.0) | 0% (0.1) | 91% (72.7) | 3% (2.1) | match |
| added_special_sparse | modalities | 3.8 | 14.6 | ×3.89 | 5% (3.2) | 0% (0.0) | 87% (58.7) | 8% (5.3) | match |
| agentic-traces | modalities | 3.0 | 12.0 | ×3.97 | 2% (1.7) | 0% (0.0) | 69% (58.1) | 29% (24.6) | match |
| agentic_swe | modalities | 3.1 | 10.6 | ×3.43 | 1% (1.3) | 0% (0.0) | 66% (61.8) | 32% (30.1) | match |
| code_mixed | modalities | 3.3 | 13.7 | ×4.21 | 2% (1.5) | 0% (0.0) | 72% (56.7) | 26% (20.1) | match |
| math_latex | modalities | 3.1 | 12.4 | ×4.07 | 2% (1.9) | 0% (0.0) | 72% (57.3) | 26% (20.3) | match |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29103514310-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
