### PR TITLE
fix(tk-encode): added-vocab MPHF panics on small vocabs (bert)

### DIFF
--- a/tokenizers/tk-encode/src/added_vocabulary/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/added_vocabulary/bucket_vocab_store.rs
@@ -116,6 +116,10 @@ impl BucketVocabStore {
         let mphf = Mphf::new(&seen.into_iter().collect::<Vec<u64>>(), params);
 
         // 4. Place each token at its MPHF slot; build the slab and the id->slot reverse table.
+        //    `FastPtrHash` is NON-minimal: `index()` returns a slot in `[0, max_index())`, and
+        //    `max_index()` is ~1.01·n — larger than `n`. Size `entries` to `max_index()`, not `n`;
+        //    sizing it `n` overflowed `entries[slot]` (bert's 8 added tokens: "len is 8, index is 8").
+        //    The spare slots keep `len: 0`; real tokens are never empty, so `len != 0` = occupied.
         let total: usize = tokens.iter().map(|(s, _)| s.len()).sum();
         let max_id = tokens.iter().map(|(_, id)| *id).max().unwrap();
         let mut bytes = Vec::with_capacity(total);
@@ -125,7 +129,7 @@ impl BucketVocabStore {
                 len: 0,
                 id: 0
             };
-            n
+            mphf.max_index()
         ];
         let mut id_to_slot = vec![u32::MAX; max_id as usize + 1];
         for (s, id) in &tokens {
@@ -177,7 +181,8 @@ impl BucketVocabStore {
         let (start, len) = (e.start as usize, e.len as usize);
         // Byte equality: confirms `q` really is the token at this slot (perfect hashing only
         // guarantees a valid slot for in-vocab keys; this rejects collisions and Out Of Vocab queries).
-        if len == q.len() && self.bytes[start..start + len] == *q {
+        // `len != 0` also rejects the non-minimal PHF's spare slots (and an empty `q`).
+        if len != 0 && len == q.len() && self.bytes[start..start + len] == *q {
             Some(e.id)
         } else {
             None
@@ -209,7 +214,8 @@ impl BucketVocabStore {
     }
 
     pub fn len(&self) -> usize {
-        self.entries.len()
+        // `entries` is sized `max_index()` (≥ n) for the non-minimal PHF; spare slots have `len == 0`.
+        self.entries.iter().filter(|e| e.len != 0).count()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -219,6 +225,7 @@ impl BucketVocabStore {
     pub fn content(&self) -> Vec<(String, u32)> {
         self.entries
             .iter()
+            .filter(|m| m.len != 0) // skip the non-minimal PHF's spare slots
             .filter_map(|m| self.id_to_token(m.id).map(|token| (token, m.id)))
             .collect()
     }
@@ -232,6 +239,7 @@ impl BucketVocabStore {
     pub fn byte_content(&self) -> Vec<(Vec<u8>, u32)> {
         self.entries
             .iter()
+            .filter(|m| m.len != 0) // skip the non-minimal PHF's spare slots
             .filter_map(|m| {
                 self.id_to_token_bytes(m.id)
                     .map(|token| (token.to_vec(), m.id))
@@ -327,6 +335,25 @@ mod tests {
         let mut bytes = vocab.byte_content();
         bytes.sort();
         assert_eq!(bytes, vec![(b"hi".to_vec(), 0), (b"yo".to_vec(), 1)]);
+    }
+
+    // Regression: `FastPtrHash` is non-minimal — `index()` returns slots up to `max_index() > n`, which
+    // overflowed the (formerly `n`-sized) `entries` (bert-base-uncased's 8 added tokens panicked with
+    // "len is 8 but the index is 8"). Whether it fires depends on the exact keys, so sweep small sizes:
+    // every token round-trips, `len()`/`content()` exclude the spare slots, and OOV misses.
+    #[test]
+    fn small_vocab_sizes_never_overflow() {
+        for n in 1..=64usize {
+            let toks: Vec<(Vec<u8>, u32)> =
+                (0..n).map(|i| (format!("tok{i:04}").into_bytes(), i as u32)).collect();
+            let vocab = BucketVocabStore::build(toks.clone());
+            assert_eq!(vocab.len(), n, "len mismatch at n={n}");
+            assert_eq!(vocab.content().len(), n, "content leaked a spare slot at n={n}");
+            for (s, id) in &toks {
+                assert_eq!(vocab.get_bytes(s), Some(*id), "roundtrip failed at n={n} for {s:?}");
+            }
+            assert_eq!(vocab.token_to_id("absent"), None, "oov leaked at n={n}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The crash

Running the pipeline benchmark on **bert-base-uncased** panics while building its added vocabulary:

```
thread 'main' panicked at tk-encode/src/added_vocabulary/bucket_vocab_store.rs:137:20:
index out of bounds: the len is 8 but the index is 8
```

## Root cause — the ptr_hash 2.0.1 bump

Commit `9f9b2ec7` ("bump ptr_hash to 2.0.1") switched the MPHF type:

```diff
-type Mphf = PtrHash<u64, Linear>;      // minimal:      index() in [0, n)
+type Mphf = FastPtrHash<NoHash, u64>;  // non-minimal:  index() in [0, max_index())
```

`FastPtrHash` is **non-minimal**: `index()` returns a slot in `[0, max_index())` and `max_index() ≈ 1.01·n` — larger than `n`. But `entries` was still sized `n`, so a token hashing to the top slot overflowed it (bert has 8 added tokens → slot 8 → `entries[8]` on a len-8 Vec). It only fired for vocab sizes whose keys used the top slot, which is why other models and the existing tests passed by luck.

## Minimal fix

Size `entries` to `mphf.max_index()` (the crate's documented contract) and treat the `max_index()−n` spare slots as empty via `len != 0` — real tokens are never empty — in the query, `len()`, `content()`, and `byte_content()`.

**5 one-line code changes, no struct change**; `entries` grows by at most one slot.

**Why not just revert to the minimal `PtrHash`/`DefaultPtrHash`** (which would keep `index() ∈ [0, n)` and need zero other changes)? Under 2.0.1 the minimal variant **segfaults on an OOV query against a single-key vocab** (n=1) — and the added-token matcher issues OOV probes constantly (`token_to_id("")` in the tests would crash). That's almost certainly why the bump moved off the minimal PHF, so keeping `FastPtrHash` + correct sizing is the safe route.

## Testing

The hf registry mirror here can't resolve `ptr_hash 2.0.1`, so I verified against the vendored 2.0.1 source across **n = 1..=64**:
- `FastPtrHash` puts a key at slot ≥ n for many sizes incl. **n=8** — reproduces the exact crash;
- the fix builds, round-trips every token, and misses OOV/empty for all sizes; `len()`/`content()` exclude the spare slots; `entries` is at most `n+1`.

Adds `small_vocab_sizes_never_overflow` (n=1..=64), covering the n=8 crash and the n=1 edge.

> Note: the committed `Cargo.lock` still pins `ptr_hash 1.1.0` while `Cargo.toml` requires `2.0.1` (pre-existing from the bump); CI resolves 2.0.1 at build. Out of scope here.