### PR TITLE
Emit UserWarning from Split.pre_tokenize_str() on zero matches

### DIFF
--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -40,3 +40,8 @@ pub(crate) fn deprecation_warning(py: Python<'_>, version: &str, message: &str) 
     let full_message = format!("Deprecated in {version}: {message}");
     pyo3::PyErr::warn(py, &deprecation_warning, &CString::new(full_message)?, 0)
 }
+
+pub(crate) fn user_warning(py: Python<'_>, message: &str) -> PyResult<()> {
+    let user_warning = py.import("builtins")?.getattr("UserWarning")?;
+    pyo3::PyErr::warn(py, &user_warning, &CString::new(message)?, 0)
+}

--- a/bindings/python/src/pre_tokenizers.rs
+++ b/bindings/python/src/pre_tokenizers.rs
@@ -180,16 +180,37 @@ impl PyPreTokenizer {
     ///     :obj:`List[Tuple[str, Offsets]]`:
     ///         A list of tuple with the pre-tokenized parts and their offsets
     #[pyo3(text_signature = "(self, sequence)")]
-    fn pre_tokenize_str(&self, s: &str) -> PyResult<Vec<(String, Offsets)>> {
+    fn pre_tokenize_str(&self, py: Python<'_>, s: &str) -> PyResult<Vec<(String, Offsets)>> {
         let mut pretokenized = tk::tokenizer::PreTokenizedString::from(s);
 
         ToPyResult(self.pretok.pre_tokenize(&mut pretokenized)).into_py()?;
 
-        Ok(pretokenized
+        let result: Vec<(String, Offsets)> = pretokenized
             .get_splits(tk::OffsetReferential::Original, tk::OffsetType::Char)
             .into_iter()
             .map(|(s, o, _)| (s.to_owned(), o))
-            .collect())
+            .collect();
+
+        if let PyPreTokenizerTypeWrapper::Single(ref single) = self.pretok {
+            if let Ok(guard) = single.read() {
+                if let PyPreTokenizerWrapper::Wrapped(PreTokenizerWrapper::Split(ref split)) =
+                    *guard
+                {
+                    if let tk::pre_tokenizers::split::SplitPattern::String(ref pat) = split.pattern
+                    {
+                        let char_len = s.chars().count();
+                        if char_len > 1 && result.len() == 1 && result[0].1 == (0, char_len) {
+                            let msg = format!(
+                                "Split(pattern={pat:?}, ...).pre_tokenize_str() returned the entire input as a single piece (no matches). If you intended regex semantics, wrap the pattern in tokenizers.Regex(); a plain string is matched literally."
+                            );
+                            crate::error::user_warning(py, &msg)?;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(result)
     }
 
     fn __repr__(&self) -> PyResult<String> {

--- a/bindings/python/tests/bindings/test_pre_tokenizers.py
+++ b/bindings/python/tests/bindings/test_pre_tokenizers.py
@@ -64,6 +64,39 @@ class TestSplit:
         assert isinstance(pre_tokenizer_with_invert, Split)
         assert isinstance(pickle.loads(pickle.dumps(Split(" ", "removed", True))), Split)
 
+    def test_warn_str_pattern_no_match(self):
+        from tokenizers import Regex
+        import warnings
+
+        # String pattern that looks like regex → no matches → warning fires
+        pre_tokenizer = Split(pattern="[a-z]+", behavior="isolated")
+        with pytest.warns(UserWarning, match="returned the entire input as a single piece"):
+            pre_tokenizer.pre_tokenize_str("hello world")
+
+        # Regex pattern with the same expression → matches fine → no warning
+        pre_tokenizer_regex = Split(pattern=Regex("[a-z]+"), behavior="isolated")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            pre_tokenizer_regex.pre_tokenize_str("hello world")
+
+        # String pattern that genuinely matches (space) → no warning
+        pre_tokenizer_space = Split(pattern=" ", behavior="removed")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = pre_tokenizer_space.pre_tokenize_str("hello world")
+            assert len(result) == 2
+
+        # Single-char input → guarded by len > 1 → no warning
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            pre_tokenizer.pre_tokenize_str("a")
+
+        # Empty input → no warning
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            pre_tokenizer.pre_tokenize_str("")
+
+
 
 class TestWhitespace:
     def test_instantiate(self):


### PR DESCRIPTION
Closes #2109

 ## What this PR does                                                                                                                                                                   
                                                                                                                                                                                           
    When `Split` is configured with a plain string pattern (not wrapped in `Regex()`) and `pre_tokenize_str()` returns the entire input as a single piece (zero matches), this PR emits a  
  `UserWarning` suggesting the user wrap the pattern in `tokenizers.Regex()`.                                                                                                              
                                                                                                                                                                                           
    This catches the common silent-failure mode where users pass regex metacharacters as a literal string (e.g. `"[a-z]+"`), which matches nothing in natural text and silently returns the
  full input unchanged — potentially causing months of incorrect tokenization downstream.                                                                                                  
                                                                                                                                                                                           
    ## Example                                                                                                                                                                             
                                                                                                                                                                                           
    ```python                                                                                                                                                                              
    from tokenizers.pre_tokenizers import Split                                                                                                                                            
                                                                                                                                                                                           
    # BEFORE: returns [("hello world", (0, 11))], completely silent                                                                                                                        
    Split(pattern="[a-z]+", behavior="isolated").pre_tokenize_str("hello world")                                                                                                           
                                                                                                                                                                                           
    # AFTER: same return value + UserWarning:                                                                                                                                              
    # "Split(pattern="[a-z]+", ...).pre_tokenize_str() returned the entire                                                                                                                 
    #  input as a single piece (no matches). If you intended regex semantics,                                                                                                              
    #  wrap the pattern in tokenizers.Regex(); a plain string is matched literally."                                                                                                       
                                                                                                                                                                                           
  ## Changes                                                                                                                                                                               
                                                                                                                                                                                           
  •  bindings/python/src/error.rs  — Added  user_warning()  helper (mirrors existing  deprecation_warning() )                                                                              
  •  bindings/python/src/pre_tokenizers.rs  — Added zero-match detection in  pre_tokenize_str()  for  String -pattern  Split                                                               
  •  bindings/python/tests/bindings/test_pre_tokenizers.py  — Added tests covering: warning fires, no warning for  Regex , no warning for working string patterns, single-char input, and  
  empty input                                                                                                                                                                              
                                                                                                                                                                                           
  ## Design decisions                                                                                                                                                                      
  
  • Warning only fires for  SplitPattern::String , never for  Regex 
  • Warning only fires when  len(input) > 1  and result is exactly 1 piece spanning the full input
  •  encode()  and training are completely unchanged — this only affects  pre_tokenize_str() 
  • Warning is suppressible via standard  warnings.filterwarnings("ignore") 