### PR TITLE
feat(bpe): ScratchPool pattern + BPE word cache

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/mod.rs
+++ b/tokenizers/tk-encode/src/models/bpe/mod.rs
@@ -3,6 +3,7 @@ use std::{iter, mem};
 
 mod model;
 mod serialization;
+mod word_cache;
 pub mod word;
 
 pub type Pair = (u32, u32);

--- a/tokenizers/tk-encode/src/models/bpe/mod.rs
+++ b/tokenizers/tk-encode/src/models/bpe/mod.rs
@@ -3,8 +3,8 @@ use std::{iter, mem};
 
 mod model;
 mod serialization;
-mod word_cache;
 pub mod word;
+mod word_cache;
 
 pub type Pair = (u32, u32);
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -862,7 +862,18 @@ pub struct BpeScratch {
     pub(crate) skip: Vec<Merge>,
     pub(crate) word: Word,
 }
-impl ModelScratch for BpeScratch {}
+impl ModelScratch for BpeScratch {
+    fn clear(&mut self) {
+        let Self {
+            merge_queue,
+            skip,
+            word,
+        } = self;
+        merge_queue.clear();
+        skip.clear();
+        word.clear();
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -845,7 +845,7 @@ impl pipeline::Model for PipelineBPE {
         } = scratch;
 
         if let Some(cache) = word_cache
-            && let Some(hit) = cache.get(sequence)
+            && let Some(hit) = cache.get(sequence.as_bytes())
         {
             output.extend(hit.iter().map(|&id| PipelineToken { id }));
             return Ok(());
@@ -858,7 +858,7 @@ impl pipeline::Model for PipelineBPE {
         {
             let ids = word.get_chars();
             output.extend(ids.iter().map(|&id| PipelineToken { id }));
-            cache.insert(sequence.to_string(), ids);
+            cache.insert(sequence.as_bytes(), ids.as_slice());
         } else {
             output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         }
@@ -871,7 +871,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
-            word_cache: self.cache_capacity.map(WordCache::new),
+            word_cache: self.cache_capacity.map(|_| WordCache::new()),
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -866,9 +866,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
-            word_cache: self
-                .cache_capacity
-                .map(|capacity| WordCache::init(capacity)),
+            word_cache: self.cache_capacity.map(WordCache::init),
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1438,6 +1438,25 @@ mod tests {
             assert!(pipeline_ids(&pipeline, "").is_empty());
         }
 
+        // The scratch pool hands the SAME scratch to successive encodes. A bug leaking
+        // state between calls (an undrained merge queue, a stale word buffer) would
+        // corrupt every encode after the first. Drive several inputs — including
+        // repeats and an empty string — through one reused scratch and check each still
+        // matches the fresh-scratch reference. This is the invariant the pool relies on.
+        #[test]
+        fn reused_scratch_matches_fresh() {
+            let bpe = hello_builder().build().unwrap();
+            let reference = bpe.clone();
+            let model = PipelineBPE::from_bpe(bpe, false).unwrap();
+            let mut scratch = model.init_scratch();
+            for input in ["hello", "hell", "helo", "oleh", "hello", "", "hxe"] {
+                let mut out = Vec::new();
+                pipeline::Model::tokenize_pipeline(&model, input, &mut scratch, &mut out).unwrap();
+                let got: Vec<u32> = out.iter().map(|t| t.id).collect();
+                assert_eq!(got, reference_ids(&reference, input), "{input:?}");
+            }
+        }
+
         #[test]
         fn unknown_char_without_unk_is_dropped() {
             let bpe = hello_builder().build().unwrap();

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,6 +1,6 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::models::bpe::Merge;
-use crate::models::bpe::word_cache::{MAX_SEQUENCE_SIZE, WordCache};
+use crate::models::bpe::word_cache::WordCache;
 use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
@@ -854,7 +854,7 @@ impl pipeline::Model for PipelineBPE {
         self.merge_word(sequence, merge_queue, skip, word);
 
         if let Some(cache) = word_cache
-            && sequence.len() < MAX_SEQUENCE_SIZE
+            && sequence.len() < MAX_LENGTH
         {
             let ids = word.get_chars();
             output.extend(ids.iter().map(|&id| PipelineToken { id }));

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,6 +1,6 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::models::bpe::Merge;
-use crate::models::bpe::word_cache::WordCache;
+use crate::models::bpe::word_cache::{MAX_SEQUENCE_SIZE, WordCache};
 use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
@@ -853,10 +853,15 @@ impl pipeline::Model for PipelineBPE {
 
         self.merge_word(sequence, merge_queue, skip, word);
 
-        if let Some(cache) = word_cache {
-            cache.insert(sequence.to_string(), word.get_chars());
+        if let Some(cache) = word_cache
+            && sequence.len() < MAX_SEQUENCE_SIZE
+        {
+            let ids = word.get_chars();
+            output.extend(ids.iter().map(|&id| PipelineToken { id }));
+            cache.insert(sequence.to_string(), ids);
+        } else {
+            output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         }
-        output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
 
         Ok(())
     }
@@ -866,7 +871,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
-            word_cache: self.cache_capacity.map(WordCache::init),
+            word_cache: self.cache_capacity.map(WordCache::new),
         }
     }
 }
@@ -884,12 +889,12 @@ impl ModelScratch for BpeScratch {
             merge_queue,
             skip,
             word,
-            word_cache: _cache,
+            word_cache: _,
         } = self;
         merge_queue.clear();
         skip.clear();
         word.clear();
-        // We don't reset _word_cache on purpose, so it stays warm for future callers
+        // The word cache is intentionally kept across clears so it stays warm for future callers
     }
 }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -822,18 +822,12 @@ impl pipeline::Model for PipelineBPE {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
+        let sequence = split.as_str();
         if sequence.is_empty() {
-            return Ok(());
-        }
-
-        if self.ignore_merges
-            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
-        {
-            output.push(PipelineToken { id });
             return Ok(());
         }
 
@@ -845,16 +839,22 @@ impl pipeline::Model for PipelineBPE {
         } = scratch;
 
         if let Some(cache) = word_cache
-            && let Some(hit) = cache.get(sequence.as_bytes())
+            && let Some(hit) = cache.get(split.as_bytes(), split.head())
         {
             output.extend(hit.iter().map(|&id| PipelineToken { id }));
+            return Ok(());
+        }
+        if self.ignore_merges
+            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
+        {
+            output.push(PipelineToken { id });
             return Ok(());
         }
 
         self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         if let Some(cache) = word_cache {
-            cache.insert(sequence.as_bytes(), word.get_chars_iter());
+            cache.insert(split.as_bytes(), split.head(), word.get_chars_iter());
         }
 
         Ok(())
@@ -1428,7 +1428,8 @@ mod tests {
         fn pipeline_ids(model: &PipelineBPE, sequence: &str) -> Vec<u32> {
             let mut out = Vec::new();
             let mut scratch = model.init_scratch();
-            pipeline::Model::tokenize_pipeline(model, sequence, &mut scratch, &mut out).unwrap();
+            pipeline::Model::tokenize_pipeline(model, sequence.into(), &mut scratch, &mut out)
+                .unwrap();
             out.iter().map(|t| t.id).collect()
         }
 
@@ -1480,7 +1481,8 @@ mod tests {
             let mut scratch = model.init_scratch();
             for input in ["hello", "hell", "helo", "oleh", "hello", "", "hxe"] {
                 let mut out = Vec::new();
-                pipeline::Model::tokenize_pipeline(&model, input, &mut scratch, &mut out).unwrap();
+                pipeline::Model::tokenize_pipeline(&model, input.into(), &mut scratch, &mut out)
+                    .unwrap();
                 let got: Vec<u32> = out.iter().map(|t| t.id).collect();
                 assert_eq!(got, reference_ids(&reference, input), "{input:?}");
             }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -870,6 +870,7 @@ impl pipeline::Model for PipelineBPE {
     }
 }
 
+#[derive(Default)]
 pub struct BpeScratch {
     pub(crate) merge_queue: QuaternaryHeap<Merge>,
     pub(crate) skip: Vec<Merge>,

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,5 +1,6 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::models::bpe::Merge;
+use crate::models::bpe::word_cache::WordCache;
 use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
@@ -680,6 +681,7 @@ pub struct PipelineBPE {
     vocab: BucketVocabStore,
     merges: MergeMap,
     ignore_merges: bool,
+    cache_capacity: Option<usize>,
 }
 
 enum Atoms {
@@ -760,6 +762,7 @@ impl PipelineBPE {
             ignore_merges,
             merges,
             vocab,
+            cache_capacity: model.cache.map(|c| c.capacity),
         })
     }
 
@@ -834,15 +837,25 @@ impl pipeline::Model for PipelineBPE {
             return Ok(());
         }
 
-        // TODO: persistent cache mapping &str -> &[u32]
-
         let BpeScratch {
             merge_queue,
             skip,
             word,
+            word_cache,
         } = scratch;
 
+        if let Some(cache) = word_cache
+            && let Some(hit) = cache.get(sequence)
+        {
+            output.extend(hit.iter().map(|&id| PipelineToken { id }));
+            return Ok(());
+        }
+
         self.merge_word(sequence, merge_queue, skip, word);
+
+        if let Some(cache) = word_cache {
+            cache.insert(sequence.to_string(), word.get_chars());
+        }
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
 
         Ok(())
@@ -853,6 +866,9 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
+            word_cache: self
+                .cache_capacity
+                .map(|capacity| WordCache::init(capacity)),
         }
     }
 }
@@ -861,17 +877,21 @@ pub struct BpeScratch {
     pub(crate) merge_queue: QuaternaryHeap<Merge>,
     pub(crate) skip: Vec<Merge>,
     pub(crate) word: Word,
+    pub(crate) word_cache: Option<WordCache>,
 }
+
 impl ModelScratch for BpeScratch {
     fn clear(&mut self) {
         let Self {
             merge_queue,
             skip,
             word,
+            word_cache: _cache,
         } = self;
         merge_queue.clear();
         skip.clear();
         word.clear();
+        // We don't reset _word_cache on purpose, so it stays warm for future callers
     }
 }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -762,7 +762,7 @@ impl PipelineBPE {
             ignore_merges,
             merges,
             vocab,
-            cache_capacity: model.cache.map(|c| c.capacity),
+            cache_capacity: model.cache.map(|c| c.capacity).filter(|&c| c > 0),
         })
     }
 
@@ -852,15 +852,9 @@ impl pipeline::Model for PipelineBPE {
         }
 
         self.merge_word(sequence, merge_queue, skip, word);
-
-        if let Some(cache) = word_cache
-            && sequence.len() < MAX_LENGTH
-        {
-            let ids = word.get_chars();
-            output.extend(ids.iter().map(|&id| PipelineToken { id }));
-            cache.insert(sequence.as_bytes(), ids.as_slice());
-        } else {
-            output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+        output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+        if let Some(cache) = word_cache {
+            cache.insert(sequence.as_bytes(), word.get_chars_iter());
         }
 
         Ok(())
@@ -871,7 +865,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
-            word_cache: self.cache_capacity.map(|_| WordCache::new()),
+            word_cache: self.cache_capacity.map(WordCache::new),
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word.rs
@@ -276,7 +276,7 @@ impl Word {
         self.get_chars_iter().collect()
     }
 
-    pub fn get_chars_iter(&self) -> impl Iterator<Item = u32> + '_ {
+    pub fn get_chars_iter(&self) -> impl ExactSizeIterator<Item = u32> + '_ {
         self.symbols.iter().map(|s| s.c)
     }
 

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,29 +1,83 @@
-use ahash::AHashMap;
+use std::ops::Range;
 
+use ahash::RandomState;
 
-/// naive implem of word -> IDs cache
+use crate::utils::cache::MAX_LENGTH;
+
+#[derive(Clone, Copy, Default)]
+struct CacheSlot {
+    hash: u64,
+    key_offsets: (u32, u16),
+    ids_offsets: (u32, u16),
+}
+
+impl CacheSlot {
+    fn id_range(&self) -> Range<usize> {
+        let (start, len) = self.ids_offsets;
+        start as usize..(start as usize + len as usize)
+    }
+
+    fn key_range(&self) -> Range<usize> {
+        let (start, len) = self.key_offsets;
+        start as usize..(start as usize + len as usize)
+    }
+}
+
 pub struct WordCache {
-    capacity: usize,
-    lookup: AHashMap<String, Box<[u32]>>,
+    hasher: RandomState,
+    slots: Box<[CacheSlot]>,
+    key_bytes: Vec<u8>,
+    ids: Vec<u32>,
+    slot_mask: u64,
 }
 
 impl WordCache {
-    pub fn new(capacity: usize) -> Self {
+    pub fn new() -> Self {
+        // todo: make capacity configurable
+        const CAPACITY: usize = 1 << 16;
+        const MASK: u64 = (CAPACITY as u64) - 1;
         Self {
-            capacity,
-            lookup: AHashMap::with_capacity(capacity),
+            hasher: RandomState::new(),
+            slots: vec![CacheSlot::default(); CAPACITY].into_boxed_slice(),
+            ids: Vec::with_capacity(CAPACITY * MAX_LENGTH),
+            key_bytes: Vec::with_capacity(CAPACITY * MAX_LENGTH),
+            slot_mask: MASK,
         }
     }
 
-    pub fn get(&self, key: &str) -> Option<&[u32]> {
-        self.lookup.get(key).map(|bx| &bx[..])
+    pub fn get(&self, key: &[u8]) -> Option<&[u32]> {
+        let hash = self.hasher.hash_one(key);
+        let slot = self.slots[(hash & self.slot_mask) as usize];
+        if hash != slot.hash {
+            return None;
+        }
+        if key != &self.key_bytes[slot.key_range()] {
+            return None;
+        }
+        Some(&self.ids[slot.id_range()])
     }
 
-    pub fn insert(&mut self, k: String, v: Vec<u32>) {
-        if self.lookup.len() >= self.capacity {
-            // Pop an arbitrary entry
-            self.lookup.extract_if(|_, _| true).next();
+    pub fn insert(&mut self, key: &[u8], ids: &[u32]) {
+        if key.len() > MAX_LENGTH {
+            return;
         }
-        self.lookup.insert(k, v.into_boxed_slice());
+        let hash = self.hasher.hash_one(key);
+        let slot_idx = (hash & self.slot_mask) as usize;
+
+        if self.slots[slot_idx].hash != 0 {
+            // slot already taken: skip insert
+            // caveat: a key whose hash lower bits resolves to 0 never gets cached
+            return;
+        }
+        let key_offsets = (self.key_bytes.len() as u32, key.len() as u16);
+        self.key_bytes.extend_from_slice(key);
+        let ids_offsets = (self.ids.len() as u32, ids.len() as u16);
+        self.ids.extend_from_slice(ids);
+
+        self.slots[slot_idx] = CacheSlot {
+            hash,
+            key_offsets,
+            ids_offsets,
+        };
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,0 +1,28 @@
+use ahash::AHashMap;
+
+/// naive implem of word -> IDs cache
+pub struct WordCache {
+    capacity: usize,
+    lookup: AHashMap<String, Box<[u32]>>,
+}
+
+impl WordCache {
+    pub fn init(capacity: usize) -> Self {
+        Self {
+            capacity,
+            lookup: AHashMap::with_capacity(capacity),
+        }
+    }
+
+    pub fn get<'a>(&'a self, key: &str) -> Option<&'a [u32]> {
+        self.lookup.get(key).map(|bx| &bx[..])
+    }
+
+    pub fn insert(&mut self, k: String, v: Vec<u32>) {
+        if self.lookup.len() >= self.capacity {
+            // Pop an arbitrary entry
+            self.lookup.extract_if(|_, _| true).next();
+        }
+        self.lookup.insert(k, v.into_boxed_slice());
+    }
+}

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -4,79 +4,131 @@ use ahash::RandomState;
 
 use crate::utils::cache::MAX_LENGTH;
 
+const WAYS: usize = 4;
+
 #[derive(Clone, Copy, Default)]
 struct CacheSlot {
-    hash: u64,
-    key_offsets: (u32, u16),
-    ids_offsets: (u32, u16),
+    tag: u32,
+    key_off: u32,
+    ids_off: u32,
+    key_len: u16,
+    ids_len: u16,
 }
+
+#[derive(Clone, Copy, Default)]
+#[repr(align(64))]
+struct Bucket([CacheSlot; WAYS]);
 
 impl CacheSlot {
     fn id_range(&self) -> Range<usize> {
-        let (start, len) = self.ids_offsets;
-        start as usize..(start as usize + len as usize)
+        self.ids_off as usize..(self.ids_off as usize + self.ids_len as usize)
     }
 
     fn key_range(&self) -> Range<usize> {
-        let (start, len) = self.key_offsets;
-        start as usize..(start as usize + len as usize)
+        self.key_off as usize..(self.key_off as usize + self.key_len as usize)
     }
 }
 
 pub struct WordCache {
     hasher: RandomState,
-    slots: Box<[CacheSlot]>,
+    buckets: Box<[Bucket]>,
     key_bytes: Vec<u8>,
     ids: Vec<u32>,
-    slot_mask: u64,
+    bucket_mask: u64,
 }
 
 impl WordCache {
-    pub fn new() -> Self {
-        // todo: make capacity configurable
-        const CAPACITY: usize = 1 << 16;
-        const MASK: u64 = (CAPACITY as u64) - 1;
+    pub fn new(capacity: usize) -> Self {
+        let n_buckets = (capacity.next_power_of_two() / WAYS).max(1);
         Self {
             hasher: RandomState::new(),
-            slots: vec![CacheSlot::default(); CAPACITY].into_boxed_slice(),
+            buckets: vec![Bucket::default(); n_buckets].into_boxed_slice(),
             ids: Vec::with_capacity(256),
             key_bytes: Vec::with_capacity(1024),
-            slot_mask: MASK,
+            bucket_mask: (n_buckets as u64) - 1,
         }
+    }
+
+    // The low hash bits pick the bucket index, the high bits form the occupancy tag
+	// 0x0 tag is reserved for empty spots (hence the `| 1`)
+    fn locate(&self, key: &[u8]) -> (usize, u32) {
+        let hash = self.hasher.hash_one(key);
+        ((hash & self.bucket_mask) as usize, (hash >> 32) as u32 | 1)
     }
 
     pub fn get(&self, key: &[u8]) -> Option<&[u32]> {
-        let hash = self.hasher.hash_one(key) | 1;
-        let slot = self.slots[(hash & self.slot_mask) as usize];
-        if hash != slot.hash {
+        if key.len() > MAX_LENGTH {
             return None;
         }
-        if key != &self.key_bytes[slot.key_range()] {
-            return None;
+        let (bucket_idx, tag) = self.locate(key);
+        for slot in &self.buckets[bucket_idx].0 {
+            if slot.tag == tag && key == &self.key_bytes[slot.key_range()] {
+                return Some(&self.ids[slot.id_range()]);
+            }
         }
-        Some(&self.ids[slot.id_range()])
+        None
     }
 
-    pub fn insert(&mut self, key: &[u8], ids: &[u32]) {
+    pub fn insert(&mut self, key: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
         if key.len() > MAX_LENGTH {
             return;
         }
-        let hash = self.hasher.hash_one(key) | 1;
-        let slot_idx = (hash & self.slot_mask) as usize;
-
-        if self.slots[slot_idx].hash != 0 {
-            // slot already taken: skip insert
+        let (bucket_idx, tag) = self.locate(key);
+        let Some(slot) = self.buckets[bucket_idx]
+            .0
+            .iter()
+            .position(|slot| slot.tag == 0)
+        else {
+            // bucket full: skip insert
             return;
-        }
-        let key_offsets = (self.key_bytes.len() as u32, key.len() as u16);
-        self.key_bytes.extend_from_slice(key);
-        let ids_offsets = (self.ids.len() as u32, ids.len() as u16);
-        self.ids.extend_from_slice(ids);
-
-        self.slots[slot_idx] = CacheSlot {
-            hash,
-            key_offsets,
-            ids_offsets,
         };
+        self.buckets[bucket_idx].0[slot] = CacheSlot {
+            tag,
+            key_off: self.key_bytes.len() as u32,
+            key_len: key.len() as u16,
+            ids_off: self.ids.len() as u32,
+            ids_len: ids.len() as u16,
+        };
+        self.key_bytes.extend_from_slice(key);
+        self.ids.extend(ids);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let mut cache = WordCache::new(1 << 8);
+        assert_eq!(cache.get(b"hello"), None);
+        cache.insert(b"hello", [1u32, 2, 3].into_iter());
+        cache.insert(b"world", [4u32].into_iter());
+        assert_eq!(cache.get(b"hello"), Some(&[1u32, 2, 3][..]));
+        assert_eq!(cache.get(b"world"), Some(&[4u32][..]));
+        assert_eq!(cache.get(b"hell"), None);
+    }
+
+    #[test]
+    fn single_bucket_holds_ways_entries_then_freezes() {
+        // capacity <= WAYS collapses to one bucket, making conflicts deterministic
+        let mut cache = WordCache::new(1);
+        let keys: Vec<Vec<u8>> = (0..WAYS as u8 + 2).map(|i| vec![i; 3]).collect();
+        for (i, key) in keys.iter().enumerate() {
+            cache.insert(key, [i as u32].into_iter());
+        }
+        let cached = keys.iter().filter(|k| cache.get(k).is_some()).count();
+        assert_eq!(cached, WAYS);
+        for (i, key) in keys.iter().enumerate().take(WAYS) {
+            assert_eq!(cache.get(key), Some(&[i as u32][..]));
+        }
+    }
+
+    #[test]
+    fn oversized_keys_are_ignored() {
+        let mut cache = WordCache::new(1 << 8);
+        let big = vec![7u8; MAX_LENGTH + 1];
+        cache.insert(&big, [1u32].into_iter());
+        assert_eq!(cache.get(&big), None);
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,6 +1,5 @@
 use ahash::AHashMap;
 
-pub(crate) const MAX_SEQUENCE_SIZE: usize = 256;
 
 /// naive implem of word -> IDs cache
 pub struct WordCache {

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,5 +1,7 @@
 use ahash::AHashMap;
 
+pub(crate) const MAX_SEQUENCE_SIZE: usize = 256;
+
 /// naive implem of word -> IDs cache
 pub struct WordCache {
     capacity: usize,
@@ -7,14 +9,14 @@ pub struct WordCache {
 }
 
 impl WordCache {
-    pub fn init(capacity: usize) -> Self {
+    pub fn new(capacity: usize) -> Self {
         Self {
             capacity,
             lookup: AHashMap::with_capacity(capacity),
         }
     }
 
-    pub fn get<'a>(&'a self, key: &str) -> Option<&'a [u32]> {
+    pub fn get(&self, key: &str) -> Option<&[u32]> {
         self.lookup.get(key).map(|bx| &bx[..])
     }
 

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,96 +1,655 @@
-use std::ops::Range;
+//! Remembers the token ids a word encodes to, so BPE only has to merge it once.
+//!
+//! Text repeats itself: a few thousand distinct words usually cover nearly every
+//! word of a document, and merging is the most expensive thing the BPE model
+//! does. So the second time a word shows up, the answer should come from a table
+//! instead of from the merge loop. Both sides of that table are on the hot path:
+//! a hit has to be far cheaper than merging, and a miss has to cost close to
+//! nothing, because every word pays for one the first time it is seen.
+//!
+//! There are four pieces. The table is `N` fixed-size slots, `N` being the
+//! requested capacity rounded up to a power of two; beside it one byte per slot
+//! records how much that slot is being used; and two arenas hold what a slot is
+//! too small for:
+//!
+//! ```text
+//!   slots     [Slot; N]      32 bytes each, one word per slot
+//!   freqs     [u8; N]        how used each slot is — and 0 means "never written"
+//!   key_bytes Slab<u8>       the bytes of words longer than 15
+//!   ids       Slab<u32>      id runs longer than 3
+//! ```
+//!
+//! One `WordCache` lives in one scratch buffer, so it is owned by a single
+//! thread: no sharing, no locking, no atomics.
+//!
+//! # Looking a word up
+//!
+//! A word's hash picks its *home* slot. If another word is already sitting
+//! there, the search steps forward one slot at a time — this is open addressing
+//! with linear probing — for at most [`WINDOW`] slots:
+//!
+//! ```text
+//!   get(b"tion")      home = hash(b"tion") & (N - 1) = 4
+//!
+//!     slot 3  │ "port"  │
+//!     slot 4  │ "ation" │ ← home, but another word got here first: step forward
+//!     slot 5  │ "tion"  │ ← the key matches: hit, hand back its ids
+//!     slot 6  │  empty  │
+//!     slot 7  │ "the"   │
+//!
+//!   get(b"xyz")       home = 4 → not "ation", not "tion", slot 6 is empty → miss
+//! ```
+//!
+//! A walk may stop at that empty slot instead of going the full [`WINDOW`],
+//! because no slot ever goes back to being empty once it has been used: an empty
+//! slot means nothing was ever stored beyond it.
+//!
+//! # What a slot holds
+//!
+//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and four bytes
+//! of bookkeeping, one of them spare. It takes one of three shapes, depending on
+//! how long the word is and how many ids it encoded to. The first is the common
+//! case for English or code — a short word encoding to one or two tokens — and it
+//! touches nothing but the slot itself:
+//!
+//! ```text
+//!  (1) at most 15 bytes, at most 3 ids — the slot holds everything
+//!
+//!     b"tion" → [5378, 262]
+//!    key     │ t  i  o  n  00 … 00 │ 4 │   the word, length in the top byte
+//!    payload │ 5378 │ 262 │  ·  │          the ids, right here
+//!    len     2                             2 of the 3 payload words are ids
+//!    key_len 0                             none of it is in key_bytes
+//!
+//!  (2) at most 15 bytes, more than 3 ids — the ids move to the arena
+//!
+//!     b"电脑" (6 bytes) → 8 ids
+//!    key     │ e7 94 b5 e8 84 91 … │ 6 │   still the word itself
+//!    payload │  ·  │  40  │  8  │          8 ids, in the ids arena at 40
+//!    len     SPILLED                       payload is coordinates, not ids
+//!    key_len 0
+//!
+//!  (3) over 15 bytes — the bytes move too, and the key becomes a hash
+//!
+//!     b"unbelievabilities" (17 bytes) → 6 ids
+//!    key     │ hash(word) │ LONG_TAG │   no room for 17 bytes
+//!    payload │  12  │  40  │  6  │       bytes at 12, ids at 40
+//!    len     SPILLED
+//!    key_len 17                          so a hit has to check those bytes
+//! ```
+//!
+//! Shape (3) is the only one where a matching `key` is not proof: two different
+//! long words can hash alike, so a hit there also compares the bytes in
+//! `key_bytes`. Shapes (1) and (2) carry the word itself in the key, so an equal
+//! key *is* an equal word — one register-wide comparison, no memory to chase.
+//!
+//! # The life of an entry
+//!
+//! An entry is born on a miss, keeps its slot for as long as it is being used,
+//! and is eventually overwritten by another word that hashes into the same
+//! window. All of that is decided by `freqs` — here are four of one window's
+//! sixteen bytes over time:
+//!
+//! ```text
+//!                                                    A    B    C    D
+//!    1. A, B, C inserted, each starting at            1    1    1    0
+//!       NEWBORN — on probation, but not free
+//!
+//!    2. B is looked up three times, C once            1    4    2    0
+//!
+//!    3. D takes the last free slot, then a hit        1    4    2    2
+//!
+//!    4. E arrives and the window is full:
+//!
+//!         A is the coldest — stored, never used       1    4    2    2
+//!         every frequency halves, floored at 1        1    2    1    1
+//!         A's slot goes to E, back at NEWBORN         1    2    1    1
+//!                                                     ▲ E's now; A's arena runs,
+//!                                                       if it had any, come back
+//! ```
+//!
+//! Halving is what keeps this from being "whoever got there first wins": B was
+//! hot once, but unless it keeps earning hits it will be down with the rest by
+//! the time the next word needs a slot. C and D are one unlucky moment from
+//! eviction and one hit from safety.
+//!
+//! The floor at [`NEWBORN`] is what lets the same byte also mean *free*: no live
+//! entry can ever fall to 0, so a 0 says nothing was ever stored in that slot, and
+//! one scan of sixteen bytes answers both "is there a free slot here?" and "which
+//! entry is coldest?".
+//!
+//! Overwriting the victim where it lies is what keeps the whole structure small.
+//! Removing an entry from an open-addressed table normally needs a tombstone or a
+//! backward shift, because a probe walk stops at the first empty slot and a hole
+//! in the middle of a chain would cut the walk short. Here nothing is ever
+//! removed: a slot goes from empty to occupied once and after that only ever
+//! changes owner. That is what lets a lookup stop at the first empty slot, and it
+//! is why the window has to be bounded — in a saturated table, that bound is all
+//! that stops a walk from running over the whole table.
+//!
+//! ## Why the frequencies are not in the slot
+//!
+//! There is room for them — the slot has a spare byte where one used to sit. But
+//! then a window's sixteen frequencies would be sixteen bytes scattered across
+//! eight cache lines of slot table, read one slot at a time. In their own array
+//! they are sixteen *consecutive* bytes, and picking a slot compiles to a 16-byte
+//! load, a vector minimum, and — when the window is full — a vector shift and a
+//! vector maximum to age the whole window at once.
+//!
+//! That is a trade, not a free win: a hit now also writes a byte to a line it
+//! would otherwise never touch, which buys nothing while the table still has room.
+//! Measured over 24 model × corpus × capacity combinations, against the same cache
+//! with `freq` back in the slot (`examples/cache_freq_bench.rs` — it runs both in
+//! one binary, because cross-binary timings here swing ±30% on code layout alone):
+//!
+//! ```text
+//!   evictions per 1000 lookups        time per word
+//!            0 -   2                      ×1.02      ← paying, getting nothing
+//!            5 - 100                      ×1.01
+//!          136 - 160                      ×0.96
+//!          230 - 240                      ×0.91
+//!          376 - 442                      ×0.92
+//! ```
+//!
+//! So the crossover is around 50 evictions per 1000 lookups. A cache comfortably
+//! larger than the corpus in front of it stays below that and pays the 2% — at the
+//! default capacity most of our fixtures never evict at all. A cache that is
+//! actually working sits above it: a table smaller than the vocabulary it sees, or
+//! a long-lived process whose traffic keeps changing shape.
+//!
+//! # Where an evicted entry's space goes
+//!
+//! Whatever A had in the arenas is handed back when A is overwritten, and the
+//! next word of the same shape takes it. Runs are never moved and never
+//! rounded up, because there is a free list for every length a run can have
+//! (see [`Slab`], and [`MAX_LENGTH`] for why that is finite):
+//!
+//! ```text
+//!   the ids arena, just after A — which had 6 ids at offset 12 — was evicted
+//!
+//!     data  ┌─────┬────────────────────────────┬─────┐
+//!           │  …  │ A's 6 ids, at offset 12    │  …  │   nothing is moved
+//!           └─────┴────────────────────────────┴─────┘
+//!
+//!     free  len 6 → [ 12 ]   the next word with 6 ids is handed offset 12
+//!           len 8 → [ ]      one list per length, 0 … MAX_LENGTH
+//! ```
+//!
+//! So the arenas hold the live set rather than every word ever seen. Without
+//! reuse they could only grow, and reclaiming them would mean copying every live
+//! entry into a second buffer — twice the memory for the same number of entries.
+//!
+//! # Why open addressing, and not fixed buckets
+//!
+//! The previous version of this cache was 4-way set-associative: the table was
+//! cut into buckets of four slots and a word could only live in the one bucket
+//! its hash picked. That is a single load per lookup and easy to reason about,
+//! but a word whose four slots are taken can never be cached at all, however
+//! empty the rest of the table is:
+//!
+//! ```text
+//!   4-way buckets — a word belongs to exactly one bucket of four
+//!
+//!     bucket 0        bucket 1        bucket 2
+//!     │●│●│●│●│       │●│·│·│·│       │·│·│·│·│
+//!      ▲
+//!      └ full, so this word goes uncached — the free slots one
+//!        bucket over may as well not exist
+//!
+//!   open addressing — the word walks on to the next free slot
+//!
+//!     │●│●│●│●│·│·│·│·│·│·│·│·│·│·│·│·│
+//!      ▲       ▲
+//!      home    └ stored here instead; only WINDOW slots taken in a
+//!                row can turn a word away
+//! ```
+//!
+//! With buckets that small, being locked out starts happening long before the
+//! table is genuinely full. On our multilingual fixtures it cost between 0.1% and
+//! 4% of all lookups, worst on Korean and Chinese, where a document holds far
+//! more distinct words.
+//!
+//! Probing a window closed that gap: on the same fixtures the misses went to ~0,
+//! and in the encoder (`examples/fixture_bench.rs`) the many-distinct-word
+//! scripts spent 10-40% less time in the model stage. English and code came out
+//! inside the noise —
+//! and the noise there is wide: running one binary against *itself* swings the
+//! model stage by ±30%, so measure that floor before believing anything smaller.
+//!
+//! # Why not a `HashMap`
+//!
+//! The legacy BPE model in `model.rs` caches in a thread-local
+//! `AHashMap<String, Word>` (`BPE_LOCAL_CACHE`), so the comparison is concrete.
+//! On a warm benchmark, where every word is already in the map, a hash map is
+//! not far off this table — it has no bucket conflicts either. What it cannot do
+//! is the rest of the job:
+//!
+//! - **Every word it accepts goes to the allocator.** The map owns its keys, so
+//!   an accepted word is copied into a fresh `String`, and each value keeps a
+//!   heap buffer of its own alive. That cost lands on misses, which is where a
+//!   cache can least afford it: a word misses the first time it is ever seen.
+//!   Here an insert writes into space that already exists.
+//! - **A hit is two more random loads.** The key bytes and the value both live
+//!   in their own heap blocks, elsewhere in memory from the table that pointed
+//!   at them. A slot here answers the common word out of the 32 bytes the probe
+//!   has already read.
+//! - **It cannot make room.** A `HashMap` grows until something stops it, and
+//!   the only thing it can do when stopped is refuse: the legacy cache inserts
+//!   `while local.len() < capacity`, so the words from the first pages of text
+//!   keep their places forever, however useless they turn out to be. Choosing
+//!   *which* entry to drop needs evidence about how much each one is used, and
+//!   somewhere to keep it — the frequency byte beside every slot.
+//! - **Entries cost more than twice the memory.** 24 bytes for the `String` and
+//!   24 for the value's vector inside the table, before the two heap blocks they
+//!   point at, against 32 bytes here for the common word.
+//!
+//! A *shared* map costs more again: [`crate::utils::cache::Cache`], which the
+//! Unigram model still uses, wraps one in an `RwLock` and then has to
+//! `try_read`/`try_write` and silently drop the read or the write whenever
+//! another thread holds it.
 
 use ahash::RandomState;
 
-use crate::utils::cache::MAX_LENGTH;
+/// Longest word the cache will store, in bytes.
+///
+/// Long words are rare and rarely repeat, so storing them buys little, and the
+/// lookup for one is a hash over every byte to learn nothing. The cap is also
+/// what makes the arenas' free lists possible (one list per length) and what
+/// bounds a run's size at all: a tokenizer with no pre-tokenizer hands this
+/// model whole documents as single "words", and uncapped the cache would
+/// cheerfully memoize documents.
+const MAX_LENGTH: usize = 1024;
+/// Slots searched from a word's home position. Linear probing normally settles
+/// in one or two, but the walk has to stop somewhere: nothing is ever removed,
+/// so a saturated table would otherwise scan forever looking for an empty slot.
+const WINDOW: usize = 16;
+/// Ids carried in the slot itself — three `u32`s is what fits beside the key.
+/// Enough for 80-96% of lookups on English or code, but only about a quarter of
+/// them on Chinese or Korean, where a vocabulary holding none of those scripts
+/// spends ten ids or more on one word. `examples/cache_freq_bench.rs --lengths`
+/// prints the distribution per model and corpus.
+const INLINE_IDS: usize = 3;
+/// `len` marker for an entry whose ids, and possibly whose bytes, are in the
+/// arenas.
+const SPILLED: u8 = u8::MAX;
+/// Set in `key` when it holds the hash of a long word instead of the word
+/// itself. Packed keys carry their length (1..=15) in the top byte, so a hashed
+/// key can never be mistaken for a packed one, and neither can be 0 — the
+/// empty-slot marker.
+const LONG_TAG: u128 = 1 << 127;
+/// A `freqs` entry for a slot nothing has been stored in yet. Live entries are at
+/// least [`NEWBORN`], so the one array answers both "is this slot free?" and "how
+/// much is this entry being used?" — see [`WordCache::pick_slot`].
+const FREE: u8 = 0;
+/// Where a new entry's frequency starts: on probation, but not free.
+const NEWBORN: u8 = 1;
 
-const WAYS: usize = 4;
+/// A word of 1..=15 bytes packed into a `u128`: bytes in the low lanes, length
+/// in the top byte. Including the length keeps `"a"` and `"a\0"` apart, and the
+/// whole key comparison becomes one register-wide equality instead of a
+/// `memcmp` against bytes somewhere else in memory.
+///
+/// `head` is 16 bytes starting where the word does, which callers that know what
+/// surrounds the word can hand over — see `Split::head`. Taking the whole window
+/// and masking the surplus off costs one load, where copying just the word's own
+/// bytes costs a call into `memcpy`: its length is only known at run time, and
+/// LLVM can fold a copy into a load only when the length is a constant. That one
+/// call was about a third of what building a key cost.
+fn pack_word(word: &[u8], head: Option<&[u8; 16]>) -> Option<u128> {
+    let len = word.len();
+    if len == 0 || len > 15 {
+        return None;
+    }
+    debug_assert!(
+        head.is_none_or(|head| head[..len] == *word),
+        "head has to start where the word does"
+    );
+    let lanes = match head {
+        Some(head) => u128::from_le_bytes(*head),
+        None => {
+            let mut lanes = [0u8; 16];
+            lanes[..len].copy_from_slice(word);
+            u128::from_le_bytes(lanes)
+        }
+    };
+    Some((lanes & (u128::MAX >> (8 * (16 - len)))) | ((len as u128) << 120))
+}
 
+/// One entry, in the three shapes the module docs draw out. In short:
+///
+/// - `key` is the word itself when it fits in 15 bytes, otherwise its hash with
+///   [`LONG_TAG`] set.
+/// - `payload` is the token ids while `len` counts them, and becomes
+///   `[key_off, ids_off, ids_len]` once `len` is [`SPILLED`] — which is what the
+///   `key_off`/`ids_off`/`ids_len` readers below are for.
+/// - `key_len` is 0 unless the word's bytes went to `key_bytes`, so it doubles as
+///   "does a matching `key` need confirming?".
+///
+/// How much an entry is used is *not* here — it lives in `WordCache::freqs`, for
+/// the reasons the module docs give. The byte it left behind cannot be spent on
+/// anything: `key`'s 16-byte alignment fixes the slot at 32 bytes, and a fourth
+/// inline id would need four. That the size is 32 is the point of the layout —
+/// a hit reads the key, the ids and the bookkeeping in one go.
 #[derive(Clone, Copy, Default)]
-struct CacheSlot {
-    tag: u32,
-    key_off: u32,
-    ids_off: u32,
+#[repr(C)]
+struct Slot {
+    key: u128,
+    payload: [u32; INLINE_IDS],
+    len: u8,
+    _pad: u8,
     key_len: u16,
-    ids_len: u16,
 }
 
-#[derive(Clone, Copy, Default)]
-#[repr(align(64))]
-struct Bucket([CacheSlot; WAYS]);
+const _: () = assert!(std::mem::size_of::<Slot>() == 32);
 
-impl CacheSlot {
-    fn id_range(&self) -> Range<usize> {
-        self.ids_off as usize..(self.ids_off as usize + self.ids_len as usize)
+impl Slot {
+    fn is_empty(&self) -> bool {
+        self.key == 0
     }
 
-    fn key_range(&self) -> Range<usize> {
-        self.key_off as usize..(self.key_off as usize + self.key_len as usize)
+    fn spilled(&self) -> bool {
+        self.len == SPILLED
+    }
+
+    fn key_off(&self) -> u32 {
+        self.payload[0]
+    }
+
+    fn ids_off(&self) -> u32 {
+        self.payload[1]
+    }
+
+    fn ids_len(&self) -> usize {
+        self.payload[2] as usize
     }
 }
 
+/// A grow-only arena that reuses the space of evicted entries instead of
+/// compacting.
+///
+/// Freed runs go on a free list per exact length. That is only practical because
+/// `MAX_LENGTH` bounds every run: there is a list for every length a run can
+/// have, so a freed run is always reusable by the next word of the same shape
+/// and no length is ever rounded up to a bigger class. The price is
+/// `MAX_LENGTH + 1` empty `Vec`s per arena.
+struct Slab<T> {
+    data: Vec<T>,
+    free: Box<[Vec<u32>]>,
+    /// Ceiling on `data`, not a reservation.
+    budget: usize,
+}
+
+impl<T: Copy + Default> Slab<T> {
+    fn new(budget: usize) -> Self {
+        Self {
+            data: Vec::new(),
+            free: (0..=MAX_LENGTH).map(|_| Vec::new()).collect(),
+            budget,
+        }
+    }
+
+    /// A run of `len` items, or `None` once the budget is spent.
+    fn alloc(&mut self, len: usize) -> Option<u32> {
+        if let Some(off) = self.free[len].pop() {
+            return Some(off);
+        }
+        if self.data.len() + len > self.budget {
+            return None;
+        }
+        let off = self.data.len() as u32;
+        self.data.resize(self.data.len() + len, T::default());
+        Some(off)
+    }
+
+    fn release(&mut self, off: u32, len: usize) {
+        self.free[len].push(off);
+    }
+
+    fn get(&self, off: u32, len: usize) -> &[T] {
+        &self.data[off as usize..off as usize + len]
+    }
+
+    fn fill(&mut self, off: u32, len: usize, values: impl Iterator<Item = T>) {
+        for (dst, value) in self.data[off as usize..off as usize + len]
+            .iter_mut()
+            .zip(values)
+        {
+            *dst = value;
+        }
+    }
+}
+
+/// Word bytes to token ids. See the module docs for the design.
 pub struct WordCache {
     hasher: RandomState,
-    buckets: Box<[Bucket]>,
-    key_bytes: Vec<u8>,
-    ids: Vec<u32>,
-    bucket_mask: u64,
+    slots: Box<[Slot]>,
+    key_bytes: Slab<u8>,
+    ids: Slab<u32>,
+    /// How much each slot is being used, one byte per slot, [`FREE`] while the
+    /// slot has never been written. Outside the slots so that a whole window's
+    /// worth is 16 consecutive bytes — see [`WordCache::pick_slot`].
+    freqs: Box<[u8]>,
+    /// `slots.len() - 1`. The table is a power of two, so this folds a hash into
+    /// a slot index.
+    mask: usize,
 }
 
 impl WordCache {
     pub fn new(capacity: usize) -> Self {
-        let n_buckets = (capacity.next_power_of_two() / WAYS).max(1);
+        let n_slots = capacity.next_power_of_two().max(WINDOW);
         Self {
             hasher: RandomState::new(),
-            buckets: vec![Bucket::default(); n_buckets].into_boxed_slice(),
-            ids: Vec::with_capacity(256),
-            key_bytes: Vec::with_capacity(1024),
-            bucket_mask: (n_buckets as u64) - 1,
+            slots: vec![Slot::default(); n_slots].into_boxed_slice(),
+            // Ceilings, not reservations: the arenas grow only as far as the live
+            // set takes them. Deliberately generous, so that the slot table is
+            // what runs out first — an arena that turns inserts away while slots
+            // sit empty is a capacity limit in disguise, and tighter numbers here
+            // measured exactly that (tens of thousands of words refused at 35%
+            // occupancy). The worst case they have to cover is a vocabulary with
+            // no CJK in it, which spends ~17 ids on a single Chinese word.
+            key_bytes: Slab::new(n_slots * 48),
+            ids: Slab::new(n_slots * 16),
+            freqs: vec![FREE; n_slots].into_boxed_slice(),
+            mask: n_slots - 1,
         }
     }
 
-    // The low hash bits pick the bucket index, the high bits form the occupancy tag
-    // 0x0 tag is reserved for empty spots (hence the `| 1`)
-    fn locate(&self, key: &[u8]) -> (usize, u32) {
-        let hash = self.hasher.hash_one(key);
-        ((hash & self.bucket_mask) as usize, (hash >> 32) as u32 | 1)
-    }
-
-    pub fn get(&self, key: &[u8]) -> Option<&[u32]> {
-        if key.len() > MAX_LENGTH {
+    /// The ids `word` encoded to last time, if the entry is still there.
+    ///
+    /// `head` is the window `pack_word` builds the key from, and passing `None`
+    /// only costs speed. Takes `&mut self` because a hit is also a vote for keeping
+    /// the entry.
+    pub fn get(&mut self, word: &[u8], head: Option<&[u8; 16]>) -> Option<&[u32]> {
+        if word.len() > MAX_LENGTH {
             return None;
         }
-        let (bucket_idx, tag) = self.locate(key);
-        for slot in &self.buckets[bucket_idx].0 {
-            if slot.tag == tag && key == &self.key_bytes[slot.key_range()] {
-                return Some(&self.ids[slot.id_range()]);
+        let (key, hash) = self.slot_key(word, head);
+        let index = self.find(key, hash, word)?;
+        self.freqs[index] = self.freqs[index].saturating_add(1);
+        let slot = self.slots[index];
+        if slot.spilled() {
+            return Some(self.ids.get(slot.ids_off(), slot.ids_len()));
+        }
+        Some(&self.slots[index].payload[..slot.len as usize])
+    }
+
+    /// Remember what `word` encoded to. Silently does nothing for a word over
+    /// [`MAX_LENGTH`] or when an arena is full: a cache is free to forget, and
+    /// the caller has the ids either way.
+    pub fn insert(
+        &mut self,
+        word: &[u8],
+        head: Option<&[u8; 16]>,
+        ids: impl ExactSizeIterator<Item = u32>,
+    ) {
+        if word.len() > MAX_LENGTH {
+            return;
+        }
+        let (key, hash) = self.slot_key(word, head);
+        // Callers insert after a miss, so there is no existing entry to update.
+        let Some(entry) = self.build_entry(key, word, ids) else {
+            return;
+        };
+        let index = self.pick_slot(hash);
+        self.reclaim(index);
+        self.slots[index] = entry;
+        // Both writes or neither: a slot is occupied exactly when its frequency is
+        // above [`FREE`], and `pick_slot` reads emptiness out of `freqs` alone.
+        self.freqs[index] = NEWBORN;
+    }
+
+    /// The value a slot stores in its `key`, and the hash that places it. A short
+    /// word is its own key; a longer one keys on a tagged hash and has to be
+    /// confirmed against `key_bytes`, since two long words can hash alike.
+    ///
+    /// A packed key is hashed as one `u128`, not as the word's bytes it was built
+    /// from. Hashing a slice makes aHash mix the length in and then branch on it to
+    /// choose a read width; a `u128` is one fixed-width fold with nothing to decide.
+    /// The key already carries the length, so nothing is lost.
+    fn slot_key(&self, word: &[u8], head: Option<&[u8; 16]>) -> (u128, u64) {
+        match pack_word(word, head) {
+            Some(packed) => (packed, self.hasher.hash_one(packed)),
+            None => {
+                let hash = self.hasher.hash_one(word);
+                ((hash as u128) | LONG_TAG, hash)
+            }
+        }
+    }
+
+    /// The slot holding `word`, searched from its home position. Stopping at the
+    /// first empty slot is safe because slots never go back to being empty: an
+    /// empty one means the word was never stored.
+    fn find(&self, key: u128, hash: u64, word: &[u8]) -> Option<usize> {
+        for step in 0..WINDOW {
+            let index = (hash as usize + step) & self.mask;
+            let slot = &self.slots[index];
+            if slot.is_empty() {
+                return None;
+            }
+            if slot.key == key && self.holds_word(slot, word) {
+                return Some(index);
             }
         }
         None
     }
 
-    pub fn insert(&mut self, key: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
-        if key.len() > MAX_LENGTH {
+    /// Whether the entry really is `word`'s. A packed key is the word itself and
+    /// needs nothing further; a hashed one is only as good as its bytes.
+    fn holds_word(&self, slot: &Slot, word: &[u8]) -> bool {
+        slot.key_len == 0 || self.key_bytes.get(slot.key_off(), slot.key_len as usize) == word
+    }
+
+    /// The entry to store, with whatever does not fit in a slot copied into the
+    /// arenas. `None` when an arena is full, so a rejected insert leaves the
+    /// table and the arenas exactly as they were.
+    fn build_entry(
+        &mut self,
+        key: u128,
+        word: &[u8],
+        ids: impl ExactSizeIterator<Item = u32>,
+    ) -> Option<Slot> {
+        let long = key & LONG_TAG != 0;
+        let ids_len = ids.len();
+        if !long && ids_len <= INLINE_IDS {
+            let mut payload = [0u32; INLINE_IDS];
+            for (dst, id) in payload.iter_mut().zip(ids) {
+                *dst = id;
+            }
+            return Some(Slot {
+                key,
+                payload,
+                len: ids_len as u8,
+                _pad: 0,
+                key_len: 0,
+            });
+        }
+        // A short word stays in the key, which is a zero-length run here.
+        let key_len = if long { word.len() } else { 0 };
+        let key_off = self.key_bytes.alloc(key_len)?;
+        let Some(ids_off) = self.ids.alloc(ids_len) else {
+            self.key_bytes.release(key_off, key_len);
+            return None;
+        };
+        self.key_bytes.fill(key_off, key_len, word.iter().copied());
+        self.ids.fill(ids_off, ids_len, ids);
+        Some(Slot {
+            key,
+            payload: [key_off, ids_off, ids_len as u32],
+            len: SPILLED,
+            _pad: 0,
+            key_len: key_len as u16,
+        })
+    }
+
+    /// The slot the next entry goes in: the first free one in the window, or the
+    /// coldest one if they are all taken.
+    ///
+    /// `#[inline]` because this and [`WordCache::reclaim`] exist to give the steps
+    /// of `insert` names, not to be called: left out of line they cost `insert` two
+    /// calls and the pointers it had already loaded.
+    ///
+    /// This reads nothing but `freqs`, which is why the frequencies live outside
+    /// the slots. A window's worth of them is 16 consecutive bytes, so the whole
+    /// decision is a 16-byte load, a vector minimum, and — when the window is full
+    /// — a vector shift to age it. Reading a `freq` out of each slot instead would
+    /// mean 16 strided reads over 8 cache lines. Both jobs come out of the one
+    /// array because [`FREE`] is a frequency no live entry can have.
+    #[inline]
+    fn pick_slot(&mut self, hash: u64) -> usize {
+        let home = hash as usize & self.mask;
+        let Some(&window) = self.freqs[home..].first_chunk::<WINDOW>() else {
+            return self.pick_slot_wrapping(home);
+        };
+        let coldest = window.iter().copied().min().unwrap_or(FREE);
+        let offset = window.iter().position(|&freq| freq == coldest).unwrap_or(0);
+        if coldest == FREE {
+            return home + offset;
+        }
+        // Age the window on the way past: every entry in it now has to be used
+        // again before the next word arrives here, or become the next victim. The
+        // floor keeps them all distinguishable from a free slot.
+        for freq in &mut self.freqs[home..home + WINDOW] {
+            *freq = (*freq >> 1).max(NEWBORN);
+        }
+        home + offset
+    }
+
+    /// [`WordCache::pick_slot`] for the one home in `mask + 1` whose window runs
+    /// off the end of the table: same policy, read one slot at a time, because the
+    /// frequencies are not contiguous there.
+    #[inline]
+    fn pick_slot_wrapping(&mut self, home: usize) -> usize {
+        // Seeded at `home` rather than 0 so that a window whose entries have all
+        // reached the maximum frequency still evicts one of its own.
+        let mut coldest = (u8::MAX, home);
+        for step in 0..WINDOW {
+            let index = (home + step) & self.mask;
+            let freq = self.freqs[index];
+            if freq == FREE {
+                return index;
+            }
+            if freq < coldest.0 {
+                coldest = (freq, index);
+            }
+        }
+        for step in 0..WINDOW {
+            let freq = &mut self.freqs[(home + step) & self.mask];
+            *freq = (*freq >> 1).max(NEWBORN);
+        }
+        coldest.1
+    }
+
+    /// Hand an overwritten entry's arena runs back, so the next entry can use
+    /// them.
+    #[inline]
+    fn reclaim(&mut self, index: usize) {
+        let slot = self.slots[index];
+        if !slot.spilled() {
             return;
         }
-        let (bucket_idx, tag) = self.locate(key);
-        let Some(slot) = self.buckets[bucket_idx]
-            .0
-            .iter()
-            .position(|slot| slot.tag == 0)
-        else {
-            // bucket full: skip insert
-            return;
-        };
-        self.buckets[bucket_idx].0[slot] = CacheSlot {
-            tag,
-            key_off: self.key_bytes.len() as u32,
-            key_len: key.len() as u16,
-            ids_off: self.ids.len() as u32,
-            ids_len: ids.len() as u16,
-        };
-        self.key_bytes.extend_from_slice(key);
-        self.ids.extend(ids);
+        self.key_bytes
+            .release(slot.key_off(), slot.key_len as usize);
+        self.ids.release(slot.ids_off(), slot.ids_len());
     }
 }
 
@@ -101,34 +660,223 @@ mod tests {
     #[test]
     fn roundtrip() {
         let mut cache = WordCache::new(1 << 8);
-        assert_eq!(cache.get(b"hello"), None);
-        cache.insert(b"hello", [1u32, 2, 3].into_iter());
-        cache.insert(b"world", [4u32].into_iter());
-        assert_eq!(cache.get(b"hello"), Some(&[1u32, 2, 3][..]));
-        assert_eq!(cache.get(b"world"), Some(&[4u32][..]));
-        assert_eq!(cache.get(b"hell"), None);
+        assert_eq!(cache.get(b"hello", None), None);
+        cache.insert(b"hello", None, [1u32, 2, 3].into_iter());
+        cache.insert(b"world", None, [4u32].into_iter());
+        assert_eq!(cache.get(b"hello", None), Some(&[1u32, 2, 3][..]));
+        assert_eq!(cache.get(b"world", None), Some(&[4u32][..]));
+        assert_eq!(cache.get(b"hell", None), None);
+    }
+
+    /// The three properties the whole key encoding rests on: a packed key is
+    /// unique per word, is never `0` (the empty-slot marker), and never looks
+    /// like a hashed key.
+    #[test]
+    fn packed_keys_are_unique_and_tagged() {
+        assert_ne!(pack_word(b"a", None), pack_word(b"a\0", None));
+        assert_ne!(pack_word(&[0u8; 15], None), Some(0));
+        assert_eq!(pack_word(&[0u8; 15], None).unwrap() & LONG_TAG, 0);
+        assert_eq!(pack_word(b"", None), None);
+        assert_eq!(pack_word(&[b'x'; 16], None), None);
+    }
+
+    /// The window is a shortcut for reading the word, not part of what is stored:
+    /// the bytes it carries past the word belong to the neighbours and have to be
+    /// masked away. If any of them survived into the key, a word looked up with a
+    /// window would miss the entry stored without one — and every hit in a real
+    /// encode would depend on where in its chunk the word happened to sit.
+    #[test]
+    fn the_window_past_the_word_is_masked_off() {
+        let chunk = b"the quick brown fox jumps over the lazy dog";
+        let mut cache = WordCache::new(1 << 8);
+        for (start, len) in [(0usize, 3usize), (4, 5), (10, 5), (16, 3), (26, 4)] {
+            let word = &chunk[start..start + len];
+            let head: &[u8; 16] = chunk[start..start + 16].try_into().unwrap();
+            assert_eq!(
+                cache.slot_key(word, None),
+                cache.slot_key(word, Some(head)),
+                "{word:?}"
+            );
+            cache.insert(word, None, [start as u32].into_iter());
+            assert_eq!(cache.get(word, Some(head)), Some(&[start as u32][..]));
+        }
+    }
+
+    /// A short word's placement now comes out of its packed key rather than its
+    /// bytes, which leaves the hash doing all of the mixing. Words that differ in
+    /// one byte pack to keys that differ in one byte, so an index taken from those
+    /// bits as they are — `packed as u64` — drops most of these on one slot.
+    #[test]
+    fn short_words_spread_across_the_table() {
+        let cache = WordCache::new(1 << 12);
+        let homes: std::collections::HashSet<usize> = (0..1000)
+            .map(|i| {
+                let (_, hash) = cache.slot_key(format!("tok{i}").as_bytes(), None);
+                hash as usize & cache.mask
+            })
+            .collect();
+        // 1000 words over 4096 slots share homes by chance alone; ~887 distinct is
+        // as good as a perfect hash gets, so the floor is well under it.
+        assert!(homes.len() > 820, "only {} distinct homes", homes.len());
     }
 
     #[test]
-    fn single_bucket_holds_ways_entries_then_freezes() {
-        // capacity <= WAYS collapses to one bucket, making conflicts deterministic
-        let mut cache = WordCache::new(1);
-        let keys: Vec<Vec<u8>> = (0..WAYS as u8 + 2).map(|i| vec![i; 3]).collect();
-        for (i, key) in keys.iter().enumerate() {
-            cache.insert(key, [i as u32].into_iter());
-        }
-        let cached = keys.iter().filter(|k| cache.get(k).is_some()).count();
-        assert_eq!(cached, WAYS);
-        for (i, key) in keys.iter().enumerate().take(WAYS) {
-            assert_eq!(cache.get(key), Some(&[i as u32][..]));
-        }
-    }
-
-    #[test]
-    fn oversized_keys_are_ignored() {
+    fn oversized_words_are_ignored() {
         let mut cache = WordCache::new(1 << 8);
         let big = vec![7u8; MAX_LENGTH + 1];
-        cache.insert(&big, [1u32].into_iter());
-        assert_eq!(cache.get(&big), None);
+        cache.insert(&big, None, [1u32].into_iter());
+        assert_eq!(cache.get(&big, None), None);
+    }
+
+    /// Both sides of the 15-byte packing boundary and both sides of the inline/
+    /// arena boundary have to survive a round trip, including the long word whose
+    /// stored `key` is only a hash and needs the byte comparison to confirm it.
+    #[test]
+    fn every_slot_shape_round_trips() {
+        let mut cache = WordCache::new(1 << 8);
+        let long = vec![b'x'; 200];
+        let cases: [(&[u8], Vec<u32>); 6] = [
+            (b"short", vec![1]),
+            (b"short-wide", (0..40).collect()),
+            (b"fifteen-bytes.", vec![2]),
+            (b"sixteen-bytes.aa", vec![3]),
+            (&long, vec![9]),
+            (&long[..64], (0..64).collect()),
+        ];
+        for (word, ids) in &cases {
+            cache.insert(word, None, ids.clone().into_iter());
+        }
+        for (word, ids) in &cases {
+            assert_eq!(cache.get(word, None), Some(&ids[..]), "{word:?}");
+        }
+    }
+
+    /// Two long words can hash to the same key, and then only their bytes tell
+    /// them apart. Real hash collisions are too rare to write a test around, so
+    /// forge one: park another word's entry on this word's home slot and stamp
+    /// this word's key on it. The lookup has to walk past it.
+    #[test]
+    fn a_hashed_key_is_confirmed_against_the_word_bytes() {
+        let mut cache = WordCache::new(1 << 8);
+        let mine = vec![b'a'; 40];
+        let theirs = vec![b'b'; 40];
+
+        cache.insert(&theirs, None, [7u32].into_iter());
+        let (their_key, their_hash) = cache.slot_key(&theirs, None);
+        let their_slot = cache.slots[cache.find(their_key, their_hash, &theirs).unwrap()];
+        let (my_key, my_hash) = cache.slot_key(&mine, None);
+        cache.slots[my_hash as usize & cache.mask] = Slot {
+            key: my_key,
+            ..their_slot
+        };
+
+        cache.insert(&mine, None, [1u32, 2].into_iter());
+        assert_eq!(cache.get(&mine, None), Some(&[1u32, 2][..]));
+    }
+
+    /// A word that hashes into a full window takes the coldest slot rather than
+    /// being turned away, and the words that were actually used keep their place.
+    #[test]
+    fn a_full_window_evicts_its_coldest_entry() {
+        let mut cache = WordCache::new(WINDOW);
+        let words: Vec<Vec<u8>> = (0..WINDOW as u8).map(|i| vec![i; 4]).collect();
+        for (i, word) in words.iter().enumerate() {
+            cache.insert(word, None, [i as u32].into_iter());
+        }
+        // Every word but the first earns a hit, leaving one clear coldest slot.
+        for word in &words[1..] {
+            assert!(cache.get(word, None).is_some());
+        }
+        cache.insert(b"newcomer", None, [999u32].into_iter());
+        assert_eq!(cache.get(b"newcomer", None), Some(&[999u32][..]));
+        assert_eq!(
+            cache.get(&words[0], None),
+            None,
+            "the unused entry should have gone"
+        );
+        for (i, word) in words.iter().enumerate().skip(1) {
+            assert_eq!(
+                cache.get(word, None),
+                Some(&[i as u32][..]),
+                "used entry {i} was dropped"
+            );
+        }
+    }
+
+    /// Reusing an evicted entry's arena run is where this design can go wrong:
+    /// hand one run to two live entries and a hit starts returning another word's
+    /// ids. Churn a table far too small for the input and demand the invariant
+    /// that matters — an entry may be evicted, but a hit is never wrong.
+    #[test]
+    fn a_hit_never_returns_another_words_ids() {
+        let mut cache = WordCache::new(64);
+        let mut expected: Vec<(Vec<u8>, Vec<u32>)> = Vec::new();
+        for i in 0..2000usize {
+            let word = match i % 4 {
+                0 => format!("w{i}"),
+                1 => format!("a-long-word-past-fifteen-bytes-{i}"),
+                2 => format!("k{i}xxxxxxxxxxxx"),
+                _ => format!("{}-{i}", "z".repeat(i % 40)),
+            }
+            .into_bytes();
+            let ids: Vec<u32> = (0..=(i % 9) as u32).map(|k| i as u32 * 16 + k).collect();
+            cache.insert(&word, None, ids.clone().into_iter());
+            expected.push((word, ids));
+        }
+        let mut live = 0;
+        for (word, ids) in &expected {
+            if let Some(hit) = cache.get(word, None) {
+                assert_eq!(hit, &ids[..], "{word:?}");
+                live += 1;
+            }
+        }
+        assert!(live > 0, "everything was evicted — the test proves nothing");
+    }
+
+    /// `find` reads emptiness off the slot's key and `pick_slot` reads it off the
+    /// frequency, so the two have to agree about every slot, always. They only can
+    /// if `insert` writes both and the aging never lets a live entry reach
+    /// [`FREE`].
+    #[test]
+    fn occupancy_agrees_between_slots_and_frequencies() {
+        let mut cache = WordCache::new(64);
+        for i in 0..2000usize {
+            let word = format!("word-{i}-{}", "x".repeat(i % 20));
+            cache.insert(word.as_bytes(), None, [i as u32, 7].into_iter());
+            cache.get(word.as_bytes(), None);
+        }
+        assert!(
+            cache.freqs.iter().any(|&freq| freq != FREE),
+            "nothing was stored — the test proves nothing"
+        );
+        for (index, slot) in cache.slots.iter().enumerate() {
+            assert_eq!(
+                slot.is_empty(),
+                cache.freqs[index] == FREE,
+                "slot {index} and its frequency disagree"
+            );
+        }
+    }
+
+    /// Freed runs have to come back. Without reuse the arenas grow with every
+    /// insert until their budget is spent, and from then on the cache silently
+    /// stops accepting words even though the table has room for them.
+    #[test]
+    fn arenas_hold_the_live_set_not_every_insert() {
+        let mut cache = WordCache::new(64);
+        // Same length every time, so one free list serves every word and the
+        // bounds below are exact: 64 slots, plus the run reserved for the insert
+        // in flight before the entry it replaces gives its own run back.
+        let word = |i: usize| format!("a-long-word-past-fifteen-bytes-{i:04}");
+        for i in 0..5000usize {
+            cache.insert(word(i).as_bytes(), None, [i as u32; 8].into_iter());
+        }
+        assert_eq!(
+            cache.get(word(4999).as_bytes(), None),
+            Some(&[4999u32; 8][..]),
+            "inserts stopped landing — the arenas ran out"
+        );
+        assert!(cache.key_bytes.data.len() <= 65 * 35);
+        assert!(cache.ids.data.len() <= 65 * 8);
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -39,14 +39,14 @@ impl WordCache {
         Self {
             hasher: RandomState::new(),
             slots: vec![CacheSlot::default(); CAPACITY].into_boxed_slice(),
-            ids: Vec::with_capacity(CAPACITY * MAX_LENGTH),
-            key_bytes: Vec::with_capacity(CAPACITY * MAX_LENGTH),
+            ids: Vec::with_capacity(256),
+            key_bytes: Vec::with_capacity(1024),
             slot_mask: MASK,
         }
     }
 
     pub fn get(&self, key: &[u8]) -> Option<&[u32]> {
-        let hash = self.hasher.hash_one(key);
+        let hash = self.hasher.hash_one(key) | 1;
         let slot = self.slots[(hash & self.slot_mask) as usize];
         if hash != slot.hash {
             return None;
@@ -61,12 +61,11 @@ impl WordCache {
         if key.len() > MAX_LENGTH {
             return;
         }
-        let hash = self.hasher.hash_one(key);
+        let hash = self.hasher.hash_one(key) | 1;
         let slot_idx = (hash & self.slot_mask) as usize;
 
         if self.slots[slot_idx].hash != 0 {
             // slot already taken: skip insert
-            // caveat: a key whose hash lower bits resolves to 0 never gets cached
             return;
         }
         let key_offsets = (self.key_bytes.len() as u32, key.len() as u16);

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -50,7 +50,7 @@ impl WordCache {
     }
 
     // The low hash bits pick the bucket index, the high bits form the occupancy tag
-	// 0x0 tag is reserved for empty spots (hence the `| 1`)
+    // 0x0 tag is reserved for empty spots (hence the `| 1`)
     fn locate(&self, key: &[u8]) -> (usize, u32) {
         let hash = self.hasher.hash_one(key);
         ((hash & self.bucket_mask) as usize, (hash >> 32) as u32 | 1)

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -505,7 +505,12 @@ impl Model for Unigram {
 
 pub struct UnigramScratch {}
 
-impl pipeline::ModelScratch for UnigramScratch {}
+impl pipeline::ModelScratch for UnigramScratch {
+    fn clear(&mut self) {
+        // Using this syntax so adding fields to Unigram would trigger a compile error
+        let Self {} = self;
+    }
+}
 
 impl pipeline::Model for Unigram {
     type Scratch = UnigramScratch;

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -522,11 +522,11 @@ impl pipeline::Model for Unigram {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         _scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
-        let str_tokens = self.encode(sequence)?;
+        let str_tokens = self.encode(split.as_str())?;
 
         for string in str_tokens {
             match self.token_to_ids.token_to_id(&string) {

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -503,6 +503,7 @@ impl Model for Unigram {
     }
 }
 
+#[derive(Default)]
 pub struct UnigramScratch {}
 
 impl pipeline::ModelScratch for UnigramScratch {

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -208,7 +208,12 @@ impl Model for WordLevel {
 }
 
 type WordLevelScratch = ();
-impl ModelScratch for WordLevelScratch {}
+
+impl ModelScratch for WordLevelScratch {
+    fn clear(&mut self) {
+        // noop: wordlevel does not have a scratch
+    }
+}
 
 impl pipeline::Model for WordLevel {
     type Scratch = WordLevelScratch;

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -220,11 +220,11 @@ impl pipeline::Model for WordLevel {
     fn init_scratch(&self) -> Self::Scratch {}
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         _scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
-        if let Some(&id) = self.vocab.get(sequence) {
+        if let Some(&id) = self.vocab.get(split.as_str()) {
             output.push(PipelineToken { id })
         } else if let Some(&unk_id) = self.vocab.get(&self.unk_token) {
             output.push(PipelineToken { id: unk_id });

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -318,7 +318,12 @@ pub struct WordPieceScratch {
     candidate_str: String,
 }
 
-impl pipeline::ModelScratch for WordPieceScratch {}
+impl pipeline::ModelScratch for WordPieceScratch {
+    fn clear(&mut self) {
+        let Self { candidate_str } = self;
+        candidate_str.clear();
+    }
+}
 
 pub struct PipelineWordPiece {
     vocab_trie: yada::DoubleArray<Vec<u8>>,

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -370,10 +370,11 @@ impl pipeline::Model for PipelineWordPiece {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
+        let sequence = split.as_str();
         let checkpoint = output.len();
         let candidate = &mut scratch.candidate_str;
 

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -314,6 +314,7 @@ impl Model for WordPiece {
     }
 }
 
+#[derive(Default)]
 pub struct WordPieceScratch {
     candidate_str: String,
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
 use std::mem;
+use std::ops::Range;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::{borrow::Cow, convert::TryFrom};
 
@@ -702,7 +703,7 @@ impl PipelineTokenizer {
                                         // Tokenize each chunk
                                         for pre_token in pre_tokens.iter() {
                                             self.model.tokenize_pipeline(
-                                                &normalized_chunk[pre_token.range()],
+                                                Split::new(normalized_chunk, pre_token.range()),
                                                 scratch,
                                                 output,
                                             )?;
@@ -981,12 +982,62 @@ pub trait ModelScratch: Default {
     fn clear(&mut self);
 }
 
+/// One pre-token on its way to a model: the word to tokenize, plus the chunk of
+/// text it was split out of.
+///
+/// A model that only wants the word calls [`Split::as_str`] and is none the wiser.
+/// The chunk is carried for [`Split::head`], which hands out a fixed-size window
+/// of bytes starting at the word — the BPE word cache builds its key out of one,
+/// because copying a fixed number of bytes compiles to a load, where copying a
+/// number known only at run time is a call into `memcpy`.
+#[derive(Clone, Copy)]
+pub struct Split<'a> {
+    word: &'a str,
+    head: Option<&'a [u8; 16]>,
+}
+
+impl<'a> Split<'a> {
+    /// `range` is a byte range of `chunk`, the way a pre-tokenizer reports it.
+    pub fn new(chunk: &'a str, range: Range<usize>) -> Self {
+        Self {
+            word: &chunk[range.clone()],
+            head: chunk.as_bytes()[range.start..].first_chunk(),
+        }
+    }
+
+    pub fn as_str(&self) -> &'a str {
+        self.word
+    }
+
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.word.as_bytes()
+    }
+
+    /// The 16 bytes of the chunk that start where the word does. Anything past the
+    /// word's own length belongs to whatever follows it, so a caller has to know
+    /// how much of the window means something.
+    ///
+    /// `None` when the word starts within 16 bytes of the chunk's end and there is
+    /// nothing to read — at most one word per chunk.
+    pub fn head(&self) -> Option<&'a [u8; 16]> {
+        self.head
+    }
+}
+
+/// A bare word, with no chunk around it: there is a window only when the word is
+/// long enough to fill one on its own.
+impl<'a> From<&'a str> for Split<'a> {
+    fn from(word: &'a str) -> Self {
+        Self::new(word, 0..word.len())
+    }
+}
+
 pub trait Model {
     type Scratch: ModelScratch;
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()>;
@@ -1010,22 +1061,22 @@ impl Model for PipelineModel {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
         match (self, scratch) {
             (Self::BPE(model), PipelineModelScratch::BPE(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             (Self::Unigram(model), PipelineModelScratch::Unigram(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             (Self::WordLevel(model), PipelineModelScratch::WordLevel(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             _ => unreachable!(),
         }
@@ -1041,6 +1092,11 @@ impl Model for PipelineModel {
     }
 }
 
+// The BPE variant carries the word cache inline, making it much larger than the
+// others. Boxing it would put a pointer chase on the per-pre-token hot path to
+// save space in a struct that exists once per thread and is never moved after
+// the pool builds it.
+#[allow(clippy::large_enum_variant)]
 #[derive(Default)]
 pub enum PipelineModelScratch {
     BPE(BpeScratch),
@@ -1070,6 +1126,29 @@ mod tests {
     use crate::models::wordpiece::WordPiece;
     use crate::pre_tokenizers::byte_level::ByteLevel;
     use crate::pre_tokenizers::sequence::Sequence;
+
+    /// Everything the window is good for rests on it starting at the word's first
+    /// byte and staying inside the chunk. A window taken from the wrong offset
+    /// would silently key one word's cache entry on another word's bytes.
+    #[test]
+    fn a_splits_window_starts_at_the_word_and_stops_at_the_chunk() {
+        let chunk = "the quick brown fox jumps";
+        let word = Split::new(chunk, 4..9);
+        assert_eq!(word.as_str(), "quick");
+        assert_eq!(word.head(), Some(b"quick brown fox "));
+
+        // A word near the end has no window: 25 - 20 is under 16 bytes.
+        let last = Split::new(chunk, 20..25);
+        assert_eq!(last.as_str(), "jumps");
+        assert_eq!(last.head(), None);
+
+        // A bare word is its own chunk, so it only has a window if it fills one.
+        assert_eq!(Split::from("quick").head(), None);
+        assert_eq!(
+            Split::from("sixteen bytes ok").head(),
+            Some(b"sixteen bytes ok")
+        );
+    }
 
     struct FixedMatcher(Vec<((usize, usize), u32)>);
     impl PipelinePatternMatcher for FixedMatcher {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
-use std::sync::{Mutex, PoisonError};
+use std::mem;
+use std::sync::{Arc, Mutex, PoisonError};
 use std::{borrow::Cow, convert::TryFrom};
 
 use atomsplit::classify::classify;
@@ -396,22 +397,22 @@ pub struct PipelineTokenizer {
 }
 
 struct ScratchPool {
-    pool: Mutex<Vec<PipelineModelScratch>>,
+    pool: Arc<Mutex<Vec<PipelineModelScratch>>>,
 }
 
 impl ScratchPool {
     fn new() -> Self {
         Self {
-            pool: Mutex::new(Vec::new()),
+            pool: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
     fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
-        let maybe_scratch = self
-            .pool
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .pop(); // Release the lock
+        let maybe_scratch = {
+            let mut pool = self.pool.lock().unwrap_or_else(PoisonError::into_inner);
+            pool.pop()
+        };
+        // Lock is released here
 
         let scratch = maybe_scratch
             .map(|mut scratch| {
@@ -422,42 +423,39 @@ impl ScratchPool {
             .unwrap_or_else(|| model.init_scratch()); // If there is no scratch in the pool, init a fresh one
 
         ScratchGuard {
-            scratch: Some(scratch),
-            pool: self,
+            scratch,
+            scratch_pool: self,
         }
     }
 }
 
 /// RAAI guard for a scratch that adds it back to the pool whenever the scratch gets dropped
 struct ScratchGuard<'a> {
-    // Option so we can use `.take()` to reclaim ownership of the scratch
-    // to push it back to the pool
-    scratch: Option<PipelineModelScratch>,
-    pool: &'a ScratchPool,
+    scratch: PipelineModelScratch,
+    scratch_pool: &'a ScratchPool,
 }
 
 impl Drop for ScratchGuard<'_> {
     fn drop(&mut self) {
-        if let Some(scratch) = self.scratch.take() {
-            self.pool
-                .pool
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
-                .push(scratch);
-        }
+        let scratch = mem::take(&mut self.scratch);
+        self.scratch_pool
+            .pool
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(scratch);
     }
 }
 
 impl std::ops::Deref for ScratchGuard<'_> {
     type Target = PipelineModelScratch;
     fn deref(&self) -> &PipelineModelScratch {
-        self.scratch.as_ref().unwrap()
+        &self.scratch
     }
 }
 
 impl std::ops::DerefMut for ScratchGuard<'_> {
     fn deref_mut(&mut self) -> &mut PipelineModelScratch {
-        self.scratch.as_mut().unwrap()
+        &mut self.scratch
     }
 }
 
@@ -979,7 +977,7 @@ pub fn split_matches(
     }
 }
 
-pub trait ModelScratch {
+pub trait ModelScratch: Default {
     fn clear(&mut self);
 }
 
@@ -1043,11 +1041,14 @@ impl Model for PipelineModel {
     }
 }
 
+#[derive(Default)]
 pub enum PipelineModelScratch {
     BPE(BpeScratch),
     WordLevel(()),
     WordPiece(WordPieceScratch),
     Unigram(UnigramScratch),
+    #[default]
+    None,
 }
 
 impl ModelScratch for PipelineModelScratch {
@@ -1057,6 +1058,7 @@ impl ModelScratch for PipelineModelScratch {
             PipelineModelScratch::Unigram(scratch) => scratch.clear(),
             PipelineModelScratch::WordLevel(scratch) => scratch.clear(),
             PipelineModelScratch::WordPiece(scratch) => scratch.clear(),
+            PipelineModelScratch::None => {}
         }
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -395,42 +395,32 @@ pub struct PipelineTokenizer {
     scratch_pool: ScratchPool,
 }
 
-/// A pool of reusable per-encode scratch buffers, owned by the [`PipelineTokenizer`].
-/// [`encode`](PipelineTokenizer::encode) checks a scratch out and returns it on drop,
-/// so the tokenizer keeps a `&self` (hence `Sync`) API — `par_iter().map(|s|
-/// tok.encode(s))` just works — while each concurrent caller still gets private,
-/// warm scratch. This is the pattern `regex` uses to present `Regex: Sync` without a
-/// caller-visible cache handle.
-///
-/// The pool's lifetime is the tokenizer's: nothing is process-global (unlike a
-/// `thread_local!`), so idle scratch is freed when the tokenizer drops, and every
-/// scratch it holds was built by this instance's model — a foreign-vocab scratch is
-/// unrepresentable.
 struct ScratchPool {
-    // Not boxed: checkout is once per `encode` call (µs–ms), so the cost of moving a
-    // scratch on/off the freelist is noise — the pointer-indirection trick pays off
-    // only at regex-automata's per-search granularity.
-    idle: Mutex<Vec<PipelineModelScratch>>,
+    pool: Mutex<Vec<PipelineModelScratch>>,
 }
 
 impl ScratchPool {
     fn new() -> Self {
         Self {
-            idle: Mutex::new(Vec::new()),
+            pool: Mutex::new(Vec::new()),
         }
     }
 
-    /// Check out a scratch — a warm one off the freelist, or a fresh one built from
-    /// `model`. Population self-limits to the peak number of concurrent encodes, so
-    /// there is no cap or eviction policy to tune. The lock is held for one `pop`
-    /// (nanoseconds) and taken once per `encode`, never per pre-token.
     fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
-        let scratch = self
-            .idle
+        let maybe_scratch = self
+            .pool
             .lock()
-            .unwrap_or_else(PoisonError::into_inner) // a poisoned freelist is still a freelist
-            .pop()
-            .unwrap_or_else(|| model.init_scratch());
+            .unwrap_or_else(PoisonError::into_inner)
+            .pop(); // Release the lock
+
+        let scratch = maybe_scratch
+            .map(|mut scratch| {
+                // Lazily clear the cache
+                scratch.clear();
+                scratch
+            })
+            .unwrap_or_else(|| model.init_scratch()); // If there is no scratch in the pool, init a fresh one
+
         ScratchGuard {
             scratch: Some(scratch),
             pool: self,
@@ -438,9 +428,10 @@ impl ScratchPool {
     }
 }
 
-/// RAII checkout: returns its scratch to the pool on drop.
+/// RAAI guard for a scratch that adds it back to the pool whenever the scratch gets dropped
 struct ScratchGuard<'a> {
-    // `Option` only so `Drop` can move the scratch back out.
+    // Option so we can use `.take()` to reclaim ownership of the scratch
+    // to push it back to the pool
     scratch: Option<PipelineModelScratch>,
     pool: &'a ScratchPool,
 }
@@ -448,11 +439,8 @@ struct ScratchGuard<'a> {
 impl Drop for ScratchGuard<'_> {
     fn drop(&mut self) {
         if let Some(scratch) = self.scratch.take() {
-            // No reset needed: the model's scratch buffers self-clear at the start of
-            // each tokenize (`merge_all` clears the queue/skip, `merge_word` the word,
-            // WordPiece its candidate string). Keeping the allocation warm is the point.
             self.pool
-                .idle
+                .pool
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner)
                 .push(scratch);
@@ -991,7 +979,9 @@ pub fn split_matches(
     }
 }
 
-pub trait ModelScratch {}
+pub trait ModelScratch {
+    fn clear(&mut self);
+}
 
 pub trait Model {
     type Scratch: ModelScratch;
@@ -1060,7 +1050,16 @@ pub enum PipelineModelScratch {
     Unigram(UnigramScratch),
 }
 
-impl ModelScratch for PipelineModelScratch {}
+impl ModelScratch for PipelineModelScratch {
+    fn clear(&mut self) {
+        match self {
+            PipelineModelScratch::BPE(scratch) => scratch.clear(),
+            PipelineModelScratch::Unigram(scratch) => scratch.clear(),
+            PipelineModelScratch::WordLevel(scratch) => scratch.clear(),
+            PipelineModelScratch::WordPiece(scratch) => scratch.clear(),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
+use std::sync::{Mutex, PoisonError};
 use std::{borrow::Cow, convert::TryFrom};
 
 use atomsplit::classify::classify;
@@ -391,6 +392,85 @@ pub struct PipelineTokenizer {
     pre_tokenizer: PipelinePreTokenizer,
     model: PipelineModel,
     post_processor: PipelinePostProcessor,
+    scratch_pool: ScratchPool,
+}
+
+/// A pool of reusable per-encode scratch buffers, owned by the [`PipelineTokenizer`].
+/// [`encode`](PipelineTokenizer::encode) checks a scratch out and returns it on drop,
+/// so the tokenizer keeps a `&self` (hence `Sync`) API — `par_iter().map(|s|
+/// tok.encode(s))` just works — while each concurrent caller still gets private,
+/// warm scratch. This is the pattern `regex` uses to present `Regex: Sync` without a
+/// caller-visible cache handle.
+///
+/// The pool's lifetime is the tokenizer's: nothing is process-global (unlike a
+/// `thread_local!`), so idle scratch is freed when the tokenizer drops, and every
+/// scratch it holds was built by this instance's model — a foreign-vocab scratch is
+/// unrepresentable.
+struct ScratchPool {
+    // Not boxed: checkout is once per `encode` call (µs–ms), so the cost of moving a
+    // scratch on/off the freelist is noise — the pointer-indirection trick pays off
+    // only at regex-automata's per-search granularity.
+    idle: Mutex<Vec<PipelineModelScratch>>,
+}
+
+impl ScratchPool {
+    fn new() -> Self {
+        Self {
+            idle: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Check out a scratch — a warm one off the freelist, or a fresh one built from
+    /// `model`. Population self-limits to the peak number of concurrent encodes, so
+    /// there is no cap or eviction policy to tune. The lock is held for one `pop`
+    /// (nanoseconds) and taken once per `encode`, never per pre-token.
+    fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
+        let scratch = self
+            .idle
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) // a poisoned freelist is still a freelist
+            .pop()
+            .unwrap_or_else(|| model.init_scratch());
+        ScratchGuard {
+            scratch: Some(scratch),
+            pool: self,
+        }
+    }
+}
+
+/// RAII checkout: returns its scratch to the pool on drop.
+struct ScratchGuard<'a> {
+    // `Option` only so `Drop` can move the scratch back out.
+    scratch: Option<PipelineModelScratch>,
+    pool: &'a ScratchPool,
+}
+
+impl Drop for ScratchGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(scratch) = self.scratch.take() {
+            // No reset needed: the model's scratch buffers self-clear at the start of
+            // each tokenize (`merge_all` clears the queue/skip, `merge_word` the word,
+            // WordPiece its candidate string). Keeping the allocation warm is the point.
+            self.pool
+                .idle
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(scratch);
+        }
+    }
+}
+
+impl std::ops::Deref for ScratchGuard<'_> {
+    type Target = PipelineModelScratch;
+    fn deref(&self) -> &PipelineModelScratch {
+        self.scratch.as_ref().unwrap()
+    }
+}
+
+impl std::ops::DerefMut for ScratchGuard<'_> {
+    fn deref_mut(&mut self) -> &mut PipelineModelScratch {
+        self.scratch.as_mut().unwrap()
+    }
 }
 
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
@@ -493,6 +573,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
                 .map(PipelinePostProcessor::try_from)
                 .transpose()?
                 .unwrap_or_default(),
+            scratch_pool: ScratchPool::new(),
         })
     }
 }
@@ -523,7 +604,7 @@ impl PipelineTokenizer {
     pub fn encode(&self, input: &str, add_special_tokens: bool) -> Result<Vec<PipelineToken>> {
         let mut output = Vec::new();
         let mut pre_tokens = Vec::new();
-        let mut scratch = self.model.init_scratch();
+        let mut scratch = self.scratch_pool.get(&self.model);
 
         self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(
             input,
@@ -1313,5 +1394,61 @@ mod tests {
         );
         let err = conversion_error(&tok);
         assert!(err.contains("not supported"), "{}", err);
+    }
+
+    // The scratch pool exists so ONE `&self` tokenizer can be shared across rayon
+    // workers. Encode the same input from thousands of threads through a single shared
+    // instance; each must get private scratch and produce the sequential result. A
+    // data race or shared-scratch bug would corrupt some — and this only compiles if
+    // `PipelineTokenizer: Sync`, which the pool must preserve.
+    #[test]
+    fn encode_shared_across_threads_via_pool() {
+        use crate::models::bpe::{BpeBuilder, Merges, Vocab};
+        use rayon::prelude::*;
+
+        let vocab: Vocab = [
+            ("h", 0u32),
+            ("e", 1),
+            ("l", 2),
+            ("o", 3),
+            ("he", 4),
+            ("hel", 5),
+            ("hell", 6),
+            ("hello", 7),
+        ]
+        .into_iter()
+        .map(|(s, i)| (s.to_string(), i))
+        .collect();
+        let merges: Merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+            ("hel".to_string(), "l".to_string()),
+            ("hell".to_string(), "o".to_string()),
+        ];
+        let bpe = BpeBuilder::default()
+            .vocab_and_merges(vocab, merges)
+            .build()
+            .unwrap();
+        let tok = Tokenizer::new(bpe);
+        let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
+
+        let want: Vec<u32> = pipeline
+            .encode("hello", false)
+            .unwrap()
+            .iter()
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(want, vec![7]);
+
+        let all_match = (0..10_000u32).into_par_iter().all(|_| {
+            pipeline
+                .encode("hello", false)
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect::<Vec<_>>()
+                == want
+        });
+        assert!(all_match);
     }
 }

--- a/tokenizers/tk-encode/src/utils/cache.rs
+++ b/tokenizers/tk-encode/src/utils/cache.rs
@@ -4,10 +4,10 @@ use std::hash::Hash;
 use std::sync::RwLock;
 
 /// The default capacity for a `BPE`'s internal cache.
-pub static DEFAULT_CACHE_CAPACITY: usize = 1 << 16;
+pub static DEFAULT_CACHE_CAPACITY: usize = 65_536;
 /// The maximum length we should cache in a model
 /// Strings that are too long have minimal chances to cache hit anyway
-pub static MAX_LENGTH: usize = 128;
+pub static MAX_LENGTH: usize = 256;
 
 /// Provides a simple multithread cache to speed up BPE tokenization that will try to read values
 /// concurrently but won't block if another thread is writing.

--- a/tokenizers/tk-encode/src/utils/cache.rs
+++ b/tokenizers/tk-encode/src/utils/cache.rs
@@ -4,10 +4,10 @@ use std::hash::Hash;
 use std::sync::RwLock;
 
 /// The default capacity for a `BPE`'s internal cache.
-pub static DEFAULT_CACHE_CAPACITY: usize = 1 << 32;
+pub static DEFAULT_CACHE_CAPACITY: usize = 1 << 16;
 /// The maximum length we should cache in a model
 /// Strings that are too long have minimal chances to cache hit anyway
-pub static MAX_LENGTH: usize = 256;
+pub static MAX_LENGTH: usize = 128;
 
 /// Provides a simple multithread cache to speed up BPE tokenization that will try to read values
 /// concurrently but won't block if another thread is writing.

--- a/tokenizers/tk-encode/src/utils/cache.rs
+++ b/tokenizers/tk-encode/src/utils/cache.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use std::sync::RwLock;
 
 /// The default capacity for a `BPE`'s internal cache.
-pub static DEFAULT_CACHE_CAPACITY: usize = 10_000;
+pub static DEFAULT_CACHE_CAPACITY: usize = 1 << 32;
 /// The maximum length we should cache in a model
 /// Strings that are too long have minimal chances to cache hit anyway
 pub static MAX_LENGTH: usize = 256;

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -54,6 +54,7 @@ pub struct BucketVocabStore {
     /// MPHF's non-minimal slot range (with phantom padding slots), so its length is not the
     /// token count.
     n: usize,
+    longest_token_len: usize,
 }
 
 impl fmt::Debug for BucketVocabStore {
@@ -139,6 +140,7 @@ impl BucketVocabStore {
             n_slots
         ];
         let mut id_to_slot = vec![u32::MAX; max_id as usize + 1];
+        let mut longest_token_len = 0;
         for (s, id) in &tokens {
             assert!(
                 s.len() <= u16::MAX as usize,
@@ -152,6 +154,7 @@ impl BucketVocabStore {
             };
             id_to_slot[*id as usize] = slot as u32;
             bytes.extend_from_slice(s);
+            longest_token_len = longest_token_len.max(s.len())
         }
 
         Self {
@@ -161,6 +164,7 @@ impl BucketVocabStore {
             entries: entries.into_boxed_slice(),
             id_to_slot: id_to_slot.into_boxed_slice(),
             n,
+            longest_token_len,
         }
     }
 
@@ -174,6 +178,7 @@ impl BucketVocabStore {
             entries: Box::new([]),
             id_to_slot: Box::new([]),
             n: 0,
+            longest_token_len: 0,
         }
     }
 
@@ -185,6 +190,9 @@ impl BucketVocabStore {
     pub fn get_bytes(&self, q: &[u8]) -> Option<u32> {
         if self.entries.is_empty() {
             return None;
+        }
+        if q.len() > self.longest_token_len {
+            return None
         }
         let slot = self.mphf.index(&self.hasher.hash_one(q));
 


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`42a00a7e9 · 2026-07-27 10:49 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-overview.png" width="860">

**vs base branch** (`709ef7af5`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.87 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 12) · Pipeline 8+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 27.5 | ×3.49 | ×1.00 | 3% (1.2) | 76% (27.4) | 13% (4.8) | 7% (2.6) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 24.5 | ×5.82 | ×0.98 | 3% (1.2) | 68% (27.4) | 8% (3.3) | 21% (8.6) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 33.9 | ×5.62 | ×0.97 | 4% (1.2) | 67% (19.5) | 8% (2.5) | 21% (6.0) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 18.9 | ×4.90 | ×1.01 | 2% (1.3) | 71% (37.7) | 10% (5.4) | 16% (8.3) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 23.4 | ×6.15 | ×0.98 | 3% (1.2) | 67% (28.6) | 8% (3.4) | 22% (9.3) | 0% (0.1) | match |
| eng_Latn | lang | 4.5 | 18.3 | ×4.02 | ×1.00 | 5% (2.7) | 71% (38.5) | 8% (4.4) | 16% (8.7) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 19.7 | ×4.66 | ×0.99 | 2% (1.2) | 74% (37.4) | 7% (3.7) | 16% (8.2) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 27.1 | ×4.17 | ×0.99 | 3% (1.2) | 75% (27.4) | 8% (2.8) | 14% (5.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 27.0 | ×6.27 | ×0.98 | 3% (1.2) | 63% (23.2) | 13% (4.7) | 21% (7.7) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 27.9 | ×4.51 | ×1.00 | 3% (1.2) | 74% (26.4) | 9% (3.1) | 14% (5.0) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 17.0 | ×6.96 | ×0.96 | 2% (1.2) | 60% (35.0) | 13% (7.3) | 25% (14.7) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.7 | 23.5 | ×6.38 | ×0.99 | 3% (1.2) | 65% (27.3) | 8% (3.2) | 25% (10.6) | 0% (0.0) | match |
| tam_Taml | lang | 7.1 | 37.8 | ×5.35 | ×0.99 | 4% (1.2) | 72% (18.9) | 8% (2.1) | 15% (4.0) | 0% (0.1) | match |
| tha_Thai | lang | 8.5 | 33.2 | ×3.92 | ×1.02 | 4% (1.2) | 84% (24.9) | 7% (2.2) | 5% (1.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.8 | 19.7 | ×2.92 | ×1.00 | 3% (1.3) | 82% (40.5) | 13% (6.7) | 2% (1.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 18.5 | ×3.50 | ×1.01 | 4% (1.9) | 74% (39.7) | 13% (7.0) | 9% (4.7) | 0% (0.1) | match |
| added_special_dense | modalities | 5.4 | 38.8 | ×7.24 | ×1.00 | 21% (5.1) | 38% (9.2) | 35% (8.6) | 7% (1.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 21.4 | ×5.39 | ×1.00 | 8% (3.6) | 61% (27.9) | 19% (8.6) | 13% (5.8) | 0% (0.0) | match |
| agentic-traces | modalities | 3.9 | 18.1 | ×4.67 | ×1.00 | 5% (2.5) | 70% (38.3) | 9% (4.9) | 16% (9.0) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 19.5 | ×4.71 | ×1.00 | 4% (2.0) | 72% (38.4) | 7% (3.7) | 13% (7.1) | 4% (2.4) | match |
| code_mixed | modalities | 4.0 | 18.9 | ×4.78 | ×1.00 | 4% (2.3) | 73% (38.5) | 8% (4.1) | 14% (7.5) | 0% (0.0) | match |
| math_latex | modalities | 4.1 | 18.2 | ×4.48 | ×1.00 | 5% (2.6) | 70% (38.4) | 9% (4.8) | 16% (8.9) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×22.05 vs v0.23.1 · ×5.49 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 82+0 (peak 81)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.5 | 93.5 | ×20.83 | ×2.72 | 7% (0.7) | 0% (0.0) | 50% (4.7) | 44% (4.1) | 0% (0.0) | match |
| arb_Arab | lang | 4.5 | 103.0 | ×22.96 | ×6.19 | 7% (0.6) | 0% (0.0) | 39% (3.4) | 55% (4.8) | 0% (0.0) | match |
| ben_Beng | lang | 6.4 | 144.9 | ×22.50 | ×8.13 | 10% (0.6) | 0% (0.0) | 51% (3.2) | 39% (2.4) | 1% (0.0) | match |
| cmn_Hani | lang | 3.8 | 81.7 | ×21.46 | ×4.94 | 8% (0.8) | 0% (0.0) | 31% (3.2) | 62% (6.4) | 0% (0.0) | match |
| ell_Grek | lang | 4.8 | 114.5 | ×23.94 | ×6.41 | 8% (0.6) | 0% (0.0) | 44% (3.4) | 48% (3.7) | 0% (0.0) | match |
| eng_Latn | lang | 3.3 | 72.3 | ×21.96 | ×5.56 | 17% (2.1) | 0% (0.0) | 41% (5.1) | 42% (5.3) | 1% (0.1) | match |
| heb_Hebr | lang | 4.2 | 97.4 | ×23.39 | ×7.51 | 7% (0.6) | 0% (0.0) | 39% (3.5) | 54% (5.0) | 1% (0.0) | match |
| hin_Deva | lang | 6.0 | 136.1 | ×22.61 | ×6.39 | 9% (0.6) | 0% (0.0) | 50% (3.3) | 41% (2.7) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.4 | 115.1 | ×26.05 | ×6.41 | 10% (0.7) | 0% (0.0) | 43% (3.0) | 48% (3.3) | 0% (0.0) | match |
| kat_Geor | lang | 6.1 | 140.9 | ×23.23 | ×8.11 | 10% (0.6) | 0% (0.0) | 47% (2.9) | 42% (2.6) | 1% (0.1) | match |
| kor_Hang | lang | 3.8 | 73.3 | ×19.09 | ×3.71 | 5% (0.6) | 0% (0.0) | 30% (3.7) | 64% (7.9) | 1% (0.1) | match |
| rus_Cyrl | lang | 4.6 | 105.3 | ×22.97 | ×7.44 | 7% (0.6) | 0% (0.0) | 39% (3.3) | 53% (4.4) | 1% (0.1) | match |
| tam_Taml | lang | 6.4 | 152.6 | ×23.69 | ×8.74 | 11% (0.6) | 0% (0.0) | 48% (2.7) | 41% (2.3) | 0% (0.0) | match |
| tha_Thai | lang | 7.1 | 90.6 | ×12.72 | ×6.33 | 6% (0.6) | 0% (0.0) | 22% (2.2) | 72% (7.1) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 163.9 | ×26.71 | ×6.98 | 13% (0.8) | 0% (0.0) | 48% (2.7) | 39% (2.2) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 119.5 | ×22.12 | ×6.09 | 17% (1.3) | 0% (0.0) | 47% (3.7) | 35% (2.8) | 1% (0.1) | match |
| added_special_dense | modalities | 3.6 | 62.6 | ×17.17 | ×1.67 | 42% (6.5) | 3% (0.5) | 40% (6.1) | 16% (2.5) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 67.6 | ×16.88 | ×3.25 | 28% (3.9) | 1% (0.2) | 49% (6.9) | 22% (3.1) | 0% (0.0) | match |
| agentic-traces | modalities | 3.0 | 69.0 | ×22.81 | ×4.83 | 14% (2.0) | 0% (0.0) | 40% (5.4) | 45% (6.2) | 1% (0.1) | match |
| agentic_swe | modalities | 3.1 | 95.7 | ×30.91 | ×6.42 | 14% (1.4) | 0% (0.0) | 40% (3.9) | 46% (4.4) | 0% (0.0) | match |
| code_mixed | modalities | 3.6 | 85.1 | ×23.62 | ×5.47 | 15% (1.7) | 0% (0.0) | 42% (4.7) | 43% (4.7) | 0% (0.0) | match |
| math_latex | modalities | 2.9 | 71.4 | ×24.57 | ×5.09 | 15% (2.0) | 0% (0.0) | 41% (5.4) | 43% (5.6) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.42 | 4.68 | 5.47 | 44.3 | 20.0 | 9.2 | — | 9.5× / 8.1× | 4.3× / 3.7× | 2.0× / 1.7× | — |
| arb_Arab | 1.00 | 3.02 | 3.36 | 5.38 | 50.2 | 22.8 | 10.1 | — | 14.9× / 9.3× | 6.8× / 4.2× | 3.0× / 1.9× | — |
| ben_Beng | 1.47 | 2.92 | 3.15 | 4.60 | 37.4 | 16.4 | 7.7 | — | 11.9× / 8.1× | 5.2× / 3.6× | 2.4× / 1.7× | — |
| cmn_Hani | 1.12 | 2.31 | 3.20 | 4.38 | 63.7 | 34.5 | 14.3 | — | 19.9× / 14.5× | 10.8× / 7.9× | 4.5× / 3.3× | — |
| ell_Grek | 0.58 | 3.06 | 3.36 | 5.83 | 48.4 | 20.9 | 9.5 | — | 14.4× / 8.3× | 6.2× / 3.6× | 2.8× / 1.6× | — |
| eng_Latn | 0.10 | 1.46 | 5.14 | 6.50 | 68.1 | 39.0 | 16.4 | — | 13.3× / 10.5× | 7.6× / 6.0× | 3.2× / 2.5× | — |
| heb_Hebr | 1.00 | 3.15 | 3.53 | 5.68 | 52.9 | 23.7 | 10.6 | — | 15.0× / 9.3× | 6.7× / 4.2× | 3.0× / 1.9× | — |
| hin_Deva | 1.36 | 3.10 | 3.28 | 5.03 | 39.6 | 18.7 | 8.6 | — | 12.0× / 7.9× | 5.7× / 3.7× | 2.6× / 1.7× | — |
| jpn_Jpan | 1.56 | 3.55 | 3.00 | 4.98 | 55.7 | 27.0 | 11.8 | — | 18.6× / 11.2× | 9.0× / 5.4× | 3.9× / 2.4× | — |
| kat_Geor | 1.39 | 2.55 | 2.93 | 4.10 | 33.9 | 15.1 | 7.2 | — | 11.5× / 8.3× | 5.2× / 3.7× | 2.4× / 1.7× | — |
| kor_Hang | 1.08 | 2.80 | 3.67 | 5.39 | 53.0 | 27.1 | 11.8 | — | 14.4× / 9.8× | 7.4× / 5.0× | 3.2× / 2.2× | — |
| rus_Cyrl | 1.02 | 2.99 | 3.26 | 5.23 | 47.8 | 20.7 | 9.5 | — | 14.7× / 9.1× | 6.4× / 4.0× | 2.9× / 1.8× | — |
| tam_Taml | 0.92 | 2.94 | 2.72 | 4.74 | 32.8 | 13.6 | 6.5 | — | 12.1× / 6.9× | 5.0× / 2.9× | 2.4× / 1.4× | — |
| tha_Thai | 1.36 | 2.66 | 2.17 | 3.46 | 28.0 | 10.1 | 5.2 | — | 12.9× / 8.1× | 4.6× / 2.9× | 2.4× / 1.5× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.74 | 4.16 | 43.9 | 20.4 | 9.2 | — | 16.0× / 10.6× | 7.4× / 4.9× | 3.3× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.67 | 5.09 | 50.4 | 25.8 | 11.5 | — | 13.7× / 9.9× | 7.0× / 5.1× | 3.1× / 2.3× | — |
| added_special_dense | 0.06 | 1.47 | 6.12 | 7.54 | 185.4 | 97.1 | 39.4 | — | 30.3× / 24.6× | 15.9× / 12.9× | 6.4× / 5.2× | — |
| added_special_sparse | 0.06 | 1.47 | 6.88 | 8.30 | 108.4 | 58.4 | 24.2 | — | 15.8× / 13.1× | 8.5× / 7.0× | 3.5× / 2.9× | — |
| agentic-traces | 0.59 | 1.48 | 5.43 | 6.32 | 85.5 | 52.9 | 20.3 | — | 15.7× / 13.5× | 9.7× / 8.4× | 3.7× / 3.2× | — |
| agentic_swe | 0.65 | 1.44 | 3.92 | 4.71 | 100.6 | 65.7 | 23.9 | — | 25.7× / 21.3× | 16.8× / 13.9× | 6.1× / 5.1× | — |
| code_mixed | 0.07 | 1.45 | 4.66 | 6.04 | 77.7 | 53.9 | 18.4 | — | 16.7× / 12.9× | 11.6× / 8.9× | 3.9× / 3.0× | — |
| math_latex | 0.57 | 1.48 | 5.41 | 6.32 | 83.0 | 47.8 | 19.6 | — | 15.3× / 13.1× | 8.8× / 7.6× | 3.6× / 3.1× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×2.09 vs v0.23.1 · ×1.11 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 371) · Pipeline 275+0 (peak 370)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 10.8 | 27.8 | ×2.57 | ×1.01 | 2% (0.7) | 6% (2.1) | 0% (0.0) | 91% (32.5) | 1% (0.2) | match |
| arb_Arab | lang | 7.4 | 13.1 | ×1.76 | ×0.98 | 1% (0.6) | 3% (2.6) | 0% (0.0) | 96% (74.9) | 0% (0.0) | match |
| ben_Beng | lang | 10.7 | 18.8 | ×1.75 | ×1.01 | 1% (0.6) | 3% (1.7) | 0% (0.1) | 96% (51.9) | 0% (0.0) | match |
| cmn_Hani | lang | 13.9 | 37.2 | ×2.67 | ×1.10 | 2% (0.6) | 1% (0.3) | 0% (0.0) | 98% (27.0) | 0% (0.0) | match |
| ell_Grek | lang | 8.0 | 15.0 | ×1.87 | ×1.01 | 1% (0.6) | 4% (2.5) | 0% (0.0) | 95% (63.3) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 5.7 | ×1.44 | ×1.03 | 1% (2.1) | 3% (4.9) | 0% (0.0) | 96% (173.2) | 0% (0.0) | match |
| heb_Hebr | lang | 7.8 | 16.7 | ×2.14 | ×1.00 | 1% (0.6) | 4% (2.6) | 0% (0.0) | 94% (55.4) | 0% (0.2) | match |
| hin_Deva | lang | 8.9 | 17.7 | ×1.99 | ×1.00 | 1% (0.6) | 4% (2.3) | 0% (0.0) | 95% (51.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 11.9 | 28.9 | ×2.43 | ×1.00 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 98% (31.9) | 0% (0.0) | match |
| kat_Geor | lang | 11.8 | 24.8 | ×2.11 | ×1.01 | 1% (0.6) | 4% (1.4) | 0% (0.0) | 95% (37.7) | 0% (0.0) | match |
| kor_Hang | lang | 9.7 | 26.2 | ×2.69 | ×1.04 | 2% (0.6) | 7% (2.6) | 0% (0.0) | 91% (33.7) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.3 | 11.0 | ×1.51 | ×0.98 | 1% (0.6) | 3% (2.3) | 0% (0.0) | 98% (87.2) | 0% (0.0) | match |
| tam_Taml | lang | 11.2 | 19.7 | ×1.75 | ×1.01 | 1% (0.6) | 3% (1.3) | 0% (0.0) | 96% (47.7) | 0% (0.0) | match |
| tha_Thai | lang | 13.1 | 23.9 | ×1.82 | ×1.01 | 2% (0.7) | 2% (0.6) | 0% (0.0) | 97% (39.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.0 | 7.5 | ×1.48 | ×1.00 | 1% (0.7) | 2% (2.9) | 0% (0.0) | 97% (128.7) | 1% (0.8) | match |
| added_normalized_sparse | modalities | 4.6 | 6.6 | ×1.44 | ×1.00 | 1% (1.4) | 3% (4.3) | 0% (0.0) | 96% (143.3) | 0% (0.1) | match |
| added_special_dense | modalities | 4.8 | 35.4 | ×7.43 | ×1.75 | 34% (9.4) | 33% (8.9) | 26% (7.1) | 8% (2.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 7.2 | 45.1 | ×6.30 | ×4.61 | 26% (5.2) | 43% (8.6) | 24% (4.9) | 8% (1.7) | 0% (0.0) | match |
| agentic-traces | modalities | 4.3 | 6.5 | ×1.52 | ×1.01 | 1% (1.9) | 3% (4.5) | 0% (0.1) | 97% (147.9) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 7.0 | ×1.76 | ×1.02 | 1% (1.4) | 5% (7.6) | 0% (0.0) | 93% (131.1) | 1% (0.9) | match |
| code_mixed | modalities | 4.1 | 6.6 | ×1.62 | ×1.01 | 1% (1.7) | 4% (6.1) | 0% (0.1) | 96% (143.7) | 0% (0.0) | match |
| math_latex | modalities | 3.9 | 5.9 | ×1.51 | ×0.99 | 1% (2.0) | 3% (4.6) | 0% (0.1) | 95% (154.6) | 1% (1.2) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×28.53 vs v0.23.1 · ×3.66 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 27+0 (peak 27)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 96.8 | ×24.22 | ×1.99 | 8% (0.7) | 0% (0.0) | 45% (3.6) | 47% (3.8) | 0% (0.0) | match |
| arb_Arab | lang | 3.8 | 106.6 | ×27.79 | ×4.15 | 8% (0.6) | 0% (0.0) | 29% (2.3) | 62% (4.9) | 2% (0.1) | match |
| ben_Beng | lang | 2.9 | 97.3 | ×33.62 | ×2.20 | 6% (0.6) | 0% (0.0) | 33% (3.0) | 60% (5.5) | 1% (0.1) | match |
| cmn_Hani | lang | 3.7 | 101.0 | ×27.04 | ×3.50 | 8% (0.6) | 0% (0.0) | 29% (2.3) | 62% (4.9) | 1% (0.1) | match |
| ell_Grek | lang | 4.3 | 125.2 | ×28.94 | ×4.42 | 9% (0.6) | 0% (0.0) | 32% (2.1) | 59% (4.0) | 0% (0.0) | match |
| eng_Latn | lang | 3.5 | 85.4 | ×24.29 | ×6.08 | 20% (2.1) | 1% (0.1) | 27% (2.8) | 52% (5.4) | 0% (0.0) | match |
| heb_Hebr | lang | 3.9 | 112.8 | ×28.56 | ×3.91 | 8% (0.6) | 0% (0.0) | 29% (2.3) | 64% (4.9) | 0% (0.0) | match |
| hin_Deva | lang | 3.1 | 105.9 | ×34.47 | ×2.61 | 7% (0.6) | 0% (0.0) | 34% (3.1) | 59% (5.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.5 | 139.2 | ×30.93 | ×6.33 | 10% (0.6) | 0% (0.0) | 35% (2.1) | 56% (3.4) | 0% (0.0) | match |
| kat_Geor | lang | 4.7 | 162.4 | ×34.61 | ×2.50 | 12% (0.6) | 0% (0.0) | 40% (2.1) | 49% (2.5) | 0% (0.0) | match |
| kor_Hang | lang | 3.4 | 91.4 | ×27.15 | ×2.09 | 6% (0.6) | 0% (0.0) | 25% (2.4) | 68% (6.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.2 | 122.5 | ×29.07 | ×4.43 | 8% (0.6) | 0% (0.0) | 30% (2.1) | 62% (4.4) | 0% (0.0) | match |
| tam_Taml | lang | 2.7 | 115.1 | ×42.48 | ×1.59 | 7% (0.6) | 0% (0.0) | 33% (2.7) | 60% (4.8) | 0% (0.0) | match |
| tha_Thai | lang | 3.7 | 118.5 | ×32.40 | ×3.34 | 8% (0.6) | 0% (0.0) | 34% (2.5) | 57% (4.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.0 | 207.7 | ×34.82 | ×8.17 | 18% (0.7) | 0% (0.0) | 25% (1.1) | 54% (2.3) | 4% (0.2) | match |
| added_normalized_sparse | modalities | 5.1 | 147.4 | ×28.68 | ×6.84 | 21% (1.3) | 0% (0.0) | 32% (2.0) | 48% (3.0) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 82.5 | ×20.37 | ×1.72 | 43% (4.9) | 0% (0.0) | 38% (4.4) | 16% (1.8) | 2% (0.3) | match |
| added_special_sparse | modalities | 4.3 | 86.7 | ×20.29 | ×3.63 | 30% (3.2) | 0% (0.0) | 42% (4.5) | 29% (3.1) | 0% (0.0) | match |
| agentic-traces | modalities | 3.2 | 77.9 | ×24.56 | ×4.82 | 16% (2.0) | 0% (0.0) | 29% (3.4) | 56% (6.7) | 0% (0.0) | match |
| agentic_swe | modalities | 3.4 | 103.4 | ×30.30 | ×4.31 | 16% (1.4) | 0% (0.0) | 27% (2.4) | 58% (5.1) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 95.1 | ×27.01 | ×4.64 | 17% (1.7) | 0% (0.0) | 30% (2.9) | 54% (5.3) | 0% (0.0) | match |
| math_latex | modalities | 3.3 | 83.2 | ×25.34 | ×5.46 | 19% (2.1) | 0% (0.0) | 29% (3.3) | 52% (5.7) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.39 | 3.64 | 4.40 | 26.7 | 21.1 | 5.9 | 4.8 | 7.3× / 6.1× | 5.8× / 4.8× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 3.08 | 2.26 | 4.34 | 31.1 | 26.3 | 6.9 | 5.1 | 13.8× / 7.2× | 11.6× / 6.1× | 3.0× / 1.6× | 2.3× / 1.2× |
| ben_Beng | 1.47 | 2.91 | 2.99 | 4.43 | 63.9 | 56.3 | 13.7 | 4.0 | 21.4× / 14.4× | 18.8× / 12.7× | 4.6× / 3.1× | 1.3× / 0.9× |
| cmn_Hani | 1.12 | 2.32 | 2.33 | 3.53 | 25.7 | 21.4 | 5.9 | 2.4 | 11.0× / 7.3× | 9.2× / 6.1× | 2.5× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.06 | 2.14 | 4.62 | 27.3 | 22.6 | 6.0 | 4.7 | 12.7× / 5.9× | 10.6× / 4.9× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.46 | 2.84 | 4.20 | 42.3 | 43.6 | 12.1 | 3.8 | 14.9× / 10.1× | 15.4× / 10.4× | 4.3× / 2.9× | 1.3× / 0.9× |
| heb_Hebr | 1.00 | 3.09 | 2.28 | 4.37 | 31.0 | 26.3 | 6.9 | 3.0 | 13.6× / 7.1× | 11.6× / 6.0× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.36 | 3.09 | 3.05 | 4.78 | 60.6 | 54.9 | 13.4 | 4.3 | 19.9× / 12.7× | 18.0× / 11.5× | 4.4× / 2.8× | 1.4× / 0.9× |
| jpn_Jpan | 1.56 | 3.37 | 2.12 | 3.93 | 23.0 | 18.0 | 5.0 | 3.8 | 10.8× / 5.8× | 8.5× / 4.6× | 2.4× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.56 | 2.06 | 3.23 | 16.8 | 14.6 | 4.2 | 2.0 | 8.1× / 5.2× | 7.1× / 4.5× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.08 | 2.74 | 2.41 | 4.07 | 31.0 | 28.5 | 7.4 | 3.7 | 12.9× / 7.6× | 11.8× / 7.0× | 3.1× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.98 | 2.09 | 4.05 | 26.3 | 21.6 | 5.9 | 2.6 | 12.5× / 6.5× | 10.3× / 5.3× | 2.8× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.92 | 2.92 | 2.66 | 4.65 | 67.1 | 59.3 | 14.1 | 3.8 | 25.3× / 14.4× | 22.3× / 12.7× | 5.3× / 3.0× | 1.4× / 0.8× |
| tha_Thai | 1.36 | 2.60 | 2.49 | 3.72 | 38.8 | 32.1 | 8.8 | 3.2 | 15.6× / 10.4× | 12.9× / 8.6× | 3.5× / 2.4× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.07 | 2.48 | 22.5 | 23.4 | 6.5 | 1.9 | 21.1× / 9.1× | 22.0× / 9.4× | 6.1× / 2.6× | 1.8× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.97 | 3.39 | 29.8 | 31.7 | 8.7 | 2.7 | 15.1× / 8.8× | 16.1× / 9.4× | 4.4× / 2.6× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.37 | 5.79 | 91.0 | 100.6 | 20.2 | 3.0 | 20.8× / 15.7× | 23.0× / 17.4× | 4.6× / 3.5× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.52 | 5.94 | 59.3 | 61.8 | 15.0 | 3.4 | 13.1× / 10.0× | 13.7× / 10.4× | 3.3× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.57 | 1.52 | 3.45 | 4.39 | 56.7 | 62.0 | 15.5 | 4.6 | 16.4× / 12.9× | 18.0× / 14.1× | 4.5× / 3.5× | 1.3× / 1.1× |
| agentic_swe | 0.66 | 1.46 | 2.45 | 3.25 | 57.8 | 69.3 | 14.7 | 3.5 | 23.6× / 17.8× | 28.3× / 21.3× | 6.0× / 4.5× | 1.4× / 1.1× |
| code_mixed | 0.07 | 1.44 | 2.91 | 4.29 | 56.3 | 67.7 | 15.2 | 4.1 | 19.3× / 13.1× | 23.2× / 15.8× | 5.2× / 3.5× | 1.4× / 0.9× |
| math_latex | 0.57 | 1.48 | 3.27 | 4.19 | 50.0 | 52.3 | 14.4 | 4.2 | 15.3× / 11.9× | 16.0× / 12.5× | 4.4× / 3.4× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×18.02 vs v0.23.1 · ×3.47 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 72.5 | ×20.01 | ×3.11 | 5% (0.6) | 0% (0.0) | 42% (5.0) | 52% (6.3) | 1% (0.1) | match |
| arb_Arab | lang | 4.3 | 77.6 | ×18.05 | ×4.48 | 5% (0.6) | 0% (0.0) | 34% (3.8) | 60% (6.8) | 1% (0.1) | match |
| ben_Beng | lang | 6.4 | 108.2 | ×16.92 | ×6.17 | 7% (0.6) | 0% (0.0) | 49% (3.9) | 48% (3.8) | 0% (0.0) | match |
| cmn_Hani | lang | 4.4 | 69.1 | ×15.72 | ×5.68 | 5% (0.6) | 0% (0.0) | 26% (3.3) | 70% (8.7) | 0% (0.0) | match |
| ell_Grek | lang | 4.9 | 95.0 | ×19.31 | ×5.97 | 6% (0.6) | 0% (0.0) | 34% (3.3) | 57% (5.5) | 2% (0.2) | match |
| eng_Latn | lang | 3.7 | 63.9 | ×17.39 | ×1.50 | 15% (2.1) | 0% (0.0) | 34% (4.7) | 51% (7.1) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 76.7 | ×18.70 | ×4.62 | 5% (0.6) | 0% (0.0) | 33% (3.9) | 61% (7.2) | 1% (0.1) | match |
| hin_Deva | lang | 6.6 | 104.9 | ×15.84 | ×4.02 | 7% (0.6) | 0% (0.0) | 48% (4.1) | 41% (3.5) | 4% (0.3) | match |
| jpn_Jpan | lang | 5.1 | 92.9 | ×18.10 | ×7.26 | 7% (0.6) | 0% (0.0) | 37% (3.1) | 49% (4.1) | 7% (0.5) | match |
| kat_Geor | lang | 6.4 | 113.4 | ×17.77 | ×8.05 | 8% (0.6) | 0% (0.0) | 41% (3.0) | 53% (3.8) | 0% (0.0) | match |
| kor_Hang | lang | 3.5 | 52.9 | ×14.91 | ×3.45 | 4% (0.6) | 0% (0.0) | 25% (3.9) | 69% (10.8) | 3% (0.4) | match |
| rus_Cyrl | lang | 4.8 | 84.1 | ×17.53 | ×5.38 | 7% (0.6) | 0% (0.0) | 36% (3.2) | 60% (5.4) | 0% (0.0) | match |
| tam_Taml | lang | 6.5 | 110.9 | ×17.19 | ×8.38 | 8% (0.6) | 0% (0.0) | 46% (3.5) | 43% (3.3) | 4% (0.3) | match |
| tha_Thai | lang | 7.7 | 64.5 | ×8.42 | ×5.59 | 5% (0.6) | 0% (0.0) | 26% (3.5) | 70% (9.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.9 | 151.1 | ×30.77 | ×5.96 | 13% (0.8) | 0% (0.0) | 38% (2.3) | 49% (2.9) | 1% (0.0) | match |
| added_normalized_sparse | modalities | 4.9 | 115.4 | ×23.41 | ×2.75 | 17% (1.3) | 0% (0.0) | 40% (3.1) | 44% (3.5) | 1% (0.1) | match |
| added_special_dense | modalities | 4.0 | 71.1 | ×17.61 | ×0.94 | 40% (5.0) | 0% (0.0) | 43% (5.3) | 18% (2.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.1 | 74.6 | ×18.16 | ×0.97 | 26% (3.2) | 1% (0.1) | 50% (6.2) | 23% (2.8) | 0% (0.1) | match |
| agentic-traces | modalities | 3.5 | 62.8 | ×17.90 | ×1.63 | 14% (1.9) | 0% (0.0) | 37% (5.1) | 50% (6.9) | 0% (0.0) | match |
| agentic_swe | modalities | 3.7 | 82.7 | ×22.52 | ×2.98 | 13% (1.4) | 0% (0.0) | 36% (3.8) | 50% (5.3) | 1% (0.1) | match |
| code_mixed | modalities | 3.8 | 77.6 | ×20.49 | ×1.53 | 15% (1.7) | 0% (0.0) | 40% (4.4) | 48% (5.4) | 0% (0.0) | match |
| math_latex | modalities | 3.3 | 64.2 | ×19.25 | ×1.66 | 15% (2.0) | 0% (0.0) | 36% (5.0) | 52% (7.2) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.41 | 5.01 | 5.79 | 31.0 | 14.4 | 7.2 | 4.8 | 6.2× / 5.4× | 2.9× / 2.5× | 1.4× / 1.2× | 1.0× / 0.8× |
| arb_Arab | 1.00 | 3.09 | 3.80 | 5.89 | 35.2 | 16.0 | 7.7 | 5.0 | 9.3× / 6.0× | 4.2× / 2.7× | 2.0× / 1.3× | 1.3× / 0.8× |
| ben_Beng | 1.46 | 2.97 | 3.95 | 5.45 | 24.7 | 11.0 | 5.5 | 2.8 | 6.3× / 4.5× | 2.8× / 2.0× | 1.4× / 1.0× | 0.7× / 0.5× |
| cmn_Hani | 1.13 | 2.30 | 3.32 | 4.49 | 22.6 | 10.9 | 5.5 | 2.4 | 6.8× / 5.0× | 3.3× / 2.4× | 1.7× / 1.2× | 0.7× / 0.5× |
| ell_Grek | 0.59 | 3.00 | 3.28 | 5.70 | 31.5 | 15.5 | 7.0 | 5.1 | 9.6× / 5.5× | 4.7× / 2.7× | 2.1× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.10 | 1.47 | 4.72 | 6.09 | 46.0 | 30.0 | 14.3 | 4.2 | 9.7× / 7.6× | 6.4× / 4.9× | 3.0× / 2.3× | 0.9× / 0.7× |
| heb_Hebr | 1.00 | 3.11 | 3.88 | 5.99 | 35.1 | 17.2 | 8.1 | 2.9 | 9.1× / 5.9× | 4.4× / 2.9× | 2.1× / 1.4× | 0.7× / 0.5× |
| hin_Deva | 1.36 | 3.09 | 4.08 | 5.81 | 27.3 | 12.8 | 6.4 | 3.1 | 6.7× / 4.7× | 3.1× / 2.2× | 1.6× / 1.1× | 0.8× / 0.5× |
| jpn_Jpan | 1.55 | 3.32 | 3.07 | 4.84 | 21.2 | 9.3 | 4.8 | 3.8 | 6.9× / 4.4× | 3.0× / 1.9× | 1.6× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.51 | 2.54 | 2.97 | 4.00 | 19.8 | 10.2 | 4.6 | 2.3 | 6.7× / 4.9× | 3.4× / 2.6× | 1.5× / 1.1× | 0.8× / 0.6× |
| kor_Hang | 1.07 | 2.73 | 3.90 | 5.56 | 34.9 | 18.9 | 8.8 | 3.5 | 9.0× / 6.3× | 4.8× / 3.4× | 2.2× / 1.6× | 0.9× / 0.6× |
| rus_Cyrl | 1.02 | 2.98 | 3.21 | 5.17 | 29.9 | 14.9 | 6.7 | 4.8 | 9.3× / 5.8× | 4.7× / 2.9× | 2.1× / 1.3× | 1.5× / 0.9× |
| tam_Taml | 0.92 | 3.01 | 3.48 | 5.57 | 19.8 | 8.8 | 4.2 | 2.9 | 5.7× / 3.5× | 2.5× / 1.6× | 1.2× / 0.8× | 0.8× / 0.5× |
| tha_Thai | 1.37 | 2.56 | 3.48 | 4.67 | 13.5 | 5.6 | 2.8 | 2.3 | 3.9× / 2.9× | 1.6× / 1.2× | 0.8× / 0.6× | 0.6× / 0.5× |
| added_normalized_dense | 0.06 | 1.47 | 2.30 | 3.72 | 34.6 | 17.3 | 11.4 | 2.2 | 15.1× / 9.3× | 7.5× / 4.7× | 4.9× / 3.1× | 1.0× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.15 | 4.56 | 37.2 | 20.5 | 11.8 | 2.9 | 11.8× / 8.1× | 6.5× / 4.5× | 3.7× / 2.6× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.48 | 5.30 | 6.72 | 89.9 | 68.6 | 24.3 | 3.3 | 17.0× / 13.4× | 12.9× / 10.2× | 4.6× / 3.6× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 6.22 | 7.64 | 60.1 | 41.1 | 17.0 | 3.8 | 9.7× / 7.9× | 6.6× / 5.4× | 2.7× / 2.2× | 0.6× / 0.5× |
| agentic-traces | 0.57 | 1.48 | 5.09 | 6.00 | 55.5 | 41.9 | 17.7 | 4.9 | 10.9× / 9.3× | 8.2× / 7.0× | 3.5× / 2.9× | 1.0× / 0.8× |
| agentic_swe | 0.53 | 1.44 | 3.79 | 4.70 | 55.9 | 49.3 | 17.8 | 3.6 | 14.8× / 11.9× | 13.0× / 10.5× | 4.7× / 3.8× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.44 | 4.43 | 5.80 | 55.2 | 48.3 | 17.7 | 4.3 | 12.5× / 9.5× | 10.9× / 8.3× | 4.0× / 3.0× | 1.0× / 0.7× |
| math_latex | 0.58 | 1.48 | 4.95 | 5.86 | 52.9 | 35.7 | 16.1 | 4.5 | 10.7× / 9.0× | 7.2× / 6.1× | 3.2× / 2.7× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×19.21 vs v0.23.1 · ×3.06 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 82.1 | ×19.74 | ×1.71 | 13% (1.2) | 0% (0.0) | 38% (3.7) | 50% (4.9) | 0% (0.0) | match |
| arb_Arab | lang | 4.8 | 87.4 | ×18.06 | ×4.89 | 12% (1.2) | 0% (0.0) | 25% (2.3) | 62% (5.9) | 0% (0.0) | match |
| ben_Beng | lang | 4.3 | 97.4 | ×22.91 | ×3.66 | 12% (1.2) | 0% (0.0) | 32% (3.1) | 56% (5.5) | 0% (0.0) | match |
| cmn_Hani | lang | 5.1 | 78.2 | ×15.32 | ×5.36 | 12% (1.2) | 0% (0.0) | 25% (2.4) | 62% (6.0) | 1% (0.1) | match |
| ell_Grek | lang | 5.1 | 102.4 | ×19.94 | ×5.26 | 15% (1.2) | 0% (0.0) | 28% (2.2) | 55% (4.3) | 1% (0.1) | match |
| eng_Latn | lang | 3.9 | 73.6 | ×18.78 | ×1.65 | 25% (2.7) | 0% (0.0) | 28% (3.1) | 47% (5.1) | 0% (0.0) | match |
| heb_Hebr | lang | 4.4 | 87.3 | ×19.90 | ×3.41 | 12% (1.2) | 0% (0.0) | 25% (2.4) | 63% (6.0) | 0% (0.0) | match |
| hin_Deva | lang | 4.0 | 88.7 | ×22.43 | ×2.97 | 11% (1.2) | 0% (0.0) | 30% (3.2) | 58% (6.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.9 | 106.1 | ×18.11 | ×6.82 | 17% (1.2) | 1% (0.1) | 31% (2.2) | 52% (3.7) | 0% (0.0) | match |
| kat_Geor | lang | 6.6 | 123.2 | ×18.66 | ×5.57 | 18% (1.2) | 0% (0.0) | 33% (2.1) | 47% (3.0) | 1% (0.1) | match |
| kor_Hang | lang | 4.1 | 63.8 | ×15.39 | ×3.43 | 9% (1.2) | 0% (0.0) | 20% (2.6) | 71% (9.3) | 0% (0.1) | match |
| rus_Cyrl | lang | 5.3 | 97.8 | ×18.56 | ×5.21 | 15% (1.2) | 0% (0.0) | 27% (2.1) | 57% (4.5) | 1% (0.1) | match |
| tam_Taml | lang | 3.8 | 97.3 | ×25.49 | ×2.75 | 12% (1.2) | 0% (0.0) | 28% (2.7) | 59% (5.6) | 0% (0.0) | match |
| tha_Thai | lang | 5.0 | 90.5 | ×18.01 | ×4.30 | 13% (1.2) | 0% (0.0) | 29% (2.6) | 58% (5.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 174.2 | ×29.38 | ×6.44 | 25% (1.3) | 0% (0.0) | 21% (1.1) | 51% (2.7) | 3% (0.1) | match |
| added_normalized_sparse | modalities | 5.4 | 130.7 | ×24.30 | ×3.11 | 28% (2.0) | 0% (0.0) | 27% (1.9) | 44% (3.2) | 3% (0.2) | match |
| added_special_dense | modalities | 4.2 | 48.0 | ×11.51 | ×1.01 | 63% (12.4) | 0% (0.0) | 28% (5.5) | 9% (1.7) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.4 | 63.0 | ×14.42 | ×1.09 | 46% (7.0) | 0% (0.0) | 34% (5.1) | 20% (3.0) | 1% (0.1) | match |
| agentic-traces | modalities | 3.6 | 67.9 | ×18.79 | ×1.91 | 21% (2.6) | 0% (0.0) | 29% (3.7) | 50% (6.4) | 0% (0.0) | match |
| agentic_swe | modalities | 3.9 | 86.3 | ×22.21 | ×3.09 | 20% (2.0) | 3% (0.3) | 28% (2.8) | 51% (5.1) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 82.6 | ×20.48 | ×1.81 | 23% (2.4) | 0% (0.0) | 31% (3.2) | 46% (4.8) | 1% (0.1) | match |
| math_latex | modalities | 3.8 | 69.7 | ×18.45 | ×1.79 | 22% (2.7) | 1% (0.2) | 28% (3.4) | 48% (5.9) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.41 | 3.67 | 4.46 | 27.7 | 16.2 | 5.8 | 4.8 | 7.5× / 6.2× | 4.4× / 3.6× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 3.03 | 2.33 | 4.36 | 31.7 | 20.3 | 6.7 | 5.2 | 13.7× / 7.3× | 8.7× / 4.7× | 2.9× / 1.5× | 2.2× / 1.2× |
| ben_Beng | 1.47 | 2.92 | 3.12 | 4.57 | 46.7 | 28.4 | 10.1 | 3.7 | 15.0× / 10.2× | 9.1× / 6.2× | 3.2× / 2.2× | 1.2× / 0.8× |
| cmn_Hani | 1.13 | 2.34 | 2.40 | 3.61 | 20.0 | 11.9 | 4.7 | 2.3 | 8.3× / 5.5× | 5.0× / 3.3× | 2.0× / 1.3× | 1.0× / 0.6× |
| ell_Grek | 0.58 | 3.05 | 2.21 | 4.68 | 28.5 | 17.2 | 6.0 | 4.8 | 12.9× / 6.1× | 7.8× / 3.7× | 2.7× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.11 | 1.46 | 3.11 | 4.46 | 44.7 | 33.3 | 12.1 | 3.8 | 14.4× / 10.0× | 10.7× / 7.5× | 3.9× / 2.7× | 1.2× / 0.8× |
| heb_Hebr | 1.00 | 3.05 | 2.35 | 4.41 | 32.0 | 19.9 | 6.9 | 3.0 | 13.6× / 7.2× | 8.5× / 4.5× | 2.9× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 3.10 | 3.21 | 4.94 | 49.6 | 31.4 | 11.0 | 4.0 | 15.5× / 10.0× | 9.8× / 6.3× | 3.4× / 2.2× | 1.3× / 0.8× |
| jpn_Jpan | 1.56 | 3.34 | 2.16 | 3.94 | 18.5 | 10.1 | 4.1 | 3.8 | 8.6× / 4.7× | 4.7× / 2.6× | 1.9× / 1.0× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.58 | 2.09 | 3.28 | 17.3 | 11.2 | 4.2 | 2.0 | 8.3× / 5.3× | 5.3× / 3.4× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.12 | 2.77 | 2.61 | 4.26 | 31.9 | 21.4 | 7.4 | 3.7 | 12.2× / 7.5× | 8.2× / 5.0× | 2.8× / 1.7× | 1.4× / 0.9× |
| rus_Cyrl | 1.01 | 2.92 | 2.15 | 4.06 | 27.5 | 17.1 | 5.9 | 2.4 | 12.8× / 6.8× | 8.0× / 4.2× | 2.7× / 1.4× | 1.1× / 0.6× |
| tam_Taml | 0.92 | 2.94 | 2.71 | 4.72 | 45.5 | 26.8 | 9.7 | 3.4 | 16.8× / 9.7× | 9.9× / 5.7× | 3.6× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.36 | 2.57 | 2.61 | 3.82 | 28.8 | 16.6 | 6.7 | 3.0 | 11.0× / 7.5× | 6.4× / 4.4× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.10 | 2.51 | 24.0 | 17.4 | 6.7 | 2.0 | 21.9× / 9.5× | 15.9× / 6.9× | 6.1× / 2.7× | 1.8× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.95 | 3.37 | 31.5 | 23.3 | 8.9 | 2.7 | 16.2× / 9.4× | 12.0× / 6.9× | 4.5× / 2.6× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 5.47 | 6.89 | 96.2 | 76.8 | 21.0 | 3.3 | 17.6× / 14.0× | 14.0× / 11.2× | 3.8× / 3.0× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.12 | 6.53 | 61.9 | 46.3 | 15.0 | 3.6 | 12.1× / 9.5× | 9.1× / 7.1× | 2.9× / 2.3× | 0.7× / 0.5× |
| agentic-traces | 0.57 | 1.48 | 3.71 | 4.62 | 53.2 | 45.1 | 14.7 | 4.6 | 14.3× / 11.5× | 12.2× / 9.8× | 4.0× / 3.2× | 1.2× / 1.0× |
| agentic_swe | 0.61 | 1.45 | 2.82 | 3.65 | 56.0 | 52.9 | 15.3 | 3.4 | 19.9× / 15.4× | 18.8× / 14.5× | 5.4× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.08 | 1.44 | 3.20 | 4.56 | 53.6 | 50.4 | 15.2 | 4.0 | 16.7× / 11.7× | 15.7× / 11.0× | 4.7× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.57 | 1.48 | 3.41 | 4.33 | 51.7 | 40.4 | 13.9 | 4.2 | 15.1× / 12.0× | 11.8× / 9.3× | 4.1× / 3.2× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×4.14 vs v0.23.1 · ×1.14 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 18+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.6 | 42.8 | ×9.24 | ×1.07 | 0% (0.0) | 12% (2.8) | 0% (0.0) | 88% (20.4) | 0% (0.0) | match |
| arb_Arab | lang | 9.9 | 49.2 | ×4.97 | ×1.01 | 0% (0.0) | 16% (3.2) | 0% (0.0) | 84% (17.1) | 0% (0.0) | match |
| ben_Beng | lang | 10.8 | 79.8 | ×7.39 | ×1.05 | 0% (0.0) | 18% (2.2) | 0% (0.0) | 82% (10.3) | 0% (0.0) | match |
| cmn_Hani | lang | 9.1 | 65.4 | ×7.17 | ×1.05 | 0% (0.1) | 3% (0.5) | 0% (0.0) | 96% (14.5) | 0% (0.0) | match |
| ell_Grek | lang | 10.0 | 57.2 | ×5.70 | ×1.03 | 0% (0.0) | 18% (3.2) | 0% (0.0) | 82% (14.4) | 0% (0.0) | match |
| eng_Latn | lang | 4.2 | 6.4 | ×1.55 | ×1.00 | 0% (0.1) | 4% (6.9) | 0% (0.0) | 95% (148.3) | 0% (0.3) | match |
| heb_Hebr | lang | 9.8 | 59.4 | ×6.05 | ×1.02 | 0% (0.0) | 20% (3.3) | 0% (0.0) | 80% (13.8) | 0% (0.0) | match |
| hin_Deva | lang | 11.6 | 76.0 | ×6.56 | ×1.03 | 0% (0.0) | 22% (2.9) | 0% (0.0) | 78% (10.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 12.5 | 84.6 | ×6.74 | ×1.06 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 96% (11.2) | 0% (0.0) | match |
| kat_Geor | lang | 13.8 | 89.9 | ×6.49 | ×1.06 | 0% (0.0) | 17% (1.9) | 0% (0.0) | 82% (9.1) | 0% (0.0) | match |
| kor_Hang | lang | 7.1 | 50.5 | ×7.08 | ×1.02 | 0% (0.1) | 17% (3.3) | 0% (0.0) | 83% (16.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 8.1 | 16.1 | ×1.99 | ×1.01 | 0% (0.0) | 5% (2.9) | 0% (0.0) | 95% (59.1) | 0% (0.1) | match |
| tam_Taml | lang | 12.3 | 88.2 | ×7.15 | ×1.06 | 0% (0.0) | 16% (1.8) | 0% (0.0) | 84% (9.4) | 0% (0.0) | match |
| tha_Thai | lang | 15.5 | 86.3 | ×5.58 | ×1.05 | 0% (0.0) | 9% (1.0) | 0% (0.0) | 90% (10.4) | 1% (0.2) | match |
| added_normalized_dense | modalities | 5.5 | 8.9 | ×1.62 | ×1.00 | 0% (0.0) | 3% (3.9) | 0% (0.0) | 97% (112.3) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.8 | 7.5 | ×1.57 | ×1.02 | 0% (0.0) | 5% (6.1) | 0% (0.0) | 95% (127.0) | 1% (0.9) | match |
| added_special_dense | modalities | 4.0 | 39.7 | ×9.81 | ×1.97 | 22% (5.2) | 66% (15.7) | 5% (1.1) | 10% (2.4) | 0% (0.0) | match |
| added_special_sparse | modalities | 5.7 | 50.3 | ×8.81 | ×4.91 | 12% (2.3) | 77% (14.1) | 2% (0.5) | 9% (1.7) | 0% (0.0) | match |
| agentic-traces | modalities | 4.4 | 7.1 | ×1.62 | ×1.01 | 0% (0.1) | 5% (6.2) | 0% (0.0) | 96% (133.2) | 0% (0.0) | match |
| agentic_swe | modalities | 3.9 | 7.0 | ×1.82 | ×1.01 | 0% (0.0) | 7% (9.8) | 0% (0.0) | 93% (132.3) | 0% (0.3) | match |
| code_mixed | modalities | 4.1 | 7.0 | ×1.72 | ×1.00 | 0% (0.0) | 6% (8.0) | 0% (0.0) | 95% (135.9) | 0% (0.0) | match |
| math_latex | modalities | 4.3 | 6.8 | ×1.58 | ×1.01 | 0% (0.1) | 4% (6.5) | 0% (0.0) | 95% (139.6) | 0% (0.1) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×20.60 vs v0.23.1 · ×3.06 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 94)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 88.0 | ×20.06 | ×1.82 | 7% (0.7) | 0% (0.0) | 41% (3.7) | 51% (4.6) | 1% (0.0) | match |
| arb_Arab | lang | 4.7 | 95.4 | ×20.31 | ×5.33 | 7% (0.6) | 0% (0.0) | 27% (2.3) | 65% (5.5) | 0% (0.0) | match |
| ben_Beng | lang | 4.1 | 96.1 | ×23.23 | ×3.07 | 6% (0.6) | 0% (0.0) | 33% (3.1) | 61% (5.8) | 0% (0.0) | match |
| cmn_Hani | lang | 5.3 | 84.4 | ×15.92 | ×5.05 | 7% (0.6) | 0% (0.0) | 27% (2.4) | 65% (5.7) | 1% (0.1) | match |
| ell_Grek | lang | 5.5 | 114.5 | ×20.65 | ×5.93 | 9% (0.6) | 0% (0.0) | 31% (2.2) | 60% (4.2) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 81.0 | ×18.26 | ×1.75 | 20% (2.1) | 2% (0.2) | 29% (3.0) | 49% (5.0) | 0% (0.0) | match |
| heb_Hebr | lang | 4.6 | 94.9 | ×20.63 | ×3.65 | 7% (0.6) | 0% (0.0) | 26% (2.3) | 67% (5.9) | 0% (0.0) | match |
| hin_Deva | lang | 4.6 | 115.7 | ×25.40 | ×1.51 | 8% (0.6) | 0% (0.0) | 42% (3.2) | 50% (3.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.1 | 120.0 | ×19.69 | ×7.40 | 10% (0.6) | 0% (0.0) | 35% (2.2) | 57% (3.5) | 0% (0.0) | match |
| kat_Geor | lang | 6.0 | 140.7 | ×23.30 | ×3.79 | 10% (0.6) | 0% (0.0) | 36% (2.1) | 52% (3.1) | 2% (0.1) | match |
| kor_Hang | lang | 4.4 | 68.4 | ×15.60 | ×3.58 | 5% (0.6) | 0% (0.0) | 20% (2.5) | 73% (8.9) | 2% (0.2) | match |
| rus_Cyrl | lang | 5.5 | 106.1 | ×19.43 | ×6.48 | 8% (0.6) | 0% (0.0) | 28% (2.1) | 62% (4.8) | 3% (0.2) | match |
| tam_Taml | lang | 4.2 | 102.3 | ×24.44 | ×2.88 | 7% (0.6) | 0% (0.0) | 30% (2.7) | 63% (5.6) | 0% (0.0) | match |
| tha_Thai | lang | 5.6 | 103.3 | ×18.60 | ×5.09 | 8% (0.6) | 0% (0.0) | 34% (2.6) | 59% (4.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.2 | 183.2 | ×29.47 | ×6.74 | 16% (0.8) | 0% (0.0) | 22% (1.1) | 60% (2.9) | 2% (0.1) | match |
| added_normalized_sparse | modalities | 5.6 | 139.0 | ×24.91 | ×3.26 | 19% (1.3) | 0% (0.0) | 30% (2.0) | 50% (3.4) | 2% (0.2) | match |
| added_special_dense | modalities | 4.2 | 77.9 | ×18.35 | ×1.03 | 41% (5.0) | 1% (0.1) | 41% (5.0) | 16% (2.0) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.4 | 82.3 | ×18.51 | ×1.14 | 29% (3.2) | 0% (0.1) | 44% (4.9) | 27% (3.0) | 0% (0.0) | match |
| agentic-traces | modalities | 3.8 | 73.8 | ×19.48 | ×1.97 | 16% (1.9) | 0% (0.1) | 31% (3.7) | 52% (6.2) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 93.8 | ×22.20 | ×3.30 | 15% (1.4) | 0% (0.0) | 30% (2.8) | 53% (5.0) | 1% (0.1) | match |
| code_mixed | modalities | 4.3 | 89.4 | ×20.78 | ×1.90 | 17% (1.7) | 0% (0.0) | 34% (3.2) | 49% (4.8) | 0% (0.0) | match |
| math_latex | modalities | 3.9 | 75.4 | ×19.12 | ×1.84 | 18% (2.0) | 0% (0.0) | 31% (3.5) | 50% (5.6) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.51 | 3.67 | 4.54 | 26.3 | 15.9 | 5.8 | 4.8 | 7.2× / 5.8× | 4.3× / 3.5× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 2.97 | 2.30 | 4.27 | 30.0 | 19.8 | 6.8 | 5.2 | 13.0× / 7.0× | 8.6× / 4.6× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.47 | 2.92 | 3.10 | 4.55 | 43.8 | 27.8 | 10.1 | 3.7 | 14.1× / 9.6× | 9.0× / 6.1× | 3.3× / 2.2× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.35 | 2.38 | 3.61 | 19.2 | 11.6 | 4.7 | 2.4 | 8.0× / 5.3× | 4.9× / 3.2× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.06 | 2.18 | 4.65 | 27.1 | 16.9 | 6.0 | 4.8 | 12.4× / 5.8× | 7.8× / 3.6× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.45 | 2.98 | 4.34 | 41.8 | 33.4 | 12.2 | 3.8 | 14.0× / 9.6× | 11.2× / 7.7× | 4.1× / 2.8× | 1.3× / 0.9× |
| heb_Hebr | 1.00 | 3.20 | 2.29 | 4.49 | 29.7 | 19.2 | 7.0 | 3.1 | 13.0× / 6.6× | 8.4× / 4.3× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 3.12 | 3.21 | 4.96 | 46.5 | 30.0 | 11.3 | 4.0 | 14.5× / 9.4× | 9.3× / 6.0× | 3.5× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.55 | 3.38 | 2.18 | 4.01 | 18.0 | 9.8 | 4.1 | 3.8 | 8.3× / 4.5× | 4.5× / 2.5× | 1.9× / 1.0× | 1.7× / 0.9× |
| kat_Geor | 1.38 | 2.53 | 2.09 | 3.23 | 16.4 | 11.1 | 4.1 | 2.0 | 7.9× / 5.1× | 5.3× / 3.4× | 2.0× / 1.3× | 0.9× / 0.6× |
| kor_Hang | 1.08 | 2.73 | 2.50 | 4.16 | 30.0 | 22.0 | 7.3 | 3.7 | 12.0× / 7.2× | 8.8× / 5.3× | 2.9× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 3.06 | 2.13 | 4.16 | 25.8 | 16.2 | 5.8 | 2.4 | 12.1× / 6.2× | 7.6× / 3.9× | 2.7× / 1.4× | 1.1× / 0.6× |
| tam_Taml | 0.92 | 2.92 | 2.68 | 4.68 | 43.0 | 26.0 | 9.7 | 3.6 | 16.0× / 9.2× | 9.7× / 5.6× | 3.6× / 2.1× | 1.3× / 0.8× |
| tha_Thai | 1.36 | 2.55 | 2.60 | 3.79 | 27.4 | 16.2 | 6.7 | 3.0 | 10.5× / 7.2× | 6.2× / 4.3× | 2.6× / 1.8× | 1.1× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.09 | 2.50 | 22.6 | 16.9 | 6.4 | 2.0 | 20.8× / 9.0× | 15.6× / 6.8× | 5.9× / 2.6× | 1.8× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 2.03 | 3.45 | 29.8 | 22.6 | 8.8 | 2.7 | 14.7× / 8.6× | 11.1× / 6.6× | 4.4× / 2.6× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.98 | 6.39 | 90.3 | 71.8 | 21.5 | 3.3 | 18.1× / 14.1× | 14.4× / 11.2× | 4.3× / 3.4× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 4.94 | 6.36 | 57.9 | 47.5 | 14.9 | 3.7 | 11.7× / 9.1× | 9.6× / 7.5× | 3.0× / 2.3× | 0.8× / 0.6× |
| agentic-traces | 0.64 | 1.47 | 3.67 | 4.50 | 50.6 | 44.3 | 14.8 | 4.6 | 13.8× / 11.2× | 12.0× / 9.8× | 4.0× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.62 | 1.45 | 2.81 | 3.64 | 52.9 | 51.7 | 15.3 | 3.4 | 18.8× / 14.5× | 18.4× / 14.2× | 5.4× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.24 | 4.62 | 50.6 | 49.8 | 15.0 | 4.0 | 15.6× / 11.0× | 15.4× / 10.8× | 4.6× / 3.2× | 1.2× / 0.9× |
| math_latex | 0.56 | 1.47 | 3.47 | 4.38 | 48.8 | 39.6 | 14.1 | 4.2 | 14.1× / 11.2× | 11.4× / 9.1× | 4.1× / 3.2× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×7.27 vs v0.23.1 · ×2.11 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 193) · Pipeline 109+0 (peak 194)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 42.9 | ×11.12 | ×1.42 | 6% (1.2) | 0% (0.0) | 70% (14.3) | 24% (4.9) | 0% (0.0) | match |
| arb_Arab | lang | 4.8 | 39.8 | ×8.32 | ×2.32 | 5% (1.2) | 0% (0.0) | 72% (16.6) | 22% (5.1) | 0% (0.1) | match |
| ben_Beng | lang | 6.8 | 59.6 | ×8.73 | ×3.47 | 8% (1.2) | 0% (0.0) | 72% (10.9) | 20% (3.1) | 0% (0.0) | match |
| cmn_Hani | lang | 5.0 | 46.3 | ×9.20 | ×2.98 | 6% (1.2) | 0% (0.0) | 62% (11.7) | 32% (5.9) | 0% (0.0) | match |
| ell_Grek | lang | 5.4 | 43.2 | ×8.08 | ×2.82 | 6% (1.2) | 0% (0.0) | 71% (15.1) | 23% (4.9) | 1% (0.1) | match |
| eng_Latn | lang | 3.8 | 24.4 | ×6.33 | ×1.27 | 7% (2.7) | 0% (0.0) | 79% (30.2) | 14% (5.4) | 0% (0.0) | match |
| heb_Hebr | lang | 4.7 | 38.0 | ×8.15 | ×2.72 | 5% (1.2) | 0% (0.0) | 71% (17.3) | 27% (6.5) | 0% (0.0) | match |
| hin_Deva | lang | 6.8 | 53.7 | ×7.91 | ×2.50 | 7% (1.2) | 0% (0.0) | 75% (13.0) | 18% (3.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.8 | 60.0 | ×10.39 | ×3.94 | 8% (1.2) | 0% (0.0) | 67% (9.8) | 25% (3.7) | 0% (0.0) | match |
| kat_Geor | lang | 6.8 | 62.1 | ×9.11 | ×4.36 | 8% (1.2) | 0% (0.0) | 71% (10.2) | 21% (3.0) | 0% (0.0) | match |
| kor_Hang | lang | 4.3 | 31.0 | ×7.26 | ×2.05 | 4% (1.2) | 0% (0.0) | 66% (19.3) | 29% (8.5) | 1% (0.3) | match |
| rus_Cyrl | lang | 5.0 | 42.8 | ×8.62 | ×3.01 | 5% (1.2) | 0% (0.0) | 72% (15.2) | 23% (4.8) | 0% (0.1) | match |
| tam_Taml | lang | 6.9 | 69.2 | ×10.03 | ×4.75 | 9% (1.2) | 0% (0.0) | 70% (8.9) | 20% (2.6) | 1% (0.1) | match |
| tha_Thai | lang | 8.2 | 63.3 | ×7.76 | ×4.18 | 8% (1.2) | 0% (0.0) | 43% (6.0) | 49% (6.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.5 | 44.1 | ×7.97 | ×2.15 | 6% (1.3) | 0% (0.0) | 81% (17.5) | 14% (3.0) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 37.0 | ×7.17 | ×1.49 | 7% (1.9) | 0% (0.0) | 79% (20.5) | 14% (3.6) | 0% (0.1) | match |
| added_special_dense | modalities | 4.1 | 16.5 | ×4.05 | ×0.99 | 8% (5.1) | 0% (0.0) | 86% (51.1) | 6% (3.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 22.5 | ×5.19 | ×1.03 | 8% (3.6) | 0% (0.0) | 83% (35.7) | 9% (4.0) | 0% (0.0) | match |
| agentic-traces | modalities | 3.4 | 18.3 | ×5.39 | ×1.23 | 5% (2.5) | 0% (0.1) | 81% (43.2) | 15% (8.2) | 0% (0.0) | match |
| agentic_swe | modalities | 3.5 | 16.0 | ×4.59 | ×1.43 | 3% (2.0) | 0% (0.0) | 87% (53.3) | 11% (6.6) | 0% (0.0) | match |
| code_mixed | modalities | 3.7 | 17.5 | ×4.68 | ×1.18 | 4% (2.3) | 0% (0.0) | 86% (47.9) | 10% (5.7) | 0% (0.0) | match |
| math_latex | modalities | 3.6 | 20.7 | ×5.80 | ×1.20 | 6% (2.6) | 0% (0.0) | 80% (37.3) | 14% (6.7) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.41 | 14.31 | 15.09 | 28.4 | 14.5 | 6.6 | — | 2.0× / 1.9× | 1.0× / 1.0× | 0.5× / 0.4× | — |
| arb_Arab | 1.00 | 3.07 | 16.64 | 18.72 | 33.8 | 16.4 | 7.3 | — | 2.0× / 1.8× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| ben_Beng | 1.47 | 2.96 | 10.88 | 12.36 | 24.0 | 11.0 | 5.3 | — | 2.2× / 1.9× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| cmn_Hani | 1.13 | 2.32 | 11.68 | 12.88 | 22.7 | 11.5 | 5.5 | — | 1.9× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| ell_Grek | 0.59 | 3.01 | 15.07 | 17.49 | 29.8 | 15.4 | 6.5 | — | 2.0× / 1.7× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| eng_Latn | 0.10 | 1.46 | 30.20 | 31.57 | 44.8 | 30.3 | 13.3 | — | 1.5× / 1.4× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| heb_Hebr | 1.00 | 3.13 | 17.27 | 19.40 | 33.4 | 17.4 | 7.7 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| hin_Deva | 1.37 | 3.09 | 12.95 | 14.68 | 26.0 | 12.9 | 6.1 | — | 2.0× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| jpn_Jpan | 1.56 | 3.37 | 9.76 | 11.57 | 21.0 | 9.6 | 4.7 | — | 2.2× / 1.8× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| kat_Geor | 1.40 | 2.54 | 10.23 | 11.37 | 19.3 | 10.2 | 4.4 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| kor_Hang | 1.08 | 2.75 | 19.30 | 20.96 | 34.0 | 19.5 | 8.5 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| rus_Cyrl | 1.02 | 3.01 | 15.17 | 17.17 | 28.6 | 15.3 | 6.3 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| tam_Taml | 0.92 | 2.94 | 8.93 | 10.95 | 19.2 | 8.8 | 4.1 | — | 2.1× / 1.7× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| tha_Thai | 1.37 | 2.61 | 5.98 | 7.22 | 13.5 | 5.9 | 2.8 | — | 2.2× / 1.9× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| added_normalized_dense | 0.24 | 1.48 | 17.48 | 18.71 | 32.9 | 17.6 | 11.5 | — | 1.9× / 1.8× | 1.0× / 0.9× | 0.7× / 0.6× | — |
| added_normalized_sparse | 0.24 | 1.47 | 20.53 | 21.75 | 35.0 | 20.9 | 11.2 | — | 1.7× / 1.6× | 1.0× / 1.0× | 0.5× / 0.5× | — |
| added_special_dense | 0.24 | 1.47 | 51.06 | 52.29 | 89.7 | 68.7 | 23.7 | — | 1.8× / 1.7× | 1.3× / 1.3× | 0.5× / 0.5× | — |
| added_special_sparse | 0.24 | 1.47 | 35.69 | 36.92 | 57.8 | 41.6 | 15.8 | — | 1.6× / 1.6× | 1.2× / 1.1× | 0.4× / 0.4× | — |
| agentic-traces | 0.56 | 1.48 | 43.22 | 44.13 | 56.2 | 43.8 | 16.5 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| agentic_swe | 0.52 | 1.44 | 53.31 | 54.24 | 61.3 | 53.8 | 17.8 | — | 1.1× / 1.1× | 1.0× / 1.0× | 0.3× / 0.3× | — |
| code_mixed | 0.07 | 1.44 | 47.95 | 49.32 | 55.2 | 48.6 | 17.1 | — | 1.2× / 1.1× | 1.0× / 1.0× | 0.4× / 0.3× | — |
| math_latex | 0.57 | 1.48 | 37.26 | 38.17 | 52.8 | 37.7 | 15.3 | — | 1.4× / 1.4× | 1.0× / 1.0× | 0.4× / 0.4× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30258838171-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
