### PR TITLE
ci: faster?

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -7,7 +7,7 @@ drawn gray; the in-tree `Tokenizer` isn't benched, it's only the id oracle behin
 three always-visible charts — per-model geomean ×speedup, memory footprint, binary
 size — then one collapsed <details> per model (per-fixture speedup, thread scaling,
 stage mix, numbers table). Models the pipeline can't build yet render as "not
-supported" roadmap cards. Emits light+dark SVGs + pipeline_bench.md; the CI
+supported" roadmap cards. Emits light-theme SVGs + pipeline_bench.md; the CI
 workflow rasterizes and uploads the SVGs. Input schema: see fixture_bench.rs.
 
 No cross-model aggregate anywhere on purpose: the models exercise different
@@ -25,23 +25,13 @@ from html import escape
 from pathlib import Path
 
 INK = {
-    "light": {
-        "surface": "#fcfcfb", "card": "#ffffff", "primary": "#0b0b0b",
-        "secondary": "#52514e", "muted": "#898781", "grid": "#e1e0d9",
-        "border": "#e1e0d9", "baseline": "#c3c2b7", "critical": "#d03b3b",
-    },
-    "dark": {
-        "surface": "#1a1a19", "card": "#212120", "primary": "#ffffff",
-        "secondary": "#c3c2b7", "muted": "#898781", "grid": "#2c2c2a",
-        "border": "#33332f", "baseline": "#4a4a46", "critical": "#e66767",
-    },
+    "surface": "#fcfcfb", "card": "#ffffff", "primary": "#0b0b0b",
+    "secondary": "#52514e", "muted": "#898781", "grid": "#e1e0d9",
+    "border": "#e1e0d9", "baseline": "#c3c2b7", "critical": "#d03b3b",
 }
 # The release baseline is context-gray on purpose: in the speedup charts it *is*
 # the ×1.0 axis; in memory/binary-size it's the reference bar to read against.
-SERIES_INK = {
-    "light": {"baseline": "#898781", "pipeline": "#2a78d6"},
-    "dark": {"baseline": "#898781", "pipeline": "#3987e5"},
-}
+SERIES_INK = {"baseline": "#898781", "pipeline": "#2a78d6"}
 FONT = "-apple-system,'Segoe UI',Helvetica,Arial,sans-serif"
 GUTTER, PLOT_W, PAD_R, COL_W, ROW_H, BAR_H = 190, 540, 110, 150, 26, 16
 CHART_W = GUTTER + PLOT_W + PAD_R + COL_W
@@ -57,12 +47,8 @@ CARD_W, CARD_H = 470, 150
 # pre-tokenizer split — two distinct splitting costs. The four sum to `total`.
 STAGES = [("added_split", "added-token"), ("normalize", "normalize"),
           ("pre_tokenize", "pre-tokenize"), ("model", "model")]
-STAGE_INK = {
-    "light": {"added_split": "#7a5ea8", "normalize": "#2a9d8f",
-              "pre_tokenize": "#e0952b", "model": "#2a78d6"},
-    "dark": {"added_split": "#a48ad4", "normalize": "#3fb8a8",
-             "pre_tokenize": "#f0b45a", "model": "#3987e5"},
-}
+STAGE_INK = {"added_split": "#7a5ea8", "normalize": "#2a9d8f",
+             "pre_tokenize": "#e0952b", "model": "#2a78d6"}
 
 
 def slugify(name):
@@ -228,14 +214,14 @@ def linear_axis(ink, x, ticks, top, y, unit):
     return "".join(grid)
 
 
-def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label,
+def overview_svg(models, subtitle_base, meta, lo, hi, baseline_label,
                  speedups_of=model_speedups, title=None, ref_label=None,
                  mark_regressions=False, no_cmp_msg=None):
     """Headline chart: one row per model — name + workload desc, geomean ×speedup vs
     the reference (×1.0) with a min–max whisker across fixtures. Unsupported models
     show as muted status rows so the overview is the complete state of the world.
     `mark_regressions=True` (the "vs base branch" twin) turns slower-than-base bars red."""
-    ink, sink = INK[mode], SERIES_INK[mode]
+    ink, sink = INK, SERIES_INK
     title = title or "PipelineTokenizer vs latest release — encode throughput"
     ref_label = ref_label or baseline_label
     x = log_x(OV_GUTTER, OV_PLOT, lo, hi)
@@ -300,10 +286,10 @@ def overview_svg(models, mode, subtitle_base, meta, lo, hi, baseline_label,
     return svg_doc(ink, height, title, subtitle, axis + "".join(body) + legend, meta)
 
 
-def memory_svg(models, mode, meta, baseline_label):
+def memory_svg(models, meta, baseline_label):
     """Per model: resident-set delta of each implementation — load footprint plus
     the encode-pass delta as stacked segments, peak RSS as a tick."""
-    ink, sink = INK[mode], SERIES_INK[mode]
+    ink, sink = INK, SERIES_INK
     models = [m for m in models if isinstance(m.get("memory"), dict)]
 
     def mem(m, impl):
@@ -378,10 +364,10 @@ def memory_svg(models, mode, meta, baseline_label):
                    subtitle, grid + "".join(body) + legend, meta)
 
 
-def chart_svg(model, mode, subtitle_base, meta, lo, hi, baseline_label):
+def chart_svg(model, subtitle_base, meta, lo, hi, baseline_label):
     """Full-size per-fixture chart: the pipeline's ×speedup vs the release, with the
     `MB/s: release → Pipeline` throughput column."""
-    ink, sink = INK[mode], SERIES_INK[mode]
+    ink, sink = INK, SERIES_INK
     rows = model["results"]
     x = log_x(GUTTER, PLOT_W, lo, hi)
     ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x, min_px=34, keep=1.0)
@@ -482,14 +468,14 @@ def stage_cell(s, key):
     return f"{100 * val / total:.0f}% ({val:.1f})"
 
 
-def stage_chart_svg(model, mode, subtitle_base, meta, baseline_label):
+def stage_chart_svg(model, subtitle_base, meta, baseline_label):
     """Per-fixture 100%-normalized stacked bar of where the pipeline spends its OWN
     encode time — each stage as its share of THAT fixture's total, labelled
     `share% · ns/B`. Normalizing per row (not on a shared ns/byte scale anchored to
     the slow release) keeps the mix readable at any absolute cost; the right column
     keeps the total ns/byte and the ×speedup vs the release."""
-    ink = INK[mode]
-    sink = STAGE_INK[mode]
+    ink = INK
+    sink = STAGE_INK
     rows = [r for r in model["results"] if "stage_ns_per_byte" in r]
 
     top = 84
@@ -559,10 +545,10 @@ def stage_chart_svg(model, mode, subtitle_base, meta, baseline_label):
                    subtitle, "".join(grid) + "".join(body) + legend, meta, subtitle_base)
 
 
-def card_svg(model, mode):
+def card_svg(model):
     """Compact roadmap card for a model the pipeline can't bench yet (or that failed
     to load). Plain single-chunk text only: cairosvg mis-centers tspans."""
-    ink = INK[mode]
+    ink = INK
     pretok = model["shape"].split("·")[-1].strip()
     why = model.get("reason") or f"PipelineTokenizer has no {pretok} pre-tokenizer"
     header = 54
@@ -600,18 +586,14 @@ def detect_hardware():
     return f"{cpu} · {os.cpu_count()} cores"
 
 
-def img_url(base, run_id, slug, mode):
+def img_url(base, run_id, slug):
     if base:
-        return f"{base}/pipeline-{run_id}-{slug}-{mode}.png"
-    return f"pipeline_bench_{slug}_{mode}.png"
+        return f"{base}/pipeline-{run_id}-{slug}.png"
+    return f"pipeline_bench_{slug}.png"
 
 
 def picture(base, run_id, slug, alt, width):
-    return "\n".join([
-        "<picture>",
-        f'  <source media="(prefers-color-scheme: dark)" srcset="{img_url(base, run_id, slug, "dark")}">',
-        f'  <img alt="{escape(alt)}" src="{img_url(base, run_id, slug, "light")}" width="{width}">',
-        "</picture>"])
+    return f'<img alt="{escape(alt)}" src="{img_url(base, run_id, slug)}" width="{width}">'
 
 
 def mem_line(model, baseline_label):
@@ -627,11 +609,11 @@ def mem_line(model, baseline_label):
                          (("baseline", baseline_label), ("pipeline", "Pipeline"))))
 
 
-def binsize_svg(sizes, mode, meta, baseline_label):
+def binsize_svg(sizes, meta, baseline_label):
     """Stripped size of a minimal release-built encode program (load a
     tokenizer.json, encode one string) linking each implementation — what the
     library adds to a shipped binary. Bars 0-anchored on a linear MB axis."""
-    ink, sink = INK[mode], SERIES_INK[mode]
+    ink, sink = INK, SERIES_INK
     rows = [("baseline", baseline_label), ("pipeline", "PipelineTokenizer")]
     max_mb = max(sizes.values()) / 1e6 * 1.15
 
@@ -669,12 +651,12 @@ def has_threads(m):
     return isinstance(t, dict) and bool(t.get("counts"))
 
 
-def threads_svg(model, mode, meta, baseline_label):
+def threads_svg(model, meta, baseline_label):
     """Per model: encode throughput (MB/s) at 1/2/4/8/device-max threads — pipeline
     vs the release — with a per-row *ideal linear* tick (single-thread × N) on the
     pipeline bar, so linear vs sub-linear scaling is visible at a glance alongside
     the pipeline↔release gap; the right column carries self-scaling % of linear."""
-    ink, sink = INK[mode], SERIES_INK[mode]
+    ink, sink = INK, SERIES_INK
     t = model["threads"]
     counts, pipe, base = t["counts"], t["pipeline_mbps"], t["baseline_mbps"]
     p1 = pipe[0] if pipe and pipe[0] else None  # single-thread anchor for the linear reference
@@ -919,33 +901,31 @@ def main():
             base_lookup = None
 
     out = Path(args.out_dir)
-    for mode in ("light", "dark"):
-        (out / f"pipeline_bench_overview_{mode}.svg").write_text(
-            overview_svg(models, mode, args.subtitle, meta, lo, hi, baseline_label))
-        if base_lookup:
-            (out / f"pipeline_bench_base-overview_{mode}.svg").write_text(
-                overview_svg(models, mode, args.subtitle, meta, blo, bhi, baseline_label,
-                             speedups_of=base_speedups_of,
-                             title="PipelineTokenizer vs base branch — encode throughput",
-                             ref_label=(args.base_ref or "base branch"), mark_regressions=True,
-                             no_cmp_msg="not benched on the base branch"))
-        (out / f"pipeline_bench_memory_{mode}.svg").write_text(
-            memory_svg(models, mode, meta, baseline_label))
-        if sizes:
-            (out / f"pipeline_bench_binsize_{mode}.svg").write_text(
-                binsize_svg(sizes, mode, meta, baseline_label))
+    (out / "pipeline_bench_overview.svg").write_text(
+        overview_svg(models, args.subtitle, meta, lo, hi, baseline_label))
+    if base_lookup:
+        (out / "pipeline_bench_base-overview.svg").write_text(
+            overview_svg(models, args.subtitle, meta, blo, bhi, baseline_label,
+                         speedups_of=base_speedups_of,
+                         title="PipelineTokenizer vs base branch — encode throughput",
+                         ref_label=(args.base_ref or "base branch"), mark_regressions=True,
+                         no_cmp_msg="not benched on the base branch"))
+    (out / "pipeline_bench_memory.svg").write_text(
+        memory_svg(models, meta, baseline_label))
+    if sizes:
+        (out / "pipeline_bench_binsize.svg").write_text(
+            binsize_svg(sizes, meta, baseline_label))
     for m in models:
         slug = slugify(m["model"])
-        for mode in ("light", "dark"):
-            svg = (chart_svg(m, mode, args.subtitle, meta, lo, hi, baseline_label)
-                   if m["results"] else card_svg(m, mode))
-            (out / f"pipeline_bench_{slug}_{mode}.svg").write_text(svg)
-            if has_stages(m):
-                (out / f"pipeline_bench_{slug}-stages_{mode}.svg").write_text(
-                    stage_chart_svg(m, mode, args.subtitle, meta, baseline_label))
-            if has_threads(m):
-                (out / f"pipeline_bench_{slug}-threads_{mode}.svg").write_text(
-                    threads_svg(m, mode, meta, baseline_label))
+        svg = (chart_svg(m, args.subtitle, meta, lo, hi, baseline_label)
+               if m["results"] else card_svg(m))
+        (out / f"pipeline_bench_{slug}.svg").write_text(svg)
+        if has_stages(m):
+            (out / f"pipeline_bench_{slug}-stages.svg").write_text(
+                stage_chart_svg(m, args.subtitle, meta, baseline_label))
+        if has_threads(m):
+            (out / f"pipeline_bench_{slug}-threads.svg").write_text(
+                threads_svg(m, meta, baseline_label))
 
     (out / "pipeline_bench.md").write_text(
         render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes,

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -10,10 +10,13 @@ name: Pipeline Benchmark
 # release dep is behind tk-encode's `bench-baseline` feature, so production
 # builds never pull it.
 #
-# The work is fanned out across a matrix: each `bench` shard benches a slice of
-# the models on its own isolated 8-vCPU runner (so the multi-thread sweep is
-# accurate and the shards run in parallel), emitting a partial JSON; the single
-# `report` job then concatenates the partials and renders/uploads/updates once.
+# A `build` job compiles the bench + binsize example binaries ONCE (each with its
+# exact per-example feature set) and uploads them; the work is then fanned out across
+# a matrix: each `bench` shard downloads that binary and benches a slice of the models
+# on its own isolated 8-vCPU runner (so the multi-thread sweep is accurate and the
+# shards run in parallel), emitting a partial JSON; the single `report` job then
+# concatenates the partials and renders/uploads/updates once. Fixture corpora + model
+# tokenizers are cached across jobs (keyed on the Makefile fixture lists + manifest).
 #
 # Triggers:
 #   • push to feat/train_encode_split → benches and updates PR #2119's description.
@@ -70,17 +73,70 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUSTC_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
   # Keep in sync with the matrix.shard list below (and passed to `--shard <i> N`).
+  # sccache is scoped to the `build` job — the only job that compiles.
   SHARDS: "4"
 
 jobs:
-  # Fan-out: each shard benches the i-th of SHARDS contiguous manifest slices on
-  # its own 8-vCPU runner (isolated + parallel) and uploads its partial JSON.
+  # Compile the bench + binsize example binaries ONCE here, instead of every shard
+  # (and the report job) recompiling them. Uploaded as an artifact the other jobs
+  # download and run — so a code change is compiled a single time per run, not 5-6×.
+  build:
+    name: build bench binaries
+    # push / dispatch always run; a labeled PR runs only for our label.
+    if: github.event_name != 'pull_request' || github.event.label.name == 'run-pipeline-bench'
+    runs-on:
+      group: aws-general-8-plus
+    defaults:
+      run:
+        working-directory: tokenizers
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      # `onig_sys` (a `bench-baseline` reference-regex dep) generates its bindings with bindgen,
+      # which needs libclang. pcre2/fancy-regex don't. The runner image doesn't ship it.
+      - name: Install libclang (onig_sys → bindgen)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev
+
+      # The per-example feature sets are load-bearing and MUST stay distinct — collapsing
+      # them would corrupt what's measured:
+      #   • fixture_bench + binsize_baseline WITH `bench-baseline` → link the released crate
+      #     (fixture_bench = the throughput/memory bench; binsize_baseline = "cost of the
+      #     released lib" size number).
+      #   • binsize_pipeline WITHOUT it → the real shipping config whose size we report (none
+      #     of the benchmark-only reference-regex deps the feature drags in).
+      # These are byte-for-byte the same cargo invocations the shards / report ran before.
+      - name: Build bench + binsize binaries
+        run: |
+          cargo build --release -p tk-encode --features tk-encode/bench-baseline \
+            --example fixture_bench --example binsize_baseline
+          cargo build --release -p tk-encode --example binsize_pipeline
+
+      - name: Upload bench binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: bench-binaries
+          path: |
+            tokenizers/target/release/examples/fixture_bench
+            tokenizers/target/release/examples/binsize_baseline
+            tokenizers/target/release/examples/binsize_pipeline
+          retention-days: 3
+
+  # Fan-out: each shard benches the i-th of SHARDS contiguous manifest slices on its
+  # own 8-vCPU runner (isolated + parallel), running the prebuilt binary, and uploads
+  # its partial JSON. No toolchain here — the shards only fetch data + the binary.
   bench:
     name: bench shard ${{ matrix.shard }}
-    # push / dispatch always run; a labeled PR runs only for our label.
+    needs: build
     if: github.event_name != 'pull_request' || github.event.label.name == 'run-pipeline-bench'
     strategy:
       fail-fast: false
@@ -94,29 +150,34 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      # `onig_sys` (a `bench-baseline` reference-regex dep) generates its bindings with bindgen, which
-      # needs libclang. pcre2/fancy-regex don't. The runner image doesn't ship it.
-      - name: Install libclang (onig_sys → bindgen)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev
+      # Cache the fixture corpora + model tokenizers (one dataset@main mirror for all).
+      # `make` guards each download by file existence, so a restored data/ makes the
+      # fetch below a no-op. Keyed on the fetch inputs (Makefile fixture lists + model
+      # manifest); bump either to force a refresh if the upstream dataset changes.
+      - name: Cache fixtures + model tokenizers
+        uses: actions/cache@v4
+        with:
+          path: tokenizers/data
+          key: bench-data-${{ hashFiles('tokenizers/Makefile', 'tokenizers/tk-encode/examples/bench_models.json') }}
 
       - name: Download fixtures and model tokenizers
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make fixtures bench-models HF="uvx --from huggingface_hub hf"
 
+      - name: Download prebuilt bench binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: bench-binaries
+          path: tokenizers/target/release/examples
+
       - name: Run comparative benchmark (shard ${{ matrix.shard }} of ${{ env.SHARDS }})
         run: |
-          cargo run --release -p tk-encode --features tk-encode/bench-baseline \
-            --example fixture_bench -- --shard ${{ matrix.shard }} ${{ env.SHARDS }} \
+          chmod +x target/release/examples/fixture_bench
+          ./target/release/examples/fixture_bench --shard ${{ matrix.shard }} ${{ env.SHARDS }} \
             > "pipeline_bench_${{ matrix.shard }}.json"
           cat "pipeline_bench_${{ matrix.shard }}.json"
 
@@ -141,23 +202,23 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      # libcairo: cairosvg (chart rendering) dlopens it. libclang: onig_sys's bindgen needs it (the
-      # binsize build below pulls `bench-baseline`, which activates the onig reference-regex dep). The
-      # aws-general-8-plus runner image ships neither.
-      - name: Install libcairo + libclang
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libcairo2 libclang-dev
+      # cairosvg (chart rendering) dlopens libcairo; the runner image doesn't ship it.
+      # No Rust/libclang here — this job doesn't compile; it runs the prebuilt binaries.
+      - name: Install libcairo
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libcairo2
 
-      # Only the model tokenizers are needed here (gpt2.json for binsize); the
-      # fixture corpora aren't — the numbers already live in the shard JSONs.
+      # Same data cache as the shards. Only the model tokenizers are needed here
+      # (gpt2.json for the binsize check); the fixture corpora aren't — the numbers
+      # already live in the shard JSONs, but restoring the shared cache is a no-op fetch.
+      - name: Cache fixtures + model tokenizers
+        uses: actions/cache@v4
+        with:
+          path: tokenizers/data
+          key: bench-data-${{ hashFiles('tokenizers/Makefile', 'tokenizers/tk-encode/examples/bench_models.json') }}
+
       - name: Download model tokenizers
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -189,16 +250,22 @@ jobs:
           PY
           head -c 300 pipeline_bench.json; echo
 
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: bench-binaries
+          path: tokenizers/target/release/examples
+
       # Stripped size of a minimal encode program linking each implementation —
       # the "how much does this library add to my binary" number.
       - name: Measure binary sizes
         run: |
-          # The baseline example needs `bench-baseline` (it links the released crate);
-          # the pipeline example is built in its shipping config (NO bench-baseline) so
-          # its size reflects what a user actually links — not the benchmark-only
-          # reference-regex deps (fancy-regex/onig/pcre2/logos) the feature drags in.
-          cargo build --release -p tk-encode --features tk-encode/bench-baseline --example binsize_baseline
-          cargo build --release -p tk-encode --example binsize_pipeline
+          # Built in the `build` job with DISTINCT feature sets (binsize_baseline WITH
+          # `bench-baseline` → links the released crate; binsize_pipeline WITHOUT → the
+          # real shipping config, none of the benchmark-only reference-regex deps). We
+          # only run/strip/stat here — NEVER rebuild — so the sizes are exactly those
+          # binaries; collapsing the features would corrupt the number.
+          chmod +x target/release/examples/binsize_baseline target/release/examples/binsize_pipeline
           printf '{' > binary_sizes.json
           sep=''
           for key in baseline pipeline; do

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -289,14 +289,18 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
+          # Stage the PNGs under their Hub names, then upload the whole folder in ONE
+          # `hf upload` commit — instead of a `uvx hf upload` per file, which spawned
+          # ~30 envs and did as many serial round-trips.
+          mkdir -p charts_upload
           for png in pipeline_bench_*.png; do
-            rest="${png#pipeline_bench_}"   # <slug>_<mode>.png
-            base="${rest%.png}"             # <slug>_<mode>
-            mode="${base##*_}"              # light | dark
-            slug="${base%_*}"               # <slug>
-            uvx --from huggingface_hub hf upload hf-internal-testing/tokenizers-bench \
-              "$png" "charts/pipeline-${{ github.run_id }}-${slug}-${mode}.png" --repo-type dataset
+            slug="${png#pipeline_bench_}"   # <slug>.png
+            slug="${slug%.png}"             # <slug>
+            cp "$png" "charts_upload/pipeline-${{ github.run_id }}-${slug}.png"
           done
+          uvx --from huggingface_hub hf upload hf-internal-testing/tokenizers-bench \
+            charts_upload charts --repo-type dataset \
+            --commit-message "charts: pipeline-bench run ${{ github.run_id }}"
 
       - name: Write step summary
         run: cat pipeline_bench.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**7 / 8 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · single thread + 1/2/4/8/max-thread sweep

`73cd75be6 · 2026-07-21 20:57 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 32 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-overview.png" width="860">

**vs base branch** (`35b31244b`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-binsize.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.88 vs v0.23.1 · ×1.00 vs base</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-bert-base-uncased-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 11+0 (peak 12) · Pipeline 8+0 (peak 16)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 27.4 | ×3.47 | ×1.00 | 3% (1.2) | 76% (27.5) | 13% (4.8) | 7% (2.6) | match |
| arb_Arab | lang | 4.2 | 24.7 | ×5.83 | ×0.99 | 3% (1.2) | 69% (27.5) | 8% (3.3) | 20% (7.7) | match |
| ben_Beng | lang | 5.9 | 34.7 | ×5.91 | ×0.99 | 4% (1.2) | 68% (19.2) | 10% (2.9) | 18% (5.2) | match |
| cmn_Hani | lang | 3.9 | 18.7 | ×4.78 | ×1.00 | 2% (1.2) | 71% (37.8) | 11% (5.6) | 16% (8.4) | match |
| ell_Grek | lang | 3.8 | 23.6 | ×6.23 | ×0.99 | 3% (1.2) | 69% (28.6) | 8% (3.4) | 20% (8.5) | match |
| eng_Latn | lang | 4.6 | 18.2 | ×3.99 | ×1.00 | 5% (2.7) | 71% (38.8) | 8% (4.6) | 16% (8.6) | match |
| heb_Hebr | lang | 4.2 | 19.8 | ×4.67 | ×0.99 | 2% (1.2) | 75% (37.6) | 7% (3.6) | 15% (7.4) | match |
| hin_Deva | lang | 6.5 | 27.4 | ×4.21 | ×0.99 | 3% (1.2) | 75% (27.1) | 9% (3.2) | 13% (4.8) | match |
| jpn_Jpan | lang | 4.3 | 27.3 | ×6.34 | ×1.00 | 3% (1.2) | 64% (23.4) | 13% (4.6) | 20% (7.2) | match |
| kat_Geor | lang | 6.2 | 28.0 | ×4.52 | ×1.00 | 3% (1.2) | 75% (26.6) | 9% (3.2) | 12% (4.4) | match |
| kor_Hang | lang | 2.4 | 17.7 | ×7.26 | ×1.00 | 2% (1.2) | 63% (35.1) | 13% (7.3) | 22% (12.3) | match |
| rus_Cyrl | lang | 3.7 | 23.6 | ×6.44 | ×1.00 | 3% (1.2) | 66% (27.4) | 8% (3.2) | 24% (10.0) | match |
| tam_Taml | lang | 7.1 | 38.3 | ×5.40 | ×1.00 | 5% (1.2) | 72% (18.6) | 10% (2.7) | 13% (3.3) | match |
| tha_Thai | lang | 8.5 | 33.0 | ×3.89 | ×0.99 | 4% (1.2) | 84% (25.0) | 8% (2.3) | 5% (1.4) | match |
| added_normalized_dense | modalities | 6.7 | 19.8 | ×2.94 | ×1.00 | 3% (1.3) | 81% (40.6) | 14% (6.9) | 2% (1.1) | match |
| added_normalized_sparse | modalities | 5.3 | 18.4 | ×3.44 | ×1.01 | 4% (1.9) | 74% (40.0) | 13% (7.0) | 9% (4.9) | match |
| added_special_dense | modalities | 5.3 | 39.1 | ×7.34 | ×1.00 | 20% (5.0) | 37% (9.1) | 36% (8.9) | 6% (1.5) | match |
| added_special_sparse | modalities | 4.0 | 21.4 | ×5.39 | ×1.00 | 8% (3.7) | 60% (27.9) | 19% (8.7) | 13% (5.8) | match |
| agentic-traces | modalities | 3.9 | 18.0 | ×4.64 | ×1.00 | 5% (2.5) | 70% (38.5) | 9% (5.0) | 16% (8.9) | match |
| agentic_swe | modalities | 4.2 | 19.3 | ×4.63 | ×1.00 | 4% (2.0) | 75% (38.7) | 7% (3.7) | 14% (6.9) | match |
| code_mixed | modalities | 4.0 | 18.8 | ×4.74 | ×1.00 | 4% (2.3) | 73% (38.6) | 8% (4.2) | 15% (7.7) | match |
| math_latex | modalities | 4.1 | 18.1 | ×4.41 | ×1.00 | 5% (2.6) | 70% (38.7) | 9% (4.7) | 16% (8.9) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×4.03 vs v0.23.1 · ×1.01 vs base</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-deepseek-v4-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 96+0 (peak 96)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 34.8 | ×7.98 | ×1.03 | 2% (0.7) | 0% (0.0) | 17% (4.7) | 81% (22.1) | match |
| arb_Arab | lang | 4.4 | 17.0 | ×3.87 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (53.7) | match |
| ben_Beng | lang | 6.5 | 18.1 | ×2.80 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (3.1) | 93% (50.5) | match |
| cmn_Hani | lang | 3.9 | 17.4 | ×4.52 | ×1.02 | 1% (0.8) | 0% (0.0) | 6% (3.2) | 93% (51.3) | match |
| ell_Grek | lang | 4.8 | 17.9 | ×3.74 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (50.3) | match |
| eng_Latn | lang | 3.3 | 13.1 | ×3.97 | ×1.02 | 3% (2.1) | 0% (0.0) | 7% (5.2) | 90% (67.1) | match |
| heb_Hebr | lang | 4.1 | 13.0 | ×3.18 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (3.5) | 95% (72.0) | match |
| hin_Deva | lang | 6.1 | 21.5 | ×3.53 | ×0.99 | 1% (0.6) | 0% (0.0) | 7% (3.3) | 91% (41.5) | match |
| jpn_Jpan | lang | 4.5 | 18.2 | ×4.04 | ×0.99 | 1% (0.7) | 0% (0.0) | 6% (3.0) | 93% (48.8) | match |
| kat_Geor | lang | 6.3 | 18.5 | ×2.94 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (3.0) | 93% (49.8) | match |
| kor_Hang | lang | 3.8 | 20.1 | ×5.28 | ×1.01 | 1% (0.6) | 0% (0.0) | 8% (3.7) | 91% (44.4) | match |
| rus_Cyrl | lang | 4.6 | 14.7 | ×3.16 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (3.4) | 94% (63.6) | match |
| tam_Taml | lang | 6.7 | 18.0 | ×2.70 | ×1.01 | 1% (0.6) | 0% (0.0) | 5% (2.7) | 94% (52.0) | match |
| tha_Thai | lang | 7.3 | 15.0 | ×2.07 | ×1.00 | 1% (0.6) | 0% (0.0) | 3% (2.2) | 96% (62.7) | match |
| added_normalized_dense | modalities | 6.2 | 23.3 | ×3.75 | ×0.99 | 2% (0.8) | 0% (0.0) | 6% (2.7) | 92% (38.4) | match |
| added_normalized_sparse | modalities | 5.6 | 19.4 | ×3.45 | ×0.99 | 3% (1.3) | 0% (0.0) | 8% (3.9) | 90% (46.0) | match |
| added_special_dense | modalities | 3.7 | 36.4 | ×9.75 | ×1.01 | 24% (6.5) | 2% (0.4) | 23% (6.2) | 51% (13.4) | match |
| added_special_sparse | modalities | 4.1 | 20.4 | ×5.01 | ×1.00 | 8% (3.8) | 0% (0.2) | 14% (6.7) | 78% (37.2) | match |
| agentic-traces | modalities | 3.1 | 14.4 | ×4.68 | ×1.02 | 3% (1.9) | 0% (0.0) | 8% (5.7) | 89% (61.1) | match |
| agentic_swe | modalities | 3.1 | 14.9 | ×4.74 | ×1.00 | 2% (1.4) | 0% (0.0) | 6% (3.9) | 92% (59.7) | match |
| code_mixed | modalities | 3.6 | 15.6 | ×4.30 | ×1.01 | 3% (1.7) | 0% (0.0) | 7% (4.7) | 90% (56.9) | match |
| math_latex | modalities | 3.0 | 14.1 | ×4.74 | ×1.02 | 3% (2.0) | 0% (0.0) | 8% (5.4) | 89% (61.8) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.48 | 4.71 | 5.40 | 42.5 | 20.3 | 9.1 | — | 9.0× / 7.9× | 4.3× / 3.8× | 1.9× / 1.7× | — |
| arb_Arab | 1.15 | 2.98 | 3.40 | 5.23 | 49.5 | 22.9 | 10.1 | — | 14.6× / 9.5× | 6.7× / 4.4× | 3.0× / 1.9× | — |
| ben_Beng | 1.62 | 2.94 | 3.10 | 4.42 | 36.2 | 16.1 | 7.6 | — | 11.7× / 8.2× | 5.2× / 3.6× | 2.5× / 1.7× | — |
| cmn_Hani | 1.12 | 2.26 | 3.19 | 4.33 | 61.5 | 34.6 | 14.3 | — | 19.3× / 14.2× | 10.8× / 8.0× | 4.5× / 3.3× | — |
| ell_Grek | 0.58 | 2.98 | 3.40 | 5.80 | 47.5 | 21.2 | 9.4 | — | 14.0× / 8.2× | 6.2× / 3.7× | 2.8× / 1.6× | — |
| eng_Latn | 0.11 | 1.45 | 5.17 | 6.51 | 67.4 | 39.7 | 16.1 | — | 13.0× / 10.3× | 7.7× / 6.1× | 3.1× / 2.5× | — |
| heb_Hebr | 1.14 | 3.02 | 3.55 | 5.42 | 52.0 | 23.9 | 10.6 | — | 14.7× / 9.6× | 6.8× / 4.4× | 3.0× / 2.0× | — |
| hin_Deva | 1.52 | 3.12 | 3.28 | 4.88 | 38.6 | 19.0 | 8.6 | — | 11.8× / 7.9× | 5.8× / 3.9× | 2.6× / 1.8× | — |
| jpn_Jpan | 1.71 | 3.39 | 2.99 | 4.68 | 53.7 | 27.6 | 11.9 | — | 17.9× / 11.5× | 9.2× / 5.9× | 4.0× / 2.5× | — |
| kat_Geor | 1.54 | 2.53 | 2.97 | 3.95 | 32.6 | 15.6 | 7.1 | — | 11.0× / 8.2× | 5.3× / 4.0× | 2.4× / 1.8× | — |
| kor_Hang | 1.22 | 2.70 | 3.68 | 5.16 | 51.1 | 27.7 | 11.8 | — | 13.9× / 9.9× | 7.5× / 5.4× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.17 | 2.90 | 3.37 | 5.09 | 47.4 | 20.8 | 9.4 | — | 14.1× / 9.3× | 6.2× / 4.1× | 2.8× / 1.8× | — |
| tam_Taml | 0.93 | 2.93 | 2.69 | 4.69 | 31.6 | 14.0 | 6.6 | — | 11.8× / 6.7× | 5.2× / 3.0× | 2.4× / 1.4× | — |
| tha_Thai | 1.52 | 2.56 | 2.17 | 3.22 | 27.0 | 10.2 | 5.2 | — | 12.4× / 8.4× | 4.7× / 3.2× | 2.4× / 1.6× | — |
| added_normalized_dense | 0.06 | 1.77 | 2.72 | 4.43 | 43.3 | 20.6 | 9.1 | — | 15.9× / 9.8× | 7.6× / 4.7× | 3.3× / 2.1× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.88 | 5.29 | 49.8 | 26.0 | 11.3 | — | 12.8× / 9.4× | 6.7× / 4.9× | 2.9× / 2.1× | — |
| added_special_dense | 0.06 | 1.47 | 6.23 | 7.64 | 181.0 | 98.9 | 38.5 | — | 29.1× / 23.7× | 15.9× / 12.9× | 6.2× / 5.0× | — |
| added_special_sparse | 0.06 | 1.47 | 6.68 | 8.10 | 106.0 | 59.0 | 24.1 | — | 15.9× / 13.1× | 8.8× / 7.3× | 3.6× / 3.0× | — |
| agentic-traces | 0.73 | 1.56 | 5.67 | 6.50 | 82.8 | 52.2 | 19.6 | — | 14.6× / 12.7× | 9.2× / 8.0× | 3.5× / 3.0× | — |
| agentic_swe | 0.66 | 1.45 | 3.90 | 4.68 | 98.9 | 65.9 | 25.5 | — | 25.4× / 21.1× | 16.9× / 14.1× | 6.5× / 5.4× | — |
| code_mixed | 0.07 | 1.44 | 4.72 | 6.08 | 76.0 | 53.3 | 18.2 | — | 16.1× / 12.5× | 11.3× / 8.8× | 3.9× / 3.0× | — |
| math_latex | 0.72 | 1.48 | 5.38 | 6.14 | 80.6 | 47.7 | 18.9 | — | 15.0× / 13.1× | 8.9× / 7.8× | 3.5× / 3.1× | — |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×7.72 vs v0.23.1 · ×1.02 vs base</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-gpt2-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 30+0 (peak 30)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 47.6 | ×11.68 | ×1.03 | 3% (0.7) | 0% (0.0) | 18% (3.7) | 78% (15.7) | match |
| arb_Arab | lang | 3.9 | 25.8 | ×6.56 | ×0.97 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 92% (35.3) | match |
| ben_Beng | lang | 3.2 | 46.8 | ×14.76 | ×1.09 | 3% (0.6) | 0% (0.0) | 15% (3.0) | 83% (17.1) | match |
| cmn_Hani | lang | 3.9 | 29.4 | ×7.57 | ×0.99 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (30.2) | match |
| ell_Grek | lang | 4.4 | 29.2 | ×6.66 | ×1.04 | 2% (0.6) | 0% (0.0) | 7% (2.2) | 92% (30.7) | match |
| eng_Latn | lang | 3.5 | 13.9 | ×3.99 | ×1.00 | 3% (2.1) | 0% (0.0) | 4% (3.1) | 93% (65.4) | match |
| heb_Hebr | lang | 3.8 | 29.8 | ×7.79 | ×1.02 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (29.8) | match |
| hin_Deva | lang | 3.2 | 40.6 | ×12.52 | ×1.01 | 2% (0.6) | 0% (0.0) | 13% (3.1) | 85% (20.5) | match |
| jpn_Jpan | lang | 4.5 | 22.0 | ×4.90 | ×0.98 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (42.3) | match |
| kat_Geor | lang | 4.6 | 69.5 | ×14.97 | ×1.10 | 4% (0.6) | 0% (0.0) | 15% (2.1) | 81% (11.4) | match |
| kor_Hang | lang | 3.4 | 42.7 | ×12.66 | ×1.01 | 3% (0.6) | 0% (0.0) | 11% (2.5) | 86% (19.5) | match |
| rus_Cyrl | lang | 4.2 | 28.0 | ×6.67 | ×1.04 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 92% (32.3) | match |
| tam_Taml | lang | 2.8 | 70.5 | ×25.06 | ×1.04 | 4% (0.6) | 0% (0.0) | 20% (2.6) | 76% (10.2) | match |
| tha_Thai | lang | 3.5 | 38.7 | ×11.03 | ×1.09 | 2% (0.6) | 0% (0.0) | 10% (2.5) | 88% (22.0) | match |
| added_normalized_dense | modalities | 6.2 | 26.3 | ×4.23 | ×1.01 | 2% (0.7) | 0% (0.0) | 3% (1.2) | 95% (34.5) | match |
| added_normalized_sparse | modalities | 5.5 | 21.8 | ×3.95 | ×1.00 | 3% (1.3) | 0% (0.0) | 5% (2.1) | 92% (40.8) | match |
| added_special_dense | modalities | 4.4 | 45.5 | ×10.36 | ×0.99 | 25% (5.0) | 0% (0.0) | 21% (4.3) | 54% (10.9) | match |
| added_special_sparse | modalities | 4.4 | 23.4 | ×5.33 | ×0.99 | 8% (3.3) | 0% (0.0) | 12% (4.8) | 81% (32.8) | match |
| agentic-traces | modalities | 3.1 | 16.1 | ×5.22 | ×1.00 | 3% (1.9) | 0% (0.0) | 6% (3.6) | 91% (55.6) | match |
| agentic_swe | modalities | 3.4 | 24.3 | ×7.09 | ×1.00 | 3% (1.4) | 0% (0.0) | 6% (2.4) | 91% (36.4) | match |
| code_mixed | modalities | 3.6 | 20.2 | ×5.65 | ×0.99 | 3% (1.7) | 0% (0.0) | 6% (3.0) | 90% (43.8) | match |
| math_latex | modalities | 3.2 | 14.9 | ×4.66 | ×0.99 | 3% (2.0) | 0% (0.0) | 5% (3.5) | 92% (60.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.44 | 3.71 | 4.36 | 27.6 | 21.0 | 5.7 | 4.8 | 7.5× / 6.3× | 5.7× / 4.8× | 1.5× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.97 | 2.31 | 4.14 | 32.5 | 25.9 | 6.7 | 5.1 | 14.1× / 7.9× | 11.2× / 6.3× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.61 | 2.94 | 3.00 | 4.33 | 67.7 | 56.6 | 14.0 | 4.0 | 22.6× / 15.6× | 18.9× / 13.1× | 4.7× / 3.2× | 1.3× / 0.9× |
| cmn_Hani | 1.11 | 2.26 | 2.32 | 3.46 | 26.3 | 21.2 | 5.9 | 2.4 | 11.3× / 7.6× | 9.2× / 6.1× | 2.6× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 3.01 | 2.20 | 4.62 | 28.7 | 21.9 | 5.9 | 4.8 | 13.1× / 6.2× | 10.0× / 4.8× | 2.7× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.46 | 3.14 | 4.51 | 44.8 | 42.6 | 12.0 | 3.8 | 14.3× / 9.9× | 13.6× / 9.5× | 3.8× / 2.7× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.05 | 2.30 | 4.21 | 32.2 | 26.5 | 6.9 | 3.0 | 14.0× / 7.7× | 11.5× / 6.3× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.52 | 3.10 | 3.09 | 4.67 | 63.5 | 55.0 | 13.7 | 4.3 | 20.6× / 13.6× | 17.8× / 11.8× | 4.4× / 2.9× | 1.4× / 0.9× |
| jpn_Jpan | 1.71 | 3.33 | 2.12 | 3.74 | 23.5 | 17.8 | 5.0 | 3.9 | 11.1× / 6.3× | 8.4× / 4.7× | 2.4× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.66 | 2.57 | 2.10 | 3.01 | 17.8 | 14.4 | 4.2 | 2.0 | 8.5× / 5.9× | 6.8× / 4.8× | 2.0× / 1.4× | 0.9× / 0.7× |
| kor_Hang | 1.23 | 2.70 | 2.49 | 3.96 | 32.4 | 28.3 | 7.5 | 3.7 | 13.0× / 8.2× | 11.4× / 7.1× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.93 | 2.13 | 3.90 | 27.4 | 22.4 | 5.8 | 2.4 | 12.8× / 7.0× | 10.5× / 5.8× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.92 | 2.64 | 4.63 | 70.8 | 58.5 | 14.8 | 3.8 | 26.8× / 15.3× | 22.2× / 12.6× | 5.6× / 3.2× | 1.4× / 0.8× |
| tha_Thai | 1.51 | 2.52 | 2.52 | 3.53 | 40.5 | 31.9 | 8.9 | 3.2 | 16.1× / 11.5× | 12.7× / 9.1× | 3.5× / 2.5× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.17 | 2.59 | 22.7 | 22.7 | 6.2 | 2.0 | 19.4× / 8.8× | 19.3× / 8.8× | 5.3× / 2.4× | 1.7× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 2.11 | 3.53 | 29.6 | 31.2 | 8.4 | 2.7 | 14.0× / 8.4× | 14.7× / 8.8× | 4.0× / 2.4× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.27 | 5.68 | 93.8 | 97.4 | 19.6 | 2.9 | 22.0× / 16.5× | 22.8× / 17.1× | 4.6× / 3.4× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.78 | 6.19 | 58.0 | 61.3 | 14.3 | 3.4 | 12.1× / 9.4× | 12.8× / 9.9× | 3.0× / 2.3× | 0.7× / 0.5× |
| agentic-traces | 0.73 | 1.49 | 3.58 | 4.33 | 56.2 | 60.8 | 15.4 | 4.7 | 15.7× / 13.0× | 17.0× / 14.0× | 4.3× / 3.6× | 1.3× / 1.1× |
| agentic_swe | 0.65 | 1.45 | 2.45 | 3.25 | 60.9 | 69.2 | 14.8 | 3.5 | 24.9× / 18.8× | 28.2× / 21.3× | 6.0× / 4.6× | 1.4× / 1.1× |
| code_mixed | 0.07 | 1.46 | 2.96 | 4.36 | 59.3 | 68.3 | 15.2 | 4.1 | 20.0× / 13.6× | 23.1× / 15.7× | 5.1× / 3.5× | 1.4× / 0.9× |
| math_latex | 0.77 | 1.47 | 3.47 | 4.17 | 53.0 | 51.9 | 13.8 | 4.2 | 15.3× / 12.7× | 15.0× / 12.5× | 4.0× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×8.59 vs v0.23.1 · ×1.00 vs base</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-gpt-oss-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 4+11 (peak 16) · Pipeline 7+0 (peak 7)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.2 | 55.5 | ×17.56 | ×0.97 | 4% (0.7) | 0% (0.0) | 27% (4.7) | 69% (12.0) | match |
| arb_Arab | lang | 3.3 | 25.7 | ×7.74 | ×1.02 | 2% (0.6) | 0% (0.0) | 8% (3.2) | 90% (34.6) | match |
| ben_Beng | lang | 4.7 | 28.3 | ×6.07 | ×1.00 | 2% (0.6) | 0% (0.0) | 10% (3.6) | 88% (30.8) | match |
| cmn_Hani | lang | 3.6 | 38.5 | ×10.58 | ×1.00 | 2% (0.6) | 0% (0.0) | 13% (3.3) | 85% (21.4) | match |
| ell_Grek | lang | 3.2 | 32.0 | ×9.85 | ×0.99 | 2% (0.6) | 0% (0.0) | 10% (3.2) | 88% (27.0) | match |
| eng_Latn | lang | 2.6 | 21.3 | ×8.07 | ×1.00 | 4% (2.1) | 0% (0.0) | 10% (4.6) | 86% (40.0) | match |
| heb_Hebr | lang | 3.1 | 28.0 | ×8.99 | ×1.01 | 2% (0.6) | 0% (0.0) | 9% (3.3) | 89% (31.6) | match |
| hin_Deva | lang | 4.3 | 24.2 | ×5.58 | ×1.02 | 1% (0.6) | 0% (0.0) | 9% (3.7) | 90% (37.3) | match |
| jpn_Jpan | lang | 4.1 | 36.8 | ×8.96 | ×0.96 | 2% (0.6) | 0% (0.0) | 12% (3.0) | 86% (22.7) | match |
| kat_Geor | lang | 4.9 | 26.5 | ×5.40 | ×1.00 | 2% (0.6) | 0% (0.0) | 8% (2.8) | 91% (33.5) | match |
| kor_Hang | lang | 2.9 | 46.1 | ×15.62 | ×0.99 | 3% (0.6) | 0% (0.0) | 17% (3.6) | 80% (16.7) | match |
| rus_Cyrl | lang | 3.9 | 23.2 | ×5.89 | ×1.08 | 1% (0.6) | 0% (0.0) | 7% (3.1) | 91% (38.9) | match |
| tam_Taml | lang | 5.0 | 30.5 | ×6.06 | ×1.06 | 2% (0.6) | 0% (0.0) | 10% (3.2) | 88% (28.3) | match |
| tha_Thai | lang | 5.7 | 27.8 | ×4.89 | ×1.01 | 2% (0.6) | 0% (0.0) | 9% (3.2) | 89% (31.4) | match |
| added_normalized_dense | modalities | 4.0 | 46.2 | ×11.54 | ×1.00 | 4% (0.8) | 0% (0.0) | 11% (2.2) | 86% (17.4) | match |
| added_normalized_sparse | modalities | 3.6 | 36.5 | ×10.01 | ×1.00 | 5% (1.4) | 0% (0.0) | 12% (3.2) | 83% (21.8) | match |
| added_special_dense | modalities | 3.0 | 54.4 | ×17.83 | ×0.99 | 29% (4.9) | 1% (0.2) | 31% (5.4) | 40% (6.9) | match |
| added_special_sparse | modalities | 3.2 | 33.5 | ×10.37 | ×0.98 | 12% (3.3) | 0% (0.0) | 22% (6.2) | 67% (18.9) | match |
| agentic-traces | modalities | 2.8 | 22.4 | ×8.03 | ×0.99 | 4% (1.9) | 0% (0.0) | 11% (5.0) | 84% (36.9) | match |
| agentic_swe | modalities | 3.3 | 21.8 | ×6.62 | ×0.99 | 3% (1.4) | 0% (0.0) | 8% (3.8) | 89% (40.1) | match |
| code_mixed | modalities | 3.3 | 29.2 | ×8.87 | ×0.99 | 5% (1.7) | 0% (0.0) | 13% (4.4) | 82% (27.2) | match |
| math_latex | modalities | 2.9 | 22.4 | ×7.60 | ×1.00 | 5% (2.0) | 0% (0.0) | 11% (4.9) | 84% (37.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.44 | 4.73 | 5.38 | 30.2 | 14.3 | 7.0 | 4.8 | 6.4× / 5.6× | 3.0× / 2.7× | 1.5× / 1.3× | 1.0× / 0.9× |
| arb_Arab | 1.15 | 2.99 | 3.22 | 5.05 | 34.7 | 16.0 | 7.7 | 5.1 | 10.8× / 6.9× | 5.0× / 3.2× | 2.4× / 1.5× | 1.6× / 1.0× |
| ben_Beng | 1.61 | 2.94 | 3.63 | 4.96 | 24.4 | 10.8 | 5.5 | 2.7 | 6.7× / 4.9× | 3.0× / 2.2× | 1.5× / 1.1× | 0.7× / 0.5× |
| cmn_Hani | 1.12 | 2.26 | 3.25 | 4.39 | 21.8 | 11.1 | 5.6 | 2.5 | 6.7× / 5.0× | 3.4× / 2.5× | 1.7× / 1.3× | 0.8× / 0.6× |
| ell_Grek | 0.58 | 2.98 | 3.17 | 5.57 | 30.5 | 15.0 | 7.1 | 5.1 | 9.6× / 5.5× | 4.7× / 2.7× | 2.2× / 1.3× | 1.6× / 0.9× |
| eng_Latn | 0.12 | 1.48 | 4.59 | 5.95 | 45.3 | 29.4 | 13.8 | 4.2 | 9.9× / 7.6× | 6.4× / 4.9× | 3.0× / 2.3× | 0.9× / 0.7× |
| heb_Hebr | 1.15 | 3.02 | 3.30 | 5.17 | 34.1 | 17.1 | 8.2 | 2.7 | 10.3× / 6.6× | 5.2× / 3.3× | 2.5× / 1.6× | 0.8× / 0.5× |
| hin_Deva | 1.52 | 3.09 | 3.73 | 5.30 | 27.0 | 12.9 | 6.4 | 3.1 | 7.2× / 5.1× | 3.5× / 2.4× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.69 | 3.33 | 3.03 | 4.67 | 20.5 | 9.5 | 4.9 | 3.9 | 6.8× / 4.4× | 3.1× / 2.0× | 1.6× / 1.0× | 1.3× / 0.8× |
| kat_Geor | 1.54 | 2.56 | 2.84 | 3.86 | 19.0 | 10.6 | 4.8 | 2.2 | 6.7× / 4.9× | 3.7× / 2.7× | 1.7× / 1.2× | 0.8× / 0.6× |
| kor_Hang | 1.23 | 2.69 | 3.65 | 5.10 | 33.9 | 19.1 | 8.9 | 3.6 | 9.3× / 6.6× | 5.2× / 3.7× | 2.4× / 1.7× | 1.0× / 0.7× |
| rus_Cyrl | 1.17 | 2.96 | 3.08 | 4.87 | 29.6 | 15.2 | 6.8 | 4.9 | 9.6× / 6.1× | 4.9× / 3.1× | 2.2× / 1.4× | 1.6× / 1.0× |
| tam_Taml | 0.93 | 2.96 | 3.18 | 5.21 | 19.5 | 8.9 | 4.3 | 2.8 | 6.1× / 3.7× | 2.8× / 1.7× | 1.3× / 0.8× | 0.9× / 0.5× |
| tha_Thai | 1.51 | 2.59 | 3.20 | 4.27 | 13.3 | 5.9 | 2.8 | 2.2 | 4.2× / 3.1× | 1.8× / 1.4× | 0.9× / 0.7× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.47 | 2.19 | 3.61 | 34.9 | 17.7 | 11.3 | 2.2 | 15.9× / 9.7× | 8.1× / 4.9× | 5.1× / 3.1× | 1.0× / 0.6× |
| added_normalized_sparse | 0.06 | 1.48 | 3.23 | 4.65 | 37.3 | 20.9 | 11.5 | 3.0 | 11.6× / 8.0× | 6.5× / 4.5× | 3.6× / 2.5× | 0.9× / 0.7× |
| added_special_dense | 0.06 | 1.48 | 5.38 | 6.80 | 88.5 | 68.1 | 23.8 | 3.3 | 16.5× / 13.0× | 12.7× / 10.0× | 4.4× / 3.5× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 6.19 | 7.61 | 59.4 | 43.1 | 16.7 | 3.8 | 9.6× / 7.8× | 7.0× / 5.7× | 2.7× / 2.2× | 0.6× / 0.5× |
| agentic-traces | 0.89 | 1.47 | 5.01 | 5.59 | 54.2 | 40.8 | 16.9 | 5.0 | 10.8× / 9.7× | 8.1× / 7.3× | 3.4× / 3.0× | 1.0× / 0.9× |
| agentic_swe | 0.65 | 1.45 | 3.75 | 4.55 | 55.8 | 48.9 | 17.2 | 3.6 | 14.9× / 12.3× | 13.0× / 10.8× | 4.6× / 3.8× | 1.0× / 0.8× |
| code_mixed | 0.06 | 1.44 | 4.37 | 5.74 | 54.6 | 47.6 | 17.4 | 4.3 | 12.5× / 9.5× | 10.9× / 8.3× | 4.0× / 3.0× | 1.0× / 0.8× |
| math_latex | 0.82 | 1.48 | 4.86 | 5.53 | 52.0 | 37.0 | 16.0 | 4.6 | 10.7× / 9.4× | 7.6× / 6.7× | 3.3× / 2.9× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×12.84 vs v0.23.1 · ×1.02 vs base</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-glm-5-2-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 4+11 (peak 16) · Pipeline 6+0 (peak 6)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.6 | 64.5 | ×14.15 | ×1.00 | 8% (1.2) | 0% (0.0) | 25% (3.7) | 67% (9.9) | match |
| arb_Arab | lang | 4.2 | 72.9 | ×17.16 | ×0.98 | 9% (1.2) | 0% (0.0) | 18% (2.3) | 74% (9.6) | match |
| ben_Beng | lang | 3.5 | 70.9 | ×20.03 | ×1.01 | 9% (1.2) | 0% (0.0) | 23% (3.1) | 69% (9.3) | match |
| cmn_Hani | lang | 4.8 | 68.0 | ×14.20 | ×1.02 | 8% (1.2) | 0% (0.0) | 17% (2.4) | 75% (10.5) | match |
| ell_Grek | lang | 4.2 | 78.0 | ×18.65 | ×1.08 | 10% (1.2) | 0% (0.0) | 18% (2.2) | 73% (8.9) | match |
| eng_Latn | lang | 3.6 | 22.8 | ×6.24 | ×1.00 | 6% (2.7) | 0% (0.0) | 7% (3.1) | 87% (37.8) | match |
| heb_Hebr | lang | 3.9 | 77.9 | ×19.90 | ×1.07 | 10% (1.2) | 0% (0.0) | 19% (2.3) | 72% (8.8) | match |
| hin_Deva | lang | 3.2 | 68.7 | ×21.51 | ×1.03 | 8% (1.2) | 0% (0.0) | 23% (3.3) | 69% (9.6) | match |
| jpn_Jpan | lang | 4.8 | 75.0 | ×15.52 | ×0.99 | 9% (1.2) | 0% (0.0) | 17% (2.2) | 74% (9.4) | match |
| kat_Geor | lang | 4.6 | 83.2 | ×18.08 | ×0.98 | 10% (1.2) | 0% (0.0) | 18% (2.1) | 72% (8.3) | match |
| kor_Hang | lang | 3.6 | 68.9 | ×19.31 | ×1.03 | 8% (1.2) | 0% (0.0) | 18% (2.5) | 74% (10.3) | match |
| rus_Cyrl | lang | 4.1 | 40.9 | ×9.96 | ×1.02 | 5% (1.2) | 0% (0.0) | 9% (2.1) | 86% (20.7) | match |
| tam_Taml | lang | 3.3 | 71.9 | ×21.71 | ×1.02 | 9% (1.2) | 0% (0.0) | 20% (2.7) | 71% (9.3) | match |
| tha_Thai | lang | 4.0 | 74.9 | ×18.80 | ×1.02 | 10% (1.3) | 0% (0.0) | 19% (2.4) | 71% (9.1) | match |
| added_normalized_dense | modalities | 4.8 | 47.4 | ×9.88 | ×1.00 | 7% (1.3) | 0% (0.0) | 6% (1.2) | 88% (17.6) | match |
| added_normalized_sparse | modalities | 4.3 | 41.1 | ×9.58 | ×1.01 | 8% (1.9) | 0% (0.0) | 8% (2.0) | 84% (19.7) | match |
| added_special_dense | modalities | 3.5 | 41.7 | ×11.97 | ×1.01 | 51% (11.9) | 1% (0.2) | 20% (4.7) | 29% (6.7) | match |
| added_special_sparse | modalities | 3.6 | 34.4 | ×9.69 | ×1.03 | 23% (6.6) | 0% (0.0) | 17% (4.8) | 59% (16.8) | match |
| agentic-traces | modalities | 3.3 | 23.7 | ×7.15 | ×1.00 | 6% (2.6) | 0% (0.0) | 9% (3.7) | 85% (35.2) | match |
| agentic_swe | modalities | 3.6 | 22.4 | ×6.16 | ×1.01 | 5% (2.0) | 0% (0.0) | 6% (2.9) | 89% (39.3) | match |
| code_mixed | modalities | 3.6 | 31.1 | ×8.75 | ×1.02 | 7% (2.3) | 0% (0.0) | 10% (3.2) | 82% (26.0) | match |
| math_latex | modalities | 3.2 | 24.1 | ×7.66 | ×1.00 | 7% (2.7) | 0% (0.0) | 8% (3.4) | 85% (34.7) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.43 | 3.68 | 4.34 | 27.0 | 16.3 | 5.9 | 4.7 | 7.3× / 6.2× | 4.4× / 3.8× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.94 | 2.30 | 4.09 | 30.8 | 19.4 | 6.8 | 5.0 | 13.4× / 7.5× | 8.4× / 4.7× | 2.9× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.62 | 2.92 | 3.07 | 4.37 | 45.2 | 28.0 | 10.1 | 3.7 | 14.7× / 10.3× | 9.1× / 6.4× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.24 | 2.35 | 3.47 | 19.4 | 11.6 | 4.8 | 2.3 | 8.3× / 5.6× | 4.9× / 3.4× | 2.1× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.00 | 2.18 | 4.61 | 28.0 | 17.1 | 6.0 | 4.7 | 12.8× / 6.1× | 7.8× / 3.7× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.46 | 3.15 | 4.51 | 44.0 | 32.7 | 12.2 | 3.7 | 14.0× / 9.7× | 10.4× / 7.3× | 3.9× / 2.7× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.06 | 2.28 | 4.20 | 30.6 | 20.4 | 7.0 | 3.0 | 13.4× / 7.3× | 9.0× / 4.9× | 3.1× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.11 | 3.26 | 4.86 | 48.1 | 30.1 | 11.3 | 4.0 | 14.7× / 9.9× | 9.2× / 6.2× | 3.5× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.70 | 3.34 | 2.15 | 3.80 | 18.2 | 10.0 | 4.1 | 3.7 | 8.4× / 4.8× | 4.6× / 2.6× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.54 | 2.52 | 2.08 | 3.06 | 17.2 | 11.4 | 4.2 | 2.0 | 8.3× / 5.6× | 5.5× / 3.7× | 2.0× / 1.4× | 1.0× / 0.7× |
| kor_Hang | 1.23 | 2.68 | 2.50 | 3.95 | 30.7 | 21.3 | 7.5 | 3.7 | 12.3× / 7.8× | 8.5× / 5.4× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.96 | 2.14 | 3.94 | 26.5 | 16.6 | 5.8 | 2.6 | 12.3× / 6.7× | 7.7× / 4.2× | 2.7× / 1.5× | 1.2× / 0.7× |
| tam_Taml | 0.93 | 2.95 | 2.67 | 4.68 | 44.0 | 26.8 | 9.7 | 3.4 | 16.5× / 9.4× | 10.1× / 5.7× | 3.7× / 2.1× | 1.3× / 0.7× |
| tha_Thai | 1.53 | 2.57 | 2.41 | 3.45 | 28.4 | 16.1 | 6.7 | 3.0 | 11.8× / 8.2× | 6.7× / 4.7× | 2.8× / 1.9× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.17 | 2.59 | 23.1 | 17.3 | 6.5 | 1.8 | 19.7× / 8.9× | 14.7× / 6.7× | 5.5× / 2.5× | 1.5× / 0.7× |
| added_normalized_sparse | 0.06 | 1.48 | 1.98 | 3.40 | 30.4 | 22.7 | 8.7 | 2.5 | 15.4× / 8.9× | 11.5× / 6.7× | 4.4× / 2.6× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.77 | 4.68 | 6.39 | 93.3 | 73.6 | 21.3 | 3.2 | 19.9× / 14.6× | 15.7× / 11.5× | 4.6× / 3.3× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.79 | 6.21 | 58.9 | 46.6 | 14.9 | 3.6 | 12.3× / 9.5× | 9.7× / 7.5× | 3.1× / 2.4× | 0.8× / 0.6× |
| agentic-traces | 0.72 | 1.48 | 3.68 | 4.44 | 52.4 | 43.4 | 14.7 | 4.5 | 14.2× / 11.8× | 11.8× / 9.8× | 4.0× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.66 | 1.44 | 2.87 | 3.65 | 55.8 | 50.6 | 15.2 | 3.4 | 19.4× / 15.3× | 17.6× / 13.9× | 5.3× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.46 | 3.23 | 4.63 | 51.5 | 49.3 | 15.1 | 4.0 | 15.9× / 11.1× | 15.3× / 10.7× | 4.7× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.73 | 1.50 | 3.44 | 4.21 | 49.7 | 39.2 | 13.8 | 4.1 | 14.5× / 11.8× | 11.4× / 9.3× | 4.0× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.26 vs v0.23.1 · ×1.00 vs base</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-llama-2-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 18+0 (peak 23) · Pipeline 22+0 (peak 22)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.6 | 46.1 | ×8.29 | ×1.01 | 0% (0.0) | 14% (2.8) | 0% (0.0) | 85% (16.5) | match |
| arb_Arab | lang | 12.5 | 51.3 | ×4.11 | ×0.97 | 0% (0.0) | 18% (3.3) | 0% (0.0) | 82% (14.9) | match |
| ben_Beng | lang | 13.5 | 87.1 | ×6.44 | ×0.97 | 0% (0.0) | 21% (2.2) | 0% (0.0) | 78% (8.1) | match |
| cmn_Hani | lang | 11.2 | 70.3 | ×6.26 | ×1.00 | 0% (0.1) | 4% (0.4) | 0% (0.0) | 96% (11.9) | match |
| ell_Grek | lang | 12.5 | 61.3 | ×4.90 | ×0.97 | 0% (0.0) | 21% (3.2) | 0% (0.0) | 79% (12.1) | match |
| eng_Latn | lang | 4.4 | 6.5 | ×1.47 | ×1.00 | 0% (0.1) | 5% (6.8) | 0% (0.1) | 95% (139.6) | match |
| heb_Hebr | lang | 12.5 | 65.8 | ×5.26 | ×1.02 | 0% (0.0) | 23% (3.3) | 1% (0.1) | 76% (11.0) | match |
| hin_Deva | lang | 14.9 | 82.8 | ×5.54 | ×0.99 | 0% (0.0) | 25% (2.9) | 1% (0.1) | 74% (8.3) | match |
| jpn_Jpan | lang | 16.4 | 88.5 | ×5.39 | ×0.97 | 1% (0.0) | 4% (0.3) | 0% (0.0) | 96% (9.3) | match |
| kat_Geor | lang | 18.0 | 94.3 | ×5.25 | ×0.97 | 0% (0.0) | 20% (1.9) | 0% (0.0) | 80% (7.7) | match |
| kor_Hang | lang | 8.8 | 55.5 | ×6.32 | ×1.01 | 0% (0.1) | 20% (3.3) | 0% (0.1) | 80% (13.3) | match |
| rus_Cyrl | lang | 9.5 | 16.9 | ×1.78 | ×1.03 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (55.2) | match |
| tam_Taml | lang | 15.9 | 100.9 | ×6.34 | ×1.07 | 0% (0.0) | 18% (1.7) | 0% (0.0) | 81% (7.6) | match |
| tha_Thai | lang | 19.8 | 90.0 | ×4.54 | ×0.98 | 0% (0.0) | 10% (1.0) | 0% (0.0) | 90% (9.1) | match |
| added_normalized_dense | modalities | 6.1 | 9.0 | ×1.47 | ×1.01 | 0% (0.1) | 3% (3.8) | 0% (0.1) | 96% (106.0) | match |
| added_normalized_sparse | modalities | 5.2 | 7.5 | ×1.45 | ×0.99 | 0% (0.0) | 5% (6.0) | 0% (0.1) | 95% (121.2) | match |
| added_special_dense | modalities | 5.4 | 20.0 | ×3.72 | ×1.00 | 11% (5.2) | 33% (15.7) | 2% (0.8) | 55% (26.3) | match |
| added_special_sparse | modalities | 7.4 | 10.5 | ×1.41 | ×1.00 | 2% (2.3) | 14% (13.7) | 0% (0.1) | 83% (80.0) | match |
| agentic-traces | modalities | 4.7 | 7.3 | ×1.55 | ×1.01 | 0% (0.1) | 5% (6.1) | 0% (0.1) | 95% (125.4) | match |
| agentic_swe | modalities | 4.3 | 7.7 | ×1.80 | ×1.02 | 0% (0.0) | 8% (9.9) | 0% (0.1) | 92% (118.9) | match |
| code_mixed | modalities | 4.4 | 7.3 | ×1.65 | ×1.00 | 0% (0.0) | 6% (8.1) | 0% (0.1) | 94% (123.7) | match |
| math_latex | modalities | 4.8 | 7.0 | ×1.45 | ×1.02 | 0% (0.1) | 4% (6.4) | 0% (0.1) | 95% (138.2) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×7.00 vs v0.23.1 · ×1.06 vs base</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-llama-3-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 143+0 (peak 199) · Pipeline 145+0 (peak 200)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.6 | 55.6 | ×12.13 | ×1.09 | 4% (0.7) | 0% (0.0) | 22% (3.7) | 74% (12.3) | match |
| arb_Arab | lang | 4.9 | 18.8 | ×3.85 | ×1.04 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 94% (49.2) | match |
| ben_Beng | lang | 4.2 | 33.7 | ×7.98 | ×1.04 | 2% (0.6) | 0% (0.0) | 10% (3.0) | 88% (26.3) | match |
| cmn_Hani | lang | 5.3 | 18.3 | ×3.42 | ×1.06 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 94% (50.4) | match |
| ell_Grek | lang | 5.4 | 20.5 | ×3.79 | ×1.04 | 1% (0.6) | 0% (0.0) | 5% (2.2) | 94% (44.7) | match |
| eng_Latn | lang | 4.4 | 49.0 | ×11.08 | ×1.21 | 11% (2.2) | 0% (0.0) | 16% (3.1) | 73% (13.8) | match |
| heb_Hebr | lang | 4.5 | 28.3 | ×6.35 | ×1.02 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 92% (32.0) | match |
| hin_Deva | lang | 4.6 | 81.3 | ×17.69 | ×1.05 | 5% (0.6) | 0% (0.0) | 28% (3.2) | 66% (7.4) | match |
| jpn_Jpan | lang | 6.2 | 17.9 | ×2.88 | ×1.08 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (53.8) | match |
| kat_Geor | lang | 5.8 | 40.6 | ×7.03 | ×1.08 | 3% (0.6) | 0% (0.0) | 9% (2.1) | 89% (20.8) | match |
| kor_Hang | lang | 4.4 | 20.7 | ×4.67 | ×1.06 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 93% (44.2) | match |
| rus_Cyrl | lang | 5.5 | 17.1 | ×3.13 | ×1.01 | 1% (0.6) | 0% (0.0) | 4% (2.1) | 95% (53.3) | match |
| tam_Taml | lang | 4.2 | 38.1 | ×9.00 | ×1.04 | 2% (0.6) | 0% (0.0) | 10% (2.7) | 88% (23.5) | match |
| tha_Thai | lang | 5.7 | 22.1 | ×3.86 | ×1.05 | 1% (0.6) | 0% (0.0) | 6% (2.5) | 93% (41.0) | match |
| added_normalized_dense | modalities | 6.5 | 28.2 | ×4.36 | ×1.00 | 2% (0.7) | 0% (0.0) | 3% (1.2) | 95% (33.1) | match |
| added_normalized_sparse | modalities | 6.0 | 44.2 | ×7.40 | ×1.01 | 6% (1.4) | 0% (0.0) | 10% (2.2) | 84% (18.4) | match |
| added_special_dense | modalities | 4.5 | 76.5 | ×16.83 | ×1.05 | 39% (5.0) | 1% (0.1) | 38% (4.9) | 22% (2.7) | match |
| added_special_sparse | modalities | 4.7 | 72.5 | ×15.34 | ×1.03 | 25% (3.2) | 0% (0.0) | 38% (5.0) | 37% (4.9) | match |
| agentic-traces | modalities | 4.0 | 38.6 | ×9.54 | ×1.12 | 8% (1.9) | 0% (0.0) | 15% (3.7) | 77% (18.6) | match |
| agentic_swe | modalities | 4.4 | 29.4 | ×6.65 | ×1.08 | 4% (1.4) | 0% (0.0) | 9% (2.9) | 87% (28.1) | match |
| code_mixed | modalities | 4.4 | 49.1 | ×11.15 | ×1.12 | 9% (1.7) | 0% (0.0) | 17% (3.3) | 74% (13.9) | match |
| math_latex | modalities | 4.0 | 42.7 | ×10.55 | ×1.16 | 9% (2.0) | 0% (0.0) | 16% (3.5) | 75% (16.4) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.41 | 3.67 | 4.30 | 27.4 | 16.5 | 6.0 | 4.7 | 7.5× / 6.4× | 4.5× / 3.8× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.14 | 2.98 | 2.27 | 4.11 | 31.4 | 19.7 | 6.9 | 5.2 | 13.8× / 7.6× | 8.7× / 4.8× | 3.0× / 1.7× | 2.3× / 1.3× |
| ben_Beng | 1.61 | 2.95 | 3.05 | 4.39 | 45.8 | 28.0 | 10.5 | 3.7 | 15.0× / 10.4× | 9.2× / 6.4× | 3.4× / 2.4× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.25 | 2.35 | 3.49 | 19.5 | 11.7 | 4.7 | 2.4 | 8.3× / 5.6× | 5.0× / 3.4× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.98 | 2.18 | 4.58 | 28.6 | 17.1 | 6.2 | 4.7 | 13.1× / 6.2× | 7.8× / 3.7× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.49 | 3.06 | 4.45 | 45.5 | 33.1 | 12.4 | 3.7 | 14.9× / 10.2× | 10.8× / 7.4× | 4.0× / 2.8× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.01 | 2.29 | 4.16 | 31.7 | 19.8 | 6.9 | 3.0 | 13.8× / 7.6× | 8.6× / 4.8× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.12 | 3.16 | 4.76 | 48.5 | 30.8 | 11.8 | 4.0 | 15.4× / 10.2× | 9.8× / 6.5× | 3.8× / 2.5× | 1.3× / 0.8× |
| jpn_Jpan | 1.70 | 3.42 | 2.15 | 3.88 | 18.3 | 9.9 | 4.1 | 3.7 | 8.5× / 4.7× | 4.6× / 2.6× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.54 | 2.58 | 2.08 | 3.12 | 17.7 | 11.3 | 4.2 | 2.0 | 8.5× / 5.7× | 5.4× / 3.6× | 2.0× / 1.4× | 1.0× / 0.6× |
| kor_Hang | 1.23 | 2.69 | 2.48 | 3.95 | 31.6 | 21.5 | 7.6 | 3.6 | 12.7× / 8.0× | 8.7× / 5.4× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.91 | 2.11 | 3.86 | 27.1 | 16.4 | 5.9 | 2.4 | 12.8× / 7.0× | 7.8× / 4.2× | 2.8× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.97 | 2.67 | 4.72 | 44.7 | 26.9 | 10.1 | 3.4 | 16.7× / 9.5× | 10.1× / 5.7× | 3.8× / 2.1× | 1.3× / 0.7× |
| tha_Thai | 1.52 | 2.51 | 2.52 | 3.51 | 28.6 | 16.1 | 6.8 | 3.0 | 11.3× / 8.1× | 6.4× / 4.6× | 2.7× / 1.9× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.16 | 2.58 | 24.4 | 17.0 | 6.5 | 1.8 | 21.0× / 9.5× | 14.7× / 6.6× | 5.6× / 2.5× | 1.5× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 2.16 | 3.57 | 32.2 | 22.6 | 8.7 | 2.5 | 14.9× / 9.0× | 10.5× / 6.3× | 4.0× / 2.4× | 1.2× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 4.88 | 6.30 | 97.7 | 71.0 | 21.1 | 3.1 | 20.0× / 15.5× | 14.5× / 11.3× | 4.3× / 3.3× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.00 | 6.42 | 62.6 | 46.4 | 15.2 | 3.6 | 12.5× / 9.7× | 9.3× / 7.2× | 3.0× / 2.4× | 0.7× / 0.6× |
| agentic-traces | 0.73 | 1.48 | 3.70 | 4.45 | 54.5 | 43.7 | 15.0 | 4.6 | 14.7× / 12.2× | 11.8× / 9.8× | 4.0× / 3.4× | 1.2× / 1.0× |
| agentic_swe | 0.66 | 1.45 | 2.91 | 3.70 | 56.7 | 51.6 | 15.4 | 3.4 | 19.4× / 15.3× | 17.7× / 13.9× | 5.3× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.45 | 3.25 | 4.64 | 54.5 | 50.1 | 15.5 | 4.0 | 16.8× / 11.8× | 15.4× / 10.8× | 4.8× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.72 | 1.50 | 3.51 | 4.30 | 52.1 | 39.9 | 14.0 | 4.2 | 14.9× / 12.1× | 11.4× / 9.3× | 4.0× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29867447413-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->

