### PR TITLE
bench(pipeline): multi-thread scaling sweep vs latest release

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -689,13 +689,16 @@ def has_threads(m):
 
 
 def threads_svg(model, mode, meta, baseline_label):
-    """Per model: encode throughput (MB/s) over the whole corpus at 1/2/4/8/device-max threads —
-    pipeline vs the release — so both parallel scaling (bars grow down the rows) and the
-    pipeline↔release gap at each thread count are visible on one shared axis."""
+    """Per model: encode throughput (MB/s) at 1/2/4/8/device-max threads — pipeline vs the release —
+    with a per-row *ideal linear* tick (single-thread throughput × N) on the pipeline bar. So whether the
+    pipeline scales linearly (bar reaches the tick) or sub-linearly (bar falls short of it) is visible at a
+    glance, alongside the pipeline↔release gap; the right column carries the self-scaling % of linear."""
     ink, sink = INK[mode], SERIES_INK[mode]
     t = model["threads"]
     counts, pipe, base = t["counts"], t["pipeline_mbps"], t["baseline_mbps"]
-    vals = [v for v in pipe if v] + [v for v in base if v]
+    p1 = pipe[0] if pipe and pipe[0] else None  # single-thread anchor for the linear reference
+    ideal = [p1 * n for n in counts] if p1 else []
+    vals = [v for v in pipe if v] + [v for v in base if v] + ideal
     max_mb = (max(vals) if vals else 1.0) * 1.08
     plot_w = CHART_W - OV_GUTTER - PAD_R - COL_W
 
@@ -706,26 +709,32 @@ def threads_svg(model, mode, meta, baseline_label):
     row_h = 2 * (bar_h + gap) + 16
     col_x = CHART_W - 16
     body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-            f'text-anchor="end">Pipeline MB/s · ×vs {escape(baseline_label)}</text>',
+            f'text-anchor="end">Pipeline MB/s · self-scaling (% of linear)</text>',
             f'<text x="{OV_GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
-            f'higher is better · top bar {escape(baseline_label)}, bottom Pipeline</text>']
+            f'higher is better · top bar {escape(baseline_label)}, bottom Pipeline · tick = ideal linear</text>']
     y = top
     for i, n in enumerate(counts):
         cy = y + row_h / 2
         label = f"{n} thread" + ("" if n == 1 else "s")
         body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 4:.1f}" fill="{ink["primary"]}" '
                     f'font-size="12.5" font-weight="600" text-anchor="end">{label}</text>')
-        by = y + 8
-        for impl, series in (("baseline", base), ("pipeline", pipe)):
-            v = series[i] if i < len(series) else None
-            if v is not None:
-                body.append(hbar(x(0), x(v), by, bar_h, sink[impl]))
-            by += bar_h + gap
-        p = pipe[i] if i < len(pipe) else None
+        base_y, pipe_y = y + 8, y + 8 + bar_h + gap
         b = base[i] if i < len(base) else None
-        right = f"{p:.0f}" if p is not None else "—"
-        if p is not None and b:
-            right += f"  ×{p / b:.2f}"
+        if b is not None:
+            body.append(hbar(x(0), x(b), base_y, bar_h, sink["baseline"]))
+        p = pipe[i] if i < len(pipe) else None
+        if p is not None:
+            body.append(hbar(x(0), x(p), pipe_y, bar_h, sink["pipeline"]))
+        # Ideal-linear reference for the pipeline (single-thread × N): the bar reaching this tick == linear.
+        if p1 is not None and n > 1:
+            ix = x(p1 * n)
+            body.append(f'<line x1="{ix:.1f}" y1="{pipe_y - 2:.1f}" x2="{ix:.1f}" '
+                        f'y2="{pipe_y + bar_h + 2:.1f}" stroke="{ink["primary"]}" stroke-width="1.5"/>')
+        if p is not None and p1:
+            sc = p / p1
+            right = f"{p:.0f} · {sc:.1f}× ({sc / n * 100:.0f}%)"
+        else:
+            right = f"{p:.0f}" if p is not None else "—"
         body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{ink["secondary"]}" font-size="12" '
                     f'text-anchor="end" style="font-variant-numeric:tabular-nums">{right}</text>')
         y += row_h
@@ -743,12 +752,14 @@ def threads_svg(model, mode, meta, baseline_label):
     legend = legend_row(ink, sink, y, [
         ("swatch", "baseline", baseline_label),
         ("swatch", "pipeline", "PipelineTokenizer"),
+        ("tick", ink["primary"], "ideal linear (T₁ × N)"),
     ])
     height = y + 34
     scaling = ""
-    if len(pipe) >= 2 and pipe[0] and pipe[-1]:
-        scaling = f" · {pipe[-1] / pipe[0]:.1f}× from 1→{counts[-1]} threads"
-    subtitle = f"encode over the full corpus at N threads vs {baseline_label}{scaling}"
+    if p1 and len(pipe) >= 2 and pipe[-1]:
+        sc = pipe[-1] / p1
+        scaling = f" · pipeline {sc:.1f}× on {counts[-1]} threads ({sc / counts[-1] * 100:.0f}% of linear)"
+    subtitle = f"throughput at N threads vs {baseline_label}; tick = perfect linear scaling{scaling}"
     return svg_doc(ink, height, "Thread scaling",
                    subtitle, "".join(grid) + "".join(body) + legend, meta)
 

--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -9,6 +9,8 @@ tk-encode/bench-baseline --example fixture_bench`:
      models: [{model, shape, desc, [reason],
                memory: {baseline|pipeline:
                         {load_bytes, encode_bytes, peak_bytes} | null} | null,
+               threads: {counts: [1,2,4,8,max],
+                         pipeline_mbps: [..], baseline_mbps: [..|null]},
                results: [{fixture, group, bytes, chunks,
                           mbps: {baseline, pipeline},
                           ids_match, ids_match_baseline,
@@ -31,7 +33,8 @@ always-visible charts:
      measurement, via --binary-sizes).
 
 Everything else is collapsed into per-model <details> blocks: a per-fixture
-×speedup chart, the pipeline stage decomposition (100%-normalized per fixture —
+×speedup chart, a thread-scaling chart (encode throughput at 1/2/4/8/device-max
+threads, pipeline vs the release), the pipeline stage decomposition (100%-normalized per fixture —
 each stage as its share of that fixture's own encode time, labelled `share% ·
 ns/B`, so the mix reads regardless of how slow the release baseline is; total
 ns/B and ×speedup stay in the right column), and the numbers table (which carries
@@ -680,6 +683,76 @@ def binsize_svg(sizes, mode, meta, baseline_label):
                    subtitle, "".join(grid) + "".join(body), meta)
 
 
+def has_threads(m):
+    t = m.get("threads")
+    return isinstance(t, dict) and bool(t.get("counts"))
+
+
+def threads_svg(model, mode, meta, baseline_label):
+    """Per model: encode throughput (MB/s) over the whole corpus at 1/2/4/8/device-max threads —
+    pipeline vs the release — so both parallel scaling (bars grow down the rows) and the
+    pipeline↔release gap at each thread count are visible on one shared axis."""
+    ink, sink = INK[mode], SERIES_INK[mode]
+    t = model["threads"]
+    counts, pipe, base = t["counts"], t["pipeline_mbps"], t["baseline_mbps"]
+    vals = [v for v in pipe if v] + [v for v in base if v]
+    max_mb = (max(vals) if vals else 1.0) * 1.08
+    plot_w = CHART_W - OV_GUTTER - PAD_R - COL_W
+
+    def x(v):
+        return OV_GUTTER + v / max_mb * plot_w
+
+    top, bar_h, gap = 78, 11, 3
+    row_h = 2 * (bar_h + gap) + 16
+    col_x = CHART_W - 16
+    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+            f'text-anchor="end">Pipeline MB/s · ×vs {escape(baseline_label)}</text>',
+            f'<text x="{OV_GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
+            f'higher is better · top bar {escape(baseline_label)}, bottom Pipeline</text>']
+    y = top
+    for i, n in enumerate(counts):
+        cy = y + row_h / 2
+        label = f"{n} thread" + ("" if n == 1 else "s")
+        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 4:.1f}" fill="{ink["primary"]}" '
+                    f'font-size="12.5" font-weight="600" text-anchor="end">{label}</text>')
+        by = y + 8
+        for impl, series in (("baseline", base), ("pipeline", pipe)):
+            v = series[i] if i < len(series) else None
+            if v is not None:
+                body.append(hbar(x(0), x(v), by, bar_h, sink[impl]))
+            by += bar_h + gap
+        p = pipe[i] if i < len(pipe) else None
+        b = base[i] if i < len(base) else None
+        right = f"{p:.0f}" if p is not None else "—"
+        if p is not None and b:
+            right += f"  ×{p / b:.2f}"
+        body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{ink["secondary"]}" font-size="12" '
+                    f'text-anchor="end" style="font-variant-numeric:tabular-nums">{right}</text>')
+        y += row_h
+
+    grid = []
+    ticks = nice_ticks(max_mb)
+    for tv in ticks:
+        unit = " MB/s" if tv == ticks[-1] else ""
+        gx = x(tv)
+        grid.append(f'<line x1="{gx:.1f}" y1="{top - 6}" x2="{gx:.1f}" y2="{y - 4}" '
+                    f'stroke="{ink["grid"]}" stroke-width="1"/>')
+        grid.append(f'<text x="{gx:.1f}" y="{y + 10}" fill="{ink["muted"]}" font-size="11" '
+                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{unit}</text>')
+    y += 30
+    legend = legend_row(ink, sink, y, [
+        ("swatch", "baseline", baseline_label),
+        ("swatch", "pipeline", "PipelineTokenizer"),
+    ])
+    height = y + 34
+    scaling = ""
+    if len(pipe) >= 2 and pipe[0] and pipe[-1]:
+        scaling = f" · {pipe[-1] / pipe[0]:.1f}× from 1→{counts[-1]} threads"
+    subtitle = f"encode over the full corpus at N threads vs {baseline_label}{scaling}"
+    return svg_doc(ink, height, "Thread scaling",
+                   subtitle, "".join(grid) + "".join(body) + legend, meta)
+
+
 def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
     """Overview charts inline; everything per-model — charts and the per-fixture
     table — inside one <details> block per model, so the PR description stays a
@@ -724,6 +797,9 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
         if has_stages(m):
             md += [picture(base, run_id, f"{slug}-stages",
                            f"{m['model']} stage decomposition", 860), ""]
+        if has_threads(m):
+            md += [picture(base, run_id, f"{slug}-threads",
+                           f"{m['model']} thread scaling", 860), ""]
         md += [mem_line(m, baseline_label), ""]
         # Per-stage columns show each split's share of the pipeline's own encode time
         # with the ns/byte alongside — `share% (ns/B)` — so the split cost is readable
@@ -811,6 +887,9 @@ def main():
             if has_stages(m):
                 (out / f"pipeline_bench_{slug}-stages_{mode}.svg").write_text(
                     stage_chart_svg(m, mode, args.subtitle, meta, baseline_label))
+            if has_threads(m):
+                (out / f"pipeline_bench_{slug}-threads_{mode}.svg").write_text(
+                    threads_svg(m, mode, meta, baseline_label))
 
     (out / "pipeline_bench.md").write_text(
         render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes))

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -5,9 +5,16 @@ name: Pipeline Benchmark
 # `Tokenizer` is being phased out, so it is only the id-correctness oracle,
 # never a benched series), for every model in
 # tk-encode/examples/bench_models.json across every corpus in data/fixtures/.
-# Measures throughput (~10 kB inputs), per-implementation memory footprint
-# (RSS), and stripped minimal-binary size. The release dep is behind
-# tk-encode's `bench-baseline` feature, so production builds never pull it.
+# Measures single- and multi-thread throughput (1/2/4/8/device-max), per-
+# implementation memory footprint (RSS), and stripped minimal-binary size. The
+# release dep is behind tk-encode's `bench-baseline` feature, so production
+# builds never pull it.
+#
+# The work is fanned out across a matrix: each `bench` shard benches a slice of
+# the models on its own isolated 8-vCPU runner (so the multi-thread sweep is
+# accurate and the shards run in parallel), emitting a partial JSON; the single
+# `report` job then concatenates the partials and renders/uploads/updates once.
+#
 # Triggers:
 #   • push to feat/train_encode_split → benches and updates PR #2119's description.
 #   • add the "run-pipeline-bench" label to any PR → benches that PR and updates
@@ -54,16 +61,62 @@ concurrency:
 env:
   RUSTC_WRAPPER: sccache
   SCCACHE_GHA_ENABLED: "true"
+  # Keep in sync with the matrix.shard list below (and passed to `--shard <i> N`).
+  SHARDS: "4"
 
 jobs:
-  pipeline-bench:
-    name: PipelineTokenizer vs latest release
+  # Fan-out: each shard benches the i-th of SHARDS contiguous manifest slices on
+  # its own 8-vCPU runner (isolated + parallel) and uploads its partial JSON.
+  bench:
+    name: bench shard ${{ matrix.shard }}
     # push / dispatch always run; a labeled PR runs only for our label.
     if: github.event_name != 'pull_request' || github.event.label.name == 'run-pipeline-bench'
-    # Same dedicated runner group as benchmarks.yml — shared 2-vCPU runners
-    # produce noisy timings. The comparison is within-run (both impls, same
-    # machine, interleaved), so absolute noise matters less than for baselines,
-    # but keep the environment consistent anyway.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    runs-on:
+      group: aws-general-8-plus
+    defaults:
+      run:
+        working-directory: tokenizers
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Download fixtures and model tokenizers
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: make fixtures bench-models HF="uvx --from huggingface_hub hf"
+
+      - name: Run comparative benchmark (shard ${{ matrix.shard }} of ${{ env.SHARDS }})
+        run: |
+          cargo run --release -p tk-encode --features tk-encode/bench-baseline \
+            --example fixture_bench -- --shard ${{ matrix.shard }} ${{ env.SHARDS }} \
+            > "pipeline_bench_${{ matrix.shard }}.json"
+          cat "pipeline_bench_${{ matrix.shard }}.json"
+
+      - name: Upload shard partial
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: partial-${{ matrix.shard }}
+          path: tokenizers/pipeline_bench_${{ matrix.shard }}.json
+          retention-days: 3
+
+  # Fan-in: concatenate the shard partials (in shard order = manifest order),
+  # then render + upload charts + update the PR, once.
+  report:
+    name: PipelineTokenizer vs latest release
+    needs: bench
+    if: github.event_name != 'pull_request' || github.event.label.name == 'run-pipeline-bench'
     runs-on:
       group: aws-general-8-plus
     defaults:
@@ -86,16 +139,38 @@ jobs:
       - name: Install libcairo
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libcairo2
 
-      - name: Download fixtures and model tokenizers
+      # Only the model tokenizers are needed here (gpt2.json for binsize); the
+      # fixture corpora aren't — the numbers already live in the shard JSONs.
+      - name: Download model tokenizers
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: make fixtures bench-models HF="uvx --from huggingface_hub hf"
+        run: make bench-models HF="uvx --from huggingface_hub hf"
 
-      - name: Run comparative benchmark
+      - name: Download shard partials
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          pattern: partial-*
+          merge-multiple: true
+          path: tokenizers/partials
+
+      - name: Merge shard partials
         run: |
-          cargo run --release -p tk-encode --features tk-encode/bench-baseline \
-            --example fixture_bench > pipeline_bench.json
-          cat pipeline_bench.json
+          python3 - <<'PY'
+          import glob, json
+          parts = sorted(glob.glob('partials/**/pipeline_bench_*.json', recursive=True),
+                         key=lambda f: int(f.rsplit('_', 1)[1].split('.')[0]))
+          merged = None
+          for f in parts:
+              d = json.load(open(f))
+              if merged is None:
+                  merged = {"baseline": d["baseline"], "models": []}
+              merged["models"].extend(d["models"])
+          if merged is None:
+              raise SystemExit("no shard partials found")
+          json.dump(merged, open('pipeline_bench.json', 'w'))
+          print(f"merged {len(parts)} shard(s) -> {len(merged['models'])} models")
+          PY
+          head -c 300 pipeline_bench.json; echo
 
       # Stripped size of a minimal encode program linking each implementation —
       # the "how much does this library add to my binary" number.
@@ -120,7 +195,7 @@ jobs:
           base_url="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts"
           python3 ${{ github.workspace }}/.github/scripts/render_pipeline_bench.py \
             pipeline_bench.json \
-            --subtitle "~10 kB inputs · single thread" \
+            --subtitle "~10 kB inputs · single thread + 1/2/4/8/max-thread sweep" \
             --revision "${{ github.event.pull_request.head.sha || github.sha }}" \
             --img-base "$base_url" \
             --run-id "${{ github.run_id }}" \

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -3,11 +3,13 @@
 //! `Tokenizer` is on its way out, so the release is the reference), for every
 //! model in `examples/bench_models.json` across every corpus in `data/fixtures/`.
 //!
-//! Per fixture it measures throughput on ~10 kB inputs (the regime where
-//! per-input overhead is amortized — see `pipeline_benchmark.rs` for the size
-//! sweep). Per model it also measures resident-set deltas by re-spawning itself
-//! as `--memory <impl> <model.json>` children — one implementation per process,
-//! so allocator page reuse across implementations can't blur the attribution.
+//! Per fixture it measures single-thread throughput on ~10 kB inputs (the regime
+//! where per-input overhead is amortized — see `pipeline_benchmark.rs` for the
+//! size sweep). Per model it also (a) runs a **multi-thread throughput sweep** —
+//! pipeline vs the release at 1/2/4/8/device-max threads over the whole corpus, so
+//! parallel scaling is visible — and (b) measures resident-set deltas by re-spawning
+//! itself as `--memory <impl> <model.json>` children — one implementation per
+//! process, so allocator page reuse across implementations can't blur the attribution.
 //!
 //! The in-tree `Tokenizer` is *not* benched: it only builds the pipeline and
 //! serves as the id-correctness oracle (`ids_match`, which CI fails on).
@@ -28,6 +30,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Instant;
 
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::ThreadPoolBuilder;
 use serde_json::{json, Value};
 use tk_encode::pipeline::PipelineTokenizer;
 use tk_encode::{AddedToken, ModelWrapper, Tokenizer};
@@ -112,6 +116,68 @@ fn make_chunks(text: &str) -> Vec<String> {
 fn median_secs(mut samples: Vec<f64>) -> f64 {
     samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
     samples[samples.len() / 2]
+}
+
+/// Thread counts for the scaling sweep: 1 (the single-thread anchor) + 2/4/8 + the device max,
+/// deduped and capped at max (so an 8-core box reports `[1,2,4,8]`, a 6-core `[1,2,4,6]`).
+fn thread_counts() -> Vec<usize> {
+    let max = std::thread::available_parallelism().map_or(1, |n| n.get());
+    let mut c: Vec<usize> = IntoIterator::into_iter([1usize, 2, 4, 8, max])
+        .filter(|&n| n <= max)
+        .collect();
+    c.sort_unstable();
+    c.dedup();
+    c
+}
+
+/// Median MB/s of encoding `chunks` across `n` threads in a *private* rayon pool (so the sweep can't
+/// perturb — or be perturbed by — the global pool). One `encode` call per chunk; the sum is `black_box`'d
+/// so the work can't be elided.
+fn par_mbps(
+    encode: impl Fn(&str) -> usize + Sync,
+    chunks: &[String],
+    bytes: usize,
+    n: usize,
+) -> f64 {
+    let pool = ThreadPoolBuilder::new().num_threads(n).build().unwrap();
+    let run = || pool.install(|| chunks.par_iter().map(|c| encode(c.as_str())).sum::<usize>());
+    black_box(run()); // warm the pool + lazy structures
+    let mut samples = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let t = Instant::now();
+        black_box(run());
+        samples.push(t.elapsed().as_secs_f64());
+    }
+    bytes as f64 / median_secs(samples) / 1e6
+}
+
+/// Multi-thread throughput sweep for one model — pipeline vs the released crate at 1/2/4/8/max threads
+/// over the whole fixture corpus (thread-spawn/scheduling overhead amortized). Both impls encode the same
+/// chunk list through a fresh pool per count; interleaved so thermal drift hits them equally.
+fn bench_threads(
+    baseline: Option<&BaselineTokenizer>,
+    pipeline: &PipelineTokenizer,
+    chunks: &[String],
+) -> Value {
+    let bytes: usize = chunks.iter().map(String::len).sum();
+    let counts = thread_counts();
+    let (mut pipe, mut base) = (Vec::new(), Vec::new());
+    for &n in &counts {
+        let b = baseline.map(|b| par_mbps(|s| b.encode(s, false).unwrap().len(), chunks, bytes, n));
+        let p = par_mbps(
+            |s| pipeline.encode(s, false).unwrap().len(),
+            chunks,
+            bytes,
+            n,
+        );
+        eprintln!(
+            "    {n} thread(s): pipeline {p:.1} MB/s{}",
+            b.map_or(String::new(), |v| format!(", baseline {v:.1} MB/s"))
+        );
+        pipe.push(p);
+        base.push(b);
+    }
+    json!({ "counts": counts, "pipeline_mbps": pipe, "baseline_mbps": base })
 }
 
 fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
@@ -441,6 +507,12 @@ fn main() {
     let manifest: Vec<Value> =
         serde_json::from_str(&std::fs::read_to_string(MANIFEST).unwrap()).unwrap();
     let files = fixture_files();
+    // The whole corpus, concatenated once: the multi-thread sweep runs over all fixtures so
+    // thread-spawn/scheduling overhead is amortized and the scaling curve is stable.
+    let all_chunks: Vec<String> = files
+        .iter()
+        .flat_map(|(_, p)| make_chunks(&std::fs::read_to_string(p).unwrap()))
+        .collect();
 
     let mut models: Vec<Value> = Vec::new();
     for entry in &manifest {
@@ -515,10 +587,11 @@ fn main() {
 
         let rows = bench_model(baseline.as_ref(), &tok, &pipeline, &files);
         let memory = measure_memory(&path, baseline.is_some());
+        let threads = bench_threads(baseline.as_ref(), &pipeline, &all_chunks);
 
         models.push(json!({
             "model": name, "repo": repo, "desc": desc, "shape": shape,
-            "results": rows, "memory": memory,
+            "results": rows, "memory": memory, "threads": threads,
         }));
     }
 

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -504,8 +504,27 @@ fn main() {
         return;
     }
 
-    let manifest: Vec<Value> =
+    // Optional model sharding for CI matrix fan-out: `--shard <i> <n>` benches only the i-th of `n`
+    // contiguous manifest chunks, so the models split across parallel isolated runners and the partial
+    // JSONs are concatenated downstream. Without it, `(0, 1)` = the whole manifest, unchanged.
+    let (shard, nshards): (usize, usize) =
+        match (args.get(1).map(String::as_str), args.get(2), args.get(3)) {
+            (Some("--shard"), Some(i), Some(n)) => {
+                (i.parse().unwrap(), n.parse::<usize>().unwrap().max(1))
+            }
+            _ => (0, 1),
+        };
+    let full: Vec<Value> =
         serde_json::from_str(&std::fs::read_to_string(MANIFEST).unwrap()).unwrap();
+    let (lo, hi) = (
+        shard * full.len() / nshards,
+        (shard + 1) * full.len() / nshards,
+    );
+    let manifest = &full[lo.min(full.len())..hi.min(full.len())];
+    eprintln!(
+        "shard {shard}/{nshards}: models {lo}..{hi} of {}",
+        full.len()
+    );
     let files = fixture_files();
     // The whole corpus, concatenated once: the multi-thread sweep runs over all fixtures so
     // thread-spawn/scheduling overhead is amortized and the scaling curve is stable.
@@ -515,7 +534,7 @@ fn main() {
         .collect();
 
     let mut models: Vec<Value> = Vec::new();
-    for entry in &manifest {
+    for entry in manifest {
         let name = entry["name"].as_str().unwrap().to_string();
         let repo = entry.get("repo").and_then(Value::as_str).unwrap_or("");
         let desc = entry.get("desc").and_then(Value::as_str).unwrap_or("");


### PR DESCRIPTION
## What

Adds a **multi-thread throughput comparison** to the pipeline benchmark: pipeline vs the latest released `tokenizers` crate at **1 / 2 / 4 / 8 / device-max threads**, per model, with a visualization in the PR-description report.

## Changes

**`tk-encode/examples/fixture_bench.rs`**
- New per-model **thread sweep** (`bench_threads`): encodes the whole fixture corpus through a *private rayon pool* at each thread count (1/2/4/8/max — deduped & capped at the device max), for both the pipeline and the release baseline, interleaved.
- Emits `threads: {counts, pipeline_mbps, baseline_mbps}` in the JSON (baseline entries `null` when the release can't load a config).

**`.github/scripts/render_pipeline_bench.py`**
- New `threads_svg` "Thread scaling" chart: throughput bars at each thread count (release vs pipeline on one shared MB/s axis), the `×speedup` per count in the right column, and the `1→max` scaling factor in the subtitle. Rendered light + dark and placed in each model's `<details>` block.

**No workflow change** — `pipeline-bench.yml` already globs `pipeline_bench_*.svg` → PNG → upload, so the new charts are picked up automatically.

## Verification

- `fixture_bench` compiles with `--features bench-baseline`; `clippy` clean; `rustfmt` clean.
- Render script exercised on a sample JSON with the new `threads` field: per-model thread-scaling SVGs (light+dark) generate, the markdown embeds them, and the chart shows the ×speedup + scaling summary. Python `ast.parse` clean.
- The real numbers come from CI (fixtures + the released crate live there); this machine has no fixtures.

Base is `remove-char-repr-bpe` (where the pipeline bench + render script live).

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**5 / 6 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · single thread + 1/2/4/8/max-thread sweep

`665d7b55c · 2026-07-11 08:00 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 32 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-overview-dark.png">
  <img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-overview-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-memory-dark.png">
  <img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-memory-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-binsize-dark.png">
  <img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-binsize-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×5.15 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-bert-base-uncased-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-bert-base-uncased-threads-dark.png">
  <img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-bert-base-uncased-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 2+0 (peak 6) · Pipeline 7+0 (peak 7)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.0 | 26.2 | ×3.71 | 3% (1.2) | 72% (27.5) | 13% (5.1) | 12% (4.4) | match |
| arb_Arab | lang | 3.5 | 22.5 | ×6.49 | 3% (1.2) | 66% (28.9) | 7% (3.0) | 24% (10.6) | match |
| ben_Beng | lang | 5.2 | 31.4 | ×5.99 | 4% (1.2) | 64% (20.0) | 9% (2.8) | 23% (7.3) | match |
| cmn_Hani | lang | 3.2 | 16.7 | ×5.30 | 2% (1.2) | 64% (37.9) | 9% (5.6) | 24% (14.4) | match |
| ell_Grek | lang | 3.2 | 21.7 | ×6.76 | 3% (1.2) | 64% (29.2) | 7% (3.1) | 27% (12.4) | match |
| eng_Latn | lang | 3.8 | 17.0 | ×4.45 | 4% (2.5) | 66% (38.5) | 8% (4.8) | 21% (12.6) | match |
| heb_Hebr | lang | 3.5 | 18.3 | ×5.26 | 2% (1.2) | 72% (39.2) | 6% (3.2) | 20% (10.7) | match |
| hin_Deva | lang | 5.6 | 25.3 | ×4.48 | 3% (1.2) | 71% (27.5) | 8% (3.0) | 18% (7.0) | match |
| jpn_Jpan | lang | 3.7 | 24.3 | ×6.57 | 3% (1.2) | 58% (23.7) | 11% (4.6) | 28% (11.5) | match |
| kat_Geor | lang | 5.8 | 26.7 | ×4.63 | 3% (1.2) | 72% (27.1) | 7% (2.8) | 17% (6.5) | match |
| kor_Hang | lang | 2.2 | 16.0 | ×7.39 | 2% (1.2) | 58% (35.9) | 11% (7.0) | 29% (18.1) | match |
| rus_Cyrl | lang | 3.2 | 21.8 | ×6.89 | 3% (1.2) | 62% (28.1) | 10% (4.4) | 25% (11.4) | match |
| tam_Taml | lang | 6.6 | 35.5 | ×5.40 | 4% (1.2) | 70% (19.4) | 8% (2.3) | 17% (4.7) | match |
| tha_Thai | lang | 8.2 | 31.7 | ×3.87 | 4% (1.2) | 84% (25.9) | 7% (2.0) | 6% (1.8) | match |
| added_normalized_dense | modalities | 6.1 | 18.9 | ×3.10 | 3% (1.3) | 78% (40.5) | 16% (8.2) | 4% (1.9) | match |
| added_normalized_sparse | modalities | 4.8 | 17.3 | ×3.62 | 3% (1.9) | 70% (39.8) | 14% (8.1) | 12% (6.8) | match |
| added_special_dense | modalities | 4.8 | 34.9 | ×7.23 | 19% (5.3) | 33% (9.0) | 39% (10.9) | 9% (2.4) | match |
| added_special_sparse | modalities | 3.7 | 19.9 | ×5.35 | 8% (3.9) | 56% (27.8) | 19% (9.4) | 17% (8.2) | match |
| agentic-traces | modalities | 3.3 | 16.5 | ×4.96 | 4% (2.3) | 64% (38.4) | 8% (5.1) | 24% (14.6) | match |
| agentic_swe | modalities | 3.6 | 17.6 | ×4.93 | 3% (1.9) | 69% (38.7) | 7% (3.8) | 21% (12.1) | match |
| code_mixed | modalities | 3.4 | 17.3 | ×5.04 | 4% (2.1) | 67% (38.5) | 8% (4.4) | 22% (12.6) | match |
| math_latex | modalities | 3.5 | 16.7 | ×4.79 | 4% (2.4) | 64% (38.5) | 8% (5.0) | 23% (13.8) | match |

</details>

<details><summary><b>deepseek-v4</b> — split-heavy byte-level BPE, 3 chained regexes · ×4.83 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-deepseek-v4-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-deepseek-v4-threads-dark.png">
  <img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-deepseek-v4-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 52+0 (peak 58) · Pipeline 85+0 (peak 84)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 31.3 | ×7.84 | 2% (0.6) | 0% (0.0) | 16% (4.9) | 82% (25.1) | match |
| arb_Arab | lang | 3.7 | 16.0 | ×4.33 | 1% (0.6) | 0% (0.0) | 6% (3.7) | 93% (56.7) | match |
| ben_Beng | lang | 4.6 | 17.4 | ×3.82 | 1% (0.6) | 0% (0.0) | 6% (3.3) | 93% (52.8) | match |
| cmn_Hani | lang | 3.5 | 15.8 | ×4.53 | 1% (0.8) | 0% (0.0) | 5% (3.3) | 93% (56.5) | match |
| ell_Grek | lang | 3.7 | 17.2 | ×4.63 | 1% (0.6) | 0% (0.0) | 6% (3.7) | 92% (53.1) | match |
| eng_Latn | lang | 2.7 | 11.8 | ×4.30 | 2% (1.9) | 0% (0.0) | 7% (5.5) | 91% (75.0) | match |
| heb_Hebr | lang | 3.3 | 12.6 | ×3.86 | 1% (0.6) | 0% (0.0) | 5% (3.8) | 94% (74.0) | match |
| hin_Deva | lang | 4.3 | 21.1 | ×4.88 | 1% (0.6) | 0% (0.0) | 8% (3.5) | 91% (42.4) | match |
| jpn_Jpan | lang | 3.9 | 17.0 | ×4.41 | 1% (0.7) | 0% (0.0) | 5% (3.1) | 93% (53.3) | match |
| kat_Geor | lang | 4.6 | 17.8 | ×3.90 | 1% (0.6) | 0% (0.0) | 6% (3.1) | 93% (52.1) | match |
| kor_Hang | lang | 3.4 | 18.8 | ×5.56 | 1% (0.6) | 0% (0.0) | 8% (3.9) | 91% (47.4) | match |
| rus_Cyrl | lang | 3.7 | 14.2 | ×3.85 | 1% (0.6) | 0% (0.0) | 5% (3.7) | 94% (65.1) | match |
| tam_Taml | lang | 4.8 | 17.1 | ×3.52 | 1% (0.6) | 0% (0.0) | 5% (2.8) | 94% (54.6) | match |
| tha_Thai | lang | 5.6 | 14.2 | ×2.55 | 1% (0.6) | 0% (0.0) | 3% (2.4) | 96% (66.1) | match |
| added_normalized_dense | modalities | 3.9 | 22.3 | ×5.70 | 2% (0.8) | 0% (0.0) | 7% (3.1) | 91% (39.9) | match |
| added_normalized_sparse | modalities | 3.6 | 18.5 | ×5.06 | 3% (1.3) | 0% (0.0) | 8% (4.3) | 89% (47.1) | match |
| added_special_dense | modalities | 3.0 | 31.4 | ×10.60 | 22% (6.6) | 3% (0.8) | 18% (5.5) | 57% (16.9) | match |
| added_special_sparse | modalities | 3.2 | 18.8 | ×5.95 | 8% (4.2) | 0% (0.0) | 13% (6.7) | 79% (40.7) | match |
| agentic-traces | modalities | 2.5 | 12.9 | ×5.25 | 2% (1.8) | 0% (0.0) | 8% (5.9) | 90% (68.5) | match |
| agentic_swe | modalities | 2.3 | 13.6 | ×5.82 | 2% (1.3) | 0% (0.0) | 6% (4.5) | 92% (67.5) | match |
| code_mixed | modalities | 2.6 | 14.0 | ×5.38 | 2% (1.6) | 0% (0.0) | 7% (5.1) | 91% (63.6) | match |
| math_latex | modalities | 2.5 | 12.6 | ×5.08 | 2% (1.9) | 0% (0.0) | 7% (5.8) | 90% (69.9) | match |

</details>

<details><summary><b>gpt2</b> — standalone ByteLevel pre-tokenizer · ×8.79 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-gpt2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-gpt2-threads-dark.png">
  <img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-gpt2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 17+1 (peak 19) · Pipeline 20+0 (peak 20)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 44.7 | ×11.52 | 3% (0.7) | 0% (0.0) | 20% (4.2) | 77% (16.4) | match |
| arb_Arab | lang | 3.2 | 24.0 | ×7.61 | 1% (0.6) | 0% (0.0) | 7% (3.0) | 91% (37.6) | match |
| ben_Beng | lang | 2.2 | 35.0 | ×16.06 | 2% (0.6) | 0% (0.0) | 13% (3.7) | 85% (23.8) | match |
| cmn_Hani | lang | 3.3 | 25.6 | ×7.84 | 2% (0.6) | 0% (0.0) | 7% (2.7) | 91% (34.8) | match |
| ell_Grek | lang | 3.3 | 26.2 | ×8.01 | 2% (0.6) | 0% (0.0) | 8% (3.0) | 90% (33.8) | match |
| eng_Latn | lang | 2.8 | 12.8 | ×4.60 | 3% (2.0) | 0% (0.0) | 5% (3.5) | 93% (71.4) | match |
| heb_Hebr | lang | 3.1 | 27.2 | ×8.66 | 2% (0.6) | 0% (0.0) | 8% (3.0) | 90% (32.3) | match |
| hin_Deva | lang | 2.6 | 30.7 | ×11.92 | 2% (0.6) | 0% (0.0) | 12% (3.8) | 86% (27.7) | match |
| jpn_Jpan | lang | 3.6 | 20.3 | ×5.72 | 1% (0.6) | 0% (0.0) | 5% (2.4) | 94% (45.0) | match |
| kat_Geor | lang | 3.6 | 59.0 | ×16.27 | 4% (0.6) | 0% (0.0) | 16% (2.6) | 80% (12.9) | match |
| kor_Hang | lang | 3.0 | 36.1 | ×12.19 | 2% (0.6) | 0% (0.0) | 11% (3.0) | 87% (23.0) | match |
| rus_Cyrl | lang | 3.3 | 26.0 | ×7.86 | 2% (0.6) | 0% (0.0) | 8% (2.9) | 91% (34.3) | match |
| tam_Taml | lang | 2.1 | 43.5 | ×20.49 | 3% (0.6) | 0% (0.0) | 15% (3.3) | 83% (18.5) | match |
| tha_Thai | lang | 2.8 | 29.8 | ×10.47 | 2% (0.6) | 0% (0.0) | 9% (3.0) | 89% (29.1) | match |
| added_normalized_dense | modalities | 3.5 | 24.8 | ×7.03 | 2% (0.8) | 0% (0.0) | 4% (1.7) | 94% (35.8) | match |
| added_normalized_sparse | modalities | 3.3 | 20.5 | ×6.20 | 3% (1.4) | 0% (0.0) | 5% (2.5) | 92% (43.5) | match |
| added_special_dense | modalities | 3.4 | 40.8 | ×12.07 | 21% (5.0) | 1% (0.1) | 15% (3.5) | 63% (14.6) | match |
| added_special_sparse | modalities | 3.2 | 21.5 | ×6.67 | 7% (3.3) | 0% (0.0) | 10% (4.6) | 83% (36.9) | match |
| agentic-traces | modalities | 2.4 | 14.6 | ×6.13 | 3% (1.8) | 0% (0.0) | 6% (3.9) | 92% (61.6) | match |
| agentic_swe | modalities | 2.4 | 20.4 | ×8.45 | 3% (1.3) | 0% (0.0) | 6% (3.0) | 91% (43.7) | match |
| code_mixed | modalities | 2.4 | 17.9 | ×7.48 | 3% (1.5) | 0% (0.0) | 6% (3.4) | 91% (49.9) | match |
| math_latex | modalities | 2.6 | 13.7 | ×5.33 | 3% (1.9) | 0% (0.0) | 5% (3.7) | 92% (66.2) | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×4.10 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-2-threads-dark.png">
  <img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 14+0 (peak 15) · Pipeline 14+0 (peak 14)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 48.2 | ×10.95 | 0% (0.0) | 13% (2.7) | 0% (0.0) | 87% (17.4) | match |
| arb_Arab | lang | 9.5 | 54.6 | ×5.76 | 0% (0.0) | 17% (3.1) | 0% (0.0) | 82% (14.9) | match |
| ben_Beng | lang | 10.3 | 92.3 | ×8.98 | 0% (0.0) | 19% (2.1) | 0% (0.0) | 80% (8.5) | match |
| cmn_Hani | lang | 8.7 | 75.2 | ×8.61 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 96% (12.1) | match |
| ell_Grek | lang | 9.6 | 65.6 | ×6.86 | 0% (0.0) | 20% (3.0) | 1% (0.1) | 79% (11.7) | match |
| eng_Latn | lang | 4.3 | 6.8 | ×1.56 | 0% (0.1) | 5% (6.7) | 0% (0.0) | 95% (139.6) | match |
| heb_Hebr | lang | 9.3 | 68.0 | ×7.27 | 0% (0.0) | 22% (3.2) | 0% (0.0) | 78% (11.2) | match |
| hin_Deva | lang | 11.4 | 89.0 | ×7.81 | 0% (0.0) | 25% (2.8) | 0% (0.0) | 75% (8.2) | match |
| jpn_Jpan | lang | 12.3 | 98.3 | ×8.00 | 0% (0.0) | 3% (0.3) | 0% (0.0) | 96% (9.4) | match |
| kat_Geor | lang | 13.2 | 95.5 | ×7.21 | 0% (0.0) | 18% (1.8) | 0% (0.0) | 82% (8.4) | match |
| kor_Hang | lang | 6.8 | 58.0 | ×8.48 | 0% (0.1) | 19% (3.2) | 0% (0.0) | 81% (13.5) | match |
| rus_Cyrl | lang | 8.5 | 17.1 | ×2.01 | 0% (0.0) | 5% (2.7) | 0% (0.0) | 95% (55.0) | match |
| tam_Taml | lang | 11.7 | 104.2 | ×8.94 | 0% (0.0) | 18% (1.6) | 0% (0.0) | 82% (7.7) | match |
| tha_Thai | lang | 14.7 | 97.8 | ×6.65 | 0% (0.0) | 9% (0.9) | 0% (0.0) | 90% (8.9) | match |
| added_normalized_dense | modalities | 5.4 | 9.3 | ×1.73 | 0% (0.1) | 3% (3.7) | 0% (0.0) | 97% (107.7) | match |
| added_normalized_sparse | modalities | 4.8 | 7.9 | ×1.63 | 0% (0.1) | 5% (6.0) | 0% (0.0) | 95% (118.8) | match |
| added_special_dense | modalities | 4.7 | 19.7 | ×4.18 | 10% (5.2) | 31% (15.5) | 2% (1.2) | 56% (27.9) | match |
| added_special_sparse | modalities | 6.8 | 10.2 | ×1.50 | 2% (2.1) | 14% (13.6) | 0% (0.3) | 83% (80.4) | match |
| agentic-traces | modalities | 4.5 | 7.6 | ×1.70 | 0% (0.1) | 5% (6.0) | 0% (0.0) | 95% (124.7) | match |
| agentic_swe | modalities | 4.1 | 7.9 | ×1.94 | 0% (0.1) | 7% (9.4) | 0% (0.0) | 92% (116.3) | match |
| code_mixed | modalities | 4.2 | 7.6 | ×1.81 | 0% (0.0) | 6% (7.8) | 0% (0.0) | 94% (122.3) | match |
| math_latex | modalities | 4.4 | 7.2 | ×1.63 | 0% (0.1) | 5% (6.3) | 0% (0.0) | 95% (132.2) | match |

</details>

<details><summary><b>llama-3</b> — split-heavy byte-level BPE, single regex · ×7.92 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-3-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-3-threads-dark.png">
  <img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-llama-3-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 128+0 (peak 189) · Pipeline 130+0 (peak 190)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.2 | 41.2 | ×12.71 | 3% (0.7) | 0% (0.0) | 24% (5.2) | 74% (16.2) | match |
| arb_Arab | lang | 3.7 | 17.6 | ×4.71 | 1% (0.6) | 0% (0.0) | 8% (4.2) | 91% (50.1) | match |
| ben_Beng | lang | 2.9 | 28.0 | ×9.60 | 2% (0.6) | 0% (0.0) | 15% (5.1) | 84% (29.0) | match |
| cmn_Hani | lang | 4.2 | 16.5 | ×3.98 | 1% (0.6) | 0% (0.0) | 6% (3.3) | 93% (53.6) | match |
| ell_Grek | lang | 4.0 | 19.1 | ×4.79 | 1% (0.6) | 0% (0.0) | 8% (4.0) | 91% (46.1) | match |
| eng_Latn | lang | 3.5 | 38.3 | ×10.82 | 9% (2.0) | 0% (0.0) | 25% (5.6) | 66% (14.9) | match |
| heb_Hebr | lang | 3.3 | 24.7 | ×7.44 | 2% (0.6) | 0% (0.0) | 11% (4.2) | 88% (34.4) | match |
| hin_Deva | lang | 3.7 | 66.1 | ×18.00 | 4% (0.6) | 0% (0.0) | 40% (5.5) | 56% (7.7) | match |
| jpn_Jpan | lang | 4.6 | 16.2 | ×3.54 | 1% (0.6) | 0% (0.0) | 5% (3.0) | 94% (55.3) | match |
| kat_Geor | lang | 3.9 | 35.9 | ×9.22 | 2% (0.6) | 0% (0.0) | 12% (3.2) | 86% (22.6) | match |
| kor_Hang | lang | 3.6 | 19.0 | ×5.26 | 1% (0.6) | 0% (0.0) | 8% (4.3) | 90% (45.9) | match |
| rus_Cyrl | lang | 4.0 | 16.3 | ×4.04 | 1% (0.6) | 0% (0.0) | 7% (3.9) | 92% (54.5) | match |
| tam_Taml | lang | 2.9 | 30.1 | ×10.32 | 2% (0.6) | 0% (0.0) | 15% (4.7) | 84% (26.7) | match |
| tha_Thai | lang | 4.4 | 20.0 | ×4.55 | 1% (0.6) | 0% (0.0) | 8% (3.9) | 91% (43.9) | match |
| added_normalized_dense | modalities | 4.0 | 26.1 | ×6.60 | 2% (0.8) | 0% (0.0) | 7% (2.7) | 91% (33.6) | match |
| added_normalized_sparse | modalities | 4.1 | 39.1 | ×9.46 | 5% (1.3) | 0% (0.0) | 17% (4.0) | 78% (19.1) | match |
| added_special_dense | modalities | 3.5 | 48.2 | ×13.83 | 26% (5.0) | 0% (0.1) | 57% (10.9) | 16% (3.1) | match |
| added_special_sparse | modalities | 3.8 | 49.9 | ×13.15 | 19% (3.4) | 0% (0.0) | 54% (9.9) | 28% (5.2) | match |
| agentic-traces | modalities | 3.2 | 32.5 | ×10.12 | 6% (1.7) | 0% (0.0) | 23% (6.4) | 71% (19.9) | match |
| agentic_swe | modalities | 3.3 | 25.6 | ×7.86 | 4% (1.3) | 0% (0.0) | 15% (5.5) | 81% (29.1) | match |
| code_mixed | modalities | 3.4 | 40.3 | ×11.81 | 7% (1.5) | 0% (0.0) | 26% (5.8) | 67% (14.7) | match |
| math_latex | modalities | 3.2 | 34.4 | ×10.65 | 7% (1.9) | 0% (0.0) | 24% (6.2) | 69% (17.7) | match |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29145198644-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->

