### PR TITLE
fix: skip pre-tokenizer when is_pretokenized=True

### DIFF
--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -4,7 +4,7 @@ import concurrent.futures
 import pytest
 import numpy as np
 import asyncio
-from tokenizers import AddedToken, Encoding, Tokenizer, decoders
+from tokenizers import AddedToken, Encoding, Tokenizer, decoders, pre_tokenizers
 from tokenizers.implementations import BertWordPieceTokenizer
 from tokenizers.models import BPE, Model, Unigram
 from tokenizers.pre_tokenizers import ByteLevel, Metaspace
@@ -188,6 +188,12 @@ class TestTokenizer:
         # Can encode a single pre-tokenized sequence
         output = tokenizer.encode(["my", "name", "is", "john"], is_pretokenized=True)
         assert output.tokens == ["my", "name", "is", "john"]
+
+        # is_pretokenized should skip the pre-tokenizer (issue #1695)
+        tokenizer.add_tokens(["<eos>"])
+        tokenizer.pre_tokenizer = pre_tokenizers.Split("", "isolated")
+        output = tokenizer.encode(["<eos>"], is_pretokenized=True)
+        assert output.tokens == ["<eos>"]
 
         # Can encode a batch with both a single sequence and a pair of sequences
         output = tokenizer.encode_batch(["my name is john", ("my name is john", "pair")])

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -766,10 +766,14 @@ where
         offsets_type: OffsetType,
     ) -> Result<Encoding> {
         let encode = |is_pre_tokenized, subseq_idx, subseq| -> Result<Encoding> {
-            let normalized = self
+            let pre_tokenized = self
                 .added_vocabulary
                 .extract_and_normalize(self.normalizer.as_ref(), subseq);
-            let pre_tokenized = self.do_pre_tokenize(normalized)?;
+            let pre_tokenized = if is_pre_tokenized {
+                pre_tokenized
+            } else {
+                self.do_pre_tokenize(pre_tokenized)?
+            };
             let subseq_encoding = self.do_tokenize(
                 pre_tokenized,
                 type_id,


### PR DESCRIPTION
Fixes #1695

When `encode` is called with `is_pretokenized=True`, the input is already split into tokens, so the tokenizer's pre-tokenizer should not be applied again. This change skips `do_pre_tokenize` for pre-tokenized sequences while keeping added-vocabulary extraction and normalization.