### PR TITLE
fix: anchor ptrhash revision

### DIFF
--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -32,66 +32,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anyhow"
-version = "1.0.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary-chunks"
@@ -146,12 +102,6 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -195,17 +145,6 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
-
-[[package]]
-name = "cacheline-ef"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af737c6c59cb018ecbe6472cbdf86d39c59d78252febfe311953a991b6e4ed85"
-dependencies = [
- "common_traits",
- "epserde",
- "mem_dbg",
-]
 
 [[package]]
 name = "cast"
@@ -287,7 +226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
- "clap_derive",
 ]
 
 [[package]]
@@ -296,22 +234,8 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -321,39 +245,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
 name = "colored"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
-name = "common_traits"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda9ae1f26adcae83adb2e92f69cf59421f2a277a942f49f8e59f2fcbd7cf062"
-dependencies = [
- "anyhow",
- "half",
- "impl-tools",
 ]
 
 [[package]]
@@ -627,45 +524,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "epserde"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40d342ff20a2ce62d9a85ce406e672dfa137f902ac9670034533184f1533976"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "common_traits",
- "epserde-derive",
- "maligned",
- "mem_dbg",
- "mmap-rs",
- "sealed",
- "thiserror 2.0.18",
- "xxhash-rust",
-]
-
-[[package]]
-name = "epserde-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac80cc78b69765703f48ad93f33b8919cf5d907cda7459ad6ba2919cbbe605dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -724,6 +586,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -859,10 +727,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.5.0"
+name = "hashbrown"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -885,7 +758,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "ureq",
  "windows-sys 0.60.2",
 ]
@@ -1098,30 +971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-tools"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae95c9095c2f1126d7db785955c73cdc5fc33e7c3fa911bd4a42931672029a7"
-dependencies = [
- "autocfg",
- "impl-tools-lib",
- "proc-macro-error2",
- "syn",
-]
-
-[[package]]
-name = "impl-tools-lib"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "indicatif"
 version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,12 +1012,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1260,15 +1103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mach2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "macro_rules_attribute"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,28 +1119,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
-name = "maligned"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e88c3cbe8288f77f293e48a28b3232e3defd203a6d839fa7f68ea4329e83464"
-
-[[package]]
 name = "mem_dbg"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728cc9dc97593cd22f7bc81fbef70a2d391d7a9a855e7d658b653318124a6cf0"
+checksum = "f4ef2d80bfa14894b6d5a3ff537e7e9a908dbf4c95de8a5b8ad2a473301676e6"
 dependencies = [
- "bitflags 2.13.0",
- "maligned",
+ "bitflags",
+ "hashbrown",
  "mem_dbg-derive",
- "mmap-rs",
 ]
 
 [[package]]
 name = "mem_dbg-derive"
-version = "0.2.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84f40c93b0508d5565db79a814d02d5b2545967205ce44be211592aafa34d6c"
+checksum = "73acd151c6ce84a41d8d6fb0958d9a3d5a18d649ad5a85ad5b719439af8ad257"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1318,15 +1145,6 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -1356,23 +1174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mmap-rs"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86968d85441db75203c34deefd0c88032f275aaa85cee19a1dcfff6ae9df56da"
-dependencies = [
- "bitflags 1.3.2",
- "combine",
- "libc",
- "mach2",
- "nix",
- "sysctl",
- "thiserror 1.0.69",
- "widestring",
- "windows",
-]
-
-[[package]]
 name = "monostate"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,19 +1200,6 @@ name = "nanorand"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
- "pin-utils",
-]
 
 [[package]]
 name = "nom"
@@ -1454,18 +1242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "onig"
 version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1516,12 +1298,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1582,27 +1358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,31 +1368,21 @@ dependencies = [
 
 [[package]]
 name = "ptr_hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4e4fb9c4c2ba3e5b060f53ef46afd3de37345b08e3ec0f2c65e0ca1d57ccbd"
+version = "2.0.0-alpha.1"
+source = "git+https://github.com/RagnarGrootKoerkamp/PtrHash.git?rev=d637316#d6373165c0da544ba73062e832f23c386eb81e16"
 dependencies = [
- "anyhow",
  "bitvec",
- "cacheline-ef",
- "clap",
  "colored",
- "common_traits",
- "epserde",
- "epserde-derive",
  "fastrand",
  "fxhash",
  "itertools 0.14.0",
- "lazy_static",
  "log",
  "mem_dbg",
  "rand",
  "rand_chacha",
  "rayon",
  "rdst",
- "rustc-hash",
  "serde",
- "sucds",
  "tempfile",
  "xxhash-rust",
 ]
@@ -1656,7 +1401,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1677,7 +1422,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1807,7 +1552,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1906,7 +1651,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1968,17 +1713,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "sealed"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2127,16 +1861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "sucds"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd324eaa05be64f105ea5269bb8aabd70e5dd57fa5c673b167f451b07d6c0dcd"
-dependencies = [
- "anyhow",
- "num-traits",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,20 +1892,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysctl"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
-dependencies = [
- "bitflags 2.13.0",
- "byteorder",
- "enum-as-inner",
- "libc",
- "thiserror 1.0.69",
- "walkdir",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,31 +1912,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2337,7 +2027,7 @@ dependencies = [
  "serde_json",
  "spm_precompiled",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokenizers 0.23.1",
  "tracing",
  "tracing-subscriber",
@@ -2365,7 +2055,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tk-encode",
 ]
 
@@ -2397,7 +2087,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 2.0.18",
+ "thiserror",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -2476,7 +2166,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -2655,12 +2345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,12 +2506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,15 +2535,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows-link"
@@ -2911,21 +2580,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -2959,12 +2613,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2977,12 +2625,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2992,12 +2634,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3025,12 +2661,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3040,12 +2670,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3061,12 +2685,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3076,12 +2694,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -2000,7 +2000,6 @@ version = "0.23.2-dev.0"
 dependencies = [
  "ahash",
  "assert_approx_eq",
- "compact_str",
  "criterion 0.6.0",
  "daachorse 3.0.2",
  "dary_heap",
@@ -2022,7 +2021,6 @@ dependencies = [
  "rayon-cond",
  "regex",
  "regex-automata",
- "regex-syntax",
  "serde",
  "serde_json",
  "spm_precompiled",

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -30,7 +30,6 @@ path = "src/lib.rs"
 rand = "0.9"
 onig = { version = "6.5.1", default-features = false, optional = true }
 regex = "1.10"
-regex-syntax = "0.8"
 regex-automata = "0.4"
 rayon = "1.10"
 rayon-cond = "0.4"
@@ -52,11 +51,10 @@ paste = "1.0.14"
 macro_rules_attribute = "0.2.0"
 thiserror = "2"
 fancy-regex = { version = "0.17", optional = true }
-getrandom = { version = "0.3" }
+getrandom = { version = "0.3", optional = true }
 monostate = "0.1.12"
 ahash = { version = "0.8.11", features = ["serde"] }
 dary_heap = { version = "0.3.6", features = ["serde"] }
-compact_str = { version = "0.9", features = ["serde"] }
 ptr_hash = { git = "https://github.com/RagnarGrootKoerkamp/PtrHash.git", rev = "d637316", default-features = false }
 memchr = "2.8.2"
 unicode-normalization = "0.1.25"
@@ -69,7 +67,9 @@ tokenizers-release = { package = "tokenizers", version = "=0.23.1", optional = t
 # TODO: onig is C (Oniguruma, archived upstream). We're moving to the pure-Rust
 # fancy-regex backend by default; once the legacy pre-tokenizers are gone, drop
 # the `onig` feature + `src/utils/onig.rs` entirely.
-default = ["progressbar", "fancy-regex"]
+# progressbar is not a default: nothing in tk-encode draws a progress bar; tk-train
+# forwards `tk-encode/progressbar` from its own default feature set.
+default = ["fancy-regex"]
 progressbar = ["indicatif"]
 http = ["hf-hub"]
 unstable_wasm = ["fancy-regex", "getrandom/wasm_js"]

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -57,7 +57,7 @@ monostate = "0.1.12"
 ahash = { version = "0.8.11", features = ["serde"] }
 dary_heap = { version = "0.3.6", features = ["serde"] }
 compact_str = { version = "0.9", features = ["serde"] }
-ptr_hash = { version = "1.1.0" }
+ptr_hash = { git = "https://github.com/RagnarGrootKoerkamp/PtrHash.git", rev = "d637316", default-features = false }
 memchr = "2.8.2"
 unicode-normalization = "0.1.25"
 yada = "0.7.0"

--- a/tokenizers/tk-encode/src/lib.rs
+++ b/tokenizers/tk-encode/src/lib.rs
@@ -75,9 +75,8 @@
 //!
 //! # Features
 //!
-//! - **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
-//!   compilation for certain targets is not supported by the [termios](https://crates.io/crates/termios)
-//!   dependency of the [indicatif](https://crates.io/crates/indicatif) progress bar.
+//! - **progressbar**: Enables the [indicatif](https://crates.io/crates/indicatif) progress bar
+//!   re-exported for trainers. Disabled by default: encoding never draws a progress bar.
 //!
 //! - **http**: This feature enables downloading the tokenizer via HTTP. It is disabled by default.
 //!   With this feature enabled, `Tokenizer::from_pretrained` becomes accessible.


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**5 / 6 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · single thread + 1/2/4/8/max-thread sweep

`6bd3a1229 · 2026-07-11 09:57 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 32 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-overview-dark.png">
  <img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-overview-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-memory-dark.png">
  <img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-memory-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-binsize-dark.png">
  <img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-binsize-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×5.03 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-bert-base-uncased-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-bert-base-uncased-threads-dark.png">
  <img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-bert-base-uncased-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 2+0 (peak 6) · Pipeline 7+0 (peak 7)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 6.9 | 23.5 | ×3.41 | 3% (1.2) | 66% (27.8) | 21% (8.8) | 10% (4.2) | match |
| arb_Arab | lang | 3.4 | 18.7 | ×5.47 | 2% (1.2) | 54% (28.5) | 23% (12.3) | 21% (10.9) | match |
| ben_Beng | lang | 5.1 | 27.1 | ×5.27 | 3% (1.2) | 54% (19.8) | 22% (8.1) | 20% (7.4) | match |
| cmn_Hani | lang | 3.0 | 15.5 | ×5.11 | 2% (1.2) | 59% (37.9) | 16% (10.5) | 23% (14.7) | match |
| ell_Grek | lang | 3.2 | 18.1 | ×5.72 | 2% (1.2) | 54% (29.6) | 23% (12.6) | 21% (11.6) | match |
| eng_Latn | lang | 3.7 | 17.4 | ×4.63 | 5% (2.7) | 68% (38.8) | 6% (3.5) | 21% (12.3) | match |
| heb_Hebr | lang | 3.4 | 15.8 | ×4.60 | 2% (1.2) | 61% (38.6) | 19% (12.2) | 17% (10.9) | match |
| hin_Deva | lang | 5.5 | 23.0 | ×4.16 | 3% (1.2) | 64% (27.6) | 17% (7.1) | 16% (7.1) | match |
| jpn_Jpan | lang | 3.6 | 21.3 | ×5.90 | 3% (1.2) | 51% (23.8) | 22% (10.3) | 24% (11.4) | match |
| kat_Geor | lang | 5.6 | 23.0 | ×4.11 | 3% (1.2) | 62% (27.0) | 21% (9.1) | 14% (6.2) | match |
| kor_Hang | lang | 2.1 | 13.3 | ×6.26 | 2% (1.2) | 47% (35.6) | 28% (20.8) | 23% (17.4) | match |
| rus_Cyrl | lang | 3.1 | 18.1 | ×5.84 | 2% (1.2) | 52% (28.5) | 23% (12.6) | 23% (12.5) | match |
| tam_Taml | lang | 6.5 | 30.1 | ×4.65 | 4% (1.2) | 58% (19.1) | 23% (7.6) | 15% (4.9) | match |
| tha_Thai | lang | 7.9 | 27.5 | ×3.50 | 3% (1.2) | 71% (25.5) | 20% (7.0) | 6% (2.2) | match |
| added_normalized_dense | modalities | 6.0 | 21.9 | ×3.67 | 3% (1.3) | 91% (40.6) | 3% (1.5) | 3% (1.4) | match |
| added_normalized_sparse | modalities | 4.7 | 19.3 | ×4.11 | 4% (1.9) | 79% (40.2) | 4% (2.3) | 13% (6.5) | match |
| added_special_dense | modalities | 4.7 | 51.2 | ×11.00 | 28% (5.3) | 48% (9.1) | 12% (2.2) | 12% (2.3) | match |
| added_special_sparse | modalities | 3.6 | 23.1 | ×6.36 | 9% (3.7) | 67% (28.3) | 6% (2.7) | 18% (7.5) | match |
| agentic-traces | modalities | 3.3 | 16.7 | ×5.14 | 4% (2.5) | 65% (38.5) | 7% (3.9) | 24% (14.5) | match |
| agentic_swe | modalities | 3.5 | 17.9 | ×5.14 | 4% (2.0) | 70% (38.7) | 5% (2.8) | 22% (12.0) | match |
| code_mixed | modalities | 3.4 | 17.5 | ×5.22 | 4% (2.3) | 68% (38.5) | 6% (3.5) | 22% (12.4) | match |
| math_latex | modalities | 3.4 | 17.0 | ×5.00 | 4% (2.6) | 66% (38.7) | 6% (3.6) | 23% (13.7) | match |

</details>

<details><summary><b>deepseek-v4</b> — split-heavy byte-level BPE, 3 chained regexes · ×2.62 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-deepseek-v4-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-deepseek-v4-threads-dark.png">
  <img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-deepseek-v4-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 52+0 (peak 57) · Pipeline 85+0 (peak 84)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.7 | 14.1 | ×3.77 | 1% (0.7) | 0% (0.0) | 63% (43.4) | 36% (24.8) | match |
| arb_Arab | lang | 3.6 | 9.2 | ×2.54 | 1% (0.6) | 0% (0.0) | 48% (50.9) | 52% (55.1) | match |
| ben_Beng | lang | 4.4 | 11.1 | ×2.52 | 1% (0.6) | 0% (0.0) | 42% (37.7) | 58% (52.0) | match |
| cmn_Hani | lang | 3.3 | 7.9 | ×2.41 | 1% (0.8) | 0% (0.0) | 53% (65.5) | 46% (56.5) | match |
| ell_Grek | lang | 3.7 | 9.8 | ×2.67 | 1% (0.6) | 0% (0.0) | 48% (49.1) | 51% (52.1) | match |
| eng_Latn | lang | 2.7 | 6.6 | ×2.48 | 1% (2.2) | 0% (0.0) | 48% (70.8) | 51% (75.5) | match |
| heb_Hebr | lang | 3.1 | 8.0 | ×2.55 | 0% (0.6) | 0% (0.0) | 42% (52.4) | 57% (70.8) | match |
| hin_Deva | lang | 4.1 | 11.8 | ×2.88 | 1% (0.7) | 0% (0.0) | 47% (39.3) | 52% (43.3) | match |
| jpn_Jpan | lang | 3.7 | 8.9 | ×2.36 | 1% (0.7) | 0% (0.0) | 53% (60.3) | 46% (52.8) | match |
| kat_Geor | lang | 4.4 | 11.6 | ×2.67 | 1% (0.6) | 0% (0.0) | 40% (34.8) | 59% (50.7) | match |
| kor_Hang | lang | 3.2 | 9.8 | ×3.05 | 1% (0.6) | 0% (0.0) | 54% (54.2) | 45% (45.1) | match |
| rus_Cyrl | lang | 3.5 | 8.9 | ×2.54 | 1% (0.6) | 0% (0.0) | 43% (49.0) | 56% (63.8) | match |
| tam_Taml | lang | 4.7 | 11.3 | ×2.41 | 1% (0.6) | 0% (0.0) | 37% (32.7) | 62% (54.6) | match |
| tha_Thai | lang | 5.4 | 10.8 | ×2.00 | 1% (0.6) | 0% (0.0) | 31% (28.2) | 68% (62.5) | match |
| added_normalized_dense | modalities | 3.8 | 11.8 | ×3.15 | 1% (0.8) | 0% (0.0) | 53% (42.6) | 46% (37.7) | match |
| added_normalized_sparse | modalities | 3.6 | 10.0 | ×2.82 | 1% (1.3) | 0% (0.0) | 51% (48.8) | 48% (45.9) | match |
| added_special_dense | modalities | 2.9 | 7.3 | ×2.54 | 5% (6.7) | 0% (0.2) | 82% (114.1) | 13% (18.5) | match |
| added_special_sparse | modalities | 3.1 | 7.5 | ×2.40 | 3% (3.9) | 0% (0.1) | 64% (81.9) | 33% (42.7) | match |
| agentic-traces | modalities | 2.4 | 6.2 | ×2.59 | 1% (1.9) | 0% (0.0) | 55% (87.3) | 44% (69.0) | match |
| agentic_swe | modalities | 2.3 | 5.9 | ×2.50 | 1% (1.4) | 0% (0.0) | 61% (102.8) | 39% (65.5) | match |
| code_mixed | modalities | 2.6 | 6.9 | ×2.64 | 1% (1.7) | 0% (0.0) | 53% (76.1) | 46% (65.9) | match |
| math_latex | modalities | 2.4 | 6.3 | ×2.59 | 1% (2.0) | 0% (0.0) | 55% (87.2) | 44% (70.1) | match |

</details>

<details><summary><b>gpt2</b> — standalone ByteLevel pre-tokenizer · ×7.81 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-gpt2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-gpt2-threads-dark.png">
  <img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-gpt2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 17+2 (peak 19) · Pipeline 20+0 (peak 21)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 40.9 | ×10.37 | 3% (0.7) | 0% (0.0) | 26% (6.1) | 71% (16.6) | match |
| arb_Arab | lang | 3.2 | 22.7 | ×7.13 | 1% (0.6) | 0% (0.0) | 17% (7.3) | 82% (35.4) | match |
| ben_Beng | lang | 2.2 | 28.8 | ×13.00 | 2% (0.6) | 0% (0.0) | 33% (11.1) | 66% (22.3) | match |
| cmn_Hani | lang | 3.3 | 24.1 | ×7.32 | 2% (0.6) | 0% (0.0) | 14% (5.6) | 85% (33.9) | match |
| ell_Grek | lang | 3.3 | 23.8 | ×7.20 | 1% (0.6) | 0% (0.0) | 16% (6.7) | 82% (34.0) | match |
| eng_Latn | lang | 2.8 | 11.7 | ×4.12 | 3% (2.1) | 0% (0.0) | 13% (10.8) | 85% (71.0) | match |
| heb_Hebr | lang | 3.2 | 25.3 | ×7.94 | 2% (0.6) | 0% (0.0) | 19% (7.4) | 79% (30.8) | match |
| hin_Deva | lang | 2.6 | 27.0 | ×10.23 | 2% (0.6) | 0% (0.0) | 30% (11.0) | 68% (24.9) | match |
| jpn_Jpan | lang | 3.5 | 19.6 | ×5.53 | 1% (0.6) | 0% (0.0) | 10% (4.9) | 89% (44.3) | match |
| kat_Geor | lang | 3.6 | 52.8 | ×14.70 | 3% (0.6) | 0% (0.0) | 26% (4.8) | 70% (12.7) | match |
| kor_Hang | lang | 2.9 | 32.4 | ×11.02 | 2% (0.6) | 0% (0.0) | 25% (7.5) | 73% (21.7) | match |
| rus_Cyrl | lang | 3.3 | 23.1 | ×6.96 | 1% (0.6) | 0% (0.0) | 15% (6.5) | 83% (35.5) | match |
| tam_Taml | lang | 2.1 | 33.6 | ×15.87 | 2% (0.6) | 0% (0.0) | 40% (11.7) | 58% (16.9) | match |
| tha_Thai | lang | 2.8 | 29.6 | ×10.43 | 2% (0.6) | 0% (0.0) | 23% (7.6) | 75% (24.5) | match |
| added_normalized_dense | modalities | 3.5 | 22.8 | ×6.45 | 2% (0.7) | 0% (0.0) | 15% (6.5) | 83% (35.1) | match |
| added_normalized_sparse | modalities | 3.3 | 18.5 | ×5.59 | 3% (1.3) | 0% (0.0) | 16% (8.1) | 82% (42.8) | match |
| added_special_dense | modalities | 3.4 | 32.4 | ×9.48 | 18% (5.2) | 0% (0.0) | 29% (8.5) | 53% (15.6) | match |
| added_special_sparse | modalities | 3.2 | 19.0 | ×5.87 | 6% (3.3) | 0% (0.0) | 21% (10.5) | 73% (37.0) | match |
| agentic-traces | modalities | 2.4 | 13.0 | ×5.48 | 3% (1.9) | 0% (0.0) | 18% (13.3) | 80% (60.6) | match |
| agentic_swe | modalities | 2.4 | 17.5 | ×7.30 | 2% (1.4) | 0% (0.0) | 23% (12.5) | 75% (41.7) | match |
| code_mixed | modalities | 2.4 | 15.5 | ×6.52 | 3% (1.7) | 0% (0.0) | 20% (12.9) | 77% (48.5) | match |
| math_latex | modalities | 2.6 | 12.3 | ×4.80 | 3% (2.0) | 0% (0.0) | 15% (12.2) | 82% (65.4) | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×2.93 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-2-threads-dark.png">
  <img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 14+0 (peak 15) · Pipeline 15+0 (peak 15)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 33.4 | ×7.62 | 0% (0.0) | 41% (12.6) | 3% (0.9) | 56% (17.1) | match |
| arb_Arab | lang | 9.4 | 33.9 | ×3.59 | 0% (0.0) | 47% (14.4) | 4% (1.2) | 49% (14.8) | match |
| ben_Beng | lang | 10.1 | 50.3 | ×4.99 | 0% (0.0) | 54% (10.9) | 3% (0.6) | 43% (8.7) | match |
| cmn_Hani | lang | 8.6 | 62.9 | ×7.33 | 0% (0.1) | 19% (2.9) | 0% (0.0) | 80% (12.1) | match |
| ell_Grek | lang | 9.4 | 36.9 | ×3.94 | 0% (0.0) | 54% (15.0) | 3% (0.9) | 43% (12.0) | match |
| eng_Latn | lang | 4.2 | 5.9 | ×1.40 | 0% (0.1) | 17% (28.4) | 1% (1.5) | 82% (139.7) | match |
| heb_Hebr | lang | 9.1 | 31.5 | ×3.46 | 0% (0.0) | 76% (21.9) | 0% (0.0) | 39% (11.2) | match |
| hin_Deva | lang | 11.1 | 45.0 | ×4.06 | 0% (0.0) | 61% (13.9) | 3% (0.7) | 36% (8.2) | match |
| jpn_Jpan | lang | 12.2 | 78.7 | ×6.47 | 0% (0.1) | 22% (2.7) | 0% (0.0) | 78% (9.3) | match |
| kat_Geor | lang | 13.1 | 59.9 | ×4.57 | 0% (0.0) | 55% (9.2) | 3% (0.4) | 43% (7.2) | match |
| kor_Hang | lang | 6.8 | 32.4 | ×4.76 | 0% (0.1) | 58% (16.9) | 0% (0.0) | 46% (13.4) | match |
| rus_Cyrl | lang | 8.4 | 14.3 | ×1.70 | 0% (0.0) | 20% (14.1) | 3% (1.9) | 77% (55.3) | match |
| tam_Taml | lang | 11.5 | 60.6 | ×5.26 | 0% (0.0) | 50% (8.3) | 2% (0.4) | 48% (8.0) | match |
| tha_Thai | lang | 14.4 | 72.6 | ×5.06 | 0% (0.0) | 34% (4.6) | 1% (0.1) | 65% (8.8) | match |
| added_normalized_dense | modalities | 5.3 | 8.5 | ×1.60 | 0% (0.1) | 16% (19.4) | 0% (0.0) | 84% (101.2) | match |
| added_normalized_sparse | modalities | 4.8 | 6.9 | ×1.44 | 0% (0.1) | 19% (26.9) | 0% (0.0) | 83% (117.7) | match |
| added_special_dense | modalities | 4.6 | 12.1 | ×2.63 | 6% (5.1) | 54% (42.5) | 3% (2.5) | 37% (29.3) | match |
| added_special_sparse | modalities | 6.7 | 7.8 | ×1.17 | 2% (2.1) | 32% (40.7) | 1% (1.7) | 65% (81.2) | match |
| agentic-traces | modalities | 4.2 | 6.6 | ×1.56 | 0% (0.1) | 18% (26.8) | 1% (1.3) | 81% (124.1) | match |
| agentic_swe | modalities | 4.1 | 6.0 | ×1.48 | 0% (0.0) | 32% (51.8) | 0% (0.0) | 70% (114.9) | match |
| code_mixed | modalities | 4.0 | 6.3 | ×1.58 | 0% (0.0) | 24% (38.2) | 1% (1.9) | 75% (120.8) | match |
| math_latex | modalities | 4.4 | 6.3 | ×1.44 | 0% (0.1) | 18% (28.0) | 0% (0.0) | 83% (132.3) | match |

</details>

<details><summary><b>llama-3</b> — split-heavy byte-level BPE, single regex · ×4.09 vs v0.23.1</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-3-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-3-threads-dark.png">
  <img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-llama-3-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 128+0 (peak 188) · Pipeline 129+0 (peak 189)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.1 | 21.4 | ×6.92 | 1% (0.7) | 0% (0.0) | 64% (28.5) | 35% (15.7) | match |
| arb_Arab | lang | 3.6 | 12.1 | ×3.30 | 1% (0.6) | 0% (0.0) | 40% (32.7) | 59% (48.7) | match |
| ben_Beng | lang | 2.8 | 13.8 | ×4.99 | 1% (0.6) | 0% (0.0) | 60% (44.3) | 39% (29.3) | match |
| cmn_Hani | lang | 4.0 | 13.3 | ×3.33 | 1% (0.6) | 0% (0.0) | 27% (19.7) | 72% (52.7) | match |
| ell_Grek | lang | 3.9 | 13.1 | ×3.34 | 1% (0.6) | 0% (0.0) | 38% (28.2) | 61% (45.0) | match |
| eng_Latn | lang | 3.5 | 14.9 | ×4.22 | 3% (2.1) | 0% (0.0) | 71% (43.8) | 26% (15.9) | match |
| heb_Hebr | lang | 3.2 | 15.3 | ×4.79 | 1% (0.6) | 0% (0.0) | 49% (32.4) | 50% (32.9) | match |
| hin_Deva | lang | 3.7 | 16.8 | ×4.54 | 1% (0.6) | 0% (0.0) | 85% (49.0) | 14% (7.9) | match |
| jpn_Jpan | lang | 4.4 | 13.2 | ×3.03 | 1% (0.6) | 0% (0.0) | 25% (18.5) | 74% (54.9) | match |
| kat_Geor | lang | 3.8 | 23.9 | ×6.31 | 1% (0.6) | 0% (0.0) | 43% (17.4) | 56% (22.5) | match |
| kor_Hang | lang | 3.5 | 12.4 | ×3.58 | 1% (0.6) | 0% (0.0) | 40% (31.5) | 59% (46.0) | match |
| rus_Cyrl | lang | 4.0 | 11.8 | ×2.98 | 1% (0.6) | 0% (0.0) | 35% (28.4) | 65% (52.8) | match |
| tam_Taml | lang | 2.7 | 13.9 | ×5.17 | 1% (0.6) | 0% (0.0) | 64% (46.9) | 35% (25.7) | match |
| tha_Thai | lang | 4.2 | 13.4 | ×3.15 | 1% (0.6) | 0% (0.0) | 40% (29.2) | 59% (42.9) | match |
| added_normalized_dense | modalities | 3.8 | 16.6 | ×4.34 | 1% (0.8) | 0% (0.0) | 44% (26.4) | 55% (32.8) | match |
| added_normalized_sparse | modalities | 4.0 | 18.3 | ×4.54 | 3% (1.4) | 0% (0.0) | 61% (31.8) | 37% (19.1) | match |
| added_special_dense | modalities | 3.4 | 12.9 | ×3.77 | 7% (5.3) | 0% (0.0) | 89% (69.3) | 4% (3.5) | match |
| added_special_sparse | modalities | 3.7 | 15.1 | ×4.09 | 5% (3.4) | 0% (0.0) | 87% (59.4) | 8% (5.5) | match |
| agentic-traces | modalities | 3.1 | 12.3 | ×3.97 | 2% (1.9) | 0% (0.0) | 68% (53.6) | 30% (23.5) | match |
| agentic_swe | modalities | 3.1 | 10.7 | ×3.45 | 2% (1.4) | 0% (0.0) | 64% (57.0) | 34% (30.2) | match |
| code_mixed | modalities | 3.3 | 13.4 | ×4.10 | 2% (1.7) | 0% (0.0) | 77% (58.3) | 21% (15.7) | match |
| math_latex | modalities | 3.0 | 13.2 | ×4.33 | 3% (2.0) | 0% (0.0) | 73% (55.1) | 25% (18.8) | match |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29148312638-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->

