### PR TITLE
Fix Metaspace decoder dropping internal spaces in the first token

### DIFF
--- a/tokenizers/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/src/pre_tokenizers/metaspace.rs
@@ -155,9 +155,13 @@ impl Decoder for Metaspace {
             .map(|(i, token)| {
                 token
                     .chars()
-                    .flat_map(|c| {
+                    .enumerate()
+                    .filter_map(|(j, c)| {
                         if c == self.replacement {
-                            if i == 0 && self.prepend_scheme != PrependScheme::Never {
+                            // Only strip the single replacement char that was
+                            // prepended during pre-tokenization; any other
+                            // occurrence is a real word boundary.
+                            if i == 0 && j == 0 && self.prepend_scheme != PrependScheme::Never {
                                 None
                             } else {
                                 Some(' ')
@@ -366,5 +370,28 @@ mod tests {
             .decode_chain(vec!["▁Hey".into(), "▁friend!".into()])
             .unwrap();
         assert_eq!(res, vec![" Hey", " friend!"]);
+    }
+
+    #[test]
+    fn decode_first_token_with_internal_replacement() {
+        // Only the single prepended replacement char should be stripped from
+        // the first token; internal ones are real word boundaries.
+        let decoder = Metaspace::new('▁', PrependScheme::Always, true);
+        let res = decoder
+            .decode_chain(vec!["▁in▁the".into(), "▁house".into()])
+            .unwrap();
+        assert_eq!(res, vec!["in the", " house"]);
+
+        // Same thing without splitting (single multi-word token).
+        let decoder = Metaspace::new('▁', PrependScheme::Always, false);
+        let res = decoder.decode_chain(vec!["▁Hey▁friend".into()]).unwrap();
+        assert_eq!(res, vec!["Hey friend"]);
+
+        // With `Never`, nothing was prepended so nothing should be stripped.
+        let decoder = Metaspace::new('▁', PrependScheme::Never, true);
+        let res = decoder
+            .decode_chain(vec!["▁in▁the".into(), "▁house".into()])
+            .unwrap();
+        assert_eq!(res, vec![" in the", " house"]);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the `Metaspace` decoder silently dropping internal word-boundary spaces in the **first** decoded token.

### Bug

`Metaspace::decode_chain` is supposed to strip the single leading replacement char (`▁`) that pre-tokenization prepended (when `prepend_scheme != Never`) and turn every other replacement char into a space. Instead, for token `i == 0` the closure mapped **every** occurrence of the replacement char to `None`:

```rust
if c == self.replacement {
    if i == 0 && self.prepend_scheme != PrependScheme::Never {
        None          // deletes ALL ▁ in the first token, not just the prepended one
    } else {
        Some(' ')
    }
}
```

So any first token containing more than one metaspace char loses its internal spaces:

- default `split=true`, with a BPE-merged token spanning a space: `decode_chain(["▁in▁the", "▁house"])` → `"inthe house"` instead of `"in the house"`
- `split=false` on multi-word input: `decode_chain(["▁Hey▁friend"])` → `"Heyfriend"` instead of `"Hey friend"`

### Fix

Track the char position within the token and drop the replacement char only at position 0 of the first token; every other occurrence decodes to a space. This matches the SentencePiece convention (replace all `▁` with spaces, strip exactly the one prepended prefix space) and the `transformers` slow-tokenizer behavior.

### How tested

- Added `decode_first_token_with_internal_replacement` covering `split=true`, `split=false`, and `PrependScheme::Never` (unchanged: nothing stripped). The test fails on `main` (`left: ["inthe", " house"], right: ["in the", " house"]`) and passes with the fix.
- Full rust suite: `cargo test --manifest-path ./tokenizers/Cargo.toml --lib` → 202 passed, 0 failed. `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.
- Existing decode tests for `Always`/`Never` schemes (single leading `▁` first tokens) are unaffected, as are the Python-binding `Metaspace` decode expectations.
