### PR TITLE
Fix token_to_sequence returning Some(0) for out-of-bounds index

### DIFF
--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -210,7 +210,7 @@ impl Encoding {
 
     /// Returns the index of the sequence containing the given token
     pub fn token_to_sequence(&self, token: usize) -> Option<usize> {
-        if token > self.len() {
+        if token >= self.len() {
             None
         } else if self.sequence_ranges.is_empty() {
             Some(0)
@@ -565,6 +565,20 @@ impl std::iter::FromIterator<(u32, String, (usize, usize), Option<u32>, u32)> fo
 mod tests {
     use super::*;
     use std::iter::FromIterator;
+
+    #[test]
+    fn token_to_sequence_out_of_bounds() {
+        // An unprocessed encoding has no `sequence_ranges`, so every in-range token
+        // maps to sequence 0. Out-of-range indices (>= len) must return `None`, like
+        // the sibling accessors `token_to_chars`/`token_to_word` do via `.get(token)`.
+        let encoding = Encoding {
+            ids: vec![1, 2, 3],
+            ..Default::default()
+        };
+        assert_eq!(encoding.token_to_sequence(2), Some(0)); // last valid index
+        assert_eq!(encoding.token_to_sequence(3), None); // == len, out of bounds
+        assert_eq!(encoding.token_to_sequence(4), None); // > len, out of bounds
+    }
 
     #[test]
     fn merge_encodings() {


### PR DESCRIPTION
## Problem

`Encoding::token_to_sequence` guards the index with `>` instead of `>=`:

```rust
pub fn token_to_sequence(&self, token: usize) -> Option<usize> {
    if token > self.len() {
        None
    } else if self.sequence_ranges.is_empty() {
        Some(0)
    } else {
        self.sequence_ranges.iter().find_map(|(seq_id, range)| {
            if range.contains(&token) { Some(*seq_id) } else { None }
        })
    }
}
```

Valid token indices are `0..len`, so `token == len` is out of bounds and should return `None`. But `token > self.len()` lets it through, and for an **unprocessed** encoding (empty `sequence_ranges`, e.g. from `Encoding::from_tokens` or a raw model output) it falls to `Some(0)`.

## Evidence (sibling accessors prove intent)

Every other index-based accessor in the same file treats `index >= len` as out of bounds:

- `token_to_chars` → `self.offsets.get(token)` → `None` at `token == len`
- `token_to_word` → `self.words.get(token)` → `None` at `token == len`

Only `token_to_sequence` admits `token == len`. `token_to_sequence` is public API (also exposed through the Python and Node bindings), so a caller doing `encoding.token_to_sequence(len)` on a single-sequence/unprocessed encoding gets `0` rather than `None`.

## Fix

```rust
if token >= self.len() {
```

Processed encodings are unaffected — their `sequence_ranges` are populated and never contain `len`, so the boundary already resolved to `None` via `find_map`; existing tests (`processors::bert`, `processors::roberta`, Python `test_encoding.py`) still pass. A regression test is added for the unprocessed-encoding boundary.
