### PR TITLE
bench(pipeline): add sebpop/upstream as a second reference series

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -6,28 +6,33 @@ Input: JSON object from `cargo run --release -p tk-encode --features
 tk-encode/bench-baseline --example fixture_bench`:
 
     {baseline: {crate, version},
+     sebpop: {crate, ref},
      models: [{model, shape, desc, [reason],
-               memory: {baseline|pipeline:
+               memory: {baseline|sebpop|pipeline:
                         {load_bytes, encode_bytes, peak_bytes} | null} | null,
                threads: {counts: [1,2,4,8,max],
-                         pipeline_mbps: [..], baseline_mbps: [..|null]},
+                         pipeline_mbps: [..], baseline_mbps: [..|null],
+                         sebpop_mbps: [..|null]},
                results: [{fixture, group, bytes, chunks,
-                          mbps: {baseline, pipeline},
-                          ids_match, ids_match_baseline,
+                          mbps: {baseline, sebpop, pipeline},
+                          ids_match, ids_match_baseline, ids_match_sebpop,
                           stage_ns_per_byte: {added_split, normalize,
                                               pre_tokenize, model, total},
                           pretok_vs_regex: {cls_simd, cls_scalar,
                                             onig|null, fancy|null,
                                             pcre2|null, logos|null}}]}]}
 
-Two series: `baseline` — the latest released tokenizers crate, the bar to beat
-(the in-tree Tokenizer is on its way out, so it isn't benched; it only serves
-as the id oracle behind `ids_match`) — drawn gray as context, and `pipeline` —
-the experimental PipelineTokenizer, blue. The report leads with three
+Three series: `baseline` — the latest released tokenizers crate, the bar to
+beat (the in-tree Tokenizer is on its way out, so it isn't benched; it only
+serves as the id oracle behind `ids_match`) — drawn gray as context; `sebpop`
+— the tokenizers crate from sebpop's performance branch, green; and `pipeline`
+— the experimental PipelineTokenizer, blue. The `sebpop` keys are optional
+everywhere so older cached JSONs still render. The report leads with
 always-visible charts:
 
   1. throughput overview — per model, geomean ×speedup of the pipeline against
-     the release (×1.0 = release), with a min–max whisker across fixtures (no
+     the release (×1.0 = release), with a min–max whisker across fixtures, plus
+     a second (green) bar for sebpop's branch on the same vs-release axis (no
      cross-model aggregate: the models exercise different execution modes, so
      averaging them means nothing);
   2. memory overview — per model, resident-set delta after load plus the encode
@@ -68,10 +73,11 @@ INK = {
 }
 # Series identity: the release baseline is context-gray on purpose — in the
 # speedup charts it *is* the ×1.0 axis, in memory/binary-size it's the
-# reference bar the pipeline is read against.
+# reference bar the pipeline is read against. sebpop's branch is the second
+# reference, green.
 SERIES_INK = {
-    "light": {"baseline": "#898781", "pipeline": "#2a78d6"},
-    "dark": {"baseline": "#898781", "pipeline": "#3987e5"},
+    "light": {"baseline": "#898781", "sebpop": "#2f9e44", "pipeline": "#2a78d6"},
+    "dark": {"baseline": "#898781", "sebpop": "#57c464", "pipeline": "#3987e5"},
 }
 FONT = "-apple-system,'Segoe UI',Helvetica,Arial,sans-serif"
 GUTTER, PLOT_W, PAD_R, COL_W, ROW_H, BAR_H = 190, 540, 110, 150, 26, 16
@@ -142,6 +148,27 @@ def speedup(row):
 
 def model_speedups(model):
     return [v for v in (speedup(r) for r in model["results"]) if v]
+
+
+def sebpop_speedup(row):
+    """Pipeline throughput ÷ sebpop-branch throughput for the same fixture."""
+    s, p = row["mbps"].get("sebpop"), row["mbps"]["pipeline"]
+    return p / s if s and p else None
+
+
+def sebpop_model_speedups(model):
+    return [v for v in (sebpop_speedup(r) for r in model["results"]) if v]
+
+
+def sebpop_rel_release(row):
+    """sebpop-branch throughput ÷ release throughput — sebpop's own speedup on
+    the same vs-release axis the pipeline bars are drawn on."""
+    b, s = row["mbps"]["baseline"], row["mbps"].get("sebpop")
+    return s / b if b and s else None
+
+
+def sebpop_rel_model_speedups(model):
+    return [v for v in (sebpop_rel_release(r) for r in model["results"]) if v]
 
 
 def base_speedup(row, base_lookup, model_name):
@@ -242,7 +269,8 @@ def speedup_axis(ink, x, ticks, top, bottom):
 
 def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label,
                  speedups_of=model_speedups, title=None, ref_label=None,
-                 mark_regressions=False, no_cmp_msg=None):
+                 mark_regressions=False, no_cmp_msg=None,
+                 speedups2_of=None, series2_label=None):
     """The headline chart: a row per manifest model — name + workload desc,
     geomean ×speedup of the pipeline vs the reference (×1.0) with a min–max
     whisker across fixtures. No cross-model aggregate on purpose: the models
@@ -251,7 +279,9 @@ def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label,
 
     Defaults draw "vs latest release". Pass `speedups_of=base_model_speedups`-style
     with `mark_regressions=True` for the "vs base branch" twin: bars for models that
-    got slower than the base branch turn red."""
+    got slower than the base branch turn red. Pass `speedups2_of`/`series2_label`
+    to add a second series (sebpop's branch, green) as a second bar per model on
+    the same vs-reference axis."""
     ink, sink = INK[mode], SERIES_INK[mode]
     title = title or "PipelineTokenizer vs latest release — encode throughput"
     ref_label = ref_label or baseline_label
@@ -260,6 +290,24 @@ def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label,
         return OV_GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * OV_PLOT
 
     ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x, min_px=34, keep=1.0)
+
+    def series_bar(vals, cy, bar_h, color, label_fill, label_size, label_weight):
+        """One geomean bar + min–max whisker + ×label, centered on `cy`."""
+        g, mn, mx = geomean(vals), min(vals), max(vals)
+        parts = [hbar(x(1.0), x(g), cy - bar_h / 2, bar_h, color),
+                 f'<line x1="{x(mn):.1f}" y1="{cy:.1f}" x2="{x(mx):.1f}" y2="{cy:.1f}" '
+                 f'stroke="{ink["secondary"]}" stroke-width="1.5"/>']
+        for v in (mn, mx):
+            parts.append(f'<line x1="{x(v):.1f}" y1="{cy - 4:.1f}" x2="{x(v):.1f}" y2="{cy + 4:.1f}" '
+                         f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
+        anchor, lx = (("start", max(x(mx), x(1.0)) + 8) if g >= 1
+                      else ("end", min(x(mn), x(1.0)) - 8))
+        if anchor == "end" and lx - 40 < OV_GUTTER + 4:
+            anchor, lx = "start", max(x(mx), x(1.0)) + 8
+        parts.append(f'<text x="{lx:.1f}" y="{cy + 4:.1f}" fill="{label_fill}" '
+                     f'font-size="{label_size}" font-weight="{label_weight}" text-anchor="{anchor}" '
+                     f'style="font-variant-numeric:tabular-nums">×{g:.2f}</text>')
+        return parts
 
     top, row_h = 74, 40
     col_x = CHART_W - 16
@@ -274,22 +322,16 @@ def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label,
         body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 11:.1f}" fill="{ink["muted"]}" '
                     f'font-size="10.5" text-anchor="end">{escape(desc)}</text>')
         vals = speedups_of(m)
+        vals2 = speedups2_of(m) if speedups2_of else None
         if vals:
-            g, mn, mx = geomean(vals), min(vals), max(vals)
+            g = geomean(vals)
             bar_color = ink["critical"] if (mark_regressions and g < 1) else sink["pipeline"]
-            body.append(hbar(x(1.0), x(g), cy - 7, 14, bar_color))
-            body.append(f'<line x1="{x(mn):.1f}" y1="{cy:.1f}" x2="{x(mx):.1f}" y2="{cy:.1f}" '
-                        f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
-            for v in (mn, mx):
-                body.append(f'<line x1="{x(v):.1f}" y1="{cy - 4:.1f}" x2="{x(v):.1f}" y2="{cy + 4:.1f}" '
-                            f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
-            anchor, lx = (("start", max(x(mx), x(1.0)) + 8) if g >= 1
-                          else ("end", min(x(mn), x(1.0)) - 8))
-            if anchor == "end" and lx - 40 < OV_GUTTER + 4:
-                anchor, lx = "start", max(x(mx), x(1.0)) + 8
-            body.append(f'<text x="{lx:.1f}" y="{cy + 4:.1f}" fill="{ink["primary"]}" font-size="12" '
-                        f'font-weight="600" text-anchor="{anchor}" '
-                        f'style="font-variant-numeric:tabular-nums">×{g:.2f}</text>')
+            if vals2:
+                # two bars on the same axis: pipeline on top, the second series below
+                body += series_bar(vals, cy - 7, 11, bar_color, ink["primary"], 11, 600)
+                body += series_bar(vals2, cy + 7, 11, sink["sebpop"], ink["secondary"], 10.5, 400)
+            else:
+                body += series_bar(vals, cy, 14, bar_color, ink["primary"], 12, 600)
             bad = sum(1 for r in m["results"] if r["ids_match"] is False)
             right, fill = ((f"⚠ {bad} differ", ink["critical"]) if bad
                            else (f'{len(m["results"])} · ids ok', ink["secondary"]))
@@ -310,21 +352,23 @@ def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label,
 
     axis = speedup_axis(ink, x, ticks, top, y + 4)
     y += 30
-    legend = legend_row(ink, sink, y, [
-        ("swatch", "pipeline", "PipelineTokenizer"),
-        ("tick", ink["baseline"], f"×1.0 = {ref_label}"),
-    ])
+    entries = [("swatch", "pipeline", "PipelineTokenizer")]
+    if speedups2_of:
+        entries.append(("swatch", "sebpop", series2_label))
+    entries.append(("tick", ink["baseline"], f"×1.0 = {ref_label}"))
+    legend = legend_row(ink, sink, y, entries)
     height = y + 34
     subtitle = (f"geomean ×speedup per model vs {ref_label} · "
                 f"whisker: min–max across fixtures · {subtitle_base}")
     return svg_doc(ink, height, title, subtitle, axis + "".join(body) + legend, meta)
 
 
-def memory_svg(models, mode, meta, baseline_label):
+def memory_svg(models, mode, meta, baseline_label, sebpop_label=None):
     """Per model: resident-set delta of each implementation — load footprint plus
     the encode-pass delta as stacked segments, peak RSS as a tick."""
     ink, sink = INK[mode], SERIES_INK[mode]
     models = [m for m in models if isinstance(m.get("memory"), dict)]
+    impls = ("baseline", "sebpop", "pipeline") if sebpop_label else ("baseline", "pipeline")
 
     def mem(m, impl):
         d = m["memory"].get(impl)
@@ -335,7 +379,7 @@ def memory_svg(models, mode, meta, baseline_label):
 
     vals = []
     for m in models:
-        for impl in ("baseline", "pipeline"):
+        for impl in impls:
             d = mem(m, impl)
             if d:
                 vals.append((d["load_bytes"] or 0) + (d["encode_bytes"] or 0))
@@ -349,10 +393,14 @@ def memory_svg(models, mode, meta, baseline_label):
     def x(v):
         return OV_GUTTER + v / max_mb * plot_w
 
-    top, bar_h, row_h = 78, 12, 2 * (12 + 3) + 16
+    top, bar_h = 78, 12
+    row_h = len(impls) * (bar_h + 3) + 16
     col_x = CHART_W - 16
+    col_head = "MB: " + " → ".join(
+        {"baseline": baseline_label, "sebpop": sebpop_label, "pipeline": "Pipeline"}[i]
+        for i in impls)
     body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-            f'text-anchor="end">MB: {escape(baseline_label)} → Pipeline</text>',
+            f'text-anchor="end">{escape(col_head)}</text>',
             f'<text x="{OV_GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
             f'smaller is better · solid: after load · translucent: encode-pass delta</text>']
     y = top
@@ -362,7 +410,7 @@ def memory_svg(models, mode, meta, baseline_label):
                     f'font-size="12.5" font-weight="600" text-anchor="end">{escape(m["model"])}</text>')
         totals = []
         by = y + 8
-        for impl in ("baseline", "pipeline"):
+        for impl in impls:
             d = mem(m, impl)
             if not d:
                 totals.append(None)
@@ -395,20 +443,23 @@ def memory_svg(models, mode, meta, baseline_label):
         grid.append(f'<text x="{x(tv):.1f}" y="{y + 10}" fill="{ink["muted"]}" font-size="11" '
                     f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{unit}</text>')
     y += 30
-    legend = legend_row(ink, sink, y, [
-        ("swatch", "baseline", baseline_label),
-        ("swatch", "pipeline", "PipelineTokenizer"),
-        ("tick", ink["primary"], "peak RSS (VmHWM)"),
-    ])
+    entries = [("swatch", "baseline", baseline_label)]
+    if sebpop_label:
+        entries.append(("swatch", "sebpop", sebpop_label))
+    entries += [("swatch", "pipeline", "PipelineTokenizer"),
+                ("tick", ink["primary"], "peak RSS (VmHWM)")]
+    legend = legend_row(ink, sink, y, entries)
     height = y + 34
     subtitle = "resident-set delta per implementation, one process each · load + encode pass"
     return svg_doc(ink, height, "Memory footprint",
                    subtitle, "".join(grid) + "".join(body) + legend, meta)
 
 
-def chart_svg(model, mode, subtitle_base, meta, lo, hi, baseline_label):
-    """Full-size per-fixture chart: the pipeline's ×speedup vs the release, with
-    the `MB/s: release → Pipeline` throughput column."""
+def chart_svg(model, mode, subtitle_base, meta, lo, hi, baseline_label,
+              sebpop_label=None):
+    """Full-size per-fixture chart: the pipeline's ×speedup vs the release —
+    with sebpop's branch as a second bar on the same vs-release axis — and the
+    `MB/s: release → sebpop → Pipeline` throughput column."""
     ink, sink = INK[mode], SERIES_INK[mode]
     rows = model["results"]
 
@@ -419,10 +470,13 @@ def chart_svg(model, mode, subtitle_base, meta, lo, hi, baseline_label):
 
     top = 74
     col_x = GUTTER + PLOT_W + PAD_R + COL_W - 16
+    col_head = (f"MB/s: {baseline_label} → {sebpop_label} → Pipeline" if sebpop_label
+                else f"MB/s: {baseline_label} → Pipeline")
     body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
-            f'text-anchor="end">MB/s: {escape(baseline_label)} → Pipeline</text>']
+            f'text-anchor="end">{escape(col_head)}</text>']
     y = top
     baseline_id_note = False
+    sebpop_id_note = False
     for key, title in GROUPS:
         # stable order (alphabetical by fixture) so a fixture keeps its row across
         # runs and lines up with the stage-decomposition chart — not sorted by the
@@ -439,38 +493,52 @@ def chart_svg(model, mode, subtitle_base, meta, lo, hi, baseline_label):
             if r.get("ids_match_baseline") is False:
                 label += " †"
                 baseline_id_note = True
+            if r.get("ids_match_sebpop") is False:
+                label += " ‡"
+                sebpop_id_note = True
             body.append(f'<text x="{GUTTER - 10}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
                         f'font-size="12.5" text-anchor="end">{escape(label)}</text>')
             v = speedup(r)
-            by = y + (ROW_H - BAR_H) / 2
-            if v:
-                body.append(hbar(x(1.0), x(v), by, BAR_H, sink["pipeline"]))
-                txt = f"×{v:.2f}"
-                fill = ink["primary"]
-                if r["ids_match"] is False:
+            sv = sebpop_rel_release(r) if sebpop_label else None
+            # one full-height pipeline bar, or — when sebpop benched this fixture —
+            # two half-height bars on the same vs-release axis (pipeline on top)
+            series = ([("pipeline", v, y + (ROW_H - BAR_H) / 2, BAR_H, 12)] if not sv else
+                      [("pipeline", v, y + (ROW_H - 20) / 2, 9, 10.5),
+                       ("sebpop", sv, y + (ROW_H - 20) / 2 + 11, 9, 10.5)])
+            for skey, val, by, bh, fs in series:
+                if not val:
+                    continue
+                body.append(hbar(x(1.0), x(val), by, bh, sink[skey]))
+                txt = f"×{val:.2f}"
+                fill = ink["primary"] if skey == "pipeline" else ink["secondary"]
+                if skey == "pipeline" and r["ids_match"] is False:
                     txt += "  ⚠ ids differ"
                     fill = ink["critical"]
-                anchor, lx = ("start", max(x(1.0), x(v)) + 6) if v >= 1 else ("end", min(x(1.0), x(v)) - 6)
+                anchor, lx = (("start", max(x(1.0), x(val)) + 6) if val >= 1
+                              else ("end", min(x(1.0), x(val)) - 6))
                 # a long label left of a slow bar would run into the fixture
                 # names — flip it to the empty space right of the ×1.0 axis
                 if anchor == "end" and lx - len(txt) * 6.7 < GUTTER + 4:
                     anchor, lx = "start", x(1.0) + 6
-                body.append(f'<text x="{lx:.1f}" y="{y + ROW_H / 2 + 4}" fill="{fill}" '
-                            f'font-size="12" font-weight="600" text-anchor="{anchor}" '
+                body.append(f'<text x="{lx:.1f}" y="{by + bh / 2 + 4:.1f}" fill="{fill}" '
+                            f'font-size="{fs}" font-weight="600" text-anchor="{anchor}" '
                             f'style="font-variant-numeric:tabular-nums">{txt}</text>')
             mb = r["mbps"]
+            col_vals = ([mb.get("baseline"), mb.get("sebpop"), mb.get("pipeline")] if sebpop_label
+                        else [mb.get("baseline"), mb.get("pipeline")])
             body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
                         f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
-                        f'{chain([mb.get("baseline"), mb.get("pipeline")])}</text>')
+                        f'{chain(col_vals)}</text>')
             y += ROW_H
         y += 10
 
     axis = speedup_axis(ink, x, ticks, top, y)
     y += 26
-    legend = legend_row(ink, sink, y, [
-        ("swatch", "pipeline", "PipelineTokenizer"),
-        ("tick", ink["baseline"], f"×1.0 = {baseline_label}"),
-    ])
+    entries = [("swatch", "pipeline", "PipelineTokenizer")]
+    if sebpop_label:
+        entries.append(("swatch", "sebpop", sebpop_label))
+    entries.append(("tick", ink["baseline"], f"×1.0 = {baseline_label}"))
+    legend = legend_row(ink, sink, y, entries)
     height = y + 44
 
     parts = [model["shape"]]
@@ -479,8 +547,13 @@ def chart_svg(model, mode, subtitle_base, meta, lo, hi, baseline_label):
         parts.append(f"geomean ×{geomean(vals):.2f} vs {baseline_label}")
     else:
         parts.append(f"{baseline_label} can’t load this model — no comparison")
+    svals = sebpop_model_speedups(model)
+    if svals:
+        parts.append(f"×{geomean(svals):.2f} vs {sebpop_label}")
     if baseline_id_note:
         parts.append(f"† ids differ from {baseline_label}")
+    if sebpop_id_note:
+        parts.append(f"‡ ids differ from {sebpop_label}")
     return svg_doc(ink, height, f'{model["model"]} — PipelineTokenizer encode throughput',
                    " · ".join(parts), axis + "".join(body) + legend, meta, subtitle_base)
 
@@ -650,7 +723,7 @@ def picture(base, run_id, slug, alt, width):
         "</picture>"])
 
 
-def mem_line(model, baseline_label):
+def mem_line(model, baseline_label, sebpop_label=None):
     mem = model["memory"]
     def part(impl, label):
         d = mem.get(impl)
@@ -658,17 +731,23 @@ def mem_line(model, baseline_label):
             return f"{label} —"
         cell = lambda k: ("—" if d.get(k) is None else f"{max(0, d[k]) / 1e6:.0f}")
         return f"{label} {cell('load_bytes')}+{cell('encode_bytes')} (peak {cell('peak_bytes')})"
+    impls = [("baseline", baseline_label)]
+    if sebpop_label:
+        impls.append(("sebpop", sebpop_label))
+    impls.append(("pipeline", "Pipeline"))
     return ("**Memory** (RSS MB, load+encode): "
-            + " · ".join(part(i, l) for i, l in
-                         (("baseline", baseline_label), ("pipeline", "Pipeline"))))
+            + " · ".join(part(i, l) for i, l in impls))
 
 
-def binsize_svg(sizes, mode, meta, baseline_label):
+def binsize_svg(sizes, mode, meta, baseline_label, sebpop_label=None):
     """Stripped size of a minimal release-built encode program (load a
     tokenizer.json, encode one string) linking each implementation — what the
     library adds to a shipped binary. Bars are 0-anchored on a linear MB axis."""
     ink, sink = INK[mode], SERIES_INK[mode]
-    rows = [("baseline", baseline_label), ("pipeline", "PipelineTokenizer")]
+    rows = [("baseline", baseline_label)]
+    if sebpop_label and "sebpop" in sizes:
+        rows.append(("sebpop", sebpop_label))
+    rows.append(("pipeline", "PipelineTokenizer"))
     max_mb = max(sizes.values()) / 1e6 * 1.15
     plot_w = CHART_W - OV_GUTTER - PAD_R - COL_W
 
@@ -713,17 +792,21 @@ def has_threads(m):
     return isinstance(t, dict) and bool(t.get("counts"))
 
 
-def threads_svg(model, mode, meta, baseline_label):
-    """Per model: encode throughput (MB/s) at 1/2/4/8/device-max threads — pipeline vs the release —
-    with a per-row *ideal linear* tick (single-thread throughput × N) on the pipeline bar. So whether the
-    pipeline scales linearly (bar reaches the tick) or sub-linearly (bar falls short of it) is visible at a
-    glance, alongside the pipeline↔release gap; the right column carries the self-scaling % of linear."""
+def threads_svg(model, mode, meta, baseline_label, sebpop_label=None):
+    """Per model: encode throughput (MB/s) at 1/2/4/8/device-max threads — pipeline vs the release (and
+    sebpop's branch when present) — with a per-row *ideal linear* tick (single-thread throughput × N) on
+    the pipeline bar. So whether the pipeline scales linearly (bar reaches the tick) or sub-linearly (bar
+    falls short of it) is visible at a glance, alongside the pipeline↔reference gaps; the right column
+    carries the self-scaling % of linear."""
     ink, sink = INK[mode], SERIES_INK[mode]
     t = model["threads"]
     counts, pipe, base = t["counts"], t["pipeline_mbps"], t["baseline_mbps"]
+    seb = t.get("sebpop_mbps") or []
+    has_seb = bool(sebpop_label) and any(v for v in seb)
     p1 = pipe[0] if pipe and pipe[0] else None  # single-thread anchor for the linear reference
     ideal = [p1 * n for n in counts] if p1 else []
-    vals = [v for v in pipe if v] + [v for v in base if v] + ideal
+    vals = ([v for v in pipe if v] + [v for v in base if v]
+            + [v for v in seb if v] + ideal)
     max_mb = (max(vals) if vals else 1.0) * 1.08
     plot_w = CHART_W - OV_GUTTER - PAD_R - COL_W
 
@@ -731,22 +814,30 @@ def threads_svg(model, mode, meta, baseline_label):
         return OV_GUTTER + v / max_mb * plot_w
 
     top, bar_h, gap = 78, 11, 3
-    row_h = 2 * (bar_h + gap) + 16
+    nbars = 3 if has_seb else 2
+    row_h = nbars * (bar_h + gap) + 16
     col_x = CHART_W - 16
+    order = (f"bars: {baseline_label} → {sebpop_label} → Pipeline" if has_seb
+             else f"top bar {baseline_label}, bottom Pipeline")
     body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
             f'text-anchor="end">Pipeline MB/s · self-scaling (% of linear)</text>',
             f'<text x="{OV_GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
-            f'higher is better · top bar {escape(baseline_label)}, bottom Pipeline · tick = ideal linear</text>']
+            f'higher is better · {escape(order)} · tick = ideal linear</text>']
     y = top
     for i, n in enumerate(counts):
         cy = y + row_h / 2
         label = f"{n} thread" + ("" if n == 1 else "s")
         body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 4:.1f}" fill="{ink["primary"]}" '
                     f'font-size="12.5" font-weight="600" text-anchor="end">{label}</text>')
-        base_y, pipe_y = y + 8, y + 8 + bar_h + gap
+        base_y = y + 8
+        pipe_y = base_y + (nbars - 1) * (bar_h + gap)
         b = base[i] if i < len(base) else None
         if b is not None:
             body.append(hbar(x(0), x(b), base_y, bar_h, sink["baseline"]))
+        if has_seb:
+            s = seb[i] if i < len(seb) else None
+            if s is not None:
+                body.append(hbar(x(0), x(s), base_y + bar_h + gap, bar_h, sink["sebpop"]))
         p = pipe[i] if i < len(pipe) else None
         if p is not None:
             body.append(hbar(x(0), x(p), pipe_y, bar_h, sink["pipeline"]))
@@ -774,17 +865,19 @@ def threads_svg(model, mode, meta, baseline_label):
         grid.append(f'<text x="{gx:.1f}" y="{y + 10}" fill="{ink["muted"]}" font-size="11" '
                     f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{unit}</text>')
     y += 30
-    legend = legend_row(ink, sink, y, [
-        ("swatch", "baseline", baseline_label),
-        ("swatch", "pipeline", "PipelineTokenizer"),
-        ("tick", ink["primary"], "ideal linear (T₁ × N)"),
-    ])
+    entries = [("swatch", "baseline", baseline_label)]
+    if has_seb:
+        entries.append(("swatch", "sebpop", sebpop_label))
+    entries += [("swatch", "pipeline", "PipelineTokenizer"),
+                ("tick", ink["primary"], "ideal linear (T₁ × N)")]
+    legend = legend_row(ink, sink, y, entries)
     height = y + 34
     scaling = ""
     if p1 and len(pipe) >= 2 and pipe[-1]:
         sc = pipe[-1] / p1
         scaling = f" · pipeline {sc:.1f}× on {counts[-1]} threads ({sc / counts[-1] * 100:.0f}% of linear)"
-    subtitle = f"throughput at N threads vs {baseline_label}; tick = perfect linear scaling{scaling}"
+    refs = f"{baseline_label} + {sebpop_label}" if has_seb else baseline_label
+    subtitle = f"throughput at N threads vs {refs}; tick = perfect linear scaling{scaling}"
     return svg_doc(ink, height, "Thread scaling",
                    subtitle, "".join(grid) + "".join(body) + legend, meta)
 
@@ -836,16 +929,22 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
     different execution modes, so only per-model geomeans are meaningful."""
     models = data["models"]
     baseline_label = f'v{data["baseline"]["version"]}'
+    sebpop_label = data.get("sebpop", {}).get("ref")
     benched = [m for m in models if m["results"]]
     unsupported = [m for m in models if not m["results"]]
     mismatches = [f"{m['model']}/{r['fixture']}"
                   for m in benched for r in m["results"] if r["ids_match"] is False]
     base_mismatch = sorted({m["model"] for m in benched
                             for r in m["results"] if r.get("ids_match_baseline") is False})
+    seb_mismatch = sorted({m["model"] for m in benched
+                           for r in m["results"] if r.get("ids_match_sebpop") is False})
 
+    refs = f"`tokenizers` {baseline_label} (latest release)"
+    if sebpop_label:
+        refs += f" and `{sebpop_label}`"
     md = ["## PipelineTokenizer benchmark", "",
           f"**{len(benched)} / {len(models)} models supported** — PipelineTokenizer vs "
-          f"`tokenizers` {baseline_label} (latest release) · {subtitle_base}", "",
+          f"{refs} · {subtitle_base}", "",
           f"`{meta[0]}` · {meta[1]}", "",
           picture(base, run_id, "overview", "Per-model encode throughput vs latest release", 860), ""]
     if base_lookup:
@@ -863,6 +962,9 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
         md += [f"> ℹ️ Token ids differ from {baseline_label} on: {', '.join(base_mismatch)} "
                f"(† in the per-model charts) — expected when this branch fixes encode bugs, "
                f"but worth a look.", ""]
+    if seb_mismatch:
+        md += [f"> ℹ️ Token ids differ from {sebpop_label} on: {', '.join(seb_mismatch)} "
+               f"(‡ in the per-model charts).", ""]
 
     for m in benched:
         slug = slugify(m["model"])
@@ -870,6 +972,9 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
         vals = model_speedups(m)
         summary = (f"×{geomean(vals):.2f} vs {baseline_label}" if vals
                    else f"{baseline_label} can't load — no comparison")
+        svals = sebpop_model_speedups(m)
+        if svals:
+            summary += f" · ×{geomean(svals):.2f} vs {sebpop_label}"
         if base_lookup:
             bvals = base_model_speedups(m, base_lookup)
             if bvals:
@@ -884,15 +989,19 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
         if has_threads(m):
             md += [picture(base, run_id, f"{slug}-threads",
                            f"{m['model']} thread scaling", 860), ""]
-        md += [mem_line(m, baseline_label), ""]
+        md += [mem_line(m, baseline_label, sebpop_label), ""]
         # Per-stage columns show each split's share of the pipeline's own encode time
         # with the ns/byte alongside — `share% (ns/B)` — so the split cost is readable
         # as text regardless of how slow the release baseline is.
+        seb_mb_col = f" {sebpop_label} MB/s |" if sebpop_label else ""
+        seb_vs_col = f" vs {sebpop_label} |" if sebpop_label else ""
+        seb_sep = "---:|" if sebpop_label else ""
         base_col = " Δ base |" if base_lookup else ""
         base_sep = "---:|" if base_lookup else ""
-        md += [f"| Fixture | Group | {baseline_label} MB/s | Pipeline MB/s | Speedup |{base_col} "
+        md += [f"| Fixture | Group | {baseline_label} MB/s |{seb_mb_col} Pipeline MB/s "
+               f"| vs {baseline_label} |{seb_vs_col}{base_col} "
                "added-token | normalize | pre-tokenize | model | Ids |",
-               f"|---|---|---:|---:|---:|{base_sep}---:|---:|---:|---:|:--|"]
+               f"|---|---|---:|{seb_sep}---:|---:|{seb_sep}{base_sep}---:|---:|---:|---:|:--|"]
         for r in sorted(m["results"], key=lambda r: (r["group"], r["fixture"])):
             mb = r["mbps"]
             flags = []
@@ -900,17 +1009,22 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
                 flags.append("⚠️ ≠ tree")
             if r.get("ids_match_baseline") is False:
                 flags.append(f"≠ {baseline_label}")
+            if r.get("ids_match_sebpop") is False:
+                flags.append(f"≠ {sebpop_label}")
             ids = " · ".join(flags) if flags else "match"
             s = r.get("stage_ns_per_byte")
             stages = " ".join(f"| {stage_cell(s, k)}"
                               for k in ("added_split", "normalize", "pre_tokenize", "model"))
+            seb_mb_cell = f"| {fnum(mb.get('sebpop'))} " if sebpop_label else ""
+            seb_vs_cell = (f"| {fnum(sebpop_speedup(r), '×{:.2f}')} "
+                           if sebpop_label else "")
             base_cell = (f"| {fnum(base_speedup(r, base_lookup, m['model']), '×{:.2f}')} "
                          if base_lookup else "")
             md.append(
                 f"| {r['fixture']} | {r['group']} "
-                f"| {fnum(mb.get('baseline'))} | {fnum(mb.get('pipeline'))} "
+                f"| {fnum(mb.get('baseline'))} {seb_mb_cell}| {fnum(mb.get('pipeline'))} "
                 f"| {fnum(speedup(r), '×{:.2f}')} "
-                f"{base_cell}{stages} | {ids} |")
+                f"{seb_vs_cell}{base_cell}{stages} | {ids} |")
         md += pretok_compare_md(m)
         md += ["", "</details>", ""]
 
@@ -959,9 +1073,15 @@ def main():
     data = json.loads(Path(args.results).read_text())
     models = data["models"]
     baseline_label = f'v{data["baseline"]["version"]}'
+    sebpop_label = data.get("sebpop", {}).get("ref")
     sizes = json.loads(Path(args.binary_sizes).read_text()) if args.binary_sizes else None
     benched = [m for m in models if m["results"]]
     lo, hi = scale(benched)
+    if sebpop_label:
+        # sebpop's bars share the vs-release axis with the pipeline's — widen
+        # the range so neither series falls off the plot
+        slo, shi = scale(benched, sebpop_rel_model_speedups)
+        lo, hi = min(lo, slo), max(hi, shi)
 
     # "vs base branch": join the PR results against the base branch's cached run by
     # (model, fixture). base_lookup[(model, fixture)] = base pipeline MB/s.
@@ -979,7 +1099,9 @@ def main():
     out = Path(args.out_dir)
     for mode in ("light", "dark"):
         (out / f"pipeline_bench_overview_{mode}.svg").write_text(
-            overview_svg(models, mode, args.subtitle, meta, lo, hi, baseline_label))
+            overview_svg(models, mode, args.subtitle, meta, lo, hi, baseline_label,
+                         speedups2_of=(sebpop_rel_model_speedups if sebpop_label else None),
+                         series2_label=sebpop_label))
         if base_lookup:
             (out / f"pipeline_bench_base-overview_{mode}.svg").write_text(
                 overview_svg(models, mode, args.subtitle, meta, blo, bhi, baseline_label,
@@ -988,14 +1110,15 @@ def main():
                              ref_label=(args.base_ref or "base branch"), mark_regressions=True,
                              no_cmp_msg="not benched on the base branch"))
         (out / f"pipeline_bench_memory_{mode}.svg").write_text(
-            memory_svg(models, mode, meta, baseline_label))
+            memory_svg(models, mode, meta, baseline_label, sebpop_label))
         if sizes:
             (out / f"pipeline_bench_binsize_{mode}.svg").write_text(
-                binsize_svg(sizes, mode, meta, baseline_label))
+                binsize_svg(sizes, mode, meta, baseline_label, sebpop_label))
     for m in models:
         slug = slugify(m["model"])
         for mode in ("light", "dark"):
-            svg = (chart_svg(m, mode, args.subtitle, meta, lo, hi, baseline_label)
+            svg = (chart_svg(m, mode, args.subtitle, meta, lo, hi, baseline_label,
+                             sebpop_label)
                    if m["results"] else card_svg(m, mode))
             (out / f"pipeline_bench_{slug}_{mode}.svg").write_text(svg)
             if has_stages(m):
@@ -1003,7 +1126,7 @@ def main():
                     stage_chart_svg(m, mode, args.subtitle, meta, baseline_label))
             if has_threads(m):
                 (out / f"pipeline_bench_{slug}-threads_{mode}.svg").write_text(
-                    threads_svg(m, mode, meta, baseline_label))
+                    threads_svg(m, mode, meta, baseline_label, sebpop_label))
 
     (out / "pipeline_bench.md").write_text(
         render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes,
@@ -1016,6 +1139,12 @@ def main():
         for m in benched if model_speedups(m))
     print(f"{len(benched)}/{len(models)} supported"
           + (f" · vs {baseline_label}: {per_model}" if per_model else ""))
+    if sebpop_label:
+        vs_seb = " · ".join(
+            f"{m['model']} x{geomean(sebpop_model_speedups(m)):.3f}"
+            for m in benched if sebpop_model_speedups(m))
+        print(f"vs {sebpop_label}: {vs_seb}" if vs_seb
+              else f"vs {sebpop_label}: no comparable fixtures")
     if base_lookup:
         vs_base = " · ".join(
             f"{m['model']} x{geomean(base_speedups_of(m)):.3f}"

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -1,14 +1,15 @@
 name: Pipeline Benchmark
 
-# Comparative benchmark: the experimental `PipelineTokenizer` vs the latest
-# *released* tokenizers crate (the baseline to beat — the in-tree legacy
-# `Tokenizer` is being phased out, so it is only the id-correctness oracle,
-# never a benched series), for every model in
+# Comparative benchmark: the experimental `PipelineTokenizer` vs two references
+# — the latest *released* tokenizers crate (the baseline to beat — the in-tree
+# legacy `Tokenizer` is being phased out, so it is only the id-correctness
+# oracle, never a benched series) and sebpop's performance branch
+# (github.com/sebpop/tokenizers#upstream) — for every model in
 # tk-encode/examples/bench_models.json across every corpus in data/fixtures/.
 # Measures single- and multi-thread throughput (1/2/4/8/device-max), per-
-# implementation memory footprint (RSS), and stripped minimal-binary size. The
-# release dep is behind tk-encode's `bench-baseline` feature, so production
-# builds never pull it.
+# implementation memory footprint (RSS), and stripped minimal-binary size. Both
+# reference deps are behind tk-encode's `bench-baseline` feature, so production
+# builds never pull them.
 #
 # The work is fanned out across a matrix: each `bench` shard benches a slice of
 # the models on its own isolated 8-vCPU runner (so the multi-thread sweep is
@@ -180,7 +181,9 @@ jobs:
           for f in parts:
               d = json.load(open(f))
               if merged is None:
-                  merged = {"baseline": d["baseline"], "models": []}
+                  # carry every metadata key (baseline, sebpop, …) from the first shard
+                  merged = {k: v for k, v in d.items() if k != "models"}
+                  merged["models"] = []
               merged["models"].extend(d["models"])
           if merged is None:
               raise SystemExit("no shard partials found")
@@ -194,10 +197,10 @@ jobs:
       - name: Measure binary sizes
         run: |
           cargo build --release -p tk-encode --features tk-encode/bench-baseline \
-            --example binsize_baseline --example binsize_pipeline
+            --example binsize_baseline --example binsize_sebpop --example binsize_pipeline
           printf '{' > binary_sizes.json
           sep=''
-          for key in baseline pipeline; do
+          for key in baseline sebpop pipeline; do
             bin="target/release/examples/binsize_$key"
             "$bin" data/gpt2.json "The quick brown fox jumps 123."   # binary actually works
             strip -o "$bin.stripped" "$bin"

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -114,9 +114,14 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make fixtures bench-models HF="uvx --from huggingface_hub hf"
 
+      # bench-mimalloc: the whole bench binary (all three series uniformly) runs on
+      # mimalloc — the allocator sebpop's branch ships by default. The references are
+      # benched through `encode_fast` (see fixture_bench.rs), so sebpop's fused
+      # fast path is actually engaged.
       - name: Run comparative benchmark (shard ${{ matrix.shard }} of ${{ env.SHARDS }})
         run: |
-          cargo run --release -p tk-encode --features tk-encode/bench-baseline \
+          cargo run --release -p tk-encode \
+            --features tk-encode/bench-baseline,tk-encode/bench-mimalloc \
             --example fixture_bench -- --shard ${{ matrix.shard }} ${{ env.SHARDS }} \
             > "pipeline_bench_${{ matrix.shard }}.json"
           cat "pipeline_bench_${{ matrix.shard }}.json"
@@ -272,7 +277,7 @@ jobs:
           fi
           python3 ${{ github.workspace }}/.github/scripts/render_pipeline_bench.py \
             pipeline_bench.json \
-            --subtitle "~10 kB inputs · single thread + 1/2/4/8/max-thread sweep" \
+            --subtitle "~10 kB inputs · refs via encode_fast · mimalloc (all series) · single thread + 1/2/4/8/max-thread sweep" \
             --revision "${{ github.event.pull_request.head.sha || github.sha }}" \
             --img-base "$base_url" \
             --run-id "${{ github.run_id }}" \

--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -1218,6 +1218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1336,15 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2286,6 +2304,7 @@ dependencies = [
  "logos",
  "macro_rules_attribute",
  "memchr",
+ "mimalloc",
  "monostate",
  "onig",
  "paste",

--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -2300,6 +2300,7 @@ dependencies = [
  "spm_precompiled",
  "tempfile",
  "thiserror",
+ "tokenizers 0.22.3-dev.0",
  "tokenizers 0.23.1",
  "tracing",
  "tracing-subscriber",
@@ -2329,6 +2330,39 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tk-encode",
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.3-dev.0"
+source = "git+https://github.com/sebpop/tokenizers?branch=upstream#13699f626ffa586ec7068f4559ca42d677c49bfc"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "indicatif 0.18.5",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "paste",
+ "pcre2-sys",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
 ]
 
 [[package]]

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -63,6 +63,12 @@ yada = "0.7.0"
 # Latest released tokenizers, used as the comparison baseline by the CI benchmark
 # (examples gated on `bench-baseline`). Optional so production builds never pull it.
 tokenizers-release = { package = "tokenizers", version = "=0.23.1", optional = true }
+# sebpop's performance branch, the second comparison reference. Cargo.lock pins the
+# resolved commit — `cargo update tokenizers@0.22.3-dev.0` moves it to the branch tip.
+# His default features minus `mimalloc`: its `override` feature replaces the global
+# allocator for the whole process, which would skew every series benched in the same
+# binary.
+tokenizers-sebpop = { package = "tokenizers", git = "https://github.com/sebpop/tokenizers", branch = "upstream", default-features = false, features = ["progressbar", "pcre2", "esaxx_fast"], optional = true }
 # Reference regex engines `fixture_bench` times the classify+fsm pre-tokenize against: Oniguruma and
 # PCRE2 (both C) alongside the pure-Rust `fancy-regex` (optional, above). All three are pulled in by
 # `bench-baseline` — optional + behind that feature so the C builds happen ONLY for the CI benchmark,
@@ -81,7 +87,7 @@ progressbar = ["indicatif"]
 http = ["hf-hub"]
 unstable_wasm = ["fancy-regex", "getrandom/wasm_js"]
 rustls-tls = ["hf-hub?/rustls-tls"]
-bench-baseline = ["dep:tokenizers-release", "dep:onig", "dep:pcre2", "dep:logos", "fancy-regex"]
+bench-baseline = ["dep:tokenizers-release", "dep:tokenizers-sebpop", "dep:onig", "dep:pcre2", "dep:logos", "fancy-regex"]
 
 [dev-dependencies]
 criterion = "0.6"
@@ -100,4 +106,8 @@ required-features = ["bench-baseline"]
 
 [[example]]
 name = "binsize_baseline"
+required-features = ["bench-baseline"]
+
+[[example]]
+name = "binsize_sebpop"
 required-features = ["bench-baseline"]

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -76,6 +76,11 @@ tokenizers-sebpop = { package = "tokenizers", git = "https://github.com/sebpop/t
 onig = { version = "6.5.1", optional = true }
 pcre2 = { version = "0.2", optional = true }
 logos = { version = "0.15", optional = true } # compile-time DFA lexer reference (pure Rust)
+# Global allocator for the CI bench binary (`bench-mimalloc`): every series runs on
+# mimalloc — the allocator sebpop's branch ships by default — because one process can't
+# give each series its own allocator. No `override` feature: `#[global_allocator]` in
+# fixture_bench.rs is explicit and scoped to that binary.
+mimalloc = { version = "0.1", optional = true }
 
 [features]
 # `fancy-regex` is the OPTIONAL system-regex backend, needed ONLY for a `Split` pre-tokenizer with an
@@ -88,6 +93,7 @@ http = ["hf-hub"]
 unstable_wasm = ["fancy-regex", "getrandom/wasm_js"]
 rustls-tls = ["hf-hub?/rustls-tls"]
 bench-baseline = ["dep:tokenizers-release", "dep:tokenizers-sebpop", "dep:onig", "dep:pcre2", "dep:logos", "fancy-regex"]
+bench-mimalloc = ["dep:mimalloc"]
 
 [dev-dependencies]
 criterion = "0.6"

--- a/tokenizers/tk-encode/examples/binsize_sebpop.rs
+++ b/tokenizers/tk-encode/examples/binsize_sebpop.rs
@@ -1,0 +1,17 @@
+//! Minimal encode program measured by CI for binary size: the `tokenizers`
+//! crate from sebpop's performance branch (the second comparison reference).
+//! Structurally identical to `binsize_pipeline.rs`.
+
+use tokenizers_sebpop::Tokenizer;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: binsize_sebpop <tokenizer.json> <text>");
+    let text = args
+        .next()
+        .expect("usage: binsize_sebpop <tokenizer.json> <text>");
+    let tok = Tokenizer::from_file(path).unwrap();
+    println!("{}", tok.encode(text.as_str(), false).unwrap().len());
+}

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -991,14 +991,22 @@ fn main() {
         };
 
         // Same fallback for sebpop's branch (based on an older tree, so it may
-        // predate configs the release handles).
+        // predate configs the release handles). Probed under catch_unwind: its
+        // encode_fast panics ("offset data accessed on fast path") on any model
+        // whose normalizer mutates the string, e.g. llama-2's Prepend+Replace.
         let sebpop = match SebpopTokenizer::from_file(&path) {
             Ok(mut t) => {
                 inject_added_tokens_sebpop(&mut t);
-                match t.encode_fast(PROBE, false) {
-                    Ok(_) => Some(t),
-                    Err(e) => {
+                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    t.encode_fast(PROBE, false)
+                })) {
+                    Ok(Ok(_)) => Some(t),
+                    Ok(Err(e)) => {
                         eprintln!("  {SEBPOP_REF} loads but can't encode: {e}");
+                        None
+                    }
+                    Err(_) => {
+                        eprintln!("  {SEBPOP_REF} panics on encode_fast — skipping series");
                         None
                     }
                 }

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -5,6 +5,13 @@
 //! for every model in `examples/bench_models.json` across every corpus in
 //! `data/fixtures/`.
 //!
+//! Both references are benched through `encode_fast` (ids, no offset tracking)
+//! — the same regime the pipeline plays in, and on sebpop's branch the entry
+//! point of his fused byte-level fast path; plain `encode` would silently
+//! bypass it. With the `bench-mimalloc` feature the whole bench binary (all
+//! three series uniformly) runs on mimalloc, matching the allocator sebpop's
+//! branch ships by default — per-series allocators can't exist in one process.
+//!
 //! Per fixture it measures single-thread throughput on ~10 kB inputs (the regime
 //! where per-input overhead is amortized — see `pipeline_benchmark.rs` for the
 //! size sweep). Per model it also (a) runs a **multi-thread throughput sweep** —
@@ -40,6 +47,10 @@ use tk_encode::pipeline::{Model, PipelineTokenizer};
 use tk_encode::{AddedToken, ModelWrapper, Tokenizer};
 use tokenizers_release::{AddedToken as BaselineAddedToken, Tokenizer as BaselineTokenizer};
 use tokenizers_sebpop::{AddedToken as SebpopAddedToken, Tokenizer as SebpopTokenizer};
+
+#[cfg(feature = "bench-mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
 const MANIFEST: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/bench_models.json");
@@ -186,8 +197,10 @@ fn bench_threads(
     let counts = thread_counts();
     let (mut pipe, mut base, mut seb) = (Vec::new(), Vec::new(), Vec::new());
     for &n in &counts {
-        let b = baseline.map(|b| par_mbps(|s| b.encode(s, false).unwrap().len(), chunks, bytes, n));
-        let sp = sebpop.map(|t| par_mbps(|s| t.encode(s, false).unwrap().len(), chunks, bytes, n));
+        let b = baseline
+            .map(|b| par_mbps(|s| b.encode_fast(s, false).unwrap().len(), chunks, bytes, n));
+        let sp =
+            sebpop.map(|t| par_mbps(|s| t.encode_fast(s, false).unwrap().len(), chunks, bytes, n));
         let p = par_mbps(
             |s| pipeline.encode(s, false).unwrap().len(),
             chunks,
@@ -361,7 +374,7 @@ fn memory_child(which: &str, model: &Path) {
             inject_added_tokens_baseline(&mut tok);
             let after_load = rss_now().unwrap_or(0);
             for c in &chunks {
-                n += tok.encode(c.as_str(), false).unwrap().len();
+                n += tok.encode_fast(c.as_str(), false).unwrap().len();
             }
             (after_load, rss_now().unwrap_or(0))
         }
@@ -370,7 +383,7 @@ fn memory_child(which: &str, model: &Path) {
             inject_added_tokens_sebpop(&mut tok);
             let after_load = rss_now().unwrap_or(0);
             for c in &chunks {
-                n += tok.encode(c.as_str(), false).unwrap().len();
+                n += tok.encode_fast(c.as_str(), false).unwrap().len();
             }
             (after_load, rss_now().unwrap_or(0))
         }
@@ -714,8 +727,8 @@ fn bench_model(
     let pipe_enc = |s: &str| pipeline.encode(s, false).unwrap().len();
     // per-model: the reference regex(es) onig will time on each fixture (empty for non-regex pretoks).
     let regexes = pretok_regexes(model_json);
-    let base_enc = baseline.map(|b| move |s: &str| b.encode(s, false).unwrap().len());
-    let seb_enc = sebpop.map(|t| move |s: &str| t.encode(s, false).unwrap().len());
+    let base_enc = baseline.map(|b| move |s: &str| b.encode_fast(s, false).unwrap().len());
+    let seb_enc = sebpop.map(|t| move |s: &str| t.encode_fast(s, false).unwrap().len());
 
     let mut rows = Vec::new();
     for (group, path) in files {
@@ -742,14 +755,14 @@ fn bench_model(
             chunks
                 .iter()
                 .take(3)
-                .all(|c| b.encode(c.as_str(), false).unwrap().get_ids() == pipe_ids(c))
+                .all(|c| b.encode_fast(c.as_str(), false).unwrap().get_ids() == pipe_ids(c))
         });
         // Report-only: pipeline vs sebpop's branch.
         let ids_match_sebpop = sebpop.map(|t| {
             chunks
                 .iter()
                 .take(3)
-                .all(|c| t.encode(c.as_str(), false).unwrap().get_ids() == pipe_ids(c))
+                .all(|c| t.encode_fast(c.as_str(), false).unwrap().get_ids() == pipe_ids(c))
         });
 
         // interleave all impls so frequency/thermal drift hits them equally
@@ -963,7 +976,7 @@ fn main() {
         let baseline = match BaselineTokenizer::from_file(&path) {
             Ok(mut b) => {
                 inject_added_tokens_baseline(&mut b);
-                match b.encode(PROBE, false) {
+                match b.encode_fast(PROBE, false) {
                     Ok(_) => Some(b),
                     Err(e) => {
                         eprintln!("  baseline v{BASELINE_VERSION} loads but can't encode: {e}");
@@ -982,7 +995,7 @@ fn main() {
         let sebpop = match SebpopTokenizer::from_file(&path) {
             Ok(mut t) => {
                 inject_added_tokens_sebpop(&mut t);
-                match t.encode(PROBE, false) {
+                match t.encode_fast(PROBE, false) {
                     Ok(_) => Some(t),
                     Err(e) => {
                         eprintln!("  {SEBPOP_REF} loads but can't encode: {e}");

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -1,7 +1,9 @@
-//! Comparative benchmark of the experimental `PipelineTokenizer` against the
-//! latest *released* `tokenizers` crate (the bar to beat — the in-tree legacy
-//! `Tokenizer` is on its way out, so the release is the reference), for every
-//! model in `examples/bench_models.json` across every corpus in `data/fixtures/`.
+//! Comparative benchmark of the experimental `PipelineTokenizer` against two
+//! references — the latest *released* `tokenizers` crate (the bar to beat — the
+//! in-tree legacy `Tokenizer` is on its way out, so the release is the
+//! reference) and sebpop's performance branch (`sebpop/tokenizers#upstream`) —
+//! for every model in `examples/bench_models.json` across every corpus in
+//! `data/fixtures/`.
 //!
 //! Per fixture it measures single-thread throughput on ~10 kB inputs (the regime
 //! where per-input overhead is amortized — see `pipeline_benchmark.rs` for the
@@ -21,7 +23,7 @@
 //! one-line label of the workload archetype the model exercises, passed
 //! through to the report.
 //!
-//! Emits one JSON object (`{baseline, models}`) on stdout, consumed by
+//! Emits one JSON object (`{baseline, sebpop, models}`) on stdout, consumed by
 //! `.github/scripts/render_pipeline_bench.py` in CI.
 
 use std::convert::TryFrom;
@@ -37,11 +39,14 @@ use serde_json::{json, Value};
 use tk_encode::pipeline::{Model, PipelineTokenizer};
 use tk_encode::{AddedToken, ModelWrapper, Tokenizer};
 use tokenizers_release::{AddedToken as BaselineAddedToken, Tokenizer as BaselineTokenizer};
+use tokenizers_sebpop::{AddedToken as SebpopAddedToken, Tokenizer as SebpopTokenizer};
 
 const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
 const MANIFEST: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/bench_models.json");
 // Keep in sync with the `tokenizers-release` pin in Cargo.toml.
 const BASELINE_VERSION: &str = "0.23.1";
+// Keep in sync with the `tokenizers-sebpop` git dependency in Cargo.toml.
+const SEBPOP_REF: &str = "sebpop/upstream";
 const CHUNK_BYTES: usize = 10 * 1024;
 const MAX_CHUNKS: usize = 100;
 const REPS: usize = 5;
@@ -91,6 +96,21 @@ fn inject_added_tokens_baseline(tok: &mut BaselineTokenizer) {
         .map(|s| BaselineAddedToken::from(*s, false).normalized(true));
     let _ = tok.add_special_tokens(special);
     let _ = tok.add_tokens(normalized);
+}
+
+/// Same injection through the sebpop branch's `AddedToken` (its pre-split API
+/// takes slices, not iterators).
+fn inject_added_tokens_sebpop(tok: &mut SebpopTokenizer) {
+    let special: Vec<SebpopAddedToken> = ADDED_SPECIAL
+        .iter()
+        .map(|s| SebpopAddedToken::from(*s, true).normalized(false))
+        .collect();
+    let normalized: Vec<SebpopAddedToken> = ADDED_NORMALIZED
+        .iter()
+        .map(|s| SebpopAddedToken::from(*s, false).normalized(true))
+        .collect();
+    let _ = tok.add_special_tokens(&special);
+    let _ = tok.add_tokens(&normalized);
 }
 
 fn make_chunks(text: &str) -> Vec<String> {
@@ -152,19 +172,22 @@ fn par_mbps(
     bytes as f64 / median_secs(samples) / 1e6
 }
 
-/// Multi-thread throughput sweep for one model — pipeline vs the released crate at 1/2/4/8/max threads
-/// over the whole fixture corpus (thread-spawn/scheduling overhead amortized). Both impls encode the same
-/// chunk list through a fresh pool per count; interleaved so thermal drift hits them equally.
+/// Multi-thread throughput sweep for one model — pipeline vs the released crate vs sebpop's branch at
+/// 1/2/4/8/max threads over the whole fixture corpus (thread-spawn/scheduling overhead amortized). All
+/// impls encode the same chunk list through a fresh pool per count; interleaved so thermal drift hits
+/// them equally.
 fn bench_threads(
     baseline: Option<&BaselineTokenizer>,
+    sebpop: Option<&SebpopTokenizer>,
     pipeline: &PipelineTokenizer,
     chunks: &[String],
 ) -> Value {
     let bytes: usize = chunks.iter().map(String::len).sum();
     let counts = thread_counts();
-    let (mut pipe, mut base) = (Vec::new(), Vec::new());
+    let (mut pipe, mut base, mut seb) = (Vec::new(), Vec::new(), Vec::new());
     for &n in &counts {
         let b = baseline.map(|b| par_mbps(|s| b.encode(s, false).unwrap().len(), chunks, bytes, n));
+        let sp = sebpop.map(|t| par_mbps(|s| t.encode(s, false).unwrap().len(), chunks, bytes, n));
         let p = par_mbps(
             |s| pipeline.encode(s, false).unwrap().len(),
             chunks,
@@ -172,13 +195,15 @@ fn bench_threads(
             n,
         );
         eprintln!(
-            "    {n} thread(s): pipeline {p:.1} MB/s{}",
-            b.map_or(String::new(), |v| format!(", baseline {v:.1} MB/s"))
+            "    {n} thread(s): pipeline {p:.1} MB/s{}{}",
+            b.map_or(String::new(), |v| format!(", baseline {v:.1} MB/s")),
+            sp.map_or(String::new(), |v| format!(", sebpop {v:.1} MB/s"))
         );
         pipe.push(p);
         base.push(b);
+        seb.push(sp);
     }
-    json!({ "counts": counts, "pipeline_mbps": pipe, "baseline_mbps": base })
+    json!({ "counts": counts, "pipeline_mbps": pipe, "baseline_mbps": base, "sebpop_mbps": seb })
 }
 
 fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
@@ -340,6 +365,15 @@ fn memory_child(which: &str, model: &Path) {
             }
             (after_load, rss_now().unwrap_or(0))
         }
+        "sebpop" => {
+            let mut tok = SebpopTokenizer::from_file(model).unwrap();
+            inject_added_tokens_sebpop(&mut tok);
+            let after_load = rss_now().unwrap_or(0);
+            for c in &chunks {
+                n += tok.encode(c.as_str(), false).unwrap().len();
+            }
+            (after_load, rss_now().unwrap_or(0))
+        }
         "pipeline" => {
             let mut tok = Tokenizer::from_file(model).unwrap();
             inject_added_tokens(&mut tok);
@@ -370,10 +404,14 @@ fn memory_child(which: &str, model: &Path) {
 
 /// Re-run this binary once per available implementation to get per-impl memory
 /// numbers that a shared address space couldn't provide.
-fn measure_memory(model: &Path, baseline_ok: bool) -> Value {
+fn measure_memory(model: &Path, baseline_ok: bool, sebpop_ok: bool) -> Value {
     let exe = std::env::current_exe().unwrap();
     let mut out = serde_json::Map::new();
-    for (key, ok) in [("baseline", baseline_ok), ("pipeline", true)] {
+    for (key, ok) in [
+        ("baseline", baseline_ok),
+        ("sebpop", sebpop_ok),
+        ("pipeline", true),
+    ] {
         if !ok {
             out.insert(key.into(), Value::Null);
             continue;
@@ -667,6 +705,7 @@ fn logos_reference_ns(regexes: &[String], text: &str) -> Option<f64> {
 
 fn bench_model(
     baseline: Option<&BaselineTokenizer>,
+    sebpop: Option<&SebpopTokenizer>,
     oracle: &Tokenizer,
     pipeline: &PipelineTokenizer,
     files: &[(String, PathBuf)],
@@ -676,6 +715,7 @@ fn bench_model(
     // per-model: the reference regex(es) onig will time on each fixture (empty for non-regex pretoks).
     let regexes = pretok_regexes(model_json);
     let base_enc = baseline.map(|b| move |s: &str| b.encode(s, false).unwrap().len());
+    let seb_enc = sebpop.map(|t| move |s: &str| t.encode(s, false).unwrap().len());
 
     let mut rows = Vec::new();
     for (group, path) in files {
@@ -704,27 +744,42 @@ fn bench_model(
                 .take(3)
                 .all(|c| b.encode(c.as_str(), false).unwrap().get_ids() == pipe_ids(c))
         });
+        // Report-only: pipeline vs sebpop's branch.
+        let ids_match_sebpop = sebpop.map(|t| {
+            chunks
+                .iter()
+                .take(3)
+                .all(|c| t.encode(c.as_str(), false).unwrap().get_ids() == pipe_ids(c))
+        });
 
-        // interleave both impls so frequency/thermal drift hits them equally
+        // interleave all impls so frequency/thermal drift hits them equally
         if let Some(be) = &base_enc {
             time_pass(be, &chunks);
         }
+        if let Some(se) = &seb_enc {
+            time_pass(se, &chunks);
+        }
         time_pass(&pipe_enc, &chunks);
-        let (mut base_s, mut pipe_s) = (Vec::new(), Vec::new());
+        let (mut base_s, mut seb_s, mut pipe_s) = (Vec::new(), Vec::new(), Vec::new());
         for _ in 0..REPS {
             if let Some(be) = &base_enc {
                 base_s.push(time_pass(be, &chunks));
+            }
+            if let Some(se) = &seb_enc {
+                seb_s.push(time_pass(se, &chunks));
             }
             pipe_s.push(time_pass(&pipe_enc, &chunks));
         }
         let mbps = |secs: f64| bytes as f64 / secs / 1e6;
         let base_mbps = (!base_s.is_empty()).then(|| mbps(median_secs(base_s)));
+        let seb_mbps = (!seb_s.is_empty()).then(|| mbps(median_secs(seb_s)));
         let pipe_mbps = mbps(median_secs(pipe_s));
 
         let fmt = |v: Option<f64>| v.map_or("—".into(), |v| format!("{v:.1}"));
         eprintln!(
-            "  {name}: baseline {} MB/s, pipeline {pipe_mbps:.1} MB/s",
-            fmt(base_mbps)
+            "  {name}: baseline {} MB/s, sebpop {} MB/s, pipeline {pipe_mbps:.1} MB/s",
+            fmt(base_mbps),
+            fmt(seb_mbps)
         );
 
         // Staged decomposition of the pipeline's own encode via the ablation ladder:
@@ -788,9 +843,10 @@ fn bench_model(
             "group": group,
             "bytes": bytes,
             "chunks": chunks.len(),
-            "mbps": { "baseline": base_mbps, "pipeline": pipe_mbps },
+            "mbps": { "baseline": base_mbps, "sebpop": seb_mbps, "pipeline": pipe_mbps },
             "ids_match": ids_match,
             "ids_match_baseline": ids_match_baseline,
+            "ids_match_sebpop": ids_match_sebpop,
             "stage_ns_per_byte": {
                 "added_split": ns_added,
                 "normalize": ns_norm,
@@ -921,9 +977,35 @@ fn main() {
             }
         };
 
-        let rows = bench_model(baseline.as_ref(), &tok, &pipeline, &files, &path);
-        let memory = measure_memory(&path, baseline.is_some());
-        let threads = bench_threads(baseline.as_ref(), &pipeline, &all_chunks);
+        // Same fallback for sebpop's branch (based on an older tree, so it may
+        // predate configs the release handles).
+        let sebpop = match SebpopTokenizer::from_file(&path) {
+            Ok(mut t) => {
+                inject_added_tokens_sebpop(&mut t);
+                match t.encode(PROBE, false) {
+                    Ok(_) => Some(t),
+                    Err(e) => {
+                        eprintln!("  {SEBPOP_REF} loads but can't encode: {e}");
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("  {SEBPOP_REF} can't load this config: {e}");
+                None
+            }
+        };
+
+        let rows = bench_model(
+            baseline.as_ref(),
+            sebpop.as_ref(),
+            &tok,
+            &pipeline,
+            &files,
+            &path,
+        );
+        let memory = measure_memory(&path, baseline.is_some(), sebpop.is_some());
+        let threads = bench_threads(baseline.as_ref(), sebpop.as_ref(), &pipeline, &all_chunks);
 
         models.push(json!({
             "model": name, "repo": repo, "desc": desc, "shape": shape,
@@ -933,6 +1015,7 @@ fn main() {
 
     let out = json!({
         "baseline": { "crate": "tokenizers", "version": BASELINE_VERSION },
+        "sebpop": { "crate": "tokenizers", "ref": SEBPOP_REF },
         "models": models,
     });
     println!("{}", serde_json::to_string_pretty(&out).unwrap());


### PR DESCRIPTION
Bench the tokenizers crate from sebpop's performance branch (github.com/sebpop/tokenizers#upstream) alongside the released 0.23.1 in the pipeline benchmark: single-thread throughput per fixture, the multi-thread sweep, per-implementation memory footprint, minimal-binary size, and a report-only id-diff flag. The charts keep a single vs-release axis — sebpop renders as a second (green) bar next to the pipeline's.

The git dep uses sebpop's default features minus mimalloc: its override feature would swap the global allocator for the whole bench process and skew every series. Cargo.lock pins the resolved commit; `cargo update tokenizers@0.22.3-dev.0` moves it to the branch tip.

Older cached bench JSONs (base-branch baselines) without the sebpop keys still render unchanged.

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**7 / 8 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) and `sebpop/upstream` · ~10 kB inputs · refs via encode_fast · mimalloc (all series) · single thread + 1/2/4/8/max-thread sweep

`ae0478f5d · 2026-07-20 16:38 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 32 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-overview-dark.png">
  <img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-overview-light.png" width="860">
</picture>

**vs base branch** (`bb98d4e1f`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-base-overview-dark.png">
  <img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-base-overview-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-memory-dark.png">
  <img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-memory-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-binsize-dark.png">
  <img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-binsize-light.png" width="860">
</picture>

> ℹ️ Token ids differ from sebpop/upstream on: gpt-oss, gpt2 (‡ in the per-model charts).

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.21 vs v0.23.1 · ×2.77 vs sebpop/upstream · ×1.01 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-bert-base-uncased-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-bert-base-uncased-threads-dark.png">
  <img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-bert-base-uncased-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 8+13 (peak 21) · sebpop/upstream 8+11 (peak 19) · Pipeline 17+2 (peak 19)

| Fixture | Group | v0.23.1 MB/s | sebpop/upstream MB/s | Pipeline MB/s | vs v0.23.1 | vs sebpop/upstream | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 8.8 | 15.0 | 27.4 | ×3.11 | ×1.83 | ×1.00 | 3% (1.2) | 76% (27.5) | 13% (4.6) | 8% (2.8) | match |
| arb_Arab | lang | 4.8 | 6.8 | 24.8 | ×5.20 | ×3.66 | ×1.00 | 3% (1.2) | 69% (27.5) | 8% (3.4) | 20% (7.9) | match |
| ben_Beng | lang | 6.9 | 10.1 | 34.7 | ×5.05 | ×3.43 | ×1.00 | 4% (1.2) | 67% (19.2) | 10% (2.8) | 19% (5.3) | match |
| cmn_Hani | lang | 4.7 | 7.4 | 18.7 | ×4.00 | ×2.53 | ×1.00 | 2% (1.2) | 70% (37.4) | 11% (5.9) | 17% (8.8) | match |
| ell_Grek | lang | 4.3 | 5.9 | 23.7 | ×5.51 | ×4.02 | ×1.00 | 3% (1.2) | 68% (28.6) | 8% (3.4) | 21% (8.7) | match |
| eng_Latn | lang | 5.2 | 8.0 | 18.4 | ×3.51 | ×2.28 | ×1.00 | 5% (2.5) | 71% (38.5) | 8% (4.3) | 16% (8.7) | match |
| heb_Hebr | lang | 4.9 | 7.0 | 19.9 | ×4.08 | ×2.83 | ×0.99 | 2% (1.2) | 76% (37.7) | 6% (3.1) | 15% (7.6) | match |
| hin_Deva | lang | 7.5 | 11.7 | 27.6 | ×3.68 | ×2.35 | ×1.01 | 3% (1.2) | 74% (26.7) | 9% (3.2) | 14% (5.0) | match |
| jpn_Jpan | lang | 5.2 | 7.6 | 27.2 | ×5.26 | ×3.56 | ×1.00 | 3% (1.2) | 64% (23.3) | 13% (4.7) | 20% (7.4) | match |
| kat_Geor | lang | 7.0 | 10.0 | 28.4 | ×4.09 | ×2.85 | ×1.01 | 3% (1.2) | 71% (26.2) | 8% (3.1) | 17% (6.4) | match |
| kor_Hang | lang | 2.8 | 3.6 | 17.6 | ×6.36 | ×4.91 | ×1.00 | 2% (1.2) | 62% (34.9) | 13% (7.3) | 23% (12.7) | match |
| rus_Cyrl | lang | 4.1 | 5.5 | 23.7 | ×5.72 | ×4.29 | ×1.00 | 3% (1.2) | 66% (27.6) | 7% (2.9) | 24% (10.2) | match |
| tam_Taml | lang | 7.8 | 11.9 | 38.4 | ×4.89 | ×3.24 | ×1.00 | 4% (1.2) | 72% (18.6) | 9% (2.4) | 14% (3.7) | match |
| tha_Thai | lang | 9.2 | 13.7 | 33.5 | ×3.64 | ×2.45 | ×1.01 | 4% (1.2) | 83% (24.7) | 7% (2.2) | 5% (1.6) | match |
| added_normalized_dense | modalities | 7.7 | 12.9 | 20.7 | ×2.70 | ×1.60 | ×1.05 | 3% (1.3) | 85% (40.4) | 10% (4.8) | 2% (1.0) | match |
| added_normalized_sparse | modalities | 6.3 | 9.9 | 18.9 | ×3.01 | ×1.91 | ×1.03 | 4% (1.9) | 76% (39.9) | 12% (6.1) | 8% (4.3) | match |
| added_special_dense | modalities | 7.4 | 13.2 | 44.9 | ×6.10 | ×3.41 | ×1.18 | 23% (5.0) | 42% (9.1) | 28% (6.0) | 6% (1.4) | match |
| added_special_sparse | modalities | 5.5 | 9.4 | 22.5 | ×4.06 | ×2.40 | ×1.05 | 9% (3.8) | 64% (27.8) | 16% (7.0) | 12% (5.1) | match |
| agentic-traces | modalities | 4.9 | 7.5 | 18.1 | ×3.73 | ×2.42 | ×1.00 | 4% (2.4) | 70% (38.5) | 9% (5.0) | 16% (9.1) | match |
| agentic_swe | modalities | 5.2 | 7.9 | 19.4 | ×3.74 | ×2.44 | ×1.00 | 4% (1.9) | 75% (38.6) | 7% (3.8) | 13% (6.9) | match |
| code_mixed | modalities | 4.9 | 7.3 | 19.0 | ×3.89 | ×2.59 | ×1.00 | 4% (2.2) | 73% (38.4) | 8% (4.2) | 15% (7.6) | match |
| math_latex | modalities | 4.8 | 7.4 | 18.2 | ×3.76 | ×2.46 | ×1.00 | 4% (2.4) | 70% (38.4) | 9% (4.8) | 16% (9.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×3.76 vs v0.23.1 · ×2.05 vs sebpop/upstream · ×1.01 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-deepseek-v4-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-deepseek-v4-threads-dark.png">
  <img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-deepseek-v4-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 76+0 (peak 76) · sebpop/upstream 78+2 (peak 80) · Pipeline 114+0 (peak 114)

| Fixture | Group | v0.23.1 MB/s | sebpop/upstream MB/s | Pipeline MB/s | vs v0.23.1 | vs sebpop/upstream | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 6.6 | 7.1 | 33.9 | ×5.16 | ×4.80 | ×1.01 | 2% (0.7) | 0% (0.0) | 17% (4.8) | 81% (22.9) | match |
| arb_Arab | lang | 4.9 | 8.2 | 17.1 | ×3.49 | ×2.09 | ×1.02 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (53.9) | match |
| ben_Beng | lang | 5.9 | 9.5 | 18.5 | ×3.15 | ×1.94 | ×1.00 | 1% (0.6) | 0% (0.0) | 6% (3.2) | 93% (49.8) | match |
| cmn_Hani | lang | 4.4 | 3.8 | 17.1 | ×3.86 | ×4.48 | ×1.01 | 1% (0.8) | 0% (0.0) | 6% (3.2) | 93% (52.9) | match |
| ell_Grek | lang | 5.1 | 8.7 | 18.6 | ×3.64 | ×2.12 | ×1.04 | 1% (0.7) | 0% (0.0) | 6% (3.5) | 93% (50.7) | match |
| eng_Latn | lang | 4.0 | 8.6 | 13.1 | ×3.28 | ×1.52 | ×1.02 | 3% (2.0) | 0% (0.0) | 7% (5.0) | 91% (68.4) | match |
| heb_Hebr | lang | 4.3 | 6.7 | 13.2 | ×3.04 | ×1.96 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (3.6) | 94% (69.9) | match |
| hin_Deva | lang | 6.0 | 11.1 | 21.9 | ×3.65 | ×1.98 | ×1.01 | 1% (0.6) | 0% (0.0) | 8% (3.4) | 91% (41.0) | match |
| jpn_Jpan | lang | 5.0 | 4.6 | 18.5 | ×3.70 | ×4.04 | ×1.00 | 1% (0.7) | 0% (0.0) | 6% (3.0) | 93% (48.7) | match |
| kat_Geor | lang | 6.1 | 5.6 | 17.9 | ×2.93 | ×3.21 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (3.0) | 93% (51.8) | match |
| kor_Hang | lang | 4.8 | 5.6 | 20.2 | ×4.23 | ×3.59 | ×1.02 | 1% (0.6) | 0% (0.0) | 8% (3.9) | 91% (45.6) | match |
| rus_Cyrl | lang | 4.9 | 3.7 | 15.0 | ×3.06 | ×4.02 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 94% (61.7) | match |
| tam_Taml | lang | 6.3 | 7.0 | 18.5 | ×2.93 | ×2.65 | ×1.01 | 1% (0.6) | 0% (0.0) | 5% (2.8) | 94% (51.9) | match |
| tha_Thai | lang | 6.5 | 4.5 | 15.0 | ×2.32 | ×3.36 | ×1.00 | 1% (0.7) | 0% (0.0) | 3% (2.3) | 96% (64.0) | match |
| added_normalized_dense | modalities | 5.8 | 39.0 | 23.5 | ×4.05 | ×0.60 | ×1.01 | 2% (0.8) | 0% (0.0) | 7% (2.8) | 92% (38.5) | match |
| added_normalized_sparse | modalities | 5.4 | 32.8 | 19.8 | ×3.67 | ×0.60 | ×1.01 | 3% (1.4) | 0% (0.0) | 7% (3.8) | 90% (45.4) | match |
| added_special_dense | modalities | 4.5 | 12.1 | 36.5 | ×8.08 | ×3.01 | ×1.02 | 24% (6.3) | 1% (0.3) | 24% (6.3) | 50% (13.2) | match |
| added_special_sparse | modalities | 4.6 | 17.1 | 20.6 | ×4.45 | ×1.21 | ×1.01 | 8% (3.9) | 0% (0.1) | 14% (6.7) | 78% (37.3) | match |
| agentic-traces | modalities | 3.6 | 10.5 | 14.4 | ×4.04 | ×1.38 | ×1.01 | 3% (1.8) | 0% (0.0) | 8% (5.4) | 90% (63.6) | match |
| agentic_swe | modalities | 3.3 | 11.9 | 15.0 | ×4.51 | ×1.26 | ×0.99 | 2% (1.3) | 0% (0.0) | 6% (3.9) | 92% (60.2) | match |
| code_mixed | modalities | 3.7 | 12.8 | 15.4 | ×4.18 | ×1.20 | ×0.99 | 2% (1.6) | 0% (0.0) | 7% (4.6) | 90% (56.9) | match |
| math_latex | modalities | 3.6 | 9.6 | 14.1 | ×3.91 | ×1.46 | ×1.00 | 3% (1.9) | 0% (0.0) | 7% (5.4) | 90% (65.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.44 | 4.78 | 5.58 | 42.2 | 20.0 | 9.3 | — | 8.8× / 7.6× | 4.2× / 3.6× | 2.0× / 1.7× | — |
| arb_Arab | 1.00 | 3.03 | 3.44 | 5.47 | 49.1 | 22.3 | 10.2 | — | 14.2× / 9.0× | 6.5× / 4.1× | 3.0× / 1.9× | — |
| ben_Beng | 1.46 | 2.94 | 3.20 | 4.67 | 35.7 | 15.6 | 7.6 | — | 11.1× / 7.6× | 4.9× / 3.3× | 2.4× / 1.6× | — |
| cmn_Hani | 1.12 | 2.28 | 3.17 | 4.33 | 58.6 | 32.4 | 14.1 | — | 18.5× / 13.5× | 10.2× / 7.5× | 4.4× / 3.2× | — |
| ell_Grek | 0.59 | 2.99 | 3.45 | 5.86 | 47.0 | 20.7 | 9.7 | — | 13.6× / 8.0× | 6.0× / 3.5× | 2.8× / 1.7× | — |
| eng_Latn | 0.10 | 1.48 | 5.04 | 6.42 | 67.7 | 37.6 | 16.4 | — | 13.4× / 10.5× | 7.5× / 5.9× | 3.2× / 2.5× | — |
| heb_Hebr | 1.00 | 3.07 | 3.63 | 5.71 | 51.3 | 23.2 | 10.7 | — | 14.1× / 9.0× | 6.4× / 4.1× | 2.9× / 1.9× | — |
| hin_Deva | 1.36 | 3.09 | 3.38 | 5.11 | 37.8 | 17.9 | 8.7 | — | 11.2× / 7.4× | 5.3× / 3.5× | 2.6× / 1.7× | — |
| jpn_Jpan | 1.56 | 3.35 | 2.98 | 4.76 | 52.5 | 26.3 | 11.7 | — | 17.6× / 11.0× | 8.8× / 5.5× | 3.9× / 2.5× | — |
| kat_Geor | 1.39 | 2.55 | 3.02 | 4.18 | 31.9 | 14.7 | 7.3 | — | 10.6× / 7.6× | 4.9× / 3.5× | 2.4× / 1.7× | — |
| kor_Hang | 1.08 | 2.85 | 3.90 | 5.67 | 48.9 | 25.9 | 11.8 | — | 12.5× / 8.6× | 6.7× / 4.6× | 3.0× / 2.1× | — |
| rus_Cyrl | 1.03 | 2.93 | 3.33 | 5.23 | 46.2 | 19.8 | 9.5 | — | 13.9× / 8.8× | 5.9× / 3.8× | 2.9× / 1.8× | — |
| tam_Taml | 0.92 | 2.94 | 2.78 | 4.80 | 31.5 | 13.2 | 6.6 | — | 11.3× / 6.6× | 4.8× / 2.8× | 2.4× / 1.4× | — |
| tha_Thai | 1.36 | 2.58 | 2.32 | 3.54 | 27.2 | 9.9 | 5.4 | — | 11.7× / 7.7× | 4.3× / 2.8× | 2.3× / 1.5× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.79 | 4.20 | 41.7 | 19.3 | 9.3 | — | 15.0× / 9.9× | 6.9× / 4.6× | 3.3× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.48 | 3.77 | 5.18 | 48.3 | 25.3 | 11.8 | — | 12.8× / 9.3× | 6.7× / 4.9× | 3.1× / 2.3× | — |
| added_special_dense | 0.06 | 1.47 | 6.33 | 7.75 | 169.5 | 95.0 | 38.0 | — | 26.8× / 21.9× | 15.0× / 12.3× | 6.0× / 4.9× | — |
| added_special_sparse | 0.06 | 1.48 | 6.74 | 8.16 | 107.9 | 55.0 | 23.9 | — | 16.0× / 13.2× | 8.2× / 6.7× | 3.5× / 2.9× | — |
| agentic-traces | 0.59 | 1.48 | 5.35 | 6.25 | 84.2 | 49.5 | 19.9 | — | 15.7× / 13.5× | 9.3× / 7.9× | 3.7× / 3.2× | — |
| agentic_swe | 0.51 | 1.44 | 3.85 | 4.78 | 101.2 | 61.8 | 23.3 | — | 26.3× / 21.2× | 16.0× / 12.9× | 6.0× / 4.9× | — |
| code_mixed | 0.07 | 1.45 | 4.65 | 6.03 | 77.4 | 50.3 | 18.5 | — | 16.6× / 12.8× | 10.8× / 8.3× | 4.0× / 3.1× | — |
| math_latex | 0.57 | 1.49 | 5.37 | 6.29 | 82.4 | 48.0 | 19.3 | — | 15.3× / 13.1× | 8.9× / 7.6× | 3.6× / 3.1× | — |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×6.40 vs v0.23.1 · ×0.91 vs sebpop/upstream · ×1.00 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt2-threads-dark.png">
  <img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 20+13 (peak 34) · sebpop/upstream 27+1 (peak 28) · Pipeline 39+2 (peak 41)

| Fixture | Group | v0.23.1 MB/s | sebpop/upstream MB/s | Pipeline MB/s | vs v0.23.1 | vs sebpop/upstream | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 6.4 | 39.1 | 44.1 | ×6.84 | ×1.13 | ×1.04 | 3% (0.7) | 0% (0.0) | 17% (3.6) | 80% (17.1) | match |
| arb_Arab | lang | 4.8 | 26.4 | 26.8 | ×5.63 | ×1.01 | ×1.02 | 2% (0.6) | 0% (0.0) | 6% (2.2) | 92% (33.5) | match |
| ben_Beng | lang | 4.0 | 51.8 | 46.1 | ×11.53 | ×0.89 | ×1.05 | 3% (0.6) | 0% (0.0) | 15% (3.0) | 83% (17.2) | match |
| cmn_Hani | lang | 5.0 | 18.4 | 29.2 | ×5.86 | ×1.59 | ×1.00 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (30.1) | match |
| ell_Grek | lang | 4.9 | 24.7 | 28.8 | ×5.84 | ×1.17 | ×0.96 | 2% (0.6) | 0% (0.0) | 6% (2.2) | 92% (31.1) | match |
| eng_Latn | lang | 4.2 | 12.9 | 14.0 | ×3.34 | ×1.09 | ×0.98 | 3% (2.0) | 0% (0.0) | 4% (3.0) | 93% (64.9) | match |
| heb_Hebr | lang | 4.8 | 13.9 | 28.7 | ×6.01 | ×2.06 | ×0.98 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 92% (31.1) | match |
| hin_Deva | lang | 4.5 | 54.7 | 40.2 | ×8.89 | ×0.74 | ×1.00 | 3% (0.6) | 0% (0.0) | 13% (3.1) | 84% (20.0) | match |
| jpn_Jpan | lang | 5.1 | 14.7 | 22.6 | ×4.44 | ×1.53 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (40.6) | match |
| kat_Geor | lang | 6.0 | 59.8 | 73.6 | ×12.19 | ×1.23 | ×1.01 | 5% (0.6) | 0% (0.0) | 16% (2.1) | 80% (10.3) | match |
| kor_Hang | lang | 4.7 | 29.8 | 43.1 | ×9.19 | ×1.44 | ×1.00 | 3% (0.6) | 0% (0.0) | 11% (2.4) | 86% (18.9) | match |
| rus_Cyrl | lang | 5.0 | 19.9 | 27.9 | ×5.61 | ×1.40 | ×1.06 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 92% (32.4) | match |
| tam_Taml | lang | 3.6 | 51.5 | 67.1 | ×18.50 | ×1.30 | ×1.02 | 4% (0.6) | 0% (0.0) | 19% (2.7) | 77% (10.9) | match |
| tha_Thai | lang | 4.5 | 31.7 | 35.5 | ×7.84 | ×1.12 | ×0.99 | 2% (0.6) | 0% (0.0) | 9% (2.5) | 89% (24.2) | match |
| added_normalized_dense | modalities | 5.3 | 113.5 | 26.4 | ×5.01 | ×0.23 | ×1.01 | 2% (0.8) | 0% (0.0) | 3% (1.1) | 95% (34.3) | match |
| added_normalized_sparse | modalities | 5.1 | 90.5 | 21.9 | ×4.33 | ×0.24 | ×0.98 | 3% (1.4) | 0% (0.0) | 4% (1.9) | 93% (40.5) | match |
| added_special_dense | modalities | 6.1 | 38.1 | 47.8 | ×7.85 | ×1.26 | ×1.04 | 25% (5.0) | 0% (0.0) | 20% (4.0) | 55% (11.1) | ≠ sebpop/upstream |
| added_special_sparse | modalities | 5.2 | 54.2 | 23.8 | ×4.61 | ×0.44 | ×1.01 | 8% (3.2) | 0% (0.0) | 11% (4.4) | 81% (33.0) | ≠ sebpop/upstream |
| agentic-traces | modalities | 3.6 | 20.7 | 16.3 | ×4.49 | ×0.79 | ×0.99 | 3% (1.8) | 0% (0.0) | 6% (3.5) | 91% (55.2) | match |
| agentic_swe | modalities | 3.8 | 27.9 | 24.2 | ×6.33 | ×0.87 | ×0.98 | 3% (1.3) | 0% (0.0) | 6% (2.3) | 91% (35.8) | match |
| code_mixed | modalities | 3.8 | 48.1 | 20.3 | ×5.40 | ×0.42 | ×0.98 | 3% (1.6) | 0% (0.0) | 6% (2.8) | 91% (43.6) | match |
| math_latex | modalities | 3.8 | 17.0 | 15.2 | ×4.04 | ×0.90 | ×0.99 | 3% (1.9) | 0% (0.0) | 5% (3.3) | 92% (58.4) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.41 | 3.61 | 4.38 | 27.6 | 20.6 | 5.9 | 4.8 | 7.7× / 6.3× | 5.7× / 4.7× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 3.01 | 2.23 | 4.25 | 32.6 | 25.0 | 7.0 | 5.2 | 14.6× / 7.7× | 11.2× / 5.9× | 3.1× / 1.6× | 2.3× / 1.2× |
| ben_Beng | 1.47 | 2.91 | 3.02 | 4.46 | 67.8 | 53.8 | 14.6 | 4.1 | 22.5× / 15.2× | 17.8× / 12.0× | 4.8× / 3.3× | 1.4× / 0.9× |
| cmn_Hani | 1.12 | 2.27 | 2.31 | 3.46 | 26.2 | 20.2 | 6.0 | 2.4 | 11.3× / 7.6× | 8.7× / 5.8× | 2.6× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 3.05 | 2.16 | 4.62 | 28.7 | 21.4 | 6.1 | 4.7 | 13.3× / 6.2× | 9.9× / 4.6× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.46 | 2.98 | 4.34 | 45.0 | 41.1 | 12.5 | 3.8 | 15.1× / 10.4× | 13.8× / 9.5× | 4.2× / 2.9× | 1.3× / 0.9× |
| heb_Hebr | 1.01 | 3.11 | 2.25 | 4.36 | 32.2 | 25.6 | 7.0 | 3.1 | 14.3× / 7.4× | 11.4× / 5.9× | 3.1× / 1.6× | 1.4× / 0.7× |
| hin_Deva | 1.36 | 3.08 | 3.10 | 4.81 | 63.4 | 54.4 | 13.9 | 4.3 | 20.5× / 13.2× | 17.6× / 11.3× | 4.5× / 2.9× | 1.4× / 0.9× |
| jpn_Jpan | 1.55 | 3.40 | 2.11 | 3.96 | 23.5 | 16.9 | 5.1 | 3.9 | 11.1× / 5.9× | 8.0× / 4.3× | 2.4× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.46 | 2.57 | 2.05 | 3.15 | 17.7 | 13.9 | 4.3 | 2.1 | 8.6× / 5.6× | 6.8× / 4.4× | 2.1× / 1.3× | 1.0× / 0.7× |
| kor_Hang | 1.09 | 2.74 | 2.42 | 4.08 | 32.3 | 27.2 | 7.6 | 3.6 | 13.3× / 7.9× | 11.2× / 6.7× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.96 | 2.08 | 4.03 | 27.4 | 20.8 | 5.9 | 2.5 | 13.1× / 6.8× | 10.0× / 5.2× | 2.8× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.93 | 2.93 | 2.72 | 4.72 | 70.9 | 57.4 | 14.7 | 3.8 | 26.0× / 15.0× | 21.1× / 12.2× | 5.4× / 3.1× | 1.4× / 0.8× |
| tha_Thai | 1.36 | 2.62 | 2.47 | 3.73 | 40.4 | 31.1 | 8.9 | 3.2 | 16.3× / 10.8× | 12.6× / 8.3× | 3.6× / 2.4× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.48 | 1.05 | 2.47 | 23.9 | 22.2 | 6.2 | 2.0 | 22.7× / 9.7× | 21.1× / 9.0× | 5.9× / 2.5× | 1.9× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.90 | 3.31 | 31.7 | 30.1 | 8.5 | 2.7 | 16.7× / 9.6× | 15.9× / 9.1× | 4.5× / 2.6× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.04 | 5.45 | 95.3 | 93.9 | 20.5 | 3.1 | 23.6× / 17.5× | 23.3× / 17.2× | 5.1× / 3.8× | 0.8× / 0.6× |
| added_special_sparse | 0.06 | 1.47 | 4.44 | 5.86 | 62.2 | 58.6 | 14.6 | 3.4 | 14.0× / 10.6× | 13.2× / 10.0× | 3.3× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.58 | 1.47 | 3.47 | 4.35 | 60.1 | 58.4 | 15.7 | 4.7 | 17.3× / 13.8× | 16.9× / 13.4× | 4.5× / 3.6× | 1.4× / 1.1× |
| agentic_swe | 0.56 | 1.45 | 2.34 | 3.23 | 61.3 | 64.8 | 14.9 | 3.6 | 26.2× / 19.0× | 27.7× / 20.1× | 6.4× / 4.6× | 1.5× / 1.1× |
| code_mixed | 0.07 | 1.46 | 2.80 | 4.19 | 60.2 | 63.5 | 15.6 | 4.1 | 21.5× / 14.4× | 22.7× / 15.1× | 5.6× / 3.7× | 1.5× / 1.0× |
| math_latex | 0.57 | 1.50 | 3.27 | 4.20 | 54.0 | 50.2 | 14.5 | 4.2 | 16.5× / 12.8× | 15.4× / 11.9× | 4.4× / 3.5× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×5.04 vs v0.23.1 · ×1.94 vs sebpop/upstream · ×1.00 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt-oss-dark.png">
  <img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt-oss-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt-oss-stages-dark.png">
  <img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt-oss-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt-oss-threads-dark.png">
  <img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-gpt-oss-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 4+15 (peak 20) · sebpop/upstream 11+13 (peak 23) · Pipeline 20+0 (peak 20)

| Fixture | Group | v0.23.1 MB/s | sebpop/upstream MB/s | Pipeline MB/s | vs v0.23.1 | vs sebpop/upstream | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 6.9 | 18.6 | 61.4 | ×8.86 | ×3.30 | ×0.97 | 4% (0.7) | 0% (0.0) | 31% (4.8) | 65% (10.0) | ≠ sebpop/upstream |
| arb_Arab | lang | 6.0 | 13.1 | 25.4 | ×4.26 | ×1.94 | ×0.98 | 2% (0.6) | 0% (0.0) | 8% (3.3) | 90% (34.9) | match |
| ben_Beng | lang | 7.0 | 18.5 | 28.2 | ×4.04 | ×1.53 | ×0.98 | 2% (0.6) | 0% (0.0) | 11% (3.7) | 88% (30.3) | match |
| cmn_Hani | lang | 7.1 | 12.2 | 38.3 | ×5.40 | ×3.14 | ×0.99 | 2% (0.6) | 0% (0.0) | 14% (3.5) | 84% (21.3) | match |
| ell_Grek | lang | 6.2 | 14.7 | 32.1 | ×5.19 | ×2.18 | ×0.98 | 2% (0.6) | 0% (0.0) | 10% (3.2) | 88% (26.7) | match |
| eng_Latn | lang | 5.1 | 11.1 | 21.7 | ×4.29 | ×1.96 | ×1.01 | 5% (2.1) | 0% (0.0) | 10% (4.5) | 86% (39.0) | match |
| heb_Hebr | lang | 5.8 | 14.9 | 28.4 | ×4.88 | ×1.90 | ×1.01 | 2% (0.6) | 0% (0.0) | 10% (3.4) | 89% (30.7) | match |
| hin_Deva | lang | 6.7 | 21.5 | 24.1 | ×3.59 | ×1.12 | ×0.98 | 1% (0.6) | 0% (0.0) | 9% (3.8) | 89% (36.2) | match |
| jpn_Jpan | lang | 7.7 | 13.1 | 37.8 | ×4.93 | ×2.89 | ×0.99 | 2% (0.6) | 0% (0.0) | 13% (3.3) | 85% (21.9) | match |
| kat_Geor | lang | 7.5 | 16.8 | 27.6 | ×3.69 | ×1.64 | ×1.04 | 2% (0.6) | 0% (0.0) | 8% (2.8) | 91% (32.4) | match |
| kor_Hang | lang | 5.8 | 14.6 | 47.2 | ×8.10 | ×3.23 | ×1.00 | 3% (0.6) | 0% (0.0) | 18% (3.7) | 79% (16.1) | match |
| rus_Cyrl | lang | 6.3 | 10.4 | 23.4 | ×3.70 | ×2.26 | ×1.02 | 1% (0.6) | 0% (0.0) | 7% (3.1) | 91% (38.3) | match |
| tam_Taml | lang | 7.8 | 17.4 | 29.7 | ×3.82 | ×1.70 | ×0.98 | 2% (0.6) | 0% (0.0) | 10% (3.2) | 88% (29.1) | match |
| tha_Thai | lang | 8.7 | 14.0 | 26.9 | ×3.10 | ×1.92 | ×0.96 | 2% (0.6) | 0% (0.0) | 9% (3.3) | 89% (32.4) | match |
| added_normalized_dense | modalities | 6.6 | 33.7 | 46.1 | ×7.02 | ×1.37 | ×1.00 | 4% (0.8) | 0% (0.0) | 10% (2.1) | 86% (18.0) | match |
| added_normalized_sparse | modalities | 6.3 | 30.1 | 37.1 | ×5.86 | ×1.23 | ×1.01 | 5% (1.4) | 0% (0.0) | 12% (3.2) | 83% (21.6) | match |
| added_special_dense | modalities | 6.3 | 16.8 | 55.9 | ×8.87 | ×3.33 | ×1.10 | 29% (4.8) | 1% (0.2) | 31% (5.2) | 39% (6.7) | match |
| added_special_sparse | modalities | 5.9 | 20.7 | 35.0 | ×5.93 | ×1.69 | ×1.03 | 12% (3.2) | 0% (0.1) | 21% (5.8) | 67% (18.5) | match |
| agentic-traces | modalities | 4.7 | 14.0 | 22.7 | ×4.84 | ×1.63 | ×0.99 | 4% (1.7) | 0% (0.0) | 12% (5.0) | 84% (36.0) | match |
| agentic_swe | modalities | 4.8 | 16.7 | 22.1 | ×4.58 | ×1.33 | ×1.01 | 3% (1.3) | 0% (0.0) | 8% (3.7) | 89% (39.7) | match |
| code_mixed | modalities | 5.1 | 16.4 | 30.3 | ×5.95 | ×1.84 | ×1.00 | 5% (1.5) | 0% (0.0) | 13% (4.3) | 82% (26.6) | match |
| math_latex | modalities | 4.7 | 13.0 | 23.0 | ×4.85 | ×1.77 | ×1.00 | 4% (1.9) | 0% (0.0) | 11% (4.8) | 84% (35.9) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.46 | 4.79 | 5.62 | 29.4 | 13.4 | 7.0 | 4.7 | 6.1× / 5.2× | 2.8× / 2.4× | 1.5× / 1.3× | 1.0× / 0.8× |
| arb_Arab | 1.00 | 3.05 | 3.28 | 5.33 | 35.8 | 15.0 | 7.7 | 5.0 | 10.9× / 6.7× | 4.6× / 2.8× | 2.3× / 1.4× | 1.5× / 0.9× |
| ben_Beng | 1.47 | 2.93 | 3.71 | 5.17 | 23.7 | 10.2 | 5.5 | 2.9 | 6.4× / 4.6× | 2.7× / 2.0× | 1.5× / 1.1× | 0.8× / 0.6× |
| cmn_Hani | 1.12 | 2.33 | 3.54 | 4.75 | 21.5 | 10.4 | 5.5 | 2.5 | 6.1× / 4.5× | 2.9× / 2.2× | 1.6× / 1.2× | 0.7× / 0.5× |
| ell_Grek | 0.58 | 3.05 | 3.19 | 5.65 | 29.7 | 14.0 | 6.8 | 5.1 | 9.3× / 5.3× | 4.4× / 2.5× | 2.1× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.10 | 1.45 | 4.49 | 5.84 | 44.0 | 27.5 | 14.0 | 4.2 | 9.8× / 7.5× | 6.1× / 4.7× | 3.1× / 2.4× | 0.9× / 0.7× |
| heb_Hebr | 1.00 | 3.07 | 3.38 | 5.45 | 32.9 | 15.8 | 8.0 | 3.1 | 9.8× / 6.0× | 4.7× / 2.9× | 2.4× / 1.5× | 0.9× / 0.6× |
| hin_Deva | 1.37 | 3.12 | 3.79 | 5.55 | 26.5 | 12.0 | 6.4 | 3.2 | 7.0× / 4.8× | 3.2× / 2.2× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.56 | 3.37 | 3.30 | 5.11 | 20.0 | 8.7 | 4.8 | 3.7 | 6.1× / 3.9× | 2.6× / 1.7× | 1.4× / 0.9× | 1.1× / 0.7× |
| kat_Geor | 1.39 | 2.62 | 2.80 | 4.03 | 19.0 | 9.4 | 4.5 | 2.1 | 6.8× / 4.7× | 3.4× / 2.3× | 1.6× / 1.1× | 0.8× / 0.5× |
| kor_Hang | 1.08 | 2.79 | 3.72 | 5.42 | 32.9 | 18.0 | 8.9 | 3.6 | 8.8× / 6.1× | 4.8× / 3.3× | 2.4× / 1.6× | 1.0× / 0.7× |
| rus_Cyrl | 1.02 | 2.96 | 3.09 | 5.03 | 28.3 | 13.8 | 6.5 | 4.9 | 9.2× / 5.6× | 4.5× / 2.8× | 2.1× / 1.3× | 1.6× / 1.0× |
| tam_Taml | 0.93 | 2.93 | 3.21 | 5.20 | 18.8 | 8.2 | 4.2 | 2.9 | 5.9× / 3.6× | 2.6× / 1.6× | 1.3× / 0.8× | 0.9× / 0.6× |
| tha_Thai | 1.37 | 2.58 | 3.29 | 4.51 | 13.3 | 5.5 | 2.8 | 2.3 | 4.0× / 2.9× | 1.7× / 1.2× | 0.9× / 0.6× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.47 | 2.12 | 3.53 | 35.2 | 16.1 | 11.9 | 2.5 | 16.6× / 10.0× | 7.6× / 4.6× | 5.6× / 3.4× | 1.2× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 3.20 | 4.62 | 37.7 | 19.6 | 11.8 | 3.0 | 11.8× / 8.2× | 6.1× / 4.2× | 3.7× / 2.6× | 0.9× / 0.7× |
| added_special_dense | 0.06 | 1.48 | 5.21 | 6.63 | 85.4 | 65.3 | 24.6 | 3.4 | 16.4× / 12.9× | 12.5× / 9.8× | 4.7× / 3.7× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.76 | 7.17 | 56.2 | 38.4 | 16.6 | 3.6 | 9.8× / 7.8× | 6.7× / 5.4× | 2.9× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.57 | 1.48 | 4.98 | 5.90 | 52.0 | 38.5 | 17.5 | 4.9 | 10.4× / 8.8× | 7.7× / 6.5× | 3.5× / 3.0× | 1.0× / 0.8× |
| agentic_swe | 0.56 | 1.44 | 3.71 | 4.59 | 54.9 | 46.1 | 17.7 | 3.6 | 14.8× / 12.0× | 12.4× / 10.0× | 4.8× / 3.8× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.44 | 4.35 | 5.72 | 55.1 | 43.4 | 17.7 | 4.3 | 12.7× / 9.6× | 10.0× / 7.6× | 4.1× / 3.1× | 1.0× / 0.7× |
| math_latex | 0.73 | 1.49 | 4.83 | 5.60 | 49.9 | 33.2 | 16.0 | 4.5 | 10.3× / 8.9× | 6.9× / 5.9× | 3.3× / 2.9× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×8.20 vs v0.23.1 · ×2.48 vs sebpop/upstream · ×1.00 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-glm-5-2-dark.png">
  <img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-glm-5-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-glm-5-2-stages-dark.png">
  <img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-glm-5-2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-glm-5-2-threads-dark.png">
  <img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-glm-5-2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 2+26 (peak 28) · sebpop/upstream 11+25 (peak 36) · Pipeline 10+0 (peak 10)

| Fixture | Group | v0.23.1 MB/s | sebpop/upstream MB/s | Pipeline MB/s | vs v0.23.1 | vs sebpop/upstream | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.0 | 20.7 | 64.4 | ×9.18 | ×3.11 | ×1.09 | 8% (1.2) | 0% (0.0) | 25% (3.7) | 67% (9.8) | match |
| arb_Arab | lang | 6.3 | 21.4 | 66.4 | ×10.59 | ×3.10 | ×0.95 | 8% (1.2) | 0% (0.0) | 16% (2.3) | 76% (10.9) | match |
| ben_Beng | lang | 4.9 | 25.6 | 68.7 | ×13.92 | ×2.68 | ×1.02 | 8% (1.2) | 0% (0.0) | 22% (3.1) | 69% (9.6) | match |
| cmn_Hani | lang | 7.6 | 17.0 | 69.2 | ×9.15 | ×4.06 | ×1.02 | 9% (1.2) | 0% (0.0) | 17% (2.4) | 74% (10.2) | match |
| ell_Grek | lang | 6.5 | 21.1 | 73.5 | ×11.28 | ×3.48 | ×1.01 | 9% (1.2) | 0% (0.0) | 17% (2.2) | 74% (9.5) | match |
| eng_Latn | lang | 5.1 | 11.0 | 23.4 | ×4.57 | ×2.13 | ×1.01 | 6% (2.6) | 0% (0.0) | 7% (3.1) | 87% (36.8) | match |
| heb_Hebr | lang | 6.2 | 20.8 | 68.8 | ×11.10 | ×3.30 | ×0.95 | 8% (1.2) | 0% (0.0) | 17% (2.3) | 75% (10.3) | match |
| hin_Deva | lang | 4.6 | 23.9 | 65.4 | ×14.12 | ×2.74 | ×0.95 | 8% (1.2) | 0% (0.0) | 22% (3.2) | 70% (10.2) | match |
| jpn_Jpan | lang | 8.1 | 19.4 | 73.6 | ×9.13 | ×3.79 | ×0.99 | 9% (1.2) | 0% (0.0) | 17% (2.2) | 74% (9.5) | match |
| kat_Geor | lang | 7.9 | 25.6 | 84.0 | ×10.67 | ×3.28 | ×1.02 | 10% (1.2) | 0% (0.0) | 19% (2.1) | 71% (8.0) | match |
| kor_Hang | lang | 6.1 | 17.8 | 68.3 | ×11.25 | ×3.84 | ×0.97 | 9% (1.2) | 0% (0.0) | 18% (2.5) | 73% (10.2) | match |
| rus_Cyrl | lang | 6.5 | 15.5 | 40.3 | ×6.17 | ×2.60 | ×0.98 | 5% (1.2) | 0% (0.0) | 9% (2.2) | 86% (20.9) | match |
| tam_Taml | lang | 5.2 | 26.3 | 71.1 | ×13.59 | ×2.70 | ×0.98 | 9% (1.2) | 0% (0.0) | 20% (2.7) | 71% (9.5) | match |
| tha_Thai | lang | 6.6 | 20.3 | 69.9 | ×10.58 | ×3.45 | ×1.07 | 9% (1.2) | 0% (0.0) | 19% (2.5) | 73% (9.9) | match |
| added_normalized_dense | modalities | 7.0 | 40.5 | 47.8 | ×6.78 | ×1.18 | ×1.02 | 7% (1.4) | 0% (0.0) | 5% (1.1) | 88% (17.5) | match |
| added_normalized_sparse | modalities | 6.6 | 32.0 | 41.6 | ×6.33 | ×1.30 | ×1.03 | 8% (2.0) | 0% (0.0) | 8% (1.9) | 84% (19.4) | match |
| added_special_dense | modalities | 6.2 | 16.9 | 42.2 | ×6.80 | ×2.49 | ×1.01 | 54% (12.2) | 0% (0.0) | 23% (5.3) | 25% (5.7) | match |
| added_special_sparse | modalities | 6.0 | 20.7 | 34.5 | ×5.72 | ×1.67 | ×1.01 | 24% (6.6) | 0% (0.0) | 19% (5.4) | 58% (16.2) | match |
| agentic-traces | modalities | 4.7 | 13.8 | 24.3 | ×5.23 | ×1.77 | ×1.01 | 6% (2.4) | 0% (0.0) | 9% (3.7) | 85% (34.1) | match |
| agentic_swe | modalities | 4.7 | 16.9 | 22.0 | ×4.66 | ×1.30 | ×0.99 | 4% (1.9) | 0% (0.0) | 7% (2.8) | 89% (38.9) | match |
| code_mixed | modalities | 5.1 | 16.1 | 31.7 | ×6.17 | ×1.96 | ×1.01 | 7% (2.2) | 0% (0.0) | 11% (3.4) | 82% (25.0) | match |
| math_latex | modalities | 4.8 | 12.6 | 24.9 | ×5.19 | ×1.97 | ×1.01 | 6% (2.5) | 0% (0.0) | 9% (3.5) | 85% (33.7) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.43 | 3.68 | 4.47 | 30.6 | 15.2 | 6.0 | 4.8 | 8.3× / 6.8× | 4.1× / 3.4× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 3.05 | 2.31 | 4.36 | 35.1 | 17.8 | 6.7 | 5.1 | 15.2× / 8.0× | 7.7× / 4.1× | 2.9× / 1.5× | 2.2× / 1.2× |
| ben_Beng | 1.46 | 2.97 | 3.08 | 4.58 | 52.0 | 25.4 | 10.2 | 3.8 | 16.9× / 11.4× | 8.3× / 5.6× | 3.3× / 2.2× | 1.2× / 0.8× |
| cmn_Hani | 1.13 | 2.28 | 2.36 | 3.51 | 21.3 | 11.0 | 4.7 | 2.5 | 9.1× / 6.1× | 4.7× / 3.1× | 2.0× / 1.3× | 1.1× / 0.7× |
| ell_Grek | 0.59 | 3.06 | 2.20 | 4.67 | 31.7 | 16.4 | 6.1 | 4.7 | 14.4× / 6.8× | 7.4× / 3.5× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.12 | 1.46 | 3.06 | 4.40 | 51.2 | 31.0 | 12.2 | 3.9 | 16.8× / 11.6× | 10.1× / 7.0× | 4.0× / 2.8× | 1.3× / 0.9× |
| heb_Hebr | 1.00 | 3.10 | 2.31 | 4.42 | 35.1 | 18.3 | 6.8 | 3.1 | 15.2× / 7.9× | 7.9× / 4.1× | 2.9× / 1.5× | 1.3× / 0.7× |
| hin_Deva | 1.36 | 3.11 | 3.19 | 4.93 | 54.7 | 28.2 | 11.2 | 4.0 | 17.2× / 11.1× | 8.8× / 5.7× | 3.5× / 2.3× | 1.3× / 0.8× |
| jpn_Jpan | 1.57 | 3.40 | 2.17 | 4.00 | 19.7 | 9.4 | 4.0 | 3.8 | 9.1× / 4.9× | 4.3× / 2.3× | 1.9× / 1.0× | 1.8× / 1.0× |
| kat_Geor | 1.40 | 2.57 | 2.09 | 3.26 | 19.1 | 10.6 | 4.1 | 2.0 | 9.1× / 5.9× | 5.1× / 3.3× | 2.0× / 1.3× | 0.9× / 0.6× |
| kor_Hang | 1.13 | 2.95 | 2.51 | 4.34 | 35.4 | 20.0 | 7.5 | 3.7 | 14.1× / 8.1× | 7.9× / 4.6× | 3.0× / 1.7× | 1.5× / 0.8× |
| rus_Cyrl | 1.02 | 3.03 | 2.16 | 4.17 | 30.0 | 15.9 | 5.9 | 2.5 | 13.9× / 7.2× | 7.4× / 3.8× | 2.7× / 1.4× | 1.2× / 0.6× |
| tam_Taml | 0.92 | 3.01 | 2.67 | 4.75 | 50.6 | 24.7 | 9.8 | 3.4 | 19.0× / 10.6× | 9.3× / 5.2× | 3.7× / 2.1× | 1.3× / 0.7× |
| tha_Thai | 1.37 | 2.56 | 2.53 | 3.73 | 31.5 | 15.3 | 6.7 | 3.0 | 12.4× / 8.4× | 6.0× / 4.1× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.07 | 2.49 | 27.4 | 15.8 | 6.6 | 2.0 | 25.5× / 11.0× | 14.7× / 6.3× | 6.2× / 2.7× | 1.8× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.92 | 3.34 | 36.3 | 21.5 | 8.6 | 2.7 | 18.9× / 10.9× | 11.2× / 6.5× | 4.5× / 2.6× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 5.27 | 6.69 | 110.1 | 69.8 | 20.8 | 3.3 | 20.9× / 16.5× | 13.2× / 10.4× | 3.9× / 3.1× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.40 | 6.82 | 70.5 | 42.7 | 15.1 | 3.7 | 13.1× / 10.3× | 7.9× / 6.3× | 2.8× / 2.2× | 0.7× / 0.5× |
| agentic-traces | 0.57 | 1.47 | 3.71 | 4.61 | 61.0 | 40.8 | 14.8 | 4.7 | 16.5× / 13.2× | 11.0× / 8.8× | 4.0× / 3.2× | 1.3× / 1.0× |
| agentic_swe | 0.53 | 1.45 | 2.85 | 3.76 | 63.6 | 46.5 | 15.4 | 3.5 | 22.3× / 16.9× | 16.3× / 12.4× | 5.4× / 4.1× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.45 | 3.35 | 4.73 | 61.0 | 44.3 | 15.2 | 4.1 | 18.2× / 12.9× | 13.2× / 9.4× | 4.5× / 3.2× | 1.2× / 0.9× |
| math_latex | 0.57 | 1.48 | 3.45 | 4.36 | 59.2 | 37.5 | 14.0 | 4.3 | 17.1× / 13.6× | 10.9× / 8.6× | 4.0× / 3.2× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×2.78 vs v0.23.1 · ×0.98 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-2-threads-dark.png">
  <img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 36+11 (peak 46) · sebpop/upstream — · Pipeline 41+0 (peak 41)

| Fixture | Group | v0.23.1 MB/s | sebpop/upstream MB/s | Pipeline MB/s | vs v0.23.1 | vs sebpop/upstream | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.2 | — | 46.9 | ×6.54 | — | ×0.99 | 0% (0.0) | 15% (2.8) | 0% (0.0) | 85% (16.2) | match |
| arb_Arab | lang | 14.6 | — | 51.3 | ×3.52 | — | ×0.96 | 0% (0.0) | 18% (3.3) | 0% (0.1) | 82% (15.0) | match |
| ben_Beng | lang | 16.3 | — | 85.0 | ×5.23 | — | ×0.93 | 0% (0.0) | 20% (2.2) | 0% (0.0) | 79% (8.5) | match |
| cmn_Hani | lang | 13.9 | — | 67.9 | ×4.90 | — | ×0.93 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 96% (12.1) | match |
| ell_Grek | lang | 15.1 | — | 59.9 | ×3.97 | — | ×0.95 | 0% (0.0) | 21% (3.2) | 0% (0.0) | 79% (12.0) | match |
| eng_Latn | lang | 4.8 | — | 6.5 | ×1.37 | — | ×1.02 | 0% (0.1) | 5% (6.8) | 0% (0.1) | 95% (142.4) | match |
| heb_Hebr | lang | 14.7 | — | 63.3 | ×4.29 | — | ×0.95 | 0% (0.0) | 23% (3.4) | 0% (0.0) | 76% (11.1) | match |
| hin_Deva | lang | 17.1 | — | 81.0 | ×4.74 | — | ×0.97 | 0% (0.0) | 26% (2.8) | 1% (0.1) | 74% (8.2) | match |
| jpn_Jpan | lang | 19.1 | — | 87.8 | ×4.59 | — | ×0.93 | 1% (0.0) | 4% (0.4) | 0% (0.0) | 96% (9.3) | match |
| kat_Geor | lang | 20.7 | — | 93.8 | ×4.52 | — | ×0.94 | 0% (0.0) | 20% (1.9) | 0% (0.0) | 79% (7.6) | match |
| kor_Hang | lang | 10.3 | — | 54.0 | ×5.24 | — | ×0.95 | 0% (0.1) | 20% (3.3) | 0% (0.0) | 80% (13.5) | match |
| rus_Cyrl | lang | 9.7 | — | 16.4 | ×1.70 | — | ×0.98 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (55.8) | match |
| tam_Taml | lang | 18.7 | — | 95.7 | ×5.12 | — | ×0.98 | 0% (0.0) | 19% (1.8) | 0% (0.0) | 81% (7.5) | match |
| tha_Thai | lang | 23.1 | — | 88.7 | ×3.83 | — | ×0.94 | 0% (0.0) | 10% (1.0) | 0% (0.0) | 90% (9.1) | match |
| added_normalized_dense | modalities | 6.5 | — | 8.7 | ×1.33 | — | ×0.98 | 0% (0.0) | 3% (4.0) | 0% (0.0) | 96% (109.9) | match |
| added_normalized_sparse | modalities | 5.5 | — | 7.5 | ×1.37 | — | ×1.02 | 0% (0.0) | 5% (6.1) | 0% (0.0) | 95% (120.0) | match |
| added_special_dense | modalities | 8.2 | — | 21.0 | ×2.57 | — | ×1.03 | 10% (4.8) | 31% (14.5) | 2% (1.1) | 56% (25.9) | match |
| added_special_sparse | modalities | 10.2 | — | 10.7 | ×1.05 | — | ×1.02 | 2% (2.1) | 13% (12.2) | 1% (0.5) | 84% (76.6) | match |
| agentic-traces | modalities | 5.1 | — | 7.2 | ×1.41 | — | ×1.01 | 0% (0.1) | 5% (6.2) | 0% (0.0) | 95% (128.7) | match |
| agentic_swe | modalities | 4.5 | — | 7.5 | ×1.65 | — | ×1.00 | 0% (0.0) | 8% (9.9) | 0% (0.2) | 92% (120.6) | match |
| code_mixed | modalities | 4.7 | — | 7.2 | ×1.53 | — | ×0.99 | 0% (0.0) | 6% (8.0) | 0% (0.2) | 94% (125.8) | match |
| math_latex | modalities | 4.9 | — | 6.8 | ×1.38 | — | ×0.99 | 0% (0.1) | 4% (6.4) | 0% (0.0) | 95% (135.3) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×5.58 vs v0.23.1 · ×2.41 vs sebpop/upstream · ×1.05 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-3-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-3-threads-dark.png">
  <img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-llama-3-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 174+0 (peak 175) · sebpop/upstream 178+0 (peak 179) · Pipeline 200+0 (peak 200)

| Fixture | Group | v0.23.1 MB/s | sebpop/upstream MB/s | Pipeline MB/s | vs v0.23.1 | vs sebpop/upstream | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.1 | 6.8 | 54.9 | ×7.70 | ×8.03 | ×1.01 | 4% (0.7) | 0% (0.0) | 22% (3.7) | 74% (12.3) | match |
| arb_Arab | lang | 5.7 | 9.0 | 19.5 | ×3.41 | ×2.17 | ×1.05 | 1% (0.6) | 0% (0.0) | 5% (2.3) | 94% (46.8) | match |
| ben_Beng | lang | 5.3 | 26.8 | 33.7 | ×6.37 | ×1.26 | ×1.04 | 2% (0.6) | 0% (0.0) | 10% (3.1) | 87% (25.5) | match |
| cmn_Hani | lang | 6.3 | 4.4 | 18.7 | ×2.99 | ×4.23 | ×1.07 | 1% (0.6) | 0% (0.0) | 5% (2.3) | 94% (47.5) | match |
| ell_Grek | lang | 6.2 | 9.1 | 21.1 | ×3.42 | ×2.31 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (2.2) | 94% (44.0) | match |
| eng_Latn | lang | 6.2 | 23.7 | 47.4 | ×7.66 | ×2.00 | ×1.08 | 11% (2.0) | 0% (0.0) | 17% (3.0) | 72% (12.4) | match |
| heb_Hebr | lang | 5.8 | 13.2 | 28.0 | ×4.78 | ×2.11 | ×1.03 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 92% (31.6) | match |
| hin_Deva | lang | 6.8 | 27.8 | 83.6 | ×12.23 | ×3.00 | ×1.06 | 5% (0.6) | 0% (0.0) | 28% (3.2) | 66% (7.5) | match |
| jpn_Jpan | lang | 6.6 | 4.8 | 18.1 | ×2.75 | ×3.79 | ×1.04 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (50.2) | match |
| kat_Geor | lang | 7.7 | 12.2 | 40.5 | ×5.26 | ×3.32 | ×1.01 | 3% (0.6) | 0% (0.0) | 9% (2.1) | 89% (20.8) | match |
| kor_Hang | lang | 5.5 | 6.2 | 21.0 | ×3.78 | ×3.36 | ×1.04 | 1% (0.6) | 0% (0.0) | 6% (2.5) | 93% (42.2) | match |
| rus_Cyrl | lang | 6.0 | 7.6 | 18.1 | ×3.02 | ×2.37 | ×1.04 | 1% (0.6) | 0% (0.0) | 4% (2.1) | 95% (50.4) | match |
| tam_Taml | lang | 5.4 | 27.6 | 37.9 | ×7.00 | ×1.37 | ×1.05 | 2% (0.6) | 0% (0.0) | 10% (2.6) | 88% (23.0) | match |
| tha_Thai | lang | 6.5 | 5.4 | 22.2 | ×3.42 | ×4.10 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (2.5) | 93% (40.1) | match |
| added_normalized_dense | modalities | 6.9 | 41.6 | 28.7 | ×4.17 | ×0.69 | ×1.03 | 2% (0.8) | 0% (0.0) | 3% (1.0) | 95% (32.3) | match |
| added_normalized_sparse | modalities | 7.3 | 35.3 | 45.9 | ×6.27 | ×1.30 | ×1.04 | 7% (1.4) | 0% (0.0) | 9% (1.9) | 85% (17.9) | match |
| added_special_dense | modalities | 6.5 | 16.8 | 79.9 | ×12.37 | ×4.75 | ×1.13 | 41% (4.9) | 1% (0.2) | 42% (5.0) | 16% (1.9) | match |
| added_special_sparse | modalities | 6.9 | 22.0 | 75.9 | ×10.93 | ×3.45 | ×1.08 | 25% (3.2) | 0% (0.0) | 42% (5.2) | 33% (4.1) | match |
| agentic-traces | modalities | 5.5 | 20.1 | 39.3 | ×7.14 | ×1.95 | ×1.06 | 8% (1.8) | 0% (0.0) | 16% (3.7) | 76% (17.4) | match |
| agentic_swe | modalities | 5.4 | 22.0 | 29.6 | ×5.49 | ×1.34 | ×1.05 | 4% (1.3) | 0% (0.0) | 9% (2.8) | 87% (27.2) | match |
| code_mixed | modalities | 5.9 | 22.6 | 49.3 | ×8.32 | ×2.18 | ×1.06 | 9% (1.6) | 0% (0.0) | 18% (3.3) | 73% (12.8) | match |
| math_latex | modalities | 5.5 | 21.1 | 42.3 | ×7.66 | ×2.00 | ×1.06 | 9% (2.0) | 0% (0.0) | 17% (3.4) | 74% (15.3) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.42 | 3.67 | 4.46 | 27.4 | 15.8 | 5.9 | 4.8 | 7.5× / 6.1× | 4.3× / 3.5× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.01 | 3.08 | 2.30 | 4.37 | 31.4 | 18.6 | 6.7 | 5.1 | 13.6× / 7.2× | 8.0× / 4.2× | 2.9× / 1.5× | 2.2× / 1.2× |
| ben_Beng | 1.46 | 3.02 | 3.05 | 4.61 | 45.8 | 26.3 | 10.2 | 3.8 | 15.0× / 9.9× | 8.6× / 5.7× | 3.3× / 2.2× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.31 | 2.35 | 3.54 | 19.4 | 11.1 | 4.6 | 2.5 | 8.3× / 5.5× | 4.7× / 3.1× | 1.9× / 1.3× | 1.1× / 0.7× |
| ell_Grek | 0.58 | 3.00 | 2.19 | 4.61 | 28.6 | 16.2 | 6.1 | 4.8 | 13.1× / 6.2× | 7.4× / 3.5× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.12 | 1.48 | 3.01 | 4.37 | 44.6 | 32.2 | 12.2 | 3.9 | 14.8× / 10.2× | 10.7× / 7.4× | 4.1× / 2.8× | 1.3× / 0.9× |
| heb_Hebr | 1.00 | 3.16 | 2.29 | 4.46 | 31.4 | 18.8 | 6.8 | 3.1 | 13.7× / 7.0× | 8.2× / 4.2× | 3.0× / 1.5× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 3.13 | 3.18 | 4.94 | 49.2 | 30.3 | 11.1 | 4.1 | 15.5× / 10.0× | 9.5× / 6.1× | 3.5× / 2.2× | 1.3× / 0.8× |
| jpn_Jpan | 1.55 | 3.34 | 2.16 | 3.94 | 18.2 | 9.8 | 4.0 | 3.9 | 8.4× / 4.6× | 4.5× / 2.5× | 1.9× / 1.0× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.51 | 2.08 | 3.20 | 17.2 | 10.8 | 4.2 | 2.0 | 8.3× / 5.4× | 5.2× / 3.4× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.15 | 2.79 | 2.51 | 4.15 | 31.4 | 20.4 | 7.5 | 3.7 | 12.5× / 7.6× | 8.1× / 4.9× | 3.0× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.03 | 3.00 | 2.14 | 4.11 | 27.0 | 16.2 | 5.8 | 2.4 | 12.6× / 6.6× | 7.6× / 3.9× | 2.7× / 1.4× | 1.1× / 0.6× |
| tam_Taml | 0.92 | 2.98 | 2.65 | 4.70 | 45.5 | 25.6 | 9.8 | 3.4 | 17.2× / 9.7× | 9.7× / 5.4× | 3.7× / 2.1× | 1.3× / 0.7× |
| tha_Thai | 1.36 | 2.56 | 2.51 | 3.72 | 28.3 | 15.5 | 6.7 | 3.0 | 11.3× / 7.6× | 6.2× / 4.2× | 2.7× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.48 | 1.00 | 2.42 | 24.2 | 16.3 | 6.5 | 2.0 | 24.3× / 10.0× | 16.4× / 6.7× | 6.5× / 2.7× | 2.0× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.94 | 3.35 | 31.7 | 21.8 | 8.7 | 2.7 | 16.4× / 9.4× | 11.3× / 6.5× | 4.5× / 2.6× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.95 | 6.37 | 96.4 | 70.7 | 21.0 | 3.3 | 19.5× / 15.1× | 14.3× / 11.1× | 4.2× / 3.3× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 5.19 | 6.61 | 61.6 | 43.7 | 14.8 | 3.7 | 11.9× / 9.3× | 8.4× / 6.6× | 2.8× / 2.2× | 0.7× / 0.6× |
| agentic-traces | 0.58 | 1.48 | 3.69 | 4.59 | 54.5 | 41.3 | 15.0 | 4.7 | 14.8× / 11.9× | 11.2× / 9.0× | 4.1× / 3.3× | 1.3× / 1.0× |
| agentic_swe | 0.66 | 1.44 | 2.83 | 3.61 | 56.1 | 48.4 | 15.4 | 3.5 | 19.9× / 15.6× | 17.1× / 13.4× | 5.5× / 4.3× | 1.2× / 1.0× |
| code_mixed | 0.07 | 1.44 | 3.26 | 4.63 | 53.8 | 50.5 | 15.0 | 4.1 | 16.5× / 11.6× | 15.5× / 10.9× | 4.6× / 3.2× | 1.3× / 0.9× |
| math_latex | 0.69 | 1.48 | 3.43 | 4.22 | 51.8 | 37.8 | 14.2 | 4.3 | 15.1× / 12.3× | 11.0× / 9.0× | 4.1× / 3.4× | 1.2× / 1.0× |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29759693317-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->

