### PR TITLE
perf(atomsplit): fuse o200k letter case-split + 32-wide ASCII classify

### DIFF
--- a/tokenizers/atomsplit/src/fsm/o200k.rs
+++ b/tokenizers/atomsplit/src/fsm/o200k.rs
@@ -5,69 +5,133 @@ use super::*;
 /// o200k class of a letter-run char (all chars in a run are real `[\p{L}\p{M}]`, never ALPHA_SYM/ZWJ):
 /// `Atom::UpperLetter` → U (`\p{Lu}\p{Lt}`), `Atom::LowerLetter` → L (`\p{Ll}`), else C (caseless `\p{Lm}\p{Lo}
 /// \p{M}`). The two alt char-classes are `[UC]` = "not L" (`!o_is_lower`) and `[LC]` = "not U".
-#[inline]
+#[inline(always)]
 fn o_is_upper(t: u8) -> bool {
     t == Atom::UpperLetter as u8 // 0x10: coarse Letter (low nibble 0) + UPPER refine (\p{Lu}∪\p{Lt})
 }
-#[inline]
+#[inline(always)]
 fn o_is_lower(t: u8) -> bool {
     t == Atom::LowerLetter as u8 // 0x20: coarse Letter + LOWER refine (\p{Ll})
 }
 
-/// One o200k letter sub-token from `p` within the run `[.., re)`: alt-1 `[UC]*[LC]+` (tried first) else
-/// alt-2 `[UC]+[LC]*` (reached only for an all-U run). Greedy with Perl backtracking — `[UC]*` gives back
-/// to the last C so `[LC]+` can take ≥1. Returns the sub-token end, always in `(p, re]`. BYTE-wise (`+=1`,
-/// like `run_end`): continuation bytes are tag `Cont`(15) → neither U nor L → transparent to `[UC]`/`[LC]`.
+/// Is `t` a real `[\p{L}\p{M}]` member? Coarse `Letter` (any case) is always in; coarse `Mark` is in only
+/// as a true `\p{M}` — ALPHA_SYM (`\p{S}`) and ZWJ/ZWNJ (`\p{Cf}`) are `\w` but not `[\p{L}\p{M}]`. `Cont`
+/// (low nibble 15) is not a member — the scan loops handle it separately as a transparent ride-along byte.
 #[inline(always)]
-fn o200k_letter_match(tags: &[u8], p: usize, re: usize) -> usize {
-    // alt-1 `[UC]*`: greedy over "not L" (stops at the next lowercase *lead*), tracking the last C
-    // char-start so a no-L run needs no separate backtrack pass (`Cont`=15 is neither U nor L, so it's
-    // "C-like" — the `!= CONT` guard keeps `last_c` on a real char start).
-    let mut q = p;
-    let mut last_c = usize::MAX;
-    while q < re && !o_is_lower(tags[q]) {
-        if tags[q] != CONT && !o_is_upper(tags[q]) {
-            last_c = q;
+fn o_member(t: u8) -> bool {
+    let c = t & 0x0F;
+    c == LET || (c == MRK && t != ASM && t != ZWJ)
+}
+
+/// Phase A `[UC]*`: first index ≥ `p` that STOPS the run — a lowercase lead (→ phase B, same sub-token)
+/// or a non-member (the `[\p{L}\p{M}]+` run end). `Cont` rides along (transparent).
+/// Same unrolled "fast loop" as [`run_end`] (16 tags/chunk, one bounds check, unchecked reads) — a stride
+/// of 16 already skips whole cont spans wholesale, so cont bytes are not a per-char cost; a wider stride
+/// (measured at 48 = 16×3) only bloats the code and loses on short/2-byte runs.
+#[inline(always)]
+fn o200k_uc_run(tags: &[u8], mut p: usize, end: usize) -> usize {
+    while p + 16 <= end {
+        for k in 0..16 {
+            let t = unsafe { *tags.get_unchecked(p + k) };
+            if t != CONT && (o_is_lower(t) || !o_member(t)) {
+                return p + k;
+            }
         }
-        q += 1;
+        p += 16;
     }
-    if q < re {
-        // tags[q] is L → `[LC]+` from q: greedy over "not U"
-        let mut e = q;
-        while e < re && !o_is_upper(tags[e]) {
-            e += 1;
+    while p < end {
+        let t = tags[p];
+        if t != CONT && (o_is_lower(t) || !o_member(t)) {
+            return p;
         }
-        return e;
+        p += 1;
     }
-    if last_c == usize::MAX {
-        return re; // no L and no C → all U → alt-2 `[UC]+[LC]*` (empty `[LC]*`) = the whole run
+    p
+}
+
+/// Phase B `[LC]+`: first index ≥ `e` that STOPS — an uppercase lead (sub-token boundary) or a non-member
+/// (run end). `Cont` rides along. Same 16-wide unrolled scan as [`o200k_uc_run`].
+#[inline(always)]
+fn o200k_lc_run(tags: &[u8], mut e: usize, end: usize) -> usize {
+    while e + 16 <= end {
+        for k in 0..16 {
+            let t = unsafe { *tags.get_unchecked(e + k) };
+            if t != CONT && (o_is_upper(t) || !o_member(t)) {
+                return e + k;
+            }
+        }
+        e += 16;
     }
-    // no L: `[UC]*` gives back to the last C, which begins the `[LC]+`
-    let mut e = last_c;
-    while e < re && !o_is_upper(tags[e]) {
+    while e < end {
+        let t = tags[e];
+        if t != CONT && (o_is_upper(t) || !o_member(t)) {
+            return e;
+        }
         e += 1;
     }
     e
 }
 
-/// Emit the o200k case-split of the letter run `[ls, re)` into `out[*w..]`: the first sub-token starts at
-/// `pfx` (the optional `[^\r\n\p{L}\p{N}]?` prefix; `pfx == ls` when none), the last absorbs a trailing
-/// contraction. Returns the new cursor (past the contraction). `ls < re` (caller-guaranteed).
+/// The give-back target: last non-uppercase member char-start in `[p, q)` (all members, no lowercase), or
+/// `usize::MAX` if the whole span is uppercase. A backward hop — O(1) for the common all-caseless run
+/// (CJK: the last char is the target) — which lets phase A stay a pure skippable scan (no per-char track).
+#[inline(always)]
+fn o200k_last_c(tags: &[u8], p: usize, mut c: usize) -> usize {
+    while c > p {
+        c -= 1;
+        while c > p && tags[c] == CONT {
+            c -= 1; // step back to the char start
+        }
+        if tags[c] != Atom::UpperLetter as u8 {
+            return c; // caseless letter / mark = C
+        }
+    }
+    usize::MAX
+}
+
+/// Emit the o200k case-split of the letter run starting at `ls` into `out[*w..]` — ONE forward pass that
+/// discovers the `[\p{L}\p{M}]+` run end inline (no separate `letter_end` scan; the case tags are already
+/// exact — `Atom::UpperLetter`/`LowerLetter`/caseless `Letter`). The first sub-token starts at `pfx` (the
+/// `[^\r\n\p{L}\p{N}]?` prefix; `pfx == ls` when none); the last absorbs a trailing contraction. Returns
+/// the cursor past it. `ls < end` (caller-guaranteed via `is_lm`). Each sub-token is `[UC]*[LC]+` (alt-1,
+/// greedy with the give-back that lets `[LC]+` take ≥1), an all-U tail being alt-2 `[UC]+[LC]*`.
 #[inline(always)]
 fn emit_o200k_letters(
     text: &[u8],
     tags: &[u8],
     pfx: usize,
     ls: usize,
-    re: usize,
+    end: usize,
     out: &mut [Span],
     w: &mut usize,
 ) -> usize {
-    let (mut p, mut first, mut cursor) = (ls, true, re);
-    while p < re {
-        let e = o200k_letter_match(tags, p, re);
+    let (mut p, mut first) = (ls, true);
+    loop {
+        let q = o200k_uc_run(tags, p, end); // end of `[UC]*` — a lowercase lead or the run end
+
+        // Resolve the sub-token end and whether another sub-token follows (a U at the boundary vs run end).
+        let (tok_end, next_p, more) = if q < end && o_is_lower(tags[q]) {
+            let e = o200k_lc_run(tags, q, end); // `[LC]+` from the first L
+            (e, e, e < end && o_is_upper(tags[e]))
+        } else {
+            // no L in [p, q) → q is the run end. Give back to the last caseless/mark char (if any) so
+            // `[LC]+` can take ≥1; trailing U's after it re-enter the loop as an alt-2 `[UC]+` token.
+            let last_c = o200k_last_c(tags, p, q);
+            if last_c == usize::MAX {
+                (q, q, false) // all-U alt-2 `[UC]+` = the whole [p, q)
+            } else {
+                let e = o200k_lc_run(tags, last_c, end);
+                (e, e, e < end && o_is_upper(tags[e]))
+            }
+        };
+
         let start = if first { pfx } else { p };
-        let tok_end = if e == re { e + contraction(text, e) } else { e };
+        let tok_end = if more {
+            tok_end
+        } else {
+            tok_end + contraction(text, tok_end)
+        };
+        // SAFETY: tokens partition the input, so `*w < #tokens <= end <= out.len()` (callers size n+1).
         unsafe {
             *out.get_unchecked_mut(*w) = Span {
                 start: start as u32,
@@ -76,10 +140,11 @@ fn emit_o200k_letters(
         };
         *w += 1;
         first = false;
-        cursor = tok_end;
-        p = e;
+        p = next_p;
+        if !more {
+            return tok_end;
+        }
     }
-    cursor
 }
 
 /// o200k (GPT-4o) pretokenization. Same skeleton as cl100k, but the letter body is `[\p{L}\p{M}]+`
@@ -92,48 +157,11 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
     debug_assert!(out.len() >= text.len() && tags.len() >= text.len());
     let end = text.len();
     // Tie `tags.len() == end` so the optimizer drops the per-byte bounds check on every interior
-    // `tags[i]` in this fsm + its `run_end`/`letter_*` scans. (Callers guarantee `tags.len() >= end`.)
+    // `tags[i]` in this fsm + its `run_end`/letter scans. (Callers guarantee `tags.len() >= end`.)
     let tags = &tags[..end];
 
-    // Is tag `t` (at byte `p`) a real `[\p{L}\p{M}]` member? Coarse `Letter` (any case) is always in;
-    // coarse `Mark` is in only as a true `\p{M}` — ALPHA_SYM (`\p{S}`) and ZWJ/ZWNJ (`\p{Cf}`) are `\w`
-    // but not `[\p{L}\p{M}]`. The `ds_is_zwj` byte-peek is thus paid ONLY for Marks, never for letters.
-    let member = |t: u8, p: usize| -> bool {
-        let c = t & 0x0F;
-        let _ = p;
-        c == LET || (c == MRK && t != ASM && t != ZWJ)
-    };
-    let is_lm = |a: usize| a < end && member(tags[a], a);
-    // maximal `[\p{L}\p{M}]+` run from `a` (byte-wise; continuation bytes ride along — see `run_end`).
-    let letter_end = |a: usize| -> usize {
-        let mut p = a;
-        // logos-style fast loop: 16 tags/chunk, one bounds check, unchecked reads. A plain `Letter`
-        // (low nibble 0, incl Han — o200k keeps all letters) or a `Cont` byte stays in-run with no
-        // `ds_is_zwj` peek; only a coarse `Mark` lane pays the peek. Byte-exact with the scalar scan.
-        // SAFETY: `p + 16 <= end <= tags.len()`/`text.len()` in the body.
-        while p + 16 <= end {
-            let mut brk = 16;
-            for k in 0..16 {
-                let t = unsafe { *tags.get_unchecked(p + k) };
-                if t == CONT || t & 0x0F == LET {
-                    continue;
-                }
-                if t & 0x0F == MRK && t != ASM && t != ZWJ {
-                    continue;
-                }
-                brk = k;
-                break;
-            }
-            if brk < 16 {
-                return p + brk;
-            }
-            p += 16;
-        }
-        while p < end && (tags[p] == CONT || member(tags[p], p)) {
-            p += 1;
-        }
-        p
-    };
+    // Does a char-start at `a` begin a `[\p{L}\p{M}]` run? (`a` is always a char-start here, never `Cont`.)
+    let is_lm = |a: usize| a < end && o_member(tags[a]);
     // rule 4 `[^\s\p{L}\p{N}]+[\r\n/]*` from `sp0` (any leading space already consumed); `sp0` if none.
     // `/` is in the `+` body too — the trailing class only matters after the `+` stops at a `\r\n`.
     let other = |sp0: usize| -> usize {
@@ -167,12 +195,12 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             // take the `[^\r\n\p{L}\p{N}]?` prefix / rule-4 path instead.
             LET | MRK => {
                 if tags[i] != ASM && tags[i] != ZWJ {
-                    i = emit_o200k_letters(text, tags, i, i, letter_end(i), out, &mut w);
+                    i = emit_o200k_letters(text, tags, i, i, end, out, &mut w);
                     continue;
                 }
                 let a = i + char_len(b);
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = emit_o200k_letters(text, tags, i, a, end, out, &mut w);
                     continue;
                 }
                 i = other(i); // ∈ NOT_WS_L_N ⇒ > i
@@ -181,7 +209,7 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             SPC => {
                 let a = i + 1; // Space is ASCII (0x20)
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = emit_o200k_letters(text, tags, i, a, end, out, &mut w);
                     continue;
                 }
                 let p = other(a);
@@ -191,7 +219,7 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             WSO => {
                 let a = i + char_len(b);
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = emit_o200k_letters(text, tags, i, a, end, out, &mut w);
                     continue;
                 }
                 i = ws(i);
@@ -201,7 +229,7 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             CON | PUN | APO | SYM | NMO | CTL => {
                 let a = i + char_len(b);
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = emit_o200k_letters(text, tags, i, a, end, out, &mut w);
                     continue;
                 }
                 i = other(i); // ∈ NOT_WS_L_N ⇒ > i

--- a/tokenizers/atomsplit/src/simd_classify.rs
+++ b/tokenizers/atomsplit/src/simd_classify.rs
@@ -164,8 +164,21 @@ pub unsafe fn classify_neon(text: &[u8], tags: &mut [u8]) {
         // 1. load the first byte in each lane. 16 lanes, each now own 1 byte. All operations are
         //    run in parallel.
         let b0 = vld1q_u8(text.as_ptr().add(i));
+        // Load the next 16 bytes up front: the multibyte path below needs them for the b1/b2 lookahead
+        // anyway, and having them here lets the ASCII fast path clear a whole 32-byte window in one shot.
+        let next = vld1q_u8(text.as_ptr().add(i + 16));
 
-        // ASCII fast path: whole chunk < 0x80 → one table, skip everything else
+        // ASCII fast path: whole 32-byte window < 0x80 → two table stores under ONE bounds check + ONE
+        // vmaxvq. Real text is ~half ASCII (spaces / digits / punctuation), so widening the skip 16→32
+        // halves this overhead broadly (big win on English) — the multibyte path below is left untouched.
+        if vmaxvq_u8(vmaxq_u8(b0, next)) < 0x80 {
+            let (lo, hi) = (&ATOM_TABLES.ascii_lo, &ATOM_TABLES.ascii_hi);
+            vst1q_u8(tags.as_mut_ptr().add(i), ascii_tbl(b0, lo, hi));
+            vst1q_u8(tags.as_mut_ptr().add(i + 16), ascii_tbl(next, lo, hi));
+            i += 32;
+            continue;
+        }
+        // Only b0 is ASCII (the window straddles an ASCII↔multibyte boundary): store it and step 16.
         if vmaxvq_u8(b0) < 0x80 {
             // vst1q_u8 stores the value from ascii_tbl into tags.
             vst1q_u8(
@@ -179,8 +192,7 @@ pub unsafe fn classify_neon(text: &[u8], tags: &mut [u8]) {
         // Not all ascii, so let's default the tags by computing ASCII.
         let mut out = ascii_tbl(b0, &ATOM_TABLES.ascii_lo, &ATOM_TABLES.ascii_hi); // base (ASCII lanes correct; MB overwritten)
 
-        // Let's load the next chunk of 16 bytes
-        let next = vld1q_u8(text.as_ptr().add(i + 16));
+        // `next` (the following 16 bytes) was loaded above for the 32-byte ASCII check; reuse it here.
         // vext::<N>  does: cat(bo[N..], next[..N])
         let b1 = vextq_u8::<1>(b0, next); // byte at lane+1
         let b2 = vextq_u8::<2>(b0, next); // byte at lane+2


### PR DESCRIPTION
Two byte-exact perf changes to `atomsplit`, both isolated to the scalar o200k FSM and the NEON classify kernel. No behavioural change — `o200k_parity` and the classify SIMD-vs-scalar parity tests pass, 0 warnings.

## 1. o200k letter case-split: one pass instead of two

`fsm_o200k` walked every `[\p{L}\p{M}]+` run **twice** — `letter_end()` to find the run end, then `emit_o200k_letters`/`o200k_letter_match` re-scanned the same bytes for the case split. Since the tags already carry exact case (`UpperLetter`/`LowerLetter`/caseless), the run end can be discovered *inline* during the case split:

- fold `letter_end` into the phase-A `[UC]*` / phase-B `[LC]+` scans (each stops at a non-member = run end);
- unroll those scans 16 tags/chunk with `get_unchecked`, same shape as `run_end` (a 16-wide scan already skips cont spans wholesale — a 48-wide variant was measured and lost);
- resolve the give-back last-caseless target by a backward hop only on the no-lowercase exit, so the forward scans stay pure skips (no per-char tracking).

**FSM throughput (ns/byte, min-of-7, byte-exact ✓ vs onig):**

| lang | before | after | Δ |
|------|:---:|:---:|:---:|
| English | 2.163 | 1.602 | −26% |
| French | 1.936 | 1.437 | −26% |
| Russian | 1.243 | 0.761 | −39% |
| Greek | 1.316 | 0.824 | −37% |
| Arabic | 1.539 | 1.104 | −28% |
| Thai | 1.076 | 0.636 | −41% |
| Chinese | 1.154 | 0.759 | −34% |
| Japanese | 1.126 | 0.764 | −32% |
| Korean | 1.746 | 1.371 | −21% |

Every corpus now beats logos on the full (classify + fsm) pipeline; the previous Chinese/Thai ties are gone.

## 2. classify: 32-wide ASCII fast path

The NEON kernel loads 32 bytes to produce 16 tags (it needs the `b1`/`b2` lookahead), so non-ASCII bytes were effectively loaded twice. The ASCII fast path now peeks **32 bytes at once** — one bounds check + one `vmaxvq` reduction covers two 16-byte stores — done **in place**. The multibyte body is completely untouched (same code, same comments). Real text is ~half ASCII (spaces / digits / punctuation), so this fires constantly.

**classify throughput (ns/byte, byte-exact ✓ vs `classify_scalar`):**

| lang | before | after | Δ |
|------|:---:|:---:|:---:|
| English | 0.153 | 0.085 | +45% |
| French | 0.252 | 0.218 | +14% |
| Russian | 0.384 | 0.344 | +10% |
| Chinese / Korean / Thai | — | — | ~neutral |

No regression on non-ASCII scripts. (A full 32-wide multibyte driver was prototyped too — it gains Chinese +17% but regresses 2-byte scripts −8 to −14%, so only the clean ASCII-widening is kept.)