### PR TITLE
Upgrade hf-hub to 1.0

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -87,8 +87,8 @@ itertools = "0.14"
 log = "0.4"
 derive_builder = "0.20"
 spm_precompiled = "0.1.3"
-hf-hub = { version = "0.4.1", features = [
-  "ureq",
+hf-hub = { version = "1.0", features = [
+  "blocking",
 ], default-features = false, optional = true }
 daachorse = "3.0.0"
 paste = "1.0.14"

--- a/tokenizers/src/utils/from_pretrained.rs
+++ b/tokenizers/src/utils/from_pretrained.rs
@@ -1,5 +1,4 @@
 use crate::Result;
-use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -57,12 +56,16 @@ pub fn from_pretrained<S: AsRef<str>>(
         .into());
     }
 
-    let mut builder = ApiBuilder::from_env();
+    let mut builder = hf_hub::HFClient::builder();
     if let Some(token) = params.token {
-        builder = builder.with_token(Some(token));
+        builder = builder.token(token);
     }
-    let api = builder.build()?;
-    let repo = Repo::with_revision(identifier, RepoType::Model, params.revision);
-    let api = api.repo(repo);
-    Ok(api.get("tokenizer.json")?)
+    let client = hf_hub::HFClientSync::from_inner(builder.build()?)?;
+    let (owner, name) = hf_hub::split_id(&identifier);
+    let repo = client.model(owner, name);
+    Ok(repo
+        .download_file()
+        .filename("tokenizer.json")
+        .revision(params.revision)
+        .send()?)
 }


### PR DESCRIPTION
Upgrades the `hf-hub` dependency from 0.4 to 1.0 and migrates `from_pretrained` to the new API: the `ureq` feature is replaced by `blocking`, and the old `ApiBuilder`/`Repo` flow is replaced with `HFClientSync` + the `download_file` builder. Behavior is unchanged (env token/endpoint fallback, bare identifiers, and revisions all work as before); verified with `cargo test --features http --test from_pretrained` against the live Hub. cc @mcpotato