### PR TITLE
feat: Use BucketVocabStore in PipelineBPE

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,11 +1,11 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
-use crate::bucket_vocab_store::BucketVocabStore;
 use crate::models::bpe::Merge;
 use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
+use crate::vocab::bucket_vocab_store::BucketVocabStore;
 use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
 use dary_heap::QuaternaryHeap;

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,4 +1,5 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
+use crate::bucket_vocab_store::BucketVocabStore;
 use crate::models::bpe::Merge;
 use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
@@ -676,7 +677,7 @@ impl Model for BPE {
 
 pub struct PipelineBPE {
     atoms: Atoms,
-    vocab: VocabStore,
+    vocab: BucketVocabStore,
     merges: MergeMap,
     ignore_merges: bool,
 }
@@ -714,7 +715,8 @@ impl PipelineBPE {
         } = model;
 
         let (vocab, atoms) = if with_byte_level {
-            let vocab = byte_level::transform_vocab(vocab);
+            let mut vocab = BucketVocabStore::build(vocab.byte_content());
+            vocab = byte_level::transform_vocab(vocab);
             let mut byte_to_id = [0u32; 256];
             for b in 0u8..=255 {
                 byte_to_id[b as usize] = vocab
@@ -723,6 +725,7 @@ impl PipelineBPE {
             }
             (vocab, Atoms::Bytes { byte_to_id })
         } else {
+            let vocab = BucketVocabStore::build(vocab.byte_content());
             let unk_token = if let Some(unk_str) = unk_token {
                 let token_id = vocab
                     .token_to_id(&unk_str)

--- a/tokenizers/tk-encode/src/utils/byte_level.rs
+++ b/tokenizers/tk-encode/src/utils/byte_level.rs
@@ -1,4 +1,4 @@
-use crate::bucket_vocab_store::BucketVocabStore;
+use crate::vocab::bucket_vocab_store::BucketVocabStore;
 use ahash::AHashMap;
 use std::sync::LazyLock;
 

--- a/tokenizers/tk-encode/src/utils/byte_level.rs
+++ b/tokenizers/tk-encode/src/utils/byte_level.rs
@@ -1,4 +1,4 @@
-use crate::vocab_store::VocabStore;
+use crate::bucket_vocab_store::BucketVocabStore;
 use ahash::AHashMap;
 use std::sync::LazyLock;
 
@@ -86,8 +86,8 @@ fn reverse_lookup(c: char) -> Vec<u8> {
         .map_or_else(|| c.to_string().into_bytes(), |b| vec![*b])
 }
 
-pub(crate) fn transform_vocab(vocab: VocabStore) -> VocabStore {
-    VocabStore::build(
+pub(crate) fn transform_vocab(vocab: BucketVocabStore) -> BucketVocabStore {
+    BucketVocabStore::build(
         vocab
             .content()
             .into_iter()


### PR DESCRIPTION
# TL;DR

Use BucketVocabStore instead of VocabbStore in the BPE model


<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**7 / 8 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · single thread + 1/2/4/8/max-thread sweep

`15f3bf714 · 2026-07-22 12:18 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 16 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-overview.png" width="860">

**vs base branch** (`575582072`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-binsize.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.91 vs v0.23.1 · ×1.00 vs base</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-bert-base-uncased-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 12) · Pipeline 8+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.8 | 27.6 | ×3.54 | ×1.01 | 3% (1.2) | 76% (27.4) | 13% (4.8) | 7% (2.6) | match |
| arb_Arab | lang | 4.3 | 25.0 | ×5.89 | ×1.01 | 3% (1.2) | 69% (27.5) | 8% (3.3) | 19% (7.7) | match |
| ben_Beng | lang | 6.1 | 34.9 | ×5.74 | ×1.01 | 4% (1.2) | 67% (19.2) | 10% (2.9) | 18% (5.2) | match |
| cmn_Hani | lang | 3.9 | 18.8 | ×4.87 | ×1.00 | 2% (1.3) | 71% (37.8) | 11% (5.7) | 16% (8.5) | match |
| ell_Grek | lang | 3.8 | 23.8 | ×6.24 | ×1.01 | 3% (1.3) | 69% (28.6) | 8% (3.4) | 20% (8.5) | match |
| eng_Latn | lang | 4.5 | 18.3 | ×4.09 | ×1.01 | 5% (2.8) | 71% (38.7) | 8% (4.5) | 16% (8.6) | match |
| heb_Hebr | lang | 4.2 | 20.0 | ×4.70 | ×1.01 | 2% (1.2) | 75% (37.5) | 8% (3.8) | 15% (7.4) | match |
| hin_Deva | lang | 6.5 | 27.4 | ×4.20 | ×1.00 | 3% (1.2) | 75% (27.0) | 9% (3.2) | 13% (4.9) | match |
| jpn_Jpan | lang | 4.3 | 27.3 | ×6.34 | ×1.00 | 3% (1.2) | 64% (23.3) | 13% (4.6) | 20% (7.1) | match |
| kat_Geor | lang | 6.2 | 28.2 | ×4.55 | ×0.99 | 3% (1.2) | 75% (26.5) | 9% (3.1) | 13% (4.5) | match |
| kor_Hang | lang | 2.4 | 17.7 | ×7.26 | ×1.01 | 2% (1.3) | 63% (35.3) | 12% (6.9) | 23% (12.7) | match |
| rus_Cyrl | lang | 3.7 | 23.8 | ×6.40 | ×1.01 | 3% (1.2) | 66% (27.4) | 8% (3.2) | 24% (9.9) | match |
| tam_Taml | lang | 7.1 | 38.4 | ×5.43 | ×1.01 | 5% (1.2) | 72% (18.6) | 10% (2.5) | 14% (3.5) | match |
| tha_Thai | lang | 8.4 | 33.2 | ×3.97 | ×0.99 | 4% (1.2) | 83% (24.8) | 8% (2.3) | 5% (1.5) | match |
| added_normalized_dense | modalities | 6.7 | 19.7 | ×2.92 | ×1.00 | 3% (1.4) | 80% (40.3) | 15% (7.4) | 2% (1.0) | match |
| added_normalized_sparse | modalities | 5.3 | 18.4 | ×3.47 | ×1.01 | 4% (1.9) | 74% (39.6) | 13% (7.2) | 9% (4.7) | match |
| added_special_dense | modalities | 5.4 | 38.5 | ×7.13 | ×0.99 | 20% (5.0) | 37% (9.1) | 36% (8.9) | 7% (1.7) | match |
| added_special_sparse | modalities | 4.0 | 21.3 | ×5.33 | ×1.00 | 8% (3.6) | 61% (28.3) | 18% (8.5) | 13% (5.8) | match |
| agentic-traces | modalities | 3.9 | 18.1 | ×4.70 | ×1.01 | 4% (2.5) | 70% (38.5) | 9% (4.9) | 17% (9.1) | match |
| agentic_swe | modalities | 4.1 | 19.5 | ×4.72 | ×1.01 | 4% (1.9) | 76% (38.5) | 7% (3.6) | 14% (6.9) | match |
| code_mixed | modalities | 3.9 | 19.0 | ×4.82 | ×1.01 | 4% (2.3) | 73% (38.5) | 8% (4.2) | 14% (7.5) | match |
| math_latex | modalities | 4.0 | 18.2 | ×4.51 | ×1.01 | 5% (2.6) | 71% (38.7) | 9% (4.7) | 16% (8.8) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×4.17 vs v0.23.1 · ×1.03 vs base</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-deepseek-v4-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 82+0 (peak 82)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 33.2 | ×7.57 | ×0.99 | 2% (0.7) | 0% (0.0) | 17% (4.7) | 81% (22.8) | match |
| arb_Arab | lang | 4.2 | 17.1 | ×4.08 | ×1.02 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (53.8) | match |
| ben_Beng | lang | 6.3 | 18.6 | ×2.97 | ×1.02 | 1% (0.6) | 0% (0.0) | 6% (3.2) | 93% (49.5) | match |
| cmn_Hani | lang | 3.7 | 16.8 | ×4.61 | ×1.07 | 1% (0.8) | 0% (0.0) | 6% (3.3) | 93% (52.8) | match |
| ell_Grek | lang | 4.7 | 18.4 | ×3.92 | ×1.05 | 1% (0.6) | 0% (0.0) | 7% (3.5) | 92% (49.4) | match |
| eng_Latn | lang | 3.2 | 13.0 | ×4.10 | ×1.06 | 3% (2.1) | 0% (0.0) | 7% (5.1) | 90% (67.8) | match |
| heb_Hebr | lang | 4.0 | 13.1 | ×3.27 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (3.6) | 94% (71.5) | match |
| hin_Deva | lang | 5.9 | 22.0 | ×3.73 | ×1.02 | 1% (0.6) | 0% (0.0) | 7% (3.3) | 91% (40.5) | match |
| jpn_Jpan | lang | 4.3 | 18.3 | ×4.27 | ×1.01 | 1% (0.7) | 0% (0.0) | 6% (3.0) | 93% (49.4) | match |
| kat_Geor | lang | 6.0 | 18.5 | ×3.08 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (2.9) | 93% (49.9) | match |
| kor_Hang | lang | 3.8 | 20.2 | ×5.36 | ×1.04 | 1% (0.6) | 0% (0.0) | 8% (3.7) | 91% (44.1) | match |
| rus_Cyrl | lang | 4.4 | 14.7 | ×3.31 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (3.4) | 94% (63.0) | match |
| tam_Taml | lang | 6.3 | 18.2 | ×2.90 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (2.7) | 94% (50.3) | match |
| tha_Thai | lang | 7.0 | 14.9 | ×2.12 | ×1.01 | 1% (0.6) | 0% (0.0) | 3% (2.2) | 96% (63.2) | match |
| added_normalized_dense | modalities | 6.0 | 23.4 | ×3.90 | ×1.01 | 2% (0.7) | 0% (0.0) | 6% (2.7) | 92% (38.7) | match |
| added_normalized_sparse | modalities | 5.4 | 19.5 | ×3.63 | ×1.02 | 3% (1.3) | 0% (0.0) | 8% (3.8) | 90% (45.0) | match |
| added_special_dense | modalities | 3.6 | 37.2 | ×10.24 | ×1.06 | 25% (6.4) | 2% (0.5) | 23% (5.8) | 50% (12.9) | match |
| added_special_sparse | modalities | 4.0 | 20.7 | ×5.19 | ×1.06 | 8% (3.9) | 0% (0.1) | 14% (6.7) | 77% (36.2) | match |
| agentic-traces | modalities | 3.0 | 14.4 | ×4.85 | ×1.04 | 3% (1.9) | 0% (0.0) | 8% (5.4) | 89% (62.0) | match |
| agentic_swe | modalities | 3.0 | 15.0 | ×4.96 | ×1.03 | 2% (1.4) | 0% (0.0) | 6% (3.9) | 92% (59.7) | match |
| code_mixed | modalities | 3.5 | 15.6 | ×4.44 | ×1.03 | 3% (1.7) | 0% (0.0) | 7% (4.6) | 90% (57.3) | match |
| math_latex | modalities | 3.0 | 13.8 | ×4.65 | ×1.04 | 3% (2.0) | 0% (0.0) | 8% (5.4) | 89% (62.3) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.53 | 4.73 | 5.49 | 42.0 | 20.6 | 9.1 | — | 8.9× / 7.7× | 4.3× / 3.7× | 1.9× / 1.7× | — |
| arb_Arab | 1.15 | 2.96 | 3.44 | 5.25 | 48.9 | 23.0 | 10.2 | — | 14.2× / 9.3× | 6.7× / 4.4× | 3.0× / 1.9× | — |
| ben_Beng | 1.61 | 3.16 | 3.16 | 4.71 | 35.6 | 16.4 | 7.6 | — | 11.3× / 7.6× | 5.2× / 3.5× | 2.4× / 1.6× | — |
| cmn_Hani | 1.13 | 2.30 | 3.28 | 4.46 | 61.1 | 34.8 | 14.4 | — | 18.6× / 13.7× | 10.6× / 7.8× | 4.4× / 3.2× | — |
| ell_Grek | 0.60 | 2.99 | 3.51 | 5.91 | 47.2 | 21.3 | 9.6 | — | 13.4× / 8.0× | 6.1× / 3.6× | 2.7× / 1.6× | — |
| eng_Latn | 0.12 | 1.75 | 5.06 | 6.69 | 66.7 | 39.4 | 16.3 | — | 13.2× / 10.0× | 7.8× / 5.9× | 3.2× / 2.4× | — |
| heb_Hebr | 1.15 | 3.07 | 3.61 | 5.53 | 51.0 | 24.4 | 10.7 | — | 14.1× / 9.2× | 6.8× / 4.4× | 3.0× / 1.9× | — |
| hin_Deva | 1.51 | 3.28 | 3.33 | 5.10 | 38.0 | 18.7 | 8.6 | — | 11.4× / 7.4× | 5.6× / 3.7× | 2.6× / 1.7× | — |
| jpn_Jpan | 1.70 | 3.44 | 3.04 | 4.77 | 53.2 | 27.8 | 12.0 | — | 17.5× / 11.1× | 9.1× / 5.8× | 3.9× / 2.5× | — |
| kat_Geor | 1.54 | 2.58 | 2.93 | 3.97 | 32.1 | 15.2 | 7.2 | — | 11.0× / 8.1× | 5.2× / 3.8× | 2.5× / 1.8× | — |
| kor_Hang | 1.23 | 2.79 | 3.70 | 5.25 | 50.3 | 27.5 | 12.0 | — | 13.6× / 9.6× | 7.5× / 5.2× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.17 | 2.96 | 3.36 | 5.15 | 46.8 | 21.0 | 9.4 | — | 13.9× / 9.1× | 6.2× / 4.1× | 2.8× / 1.8× | — |
| tam_Taml | 0.93 | 2.99 | 2.70 | 4.77 | 31.4 | 13.7 | 6.5 | — | 11.6× / 6.6× | 5.1× / 2.9× | 2.4× / 1.4× | — |
| tha_Thai | 1.52 | 2.58 | 2.17 | 3.23 | 27.1 | 10.1 | 5.2 | — | 12.5× / 8.4× | 4.7× / 3.1× | 2.4× / 1.6× | — |
| added_normalized_dense | 0.06 | 1.77 | 2.74 | 4.45 | 43.0 | 20.3 | 9.3 | — | 15.7× / 9.7× | 7.4× / 4.6× | 3.4× / 2.1× | — |
| added_normalized_sparse | 0.06 | 1.77 | 3.78 | 5.49 | 50.0 | 26.0 | 11.3 | — | 13.2× / 9.1× | 6.9× / 4.7× | 3.0× / 2.1× | — |
| added_special_dense | 0.06 | 1.77 | 5.85 | 7.56 | 179.4 | 100.2 | 38.4 | — | 30.7× / 23.7× | 17.1× / 13.3× | 6.6× / 5.1× | — |
| added_special_sparse | 0.06 | 1.77 | 6.66 | 8.37 | 105.2 | 58.6 | 23.8 | — | 15.8× / 12.6× | 8.8× / 7.0× | 3.6× / 2.8× | — |
| agentic-traces | 0.75 | 1.76 | 5.40 | 6.41 | 82.6 | 54.0 | 20.1 | — | 15.3× / 12.9× | 10.0× / 8.4× | 3.7× / 3.1× | — |
| agentic_swe | 0.68 | 1.73 | 3.86 | 4.91 | 99.0 | 65.4 | 23.7 | — | 25.7× / 20.2× | 17.0× / 13.3× | 6.1× / 4.8× | — |
| code_mixed | 0.09 | 1.73 | 4.60 | 6.24 | 75.6 | 54.0 | 18.6 | — | 16.4× / 12.1× | 11.7× / 8.7× | 4.0× / 3.0× | — |
| math_latex | 0.74 | 1.77 | 5.40 | 6.43 | 80.3 | 47.9 | 19.4 | — | 14.9× / 12.5× | 8.9× / 7.5× | 3.6× / 3.0× | — |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×7.70 vs v0.23.1 · ×1.03 vs base</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-gpt2-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 28+0 (peak 28)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 47.0 | ×10.78 | ×1.00 | 3% (0.6) | 0% (0.0) | 18% (3.6) | 79% (16.1) | match |
| arb_Arab | lang | 4.2 | 27.0 | ×6.38 | ×1.03 | 2% (0.6) | 0% (0.0) | 6% (2.2) | 92% (34.1) | match |
| ben_Beng | lang | 3.2 | 47.0 | ×14.76 | ×1.02 | 3% (0.6) | 0% (0.0) | 14% (3.0) | 83% (18.1) | match |
| cmn_Hani | lang | 3.9 | 29.9 | ×7.68 | ×1.03 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (29.8) | match |
| ell_Grek | lang | 4.5 | 29.7 | ×6.57 | ×1.01 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 92% (30.4) | match |
| eng_Latn | lang | 3.7 | 14.2 | ×3.83 | ×1.04 | 3% (2.3) | 0% (0.0) | 4% (2.8) | 93% (65.0) | match |
| heb_Hebr | lang | 4.1 | 29.6 | ×7.29 | ×1.01 | 2% (0.6) | 0% (0.0) | 7% (2.2) | 92% (30.7) | match |
| hin_Deva | lang | 3.2 | 40.0 | ×12.60 | ×1.03 | 2% (0.6) | 0% (0.0) | 12% (3.1) | 86% (21.9) | match |
| jpn_Jpan | lang | 4.6 | 22.5 | ×4.95 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (41.1) | match |
| kat_Geor | lang | 4.7 | 70.4 | ×14.83 | ×1.02 | 4% (0.6) | 0% (0.0) | 15% (2.0) | 81% (11.3) | match |
| kor_Hang | lang | 3.5 | 43.3 | ×12.45 | ×0.98 | 3% (0.6) | 0% (0.0) | 11% (2.4) | 87% (19.4) | match |
| rus_Cyrl | lang | 4.3 | 28.3 | ×6.56 | ×1.02 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 92% (32.7) | match |
| tam_Taml | lang | 2.8 | 70.5 | ×25.48 | ×1.08 | 4% (0.6) | 0% (0.0) | 18% (2.7) | 77% (11.3) | match |
| tha_Thai | lang | 3.7 | 39.1 | ×10.48 | ×1.08 | 2% (0.6) | 0% (0.0) | 10% (2.5) | 88% (22.1) | match |
| added_normalized_dense | modalities | 6.0 | 26.5 | ×4.41 | ×1.03 | 2% (0.7) | 0% (0.0) | 3% (1.0) | 95% (34.8) | match |
| added_normalized_sparse | modalities | 5.2 | 21.8 | ×4.21 | ×1.01 | 3% (1.3) | 0% (0.0) | 5% (2.1) | 93% (41.3) | match |
| added_special_dense | modalities | 4.2 | 47.5 | ×11.23 | ×1.03 | 24% (4.8) | 1% (0.2) | 19% (3.8) | 56% (11.3) | match |
| added_special_sparse | modalities | 4.4 | 24.1 | ×5.52 | ×1.04 | 8% (3.2) | 0% (0.0) | 11% (4.3) | 81% (32.6) | match |
| agentic-traces | modalities | 3.3 | 16.6 | ×5.08 | ×1.04 | 3% (1.9) | 0% (0.0) | 6% (3.5) | 91% (54.2) | match |
| agentic_swe | modalities | 3.5 | 25.4 | ×7.21 | ×1.05 | 3% (1.3) | 0% (0.0) | 6% (2.4) | 91% (35.6) | match |
| code_mixed | modalities | 3.6 | 20.8 | ×5.72 | ×1.04 | 4% (1.7) | 0% (0.0) | 6% (2.9) | 90% (42.3) | match |
| math_latex | modalities | 3.4 | 15.4 | ×4.53 | ×1.03 | 3% (2.0) | 0% (0.0) | 5% (3.3) | 92% (59.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.85 | 3.53 | 3.62 | 4.30 | 27.6 | 21.6 | 5.8 | 4.7 | 7.6× / 6.4× | 6.0× / 5.0× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.20 | 2.99 | 2.23 | 4.02 | 32.1 | 26.6 | 6.8 | 5.1 | 14.4× / 8.0× | 11.9× / 6.6× | 3.1× / 1.7× | 2.3× / 1.3× |
| ben_Beng | 1.72 | 2.96 | 3.03 | 4.27 | 67.0 | 57.8 | 13.8 | 4.0 | 22.1× / 15.7× | 19.1× / 13.5× | 4.6× / 3.2× | 1.3× / 0.9× |
| cmn_Hani | 1.20 | 2.30 | 2.29 | 3.39 | 26.1 | 21.6 | 5.9 | 2.4 | 11.4× / 7.7× | 9.4× / 6.4× | 2.6× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.65 | 3.03 | 2.13 | 4.51 | 28.5 | 22.8 | 5.9 | 4.7 | 13.4× / 6.3× | 10.7× / 5.0× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.12 | 1.75 | 2.81 | 4.44 | 45.3 | 44.0 | 12.1 | 3.7 | 16.1× / 10.2× | 15.6× / 9.9× | 4.3× / 2.7× | 1.3× / 0.8× |
| heb_Hebr | 1.19 | 3.08 | 2.24 | 4.14 | 31.8 | 27.3 | 6.9 | 3.0 | 14.2× / 7.7× | 12.1× / 6.6× | 3.1× / 1.7× | 1.4× / 0.7× |
| hin_Deva | 1.63 | 3.17 | 3.06 | 4.61 | 62.8 | 56.9 | 13.5 | 4.3 | 20.5× / 13.6× | 18.6× / 12.4× | 4.4× / 2.9× | 1.4× / 0.9× |
| jpn_Jpan | 1.78 | 3.39 | 2.09 | 3.71 | 23.3 | 18.2 | 5.0 | 3.8 | 11.1× / 6.3× | 8.7× / 4.9× | 2.4× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.64 | 2.77 | 2.04 | 3.17 | 17.2 | 14.8 | 4.2 | 2.1 | 8.4× / 5.4× | 7.3× / 4.7× | 2.1× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.25 | 2.78 | 2.41 | 3.95 | 32.0 | 29.1 | 7.5 | 3.6 | 13.3× / 8.1× | 12.0× / 7.4× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.22 | 2.97 | 2.06 | 3.81 | 27.3 | 22.1 | 5.8 | 2.5 | 13.2× / 7.2× | 10.7× / 5.8× | 2.8× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 1.05 | 3.02 | 2.71 | 4.68 | 70.2 | 60.6 | 14.3 | 3.7 | 25.9× / 15.0× | 22.4× / 13.0× | 5.3× / 3.0× | 1.4× / 0.8× |
| tha_Thai | 1.62 | 2.61 | 2.47 | 3.46 | 40.2 | 32.9 | 8.7 | 3.2 | 16.3× / 11.6× | 13.3× / 9.5× | 3.5× / 2.5× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.77 | 1.03 | 2.74 | 24.1 | 23.4 | 6.3 | 1.8 | 23.3× / 8.8× | 22.7× / 8.5× | 6.1× / 2.3× | 1.7× / 0.6× |
| added_normalized_sparse | 0.06 | 1.77 | 2.09 | 3.80 | 32.3 | 32.1 | 8.5 | 2.5 | 15.4× / 8.5× | 15.3× / 8.5× | 4.0× / 2.2× | 1.2× / 0.6× |
| added_special_dense | 0.06 | 1.77 | 3.82 | 5.53 | 95.4 | 100.2 | 20.4 | 2.6 | 24.9× / 17.2× | 26.2× / 18.1× | 5.3× / 3.7× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 4.30 | 6.01 | 62.3 | 63.8 | 14.2 | 3.4 | 14.5× / 10.4× | 14.8× / 10.6× | 3.3× / 2.4× | 0.8× / 0.6× |
| agentic-traces | 0.75 | 1.75 | 3.48 | 4.48 | 59.6 | 62.6 | 15.3 | 4.6 | 17.2× / 13.3× | 18.0× / 14.0× | 4.4× / 3.4× | 1.3× / 1.0× |
| agentic_swe | 0.67 | 1.73 | 2.37 | 3.43 | 60.8 | 70.6 | 14.3 | 3.4 | 25.6× / 17.7× | 29.8× / 20.6× | 6.0× / 4.2× | 1.4× / 1.0× |
| code_mixed | 0.09 | 1.73 | 2.85 | 4.49 | 59.4 | 67.9 | 15.1 | 3.9 | 20.8× / 13.2× | 23.8× / 15.1× | 5.3× / 3.4× | 1.4× / 0.9× |
| math_latex | 0.73 | 1.76 | 3.28 | 4.31 | 53.4 | 53.2 | 14.2 | 4.1 | 16.3× / 12.4× | 16.2× / 12.3× | 4.3× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×7.72 vs v0.23.1 · ×1.02 vs base</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-gpt-oss-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 4+11 (peak 16) · Pipeline 7+0 (peak 8)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.3 | 56.3 | ×17.13 | ×0.91 | 4% (0.7) | 0% (0.0) | 29% (5.0) | 67% (11.6) | match |
| arb_Arab | lang | 4.0 | 26.0 | ×6.54 | ×1.02 | 2% (0.6) | 0% (0.0) | 10% (3.7) | 89% (33.8) | match |
| ben_Beng | lang | 5.3 | 28.6 | ×5.41 | ×1.06 | 2% (0.6) | 0% (0.0) | 12% (4.0) | 87% (30.0) | match |
| cmn_Hani | lang | 4.1 | 38.8 | ×9.43 | ×1.00 | 2% (0.6) | 0% (0.0) | 13% (3.4) | 84% (21.1) | match |
| ell_Grek | lang | 4.1 | 32.1 | ×7.85 | ×0.99 | 2% (0.6) | 0% (0.0) | 11% (3.3) | 87% (26.8) | match |
| eng_Latn | lang | 3.3 | 21.8 | ×6.69 | ×1.03 | 4% (2.1) | 0% (0.0) | 10% (4.6) | 86% (39.7) | match |
| heb_Hebr | lang | 3.9 | 27.0 | ×6.90 | ×0.96 | 2% (0.6) | 0% (0.0) | 11% (3.9) | 88% (31.8) | match |
| hin_Deva | lang | 5.2 | 23.7 | ×4.55 | ×1.01 | 1% (0.6) | 0% (0.0) | 10% (4.0) | 89% (36.9) | match |
| jpn_Jpan | lang | 4.8 | 38.6 | ×8.04 | ×1.02 | 2% (0.6) | 0% (0.0) | 12% (3.1) | 85% (21.7) | match |
| kat_Geor | lang | 5.6 | 27.2 | ×4.83 | ×1.07 | 2% (0.6) | 0% (0.0) | 8% (2.9) | 90% (32.7) | match |
| kor_Hang | lang | 3.6 | 48.8 | ×13.66 | ×1.07 | 3% (0.6) | 0% (0.0) | 18% (3.8) | 79% (16.3) | match |
| rus_Cyrl | lang | 4.6 | 23.7 | ×5.17 | ×1.05 | 1% (0.6) | 0% (0.0) | 8% (3.2) | 91% (38.0) | match |
| tam_Taml | lang | 5.7 | 30.4 | ×5.33 | ×1.05 | 2% (0.6) | 0% (0.0) | 11% (3.5) | 87% (28.3) | match |
| tha_Thai | lang | 6.2 | 27.9 | ×4.46 | ×0.98 | 2% (0.6) | 0% (0.0) | 10% (3.5) | 88% (31.2) | match |
| added_normalized_dense | modalities | 4.4 | 45.1 | ×10.25 | ×0.98 | 4% (0.7) | 0% (0.0) | 11% (2.3) | 85% (17.3) | match |
| added_normalized_sparse | modalities | 3.9 | 36.4 | ×9.29 | ×1.00 | 5% (1.4) | 0% (0.0) | 12% (3.2) | 83% (21.5) | match |
| added_special_dense | modalities | 3.3 | 55.9 | ×16.84 | ×1.02 | 29% (4.9) | 1% (0.1) | 30% (5.1) | 40% (6.7) | match |
| added_special_sparse | modalities | 3.4 | 34.5 | ×10.28 | ×1.01 | 12% (3.2) | 0% (0.0) | 21% (5.9) | 67% (18.6) | match |
| agentic-traces | modalities | 2.9 | 23.1 | ×8.00 | ×1.03 | 4% (1.9) | 0% (0.0) | 11% (4.9) | 84% (36.0) | match |
| agentic_swe | modalities | 3.5 | 22.1 | ×6.33 | ×1.03 | 3% (1.3) | 0% (0.0) | 8% (3.7) | 89% (39.3) | match |
| code_mixed | modalities | 3.4 | 30.2 | ×8.83 | ×1.02 | 5% (1.7) | 0% (0.0) | 13% (4.4) | 82% (26.5) | match |
| math_latex | modalities | 3.1 | 23.1 | ×7.52 | ×1.04 | 5% (2.0) | 0% (0.0) | 11% (4.8) | 84% (36.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.52 | 4.96 | 5.70 | 29.9 | 14.8 | 6.9 | 4.8 | 6.0× / 5.3× | 3.0× / 2.6× | 1.4× / 1.2× | 1.0× / 0.8× |
| arb_Arab | 1.15 | 2.98 | 3.74 | 5.57 | 34.4 | 16.4 | 7.6 | 5.1 | 9.2× / 6.2× | 4.4× / 2.9× | 2.0× / 1.4× | 1.4× / 0.9× |
| ben_Beng | 1.61 | 2.99 | 3.98 | 5.35 | 24.3 | 11.1 | 5.4 | 2.8 | 6.1× / 4.5× | 2.8× / 2.1× | 1.4× / 1.0× | 0.7× / 0.5× |
| cmn_Hani | 1.12 | 2.30 | 3.36 | 4.54 | 21.6 | 11.1 | 5.5 | 2.5 | 6.4× / 4.8× | 3.3× / 2.4× | 1.6× / 1.2× | 0.7× / 0.5× |
| ell_Grek | 0.59 | 3.03 | 3.26 | 5.70 | 30.4 | 15.6 | 6.9 | 5.1 | 9.3× / 5.3× | 4.8× / 2.7× | 2.1× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.12 | 1.77 | 4.59 | 6.24 | 44.7 | 30.3 | 14.1 | 4.1 | 9.7× / 7.2× | 6.6× / 4.9× | 3.1× / 2.3× | 0.9× / 0.7× |
| heb_Hebr | 1.15 | 3.08 | 3.91 | 5.85 | 33.8 | 18.1 | 8.0 | 2.8 | 8.6× / 5.8× | 4.6× / 3.1× | 2.1× / 1.4× | 0.7× / 0.5× |
| hin_Deva | 1.51 | 3.33 | 4.04 | 5.85 | 26.3 | 13.2 | 6.3 | 3.2 | 6.5× / 4.5× | 3.3× / 2.3× | 1.6× / 1.1× | 0.8× / 0.5× |
| jpn_Jpan | 1.70 | 3.40 | 3.12 | 4.81 | 20.4 | 9.4 | 4.8 | 3.8 | 6.5× / 4.2× | 3.0× / 2.0× | 1.5× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.54 | 2.62 | 2.90 | 3.98 | 19.0 | 10.8 | 4.7 | 2.2 | 6.5× / 4.8× | 3.7× / 2.7× | 1.6× / 1.2× | 0.7× / 0.5× |
| kor_Hang | 1.23 | 2.79 | 3.81 | 5.37 | 33.6 | 19.2 | 8.8 | 3.6 | 8.8× / 6.3× | 5.1× / 3.6× | 2.3× / 1.6× | 1.0× / 0.7× |
| rus_Cyrl | 1.16 | 2.98 | 3.18 | 5.00 | 30.4 | 15.5 | 6.6 | 4.8 | 9.5× / 6.1× | 4.9× / 3.1× | 2.1× / 1.3× | 1.5× / 1.0× |
| tam_Taml | 0.93 | 3.00 | 3.50 | 5.58 | 19.2 | 9.0 | 4.2 | 2.9 | 5.5× / 3.4× | 2.6× / 1.6× | 1.2× / 0.8× | 0.8× / 0.5× |
| tha_Thai | 1.51 | 2.58 | 3.46 | 4.53 | 13.1 | 5.8 | 2.8 | 2.3 | 3.8× / 2.9× | 1.7× / 1.3× | 0.8× / 0.6× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.77 | 2.32 | 4.03 | 34.8 | 17.7 | 11.5 | 2.1 | 15.0× / 8.6× | 7.7× / 4.4× | 5.0× / 2.9× | 0.9× / 0.5× |
| added_normalized_sparse | 0.06 | 1.77 | 3.17 | 4.88 | 37.0 | 21.8 | 11.7 | 2.8 | 11.7× / 7.6× | 6.9× / 4.5× | 3.7× / 2.4× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.77 | 5.12 | 6.83 | 87.4 | 70.1 | 24.3 | 3.2 | 17.1× / 12.8× | 13.7× / 10.3× | 4.7× / 3.6× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 5.90 | 7.61 | 58.8 | 43.0 | 17.1 | 3.7 | 10.0× / 7.7× | 7.3× / 5.7× | 2.9× / 2.2× | 0.6× / 0.5× |
| agentic-traces | 0.73 | 1.76 | 4.92 | 5.96 | 53.8 | 42.0 | 17.4 | 4.9 | 10.9× / 9.0× | 8.5× / 7.0× | 3.5× / 2.9× | 1.0× / 0.8× |
| agentic_swe | 0.66 | 1.73 | 3.71 | 4.77 | 55.0 | 49.4 | 17.3 | 3.6 | 14.8× / 11.5× | 13.3× / 10.3× | 4.7× / 3.6× | 1.0× / 0.7× |
| code_mixed | 0.09 | 1.74 | 4.35 | 6.00 | 54.3 | 47.3 | 17.4 | 4.2 | 12.5× / 9.0× | 10.9× / 7.9× | 4.0× / 2.9× | 1.0× / 0.7× |
| math_latex | 0.74 | 1.79 | 4.85 | 5.90 | 51.6 | 36.6 | 16.3 | 4.5 | 10.6× / 8.8× | 7.6× / 6.2× | 3.4× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×13.22 vs v0.23.1 · ×1.04 vs base</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-glm-5-2-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 4+11 (peak 15) · Pipeline 6+0 (peak 6)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.6 | 64.4 | ×13.90 | ×1.04 | 8% (1.2) | 0% (0.0) | 25% (3.7) | 67% (10.1) | match |
| arb_Arab | lang | 4.1 | 73.4 | ×17.83 | ×1.04 | 9% (1.2) | 0% (0.0) | 18% (2.3) | 73% (9.4) | match |
| ben_Beng | lang | 3.4 | 72.6 | ×21.16 | ×1.05 | 9% (1.2) | 0% (0.0) | 23% (3.1) | 68% (9.2) | match |
| cmn_Hani | lang | 4.6 | 69.8 | ×15.17 | ×1.02 | 9% (1.2) | 0% (0.0) | 17% (2.3) | 74% (10.2) | match |
| ell_Grek | lang | 4.1 | 71.1 | ×17.53 | ×0.97 | 9% (1.2) | 0% (0.0) | 17% (2.2) | 73% (9.3) | match |
| eng_Latn | lang | 3.5 | 23.1 | ×6.56 | ×1.02 | 6% (2.7) | 0% (0.0) | 7% (3.1) | 87% (37.4) | match |
| heb_Hebr | lang | 3.8 | 74.8 | ×19.88 | ×1.14 | 9% (1.2) | 0% (0.0) | 18% (2.3) | 73% (9.5) | match |
| hin_Deva | lang | 3.1 | 64.9 | ×20.85 | ×1.04 | 8% (1.2) | 0% (0.0) | 22% (3.2) | 70% (10.5) | match |
| jpn_Jpan | lang | 4.7 | 75.4 | ×16.01 | ×1.02 | 9% (1.2) | 0% (0.0) | 17% (2.2) | 74% (9.4) | match |
| kat_Geor | lang | 4.4 | 83.2 | ×18.73 | ×1.03 | 10% (1.2) | 0% (0.0) | 18% (2.1) | 72% (8.3) | match |
| kor_Hang | lang | 3.5 | 71.6 | ×20.68 | ×1.09 | 9% (1.2) | 0% (0.0) | 19% (2.5) | 72% (9.7) | match |
| rus_Cyrl | lang | 4.0 | 39.2 | ×9.84 | ×0.98 | 5% (1.2) | 0% (0.0) | 9% (2.2) | 87% (21.4) | match |
| tam_Taml | lang | 3.2 | 71.5 | ×22.40 | ×1.01 | 9% (1.2) | 0% (0.0) | 20% (2.7) | 72% (9.7) | match |
| tha_Thai | lang | 3.9 | 77.5 | ×19.89 | ×1.06 | 9% (1.2) | 0% (0.0) | 20% (2.5) | 70% (8.8) | match |
| added_normalized_dense | modalities | 4.5 | 47.9 | ×10.62 | ×1.05 | 7% (1.3) | 0% (0.0) | 5% (1.1) | 88% (17.7) | match |
| added_normalized_sparse | modalities | 4.1 | 41.3 | ×10.04 | ×1.08 | 8% (1.9) | 0% (0.0) | 9% (2.1) | 84% (19.7) | match |
| added_special_dense | modalities | 3.4 | 42.3 | ×12.56 | ×1.04 | 52% (11.8) | 0% (0.0) | 22% (5.0) | 26% (5.8) | match |
| added_special_sparse | modalities | 3.5 | 34.7 | ×10.06 | ×1.03 | 25% (6.9) | 0% (0.0) | 17% (4.8) | 58% (16.3) | match |
| agentic-traces | modalities | 3.2 | 24.2 | ×7.58 | ×1.03 | 6% (2.6) | 0% (0.0) | 9% (3.8) | 85% (35.1) | match |
| agentic_swe | modalities | 3.5 | 22.7 | ×6.42 | ×1.03 | 5% (2.0) | 0% (0.0) | 7% (2.9) | 89% (39.0) | match |
| code_mixed | modalities | 3.5 | 31.6 | ×8.91 | ×1.03 | 7% (2.3) | 0% (0.0) | 10% (3.3) | 82% (25.7) | match |
| math_latex | modalities | 3.2 | 24.5 | ×7.74 | ×1.02 | 6% (2.6) | 0% (0.0) | 9% (3.5) | 85% (34.3) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.50 | 3.71 | 4.44 | 26.3 | 16.5 | 5.9 | 4.7 | 7.1× / 5.9× | 4.5× / 3.7× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.99 | 2.32 | 4.16 | 29.8 | 19.6 | 6.8 | 5.0 | 12.8× / 7.2× | 8.5× / 4.7× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.62 | 2.99 | 3.14 | 4.52 | 43.8 | 29.2 | 10.3 | 3.7 | 13.9× / 9.7× | 9.3× / 6.5× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.31 | 2.35 | 3.53 | 18.9 | 11.9 | 4.8 | 2.4 | 8.1× / 5.4× | 5.1× / 3.4× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.60 | 3.32 | 2.21 | 4.94 | 27.4 | 17.3 | 6.1 | 4.8 | 12.4× / 5.6× | 7.8× / 3.5× | 2.7× / 1.2× | 2.2× / 1.0× |
| eng_Latn | 0.12 | 1.78 | 3.10 | 4.76 | 43.1 | 33.6 | 12.2 | 3.9 | 13.9× / 9.1× | 10.9× / 7.1× | 3.9× / 2.6× | 1.3× / 0.8× |
| heb_Hebr | 1.14 | 3.05 | 2.32 | 4.23 | 29.8 | 20.3 | 7.0 | 3.0 | 12.8× / 7.0× | 8.8× / 4.8× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.31 | 3.23 | 5.03 | 46.7 | 31.4 | 11.4 | 4.0 | 14.4× / 9.3× | 9.7× / 6.2× | 3.5× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.70 | 3.42 | 2.16 | 3.89 | 17.7 | 10.5 | 4.2 | 3.8 | 8.2× / 4.6× | 4.9× / 2.7× | 1.9× / 1.1× | 1.8× / 1.0× |
| kat_Geor | 1.54 | 2.62 | 2.09 | 3.17 | 16.2 | 11.5 | 4.3 | 2.0 | 7.7× / 5.1× | 5.5× / 3.6× | 2.0× / 1.3× | 0.9× / 0.6× |
| kor_Hang | 1.23 | 2.79 | 2.52 | 4.09 | 30.2 | 21.7 | 7.5 | 3.7 | 12.0× / 7.4× | 8.6× / 5.3× | 3.0× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.17 | 2.94 | 2.17 | 3.95 | 26.0 | 16.9 | 6.0 | 2.4 | 12.0× / 6.6× | 7.8× / 4.3× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.92 | 3.01 | 2.69 | 4.78 | 42.4 | 27.1 | 10.0 | 3.4 | 15.8× / 8.9× | 10.1× / 5.7× | 3.7× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.51 | 2.74 | 2.54 | 3.76 | 27.2 | 16.4 | 6.8 | 3.0 | 10.7× / 7.2× | 6.4× / 4.4× | 2.7× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.77 | 1.06 | 2.77 | 23.0 | 17.3 | 6.5 | 1.9 | 21.7× / 8.3× | 16.3× / 6.3× | 6.1× / 2.3× | 1.8× / 0.7× |
| added_normalized_sparse | 0.06 | 1.77 | 2.06 | 3.77 | 30.8 | 23.6 | 8.7 | 2.7 | 14.9× / 8.2× | 11.5× / 6.3× | 4.2× / 2.3× | 1.3× / 0.7× |
| added_special_dense | 0.06 | 1.77 | 4.95 | 6.66 | 93.7 | 75.7 | 20.8 | 3.1 | 18.9× / 14.1× | 15.3× / 11.4× | 4.2× / 3.1× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 4.79 | 6.50 | 59.0 | 47.5 | 15.1 | 3.5 | 12.3× / 9.1× | 9.9× / 7.3× | 3.2× / 2.3× | 0.7× / 0.5× |
| agentic-traces | 0.77 | 1.77 | 3.76 | 4.75 | 52.3 | 43.8 | 14.9 | 4.7 | 13.9× / 11.0× | 11.7× / 9.2× | 4.0× / 3.1× | 1.3× / 1.0× |
| agentic_swe | 0.67 | 1.73 | 2.89 | 3.96 | 53.8 | 51.4 | 15.3 | 3.4 | 18.6× / 13.6× | 17.7× / 13.0× | 5.3× / 3.9× | 1.2× / 0.9× |
| code_mixed | 0.08 | 1.73 | 3.27 | 4.92 | 51.9 | 49.8 | 15.0 | 4.1 | 15.9× / 10.6× | 15.3× / 10.1× | 4.6× / 3.0× | 1.3× / 0.8× |
| math_latex | 0.74 | 1.77 | 3.47 | 4.50 | 49.9 | 39.6 | 14.1 | 4.2 | 14.4× / 11.1× | 11.4× / 8.8× | 4.1× / 3.1× | 1.2× / 0.9× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.28 vs v0.23.1 · ×1.02 vs base</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-llama-2-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.6 | 46.2 | ×8.22 | ×1.01 | 0% (0.0) | 13% (2.7) | 0% (0.0) | 87% (18.0) | match |
| arb_Arab | lang | 12.2 | 51.9 | ×4.25 | ×0.99 | 0% (0.0) | 17% (3.1) | 0% (0.0) | 83% (15.3) | match |
| ben_Beng | lang | 13.3 | 86.4 | ×6.49 | ×0.99 | 0% (0.0) | 19% (2.1) | 0% (0.0) | 80% (8.7) | match |
| cmn_Hani | lang | 11.2 | 70.1 | ×6.28 | ×1.04 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 96% (13.0) | match |
| ell_Grek | lang | 12.5 | 60.3 | ×4.81 | ×1.01 | 0% (0.0) | 20% (3.1) | 0% (0.0) | 80% (12.5) | match |
| eng_Latn | lang | 4.5 | 6.6 | ×1.47 | ×1.08 | 0% (0.1) | 5% (6.8) | 0% (0.1) | 95% (140.3) | match |
| heb_Hebr | lang | 12.3 | 62.7 | ×5.09 | ×0.98 | 0% (0.0) | 21% (3.2) | 0% (0.0) | 78% (11.9) | match |
| hin_Deva | lang | 13.8 | 82.0 | ×5.96 | ×0.98 | 0% (0.0) | 24% (2.8) | 0% (0.0) | 75% (8.6) | match |
| jpn_Jpan | lang | 15.9 | 91.0 | ×5.74 | ×1.05 | 0% (0.0) | 3% (0.3) | 0% (0.0) | 96% (9.8) | match |
| kat_Geor | lang | 16.9 | 95.0 | ×5.62 | ×1.01 | 0% (0.0) | 19% (1.9) | 0% (0.0) | 81% (8.0) | match |
| kor_Hang | lang | 8.5 | 54.1 | ×6.35 | ×1.00 | 0% (0.1) | 18% (3.2) | 0% (0.0) | 81% (14.4) | match |
| rus_Cyrl | lang | 9.2 | 16.8 | ×1.83 | ×1.02 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (56.0) | match |
| tam_Taml | lang | 14.9 | 94.6 | ×6.36 | ×1.00 | 0% (0.0) | 17% (1.7) | 0% (0.0) | 82% (8.1) | match |
| tha_Thai | lang | 19.1 | 92.8 | ×4.85 | ×1.02 | 0% (0.0) | 9% (0.9) | 0% (0.0) | 91% (9.3) | match |
| added_normalized_dense | modalities | 5.9 | 8.8 | ×1.50 | ×1.01 | 0% (0.1) | 3% (3.7) | 0% (0.0) | 97% (109.6) | match |
| added_normalized_sparse | modalities | 5.2 | 7.6 | ×1.46 | ×1.01 | 0% (0.0) | 5% (6.0) | 0% (0.0) | 95% (119.9) | match |
| added_special_dense | modalities | 5.5 | 20.5 | ×3.75 | ×1.04 | 11% (5.1) | 33% (15.5) | 3% (1.2) | 54% (25.1) | match |
| added_special_sparse | modalities | 7.8 | 10.6 | ×1.35 | ×1.03 | 2% (2.2) | 15% (14.0) | 0% (0.2) | 82% (76.4) | match |
| agentic-traces | modalities | 5.0 | 7.3 | ×1.47 | ×1.02 | 0% (0.1) | 5% (6.1) | 0% (0.0) | 95% (125.6) | match |
| agentic_swe | modalities | 4.5 | 7.8 | ×1.71 | ×1.03 | 0% (0.0) | 8% (9.6) | 0% (0.0) | 92% (117.8) | match |
| code_mixed | modalities | 4.7 | 7.3 | ×1.55 | ×1.01 | 0% (0.0) | 6% (7.9) | 0% (0.0) | 94% (124.0) | match |
| math_latex | modalities | 4.9 | 7.1 | ×1.45 | ×1.06 | 0% (0.1) | 5% (6.3) | 0% (0.0) | 95% (133.0) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×7.33 vs v0.23.1 · ×1.07 vs base</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-llama-3-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 143+0 (peak 199) · Pipeline 145+0 (peak 200)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 45.3 | ×11.08 | ×0.89 | 3% (0.7) | 0% (0.0) | 20% (3.7) | 77% (14.5) | match |
| arb_Arab | lang | 4.5 | 18.1 | ×3.98 | ×1.04 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 94% (49.9) | match |
| ben_Beng | lang | 4.0 | 31.9 | ×7.88 | ×1.01 | 2% (0.6) | 0% (0.0) | 10% (3.1) | 88% (27.0) | match |
| cmn_Hani | lang | 5.0 | 16.9 | ×3.38 | ×1.08 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 95% (53.8) | match |
| ell_Grek | lang | 5.1 | 20.0 | ×3.89 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (2.2) | 94% (45.5) | match |
| eng_Latn | lang | 3.9 | 46.2 | ×11.83 | ×1.37 | 11% (2.1) | 1% (0.1) | 16% (3.0) | 72% (13.6) | match |
| heb_Hebr | lang | 4.2 | 26.2 | ×6.20 | ×0.97 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 92% (33.2) | match |
| hin_Deva | lang | 4.3 | 77.6 | ×17.95 | ×1.03 | 5% (0.6) | 0% (0.0) | 28% (3.2) | 67% (7.6) | match |
| jpn_Jpan | lang | 5.7 | 16.9 | ×2.98 | ×1.07 | 1% (0.6) | 0% (0.0) | 4% (2.1) | 95% (53.7) | match |
| kat_Geor | lang | 5.3 | 39.4 | ×7.49 | ×0.99 | 3% (0.6) | 0% (0.0) | 9% (2.1) | 89% (21.1) | match |
| kor_Hang | lang | 4.0 | 19.2 | ×4.76 | ×1.07 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 94% (46.7) | match |
| rus_Cyrl | lang | 4.8 | 17.0 | ×3.55 | ×1.07 | 1% (0.6) | 0% (0.0) | 4% (2.1) | 95% (53.6) | match |
| tam_Taml | lang | 3.8 | 35.3 | ×9.24 | ×1.00 | 2% (0.6) | 0% (0.0) | 10% (2.7) | 88% (23.9) | match |
| tha_Thai | lang | 5.2 | 20.9 | ×4.00 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 93% (43.1) | match |
| added_normalized_dense | modalities | 5.8 | 27.7 | ×4.76 | ×1.00 | 2% (0.8) | 0% (0.0) | 3% (1.1) | 95% (33.0) | match |
| added_normalized_sparse | modalities | 5.2 | 43.5 | ×8.33 | ×1.01 | 6% (1.4) | 0% (0.0) | 9% (2.0) | 85% (18.7) | match |
| added_special_dense | modalities | 4.1 | 76.3 | ×18.45 | ×1.10 | 42% (5.0) | 0% (0.0) | 40% (4.8) | 18% (2.2) | match |
| added_special_sparse | modalities | 4.3 | 70.5 | ×16.56 | ×1.01 | 26% (3.2) | 0% (0.0) | 39% (4.9) | 36% (4.5) | match |
| agentic-traces | modalities | 3.5 | 37.7 | ×10.84 | ×1.26 | 8% (1.9) | 0% (0.0) | 15% (3.7) | 77% (18.6) | match |
| agentic_swe | modalities | 3.8 | 28.8 | ×7.58 | ×1.13 | 4% (1.3) | 0% (0.0) | 9% (2.9) | 87% (28.4) | match |
| code_mixed | modalities | 4.0 | 47.1 | ×11.80 | ×1.16 | 9% (1.7) | 0% (0.0) | 17% (3.3) | 74% (14.0) | match |
| math_latex | modalities | 3.7 | 40.7 | ×10.98 | ×1.27 | 9% (2.0) | 0% (0.0) | 16% (3.4) | 75% (16.3) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.54 | 3.69 | 4.45 | 28.0 | 16.4 | 5.9 | 4.8 | 7.6× / 6.3× | 4.5× / 3.7× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 3.01 | 2.31 | 4.18 | 31.7 | 19.3 | 6.8 | 5.1 | 13.7× / 7.6× | 8.4× / 4.6× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.61 | 3.15 | 3.08 | 4.61 | 47.2 | 29.0 | 10.7 | 3.7 | 15.3× / 10.2× | 9.4× / 6.3× | 3.5× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.31 | 2.34 | 3.52 | 19.9 | 11.8 | 4.8 | 2.4 | 8.5× / 5.6× | 5.0× / 3.3× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 3.04 | 2.22 | 4.67 | 29.1 | 17.2 | 6.1 | 4.6 | 13.1× / 6.2× | 7.7× / 3.7× | 2.7× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.11 | 2.06 | 2.99 | 4.94 | 46.9 | 33.4 | 12.4 | 3.9 | 15.7× / 9.5× | 11.2× / 6.8× | 4.1× / 2.5× | 1.3× / 0.8× |
| heb_Hebr | 1.15 | 3.05 | 2.30 | 4.21 | 31.8 | 20.0 | 6.9 | 2.9 | 13.8× / 7.6× | 8.7× / 4.7× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.17 | 3.19 | 4.84 | 49.7 | 31.5 | 11.5 | 4.0 | 15.6× / 10.3× | 9.9× / 6.5× | 3.6× / 2.4× | 1.2× / 0.8× |
| jpn_Jpan | 1.70 | 3.50 | 2.14 | 3.93 | 18.5 | 10.0 | 4.2 | 3.9 | 8.7× / 4.7× | 4.7× / 2.5× | 2.0× / 1.1× | 1.8× / 1.0× |
| kat_Geor | 1.54 | 2.61 | 2.07 | 3.13 | 17.3 | 11.2 | 4.3 | 1.9 | 8.4× / 5.5× | 5.4× / 3.6× | 2.1× / 1.4× | 0.9× / 0.6× |
| kor_Hang | 1.22 | 2.82 | 2.52 | 4.11 | 32.5 | 21.6 | 7.7 | 3.7 | 12.9× / 7.9× | 8.6× / 5.3× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.17 | 2.95 | 2.13 | 3.91 | 27.5 | 17.0 | 5.9 | 2.4 | 12.9× / 7.0× | 8.0× / 4.4× | 2.8× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.92 | 2.98 | 2.67 | 4.72 | 45.6 | 27.3 | 10.2 | 3.3 | 17.1× / 9.7× | 10.2× / 5.8× | 3.8× / 2.2× | 1.2× / 0.7× |
| tha_Thai | 1.88 | 2.62 | 2.52 | 3.25 | 28.7 | 16.3 | 6.8 | 3.0 | 11.4× / 8.8× | 6.5× / 5.0× | 2.7× / 2.1× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 2.08 | 1.07 | 3.10 | 25.0 | 17.3 | 6.6 | 1.9 | 23.4× / 8.1× | 16.2× / 5.6× | 6.1× / 2.1× | 1.8× / 0.6× |
| added_normalized_sparse | 0.06 | 2.08 | 1.99 | 4.02 | 32.8 | 23.1 | 8.9 | 2.6 | 16.4× / 8.2× | 11.6× / 5.7× | 4.5× / 2.2× | 1.3× / 0.7× |
| added_special_dense | 0.06 | 2.08 | 4.79 | 6.81 | 99.0 | 74.5 | 20.9 | 3.1 | 20.7× / 14.5× | 15.6× / 10.9× | 4.4× / 3.1× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 2.08 | 4.94 | 6.97 | 63.7 | 47.5 | 15.1 | 3.5 | 12.9× / 9.1× | 9.6× / 6.8× | 3.1× / 2.2× | 0.7× / 0.5× |
| agentic-traces | 0.75 | 2.08 | 3.71 | 5.05 | 56.0 | 44.7 | 15.0 | 4.7 | 15.1× / 11.1× | 12.0× / 8.8× | 4.0× / 3.0× | 1.3× / 0.9× |
| agentic_swe | 0.66 | 2.04 | 2.90 | 4.28 | 58.5 | 51.5 | 15.5 | 3.5 | 20.1× / 13.7× | 17.7× / 12.0× | 5.3× / 3.6× | 1.2× / 0.8× |
| code_mixed | 0.09 | 2.06 | 3.26 | 5.23 | 55.8 | 49.1 | 15.1 | 4.0 | 17.1× / 10.7× | 15.1× / 9.4× | 4.6× / 2.9× | 1.2× / 0.8× |
| math_latex | 0.71 | 2.08 | 3.45 | 4.82 | 53.6 | 39.6 | 14.1 | 4.3 | 15.5× / 11.1× | 11.5× / 8.2× | 4.1× / 2.9× | 1.2× / 0.9× |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29918591026-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->


