### PR TITLE
ci: fix unfait and inconsistent pipeline bench

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -1,48 +1,18 @@
 #!/usr/bin/env python3
-"""Render the fixture_bench JSON as full-size charts + a markdown report for a
-PR description.
+"""Render the fixture_bench JSON as charts + a markdown PR report.
 
-Input: JSON object from `cargo run --release -p tk-encode --features
-tk-encode/bench-baseline --example fixture_bench`:
+Two series: `baseline` (the latest released `tokenizers` crate — the bar to beat,
+drawn gray; the in-tree `Tokenizer` isn't benched, it's only the id oracle behind
+`ids_match`) and `pipeline` (the experimental PipelineTokenizer, blue). Leads with
+three always-visible charts — per-model geomean ×speedup, memory footprint, binary
+size — then one collapsed <details> per model (per-fixture speedup, thread scaling,
+stage mix, numbers table). Models the pipeline can't build yet render as "not
+supported" roadmap cards. Emits light+dark SVGs + pipeline_bench.md; the CI
+workflow rasterizes and uploads the SVGs. Input schema: see fixture_bench.rs.
 
-    {baseline: {crate, version},
-     models: [{model, shape, desc, [reason],
-               memory: {baseline|pipeline:
-                        {load_bytes, encode_bytes, peak_bytes} | null} | null,
-               threads: {counts: [1,2,4,8,max],
-                         pipeline_mbps: [..], baseline_mbps: [..|null]},
-               results: [{fixture, group, bytes, chunks,
-                          mbps: {baseline, pipeline},
-                          ids_match, ids_match_baseline,
-                          stage_ns_per_byte: {added_split, normalize,
-                                              pre_tokenize, model, total},
-                          pretok_vs_regex: {cls_simd, cls_scalar,
-                                            onig|null, fancy|null,
-                                            pcre2|null, logos|null}}]}]}
-
-Two series: `baseline` — the latest released tokenizers crate, the bar to beat
-(the in-tree Tokenizer is on its way out, so it isn't benched; it only serves
-as the id oracle behind `ids_match`) — drawn gray as context, and `pipeline` —
-the experimental PipelineTokenizer, blue. The report leads with three
-always-visible charts:
-
-  1. throughput overview — per model, geomean ×speedup of the pipeline against
-     the release (×1.0 = release), with a min–max whisker across fixtures (no
-     cross-model aggregate: the models exercise different execution modes, so
-     averaging them means nothing);
-  2. memory overview — per model, resident-set delta after load plus the encode
-     pass, one stacked bar per implementation, tick = peak RSS;
-  3. binary size — stripped minimal encode binary per implementation (workflow
-     measurement, via --binary-sizes).
-
-Everything else is collapsed into per-model <details> blocks: a per-fixture
-×speedup chart, a thread-scaling chart (encode throughput at 1/2/4/8/device-max
-threads, pipeline vs the release), the pipeline stage decomposition (100%-normalized per fixture —
-each stage as its share of that fixture's own encode time, labelled `share% ·
-ns/B`, so the mix reads regardless of how slow the release baseline is; total
-ns/B and ×speedup stay in the right column), and the numbers table (which carries
-the same per-stage `share% (ns/B)` columns). Models the pipeline can't build yet
-render as compact "not supported" roadmap cards. Charts are full-size for zoom.
+No cross-model aggregate anywhere on purpose: the models exercise different
+execution modes (normalizer-heavy / split-heavy / model-bounded), so only
+per-model geomeans mean anything.
 """
 import argparse
 import json
@@ -66,9 +36,8 @@ INK = {
         "border": "#33332f", "baseline": "#4a4a46", "critical": "#e66767",
     },
 }
-# Series identity: the release baseline is context-gray on purpose — in the
-# speedup charts it *is* the ×1.0 axis, in memory/binary-size it's the
-# reference bar the pipeline is read against.
+# The release baseline is context-gray on purpose: in the speedup charts it *is*
+# the ×1.0 axis; in memory/binary-size it's the reference bar to read against.
 SERIES_INK = {
     "light": {"baseline": "#898781", "pipeline": "#2a78d6"},
     "dark": {"baseline": "#898781", "pipeline": "#3987e5"},
@@ -76,16 +45,16 @@ SERIES_INK = {
 FONT = "-apple-system,'Segoe UI',Helvetica,Arial,sans-serif"
 GUTTER, PLOT_W, PAD_R, COL_W, ROW_H, BAR_H = 190, 540, 110, 150, 26, 16
 CHART_W = GUTTER + PLOT_W + PAD_R + COL_W
-# Overview charts: wider gutter (model name + desc), same total width.
+# Overview / linear charts: wider gutter (model name + desc), same total width.
 OV_GUTTER, OV_PLOT = 250, 440
+OV_PLOT_W = CHART_W - OV_GUTTER - PAD_R - COL_W  # plot width for 0-anchored linear bars
 TICKS = [0.5, 0.67, 0.75, 0.8, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0, 5.0, 7.0, 10.0]
 GROUPS = [("lang", "Languages"), ("modalities", "Modalities")]
 CARD_W, CARD_H = 470, 150
 
-# Pipeline encode stages, in execution order, keyed to `stage_ns_per_byte` in the
-# fixture_bench JSON. `added_split` = the added/special-token scan (AddedVocabulary),
-# `pre_tokenize` = the pre-tokenizer split — two distinct splitting costs. The four
-# stages sum to the whole-encode total.
+# Pipeline encode stages in execution order, keyed to `stage_ns_per_byte`.
+# `added_split` = added/special-token scan (AddedVocabulary), `pre_tokenize` =
+# pre-tokenizer split — two distinct splitting costs. The four sum to `total`.
 STAGES = [("added_split", "added-token"), ("normalize", "normalize"),
           ("pre_tokenize", "pre-tokenize"), ("model", "model")]
 STAGE_INK = {
@@ -135,6 +104,13 @@ def hbar(x0, x1, y, h, color):
     return f'<path d="{bar_path(x0, x1, y, h, 4)}" fill="{color}"/>'
 
 
+def log_x(gutter, plot_w, lo, hi):
+    """A log2 x-mapping onto [gutter, gutter+plot_w] — shared by the speedup charts
+    so different models plot on the same scale and are directly comparable."""
+    span = math.log2(hi) - math.log2(lo)
+    return lambda v: gutter + (math.log2(v) - math.log2(lo)) / span * plot_w
+
+
 def speedup(row):
     b, p = row["mbps"]["baseline"], row["mbps"]["pipeline"]
     return p / b if b and p else None
@@ -145,9 +121,9 @@ def model_speedups(model):
 
 
 def base_speedup(row, base_lookup, model_name):
-    """This PR's pipeline throughput ÷ the base branch's pipeline throughput for the
-    same (model, fixture) — the "did this PR help vs the base branch" ratio. `None`
-    when the base branch didn't bench that fixture (added model, renamed fixture …)."""
+    """This PR's pipeline throughput ÷ the base branch's, for the same (model,
+    fixture) — the "did this PR help vs base" ratio. `None` when the base branch
+    didn't bench that fixture (added model, renamed fixture …)."""
     p = row["mbps"].get("pipeline")
     b = base_lookup.get((model_name, row["fixture"]))
     return p / b if b and p else None
@@ -159,8 +135,7 @@ def base_model_speedups(model, base_lookup):
 
 
 def scale(models, speedups_of=model_speedups):
-    """Shared log2 x-range across every plotted speedup, so charts for
-    different models are directly comparable."""
+    """Shared log2 x-range across every plotted speedup."""
     vals = [v for m in models for v in speedups_of(m)]
     if not vals:
         return 0.75, 1.5
@@ -168,8 +143,8 @@ def scale(models, speedups_of=model_speedups):
 
 
 def nice_ticks(vmax):
-    """Round ticks for a 0-anchored linear axis: a 1/2/2.5/5×10^k step chosen
-    so ~5 ticks fit, never exceeding vmax."""
+    """Round ticks for a 0-anchored linear axis: a 1/2/2.5/5×10^k step chosen so
+    ~5 ticks fit, never exceeding vmax."""
     raw = vmax / 5
     mag = 10 ** math.floor(math.log10(raw))
     step = next(s * mag for s in (1, 2, 2.5, 5, 10) if s * mag >= raw)
@@ -177,8 +152,8 @@ def nice_ticks(vmax):
 
 
 def thin_ticks(ticks, x, min_px=26, keep=None):
-    """Drop axis ticks that would collide at the current scale. `keep` (e.g. the
-    ×1.0 baseline) always survives."""
+    """Drop axis ticks that would collide at the current scale; `keep` (the ×1.0
+    baseline) always survives."""
     kept = [t for t in ticks if t == keep]
     for t in ticks:
         if t != keep and all(abs(x(t) - x(k)) >= min_px for k in kept):
@@ -187,16 +162,16 @@ def thin_ticks(ticks, x, min_px=26, keep=None):
 
 
 def footer_text(ink, height, meta, subtitle_base=""):
-    """Run metadata as a single muted footer line. Kept out of the header so a
-    long shape/desc subtitle can never collide with the hardware string."""
+    """Run metadata as a single muted footer line, kept out of the header so a long
+    shape/desc subtitle can't collide with the hardware string."""
     parts = [meta[0], meta[1]] + ([subtitle_base] if subtitle_base else [])
     return (f'<text x="16" y="{height - 12}" fill="{ink["muted"]}" font-size="10.5" '
             f'style="font-variant-numeric:tabular-nums">{escape(" · ".join(parts))}</text>')
 
 
 def legend_row(ink, sink, y, entries):
-    """Bottom legend: [(kind, key, label)] with kind ∈ swatch|tick|dot; `key` is
-    a series key into `sink` or a raw color."""
+    """Bottom legend: [(kind, key, label)] with kind ∈ swatch|tick|dot; `key` is a
+    series key into `sink` or a raw color."""
     parts, lx = [], GUTTER
     for kind, key, label in entries:
         color = sink.get(key, key)
@@ -240,25 +215,30 @@ def speedup_axis(ink, x, ticks, top, bottom):
     return "".join(grid) + hints
 
 
+def linear_axis(ink, x, ticks, top, y, unit):
+    """0-anchored linear gridlines + labels (`unit` on the last tick), from `top`
+    down to `y`. Shared by the memory / binary-size / thread-scaling charts."""
+    grid = []
+    for tv in ticks:
+        u = unit if tv == ticks[-1] else ""
+        grid.append(f'<line x1="{x(tv):.1f}" y1="{top - 6}" x2="{x(tv):.1f}" y2="{y - 4}" '
+                    f'stroke="{ink["grid"]}" stroke-width="1"/>')
+        grid.append(f'<text x="{x(tv):.1f}" y="{y + 10}" fill="{ink["muted"]}" font-size="11" '
+                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{u}</text>')
+    return "".join(grid)
+
+
 def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label,
                  speedups_of=model_speedups, title=None, ref_label=None,
                  mark_regressions=False, no_cmp_msg=None):
-    """The headline chart: a row per manifest model — name + workload desc,
-    geomean ×speedup of the pipeline vs the reference (×1.0) with a min–max
-    whisker across fixtures. No cross-model aggregate on purpose: the models
-    exercise different execution modes. Unsupported models appear as muted
-    status rows so the overview is the complete state of the world.
-
-    Defaults draw "vs latest release". Pass `speedups_of=base_model_speedups`-style
-    with `mark_regressions=True` for the "vs base branch" twin: bars for models that
-    got slower than the base branch turn red."""
+    """Headline chart: one row per model — name + workload desc, geomean ×speedup vs
+    the reference (×1.0) with a min–max whisker across fixtures. Unsupported models
+    show as muted status rows so the overview is the complete state of the world.
+    `mark_regressions=True` (the "vs base branch" twin) turns slower-than-base bars red."""
     ink, sink = INK[mode], SERIES_INK[mode]
     title = title or "PipelineTokenizer vs latest release — encode throughput"
     ref_label = ref_label or baseline_label
-
-    def x(v):
-        return OV_GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * OV_PLOT
-
+    x = log_x(OV_GUTTER, OV_PLOT, lo, hi)
     ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x, min_px=34, keep=1.0)
 
     top, row_h = 74, 40
@@ -344,10 +324,9 @@ def memory_svg(models, mode, meta, baseline_label):
     if not vals:
         return svg_doc(ink, 120, "Memory footprint", "no data", "", meta)
     max_mb = max(vals) * 1.05
-    plot_w = CHART_W - OV_GUTTER - PAD_R - COL_W
 
     def x(v):
-        return OV_GUTTER + v / max_mb * plot_w
+        return OV_GUTTER + v / max_mb * OV_PLOT_W
 
     top, bar_h, row_h = 78, 12, 2 * (12 + 3) + 16
     col_x = CHART_W - 16
@@ -386,14 +365,7 @@ def memory_svg(models, mode, meta, baseline_label):
                     f'{chain(totals, "{:.0f}")}</text>')
         y += row_h
 
-    grid = []
-    ticks = nice_ticks(max_mb)
-    for tv in ticks:
-        unit = " MB" if tv == ticks[-1] else ""
-        grid.append(f'<line x1="{x(tv):.1f}" y1="{top - 6}" x2="{x(tv):.1f}" y2="{y - 4}" '
-                    f'stroke="{ink["grid"]}" stroke-width="1"/>')
-        grid.append(f'<text x="{x(tv):.1f}" y="{y + 10}" fill="{ink["muted"]}" font-size="11" '
-                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{unit}</text>')
+    grid = linear_axis(ink, x, nice_ticks(max_mb), top, y, " MB")
     y += 30
     legend = legend_row(ink, sink, y, [
         ("swatch", "baseline", baseline_label),
@@ -403,18 +375,15 @@ def memory_svg(models, mode, meta, baseline_label):
     height = y + 34
     subtitle = "resident-set delta per implementation, one process each · load + encode pass"
     return svg_doc(ink, height, "Memory footprint",
-                   subtitle, "".join(grid) + "".join(body) + legend, meta)
+                   subtitle, grid + "".join(body) + legend, meta)
 
 
 def chart_svg(model, mode, subtitle_base, meta, lo, hi, baseline_label):
-    """Full-size per-fixture chart: the pipeline's ×speedup vs the release, with
-    the `MB/s: release → Pipeline` throughput column."""
+    """Full-size per-fixture chart: the pipeline's ×speedup vs the release, with the
+    `MB/s: release → Pipeline` throughput column."""
     ink, sink = INK[mode], SERIES_INK[mode]
     rows = model["results"]
-
-    def x(v):
-        return GUTTER + (math.log2(v) - math.log2(lo)) / (math.log2(hi) - math.log2(lo)) * PLOT_W
-
+    x = log_x(GUTTER, PLOT_W, lo, hi)
     ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x, min_px=34, keep=1.0)
 
     top = 74
@@ -424,9 +393,8 @@ def chart_svg(model, mode, subtitle_base, meta, lo, hi, baseline_label):
     y = top
     baseline_id_note = False
     for key, title in GROUPS:
-        # stable order (alphabetical by fixture) so a fixture keeps its row across
-        # runs and lines up with the stage-decomposition chart — not sorted by the
-        # (run-varying) speedup.
+        # stable order (alphabetical) so a fixture keeps its row across runs and
+        # lines up with the stage chart — not sorted by the (run-varying) speedup.
         group_rows = sorted((r for r in rows if r["group"] == key),
                             key=lambda r: r["fixture"])
         if not group_rows:
@@ -515,12 +483,11 @@ def stage_cell(s, key):
 
 
 def stage_chart_svg(model, mode, subtitle_base, meta, baseline_label):
-    """Per-fixture breakdown of where the pipeline spends its OWN encode time, as a
-    100%-normalized stacked bar: each stage is its share of THAT fixture's total,
-    labelled `share% · ns/B`. Normalizing per row (instead of a shared ns/byte scale
-    anchored to the slow release) keeps the mix readable no matter the absolute cost;
-    the right column keeps the total ns/byte and the ×speedup vs the release, so
-    neither the magnitude nor the comparison is lost."""
+    """Per-fixture 100%-normalized stacked bar of where the pipeline spends its OWN
+    encode time — each stage as its share of THAT fixture's total, labelled
+    `share% · ns/B`. Normalizing per row (not on a shared ns/byte scale anchored to
+    the slow release) keeps the mix readable at any absolute cost; the right column
+    keeps the total ns/byte and the ×speedup vs the release."""
     ink = INK[mode]
     sink = STAGE_INK[mode]
     rows = [r for r in model["results"] if "stage_ns_per_byte" in r]
@@ -572,7 +539,6 @@ def stage_chart_svg(model, mode, subtitle_base, meta, baseline_label):
             y += ROW_H
         y += 10
 
-    # x-axis: fixed 0–100% gridlines
     grid = []
     for pct in (0, 25, 50, 75, 100):
         gx = GUTTER + pct / 100 * PLOT_W
@@ -582,7 +548,6 @@ def stage_chart_svg(model, mode, subtitle_base, meta, baseline_label):
                     f'text-anchor="middle" style="font-variant-numeric:tabular-nums">'
                     f'{pct}{"%" if pct == 100 else ""}</text>')
 
-    # legend row: the stage colors
     y += 26
     legend = legend_row(ink, sink, y, [("swatch", k, lbl) for k, lbl in STAGES])
     height = y + 34
@@ -595,9 +560,8 @@ def stage_chart_svg(model, mode, subtitle_base, meta, baseline_label):
 
 
 def card_svg(model, mode):
-    """Compact roadmap card for a model the pipeline can't bench yet (or that
-    failed to load). Plain single-chunk text only: cairosvg mis-centers
-    text-anchor with tspans."""
+    """Compact roadmap card for a model the pipeline can't bench yet (or that failed
+    to load). Plain single-chunk text only: cairosvg mis-centers tspans."""
     ink = INK[mode]
     pretok = model["shape"].split("·")[-1].strip()
     why = model.get("reason") or f"PipelineTokenizer has no {pretok} pre-tokenizer"
@@ -666,14 +630,13 @@ def mem_line(model, baseline_label):
 def binsize_svg(sizes, mode, meta, baseline_label):
     """Stripped size of a minimal release-built encode program (load a
     tokenizer.json, encode one string) linking each implementation — what the
-    library adds to a shipped binary. Bars are 0-anchored on a linear MB axis."""
+    library adds to a shipped binary. Bars 0-anchored on a linear MB axis."""
     ink, sink = INK[mode], SERIES_INK[mode]
     rows = [("baseline", baseline_label), ("pipeline", "PipelineTokenizer")]
     max_mb = max(sizes.values()) / 1e6 * 1.15
-    plot_w = CHART_W - OV_GUTTER - PAD_R - COL_W
 
     def x(v):
-        return OV_GUTTER + v / max_mb * plot_w
+        return OV_GUTTER + v / max_mb * OV_PLOT_W
 
     top, bar_h, row_h = 74, 16, 30
     body = [f'<text x="{OV_GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
@@ -693,19 +656,12 @@ def binsize_svg(sizes, mode, meta, baseline_label):
                     f'style="font-variant-numeric:tabular-nums">{escape(txt)}</text>')
         y += row_h
 
-    grid = []
-    ticks = nice_ticks(max_mb)
-    for tv in ticks:
-        unit = " MB" if tv == ticks[-1] else ""
-        grid.append(f'<line x1="{x(tv):.1f}" y1="{top - 6}" x2="{x(tv):.1f}" y2="{y - 4}" '
-                    f'stroke="{ink["grid"]}" stroke-width="1"/>')
-        grid.append(f'<text x="{x(tv):.1f}" y="{y + 10}" fill="{ink["muted"]}" font-size="11" '
-                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{unit}</text>')
+    grid = linear_axis(ink, x, nice_ticks(max_mb), top, y, " MB")
     height = y + 44
     subtitle = ("stripped release build of a minimal encode program "
                 "(load a tokenizer.json + encode one string)")
     return svg_doc(ink, height, "Binary size",
-                   subtitle, "".join(grid) + "".join(body), meta)
+                   subtitle, grid + "".join(body), meta)
 
 
 def has_threads(m):
@@ -714,10 +670,10 @@ def has_threads(m):
 
 
 def threads_svg(model, mode, meta, baseline_label):
-    """Per model: encode throughput (MB/s) at 1/2/4/8/device-max threads — pipeline vs the release —
-    with a per-row *ideal linear* tick (single-thread throughput × N) on the pipeline bar. So whether the
-    pipeline scales linearly (bar reaches the tick) or sub-linearly (bar falls short of it) is visible at a
-    glance, alongside the pipeline↔release gap; the right column carries the self-scaling % of linear."""
+    """Per model: encode throughput (MB/s) at 1/2/4/8/device-max threads — pipeline
+    vs the release — with a per-row *ideal linear* tick (single-thread × N) on the
+    pipeline bar, so linear vs sub-linear scaling is visible at a glance alongside
+    the pipeline↔release gap; the right column carries self-scaling % of linear."""
     ink, sink = INK[mode], SERIES_INK[mode]
     t = model["threads"]
     counts, pipe, base = t["counts"], t["pipeline_mbps"], t["baseline_mbps"]
@@ -725,10 +681,9 @@ def threads_svg(model, mode, meta, baseline_label):
     ideal = [p1 * n for n in counts] if p1 else []
     vals = [v for v in pipe if v] + [v for v in base if v] + ideal
     max_mb = (max(vals) if vals else 1.0) * 1.08
-    plot_w = CHART_W - OV_GUTTER - PAD_R - COL_W
 
     def x(v):
-        return OV_GUTTER + v / max_mb * plot_w
+        return OV_GUTTER + v / max_mb * OV_PLOT_W
 
     top, bar_h, gap = 78, 11, 3
     row_h = 2 * (bar_h + gap) + 16
@@ -764,15 +719,7 @@ def threads_svg(model, mode, meta, baseline_label):
                     f'text-anchor="end" style="font-variant-numeric:tabular-nums">{right}</text>')
         y += row_h
 
-    grid = []
-    ticks = nice_ticks(max_mb)
-    for tv in ticks:
-        unit = " MB/s" if tv == ticks[-1] else ""
-        gx = x(tv)
-        grid.append(f'<line x1="{gx:.1f}" y1="{top - 6}" x2="{gx:.1f}" y2="{y - 4}" '
-                    f'stroke="{ink["grid"]}" stroke-width="1"/>')
-        grid.append(f'<text x="{gx:.1f}" y="{y + 10}" fill="{ink["muted"]}" font-size="11" '
-                    f'text-anchor="middle" style="font-variant-numeric:tabular-nums">{tv:g}{unit}</text>')
+    grid = linear_axis(ink, x, nice_ticks(max_mb), top, y, " MB/s")
     y += 30
     legend = legend_row(ink, sink, y, [
         ("swatch", "baseline", baseline_label),
@@ -786,15 +733,13 @@ def threads_svg(model, mode, meta, baseline_label):
         scaling = f" · pipeline {sc:.1f}× on {counts[-1]} threads ({sc / counts[-1] * 100:.0f}% of linear)"
     subtitle = f"throughput at N threads vs {baseline_label}; tick = perfect linear scaling{scaling}"
     return svg_doc(ink, height, "Thread scaling",
-                   subtitle, "".join(grid) + "".join(body) + legend, meta)
+                   subtitle, grid + "".join(body) + legend, meta)
 
 
 def pretok_compare_md(model):
-    """Per-fixture 'classify + fsm vs a regex engine' table: the pre-tokenize split beating both onig
-    (C) and fancy-regex (pure Rust), WITH and WITHOUT SIMD. Rendered only for regex pre-tokenizers
-    (a reference is non-null). ns/byte, lower better. pipe-SIMD = the pre-tokenize stage (SIMD classify
-    + scalar fsm); pipe-scalar swaps in the scalar classifier (= pre-tokenize + (cls_scalar - cls_simd));
-    onig/fancy run the model's own pre-tokenizer regex(es)."""
+    """Per-fixture 'classify + fsm vs a regex engine' table — the pre-tokenize split
+    vs onig/fancy/pcre2/logos on the model's own regex, WITH and WITHOUT SIMD.
+    Rendered only for regex pre-tokenizers (a reference is non-null)."""
     engines = ("onig", "fancy", "pcre2", "logos")
 
     def has_ref(r):
@@ -830,10 +775,8 @@ def pretok_compare_md(model):
 
 def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
                     base_lookup=None, base_ref=None):
-    """Overview charts inline; everything per-model — charts and the per-fixture
-    table — inside one <details> block per model, so the PR description stays a
-    single screen. No cross-model aggregate number anywhere: the models exercise
-    different execution modes, so only per-model geomeans are meaningful."""
+    """Overview charts inline; everything per-model inside one <details> block, so
+    the PR description stays a single screen."""
     models = data["models"]
     baseline_label = f'v{data["baseline"]["version"]}'
     benched = [m for m in models if m["results"]]
@@ -885,9 +828,9 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
             md += [picture(base, run_id, f"{slug}-threads",
                            f"{m['model']} thread scaling", 860), ""]
         md += [mem_line(m, baseline_label), ""]
-        # Per-stage columns show each split's share of the pipeline's own encode time
-        # with the ns/byte alongside — `share% (ns/B)` — so the split cost is readable
-        # as text regardless of how slow the release baseline is.
+        # Per-stage columns carry each split's share of the pipeline's own encode
+        # time with the ns/byte alongside — `share% (ns/B)` — readable as text
+        # regardless of how slow the release baseline is.
         base_col = " Δ base |" if base_lookup else ""
         base_sep = "---:|" if base_lookup else ""
         md += [f"| Fixture | Group | {baseline_label} MB/s | Pipeline MB/s | Speedup |{base_col} "
@@ -914,8 +857,7 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
         md += pretok_compare_md(m)
         md += ["", "</details>", ""]
 
-    # Unsupported / failed-to-load models: roadmap cards, collapsed — they're
-    # status, not results.
+    # Unsupported / failed-to-load models: roadmap cards, collapsed — status, not results.
     if unsupported:
         names = ", ".join(f"<code>{escape(m['model'])}</code>" for m in unsupported)
         md += [f"<details><summary><b>Not yet supported:</b> {names}</summary>", "", "<table>"]
@@ -1009,8 +951,7 @@ def main():
         render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes,
                         base_lookup=base_lookup, base_ref=args.base_ref))
 
-    # per-model geomeans only — a cross-model aggregate would average unrelated
-    # execution modes (normalizer-heavy vs split-heavy vs model-bounded)
+    # per-model geomeans only — a cross-model aggregate would average unrelated modes
     per_model = " · ".join(
         f"{m['model']} x{geomean(model_speedups(m)):.3f}"
         for m in benched if model_speedups(m))

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -193,8 +193,12 @@ jobs:
       # the "how much does this library add to my binary" number.
       - name: Measure binary sizes
         run: |
-          cargo build --release -p tk-encode --features tk-encode/bench-baseline \
-            --example binsize_baseline --example binsize_pipeline
+          # The baseline example needs `bench-baseline` (it links the released crate);
+          # the pipeline example is built in its shipping config (NO bench-baseline) so
+          # its size reflects what a user actually links — not the benchmark-only
+          # reference-regex deps (fancy-regex/onig/pcre2/logos) the feature drags in.
+          cargo build --release -p tk-encode --features tk-encode/bench-baseline --example binsize_baseline
+          cargo build --release -p tk-encode --example binsize_pipeline
           printf '{' > binary_sizes.json
           sep=''
           for key in baseline pipeline; do

--- a/tokenizers/tk-encode/examples/binsize_baseline.rs
+++ b/tokenizers/tk-encode/examples/binsize_baseline.rs
@@ -13,5 +13,7 @@ fn main() {
         .next()
         .expect("usage: binsize_baseline <tokenizer.json> <text>");
     let tok = Tokenizer::from_file(path).unwrap();
-    println!("{}", tok.encode(text.as_str(), false).unwrap().len());
+    // `encode_fast` (offset-free) matches the pipeline's encode path — the path
+    // the throughput benchmark times on both sides — so the sizes compare like for like.
+    println!("{}", tok.encode_fast(text.as_str(), false).unwrap().len());
 }

--- a/tokenizers/tk-encode/examples/binsize_pipeline.rs
+++ b/tokenizers/tk-encode/examples/binsize_pipeline.rs
@@ -1,7 +1,9 @@
 //! Minimal encode program measured by CI for binary size: the `PipelineTokenizer`
 //! encode path (which still links the `Tokenizer` build path — a pipeline is
 //! built from one). Kept structurally identical to `binsize_baseline.rs` so the
-//! stripped sizes compare like for like.
+//! stripped sizes compare like for like. Built WITHOUT `bench-baseline` (unlike the
+//! baseline example), so the size is tk-encode's real shipping footprint — none of
+//! the benchmark-only reference-regex deps.
 
 use std::convert::TryFrom;
 

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -138,9 +138,9 @@ fn make_chunks(text: &str) -> Vec<String> {
     chunks
 }
 
-/// Every corpus in `data/fixtures/{lang,modalities}`, read and chunked once.
-fn load_fixtures() -> Vec<Fixture> {
-    let mut fixtures = Vec::new();
+/// The sorted `.txt` fixtures under `data/fixtures/{lang,modalities}`, tagged with group.
+fn fixture_paths() -> Vec<(&'static str, PathBuf)> {
+    let mut out = Vec::new();
     for group in ["lang", "modalities"] {
         let dir = Path::new(DATA_DIR).join("fixtures").join(group);
         let mut paths: Vec<_> = std::fs::read_dir(&dir)
@@ -149,19 +149,27 @@ fn load_fixtures() -> Vec<Fixture> {
             .filter(|p| p.extension().is_some_and(|x| x == "txt"))
             .collect();
         paths.sort();
-        for path in paths {
+        out.extend(paths.into_iter().map(|p| (group, p)));
+    }
+    out
+}
+
+/// Every corpus in `data/fixtures/{lang,modalities}`, read and chunked once.
+fn load_fixtures() -> Vec<Fixture> {
+    fixture_paths()
+        .into_iter()
+        .map(|(group, path)| {
             let name = path.file_stem().unwrap().to_str().unwrap().to_string();
             let chunks = make_chunks(&std::fs::read_to_string(&path).unwrap());
             let bytes = chunks.iter().map(String::len).sum();
-            fixtures.push(Fixture {
+            Fixture {
                 group,
                 name,
                 chunks,
                 bytes,
-            });
-        }
-    }
-    fixtures
+            }
+        })
+        .collect()
 }
 
 // ── timing helpers ──────────────────────────────────────────────────────────
@@ -266,8 +274,6 @@ fn bench_throughput(
     json!({
         "fixture": f.name,
         "group": f.group,
-        "bytes": f.bytes,
-        "chunks": f.chunks.len(),
         "mbps": { "baseline": base_mbps, "pipeline": pipe_mbps },
         "ids_match": ids_match,
         "ids_match_baseline": ids_match_baseline,
@@ -668,14 +674,35 @@ fn proc_status_bytes(key: &str) -> Option<i64> {
     Some(kb * 1024)
 }
 
+/// A small text sample for the memory child: the first `MEM_CHUNKS_PER_FIXTURE`
+/// chunks of each fixture, read as a bounded prefix instead of slurping the whole
+/// (~90 MB) corpus. Loading it all would spike the transient allocation well above
+/// the tokenizer itself, polluting `rss0` and `VmHWM` — corrupting the very numbers
+/// this child measures. The prefix contains those first chunks, so the encode pass
+/// is byte-for-byte what a full load would have produced.
+fn memory_sample() -> Vec<String> {
+    use std::io::Read;
+    let cap = (CHUNK_BYTES * (MEM_CHUNKS_PER_FIXTURE + 1)) as u64;
+    let mut chunks = Vec::new();
+    for (_, path) in fixture_paths() {
+        let mut buf = Vec::new();
+        std::fs::File::open(&path)
+            .unwrap()
+            .take(cap)
+            .read_to_end(&mut buf)
+            .unwrap();
+        let valid = std::str::from_utf8(&buf).map_or_else(|e| e.valid_up_to(), |_| buf.len());
+        let text = std::str::from_utf8(&buf[..valid]).unwrap();
+        chunks.extend(make_chunks(text).into_iter().take(MEM_CHUNKS_PER_FIXTURE));
+    }
+    chunks
+}
+
 /// `--memory <impl> <model.json>` child entry: load one implementation, encode a
 /// capped pass over the fixtures, print `{load_bytes, encode_bytes, peak_bytes}`.
 /// One implementation per process so the deltas attribute cleanly.
 fn memory_child(which: &str, model: &Path) {
-    let chunks: Vec<String> = load_fixtures()
-        .into_iter()
-        .flat_map(|f| f.chunks.into_iter().take(MEM_CHUNKS_PER_FIXTURE))
-        .collect();
+    let chunks = memory_sample();
 
     let rss0 = rss_now().unwrap_or(0);
     let mut n = 0usize;
@@ -872,7 +899,7 @@ fn main() {
             Err(e) => {
                 eprintln!("  load failed: {e}");
                 models.push(json!({
-                    "model": name, "repo": repo, "desc": desc, "shape": "?",
+                    "model": name, "desc": desc, "shape": "?",
                     "reason": format!("load error: {e}"),
                     "results": [], "memory": Value::Null,
                 }));
@@ -894,7 +921,7 @@ fn main() {
                 Err(e) => {
                     eprintln!("  pipeline builds but can't encode yet ({shape}): {e}");
                     models.push(json!({
-                        "model": name, "repo": repo, "desc": desc, "shape": shape,
+                        "model": name, "desc": desc, "shape": shape,
                         "reason": format!("{e}"),
                         "results": [], "memory": Value::Null,
                     }));
@@ -904,7 +931,7 @@ fn main() {
             Err(_) => {
                 eprintln!("  unsupported by PipelineTokenizer ({shape})");
                 models.push(json!({
-                    "model": name, "repo": repo, "desc": desc, "shape": shape,
+                    "model": name, "desc": desc, "shape": shape,
                     "results": [], "memory": Value::Null,
                 }));
                 continue;
@@ -945,7 +972,7 @@ fn main() {
         let threads = bench_threads(baseline.as_ref(), &pipeline, &all_chunks);
 
         models.push(json!({
-            "model": name, "repo": repo, "desc": desc, "shape": shape,
+            "model": name, "desc": desc, "shape": shape,
             "results": rows, "memory": memory, "threads": threads,
         }));
     }

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -2,23 +2,38 @@
 //! latest *released* `tokenizers` crate (the bar to beat — the in-tree legacy
 //! `Tokenizer` is on its way out, so the release is the reference), for every
 //! model in `examples/bench_models.json` across every corpus in `data/fixtures/`.
+//! The baseline is always driven through `encode_fast` — its offset-free path —
+//! because the pipeline's `encode` computes no offsets either; timing the
+//! baseline's offset-tracking `encode` would flatter the pipeline.
 //!
-//! Per fixture it measures single-thread throughput on ~10 kB inputs (the regime
-//! where per-input overhead is amortized — see `pipeline_benchmark.rs` for the
-//! size sweep). Per model it also (a) runs a **multi-thread throughput sweep** —
-//! pipeline vs the release at 1/2/4/8/device-max threads over the whole corpus, so
-//! parallel scaling is visible — and (b) measures resident-set deltas by re-spawning
-//! itself as `--memory <impl> <model.json>` children — one implementation per
-//! process, so allocator page reuse across implementations can't blur the attribution.
+//! Three isolated phases per model:
+//!
+//! 1. **Throughput** — single-thread warm MB/s per fixture on ~10 kB inputs
+//!    (the regime where per-input overhead is amortized — see
+//!    `pipeline_benchmark.rs` for the size sweep). Every fixture starts from a
+//!    cold cache on both sides: the pipeline is rebuilt (fresh scratch pool →
+//!    fresh BPE word cache) and the baseline is cloned (the released BPE's
+//!    `Clone` starts with an empty cache). The warm-up pass then fills each
+//!    cache from that corpus alone — the state a plain `.encode()` loop over
+//!    the corpus reaches — so per-fixture numbers don't depend on which
+//!    fixtures ran before them.
+//! 2. **Stage breakdown** — the `encode_generic::<STAGE>` ablation ladder plus
+//!    the pre-tokenize-vs-regex-engine references, on fresh caller-owned
+//!    scratches, fully separate from the phase-1 timings.
+//! 3. **Scaling & memory** — a multi-thread throughput sweep (1/2/4/8/max) over
+//!    the whole corpus on fresh instances, and resident-set deltas measured by
+//!    re-spawning this binary as `--memory <impl> <model.json>` children — one
+//!    implementation per process, so allocator page reuse can't blur the
+//!    attribution.
 //!
 //! The in-tree `Tokenizer` is *not* benched: it only builds the pipeline and
 //! serves as the id-correctness oracle (`ids_match`, which CI fails on).
 //! `ids_match_baseline` — pipeline vs the released crate — is report-only,
 //! since a branch may intentionally fix encode behavior. Models the pipeline
-//! can't build yet are reported with empty `results` (plus the failure
-//! `reason`) and their pipeline shape rather than benched — the CI grid
-//! renders those as roadmap cards. Each manifest entry carries a `desc`: a
-//! one-line label of the workload archetype the model exercises, passed
+//! can't build (or encode) yet are reported with empty `results` (plus the
+//! failure `reason`) and their pipeline shape rather than benched — the CI
+//! grid renders those as roadmap cards. Each manifest entry carries a `desc`:
+//! a one-line label of the workload archetype the model exercises, passed
 //! through to the report.
 //!
 //! Emits one JSON object (`{baseline, models}`) on stdout, consumed by
@@ -93,6 +108,15 @@ fn inject_added_tokens_baseline(tok: &mut BaselineTokenizer) {
     let _ = tok.add_tokens(normalized);
 }
 
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+struct Fixture {
+    group: &'static str,
+    name: String,
+    chunks: Vec<String>,
+    bytes: usize,
+}
+
 fn make_chunks(text: &str) -> Vec<String> {
     let mut chunks = Vec::new();
     let mut cur = String::new();
@@ -114,10 +138,438 @@ fn make_chunks(text: &str) -> Vec<String> {
     chunks
 }
 
+/// Every corpus in `data/fixtures/{lang,modalities}`, read and chunked once.
+fn load_fixtures() -> Vec<Fixture> {
+    let mut fixtures = Vec::new();
+    for group in ["lang", "modalities"] {
+        let dir = Path::new(DATA_DIR).join("fixtures").join(group);
+        let mut paths: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("{}: {e} — run `make fixtures` first", dir.display()))
+            .map(|e| e.unwrap().path())
+            .filter(|p| p.extension().is_some_and(|x| x == "txt"))
+            .collect();
+        paths.sort();
+        for path in paths {
+            let name = path.file_stem().unwrap().to_str().unwrap().to_string();
+            let chunks = make_chunks(&std::fs::read_to_string(&path).unwrap());
+            let bytes = chunks.iter().map(String::len).sum();
+            fixtures.push(Fixture {
+                group,
+                name,
+                chunks,
+                bytes,
+            });
+        }
+    }
+    fixtures
+}
+
+// ── timing helpers ──────────────────────────────────────────────────────────
+
 fn median_secs(mut samples: Vec<f64>) -> f64 {
     samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
     samples[samples.len() / 2]
 }
+
+fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
+    let start = Instant::now();
+    let mut n = 0usize;
+    for chunk in chunks {
+        n += encode(chunk);
+    }
+    black_box(n);
+    start.elapsed().as_secs_f64()
+}
+
+/// Median ns/byte of a warmed-up `run` over `len` bytes (`run` returns a value that's
+/// `black_box`'d so the work isn't optimized away).
+fn timed_ns(len: usize, mut run: impl FnMut() -> usize) -> f64 {
+    if len == 0 {
+        return 0.0;
+    }
+    run(); // warm-up
+    let mut s = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let t = Instant::now();
+        black_box(run());
+        s.push(t.elapsed().as_secs_f64());
+    }
+    median_secs(s) * 1e9 / len as f64
+}
+
+// ── phase 1: throughput ─────────────────────────────────────────────────────
+
+/// Warm single-thread throughput + the id gates for one fixture.
+///
+/// Both implementations start this fixture cold: a rebuilt pipeline (fresh
+/// scratch pool → fresh BPE word cache) and a cloned baseline (the released
+/// BPE's `Clone` starts with an empty cache). The id checks and the warm-up
+/// pass then fill the caches from this corpus alone — what a plain `.encode()`
+/// loop over it reaches — and the REPS passes measure that warm steady state.
+/// The two impls are interleaved so frequency/thermal drift hits them equally.
+fn bench_throughput(
+    baseline: Option<&BaselineTokenizer>,
+    oracle: &Tokenizer,
+    f: &Fixture,
+) -> Value {
+    let pipeline = PipelineTokenizer::try_from(oracle).expect("probed at model load");
+    let base = baseline.cloned();
+
+    let pipe_enc = |s: &str| pipeline.encode(s, false).unwrap().len();
+    let base_enc = base
+        .as_ref()
+        .map(|b| move |s: &str| b.encode_fast(s, false).unwrap().len());
+
+    let pipe_ids = |c: &String| -> Vec<u32> {
+        pipeline
+            .encode(c, false)
+            .unwrap()
+            .iter()
+            .map(|t| t.id)
+            .collect()
+    };
+    // The correctness gate CI fails on: pipeline vs this tree's Tokenizer.
+    let ids_match = f
+        .chunks
+        .iter()
+        .take(3)
+        .all(|c| oracle.encode(c.as_str(), false).unwrap().get_ids() == pipe_ids(c));
+    // Report-only: pipeline vs the released crate (a branch may fix encode bugs).
+    let ids_match_baseline = base.as_ref().map(|b| {
+        f.chunks
+            .iter()
+            .take(3)
+            .all(|c| b.encode_fast(c.as_str(), false).unwrap().get_ids() == pipe_ids(c))
+    });
+
+    if let Some(be) = &base_enc {
+        time_pass(be, &f.chunks); // warm-up
+    }
+    time_pass(&pipe_enc, &f.chunks); // warm-up
+    let (mut base_s, mut pipe_s) = (Vec::new(), Vec::new());
+    for _ in 0..REPS {
+        if let Some(be) = &base_enc {
+            base_s.push(time_pass(be, &f.chunks));
+        }
+        pipe_s.push(time_pass(&pipe_enc, &f.chunks));
+    }
+    let mbps = |secs: f64| f.bytes as f64 / secs / 1e6;
+    let base_mbps = (!base_s.is_empty()).then(|| mbps(median_secs(base_s)));
+    let pipe_mbps = mbps(median_secs(pipe_s));
+
+    eprintln!(
+        "  {}: baseline {} MB/s, pipeline {pipe_mbps:.1} MB/s",
+        f.name,
+        base_mbps.map_or("—".into(), |v| format!("{v:.1}"))
+    );
+
+    json!({
+        "fixture": f.name,
+        "group": f.group,
+        "bytes": f.bytes,
+        "chunks": f.chunks.len(),
+        "mbps": { "baseline": base_mbps, "pipeline": pipe_mbps },
+        "ids_match": ids_match,
+        "ids_match_baseline": ids_match_baseline,
+    })
+}
+
+// ── phase 2: stage breakdown + pre-tokenize references ─────────────────────
+
+/// Median wall-time (seconds) of one pass over `chunks` through the shared encode core
+/// `PipelineTokenizer::encode_generic::<STAGE>`. `STAGE` is a const generic, so each
+/// level is a branchless specialization with the later stages compiled out — timing
+/// successive levels and subtracting gives each stage's marginal cost (the ablation
+/// ladder), no profiler and no per-segment instrumentation.
+///
+/// The scratch is created fresh here (never taken from the pipeline's pool), so the
+/// stage numbers are warmed on this fixture alone and can't perturb — or be flattered
+/// by — the phase-1 cache state. Both caller-owned buffers are reused across chunks
+/// and `black_box`'d each iteration: `output` anchors the special-scan/normalize/model
+/// work, `pre_tokens` anchors the split stage, so under fat LTO no dead partial stage
+/// gets optimized away. The `black_box` lives here, in the bench — never in the library.
+fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) -> f64 {
+    let mut out = Vec::new();
+    let mut pre_tokens = Vec::new();
+    let mut scratch = pipeline.get_model().init_scratch();
+    let mut run = || {
+        for chunk in chunks {
+            out.clear();
+            let _ =
+                pipeline.encode_generic::<STAGE>(chunk, &mut pre_tokens, &mut scratch, &mut out);
+            black_box(&out);
+            black_box(&pre_tokens);
+        }
+    };
+    run(); // warm-up
+    let mut samples = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let start = Instant::now();
+        run();
+        samples.push(start.elapsed().as_secs_f64());
+    }
+    median_secs(samples)
+}
+
+/// Stage decomposition + regex-engine references for one fixture: the
+/// `stage_ns_per_byte` and `pretok_vs_regex` objects of its report row.
+fn bench_stages(pipeline: &PipelineTokenizer, f: &Fixture, regexes: &[String]) -> (Value, Value) {
+    let t_frame = stage_secs::<{ PipelineTokenizer::STAGE_FRAME }>(pipeline, &f.chunks);
+    let t_norm = stage_secs::<{ PipelineTokenizer::STAGE_NORMALIZE }>(pipeline, &f.chunks);
+    let t_split = stage_secs::<{ PipelineTokenizer::STAGE_SPLIT }>(pipeline, &f.chunks);
+    let t_model = stage_secs::<{ PipelineTokenizer::STAGE_MODEL }>(pipeline, &f.chunks);
+    // Two distinct "split" costs: `added_split` is the added/special-token scan (the
+    // SpecialSegmentIterator over the AddedVocabulary, captured by the FRAME level),
+    // `pre_tokenize` is the pre-tokenizer split. All four stages sum exactly to `total`.
+    let nspb = |secs: f64| secs * 1e9 / f.bytes as f64;
+    let (ns_added, ns_norm, ns_split, ns_model) = (
+        nspb(t_frame.max(0.0)),
+        nspb((t_norm - t_frame).max(0.0)),
+        nspb((t_split - t_norm).max(0.0)),
+        nspb((t_model - t_split).max(0.0)),
+    );
+    eprintln!(
+        "  {} stages ns/byte: added-split {ns_added:.2}, norm {ns_norm:.2}, pre-split {ns_split:.2}, model {ns_model:.2}",
+        f.name
+    );
+
+    // pre_tokenize (= classify SIMD + fsm) vs classify-scalar and vs real regex engines
+    // over the same corpus, so the report shows the split beating a regex engine both
+    // WITH and WITHOUT SIMD. `scalar_pipe` = pre_tokenize + (cls_scalar − cls_simd):
+    // fsm is the scalar jump-table in both pipes, SIMD/scalar is the classify pass only.
+    let corpus: String = f.chunks.concat();
+    let cls_simd = classify_ns(corpus.as_bytes(), false);
+    let cls_scalar = classify_ns(corpus.as_bytes(), true);
+    let onig_ns = regex_reference_ns::<onig::Regex>(&corpus, regexes);
+    let fancy_ns = regex_reference_ns::<fancy_regex::Regex>(&corpus, regexes);
+    let pcre2_ns = regex_reference_ns::<pcre2::bytes::Regex>(&corpus, regexes);
+    let logos_ns = logos_reference_ns(regexes, &corpus);
+    if [onig_ns, fancy_ns, pcre2_ns, logos_ns]
+        .iter()
+        .any(Option::is_some)
+    {
+        let scalar_pipe = ns_split + (cls_scalar - cls_simd).max(0.0);
+        let vs = |r: Option<f64>| {
+            r.map_or("—".into(), |v| {
+                format!(
+                    "{:.1}×/{:.1}×",
+                    v / ns_split.max(1e-9),
+                    v / scalar_pipe.max(1e-9)
+                )
+            })
+        };
+        eprintln!(
+            "  {} pre-tok: SIMD-cls {ns_split:.2} / scalar-cls {scalar_pipe:.2} ns/B · vs onig {} · vs fancy {} · vs pcre2 {} · vs logos {}",
+            f.name,
+            vs(onig_ns),
+            vs(fancy_ns),
+            vs(pcre2_ns),
+            vs(logos_ns)
+        );
+    }
+
+    (
+        json!({
+            "added_split": ns_added,
+            "normalize": ns_norm,
+            "pre_tokenize": ns_split,
+            "model": ns_model,
+            "total": nspb(t_model),
+        }),
+        json!({
+            "cls_simd": cls_simd,
+            "cls_scalar": cls_scalar,
+            "onig": onig_ns,
+            "fancy": fancy_ns,
+            "pcre2": pcre2_ns,
+            "logos": logos_ns,
+        }),
+    )
+}
+
+/// Median ns/byte to classify `bytes` once via the SIMD or scalar path.
+fn classify_ns(bytes: &[u8], scalar: bool) -> f64 {
+    let mut tags = vec![0u8; bytes.len()];
+    timed_ns(bytes.len(), || {
+        if scalar {
+            atomsplit::classify::classify_scalar(bytes, &mut tags);
+        } else {
+            atomsplit::classify::classify(bytes, &mut tags);
+        }
+        tags[bytes.len() / 2] as usize
+    })
+}
+
+// ── regex-engine references ─────────────────────────────────────────────────
+// The pipeline's `pre_tokenize` stage is `classify (SIMD) + fsm`; these reference
+// numbers time the model's own pre-tokenizer regex(es) — the split a regex-based
+// tokenizer actually pays for — under three real engines. Each engine only needs to
+// enumerate matches; the composed Isolated split chain is shared.
+
+/// A regex engine timed through the composed split chain.
+trait SplitEngine: Sized {
+    fn compile(pattern: &str) -> Option<Self>;
+    /// Call `on_match(start, end)` for every match in `hay`, in order.
+    fn for_each_match(&self, hay: &str, on_match: impl FnMut(usize, usize));
+}
+
+/// Oniguruma (C) — what the reference tokenizer itself uses.
+impl SplitEngine for onig::Regex {
+    fn compile(pattern: &str) -> Option<Self> {
+        onig::Regex::new(pattern).ok()
+    }
+    fn for_each_match(&self, hay: &str, mut on_match: impl FnMut(usize, usize)) {
+        for (s, e) in self.find_iter(hay) {
+            on_match(s, e);
+        }
+    }
+}
+
+/// fancy-regex (pure Rust). `find_iter` yields `Result<Match, _>`; a match error
+/// aborts that piece's pass (rare, backtrack-limit) and it is left un-split.
+impl SplitEngine for fancy_regex::Regex {
+    fn compile(pattern: &str) -> Option<Self> {
+        fancy_regex::Regex::new(pattern).ok()
+    }
+    fn for_each_match(&self, hay: &str, mut on_match: impl FnMut(usize, usize)) {
+        for m in self.find_iter(hay) {
+            let Ok(m) = m else { break };
+            on_match(m.start(), m.end());
+        }
+    }
+}
+
+/// PCRE2 (C) — built with `utf(true).ucp(true)` so `\p{L}`/`\p{N}`/`\s` are
+/// Unicode-aware and byte offsets land on char boundaries, matching the other
+/// engines, and **JIT-compiled** so PCRE2 is benched at its best.
+impl SplitEngine for pcre2::bytes::Regex {
+    fn compile(pattern: &str) -> Option<Self> {
+        pcre2::bytes::RegexBuilder::new()
+            .utf(true)
+            .ucp(true)
+            .jit_if_available(true)
+            .build(pattern)
+            .ok()
+    }
+    fn for_each_match(&self, hay: &str, mut on_match: impl FnMut(usize, usize)) {
+        for m in self.find_iter(hay.as_bytes()) {
+            let Ok(m) = m else { break };
+            on_match(m.start(), m.end());
+        }
+    }
+}
+
+/// ns/byte for the composed Isolated split chain under engine `E` — each regex splits
+/// the previous pieces (gaps + matches), exactly how the reference tokenizer applies a
+/// `Sequence` of Splits. `None` when the model has no regex pre-tokenizer, or the
+/// engine rejects a pattern.
+fn regex_reference_ns<E: SplitEngine>(text: &str, patterns: &[String]) -> Option<f64> {
+    if patterns.is_empty() || text.is_empty() {
+        return None;
+    }
+    let engines: Vec<E> = patterns
+        .iter()
+        .map(|p| E::compile(p))
+        .collect::<Option<_>>()?;
+    Some(timed_ns(text.len(), || {
+        let mut pieces = vec![(0usize, text.len())];
+        for re in &engines {
+            let mut next = Vec::with_capacity(pieces.len() * 2);
+            for (s, e) in pieces.drain(..) {
+                let mut prev = 0usize;
+                re.for_each_match(&text[s..e], |ms, me| {
+                    if ms > prev {
+                        next.push((s + prev, s + ms));
+                    }
+                    next.push((s + ms, s + me));
+                    prev = me;
+                });
+                if prev < e - s {
+                    next.push((s + prev, e));
+                }
+            }
+            pieces = next;
+        }
+        pieces.len()
+    }))
+}
+
+// logos DFA lexers approximating the GPT splits (no look-ahead / case-insensitive →
+// boundaries differ slightly; a raw-throughput reference like fancy, not a byte-exact
+// oracle). Only families logos can express get a number; deepseek / variants /
+// non-regex pretoks report null.
+#[derive(Logos)]
+enum LGpt2 {
+    #[regex(r"'s|'t|'re|'ve|'m|'ll|'d")]
+    Contraction,
+    #[regex(r" ?\p{L}+")]
+    Word,
+    #[regex(r" ?\p{N}+")]
+    Num,
+    #[regex(r" ?[^\s\p{L}\p{N}]+")]
+    Other,
+    #[regex(r"\s+")]
+    Space,
+}
+#[derive(Logos)]
+enum LCl100k {
+    #[regex(r"'s|'t|'re|'ve|'m|'ll|'d", priority = 5)]
+    Contraction,
+    #[regex(r"[^\r\n\p{L}\p{N}]?\p{L}+", priority = 4)]
+    Word,
+    #[regex(r"\p{N}\p{N}?\p{N}?")]
+    Num,
+    #[regex(r" ?[^\s\p{L}\p{N}]+[\r\n]*", priority = 2)]
+    Other,
+    #[regex(r"\s+")]
+    Space,
+}
+#[derive(Logos)]
+enum LO200k {
+    #[regex(r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+('s|'t|'re|'ve|'m|'ll|'d)?", priority = 6)]
+    LettersA,
+    #[regex(r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*('s|'t|'re|'ve|'m|'ll|'d)?", priority = 5)]
+    LettersB,
+    #[regex(r"\p{N}\p{N}?\p{N}?")]
+    Num,
+    #[regex(r" ?[^\s\p{L}\p{N}]+[\r\n/]*", priority = 2)]
+    Other,
+    #[regex(r"\s+")]
+    Space,
+}
+
+fn lex_count<'s, T: Logos<'s, Source = str>>(s: &'s str) -> usize
+where
+    T::Extras: Default,
+{
+    let mut lex = T::lexer(s);
+    let mut n = 0;
+    while lex.next().is_some() {
+        n += 1;
+    }
+    n
+}
+
+/// logos throughput (ns/byte) when the model's pre-tokenizer is a single regex logos can
+/// express (matched against the canonical gpt2/cl100k/o200k specs); `None` otherwise.
+fn logos_reference_ns(regexes: &[String], text: &str) -> Option<f64> {
+    if text.is_empty() || regexes.len() != 1 {
+        return None;
+    }
+    let r = regexes[0].as_str();
+    let f: fn(&str) -> usize = if r == atomsplit::regexes::GPT2 {
+        |s| lex_count::<LGpt2>(s)
+    } else if r == atomsplit::regexes::CL100K {
+        |s| lex_count::<LCl100k>(s)
+    } else if r == atomsplit::regexes::O200K {
+        |s| lex_count::<LO200k>(s)
+    } else {
+        return None;
+    };
+    Some(timed_ns(text.len(), || f(text)))
+}
+
+// ── phase 3: multi-thread scaling + memory ──────────────────────────────────
 
 /// Thread counts for the scaling sweep: 1 (the single-thread anchor) + 2/4/8 + the device max,
 /// deduped and capped at max (so an 8-core box reports `[1,2,4,8]`, a 6-core `[1,2,4,6]`).
@@ -154,7 +606,8 @@ fn par_mbps(
 
 /// Multi-thread throughput sweep for one model — pipeline vs the released crate at 1/2/4/8/max threads
 /// over the whole fixture corpus (thread-spawn/scheduling overhead amortized). Both impls encode the same
-/// chunk list through a fresh pool per count; interleaved so thermal drift hits them equally.
+/// chunk list through a fresh pool per count; interleaved so thermal drift hits them equally. Per-thread
+/// caches here fill from the whole mixed stream — the normal `.encode()` regime for a parallel workload.
 fn bench_threads(
     baseline: Option<&BaselineTokenizer>,
     pipeline: &PipelineTokenizer,
@@ -164,7 +617,8 @@ fn bench_threads(
     let counts = thread_counts();
     let (mut pipe, mut base) = (Vec::new(), Vec::new());
     for &n in &counts {
-        let b = baseline.map(|b| par_mbps(|s| b.encode(s, false).unwrap().len(), chunks, bytes, n));
+        let b = baseline
+            .map(|b| par_mbps(|s| b.encode_fast(s, false).unwrap().len(), chunks, bytes, n));
         let p = par_mbps(
             |s| pipeline.encode(s, false).unwrap().len(),
             chunks,
@@ -179,110 +633,6 @@ fn bench_threads(
         base.push(b);
     }
     json!({ "counts": counts, "pipeline_mbps": pipe, "baseline_mbps": base })
-}
-
-fn time_pass(encode: &dyn Fn(&str) -> usize, chunks: &[String]) -> f64 {
-    let start = Instant::now();
-    let mut n = 0usize;
-    for chunk in chunks {
-        n += encode(chunk);
-    }
-    black_box(n);
-    start.elapsed().as_secs_f64()
-}
-
-/// Median wall-time (seconds) of one pass over `chunks` through the shared encode core
-/// `PipelineTokenizer::encode_generic::<STAGE>`. `STAGE` is a const generic, so each
-/// level is a branchless specialization with the later stages compiled out — timing
-/// successive levels and subtracting gives each stage's marginal cost (the ablation
-/// ladder), no profiler and no per-segment instrumentation.
-///
-/// Both caller-owned buffers are reused across chunks and `black_box`'d each iteration:
-/// `output` anchors the special-scan/normalize/model work, `pre_tokens` anchors the
-/// split stage, so under fat LTO no dead partial stage gets optimized away. The
-/// `black_box` lives here, in the bench — never in the library.
-fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) -> f64 {
-    let mut out = Vec::new();
-    let mut pre_tokens = Vec::new();
-    let mut scratch = pipeline.get_model().init_scratch();
-    let mut run = || {
-        for chunk in chunks {
-            out.clear();
-            let _ =
-                pipeline.encode_generic::<STAGE>(chunk, &mut pre_tokens, &mut scratch, &mut out);
-            black_box(&out);
-            black_box(&pre_tokens);
-        }
-    };
-    run(); // warm-up
-    let mut samples = Vec::with_capacity(REPS);
-    for _ in 0..REPS {
-        let start = Instant::now();
-        run();
-        samples.push(start.elapsed().as_secs_f64());
-    }
-    median_secs(samples)
-}
-
-fn fixture_files() -> Vec<(String, PathBuf)> {
-    let mut files = Vec::new();
-    for group in ["lang", "modalities"] {
-        let dir = Path::new(DATA_DIR).join("fixtures").join(group);
-        let mut entries: Vec<_> = std::fs::read_dir(&dir)
-            .unwrap_or_else(|e| panic!("{}: {e} — run `make fixtures` first", dir.display()))
-            .map(|e| e.unwrap().path())
-            .filter(|p| p.extension().is_some_and(|x| x == "txt"))
-            .collect();
-        entries.sort();
-        for path in entries {
-            files.push((group.to_string(), path));
-        }
-    }
-    files
-}
-
-/// Local path to a manifest entry's config: `data/<file>`, else `data/<name>.json`.
-/// Both come from the test-data dataset (see the Makefile `bench-models` target).
-fn model_path(entry: &Value) -> PathBuf {
-    let name = entry["name"].as_str().unwrap();
-    let file = entry
-        .get("file")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .unwrap_or_else(|| format!("{name}.json"));
-    Path::new(DATA_DIR).join(file)
-}
-
-fn model_kind(tok: &Tokenizer) -> &'static str {
-    match tok.get_model() {
-        ModelWrapper::BPE(_) => "BPE",
-        ModelWrapper::WordPiece(_) => "WordPiece",
-        ModelWrapper::WordLevel(_) => "WordLevel",
-        ModelWrapper::Unigram(_) => "Unigram",
-    }
-}
-
-/// A short pre-tokenizer descriptor read from the raw json — its `type`, and for
-/// a Sequence the (de-duplicated) inner types, e.g. `Split+ByteLevel`.
-fn pretok_label(path: &Path) -> String {
-    let v: Value = std::fs::read_to_string(path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or(Value::Null);
-    let pt = &v["pre_tokenizer"];
-    match pt["type"].as_str() {
-        None => "None".to_string(),
-        Some("Sequence") => {
-            let mut inner: Vec<&str> = pt["pretokenizers"]
-                .as_array()
-                .map(|a| a.iter().filter_map(|x| x["type"].as_str()).collect())
-                .unwrap_or_default();
-            inner.dedup();
-            inner.join("+")
-        }
-        Some("BertPreTokenizer") => "Bert".to_string(),
-        Some(other) => other.to_string(),
-    }
 }
 
 /// Resident set size in bytes. Exact on Linux (`/proc`); on macOS a `ps`
@@ -322,11 +672,10 @@ fn proc_status_bytes(key: &str) -> Option<i64> {
 /// capped pass over the fixtures, print `{load_bytes, encode_bytes, peak_bytes}`.
 /// One implementation per process so the deltas attribute cleanly.
 fn memory_child(which: &str, model: &Path) {
-    let mut chunks: Vec<String> = Vec::new();
-    for (_, path) in &fixture_files() {
-        let text = std::fs::read_to_string(path).unwrap();
-        chunks.extend(make_chunks(&text).into_iter().take(MEM_CHUNKS_PER_FIXTURE));
-    }
+    let chunks: Vec<String> = load_fixtures()
+        .into_iter()
+        .flat_map(|f| f.chunks.into_iter().take(MEM_CHUNKS_PER_FIXTURE))
+        .collect();
 
     let rss0 = rss_now().unwrap_or(0);
     let mut n = 0usize;
@@ -336,7 +685,7 @@ fn memory_child(which: &str, model: &Path) {
             inject_added_tokens_baseline(&mut tok);
             let after_load = rss_now().unwrap_or(0);
             for c in &chunks {
-                n += tok.encode(c.as_str(), false).unwrap().len();
+                n += tok.encode_fast(c.as_str(), false).unwrap().len();
             }
             (after_load, rss_now().unwrap_or(0))
         }
@@ -398,15 +747,51 @@ fn measure_memory(model: &Path, baseline_ok: bool) -> Value {
     Value::Object(out)
 }
 
-// ── pre-tokenize comparison: classify (SIMD vs scalar) + fsm, vs an onig regex reference ──
-// The pipeline's `pre_tokenize` stage is `classify (SIMD) + fsm`. These numbers let the report show it
-// beating a real regex engine both WITH and WITHOUT SIMD: `classify`/`classify_scalar` over the same
-// bytes isolate the classify half (scalar-pipeline = pre_tokenize + (cls_scalar − cls_simd)), and `onig`
-// times the model's own pre-tokenizer regex(es) — the split a regex-based tokenizer actually pays for.
+// ── model manifest helpers ──────────────────────────────────────────────────
 
-/// GPT-2's implicit pre-tokenize regex (a byte-map `ByteLevel` splits on this before mapping bytes) —
-/// the canonical spec in atomsplit.
-use atomsplit::regexes::GPT2 as GPT2_REGEX;
+/// Local path to a manifest entry's config: `data/<file>`, else `data/<name>.json`.
+/// Both come from the test-data dataset (see the Makefile `bench-models` target).
+fn model_path(entry: &Value) -> PathBuf {
+    let name = entry["name"].as_str().unwrap();
+    let file = entry
+        .get("file")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("{name}.json"));
+    Path::new(DATA_DIR).join(file)
+}
+
+fn model_kind(tok: &Tokenizer) -> &'static str {
+    match tok.get_model() {
+        ModelWrapper::BPE(_) => "BPE",
+        ModelWrapper::WordPiece(_) => "WordPiece",
+        ModelWrapper::WordLevel(_) => "WordLevel",
+        ModelWrapper::Unigram(_) => "Unigram",
+    }
+}
+
+/// A short pre-tokenizer descriptor read from the raw json — its `type`, and for
+/// a Sequence the (de-duplicated) inner types, e.g. `Split+ByteLevel`.
+fn pretok_label(path: &Path) -> String {
+    let v: Value = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or(Value::Null);
+    let pt = &v["pre_tokenizer"];
+    match pt["type"].as_str() {
+        None => "None".to_string(),
+        Some("Sequence") => {
+            let mut inner: Vec<&str> = pt["pretokenizers"]
+                .as_array()
+                .map(|a| a.iter().filter_map(|x| x["type"].as_str()).collect())
+                .unwrap_or_default();
+            inner.dedup();
+            inner.join("+")
+        }
+        Some("BertPreTokenizer") => "Bert".to_string(),
+        Some(other) => other.to_string(),
+    }
+}
 
 fn split_regex(p: &Value) -> Option<String> {
     (p["type"].as_str() == Some("Split"))
@@ -415,8 +800,8 @@ fn split_regex(p: &Value) -> Option<String> {
 }
 
 /// The ordered Split regexes a model's pre-tokenizer applies (deepseek → 3; a lone `Split` → 1; a
-/// byte-map `ByteLevel` with no Split → GPT-2's implicit regex). Empty → no regex reference (Bert,
-/// Metaspace, WhitespaceSplit, …) → onig reported null for that model.
+/// byte-map `ByteLevel` with no Split → GPT-2's implicit regex, the canonical spec in atomsplit).
+/// Empty → no regex reference (Bert, Metaspace, WhitespaceSplit, …) → engines report null.
 fn pretok_regexes(path: &Path) -> Vec<String> {
     let v: Value = std::fs::read_to_string(path)
         .ok()
@@ -425,393 +810,20 @@ fn pretok_regexes(path: &Path) -> Vec<String> {
     let pt = &v["pre_tokenizer"];
     match pt["type"].as_str() {
         Some("Split") => split_regex(pt).into_iter().collect(),
-        Some("ByteLevel") => vec![GPT2_REGEX.to_string()],
+        Some("ByteLevel") => vec![atomsplit::regexes::GPT2.to_string()],
         Some("Sequence") => {
             let arr = pt["pretokenizers"].as_array().cloned().unwrap_or_default();
             let res: Vec<String> = arr.iter().filter_map(split_regex).collect();
             if !res.is_empty() {
                 res
             } else if arr.iter().any(|p| p["type"] == "ByteLevel") {
-                vec![GPT2_REGEX.to_string()]
+                vec![atomsplit::regexes::GPT2.to_string()]
             } else {
                 vec![]
             }
         }
         _ => vec![],
     }
-}
-
-/// Median ns/byte of a warmed-up `run` over `len` bytes (`run` returns a value that's `black_box`'d so
-/// the work isn't optimized away).
-fn timed_ns(len: usize, mut run: impl FnMut() -> usize) -> f64 {
-    if len == 0 {
-        return 0.0;
-    }
-    run(); // warm-up
-    let mut s = Vec::with_capacity(REPS);
-    for _ in 0..REPS {
-        let t = Instant::now();
-        black_box(run());
-        s.push(t.elapsed().as_secs_f64());
-    }
-    median_secs(s) * 1e9 / len as f64
-}
-
-/// Median ns/byte to classify `bytes` once via the SIMD or scalar path.
-fn classify_ns(bytes: &[u8], scalar: bool) -> f64 {
-    let mut tags = vec![0u8; bytes.len()];
-    timed_ns(bytes.len(), || {
-        if scalar {
-            atomsplit::classify::classify_scalar(bytes, &mut tags);
-        } else {
-            atomsplit::classify::classify(bytes, &mut tags);
-        }
-        tags[bytes.len() / 2] as usize
-    })
-}
-
-/// ns/byte for the composed Isolated split chain under onig — each regex splits the previous pieces
-/// (gaps + matches), exactly how the reference tokenizer applies a `Sequence` of Splits. `None` when the
-/// model has no regex pre-tokenizer, or onig rejects a pattern.
-fn onig_reference_ns(text: &str, regexes: &[String]) -> Option<f64> {
-    if regexes.is_empty() || text.is_empty() {
-        return None;
-    }
-    let res: Vec<onig::Regex> = regexes
-        .iter()
-        .map(|r| onig::Regex::new(r))
-        .collect::<Result<_, _>>()
-        .ok()?;
-    Some(timed_ns(text.len(), || {
-        let mut pieces = vec![(0usize, text.len())];
-        for re in &res {
-            let mut next = Vec::with_capacity(pieces.len() * 2);
-            for (s, e) in pieces.drain(..) {
-                let sub = &text[s..e];
-                let mut prev = 0usize;
-                for (ms, me) in re.find_iter(sub) {
-                    if ms > prev {
-                        next.push((s + prev, s + ms));
-                    }
-                    next.push((s + ms, s + me));
-                    prev = me;
-                }
-                if prev < sub.len() {
-                    next.push((s + prev, e));
-                }
-            }
-            pieces = next;
-        }
-        pieces.len()
-    }))
-}
-
-/// Same composed Isolated split chain, but under the pure-Rust `fancy-regex` engine — a second
-/// reference. `find_iter` yields `Result<Match, _>`; a match error aborts that regex's pass (rare,
-/// backtrack-limit) and the piece is left un-split. `None` if no regex pre-tokenizer or a bad pattern.
-fn fancy_reference_ns(text: &str, regexes: &[String]) -> Option<f64> {
-    if regexes.is_empty() || text.is_empty() {
-        return None;
-    }
-    let res: Vec<fancy_regex::Regex> = regexes
-        .iter()
-        .map(|r| fancy_regex::Regex::new(r))
-        .collect::<Result<_, _>>()
-        .ok()?;
-    Some(timed_ns(text.len(), || {
-        let mut pieces = vec![(0usize, text.len())];
-        for re in &res {
-            let mut next = Vec::with_capacity(pieces.len() * 2);
-            for (s, e) in pieces.drain(..) {
-                let sub = &text[s..e];
-                let mut prev = 0usize;
-                for m in re.find_iter(sub) {
-                    let Ok(m) = m else { break };
-                    let (ms, me) = (m.start(), m.end());
-                    if ms > prev {
-                        next.push((s + prev, s + ms));
-                    }
-                    next.push((s + ms, s + me));
-                    prev = me;
-                }
-                if prev < sub.len() {
-                    next.push((s + prev, e));
-                }
-            }
-            pieces = next;
-        }
-        pieces.len()
-    }))
-}
-
-/// Same composed chain under PCRE2 (C) — the third reference. Built with `utf(true).ucp(true)` so
-/// `\p{L}`/`\p{N}`/`\s` are Unicode-aware and byte offsets land on char boundaries, matching onig and
-/// fancy-regex, and **JIT-compiled** (`jit_if_available`) so PCRE2 is benched at its best. Operates on
-/// `&[u8]`; `find_iter` yields `Result<Match, _>` (a match error breaks the pass). `None` if no regex
-/// pre-tokenizer, or PCRE2 rejects/fails a pattern.
-fn pcre2_reference_ns(text: &str, regexes: &[String]) -> Option<f64> {
-    if regexes.is_empty() || text.is_empty() {
-        return None;
-    }
-    let res: Vec<pcre2::bytes::Regex> = regexes
-        .iter()
-        .map(|r| {
-            pcre2::bytes::RegexBuilder::new()
-                .utf(true)
-                .ucp(true)
-                .jit_if_available(true) // PCRE2's JIT is where its speed is — bench it at its best.
-                .build(r)
-        })
-        .collect::<Result<_, _>>()
-        .ok()?;
-    let bytes = text.as_bytes();
-    Some(timed_ns(text.len(), || {
-        let mut pieces = vec![(0usize, text.len())];
-        for re in &res {
-            let mut next = Vec::with_capacity(pieces.len() * 2);
-            for (s, e) in pieces.drain(..) {
-                let sub = &bytes[s..e];
-                let mut prev = 0usize;
-                for m in re.find_iter(sub) {
-                    let Ok(m) = m else { break };
-                    let (ms, me) = (m.start(), m.end());
-                    if ms > prev {
-                        next.push((s + prev, s + ms));
-                    }
-                    next.push((s + ms, s + me));
-                    prev = me;
-                }
-                if prev < sub.len() {
-                    next.push((s + prev, e));
-                }
-            }
-            pieces = next;
-        }
-        pieces.len()
-    }))
-}
-
-// logos DFA lexers approximating the GPT splits (no look-ahead / case-insensitive → boundaries differ
-// slightly; a raw-throughput reference like fancy, not a byte-exact oracle). Only families logos can
-// express get a number; deepseek / variants / non-regex pretoks report null.
-#[derive(Logos)]
-enum LGpt2 {
-    #[regex(r"'s|'t|'re|'ve|'m|'ll|'d")]
-    Contraction,
-    #[regex(r" ?\p{L}+")]
-    Word,
-    #[regex(r" ?\p{N}+")]
-    Num,
-    #[regex(r" ?[^\s\p{L}\p{N}]+")]
-    Other,
-    #[regex(r"\s+")]
-    Space,
-}
-#[derive(Logos)]
-enum LCl100k {
-    #[regex(r"'s|'t|'re|'ve|'m|'ll|'d", priority = 5)]
-    Contraction,
-    #[regex(r"[^\r\n\p{L}\p{N}]?\p{L}+", priority = 4)]
-    Word,
-    #[regex(r"\p{N}\p{N}?\p{N}?")]
-    Num,
-    #[regex(r" ?[^\s\p{L}\p{N}]+[\r\n]*", priority = 2)]
-    Other,
-    #[regex(r"\s+")]
-    Space,
-}
-#[derive(Logos)]
-enum LO200k {
-    #[regex(r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+('s|'t|'re|'ve|'m|'ll|'d)?", priority = 6)]
-    LettersA,
-    #[regex(r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*('s|'t|'re|'ve|'m|'ll|'d)?", priority = 5)]
-    LettersB,
-    #[regex(r"\p{N}\p{N}?\p{N}?")]
-    Num,
-    #[regex(r" ?[^\s\p{L}\p{N}]+[\r\n/]*", priority = 2)]
-    Other,
-    #[regex(r"\s+")]
-    Space,
-}
-
-fn lex_count<'s, T: Logos<'s, Source = str>>(s: &'s str) -> usize
-where
-    T::Extras: Default,
-{
-    let mut lex = T::lexer(s);
-    let mut n = 0;
-    while lex.next().is_some() {
-        n += 1;
-    }
-    n
-}
-
-/// logos throughput (ns/byte) when the model's pre-tokenizer is a single regex logos can express (matched
-/// against the canonical gpt2/cl100k/o200k specs); `None` otherwise (deepseek, cl100k-variants, non-regex).
-fn logos_reference_ns(regexes: &[String], text: &str) -> Option<f64> {
-    if text.is_empty() || regexes.len() != 1 {
-        return None;
-    }
-    let r = regexes[0].as_str();
-    let f: fn(&str) -> usize = if r == atomsplit::regexes::GPT2 {
-        |s| lex_count::<LGpt2>(s)
-    } else if r == atomsplit::regexes::CL100K {
-        |s| lex_count::<LCl100k>(s)
-    } else if r == atomsplit::regexes::O200K {
-        |s| lex_count::<LO200k>(s)
-    } else {
-        return None;
-    };
-    Some(timed_ns(text.len(), || f(text)))
-}
-
-fn bench_model(
-    baseline: Option<&BaselineTokenizer>,
-    oracle: &Tokenizer,
-    pipeline: &PipelineTokenizer,
-    files: &[(String, PathBuf)],
-    model_json: &Path,
-) -> Vec<Value> {
-    let pipe_enc = |s: &str| pipeline.encode(s, false).unwrap().len();
-    // per-model: the reference regex(es) onig will time on each fixture (empty for non-regex pretoks).
-    let regexes = pretok_regexes(model_json);
-    let base_enc = baseline.map(|b| move |s: &str| b.encode(s, false).unwrap().len());
-
-    let mut rows = Vec::new();
-    for (group, path) in files {
-        let name = path.file_stem().unwrap().to_str().unwrap().to_string();
-        let text = std::fs::read_to_string(path).unwrap();
-        let chunks = make_chunks(&text);
-        let bytes: usize = chunks.iter().map(String::len).sum();
-
-        let pipe_ids = |c: &String| -> Vec<u32> {
-            pipeline
-                .encode(c, false)
-                .unwrap()
-                .iter()
-                .map(|t| t.id)
-                .collect()
-        };
-        // The correctness gate CI fails on: pipeline vs this tree's Tokenizer.
-        let ids_match = chunks
-            .iter()
-            .take(3)
-            .all(|c| oracle.encode(c.as_str(), false).unwrap().get_ids() == pipe_ids(c));
-        // Report-only: pipeline vs the released crate (a branch may fix encode bugs).
-        let ids_match_baseline = baseline.map(|b| {
-            chunks
-                .iter()
-                .take(3)
-                .all(|c| b.encode(c.as_str(), false).unwrap().get_ids() == pipe_ids(c))
-        });
-
-        // interleave both impls so frequency/thermal drift hits them equally
-        if let Some(be) = &base_enc {
-            time_pass(be, &chunks);
-        }
-        time_pass(&pipe_enc, &chunks);
-        let (mut base_s, mut pipe_s) = (Vec::new(), Vec::new());
-        for _ in 0..REPS {
-            if let Some(be) = &base_enc {
-                base_s.push(time_pass(be, &chunks));
-            }
-            pipe_s.push(time_pass(&pipe_enc, &chunks));
-        }
-        let mbps = |secs: f64| bytes as f64 / secs / 1e6;
-        let base_mbps = (!base_s.is_empty()).then(|| mbps(median_secs(base_s)));
-        let pipe_mbps = mbps(median_secs(pipe_s));
-
-        let fmt = |v: Option<f64>| v.map_or("—".into(), |v| format!("{v:.1}"));
-        eprintln!(
-            "  {name}: baseline {} MB/s, pipeline {pipe_mbps:.1} MB/s",
-            fmt(base_mbps)
-        );
-
-        // Staged decomposition of the pipeline's own encode via the ablation ladder:
-        // time each cumulative stage level, then subtract to isolate each stage's cost
-        // (e.g. model = t_model - t_split). Levels are the named STAGE_* consts on
-        // PipelineTokenizer rather than bare 0/1/2/3.
-        let t_frame = stage_secs::<{ PipelineTokenizer::STAGE_FRAME }>(pipeline, &chunks);
-        let t_norm = stage_secs::<{ PipelineTokenizer::STAGE_NORMALIZE }>(pipeline, &chunks);
-        let t_split = stage_secs::<{ PipelineTokenizer::STAGE_SPLIT }>(pipeline, &chunks);
-        let t_model = stage_secs::<{ PipelineTokenizer::STAGE_MODEL }>(pipeline, &chunks);
-        // Two distinct "split" costs are separated here: `added_split` is the
-        // added/special-token scan (the SpecialSegmentIterator over the AddedVocabulary,
-        // captured by the FRAME level), `pre_tokenize` is the pre-tokenizer split. All
-        // four stages sum exactly to `total`.
-        let nspb = |secs: f64| secs * 1e9 / bytes as f64;
-        let (ns_added, ns_norm, ns_split, ns_model) = (
-            nspb(t_frame.max(0.0)),
-            nspb((t_norm - t_frame).max(0.0)),
-            nspb((t_split - t_norm).max(0.0)),
-            nspb((t_model - t_split).max(0.0)),
-        );
-        eprintln!(
-            "    stages ns/byte: added-split {ns_added:.2}, norm {ns_norm:.2}, pre-split {ns_split:.2}, model {ns_model:.2}"
-        );
-
-        // pre_tokenize (= classify SIMD + fsm) vs classify-scalar and vs the onig regex reference, over
-        // the same corpus. Report shows the split beating a regex engine with AND without SIMD.
-        let corpus: String = chunks.concat();
-        let cls_simd = classify_ns(corpus.as_bytes(), false);
-        let cls_scalar = classify_ns(corpus.as_bytes(), true);
-        let onig_ns = onig_reference_ns(&corpus, &regexes);
-        let fancy_ns = fancy_reference_ns(&corpus, &regexes);
-        let pcre2_ns = pcre2_reference_ns(&corpus, &regexes);
-        let logos_ns = logos_reference_ns(&regexes, &corpus);
-        if [onig_ns, fancy_ns, pcre2_ns, logos_ns]
-            .iter()
-            .any(Option::is_some)
-        {
-            // fsm is the scalar jump-table in both pipes; SIMD/scalar is the classify pass only.
-            let scalar_pipe = ns_split + (cls_scalar - cls_simd).max(0.0);
-            let vs = |r: Option<f64>| {
-                r.map_or("—".into(), |v| {
-                    format!(
-                        "{:.1}×/{:.1}×",
-                        v / ns_split.max(1e-9),
-                        v / scalar_pipe.max(1e-9)
-                    )
-                })
-            };
-            eprintln!(
-                "    pre-tok: SIMD-cls {ns_split:.2} / scalar-cls {scalar_pipe:.2} ns/B · vs onig {} · vs fancy {} · vs pcre2 {} · vs logos {}",
-                vs(onig_ns),
-                vs(fancy_ns),
-                vs(pcre2_ns),
-                vs(logos_ns)
-            );
-        }
-
-        rows.push(json!({
-            "fixture": name,
-            "group": group,
-            "bytes": bytes,
-            "chunks": chunks.len(),
-            "mbps": { "baseline": base_mbps, "pipeline": pipe_mbps },
-            "ids_match": ids_match,
-            "ids_match_baseline": ids_match_baseline,
-            "stage_ns_per_byte": {
-                "added_split": ns_added,
-                "normalize": ns_norm,
-                "pre_tokenize": ns_split,
-                "model": ns_model,
-                "total": nspb(t_model),
-            },
-            // classify SIMD vs scalar + the onig / fancy-regex references for the pre-tokenize regex
-            // (null when the model has no regex pre-tokenizer). simd-pipe = pre_tokenize; scalar-pipe =
-            // pre_tokenize + (cls_scalar − cls_simd); the renderer derives the ×-vs-engine ratios.
-            "pretok_vs_regex": {
-                "cls_simd": cls_simd,
-                "cls_scalar": cls_scalar,
-                "onig": onig_ns,
-                "fancy": fancy_ns,
-                "pcre2": pcre2_ns,
-                "logos": logos_ns,
-            },
-        }));
-    }
-    rows
 }
 
 fn main() {
@@ -842,13 +854,10 @@ fn main() {
         "shard {shard}/{nshards}: models {lo}..{hi} of {}",
         full.len()
     );
-    let files = fixture_files();
-    // The whole corpus, concatenated once: the multi-thread sweep runs over all fixtures so
+    let fixtures = load_fixtures();
+    // The whole corpus, flattened once: the multi-thread sweep runs over all fixtures so
     // thread-spawn/scheduling overhead is amortized and the scaling curve is stable.
-    let all_chunks: Vec<String> = files
-        .iter()
-        .flat_map(|(_, p)| make_chunks(&std::fs::read_to_string(p).unwrap()))
-        .collect();
+    let all_chunks: Vec<String> = fixtures.iter().flat_map(|f| f.chunks.clone()).collect();
 
     let mut models: Vec<Value> = Vec::new();
     for entry in manifest {
@@ -871,7 +880,7 @@ fn main() {
             }
         };
         // Give every model the benchmark's added tokens so the `added_*` fixtures have
-        // something to match, before the pipeline is derived from `tok`.
+        // something to match, before any pipeline is derived from `tok`.
         inject_added_tokens(&mut tok);
         let shape = format!("{} · {}", model_kind(&tok), pretok_label(&path));
 
@@ -907,7 +916,7 @@ fn main() {
         let baseline = match BaselineTokenizer::from_file(&path) {
             Ok(mut b) => {
                 inject_added_tokens_baseline(&mut b);
-                match b.encode(PROBE, false) {
+                match b.encode_fast(PROBE, false) {
                     Ok(_) => Some(b),
                     Err(e) => {
                         eprintln!("  baseline v{BASELINE_VERSION} loads but can't encode: {e}");
@@ -921,7 +930,17 @@ fn main() {
             }
         };
 
-        let rows = bench_model(baseline.as_ref(), &tok, &pipeline, &files, &path);
+        let mut rows: Vec<Value> = fixtures
+            .iter()
+            .map(|f| bench_throughput(baseline.as_ref(), &tok, f))
+            .collect();
+        let regexes = pretok_regexes(&path);
+        for (row, f) in rows.iter_mut().zip(&fixtures) {
+            let (stages, pretok) = bench_stages(&pipeline, f, &regexes);
+            let row = row.as_object_mut().unwrap();
+            row.insert("stage_ns_per_byte".into(), stages);
+            row.insert("pretok_vs_regex".into(), pretok);
+        }
         let memory = measure_memory(&path, baseline.is_some());
         let threads = bench_threads(baseline.as_ref(), &pipeline, &all_chunks);
 


### PR DESCRIPTION
# Fix unfair and inconsistent numbers in the tokenizer benchmark

This benchmark compares our new PipelineTokenizer against the current released tokenizer. Two bugs made the numbers misleading, plus some cleanup:

- Cache bug: the benchmark reused the same warm cache across all 18 test files instead of resetting it for each one. So results depended on which file happened to run first, not on real performance.
- Unfair comparison: the baseline (released tokenizer) was timed using its slower mode that also computes text offsets, while our pipeline never computes offsets. This made the baseline look artificially slower. Both are now timed the same way (encode_fast, no offsets).
- Cleaner structure: the benchmark now runs in 3 separate steps — throughput, stage-by-stage timing, and scaling/memory — so one step can't quietly skew another.
- Cleanup: removed duplicated code for reading test files and for the 3 regex-engine comparisons (onig/fancy/pcre2), no behavior change there.

The JSON output format is unchanged, so the CI report/charts still work the same way. Verified on the gpt2 model: all 18 test files still produce matching token ids.

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**7 / 8 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · single thread + 1/2/4/8/max-thread sweep

`2f606e349 · 2026-07-21 19:12 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 16 cores

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-overview-dark.png">
  <img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-overview-light.png" width="860">
</picture>

**vs base branch** (`bb98d4e1f`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-base-overview-dark.png">
  <img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-base-overview-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-memory-dark.png">
  <img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-memory-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-binsize-dark.png">
  <img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-binsize-light.png" width="860">
</picture>

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.94 vs v0.23.1 · ×1.00 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-bert-base-uncased-dark.png">
  <img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-bert-base-uncased-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-bert-base-uncased-stages-dark.png">
  <img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-bert-base-uncased-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-bert-base-uncased-threads-dark.png">
  <img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-bert-base-uncased-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 2+1 (peak 2) · Pipeline 3+0 (peak 3)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 27.5 | ×3.50 | ×1.00 | 3% (1.2) | 75% (27.4) | 13% (4.8) | 9% (3.3) | match |
| arb_Arab | lang | 4.2 | 24.9 | ×5.92 | ×1.00 | 3% (1.2) | 68% (27.4) | 8% (3.4) | 21% (8.7) | match |
| ben_Beng | lang | 6.0 | 34.8 | ×5.78 | ×1.00 | 4% (1.2) | 66% (19.1) | 11% (3.1) | 20% (5.7) | match |
| cmn_Hani | lang | 3.8 | 18.8 | ×4.92 | ×1.01 | 2% (1.3) | 69% (37.5) | 11% (5.7) | 18% (9.6) | match |
| ell_Grek | lang | 3.8 | 23.7 | ×6.25 | ×1.00 | 3% (1.2) | 67% (28.6) | 8% (3.4) | 22% (9.4) | match |
| eng_Latn | lang | 4.4 | 18.2 | ×4.16 | ×1.00 | 5% (2.6) | 68% (38.7) | 8% (4.4) | 19% (10.8) | match |
| heb_Hebr | lang | 4.2 | 19.7 | ×4.70 | ×0.99 | 2% (1.2) | 74% (37.5) | 7% (3.6) | 17% (8.6) | match |
| hin_Deva | lang | 6.5 | 27.3 | ×4.19 | ×1.00 | 3% (1.2) | 74% (27.1) | 8% (3.1) | 15% (5.4) | match |
| jpn_Jpan | lang | 4.3 | 27.3 | ×6.39 | ×1.00 | 3% (1.2) | 63% (23.3) | 13% (4.7) | 21% (7.6) | match |
| kat_Geor | lang | 6.2 | 28.1 | ×4.57 | ×1.00 | 3% (1.2) | 74% (26.5) | 9% (3.1) | 14% (5.1) | match |
| kor_Hang | lang | 2.4 | 17.6 | ×7.41 | ×1.00 | 2% (1.2) | 62% (35.1) | 13% (7.6) | 23% (13.1) | match |
| rus_Cyrl | lang | 3.6 | 23.8 | ×6.57 | ×1.00 | 3% (1.2) | 64% (27.3) | 8% (3.3) | 25% (10.8) | match |
| tam_Taml | lang | 7.0 | 38.4 | ×5.50 | ×1.00 | 4% (1.2) | 70% (18.5) | 10% (2.5) | 16% (4.1) | match |
| tha_Thai | lang | 8.3 | 33.1 | ×3.99 | ×1.00 | 4% (1.2) | 82% (24.6) | 9% (2.6) | 6% (1.7) | match |
| added_normalized_dense | modalities | 6.7 | 19.7 | ×2.95 | ×1.00 | 3% (1.4) | 78% (40.4) | 13% (6.9) | 7% (3.4) | match |
| added_normalized_sparse | modalities | 5.3 | 18.4 | ×3.48 | ×1.00 | 4% (2.1) | 71% (39.8) | 13% (7.2) | 12% (6.9) | match |
| added_special_dense | modalities | 5.3 | 38.6 | ×7.23 | ×1.02 | 21% (5.1) | 37% (9.1) | 34% (8.4) | 8% (2.0) | match |
| added_special_sparse | modalities | 4.0 | 21.4 | ×5.40 | ×1.00 | 8% (3.7) | 60% (28.0) | 18% (8.3) | 15% (6.9) | match |
| agentic-traces | modalities | 3.8 | 18.0 | ×4.69 | ×0.99 | 5% (2.7) | 67% (38.4) | 8% (4.9) | 20% (11.2) | match |
| agentic_swe | modalities | 4.1 | 19.4 | ×4.74 | ×1.00 | 4% (1.9) | 73% (38.6) | 7% (3.6) | 17% (9.1) | match |
| code_mixed | modalities | 3.9 | 18.9 | ×4.82 | ×1.00 | 4% (2.2) | 71% (38.5) | 8% (4.1) | 18% (9.6) | match |
| math_latex | modalities | 4.0 | 18.1 | ×4.50 | ×1.00 | 5% (2.6) | 67% (38.5) | 8% (4.7) | 20% (11.3) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×4.13 vs v0.23.1 · ×1.00 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-deepseek-v4-dark.png">
  <img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-deepseek-v4-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-deepseek-v4-stages-dark.png">
  <img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-deepseek-v4-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-deepseek-v4-threads-dark.png">
  <img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-deepseek-v4-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 35+0 (peak 35) · Pipeline 67+0 (peak 66)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 34.7 | ×8.10 | ×1.03 | 2% (0.7) | 0% (0.0) | 17% (4.8) | 80% (22.4) | match |
| arb_Arab | lang | 4.3 | 16.7 | ×3.90 | ×1.00 | 1% (0.6) | 0% (0.0) | 6% (3.5) | 93% (54.4) | match |
| ben_Beng | lang | 6.4 | 18.1 | ×2.83 | ×0.99 | 1% (0.6) | 0% (0.0) | 6% (3.2) | 93% (50.7) | match |
| cmn_Hani | lang | 3.6 | 16.4 | ×4.53 | ×0.97 | 1% (0.8) | 0% (0.0) | 6% (3.2) | 93% (52.8) | match |
| ell_Grek | lang | 4.7 | 18.1 | ×3.85 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (3.5) | 93% (50.5) | match |
| eng_Latn | lang | 3.2 | 12.8 | ×4.04 | ×0.99 | 3% (2.1) | 0% (0.0) | 7% (5.1) | 91% (69.1) | match |
| heb_Hebr | lang | 3.8 | 13.0 | ×3.45 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (3.6) | 94% (72.0) | match |
| hin_Deva | lang | 6.0 | 21.9 | ×3.65 | ×1.01 | 1% (0.6) | 0% (0.0) | 7% (3.4) | 91% (41.5) | match |
| jpn_Jpan | lang | 4.3 | 18.3 | ×4.28 | ×0.99 | 1% (0.7) | 0% (0.0) | 6% (3.0) | 93% (50.5) | match |
| kat_Geor | lang | 6.2 | 18.1 | ×2.93 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (3.0) | 93% (51.6) | match |
| kor_Hang | lang | 3.6 | 19.8 | ×5.45 | ×1.00 | 1% (0.6) | 0% (0.0) | 8% (3.8) | 91% (45.0) | match |
| rus_Cyrl | lang | 4.5 | 14.8 | ×3.29 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 94% (62.3) | match |
| tam_Taml | lang | 6.5 | 18.0 | ×2.77 | ×0.98 | 1% (0.6) | 0% (0.0) | 5% (2.8) | 94% (51.6) | match |
| tha_Thai | lang | 7.0 | 14.9 | ×2.12 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 96% (62.9) | match |
| added_normalized_dense | modalities | 6.3 | 23.3 | ×3.71 | ×1.00 | 2% (0.7) | 0% (0.0) | 7% (2.9) | 91% (37.9) | match |
| added_normalized_sparse | modalities | 5.4 | 19.5 | ×3.59 | ×0.99 | 3% (1.3) | 0% (0.0) | 8% (3.8) | 90% (45.3) | match |
| added_special_dense | modalities | 3.6 | 36.1 | ×9.91 | ×1.01 | 25% (6.3) | 2% (0.5) | 24% (6.1) | 50% (12.7) | match |
| added_special_sparse | modalities | 4.0 | 20.4 | ×5.16 | ×1.00 | 8% (3.9) | 0% (0.1) | 14% (6.7) | 77% (36.8) | match |
| agentic-traces | modalities | 2.9 | 14.1 | ×4.96 | ×0.99 | 3% (1.9) | 0% (0.0) | 8% (5.4) | 89% (61.7) | match |
| agentic_swe | modalities | 3.1 | 14.9 | ×4.84 | ×0.99 | 2% (1.4) | 0% (0.0) | 6% (3.9) | 92% (61.3) | match |
| code_mixed | modalities | 3.6 | 15.5 | ×4.31 | ×1.00 | 3% (1.6) | 0% (0.0) | 7% (4.7) | 90% (56.8) | match |
| math_latex | modalities | 2.9 | 14.0 | ×4.75 | ×0.99 | 3% (2.0) | 0% (0.0) | 8% (5.4) | 90% (64.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.39 | 4.76 | 5.52 | 42.5 | 20.7 | 9.2 | — | 8.9× / 7.7× | 4.4× / 3.8× | 1.9× / 1.7× | — |
| arb_Arab | 1.01 | 2.98 | 3.46 | 5.44 | 50.0 | 22.6 | 10.4 | — | 14.4× / 9.2× | 6.5× / 4.2× | 3.0× / 1.9× | — |
| ben_Beng | 1.47 | 2.98 | 3.23 | 4.74 | 36.1 | 16.1 | 7.6 | — | 11.2× / 7.6× | 5.0× / 3.4× | 2.4× / 1.6× | — |
| cmn_Hani | 1.13 | 2.34 | 3.19 | 4.40 | 62.2 | 33.7 | 14.8 | — | 19.5× / 14.1× | 10.6× / 7.7× | 4.6× / 3.4× | — |
| ell_Grek | 0.58 | 2.98 | 3.47 | 5.87 | 47.5 | 21.2 | 9.7 | — | 13.7× / 8.1× | 6.1× / 3.6× | 2.8× / 1.6× | — |
| eng_Latn | 0.12 | 1.46 | 5.06 | 6.40 | 68.5 | 39.0 | 16.4 | — | 13.5× / 10.7× | 7.7× / 6.1× | 3.2× / 2.6× | — |
| heb_Hebr | 1.01 | 3.12 | 3.63 | 5.74 | 51.5 | 23.9 | 10.8 | — | 14.2× / 9.0× | 6.6× / 4.2× | 3.0× / 1.9× | — |
| hin_Deva | 1.37 | 3.11 | 3.38 | 5.12 | 38.4 | 19.1 | 8.6 | — | 11.4× / 7.5× | 5.6× / 3.7× | 2.5× / 1.7× | — |
| jpn_Jpan | 1.56 | 3.37 | 2.99 | 4.80 | 54.1 | 27.1 | 12.1 | — | 18.1× / 11.3× | 9.1× / 5.7× | 4.1× / 2.5× | — |
| kat_Geor | 1.38 | 2.52 | 3.05 | 4.19 | 32.3 | 14.8 | 7.2 | — | 10.6× / 7.7× | 4.9× / 3.5× | 2.4× / 1.7× | — |
| kor_Hang | 1.22 | 2.79 | 3.76 | 5.33 | 51.0 | 27.1 | 11.9 | — | 13.6× / 9.6× | 7.2× / 5.1× | 3.2× / 2.2× | — |
| rus_Cyrl | 1.02 | 2.97 | 3.32 | 5.27 | 47.6 | 20.7 | 9.7 | — | 14.3× / 9.0× | 6.2× / 3.9× | 2.9× / 1.8× | — |
| tam_Taml | 0.92 | 2.93 | 2.77 | 4.78 | 31.6 | 13.6 | 6.7 | — | 11.4× / 6.6× | 4.9× / 2.8× | 2.4× / 1.4× | — |
| tha_Thai | 1.36 | 2.57 | 2.35 | 3.56 | 27.1 | 10.1 | 5.2 | — | 11.6× / 7.6× | 4.3× / 2.9× | 2.2× / 1.5× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.89 | 4.31 | 44.8 | 19.9 | 9.4 | — | 15.5× / 10.4× | 6.9× / 4.6× | 3.3× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.48 | 3.79 | 5.21 | 51.0 | 25.6 | 11.3 | — | 13.4× / 9.8× | 6.7× / 4.9× | 3.0× / 2.2× | — |
| added_special_dense | 0.06 | 1.47 | 6.08 | 7.50 | 181.3 | 97.1 | 39.8 | — | 29.8× / 24.2× | 16.0× / 13.0× | 6.6× / 5.3× | — |
| added_special_sparse | 0.06 | 1.48 | 6.73 | 8.14 | 106.5 | 57.5 | 25.1 | — | 15.8× / 13.1× | 8.5× / 7.1× | 3.7× / 3.1× | — |
| agentic-traces | 0.62 | 1.48 | 5.41 | 6.27 | 83.5 | 53.4 | 20.2 | — | 15.4× / 13.3× | 9.9× / 8.5× | 3.7× / 3.2× | — |
| agentic_swe | 0.54 | 1.45 | 3.87 | 4.77 | 100.1 | 66.5 | 24.1 | — | 25.9× / 21.0× | 17.2× / 13.9× | 6.2× / 5.0× | — |
| code_mixed | 0.26 | 1.44 | 4.73 | 5.91 | 76.5 | 53.2 | 18.9 | — | 16.2× / 12.9× | 11.3× / 9.0× | 4.0× / 3.2× | — |
| math_latex | 0.56 | 1.48 | 5.41 | 6.32 | 81.8 | 47.8 | 19.5 | — | 15.1× / 12.9× | 8.8× / 7.6× | 3.6× / 3.1× | — |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×8.25 vs v0.23.1 · ×0.94 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt2-dark.png">
  <img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt2-stages-dark.png">
  <img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt2-threads-dark.png">
  <img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 11+1 (peak 11) · Pipeline 14+0 (peak 13)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 2.8 | 52.2 | ×18.68 | ×1.23 | 4% (0.7) | 0% (0.0) | 20% (3.6) | 77% (14.2) | match |
| arb_Arab | lang | 3.5 | 23.4 | ×6.76 | ×0.89 | 1% (0.6) | 0% (0.0) | 5% (2.3) | 94% (44.3) | match |
| ben_Beng | lang | 2.6 | 35.9 | ×13.71 | ×0.81 | 3% (0.6) | 0% (0.0) | 14% (3.0) | 83% (18.1) | match |
| cmn_Hani | lang | 4.0 | 29.3 | ×7.32 | ×1.01 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (30.3) | match |
| ell_Grek | lang | 4.4 | 29.5 | ×6.63 | ×0.98 | 3% (1.1) | 0% (0.0) | 9% (3.1) | 88% (29.2) | match |
| eng_Latn | lang | 3.4 | 13.7 | ×4.01 | ×0.96 | 3% (2.1) | 0% (0.0) | 4% (3.1) | 93% (66.4) | match |
| heb_Hebr | lang | 3.1 | 29.3 | ×9.53 | ×1.00 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (30.6) | match |
| hin_Deva | lang | 2.7 | 33.5 | ×12.50 | ×0.84 | 2% (0.6) | 0% (0.0) | 13% (3.1) | 85% (20.8) | match |
| jpn_Jpan | lang | 4.5 | 21.6 | ×4.80 | ×0.98 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (42.2) | match |
| kat_Geor | lang | 3.9 | 62.5 | ×16.22 | ×0.85 | 6% (0.8) | 0% (0.0) | 12% (1.8) | 83% (12.6) | match |
| kor_Hang | lang | 2.5 | 41.3 | ×16.41 | ×0.95 | 3% (0.6) | 0% (0.0) | 11% (2.4) | 87% (19.6) | match |
| rus_Cyrl | lang | 3.3 | 26.2 | ×8.04 | ×1.00 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 93% (34.2) | match |
| tam_Taml | lang | 2.5 | 64.4 | ×25.34 | ×0.98 | 4% (0.6) | 0% (0.0) | 19% (2.7) | 77% (11.5) | match |
| tha_Thai | lang | 3.3 | 37.2 | ×11.12 | ×1.03 | 2% (0.6) | 0% (0.0) | 10% (2.6) | 88% (22.7) | match |
| added_normalized_dense | modalities | 6.2 | 26.4 | ×4.27 | ×1.01 | 2% (0.8) | 0% (0.0) | 3% (1.1) | 95% (34.9) | match |
| added_normalized_sparse | modalities | 5.3 | 22.1 | ×4.15 | ×0.99 | 3% (1.4) | 0% (0.0) | 4% (1.9) | 93% (40.6) | match |
| added_special_dense | modalities | 2.2 | 23.8 | ×11.02 | ×0.52 | 25% (4.9) | 0% (0.1) | 20% (4.0) | 55% (10.9) | match |
| added_special_sparse | modalities | 4.3 | 23.6 | ×5.44 | ×1.00 | 8% (3.2) | 0% (0.0) | 12% (4.7) | 80% (32.5) | match |
| agentic-traces | modalities | 2.8 | 16.2 | ×5.87 | ×0.99 | 3% (1.9) | 0% (0.0) | 6% (3.5) | 91% (56.0) | match |
| agentic_swe | modalities | 3.5 | 23.9 | ×6.85 | ×0.97 | 3% (1.4) | 0% (0.0) | 6% (2.5) | 91% (36.6) | match |
| code_mixed | modalities | 3.5 | 20.1 | ×5.75 | ×0.97 | 5% (2.3) | 1% (0.3) | 5% (2.4) | 90% (43.6) | match |
| math_latex | modalities | 3.0 | 15.2 | ×5.10 | ×0.98 | 2% (2.2) | 1% (0.7) | 4% (4.7) | 93% (104.6) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.66 | 3.43 | 3.63 | 4.39 | 28.1 | 21.7 | 5.8 | 4.8 | 7.7× / 6.4× | 6.0× / 4.9× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 3.07 | 2.28 | 4.35 | 54.5 | 47.9 | 13.7 | 5.0 | 23.9× / 12.5× | 21.0× / 11.0× | 6.0× / 3.2× | 2.2× / 1.2× |
| ben_Beng | 1.47 | 2.92 | 3.04 | 4.48 | 68.0 | 78.8 | 25.3 | 4.0 | 22.4× / 15.2× | 25.9× / 17.6× | 8.3× / 5.6× | 1.3× / 0.9× |
| cmn_Hani | 1.37 | 2.32 | 2.32 | 3.27 | 26.4 | 25.1 | 11.2 | 3.2 | 11.4× / 8.1× | 10.8× / 7.7× | 4.8× / 3.4× | 1.4× / 1.0× |
| ell_Grek | 0.58 | 4.75 | 3.08 | 7.24 | 29.0 | 28.9 | 6.0 | 4.7 | 9.4× / 4.0× | 9.4× / 4.0× | 2.0× / 0.8× | 1.5× / 0.7× |
| eng_Latn | 0.09 | 1.45 | 3.08 | 4.44 | 46.0 | 43.9 | 12.1 | 3.7 | 14.9× / 10.4× | 14.3× / 9.9× | 3.9× / 2.7× | 1.2× / 0.8× |
| heb_Hebr | 1.01 | 3.08 | 2.28 | 4.35 | 44.3 | 26.9 | 6.9 | 3.0 | 19.4× / 10.2× | 11.8× / 6.2× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.36 | 3.09 | 3.07 | 4.80 | 63.7 | 91.8 | 13.8 | 4.3 | 20.7× / 13.3× | 29.9× / 19.1× | 4.5× / 2.9× | 1.4× / 0.9× |
| jpn_Jpan | 1.56 | 3.36 | 2.12 | 3.92 | 23.8 | 19.9 | 7.5 | 4.1 | 11.3× / 6.1× | 9.4× / 5.1× | 3.5× / 1.9× | 1.9× / 1.0× |
| kat_Geor | 2.24 | 4.15 | 1.83 | 3.74 | 17.9 | 15.0 | 4.1 | 2.1 | 9.8× / 4.8× | 8.2× / 4.0× | 2.3× / 1.1× | 1.1× / 0.6× |
| kor_Hang | 1.08 | 2.78 | 2.43 | 4.13 | 32.7 | 28.8 | 7.4 | 3.6 | 13.5× / 7.9× | 11.8× / 7.0× | 3.1× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.98 | 2.09 | 4.06 | 27.7 | 21.7 | 5.7 | 2.5 | 13.2× / 6.8× | 10.4× / 5.3× | 2.7× / 1.4× | 1.2× / 0.6× |
| tam_Taml | 0.92 | 2.94 | 2.74 | 4.76 | 71.9 | 60.2 | 14.4 | 3.8 | 26.2× / 15.1× | 21.9× / 12.7× | 5.3× / 3.0× | 1.4× / 0.8× |
| tha_Thai | 1.38 | 2.55 | 2.61 | 3.78 | 41.9 | 32.5 | 8.9 | 3.3 | 16.0× / 11.1× | 12.4× / 8.6× | 3.4× / 2.4× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.10 | 2.52 | 24.2 | 23.3 | 6.2 | 1.8 | 22.0× / 9.6× | 21.1× / 9.2× | 5.7× / 2.5× | 1.6× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.91 | 3.33 | 32.3 | 31.8 | 8.4 | 2.5 | 16.9× / 9.7× | 16.6× / 9.6× | 4.4× / 2.5× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 3.95 | 5.37 | 97.3 | 97.3 | 19.8 | 2.8 | 24.6× / 18.1× | 24.6× / 18.1× | 5.0× / 3.7× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.69 | 6.10 | 63.6 | 61.1 | 14.4 | 3.4 | 13.6× / 10.4× | 13.0× / 10.0× | 3.1× / 2.4× | 0.7× / 0.6× |
| agentic-traces | 0.56 | 3.11 | 3.48 | 6.02 | 105.9 | 68.5 | 24.5 | 4.7 | 30.4× / 17.6× | 19.7× / 11.4× | 7.1× / 4.1× | 1.3× / 0.8× |
| agentic_swe | 0.65 | 1.45 | 2.48 | 3.27 | 63.5 | 121.5 | 28.9 | 5.2 | 25.6× / 19.4× | 49.0× / 37.1× | 11.7× / 8.8× | 2.1× / 1.6× |
| code_mixed | 0.07 | 1.44 | 2.39 | 3.76 | 60.5 | 69.0 | 28.4 | 6.0 | 25.4× / 16.1× | 28.9× / 18.4× | 11.9× / 7.6× | 2.5× / 1.6× |
| math_latex | 1.08 | 2.08 | 4.72 | 5.73 | 86.9 | 53.1 | 14.2 | 4.2 | 18.4× / 15.2× | 11.2× / 9.3× | 3.0× / 2.5× | 0.9× / 0.7× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×8.72 vs v0.23.1 · ×0.99 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt-oss-dark.png">
  <img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt-oss-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt-oss-stages-dark.png">
  <img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt-oss-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt-oss-threads-dark.png">
  <img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-gpt-oss-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 2+1 (peak 3) · Pipeline 3+0 (peak 3)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.0 | 61.2 | ×20.63 | ×0.97 | 4% (0.7) | 0% (0.0) | 31% (4.8) | 65% (10.2) | match |
| arb_Arab | lang | 3.2 | 26.1 | ×8.16 | ×1.01 | 2% (0.6) | 0% (0.0) | 9% (3.3) | 90% (34.5) | match |
| ben_Beng | lang | 4.2 | 28.3 | ×6.67 | ×0.99 | 2% (0.6) | 0% (0.0) | 10% (3.7) | 88% (31.2) | match |
| cmn_Hani | lang | 3.5 | 38.4 | ×10.90 | ×0.99 | 2% (0.6) | 0% (0.0) | 12% (3.5) | 86% (26.4) | match |
| ell_Grek | lang | 3.3 | 31.2 | ×9.51 | ×0.95 | 2% (0.6) | 0% (0.0) | 10% (3.2) | 88% (27.1) | match |
| eng_Latn | lang | 2.6 | 21.4 | ×8.17 | ×0.99 | 5% (2.1) | 0% (0.0) | 11% (5.2) | 84% (39.4) | match |
| heb_Hebr | lang | 3.2 | 26.9 | ×8.49 | ×0.95 | 2% (0.6) | 0% (0.0) | 12% (4.3) | 86% (31.2) | match |
| hin_Deva | lang | 4.6 | 24.7 | ×5.41 | ×1.00 | 1% (0.6) | 0% (0.0) | 9% (3.8) | 89% (37.0) | match |
| jpn_Jpan | lang | 4.2 | 37.3 | ×8.85 | ×0.98 | 2% (0.6) | 0% (0.0) | 13% (3.3) | 85% (22.2) | match |
| kat_Geor | lang | 5.0 | 26.3 | ×5.30 | ×0.99 | 2% (0.6) | 0% (0.0) | 8% (2.8) | 91% (33.9) | match |
| kor_Hang | lang | 3.0 | 44.8 | ×14.80 | ×0.95 | 3% (0.6) | 0% (0.0) | 17% (3.7) | 80% (17.5) | match |
| rus_Cyrl | lang | 3.8 | 23.2 | ×6.16 | ×1.01 | 2% (0.7) | 0% (0.0) | 7% (3.1) | 91% (39.1) | match |
| tam_Taml | lang | 5.1 | 30.3 | ×5.98 | ×1.00 | 2% (0.6) | 0% (0.0) | 10% (3.2) | 88% (28.6) | match |
| tha_Thai | lang | 5.8 | 27.9 | ×4.80 | ×1.00 | 1% (0.6) | 0% (0.0) | 7% (3.2) | 91% (40.8) | match |
| added_normalized_dense | modalities | 4.1 | 45.9 | ×11.31 | ×1.00 | 4% (0.7) | 0% (0.0) | 11% (2.2) | 86% (17.9) | match |
| added_normalized_sparse | modalities | 3.6 | 36.4 | ×10.21 | ×0.99 | 5% (1.3) | 0% (0.0) | 12% (3.1) | 84% (22.2) | match |
| added_special_dense | modalities | 3.0 | 55.3 | ×18.57 | ×1.08 | 28% (4.9) | 1% (0.2) | 29% (5.2) | 42% (7.4) | match |
| added_special_sparse | modalities | 3.2 | 34.2 | ×10.51 | ×1.00 | 11% (3.2) | 0% (0.0) | 21% (6.1) | 68% (19.5) | match |
| agentic-traces | modalities | 2.7 | 22.5 | ×8.20 | ×0.98 | 4% (1.9) | 0% (0.0) | 12% (5.1) | 84% (36.5) | match |
| agentic_swe | modalities | 3.2 | 21.8 | ×6.77 | ×1.00 | 3% (1.3) | 0% (0.0) | 8% (3.8) | 89% (40.7) | match |
| code_mixed | modalities | 3.2 | 29.8 | ×9.30 | ×0.99 | 5% (1.7) | 0% (0.0) | 13% (4.4) | 82% (27.5) | match |
| math_latex | modalities | 2.9 | 22.7 | ×7.78 | ×0.99 | 5% (2.1) | 0% (0.0) | 11% (5.0) | 84% (36.7) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.39 | 4.84 | 5.59 | 30.6 | 14.0 | 6.9 | 4.8 | 6.3× / 5.5× | 2.9× / 2.5× | 1.4× / 1.2× | 1.0× / 0.9× |
| arb_Arab | 1.00 | 3.02 | 3.29 | 5.31 | 34.9 | 16.1 | 7.7 | 5.2 | 10.6× / 6.6× | 4.9× / 3.0× | 2.3× / 1.5× | 1.6× / 1.0× |
| ben_Beng | 1.47 | 2.88 | 3.69 | 5.10 | 24.3 | 10.9 | 5.4 | 2.8 | 6.6× / 4.8× | 3.0× / 2.1× | 1.5× / 1.1× | 0.8× / 0.5× |
| cmn_Hani | 1.12 | 2.33 | 3.52 | 4.72 | 22.0 | 10.8 | 5.5 | 2.5 | 6.3× / 4.7× | 3.1× / 2.3× | 1.6× / 1.2× | 0.7× / 0.5× |
| ell_Grek | 0.58 | 2.98 | 3.20 | 5.60 | 30.9 | 15.2 | 6.8 | 5.1 | 9.7× / 5.5× | 4.8× / 2.7× | 2.1× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.12 | 1.45 | 5.20 | 6.54 | 46.4 | 29.2 | 13.8 | 4.2 | 8.9× / 7.1× | 5.6× / 4.5× | 2.6× / 2.1× | 0.8× / 0.6× |
| heb_Hebr | 1.01 | 3.06 | 4.26 | 6.31 | 34.4 | 17.0 | 8.0 | 2.9 | 8.1× / 5.5× | 4.0× / 2.7× | 1.9× / 1.3× | 0.7× / 0.5× |
| hin_Deva | 1.36 | 3.09 | 3.80 | 5.53 | 26.6 | 12.7 | 6.3 | 3.3 | 7.0× / 4.8× | 3.3× / 2.3× | 1.7× / 1.1× | 0.9× / 0.6× |
| jpn_Jpan | 1.55 | 3.32 | 3.28 | 5.04 | 20.5 | 9.2 | 4.7 | 3.8 | 6.3× / 4.1× | 2.8× / 1.8× | 1.4× / 0.9× | 1.1× / 0.7× |
| kat_Geor | 1.39 | 2.60 | 2.82 | 4.04 | 19.1 | 10.1 | 4.7 | 2.1 | 6.8× / 4.7× | 3.6× / 2.5× | 1.7× / 1.2× | 0.7× / 0.5× |
| kor_Hang | 1.09 | 2.78 | 3.71 | 5.41 | 34.2 | 18.7 | 8.7 | 3.7 | 9.2× / 6.3× | 5.0× / 3.5× | 2.3× / 1.6× | 1.0× / 0.7× |
| rus_Cyrl | 1.03 | 2.95 | 3.10 | 5.03 | 29.6 | 14.9 | 6.6 | 4.8 | 9.5× / 5.9× | 4.8× / 3.0× | 2.1× / 1.3× | 1.6× / 1.0× |
| tam_Taml | 0.92 | 2.93 | 3.23 | 5.23 | 19.5 | 8.6 | 4.2 | 3.1 | 6.0× / 3.7× | 2.7× / 1.6× | 1.3× / 0.8× | 1.0× / 0.6× |
| tha_Thai | 1.36 | 2.53 | 3.24 | 4.41 | 13.3 | 5.7 | 2.7 | 2.4 | 4.1× / 3.0× | 1.8× / 1.3× | 0.8× / 0.6× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.48 | 2.18 | 3.60 | 35.5 | 17.3 | 11.4 | 2.0 | 16.2× / 9.8× | 7.9× / 4.8× | 5.2× / 3.2× | 0.9× / 0.6× |
| added_normalized_sparse | 0.06 | 1.48 | 3.12 | 4.54 | 38.3 | 20.9 | 11.6 | 2.8 | 12.3× / 8.4× | 6.7× / 4.6× | 3.7× / 2.6× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.47 | 5.16 | 6.57 | 92.1 | 67.8 | 23.7 | 3.2 | 17.9× / 14.0× | 13.1× / 10.3× | 4.6× / 3.6× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 6.11 | 7.53 | 60.5 | 40.9 | 16.9 | 3.7 | 9.9× / 8.0× | 6.7× / 5.4× | 2.8× / 2.2× | 0.6× / 0.5× |
| agentic-traces | 0.59 | 1.48 | 5.08 | 5.97 | 55.5 | 40.1 | 20.8 | 5.0 | 10.9× / 9.3× | 7.9× / 6.7× | 4.1× / 3.5× | 1.0× / 0.8× |
| agentic_swe | 0.51 | 1.44 | 3.76 | 4.69 | 56.4 | 48.4 | 17.2 | 3.6 | 15.0× / 12.0× | 12.9× / 10.3× | 4.6× / 3.7× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.46 | 4.44 | 5.83 | 56.1 | 47.1 | 17.2 | 4.3 | 12.6× / 9.6× | 10.6× / 8.1× | 3.9× / 2.9× | 1.0× / 0.7× |
| math_latex | 0.56 | 1.48 | 4.98 | 5.90 | 52.9 | 35.6 | 15.9 | 4.6 | 10.6× / 9.0× | 7.2× / 6.0× | 3.2× / 2.7× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×13.16 vs v0.23.1 · ×1.00 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-glm-5-2-dark.png">
  <img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-glm-5-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-glm-5-2-stages-dark.png">
  <img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-glm-5-2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-glm-5-2-threads-dark.png">
  <img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-glm-5-2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 2+1 (peak 3) · Pipeline 3+0 (peak 3)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.5 | 65.3 | ×14.47 | ×1.10 | 8% (1.2) | 0% (0.0) | 25% (3.7) | 66% (9.7) | match |
| arb_Arab | lang | 4.0 | 73.8 | ×18.48 | ×1.05 | 9% (1.2) | 0% (0.0) | 18% (2.3) | 73% (9.3) | match |
| ben_Beng | lang | 3.4 | 70.0 | ×20.66 | ×1.04 | 8% (1.2) | 0% (0.0) | 22% (3.1) | 70% (9.7) | match |
| cmn_Hani | lang | 4.6 | 68.5 | ×15.01 | ×1.01 | 9% (1.2) | 0% (0.0) | 17% (2.4) | 74% (10.4) | match |
| ell_Grek | lang | 3.9 | 70.5 | ×18.01 | ×0.97 | 9% (1.2) | 0% (0.0) | 17% (2.2) | 74% (9.8) | match |
| eng_Latn | lang | 3.4 | 22.7 | ×6.70 | ×0.98 | 6% (2.6) | 0% (0.1) | 7% (3.1) | 86% (37.2) | match |
| heb_Hebr | lang | 3.6 | 76.7 | ×21.16 | ×1.06 | 10% (1.2) | 0% (0.0) | 19% (2.3) | 72% (8.8) | match |
| hin_Deva | lang | 3.0 | 64.8 | ×21.52 | ×0.95 | 8% (1.2) | 0% (0.0) | 22% (3.2) | 70% (10.4) | match |
| jpn_Jpan | lang | 4.7 | 70.7 | ×15.20 | ×0.96 | 9% (1.2) | 1% (0.1) | 16% (2.2) | 75% (10.1) | match |
| kat_Geor | lang | 4.3 | 79.1 | ×18.25 | ×0.96 | 10% (1.2) | 0% (0.0) | 17% (2.1) | 73% (8.8) | match |
| kor_Hang | lang | 3.2 | 68.4 | ×21.25 | ×0.97 | 9% (1.2) | 0% (0.0) | 18% (2.5) | 73% (10.1) | match |
| rus_Cyrl | lang | 3.7 | 40.5 | ×10.90 | ×0.99 | 5% (1.2) | 0% (0.0) | 9% (2.2) | 86% (20.4) | match |
| tam_Taml | lang | 3.2 | 69.6 | ×21.49 | ×0.96 | 9% (1.2) | 0% (0.0) | 20% (2.7) | 72% (9.6) | match |
| tha_Thai | lang | 3.8 | 69.0 | ×18.07 | ×1.06 | 9% (1.2) | 0% (0.0) | 18% (2.5) | 73% (10.0) | match |
| added_normalized_dense | modalities | 4.7 | 48.3 | ×10.36 | ×1.03 | 7% (1.3) | 0% (0.0) | 6% (1.1) | 88% (17.5) | match |
| added_normalized_sparse | modalities | 4.2 | 41.3 | ×9.78 | ×1.03 | 8% (1.9) | 0% (0.0) | 9% (2.1) | 83% (19.5) | match |
| added_special_dense | modalities | 3.4 | 40.2 | ×11.78 | ×0.96 | 51% (11.9) | 0% (0.0) | 23% (5.3) | 25% (5.9) | match |
| added_special_sparse | modalities | 3.5 | 33.8 | ×9.59 | ×0.99 | 24% (6.8) | 0% (0.0) | 18% (5.2) | 58% (16.5) | match |
| agentic-traces | modalities | 3.2 | 23.9 | ×7.45 | ×0.99 | 6% (2.6) | 0% (0.0) | 9% (3.8) | 85% (34.7) | match |
| agentic_swe | modalities | 3.5 | 22.0 | ×6.24 | ×0.99 | 4% (2.0) | 0% (0.0) | 6% (2.9) | 89% (39.7) | match |
| code_mixed | modalities | 3.5 | 31.1 | ×8.88 | ×0.99 | 7% (2.3) | 0% (0.0) | 11% (3.3) | 82% (25.7) | match |
| math_latex | modalities | 3.1 | 23.9 | ×7.77 | ×0.97 | 6% (2.6) | 0% (0.1) | 9% (3.5) | 85% (34.3) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.41 | 3.69 | 4.47 | 27.9 | 16.1 | 5.8 | 4.7 | 7.6× / 6.2× | 4.4× / 3.6× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.01 | 3.06 | 2.30 | 4.35 | 31.7 | 19.5 | 6.7 | 5.1 | 13.8× / 7.3× | 8.5× / 4.5× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.47 | 2.97 | 3.07 | 4.57 | 46.8 | 27.4 | 10.1 | 3.7 | 15.2× / 10.2× | 8.9× / 6.0× | 3.3× / 2.2× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.26 | 2.37 | 3.51 | 19.8 | 11.5 | 4.7 | 2.3 | 8.3× / 5.6× | 4.8× / 3.3× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.03 | 2.21 | 4.66 | 28.9 | 16.7 | 6.1 | 4.8 | 13.1× / 6.2× | 7.6× / 3.6× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.11 | 1.46 | 3.13 | 4.48 | 45.2 | 33.7 | 12.2 | 3.8 | 14.4× / 10.1× | 10.8× / 7.5× | 3.9× / 2.7× | 1.2× / 0.8× |
| heb_Hebr | 1.00 | 3.10 | 2.31 | 4.42 | 31.8 | 19.8 | 6.9 | 3.0 | 13.8× / 7.2× | 8.5× / 4.5× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 3.12 | 3.19 | 4.94 | 49.0 | 30.8 | 11.1 | 4.0 | 15.4× / 9.9× | 9.7× / 6.2× | 3.5× / 2.2× | 1.3× / 0.8× |
| jpn_Jpan | 1.56 | 3.37 | 2.15 | 3.96 | 18.4 | 9.7 | 4.1 | 3.9 | 8.6× / 4.7× | 4.5× / 2.4× | 1.9× / 1.0× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.61 | 2.08 | 3.30 | 17.5 | 11.3 | 4.2 | 1.9 | 8.4× / 5.3× | 5.4× / 3.4× | 2.0× / 1.3× | 0.9× / 0.6× |
| kor_Hang | 1.19 | 2.75 | 2.51 | 4.07 | 31.8 | 20.7 | 7.3 | 3.7 | 12.6× / 7.8× | 8.2× / 5.1× | 2.9× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.92 | 2.17 | 4.07 | 27.4 | 17.0 | 5.8 | 2.4 | 12.6× / 6.7× | 7.8× / 4.2× | 2.7× / 1.4× | 1.1× / 0.6× |
| tam_Taml | 0.92 | 2.94 | 2.68 | 4.70 | 45.5 | 26.7 | 9.8 | 3.3 | 17.0× / 9.7× | 10.0× / 5.7× | 3.7× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.36 | 2.57 | 2.52 | 3.73 | 28.9 | 16.0 | 6.6 | 3.0 | 11.5× / 7.8× | 6.3× / 4.3× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.07 | 1.48 | 1.13 | 2.53 | 24.7 | 16.8 | 6.5 | 1.9 | 21.9× / 9.8× | 15.0× / 6.7× | 5.8× / 2.6× | 1.7× / 0.8× |
| added_normalized_sparse | 0.06 | 1.48 | 2.09 | 3.51 | 32.2 | 23.0 | 8.7 | 2.6 | 15.4× / 9.2× | 11.0× / 6.5× | 4.2× / 2.5× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.48 | 5.30 | 6.72 | 97.6 | 72.9 | 21.2 | 3.1 | 18.4× / 14.5× | 13.7× / 10.8× | 4.0× / 3.2× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.21 | 6.63 | 62.6 | 47.4 | 15.2 | 3.5 | 12.0× / 9.4× | 9.1× / 7.2× | 2.9× / 2.3× | 0.7× / 0.5× |
| agentic-traces | 0.57 | 1.51 | 3.78 | 4.72 | 54.5 | 42.8 | 14.7 | 4.6 | 14.4× / 11.5× | 11.3× / 9.1× | 3.9× / 3.1× | 1.2× / 1.0× |
| agentic_swe | 0.54 | 1.45 | 2.86 | 3.77 | 56.8 | 49.3 | 15.5 | 3.4 | 19.9× / 15.1× | 17.2× / 13.1× | 5.4× / 4.1× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.31 | 4.67 | 54.3 | 49.2 | 15.0 | 4.1 | 16.4× / 11.6× | 14.9× / 10.5× | 4.5× / 3.2× | 1.2× / 0.9× |
| math_latex | 0.56 | 1.48 | 3.53 | 4.45 | 52.4 | 38.8 | 14.2 | 4.2 | 14.8× / 11.8× | 11.0× / 8.7× | 4.0× / 3.2× | 1.2× / 0.9× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.28 vs v0.23.1 · ×0.98 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-2-dark.png">
  <img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-2-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-2-stages-dark.png">
  <img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-2-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-2-threads-dark.png">
  <img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-2-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 8+1 (peak 8) · Pipeline 8+0 (peak 8)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.6 | 46.6 | ×8.35 | ×0.99 | 0% (0.0) | 13% (2.7) | 0% (0.0) | 87% (17.9) | match |
| arb_Arab | lang | 12.7 | 53.4 | ×4.22 | ×1.00 | 0% (0.0) | 17% (3.2) | 0% (0.0) | 83% (15.4) | match |
| ben_Beng | lang | 13.6 | 91.7 | ×6.74 | ×1.01 | 0% (0.0) | 21% (2.1) | 0% (0.0) | 79% (8.2) | match |
| cmn_Hani | lang | 11.4 | 71.4 | ×6.25 | ×0.98 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 96% (12.6) | match |
| ell_Grek | lang | 12.9 | 62.5 | ×4.86 | ×1.00 | 0% (0.0) | 20% (3.1) | 0% (0.1) | 80% (12.4) | match |
| eng_Latn | lang | 4.2 | 6.0 | ×1.43 | ×0.94 | 0% (0.1) | 4% (6.9) | 0% (0.0) | 96% (155.1) | match |
| heb_Hebr | lang | 12.7 | 65.7 | ×5.17 | ×0.99 | 0% (0.0) | 23% (3.3) | 0% (0.0) | 77% (11.3) | match |
| hin_Deva | lang | 14.7 | 85.3 | ×5.81 | ×1.02 | 0% (0.0) | 25% (2.8) | 0% (0.0) | 74% (8.2) | match |
| jpn_Jpan | lang | 16.6 | 90.7 | ×5.48 | ×0.96 | 1% (0.1) | 3% (0.3) | 0% (0.0) | 96% (9.7) | match |
| kat_Geor | lang | 17.8 | 97.6 | ×5.47 | ×0.97 | 1% (0.1) | 19% (1.9) | 0% (0.0) | 80% (7.7) | match |
| kor_Hang | lang | 8.7 | 55.8 | ×6.40 | ×0.99 | 0% (0.1) | 19% (3.2) | 0% (0.0) | 80% (13.8) | match |
| rus_Cyrl | lang | 9.1 | 16.7 | ×1.84 | ×1.00 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (56.7) | match |
| tam_Taml | lang | 15.8 | 95.2 | ×6.03 | ×0.98 | 1% (0.0) | 18% (1.8) | 0% (0.0) | 82% (8.1) | match |
| tha_Thai | lang | 19.8 | 93.3 | ×4.71 | ×0.98 | 0% (0.0) | 9% (0.9) | 0% (0.0) | 91% (9.3) | match |
| added_normalized_dense | modalities | 5.7 | 8.7 | ×1.53 | ×0.99 | 0% (0.1) | 3% (3.8) | 0% (0.1) | 97% (109.2) | match |
| added_normalized_sparse | modalities | 4.9 | 7.0 | ×1.43 | ×0.95 | 0% (0.0) | 4% (6.1) | 0% (0.0) | 96% (134.0) | match |
| added_special_dense | modalities | 5.3 | 19.9 | ×3.72 | ×0.97 | 11% (5.2) | 32% (15.5) | 2% (0.8) | 55% (26.3) | match |
| added_special_sparse | modalities | 7.3 | 10.4 | ×1.42 | ×0.99 | 2% (2.3) | 15% (13.7) | 0% (0.1) | 83% (77.7) | match |
| agentic-traces | modalities | 4.5 | 6.8 | ×1.50 | ×0.95 | 0% (0.1) | 4% (6.2) | 0% (0.1) | 96% (139.4) | match |
| agentic_swe | modalities | 4.1 | 7.1 | ×1.71 | ×0.94 | 0% (0.0) | 7% (9.8) | 0% (0.3) | 93% (133.1) | match |
| code_mixed | modalities | 4.2 | 6.9 | ×1.63 | ×0.95 | 0% (0.0) | 6% (8.0) | 0% (0.1) | 94% (136.0) | match |
| math_latex | modalities | 4.4 | 6.5 | ×1.48 | ×0.94 | 0% (0.1) | 4% (6.4) | 0% (0.0) | 96% (145.0) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×7.28 vs v0.23.1 · ×0.95 vs base</summary>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-3-dark.png">
  <img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-3-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-3-stages-dark.png">
  <img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-3-stages-light.png" width="860">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-3-threads-dark.png">
  <img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-llama-3-threads-light.png" width="860">
</picture>

**Memory** (RSS MB, load+encode): v0.23.1 136+1 (peak 165) · Pipeline 127+0 (peak 166)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 50.2 | ×12.99 | ×0.92 | 4% (0.7) | 0% (0.0) | 20% (3.7) | 77% (14.2) | match |
| arb_Arab | lang | 3.9 | 17.8 | ×4.63 | ×0.96 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 95% (51.5) | match |
| ben_Beng | lang | 4.1 | 32.8 | ×8.00 | ×1.01 | 2% (0.6) | 0% (0.0) | 10% (3.1) | 88% (26.4) | match |
| cmn_Hani | lang | 4.6 | 16.8 | ×3.65 | ×0.96 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 95% (54.6) | match |
| ell_Grek | lang | 4.8 | 19.9 | ×4.14 | ×0.97 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 94% (46.6) | match |
| eng_Latn | lang | 4.0 | 38.4 | ×9.55 | ×0.87 | 8% (2.1) | 0% (0.1) | 13% (3.1) | 79% (19.5) | match |
| heb_Hebr | lang | 3.8 | 28.0 | ×7.41 | ×1.03 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 92% (31.9) | match |
| hin_Deva | lang | 4.2 | 76.6 | ×18.27 | ×0.97 | 8% (0.9) | 0% (0.0) | 27% (3.2) | 69% (8.3) | match |
| jpn_Jpan | lang | 5.4 | 16.2 | ×3.03 | ×0.94 | 1% (0.6) | 0% (0.0) | 4% (2.1) | 95% (55.8) | match |
| kat_Geor | lang | 5.2 | 40.4 | ×7.79 | ×1.01 | 3% (0.6) | 0% (0.0) | 9% (2.1) | 89% (21.2) | match |
| kor_Hang | lang | 3.4 | 18.7 | ×5.48 | ×0.93 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 94% (48.0) | match |
| rus_Cyrl | lang | 4.7 | 16.7 | ×3.58 | ×0.96 | 1% (0.6) | 0% (0.0) | 4% (2.1) | 95% (57.2) | match |
| tam_Taml | lang | 4.0 | 36.4 | ×9.15 | ×1.01 | 2% (0.6) | 0% (0.0) | 10% (2.7) | 88% (23.8) | match |
| tha_Thai | lang | 5.1 | 21.0 | ×4.13 | ×0.96 | 1% (0.6) | 0% (0.0) | 5% (2.6) | 93% (43.6) | match |
| added_normalized_dense | modalities | 6.2 | 27.0 | ×4.38 | ×0.97 | 3% (1.1) | 0% (0.0) | 3% (1.0) | 95% (33.3) | match |
| added_normalized_sparse | modalities | 5.5 | 42.7 | ×7.74 | ×0.97 | 6% (1.4) | 0% (0.0) | 9% (2.0) | 85% (18.9) | match |
| added_special_dense | modalities | 4.3 | 69.4 | ×16.28 | ×0.98 | 40% (5.0) | 0% (0.0) | 41% (5.2) | 19% (2.4) | match |
| added_special_sparse | modalities | 4.3 | 69.7 | ×16.11 | ×0.99 | 25% (3.2) | 0% (0.0) | 41% (5.2) | 34% (4.4) | match |
| agentic-traces | modalities | 3.5 | 32.4 | ×9.32 | ×0.87 | 7% (1.9) | 0% (0.0) | 13% (3.8) | 80% (22.9) | match |
| agentic_swe | modalities | 4.0 | 26.5 | ×6.64 | ×0.94 | 4% (1.3) | 0% (0.0) | 8% (2.9) | 88% (32.4) | match |
| code_mixed | modalities | 4.1 | 42.0 | ×10.37 | ×0.90 | 8% (1.6) | 0% (0.0) | 15% (3.3) | 77% (17.0) | match |
| math_latex | modalities | 3.4 | 33.6 | ×9.95 | ×0.84 | 7% (2.0) | 0% (0.0) | 13% (3.5) | 80% (21.7) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.39 | 3.71 | 4.46 | 27.3 | 16.6 | 6.1 | 4.8 | 7.4× / 6.1× | 4.5× / 3.7× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 2.99 | 2.32 | 4.31 | 31.0 | 20.2 | 7.0 | 5.1 | 13.4× / 7.2× | 8.7× / 4.7× | 3.0× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.47 | 2.96 | 3.07 | 4.56 | 45.2 | 28.8 | 10.7 | 3.7 | 14.7× / 9.9× | 9.4× / 6.3× | 3.5× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.13 | 2.29 | 2.42 | 3.58 | 19.3 | 11.7 | 4.8 | 2.4 | 8.0× / 5.4× | 4.8× / 3.3× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.12 | 2.20 | 4.74 | 28.3 | 18.0 | 6.3 | 4.8 | 12.9× / 6.0× | 8.2× / 3.8× | 2.9× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.45 | 3.12 | 4.48 | 44.3 | 34.3 | 12.8 | 3.8 | 14.2× / 9.9× | 11.0× / 7.7× | 4.1× / 2.9× | 1.2× / 0.8× |
| heb_Hebr | 1.00 | 3.08 | 2.30 | 4.39 | 30.9 | 20.8 | 7.1 | 3.0 | 13.4× / 7.0× | 9.0× / 4.7× | 3.1× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 3.12 | 3.20 | 4.95 | 48.9 | 30.8 | 11.6 | 4.0 | 15.3× / 9.9× | 9.6× / 6.2× | 3.6× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.55 | 3.35 | 2.15 | 3.95 | 18.1 | 10.3 | 4.1 | 3.8 | 8.4× / 4.6× | 4.8× / 2.6× | 1.9× / 1.0× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.57 | 2.08 | 3.26 | 17.1 | 11.6 | 4.3 | 2.1 | 8.2× / 5.2× | 5.6× / 3.6× | 2.0× / 1.3× | 1.0× / 0.7× |
| kor_Hang | 1.08 | 2.78 | 2.52 | 4.22 | 31.2 | 22.2 | 8.0 | 3.7 | 12.3× / 7.4× | 8.8× / 5.3× | 3.2× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.97 | 2.15 | 4.09 | 26.8 | 16.6 | 6.2 | 2.4 | 12.5× / 6.6× | 7.7× / 4.0× | 2.9× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.96 | 2.66 | 4.69 | 44.3 | 27.8 | 10.3 | 3.3 | 16.7× / 9.4× | 10.4× / 5.9× | 3.9× / 2.2× | 1.3× / 0.7× |
| tha_Thai | 1.36 | 2.55 | 2.56 | 3.75 | 28.2 | 16.3 | 7.1 | 3.0 | 11.0× / 7.5× | 6.4× / 4.3× | 2.8× / 1.9× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.48 | 0.99 | 2.41 | 24.4 | 17.1 | 6.5 | 1.9 | 24.7× / 10.1× | 17.3× / 7.1× | 6.6× / 2.7× | 1.9× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.97 | 3.39 | 31.1 | 22.8 | 8.8 | 2.6 | 15.8× / 9.2× | 11.6× / 6.7× | 4.5× / 2.6× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 5.17 | 6.58 | 95.2 | 76.9 | 21.4 | 3.1 | 18.4× / 14.5× | 14.9× / 11.7× | 4.1× / 3.2× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 5.22 | 6.64 | 61.0 | 46.2 | 15.2 | 3.5 | 11.7× / 9.2× | 8.8× / 7.0× | 2.9× / 2.3× | 0.7× / 0.5× |
| agentic-traces | 0.57 | 1.48 | 3.76 | 4.67 | 53.4 | 49.5 | 15.5 | 4.6 | 14.2× / 11.4× | 13.2× / 10.6× | 4.1× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.51 | 1.45 | 2.89 | 3.83 | 55.8 | 57.3 | 15.9 | 3.4 | 19.3× / 14.6× | 19.9× / 15.0× | 5.5× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.30 | 4.67 | 53.6 | 56.0 | 15.6 | 4.1 | 16.2× / 11.5× | 17.0× / 12.0× | 4.7× / 3.4× | 1.2× / 0.9× |
| math_latex | 0.57 | 1.48 | 3.52 | 4.44 | 51.4 | 40.3 | 14.5 | 4.2 | 14.6× / 11.6× | 11.4× / 9.1× | 4.1× / 3.3× | 1.2× / 0.9× |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-t5-base-dark.png">
  <img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29859852450-t5-base-light.png" width="420">
</picture>
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->

