### PR TITLE
pipeline-bench: show wins vs the base branch

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -141,10 +141,24 @@ def model_speedups(model):
     return [v for v in (speedup(r) for r in model["results"]) if v]
 
 
-def scale(models):
+def base_speedup(row, base_lookup, model_name):
+    """This PR's pipeline throughput ÷ the base branch's pipeline throughput for the
+    same (model, fixture) — the "did this PR help vs the base branch" ratio. `None`
+    when the base branch didn't bench that fixture (added model, renamed fixture …)."""
+    p = row["mbps"].get("pipeline")
+    b = base_lookup.get((model_name, row["fixture"]))
+    return p / b if b and p else None
+
+
+def base_model_speedups(model, base_lookup):
+    return [v for v in (base_speedup(r, base_lookup, model["model"])
+                        for r in model["results"]) if v]
+
+
+def scale(models, speedups_of=model_speedups):
     """Shared log2 x-range across every plotted speedup, so charts for
     different models are directly comparable."""
-    vals = [v for m in models for v in model_speedups(m)]
+    vals = [v for m in models for v in speedups_of(m)]
     if not vals:
         return 0.75, 1.5
     return min(0.75, min(vals) / 1.08), max(1.5, max(vals) * 1.08)
@@ -223,13 +237,21 @@ def speedup_axis(ink, x, ticks, top, bottom):
     return "".join(grid) + hints
 
 
-def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label):
+def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label,
+                 speedups_of=model_speedups, title=None, ref_label=None,
+                 mark_regressions=False, no_cmp_msg=None):
     """The headline chart: a row per manifest model — name + workload desc,
-    geomean ×speedup of the pipeline vs the release (×1.0) with a min–max
+    geomean ×speedup of the pipeline vs the reference (×1.0) with a min–max
     whisker across fixtures. No cross-model aggregate on purpose: the models
     exercise different execution modes. Unsupported models appear as muted
-    status rows so the overview is the complete state of the world."""
+    status rows so the overview is the complete state of the world.
+
+    Defaults draw "vs latest release". Pass `speedups_of=base_model_speedups`-style
+    with `mark_regressions=True` for the "vs base branch" twin: bars for models that
+    got slower than the base branch turn red."""
     ink, sink = INK[mode], SERIES_INK[mode]
+    title = title or "PipelineTokenizer vs latest release — encode throughput"
+    ref_label = ref_label or baseline_label
 
     def x(v):
         return OV_GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * OV_PLOT
@@ -248,10 +270,11 @@ def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label):
         desc = m.get("desc") or m["shape"]
         body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 11:.1f}" fill="{ink["muted"]}" '
                     f'font-size="10.5" text-anchor="end">{escape(desc)}</text>')
-        vals = model_speedups(m)
+        vals = speedups_of(m)
         if vals:
             g, mn, mx = geomean(vals), min(vals), max(vals)
-            body.append(hbar(x(1.0), x(g), cy - 7, 14, sink["pipeline"]))
+            bar_color = ink["critical"] if (mark_regressions and g < 1) else sink["pipeline"]
+            body.append(hbar(x(1.0), x(g), cy - 7, 14, bar_color))
             body.append(f'<line x1="{x(mn):.1f}" y1="{cy:.1f}" x2="{x(mx):.1f}" y2="{cy:.1f}" '
                         f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
             for v in (mn, mx):
@@ -270,9 +293,9 @@ def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label):
             body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{fill}" font-size="12" '
                         f'text-anchor="end" style="font-variant-numeric:tabular-nums">{right}</text>')
         elif m["results"]:
+            msg = no_cmp_msg or f"benched, but {baseline_label} can’t load this model — no comparison"
             body.append(f'<text x="{x(1.0) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["muted"]}" '
-                        f'font-size="11.5" font-style="italic">benched, but {escape(baseline_label)} '
-                        f'can’t load this model — no comparison</text>')
+                        f'font-size="11.5" font-style="italic">{escape(msg)}</text>')
         else:
             pretok = m["shape"].split("·")[-1].strip()
             why = (m.get("reason") or f"no {pretok} pre-tokenizer")
@@ -286,13 +309,12 @@ def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label):
     y += 30
     legend = legend_row(ink, sink, y, [
         ("swatch", "pipeline", "PipelineTokenizer"),
-        ("tick", ink["baseline"], f"×1.0 = {baseline_label}"),
+        ("tick", ink["baseline"], f"×1.0 = {ref_label}"),
     ])
     height = y + 34
-    subtitle = (f"geomean ×speedup per model vs {baseline_label} · "
+    subtitle = (f"geomean ×speedup per model vs {ref_label} · "
                 f"whisker: min–max across fixtures · {subtitle_base}")
-    return svg_doc(ink, height, "PipelineTokenizer vs latest release — encode throughput",
-                   subtitle, axis + "".join(body) + legend, meta)
+    return svg_doc(ink, height, title, subtitle, axis + "".join(body) + legend, meta)
 
 
 def memory_svg(models, mode, meta, baseline_label):
@@ -764,7 +786,8 @@ def threads_svg(model, mode, meta, baseline_label):
                    subtitle, "".join(grid) + "".join(body) + legend, meta)
 
 
-def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
+def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
+                    base_lookup=None, base_ref=None):
     """Overview charts inline; everything per-model — charts and the per-fixture
     table — inside one <details> block per model, so the PR description stays a
     single screen. No cross-model aggregate number anywhere: the models exercise
@@ -782,8 +805,12 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
           f"**{len(benched)} / {len(models)} models supported** — PipelineTokenizer vs "
           f"`tokenizers` {baseline_label} (latest release) · {subtitle_base}", "",
           f"`{meta[0]}` · {meta[1]}", "",
-          picture(base, run_id, "overview", "Per-model encode throughput vs latest release", 860), "",
-          picture(base, run_id, "memory", "Per-model memory footprint", 860), ""]
+          picture(base, run_id, "overview", "Per-model encode throughput vs latest release", 860), ""]
+    if base_lookup:
+        md += [f"**vs base branch** (`{escape(base_ref or 'base')}`) — per-model geomean ×speedup of "
+               f"this PR's PipelineTokenizer against the base branch's; **regressions in red**.", "",
+               picture(base, run_id, "base-overview", "Per-model encode throughput vs base branch", 860), ""]
+    md += [picture(base, run_id, "memory", "Per-model memory footprint", 860), ""]
     if sizes:
         md += [picture(base, run_id, "binsize", "Minimal encode binary size", 860), ""]
 
@@ -801,6 +828,10 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
         vals = model_speedups(m)
         summary = (f"×{geomean(vals):.2f} vs {baseline_label}" if vals
                    else f"{baseline_label} can't load — no comparison")
+        if base_lookup:
+            bvals = base_model_speedups(m, base_lookup)
+            if bvals:
+                summary += f" · ×{geomean(bvals):.2f} vs base"
         flag = " · ⚠ ids differ" if any(r["ids_match"] is False for r in m["results"]) else ""
         md += [f"<details><summary><b>{escape(m['model'])}</b> — {escape(desc)} · "
                f"{summary}{flag}</summary>", ""]
@@ -815,9 +846,11 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
         # Per-stage columns show each split's share of the pipeline's own encode time
         # with the ns/byte alongside — `share% (ns/B)` — so the split cost is readable
         # as text regardless of how slow the release baseline is.
-        md += [f"| Fixture | Group | {baseline_label} MB/s | Pipeline MB/s | Speedup "
-               "| added-token | normalize | pre-tokenize | model | Ids |",
-               "|---|---|---:|---:|---:|---:|---:|---:|---:|:--|"]
+        base_col = " Δ base |" if base_lookup else ""
+        base_sep = "---:|" if base_lookup else ""
+        md += [f"| Fixture | Group | {baseline_label} MB/s | Pipeline MB/s | Speedup |{base_col} "
+               "added-token | normalize | pre-tokenize | model | Ids |",
+               f"|---|---|---:|---:|---:|{base_sep}---:|---:|---:|---:|:--|"]
         for r in sorted(m["results"], key=lambda r: (r["group"], r["fixture"])):
             mb = r["mbps"]
             flags = []
@@ -829,11 +862,13 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes):
             s = r.get("stage_ns_per_byte")
             stages = " ".join(f"| {stage_cell(s, k)}"
                               for k in ("added_split", "normalize", "pre_tokenize", "model"))
+            base_cell = (f"| {fnum(base_speedup(r, base_lookup, m['model']), '×{:.2f}')} "
+                         if base_lookup else "")
             md.append(
                 f"| {r['fixture']} | {r['group']} "
                 f"| {fnum(mb.get('baseline'))} | {fnum(mb.get('pipeline'))} "
                 f"| {fnum(speedup(r), '×{:.2f}')} "
-                f"{stages} | {ids} |")
+                f"{base_cell}{stages} | {ids} |")
         md += ["", "</details>", ""]
 
     # Unsupported / failed-to-load models: roadmap cards, collapsed — they're
@@ -862,6 +897,10 @@ def main():
     ap.add_argument("--run-id", default="local")
     ap.add_argument("--binary-sizes", default="",
                     help="JSON file {baseline, pipeline} of stripped binary bytes")
+    ap.add_argument("--base-bench", default="",
+                    help="base branch's cached fixture_bench JSON — enables the 'vs base branch' chart")
+    ap.add_argument("--base-ref", default="",
+                    help="label for the base branch baseline (e.g. short sha)")
     args = ap.parse_args()
 
     rev = args.revision
@@ -880,10 +919,31 @@ def main():
     sizes = json.loads(Path(args.binary_sizes).read_text()) if args.binary_sizes else None
     benched = [m for m in models if m["results"]]
     lo, hi = scale(benched)
+
+    # "vs base branch": join the PR results against the base branch's cached run by
+    # (model, fixture). base_lookup[(model, fixture)] = base pipeline MB/s.
+    base_lookup, base_speedups_of, blo, bhi = None, None, lo, hi
+    if args.base_bench and Path(args.base_bench).exists():
+        base_data = json.loads(Path(args.base_bench).read_text())
+        base_lookup = {(bm["model"], r["fixture"]): r["mbps"].get("pipeline")
+                       for bm in base_data["models"] for r in bm["results"]}
+        if any(base_lookup.values()):
+            base_speedups_of = lambda m: base_model_speedups(m, base_lookup)  # noqa: E731
+            blo, bhi = scale(benched, base_speedups_of)
+        else:
+            base_lookup = None
+
     out = Path(args.out_dir)
     for mode in ("light", "dark"):
         (out / f"pipeline_bench_overview_{mode}.svg").write_text(
             overview_svg(models, mode, args.subtitle, meta, lo, hi, baseline_label))
+        if base_lookup:
+            (out / f"pipeline_bench_base-overview_{mode}.svg").write_text(
+                overview_svg(models, mode, args.subtitle, meta, blo, bhi, baseline_label,
+                             speedups_of=base_speedups_of,
+                             title="PipelineTokenizer vs base branch — encode throughput",
+                             ref_label=(args.base_ref or "base branch"), mark_regressions=True,
+                             no_cmp_msg="not benched on the base branch"))
         (out / f"pipeline_bench_memory_{mode}.svg").write_text(
             memory_svg(models, mode, meta, baseline_label))
         if sizes:
@@ -903,7 +963,8 @@ def main():
                     threads_svg(m, mode, meta, baseline_label))
 
     (out / "pipeline_bench.md").write_text(
-        render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes))
+        render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes,
+                        base_lookup=base_lookup, base_ref=args.base_ref))
 
     # per-model geomeans only — a cross-model aggregate would average unrelated
     # execution modes (normalizer-heavy vs split-heavy vs model-bounded)
@@ -912,6 +973,12 @@ def main():
         for m in benched if model_speedups(m))
     print(f"{len(benched)}/{len(models)} supported"
           + (f" · vs {baseline_label}: {per_model}" if per_model else ""))
+    if base_lookup:
+        vs_base = " · ".join(
+            f"{m['model']} x{geomean(base_speedups_of(m)):.3f}"
+            for m in benched if base_speedups_of(m))
+        print(f"vs base ({args.base_ref or 'base'}): {vs_base}" if vs_base
+              else "vs base: no overlapping fixtures")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -26,6 +26,16 @@ name: Pipeline Benchmark
 #     default branch).
 # Either way it maintains a marker-delimited benchmark section (graph + table)
 # in the target PR's description; the workflow run itself is the PR check.
+#
+# vs base branch: besides the "vs latest release" charts, the report shows a
+# "vs base branch" overview — this run's PipelineTokenizer against the base
+# branch's, per fixture, so a PR's own wins/regressions are visible (regressions
+# in red). The base's numbers are cached: a push to feat/train_encode_split
+# uploads its merged JSON to the HF Hub dataset as baselines/pipeline-<sha>.json
+# and force-moves the lightweight `pipeline-baseline` git tag to that commit
+# ("add the tag if not there"). A PR run resolves that tag, downloads the cached
+# JSON, and diffs against it ("otherwise read the data and plot the diff"). No
+# tag yet (or no cached JSON) → the base overview is skipped, release charts stay.
 
 on:
   push:
@@ -46,7 +56,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write       # force-move the `pipeline-baseline` tag on base-branch pushes
   issues: write         # remove the trigger label
   pull-requests: write  # edit the PR description
 
@@ -190,16 +200,53 @@ jobs:
           printf '}\n' >> binary_sizes.json
           cat binary_sizes.json
 
+      # "vs base branch": the `pipeline-baseline` tag pins the base commit whose
+      # merged bench is cached on HF Hub; resolve it and pull the JSON so the
+      # renderer can diff this run against it. Skipped (has_base=false) when the
+      # tag is absent, points at this same commit, or its JSON is missing — the
+      # release charts render regardless.
+      - name: Resolve base-branch baseline
+        id: base
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          CUR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          base_sha=$(git ls-remote origin refs/tags/pipeline-baseline | awk '{print $1}' | head -1)
+          if [ -z "$base_sha" ]; then
+            echo "No pipeline-baseline tag yet — base comparison skipped."
+            echo "has_base=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$base_sha" = "$CUR_SHA" ]; then
+            echo "Baseline tag points at this commit — nothing to diff."
+            echo "has_base=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-bench \
+            "baselines/pipeline-$base_sha.json" --repo-type dataset --local-dir base_dir 2>/dev/null || true
+          if [ -f "base_dir/baselines/pipeline-$base_sha.json" ]; then
+            echo "has_base=true" >> "$GITHUB_OUTPUT"
+            echo "base_json=base_dir/baselines/pipeline-$base_sha.json" >> "$GITHUB_OUTPUT"
+            echo "base_sha=${base_sha:0:9}" >> "$GITHUB_OUTPUT"
+            echo "Base baseline: $base_sha"
+          else
+            echo "Tag present but no cached JSON for $base_sha — base comparison skipped."
+            echo "has_base=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Render report
         run: |
           base_url="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts"
+          base_args=""
+          if [ "${{ steps.base.outputs.has_base }}" = "true" ]; then
+            base_args="--base-bench ${{ steps.base.outputs.base_json }} --base-ref ${{ steps.base.outputs.base_sha }}"
+          fi
           python3 ${{ github.workspace }}/.github/scripts/render_pipeline_bench.py \
             pipeline_bench.json \
             --subtitle "~10 kB inputs · single thread + 1/2/4/8/max-thread sweep" \
             --revision "${{ github.event.pull_request.head.sha || github.sha }}" \
             --img-base "$base_url" \
             --run-id "${{ github.run_id }}" \
-            --binary-sizes binary_sizes.json
+            --binary-sizes binary_sizes.json \
+            $base_args
           uvx --with cairosvg python -c "
           import cairosvg, glob
           for f in glob.glob('pipeline_bench_*.svg'):
@@ -266,6 +313,24 @@ jobs:
                  for r in m['results'] if r.get('ids_match') is False]
           sys.exit(f'ids diverge on: {bad}' if bad else 0)
           "
+
+      # Establish/refresh the base-branch baseline: on a push to
+      # feat/train_encode_split, cache this commit's merged bench on HF Hub and
+      # force-move the `pipeline-baseline` tag to it. Runs only after the id check
+      # passes, so a broken base never becomes the baseline. The tag push is a
+      # refs/tags update — it does NOT match the `push: branches` trigger, so no
+      # re-run loop. Uses the checkout's persisted GITHUB_TOKEN (contents: write).
+      - name: Publish base-branch baseline
+        if: github.event_name == 'push'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          sha="${{ github.sha }}"
+          uvx --from huggingface_hub hf upload hf-internal-testing/tokenizers-bench \
+            pipeline_bench.json "baselines/pipeline-$sha.json" --repo-type dataset
+          git tag -f pipeline-baseline "$sha"
+          git push -f origin "refs/tags/pipeline-baseline"
+          echo "Published baseline for $sha and moved the pipeline-baseline tag."
 
       - name: Upload results artifact
         if: always()

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -57,6 +57,7 @@ on:
 
 permissions:
   contents: write       # force-move the `pipeline-baseline` tag on base-branch pushes
+  actions: read         # download the base branch's bench artifact (baseline fallback)
   issues: write         # remove the trigger label
   pull-requests: write  # edit the PR description
 
@@ -200,44 +201,65 @@ jobs:
           printf '}\n' >> binary_sizes.json
           cat binary_sizes.json
 
-      # "vs base branch": the `pipeline-baseline` tag pins the base commit whose
-      # merged bench is cached on HF Hub; resolve it and pull the JSON so the
-      # renderer can diff this run against it. Skipped (has_base=false) when the
-      # tag is absent, points at this same commit, or its JSON is missing — the
-      # release charts render regardless.
+      # "vs base branch": find the base branch's bench to diff this run against.
+      #   1. Primary — the `pipeline-baseline` tag pins a base commit whose merged
+      #      bench is cached on HF Hub (durable, survives artifact expiry).
+      #   2. Fallback — before that tag exists (e.g. on this very PR, or any PR
+      #      before the feature has merged + a base push), use the newest
+      #      successful base-branch bench *artifact*. Always available, so the
+      #      comparison shows up without any manual seeding.
+      # Skipped (has_base=false) only when neither exists or both point at this
+      # same commit; the release charts render regardless.
       - name: Resolve base-branch baseline
         id: base
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
+          # 1. tag -> HF Hub JSON
           base_sha=$(git ls-remote origin refs/tags/pipeline-baseline | awk '{print $1}' | head -1)
-          if [ -z "$base_sha" ]; then
-            echo "No pipeline-baseline tag yet — base comparison skipped."
-            echo "has_base=false" >> "$GITHUB_OUTPUT"; exit 0
+          if [ -n "$base_sha" ] && [ "$base_sha" != "$CUR_SHA" ]; then
+            uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-bench \
+              "baselines/pipeline-$base_sha.json" --repo-type dataset --local-dir base_dir 2>/dev/null || true
+            if [ -f "base_dir/baselines/pipeline-$base_sha.json" ]; then
+              {
+                echo "has_base=true"
+                echo "base_json=base_dir/baselines/pipeline-$base_sha.json"
+                echo "base_ref=${base_sha:0:9}"
+              } >> "$GITHUB_OUTPUT"
+              echo "Base baseline from pipeline-baseline tag ($base_sha)."; exit 0
+            fi
           fi
-          if [ "$base_sha" = "$CUR_SHA" ]; then
-            echo "Baseline tag points at this commit — nothing to diff."
-            echo "has_base=false" >> "$GITHUB_OUTPUT"; exit 0
+          # 2. fallback -> newest successful base-branch bench artifact
+          latest=$(gh run list --workflow pipeline-bench.yml \
+            --branch feat/train_encode_split --status success --limit 1 \
+            --json databaseId,headSha \
+            --jq 'if length > 0 then "\(.[0].databaseId) \(.[0].headSha)" else "" end' \
+            2>/dev/null || true)
+          run_id=${latest%% *}
+          run_sha=${latest##* }
+          if [ -n "$run_id" ] && [ "$run_sha" != "$CUR_SHA" ]; then
+            gh run download "$run_id" --name pipeline-bench --dir base_dir 2>/dev/null || true
+            f=$(find base_dir -name pipeline_bench.json 2>/dev/null | head -1)
+            if [ -n "$f" ]; then
+              {
+                echo "has_base=true"
+                echo "base_json=$f"
+                echo "base_ref=${run_sha:0:9}"
+              } >> "$GITHUB_OUTPUT"
+              echo "Base baseline from base-branch run $run_id artifact ($run_sha)."; exit 0
+            fi
           fi
-          uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-bench \
-            "baselines/pipeline-$base_sha.json" --repo-type dataset --local-dir base_dir 2>/dev/null || true
-          if [ -f "base_dir/baselines/pipeline-$base_sha.json" ]; then
-            echo "has_base=true" >> "$GITHUB_OUTPUT"
-            echo "base_json=base_dir/baselines/pipeline-$base_sha.json" >> "$GITHUB_OUTPUT"
-            echo "base_sha=${base_sha:0:9}" >> "$GITHUB_OUTPUT"
-            echo "Base baseline: $base_sha"
-          else
-            echo "Tag present but no cached JSON for $base_sha — base comparison skipped."
-            echo "has_base=false" >> "$GITHUB_OUTPUT"
-          fi
+          echo "No base baseline available (no tag, no base-branch artifact) — comparison skipped."
+          echo "has_base=false" >> "$GITHUB_OUTPUT"
 
       - name: Render report
         run: |
           base_url="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts"
           base_args=""
           if [ "${{ steps.base.outputs.has_base }}" = "true" ]; then
-            base_args="--base-bench ${{ steps.base.outputs.base_json }} --base-ref ${{ steps.base.outputs.base_sha }}"
+            base_args="--base-bench ${{ steps.base.outputs.base_json }} --base-ref ${{ steps.base.outputs.base_ref }}"
           fi
           python3 ${{ github.workspace }}/.github/scripts/render_pipeline_bench.py \
             pipeline_bench.json \


### PR DESCRIPTION
## What

The pipeline benchmark only compared **PipelineTokenizer vs the latest released crate**. This adds a **vs base branch** comparison so a PR's *own* wins and regressions (against `feat/train_encode_split`) are visible.

- New **"vs base branch"** overview chart (per-model geomean of `PR.pipeline / base.pipeline`, **regressions in red**), placed right after the existing "vs latest release" overview.
- New **`Δ base`** column in each per-model per-fixture table.
- Per-model `<details>` summary gains `· ×N.NN vs base`.

The existing "vs latest release" charts, memory, binary-size, and thread-scaling output are untouched.

## How the baseline is stored (cached, not recomputed per PR)

Mirrors your ask — *"add the tag on base branch if not there, otherwise read the data and plot the diff"*:

- **Push to `feat/train_encode_split`** → uploads the merged bench JSON to the HF Hub dataset `hf-internal-testing/tokenizers-bench` as `baselines/pipeline-<sha>.json` and **force-moves the lightweight `pipeline-baseline` git tag** to that commit. Only runs after the id-mismatch check passes, so a broken base never becomes the baseline. (A `refs/tags/*` push does not match the `push: branches` trigger → no re-run loop.)
- **PR run** → `git ls-remote` resolves the `pipeline-baseline` tag, downloads `baselines/pipeline-<base_sha>.json`, and the renderer diffs against it.
- **No tag / no cached JSON yet** → the base overview is skipped and the release charts render exactly as before.

Requires `contents: write` (only to move the tag); uses the checkout's persisted `GITHUB_TOKEN`.

## Bootstrapping

There is no `pipeline-baseline` tag yet, so the first PR runs show only the release charts. The **first push to `feat/train_encode_split`** after this lands establishes the tag + cached JSON; every PR after that gets the base-branch diff.

## Testing

`render_pipeline_bench.py` was smoke-tested locally against synthetic base+PR JSON:
- correct ratios (a `×1.25` win and a `×0.86` regression surface in the `Δ base` column and the summary geomeans);
- a model slower than base renders its bar in the regression red;
- the no-`--base-bench` path falls back to release-only with no base artifacts or column.

Workflow YAML parses; renderer compiles.

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**5 / 6 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · single thread + 1/2/4/8/max-thread sweep

`c986534a8 · 2026-07-13 14:25 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 32 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-overview-dark.png">
  <img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-overview-light.png" width="860">
</picture>

**vs base branch** (`93650e3c5`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-base-overview-dark.png">
  <img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-base-overview-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-memory-dark.png">
  <img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-memory-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-binsize-dark.png">
  <img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-binsize-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×5.01 vs v0.23.1 · ×1.00 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-bert-base-uncased-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-bert-base-uncased-threads-dark.png">
  <img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-bert-base-uncased-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 2+0 (peak 6) · Pipeline 7+0 (peak 7)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 6.9 | 23.4 | ×3.37 | ×1.00 | 3% (1.2) | 65% (27.6) | 22% (9.5) | 10% (4.1) | match |
| arb_Arab | lang | 3.4 | 18.8 | ×5.52 | ×1.00 | 2% (1.2) | 52% (27.6) | 26% (13.9) | 20% (10.5) | match |
| ben_Beng | lang | 5.1 | 27.1 | ×5.26 | ×1.00 | 3% (1.2) | 52% (19.3) | 25% (9.1) | 20% (7.3) | match |
| cmn_Hani | lang | 3.1 | 15.6 | ×5.07 | ×1.00 | 2% (1.2) | 58% (37.7) | 18% (11.7) | 22% (14.4) | match |
| ell_Grek | lang | 3.2 | 18.2 | ×5.72 | ×1.00 | 2% (1.2) | 52% (28.7) | 25% (14.0) | 20% (11.3) | match |
| eng_Latn | lang | 3.8 | 17.4 | ×4.58 | ×1.00 | 4% (2.5) | 66% (39.0) | 9% (5.4) | 21% (12.2) | match |
| heb_Hebr | lang | 3.4 | 15.8 | ×4.61 | ×1.00 | 2% (1.2) | 60% (37.8) | 22% (13.9) | 17% (10.6) | match |
| hin_Deva | lang | 5.5 | 23.0 | ×4.15 | ×1.00 | 3% (1.2) | 62% (26.8) | 19% (8.1) | 17% (7.2) | match |
| jpn_Jpan | lang | 3.6 | 21.4 | ×5.88 | ×1.00 | 3% (1.2) | 50% (23.3) | 24% (11.1) | 24% (10.9) | match |
| kat_Geor | lang | 5.6 | 22.8 | ×4.03 | ×1.00 | 3% (1.2) | 62% (26.7) | 22% (9.7) | 13% (5.7) | match |
| kor_Hang | lang | 2.1 | 13.3 | ×6.26 | ×1.00 | 2% (1.2) | 47% (34.9) | 29% (21.8) | 23% (16.9) | match |
| rus_Cyrl | lang | 3.1 | 18.1 | ×5.87 | ×1.00 | 2% (1.2) | 50% (27.5) | 26% (14.2) | 22% (12.3) | match |
| tam_Taml | lang | 6.4 | 30.0 | ×4.67 | ×1.00 | 3% (1.2) | 57% (18.7) | 26% (8.5) | 14% (4.8) | match |
| tha_Thai | lang | 8.0 | 27.7 | ×3.45 | ×1.00 | 3% (1.2) | 69% (24.8) | 21% (7.7) | 7% (2.5) | match |
| added_normalized_dense | modalities | 6.1 | 21.8 | ×3.59 | ×1.00 | 3% (1.3) | 86% (41.0) | 7% (3.5) | 4% (1.7) | match |
| added_normalized_sparse | modalities | 4.7 | 19.4 | ×4.09 | ×1.00 | 4% (1.9) | 77% (40.4) | 9% (4.5) | 11% (5.9) | match |
| added_special_dense | modalities | 4.7 | 51.5 | ×10.86 | ×1.00 | 27% (5.1) | 47% (9.1) | 14% (2.7) | 12% (2.3) | match |
| added_special_sparse | modalities | 3.6 | 23.2 | ×6.38 | ×1.00 | 8% (3.7) | 64% (28.0) | 10% (4.4) | 18% (7.7) | match |
| agentic-traces | modalities | 3.3 | 16.8 | ×5.15 | ×1.00 | 4% (2.3) | 63% (38.9) | 10% (5.9) | 23% (14.2) | match |
| agentic_swe | modalities | 3.5 | 17.9 | ×5.12 | ×0.99 | 3% (1.9) | 68% (39.0) | 9% (4.9) | 20% (11.6) | match |
| code_mixed | modalities | 3.4 | 17.5 | ×5.20 | ×1.00 | 4% (2.1) | 66% (38.9) | 9% (5.4) | 21% (12.1) | match |
| math_latex | modalities | 3.4 | 17.1 | ×5.03 | ×1.00 | 4% (2.5) | 65% (38.8) | 9% (5.6) | 22% (13.3) | match |

</details>

<details><summary><b>deepseek-v4</b> — split-heavy byte-level BPE, 3 chained regexes · ×2.56 vs v0.23.1 · ×1.00 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-deepseek-v4-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-deepseek-v4-threads-dark.png">
  <img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-deepseek-v4-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 51+0 (peak 58) · Pipeline 85+0 (peak 84)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 14.1 | ×3.56 | ×1.00 | 1% (0.7) | 0% (0.0) | 63% (44.2) | 36% (24.8) | match |
| arb_Arab | lang | 3.6 | 9.1 | ×2.51 | ×0.99 | 1% (0.6) | 0% (0.0) | 47% (51.5) | 52% (56.4) | match |
| ben_Beng | lang | 4.5 | 11.2 | ×2.50 | ×1.01 | 1% (0.6) | 0% (0.0) | 42% (37.2) | 58% (51.5) | match |
| cmn_Hani | lang | 3.4 | 8.1 | ×2.40 | ×0.99 | 1% (0.8) | 0% (0.0) | 53% (64.4) | 46% (55.7) | match |
| ell_Grek | lang | 3.7 | 9.8 | ×2.62 | ×0.99 | 1% (0.6) | 0% (0.0) | 49% (49.3) | 51% (51.6) | match |
| eng_Latn | lang | 2.7 | 6.5 | ×2.42 | ×0.99 | 1% (2.0) | 0% (0.0) | 48% (71.2) | 51% (75.4) | match |
| heb_Hebr | lang | 3.2 | 7.9 | ×2.48 | ×1.00 | 0% (0.6) | 0% (0.0) | 43% (54.6) | 56% (70.8) | match |
| hin_Deva | lang | 4.2 | 12.0 | ×2.82 | ×1.00 | 1% (0.6) | 0% (0.0) | 48% (39.7) | 51% (42.7) | match |
| jpn_Jpan | lang | 3.8 | 8.9 | ×2.32 | ×1.00 | 1% (0.7) | 0% (0.0) | 52% (58.5) | 47% (52.8) | match |
| kat_Geor | lang | 4.4 | 11.5 | ×2.59 | ×1.01 | 1% (0.6) | 0% (0.0) | 38% (33.5) | 61% (53.0) | match |
| kor_Hang | lang | 3.4 | 9.8 | ×2.90 | ×1.00 | 1% (0.6) | 0% (0.0) | 53% (52.4) | 47% (46.7) | match |
| rus_Cyrl | lang | 3.7 | 8.9 | ×2.43 | ×1.02 | 1% (0.6) | 0% (0.0) | 43% (48.7) | 57% (65.2) | match |
| tam_Taml | lang | 4.7 | 11.6 | ×2.44 | ×1.00 | 1% (0.6) | 0% (0.0) | 37% (32.0) | 62% (53.5) | match |
| tha_Thai | lang | 5.5 | 10.9 | ×1.97 | ×1.00 | 1% (0.6) | 0% (0.0) | 30% (27.7) | 69% (63.1) | match |
| added_normalized_dense | modalities | 3.9 | 11.8 | ×3.03 | ×1.00 | 1% (0.7) | 0% (0.0) | 52% (43.1) | 47% (38.4) | match |
| added_normalized_sparse | modalities | 3.6 | 9.9 | ×2.75 | ×0.99 | 1% (1.3) | 0% (0.0) | 52% (51.7) | 47% (46.7) | match |
| added_special_dense | modalities | 2.9 | 7.1 | ×2.47 | ×1.00 | 5% (6.5) | 0% (0.5) | 83% (117.8) | 12% (17.3) | match |
| added_special_sparse | modalities | 3.1 | 7.3 | ×2.33 | ×0.98 | 3% (3.9) | 0% (0.2) | 63% (83.0) | 34% (45.3) | match |
| agentic-traces | modalities | 2.4 | 6.2 | ×2.55 | ×0.98 | 1% (1.8) | 0% (0.0) | 54% (86.2) | 45% (71.0) | match |
| agentic_swe | modalities | 2.3 | 5.7 | ×2.44 | ×0.99 | 1% (1.3) | 0% (0.0) | 60% (101.8) | 39% (65.6) | match |
| code_mixed | modalities | 2.6 | 6.9 | ×2.66 | ×0.97 | 1% (1.5) | 0% (0.0) | 56% (81.9) | 43% (62.6) | match |
| math_latex | modalities | 2.5 | 6.3 | ×2.52 | ×0.99 | 1% (1.9) | 0% (0.0) | 55% (87.4) | 44% (70.8) | match |

</details>

<details><summary><b>gpt2</b> — standalone ByteLevel pre-tokenizer · ×7.66 vs v0.23.1 · ×1.00 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-gpt2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-gpt2-threads-dark.png">
  <img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-gpt2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 17+1 (peak 19) · Pipeline 20+0 (peak 20)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 38.6 | ×9.63 | ×0.95 | 3% (0.7) | 0% (0.0) | 25% (6.3) | 72% (18.3) | match |
| arb_Arab | lang | 3.1 | 21.8 | ×6.94 | ×1.01 | 1% (0.6) | 0% (0.0) | 17% (7.6) | 82% (37.2) | match |
| ben_Beng | lang | 2.2 | 28.9 | ×13.38 | ×1.02 | 2% (0.6) | 0% (0.0) | 34% (11.6) | 64% (21.4) | match |
| cmn_Hani | lang | 3.3 | 24.7 | ×7.53 | ×1.03 | 2% (0.6) | 0% (0.0) | 14% (5.8) | 84% (33.7) | match |
| ell_Grek | lang | 3.3 | 24.5 | ×7.51 | ×1.03 | 2% (0.6) | 0% (0.0) | 17% (7.0) | 81% (32.5) | match |
| eng_Latn | lang | 2.8 | 11.8 | ×4.16 | ×1.02 | 2% (2.0) | 0% (0.0) | 13% (11.0) | 84% (70.4) | match |
| heb_Hebr | lang | 3.2 | 23.8 | ×7.37 | ×0.97 | 1% (0.6) | 0% (0.0) | 18% (7.6) | 80% (33.2) | match |
| hin_Deva | lang | 2.6 | 25.8 | ×9.84 | ×0.99 | 2% (0.6) | 0% (0.0) | 31% (11.6) | 67% (25.1) | match |
| jpn_Jpan | lang | 3.7 | 19.7 | ×5.38 | ×1.01 | 1% (0.6) | 0% (0.0) | 10% (5.0) | 89% (44.8) | match |
| kat_Geor | lang | 3.7 | 54.2 | ×14.65 | ×0.95 | 3% (0.6) | 0% (0.0) | 28% (4.9) | 69% (12.2) | match |
| kor_Hang | lang | 3.0 | 32.8 | ×10.78 | ×1.02 | 2% (0.6) | 0% (0.0) | 26% (7.7) | 72% (21.5) | match |
| rus_Cyrl | lang | 3.4 | 22.4 | ×6.62 | ×0.94 | 1% (0.6) | 0% (0.0) | 15% (6.7) | 83% (36.6) | match |
| tam_Taml | lang | 2.2 | 34.1 | ×15.72 | ×0.93 | 2% (0.6) | 0% (0.0) | 41% (11.7) | 57% (16.3) | match |
| tha_Thai | lang | 2.9 | 30.6 | ×10.48 | ×1.02 | 2% (0.6) | 0% (0.0) | 24% (7.6) | 74% (23.8) | match |
| added_normalized_dense | modalities | 3.6 | 22.3 | ×6.26 | ×1.02 | 2% (0.7) | 0% (0.0) | 16% (6.7) | 83% (35.5) | match |
| added_normalized_sparse | modalities | 3.4 | 18.1 | ×5.40 | ×1.01 | 2% (1.3) | 0% (0.0) | 16% (8.3) | 82% (44.1) | match |
| added_special_dense | modalities | 3.5 | 32.5 | ×9.41 | ×1.02 | 17% (5.0) | 0% (0.1) | 30% (8.8) | 53% (15.6) | match |
| added_special_sparse | modalities | 3.3 | 18.6 | ×5.68 | ×1.02 | 6% (3.2) | 0% (0.0) | 21% (10.9) | 73% (38.2) | match |
| agentic-traces | modalities | 2.4 | 12.9 | ×5.30 | ×1.02 | 2% (1.8) | 0% (0.0) | 18% (13.6) | 80% (60.9) | match |
| agentic_swe | modalities | 2.5 | 17.6 | ×7.15 | ×1.02 | 2% (1.3) | 0% (0.0) | 23% (12.8) | 75% (41.7) | match |
| code_mixed | modalities | 2.5 | 15.5 | ×6.31 | ×1.02 | 2% (1.6) | 0% (0.0) | 21% (13.2) | 77% (49.0) | match |
| math_latex | modalities | 2.7 | 12.4 | ×4.66 | ×1.02 | 2% (1.9) | 0% (0.0) | 16% (12.5) | 82% (65.5) | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×2.89 vs v0.23.1 · ×0.99 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-2-threads-dark.png">
  <img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 14+0 (peak 15) · Pipeline 15+0 (peak 15)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 32.8 | ×7.43 | ×1.01 | 0% (0.0) | 43% (13.0) | 2% (0.7) | 55% (16.8) | match |
| arb_Arab | lang | 9.5 | 30.2 | ×3.19 | ×0.97 | 0% (0.0) | 55% (17.5) | 0% (0.0) | 48% (15.4) | match |
| ben_Beng | lang | 10.0 | 51.5 | ×5.15 | ×1.03 | 0% (0.0) | 56% (11.0) | 2% (0.5) | 42% (8.2) | match |
| cmn_Hani | lang | 8.6 | 62.7 | ×7.29 | ×0.96 | 0% (0.1) | 20% (3.0) | 0% (0.0) | 80% (12.2) | match |
| ell_Grek | lang | 9.4 | 34.6 | ×3.68 | ×0.95 | 0% (0.0) | 58% (16.6) | 0% (0.0) | 43% (12.3) | match |
| eng_Latn | lang | 4.3 | 5.9 | ×1.36 | ×0.98 | 0% (0.1) | 18% (30.2) | 0% (0.0) | 83% (138.5) | match |
| heb_Hebr | lang | 9.1 | 34.5 | ×3.77 | ×0.97 | 0% (0.0) | 59% (17.5) | 3% (0.7) | 38% (11.2) | match |
| hin_Deva | lang | 11.2 | 44.0 | ×3.94 | ×1.03 | 0% (0.0) | 61% (14.2) | 2% (0.5) | 36% (8.3) | match |
| jpn_Jpan | lang | 12.1 | 80.6 | ×6.66 | ×0.99 | 0% (0.0) | 22% (2.7) | 0% (0.0) | 77% (9.4) | match |
| kat_Geor | lang | 13.2 | 56.8 | ×4.30 | ×0.99 | 0% (0.0) | 57% (9.6) | 0% (0.0) | 45% (7.7) | match |
| kor_Hang | lang | 6.8 | 32.4 | ×4.78 | ×0.95 | 0% (0.1) | 55% (17.1) | 2% (0.6) | 43% (13.3) | match |
| rus_Cyrl | lang | 8.5 | 13.5 | ×1.59 | ×0.92 | 0% (0.0) | 20% (14.5) | 5% (3.7) | 75% (54.4) | match |
| tam_Taml | lang | 11.5 | 59.8 | ×5.18 | ×1.02 | 0% (0.0) | 53% (8.9) | 2% (0.3) | 45% (7.4) | match |
| tha_Thai | lang | 14.2 | 73.2 | ×5.16 | ×1.00 | 0% (0.0) | 34% (4.6) | 1% (0.1) | 65% (8.9) | match |
| added_normalized_dense | modalities | 5.2 | 8.5 | ×1.62 | ×0.99 | 0% (0.1) | 15% (18.8) | 1% (0.8) | 84% (101.5) | match |
| added_normalized_sparse | modalities | 4.8 | 6.9 | ×1.44 | ×1.00 | 0% (0.1) | 19% (27.5) | 0% (0.0) | 82% (117.1) | match |
| added_special_dense | modalities | 4.7 | 12.2 | ×2.62 | ×1.05 | 6% (5.1) | 53% (43.1) | 1% (0.9) | 39% (31.9) | match |
| added_special_sparse | modalities | 6.7 | 7.8 | ×1.17 | ×0.99 | 2% (2.1) | 32% (40.7) | 1% (1.9) | 65% (82.1) | match |
| agentic-traces | modalities | 4.4 | 6.6 | ×1.51 | ×0.98 | 0% (0.1) | 18% (27.9) | 1% (1.5) | 81% (124.7) | match |
| agentic_swe | modalities | 4.0 | 6.1 | ×1.53 | ×0.98 | 0% (0.0) | 30% (49.7) | 1% (2.4) | 69% (114.9) | match |
| code_mixed | modalities | 4.1 | 6.2 | ×1.51 | ×0.98 | 0% (0.0) | 24% (39.1) | 1% (2.3) | 74% (120.7) | match |
| math_latex | modalities | 4.3 | 6.3 | ×1.45 | ×0.98 | 0% (0.1) | 17% (27.1) | 1% (1.2) | 82% (130.5) | match |

</details>

<details><summary><b>llama-3</b> — split-heavy byte-level BPE, single regex · ×3.77 vs v0.23.1 · ×0.96 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-3-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-3-threads-dark.png">
  <img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-llama-3-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 128+0 (peak 189) · Pipeline 129+0 (peak 189)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.3 | 20.0 | ×6.04 | ×0.89 | 1% (0.6) | 0% (0.0) | 66% (29.3) | 33% (14.6) | match |
| arb_Arab | lang | 3.8 | 12.0 | ×3.12 | ×1.06 | 1% (0.6) | 0% (0.0) | 39% (31.4) | 60% (48.5) | match |
| ben_Beng | lang | 2.9 | 13.8 | ×4.72 | ×1.01 | 1% (0.6) | 0% (0.0) | 62% (45.9) | 37% (27.8) | match |
| cmn_Hani | lang | 4.1 | 13.1 | ×3.16 | ×0.96 | 1% (0.6) | 0% (0.0) | 27% (20.0) | 72% (52.4) | match |
| ell_Grek | lang | 4.1 | 13.1 | ×3.19 | ×1.00 | 1% (0.6) | 0% (0.0) | 39% (29.2) | 60% (44.2) | match |
| eng_Latn | lang | 3.6 | 15.3 | ×4.26 | ×1.02 | 3% (2.0) | 0% (0.0) | 77% (49.2) | 20% (13.2) | match |
| heb_Hebr | lang | 3.3 | 15.1 | ×4.54 | ×1.03 | 1% (0.6) | 0% (0.0) | 51% (33.6) | 48% (32.1) | match |
| hin_Deva | lang | 3.7 | 16.6 | ×4.42 | ×1.00 | 1% (0.6) | 0% (0.0) | 87% (50.1) | 12% (6.8) | match |
| jpn_Jpan | lang | 4.6 | 13.3 | ×2.89 | ×0.99 | 1% (0.6) | 0% (0.0) | 25% (18.7) | 74% (54.6) | match |
| kat_Geor | lang | 4.0 | 24.0 | ×6.04 | ×1.00 | 1% (0.6) | 0% (0.0) | 45% (18.6) | 54% (22.1) | match |
| kor_Hang | lang | 3.6 | 11.3 | ×3.12 | ×0.91 | 1% (0.6) | 0% (0.0) | 41% (32.0) | 58% (45.4) | match |
| rus_Cyrl | lang | 4.0 | 11.2 | ×2.77 | ×0.91 | 1% (0.6) | 0% (0.0) | 34% (27.1) | 65% (52.6) | match |
| tam_Taml | lang | 2.9 | 13.8 | ×4.83 | ×1.04 | 1% (0.6) | 0% (0.0) | 65% (48.0) | 34% (25.4) | match |
| tha_Thai | lang | 4.4 | 13.4 | ×3.06 | ×0.99 | 1% (0.6) | 0% (0.0) | 40% (29.0) | 59% (42.8) | match |
| added_normalized_dense | modalities | 3.9 | 14.8 | ×3.78 | ×0.91 | 1% (0.7) | 0% (0.0) | 42% (24.7) | 56% (32.8) | match |
| added_normalized_sparse | modalities | 4.1 | 15.5 | ×3.81 | ×0.87 | 2% (1.2) | 0% (0.0) | 63% (32.6) | 34% (17.8) | match |
| added_special_dense | modalities | 3.4 | 10.6 | ×3.10 | ×0.86 | 7% (4.9) | 0% (0.1) | 92% (68.9) | 2% (1.3) | match |
| added_special_sparse | modalities | 3.7 | 12.6 | ×3.39 | ×0.86 | 5% (3.3) | 0% (0.0) | 88% (55.0) | 6% (4.0) | match |
| agentic-traces | modalities | 3.1 | 12.2 | ×3.93 | ×0.98 | 2% (1.8) | 0% (0.0) | 65% (58.1) | 33% (29.2) | match |
| agentic_swe | modalities | 3.2 | 10.9 | ×3.45 | ×1.00 | 1% (1.3) | 0% (0.0) | 77% (76.7) | 22% (21.8) | match |
| code_mixed | modalities | 3.3 | 11.2 | ×3.33 | ×0.84 | 2% (1.6) | 0% (0.0) | 78% (54.6) | 20% (14.2) | match |
| math_latex | modalities | 3.1 | 12.8 | ×4.10 | ×0.98 | 3% (1.9) | 0% (0.0) | 74% (54.6) | 24% (17.7) | match |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29257224215-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->

