### PR TITLE
wip: wordpiece cache

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/mod.rs
+++ b/tokenizers/tk-encode/src/models/bpe/mod.rs
@@ -4,7 +4,7 @@ use std::{iter, mem};
 mod model;
 mod serialization;
 pub mod word;
-mod word_cache;
+pub(crate) mod word_cache;
 
 pub type Pair = (u32, u32);
 

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -2,8 +2,10 @@
 //! model.
 
 use crate::models::bpe::BPE;
+use crate::models::bpe::word_cache::WordCache;
 use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
+use crate::utils::cache::DEFAULT_CACHE_CAPACITY;
 use ahash::AHashMap;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -317,12 +319,17 @@ impl Model for WordPiece {
 #[derive(Default)]
 pub struct WordPieceScratch {
     candidate_str: String,
+    word_cache: Option<WordCache>,
 }
 
 impl pipeline::ModelScratch for WordPieceScratch {
     fn clear(&mut self) {
-        let Self { candidate_str } = self;
+        let Self {
+            candidate_str,
+            word_cache: _,
+        } = self;
         candidate_str.clear();
+        // The word cache is intentionally kept across clears so it stays warm for future callers
     }
 }
 
@@ -359,23 +366,14 @@ impl TryFrom<WordPiece> for PipelineWordPiece {
     }
 }
 
-impl pipeline::Model for PipelineWordPiece {
-    type Scratch = WordPieceScratch;
-
-    fn init_scratch(&self) -> Self::Scratch {
-        Self::Scratch {
-            candidate_str: String::with_capacity(self.max_input_chars_per_word),
-        }
-    }
-
-    fn tokenize_pipeline(
+impl PipelineWordPiece {
+    fn tokenize_word(
         &self,
         sequence: &str,
-        scratch: &mut Self::Scratch,
-        output: &mut Vec<pipeline::PipelineToken>,
+        candidate: &mut String,
+        output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
         let checkpoint = output.len();
-        let candidate = &mut scratch.candidate_str;
 
         let char_len = sequence.chars().count();
         if char_len > self.max_input_chars_per_word {
@@ -417,6 +415,46 @@ impl pipeline::Model for PipelineWordPiece {
     }
 }
 
+impl pipeline::Model for PipelineWordPiece {
+    type Scratch = WordPieceScratch;
+
+    fn init_scratch(&self) -> Self::Scratch {
+        Self::Scratch {
+            candidate_str: String::with_capacity(self.max_input_chars_per_word),
+            word_cache: Some(WordCache::new(DEFAULT_CACHE_CAPACITY)),
+        }
+    }
+
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        let WordPieceScratch {
+            candidate_str,
+            word_cache,
+        } = scratch;
+
+        if let Some(cache) = word_cache
+            && let Some(hit) = cache.get(sequence.as_bytes())
+        {
+            output.extend(hit.iter().map(|&id| PipelineToken { id }));
+            return Ok(());
+        }
+
+        let checkpoint = output.len();
+        self.tokenize_word(sequence, candidate_str, output)?;
+        if let Some(cache) = word_cache {
+            cache.insert(
+                sequence.as_bytes(),
+                output[checkpoint..].iter().map(|token| token.id),
+            );
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -424,5 +462,89 @@ mod tests {
     #[test]
     fn test_error_display() {
         assert!(format!("{}", Error::MissingUnkToken).contains("Missing [UNK] token"));
+    }
+
+    mod pipeline_wordpiece {
+        use super::*;
+        use crate::pipeline::Model as PipelineModel;
+
+        fn wordpiece() -> WordPiece {
+            let vocab: Vocab = [
+                ("[UNK]", 0u32),
+                ("hell", 1),
+                ("##o", 2),
+                ("hello", 3),
+                ("world", 4),
+            ]
+            .iter()
+            .map(|&(s, i)| (s.into(), i))
+            .collect();
+            WordPieceBuilder::default()
+                .vocab(vocab)
+                .max_input_chars_per_word(8)
+                .build()
+                .unwrap()
+        }
+
+        fn pipeline_ids(
+            model: &PipelineWordPiece,
+            scratch: &mut WordPieceScratch,
+            sequence: &str,
+        ) -> Vec<u32> {
+            let mut out = Vec::new();
+            model
+                .tokenize_pipeline(sequence, scratch, &mut out)
+                .unwrap();
+            out.iter().map(|t| t.id).collect()
+        }
+
+        fn reference_ids(model: &WordPiece, sequence: &str) -> Vec<u32> {
+            model
+                .tokenize(sequence)
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect()
+        }
+
+        #[test]
+        fn tokenize_populates_word_cache() {
+            let model = PipelineWordPiece::try_from(wordpiece()).unwrap();
+            let mut scratch = model.init_scratch();
+            let mut out = Vec::new();
+            model
+                .tokenize_pipeline("hello", &mut scratch, &mut out)
+                .unwrap();
+            let cached = scratch.word_cache.as_ref().unwrap().get(b"hello");
+            assert_eq!(cached, Some(&[3u32][..]));
+        }
+
+        // Repeats through ONE scratch take the cache-hit path; every outcome
+        // (match, unk fallback, oversized, empty) must keep matching the
+        // reference model on both the miss and the hit encounter.
+        #[test]
+        fn reused_scratch_matches_reference_on_repeats() {
+            let reference = wordpiece();
+            let model = PipelineWordPiece::try_from(reference.clone()).unwrap();
+            let mut scratch = model.init_scratch();
+            for input in [
+                "hello",
+                "hullo",
+                "hello",
+                "hullo",
+                "hellohello", // 10 chars > max_input_chars_per_word
+                "hellohello",
+                "",
+                "",
+                "helloo",
+                "helloo",
+            ] {
+                assert_eq!(
+                    pipeline_ids(&model, &mut scratch, input),
+                    reference_ids(&reference, input),
+                    "{input:?}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**7 / 8 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · single thread + 1/2/4/8/max-thread sweep

`2b48e7cca · 2026-07-22 10:58 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-overview.png" width="860">

**vs base branch** (`575582072`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-binsize.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×5.21 vs v0.23.1 · ×1.07 vs base</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-bert-base-uncased-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 12) · Pipeline 8+1 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 26.6 | ×3.38 | ×0.97 | 3% (1.2) | 76% (27.4) | 13% (4.9) | 7% (2.7) | match |
| arb_Arab | lang | 4.3 | 27.5 | ×6.47 | ×1.11 | 3% (1.2) | 77% (27.6) | 9% (3.3) | 11% (3.8) | match |
| ben_Beng | lang | 6.0 | 38.8 | ×6.42 | ×1.12 | 5% (1.2) | 75% (19.1) | 12% (3.0) | 9% (2.3) | match |
| cmn_Hani | lang | 3.8 | 20.0 | ×5.20 | ×1.06 | 2% (1.2) | 76% (37.7) | 11% (5.3) | 11% (5.6) | match |
| ell_Grek | lang | 3.8 | 26.7 | ×7.00 | ×1.13 | 3% (1.2) | 78% (28.6) | 9% (3.4) | 10% (3.7) | match |
| eng_Latn | lang | 4.6 | 19.6 | ×4.31 | ×1.09 | 5% (2.6) | 77% (38.8) | 9% (4.6) | 9% (4.6) | match |
| heb_Hebr | lang | 4.2 | 21.3 | ×5.05 | ×1.07 | 3% (1.2) | 79% (37.1) | 8% (3.7) | 10% (4.7) | match |
| hin_Deva | lang | 6.5 | 29.5 | ×4.52 | ×1.08 | 4% (1.2) | 79% (26.9) | 10% (3.2) | 7% (2.5) | match |
| jpn_Jpan | lang | 4.3 | 28.8 | ×6.71 | ×1.06 | 4% (1.2) | 70% (23.5) | 13% (4.4) | 13% (4.4) | match |
| kat_Geor | lang | 6.2 | 29.6 | ×4.76 | ×1.04 | 4% (1.3) | 80% (26.4) | 10% (3.1) | 6% (2.0) | match |
| kor_Hang | lang | 2.4 | 19.3 | ×7.88 | ×1.10 | 3% (1.3) | 71% (35.3) | 14% (7.2) | 12% (5.9) | match |
| rus_Cyrl | lang | 3.7 | 28.0 | ×7.55 | ×1.19 | 3% (1.2) | 78% (27.4) | 9% (3.2) | 10% (3.5) | match |
| tam_Taml | lang | 7.1 | 41.4 | ×5.84 | ×1.08 | 5% (1.2) | 78% (18.5) | 11% (2.5) | 7% (1.7) | match |
| tha_Thai | lang | 8.4 | 33.7 | ×4.02 | ×1.01 | 4% (1.3) | 85% (24.8) | 7% (2.2) | 3% (0.8) | match |
| added_normalized_dense | modalities | 6.8 | 20.0 | ×2.95 | ×1.02 | 3% (1.4) | 82% (40.5) | 15% (7.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 19.3 | ×3.65 | ×1.06 | 4% (2.1) | 78% (39.9) | 14% (7.2) | 4% (2.1) | match |
| added_special_dense | modalities | 5.3 | 39.6 | ×7.44 | ×1.01 | 21% (5.2) | 37% (9.1) | 39% (9.5) | 3% (0.7) | match |
| added_special_sparse | modalities | 4.0 | 22.7 | ×5.74 | ×1.07 | 9% (3.7) | 65% (28.1) | 21% (9.0) | 6% (2.8) | match |
| agentic-traces | modalities | 3.9 | 18.9 | ×4.88 | ×1.06 | 5% (2.7) | 73% (38.5) | 9% (5.0) | 13% (6.7) | match |
| agentic_swe | modalities | 4.1 | 20.1 | ×4.86 | ×1.04 | 4% (2.2) | 78% (38.7) | 7% (3.7) | 10% (5.0) | match |
| code_mixed | modalities | 3.9 | 19.9 | ×5.06 | ×1.06 | 5% (2.4) | 78% (38.6) | 9% (4.3) | 9% (4.5) | match |
| math_latex | modalities | 4.0 | 19.1 | ×4.73 | ×1.06 | 5% (2.8) | 75% (38.6) | 9% (4.8) | 10% (5.3) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×21.78 vs v0.23.1 · ×5.37 vs base</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-deepseek-v4-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 96+0 (peak 96)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.5 | 91.2 | ×20.25 | ×2.72 | 7% (0.7) | 0% (0.0) | 49% (4.8) | 44% (4.2) | match |
| arb_Arab | lang | 4.5 | 97.7 | ×21.95 | ×5.79 | 7% (0.6) | 0% (0.0) | 39% (3.5) | 54% (4.8) | match |
| ben_Beng | lang | 6.4 | 138.8 | ×21.55 | ×7.60 | 9% (0.6) | 0% (0.0) | 50% (3.2) | 40% (2.6) | match |
| cmn_Hani | lang | 3.7 | 79.7 | ×21.77 | ×5.06 | 8% (0.8) | 0% (0.0) | 31% (3.2) | 61% (6.3) | match |
| ell_Grek | lang | 4.7 | 109.7 | ×23.48 | ×6.26 | 8% (0.6) | 0% (0.0) | 44% (3.5) | 49% (3.9) | match |
| eng_Latn | lang | 3.2 | 71.2 | ×22.15 | ×5.77 | 16% (2.1) | 1% (0.2) | 38% (5.0) | 45% (6.0) | match |
| heb_Hebr | lang | 3.9 | 92.8 | ×23.49 | ×7.29 | 6% (0.6) | 0% (0.0) | 38% (3.6) | 56% (5.4) | match |
| hin_Deva | lang | 6.0 | 130.7 | ×21.80 | ×6.07 | 9% (0.6) | 0% (0.0) | 50% (3.4) | 41% (2.8) | match |
| jpn_Jpan | lang | 4.4 | 113.3 | ×25.94 | ×6.25 | 9% (0.7) | 0% (0.0) | 41% (3.0) | 50% (3.6) | match |
| kat_Geor | lang | 6.1 | 137.7 | ×22.56 | ×7.71 | 9% (0.6) | 0% (0.0) | 47% (3.0) | 44% (2.8) | match |
| kor_Hang | lang | 3.7 | 71.9 | ×19.44 | ×3.68 | 5% (0.6) | 0% (0.0) | 30% (3.7) | 65% (8.0) | match |
| rus_Cyrl | lang | 4.5 | 103.4 | ×23.09 | ×7.25 | 7% (0.6) | 0% (0.0) | 40% (3.4) | 53% (4.5) | match |
| tam_Taml | lang | 6.4 | 146.2 | ×22.95 | ×8.24 | 11% (0.6) | 0% (0.0) | 49% (2.8) | 41% (2.3) | match |
| tha_Thai | lang | 6.9 | 89.0 | ×12.86 | ×6.04 | 6% (0.6) | 0% (0.0) | 23% (2.3) | 71% (7.2) | match |
| added_normalized_dense | modalities | 6.2 | 156.2 | ×25.08 | ×6.73 | 13% (0.8) | 0% (0.0) | 48% (2.8) | 39% (2.3) | match |
| added_normalized_sparse | modalities | 5.5 | 116.3 | ×21.06 | ×6.07 | 17% (1.4) | 0% (0.0) | 46% (3.7) | 39% (3.2) | match |
| added_special_dense | modalities | 3.2 | 57.9 | ×18.07 | ×1.65 | 40% (6.3) | 3% (0.4) | 42% (6.7) | 15% (2.5) | match |
| added_special_sparse | modalities | 4.1 | 65.1 | ×15.93 | ×3.33 | 27% (3.8) | 1% (0.1) | 49% (7.0) | 24% (3.4) | match |
| agentic-traces | modalities | 2.9 | 67.8 | ×23.35 | ×4.91 | 14% (1.9) | 0% (0.0) | 40% (5.5) | 46% (6.4) | match |
| agentic_swe | modalities | 2.8 | 87.7 | ×31.19 | ×5.98 | 14% (1.4) | 0% (0.0) | 38% (3.9) | 48% (4.8) | match |
| code_mixed | modalities | 3.5 | 82.8 | ×23.86 | ×5.47 | 15% (1.7) | 0% (0.0) | 40% (4.6) | 45% (5.1) | match |
| math_latex | modalities | 2.9 | 68.9 | ×24.07 | ×5.19 | 15% (2.0) | 0% (0.0) | 41% (5.5) | 44% (5.9) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.42 | 4.79 | 5.56 | 41.8 | 20.0 | 9.2 | — | 8.7× / 7.5× | 4.2× / 3.6× | 1.9× / 1.7× | — |
| arb_Arab | 1.00 | 3.08 | 3.48 | 5.56 | 48.5 | 22.9 | 10.4 | — | 13.9× / 8.7× | 6.6× / 4.1× | 3.0× / 1.9× | — |
| ben_Beng | 1.46 | 2.97 | 3.18 | 4.69 | 35.5 | 16.0 | 7.7 | — | 11.2× / 7.6× | 5.0× / 3.4× | 2.4× / 1.6× | — |
| cmn_Hani | 1.13 | 2.34 | 3.21 | 4.42 | 60.5 | 34.0 | 14.3 | — | 18.8× / 13.7× | 10.6× / 7.7× | 4.5× / 3.2× | — |
| ell_Grek | 0.58 | 3.19 | 3.48 | 6.09 | 46.7 | 21.1 | 9.9 | — | 13.4× / 7.7× | 6.1× / 3.5× | 2.8× / 1.6× | — |
| eng_Latn | 0.10 | 1.49 | 4.96 | 6.34 | 65.7 | 39.1 | 16.9 | — | 13.2× / 10.4× | 7.9× / 6.2× | 3.4× / 2.7× | — |
| heb_Hebr | 1.01 | 3.21 | 3.60 | 5.80 | 50.1 | 24.2 | 10.8 | — | 13.9× / 8.6× | 6.7× / 4.2× | 3.0× / 1.9× | — |
| hin_Deva | 1.36 | 3.16 | 3.38 | 5.18 | 37.7 | 18.5 | 8.6 | — | 11.2× / 7.3× | 5.5× / 3.6× | 2.6× / 1.7× | — |
| jpn_Jpan | 1.55 | 3.38 | 3.03 | 4.85 | 52.3 | 27.2 | 11.9 | — | 17.3× / 10.8× | 9.0× / 5.6× | 3.9× / 2.4× | — |
| kat_Geor | 1.39 | 2.55 | 2.99 | 4.15 | 31.9 | 15.0 | 7.2 | — | 10.7× / 7.7× | 5.0× / 3.6× | 2.4× / 1.7× | — |
| kor_Hang | 1.08 | 2.76 | 3.74 | 5.42 | 49.2 | 26.8 | 11.9 | — | 13.2× / 9.1× | 7.2× / 4.9× | 3.2× / 2.2× | — |
| rus_Cyrl | 1.02 | 3.03 | 3.39 | 5.41 | 46.4 | 20.6 | 9.5 | — | 13.7× / 8.6× | 6.1× / 3.8× | 2.8× / 1.7× | — |
| tam_Taml | 0.94 | 2.94 | 2.78 | 4.79 | 31.2 | 13.6 | 6.6 | — | 11.2× / 6.5× | 4.9× / 2.8× | 2.4× / 1.4× | — |
| tha_Thai | 1.36 | 2.59 | 2.32 | 3.55 | 26.8 | 10.0 | 5.2 | — | 11.5× / 7.5× | 4.3× / 2.8× | 2.3× / 1.5× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.82 | 4.23 | 42.2 | 20.8 | 9.3 | — | 15.0× / 10.0× | 7.4× / 4.9× | 3.3× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.75 | 5.16 | 48.9 | 26.5 | 11.6 | — | 13.1× / 9.5× | 7.1× / 5.1× | 3.1× / 2.3× | — |
| added_special_dense | 0.06 | 1.47 | 6.66 | 8.07 | 172.2 | 99.5 | 38.8 | — | 25.9× / 21.3× | 15.0× / 12.3× | 5.8× / 4.8× | — |
| added_special_sparse | 0.06 | 1.47 | 6.96 | 8.37 | 101.5 | 57.2 | 24.2 | — | 14.6× / 12.1× | 8.2× / 6.8× | 3.5× / 2.9× | — |
| agentic-traces | 0.57 | 1.50 | 5.47 | 6.40 | 79.9 | 54.4 | 20.7 | — | 14.6× / 12.5× | 9.9× / 8.5× | 3.8× / 3.2× | — |
| agentic_swe | 0.52 | 1.45 | 3.90 | 4.83 | 96.2 | 66.4 | 24.0 | — | 24.7× / 19.9× | 17.0× / 13.8× | 6.1× / 5.0× | — |
| code_mixed | 0.08 | 1.45 | 4.64 | 6.02 | 73.7 | 54.8 | 19.0 | — | 15.9× / 12.2× | 11.8× / 9.1× | 4.1× / 3.1× | — |
| math_latex | 0.56 | 1.49 | 5.47 | 6.39 | 78.5 | 47.4 | 20.1 | — | 14.4× / 12.3× | 8.7× / 7.4× | 3.7× / 3.1× | — |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×26.64 vs v0.23.1 · ×3.61 vs base</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-gpt2-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 30+0 (peak 30)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 104.3 | ×23.86 | ×2.21 | 8% (0.7) | 0% (0.0) | 45% (3.6) | 47% (3.8) | match |
| arb_Arab | lang | 4.2 | 109.8 | ×25.98 | ×4.19 | 8% (0.6) | 0% (0.0) | 29% (2.3) | 63% (4.9) | match |
| ben_Beng | lang | 3.3 | 100.7 | ×30.67 | ×2.20 | 6% (0.6) | 0% (0.0) | 32% (3.0) | 61% (5.7) | match |
| cmn_Hani | lang | 4.0 | 105.7 | ×26.29 | ×3.65 | 8% (0.6) | 0% (0.0) | 30% (2.3) | 63% (4.9) | match |
| ell_Grek | lang | 4.6 | 123.9 | ×26.90 | ×4.21 | 9% (0.6) | 0% (0.0) | 32% (2.2) | 59% (4.0) | match |
| eng_Latn | lang | 3.8 | 82.9 | ×22.01 | ×6.03 | 20% (2.1) | 0% (0.0) | 28% (3.0) | 53% (5.7) | match |
| heb_Hebr | lang | 4.1 | 109.3 | ×26.75 | ×3.72 | 8% (0.6) | 0% (0.0) | 29% (2.3) | 64% (5.0) | match |
| hin_Deva | lang | 3.3 | 103.3 | ×31.01 | ×2.65 | 7% (0.6) | 0% (0.0) | 34% (3.1) | 60% (5.4) | match |
| jpn_Jpan | lang | 4.6 | 130.8 | ×28.28 | ×5.82 | 10% (0.6) | 0% (0.0) | 35% (2.1) | 55% (3.3) | match |
| kat_Geor | lang | 4.7 | 156.7 | ×33.15 | ×2.27 | 12% (0.6) | 0% (0.0) | 40% (2.1) | 48% (2.5) | match |
| kor_Hang | lang | 3.4 | 89.4 | ×26.49 | ×2.02 | 6% (0.6) | 0% (0.0) | 26% (2.4) | 68% (6.4) | match |
| rus_Cyrl | lang | 4.2 | 120.3 | ×28.49 | ×4.33 | 8% (0.6) | 0% (0.0) | 30% (2.1) | 62% (4.4) | match |
| tam_Taml | lang | 2.9 | 111.0 | ×38.66 | ×1.70 | 7% (0.6) | 0% (0.0) | 32% (2.7) | 61% (5.1) | match |
| tha_Thai | lang | 3.7 | 114.7 | ×30.93 | ×3.18 | 8% (0.6) | 0% (0.0) | 33% (2.5) | 59% (4.4) | match |
| added_normalized_dense | modalities | 6.2 | 202.9 | ×32.53 | ×7.88 | 18% (0.8) | 0% (0.0) | 25% (1.1) | 57% (2.4) | match |
| added_normalized_sparse | modalities | 5.5 | 143.3 | ×25.89 | ×6.63 | 20% (1.3) | 0% (0.0) | 32% (2.1) | 48% (3.1) | match |
| added_special_dense | modalities | 4.4 | 82.3 | ×18.74 | ×1.79 | 45% (5.0) | 1% (0.1) | 34% (3.9) | 20% (2.3) | match |
| added_special_sparse | modalities | 4.6 | 83.8 | ×18.32 | ×3.61 | 29% (3.2) | 1% (0.1) | 40% (4.4) | 31% (3.4) | match |
| agentic-traces | modalities | 3.3 | 75.2 | ×23.12 | ×4.71 | 16% (1.9) | 0% (0.0) | 28% (3.5) | 56% (6.8) | match |
| agentic_swe | modalities | 3.5 | 99.2 | ×28.45 | ×4.12 | 15% (1.4) | 0% (0.0) | 26% (2.4) | 59% (5.4) | match |
| code_mixed | modalities | 3.8 | 92.3 | ×24.58 | ×4.60 | 17% (1.7) | 0% (0.0) | 29% (2.9) | 55% (5.5) | match |
| math_latex | modalities | 3.4 | 80.1 | ×23.60 | ×5.35 | 18% (2.0) | 0% (0.0) | 30% (3.4) | 52% (5.9) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.44 | 3.62 | 4.43 | 30.5 | 20.5 | 5.8 | 4.8 | 8.4× / 6.9× | 5.7× / 4.6× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.01 | 3.02 | 2.25 | 4.26 | 35.8 | 25.3 | 6.7 | 5.2 | 15.9× / 8.4× | 11.2× / 5.9× | 3.0× / 1.6× | 2.3× / 1.2× |
| ben_Beng | 1.46 | 2.92 | 3.02 | 4.48 | 75.1 | 55.0 | 13.9 | 4.0 | 24.9× / 16.8× | 18.2× / 12.3× | 4.6× / 3.1× | 1.3× / 0.9× |
| cmn_Hani | 1.12 | 2.35 | 2.32 | 3.55 | 28.8 | 20.4 | 5.8 | 2.4 | 12.4× / 8.1× | 8.8× / 5.7× | 2.5× / 1.6× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.08 | 2.16 | 4.66 | 31.7 | 21.6 | 5.9 | 4.8 | 14.7× / 6.8× | 10.0× / 4.6× | 2.7× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.46 | 3.05 | 4.41 | 51.6 | 42.2 | 11.8 | 3.8 | 16.9× / 11.7× | 13.9× / 9.6× | 3.9× / 2.7× | 1.2× / 0.9× |
| heb_Hebr | 1.01 | 3.25 | 2.27 | 4.52 | 35.6 | 26.0 | 6.8 | 2.9 | 15.7× / 7.9× | 11.5× / 5.8× | 3.0× / 1.5× | 1.3× / 0.6× |
| hin_Deva | 1.36 | 3.10 | 3.07 | 4.80 | 73.4 | 54.5 | 13.5 | 4.2 | 23.9× / 15.3× | 17.8× / 11.4× | 4.4× / 2.8× | 1.4× / 0.9× |
| jpn_Jpan | 1.56 | 3.36 | 2.11 | 3.91 | 25.6 | 17.3 | 4.9 | 3.8 | 12.1× / 6.5× | 8.2× / 4.4× | 2.3× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.55 | 2.06 | 3.22 | 19.0 | 13.9 | 4.1 | 2.0 | 9.2× / 5.9× | 6.7× / 4.3× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.08 | 2.72 | 2.44 | 4.08 | 36.1 | 27.5 | 7.4 | 3.7 | 14.8× / 8.8× | 11.3× / 6.7× | 3.0× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.97 | 2.08 | 4.03 | 30.2 | 20.7 | 5.8 | 2.6 | 14.5× / 7.5× | 9.9× / 5.1× | 2.8× / 1.4× | 1.3× / 0.6× |
| tam_Taml | 0.93 | 3.12 | 2.69 | 4.88 | 78.5 | 57.7 | 14.1 | 3.8 | 29.2× / 16.1× | 21.4× / 11.8× | 5.3× / 2.9× | 1.4× / 0.8× |
| tha_Thai | 1.36 | 2.54 | 2.47 | 3.65 | 44.8 | 31.9 | 8.7 | 3.2 | 18.1× / 12.3× | 12.9× / 8.7× | 3.5× / 2.4× | 1.3× / 0.9× |
| added_normalized_dense | 0.07 | 1.47 | 1.07 | 2.47 | 23.2 | 22.8 | 6.3 | 1.8 | 21.6× / 9.4× | 21.2× / 9.2× | 5.8× / 2.5× | 1.7× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 2.06 | 3.48 | 35.2 | 30.3 | 8.4 | 2.5 | 17.1× / 10.1× | 14.7× / 8.7× | 4.1× / 2.4× | 1.2× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 3.85 | 5.27 | 109.5 | 92.9 | 19.8 | 2.9 | 28.4× / 20.8× | 24.1× / 17.6× | 5.1× / 3.7× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 4.42 | 5.84 | 70.4 | 59.4 | 14.4 | 3.4 | 15.9× / 12.1× | 13.4× / 10.2× | 3.2× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.58 | 1.48 | 3.48 | 4.38 | 60.2 | 59.8 | 15.4 | 4.6 | 17.3× / 13.8× | 17.2× / 13.7× | 4.4× / 3.5× | 1.3× / 1.0× |
| agentic_swe | 0.51 | 1.45 | 2.41 | 3.35 | 69.7 | 67.6 | 14.5 | 3.5 | 28.9× / 20.8× | 28.0× / 20.1× | 6.0× / 4.3× | 1.4× / 1.0× |
| code_mixed | 0.07 | 1.45 | 2.88 | 4.26 | 67.6 | 66.3 | 15.1 | 3.9 | 23.5× / 15.9× | 23.0× / 15.6× | 5.2× / 3.6× | 1.4× / 0.9× |
| math_latex | 0.57 | 1.48 | 3.35 | 4.27 | 60.8 | 50.2 | 13.8 | 4.2 | 18.1× / 14.2× | 15.0× / 11.8× | 4.1× / 3.2× | 1.2× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×23.33 vs v0.23.1 · ×2.99 vs base</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-gpt-oss-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 4+11 (peak 16) · Pipeline 6+2 (peak 8)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.5 | 87.1 | ×25.18 | ×1.40 | 7% (0.7) | 0% (0.0) | 48% (4.8) | 46% (4.6) | match |
| arb_Arab | lang | 3.8 | 92.3 | ×24.28 | ×3.62 | 6% (0.6) | 0% (0.0) | 35% (3.3) | 59% (5.7) | match |
| ben_Beng | lang | 5.3 | 116.5 | ×22.04 | ×4.31 | 8% (0.6) | 0% (0.0) | 49% (3.7) | 43% (3.2) | match |
| cmn_Hani | lang | 4.0 | 97.4 | ×24.14 | ×2.52 | 7% (0.6) | 0% (0.0) | 40% (3.5) | 53% (4.6) | match |
| ell_Grek | lang | 3.8 | 100.5 | ×26.77 | ×3.11 | 7% (0.6) | 0% (0.0) | 38% (3.2) | 55% (4.7) | match |
| eng_Latn | lang | 3.0 | 65.9 | ×21.67 | ×3.12 | 15% (2.0) | 0% (0.0) | 33% (4.7) | 52% (7.3) | match |
| heb_Hebr | lang | 3.7 | 89.7 | ×24.26 | ×3.19 | 6% (0.6) | 0% (0.0) | 35% (3.4) | 59% (5.9) | match |
| hin_Deva | lang | 4.9 | 109.6 | ×22.35 | ×4.66 | 7% (0.6) | 0% (0.0) | 47% (3.8) | 46% (3.8) | match |
| jpn_Jpan | lang | 4.6 | 116.2 | ×25.16 | ×3.07 | 8% (0.6) | 0% (0.0) | 46% (3.3) | 45% (3.2) | match |
| kat_Geor | lang | 5.3 | 129.9 | ×24.38 | ×5.14 | 9% (0.6) | 0% (0.0) | 44% (2.8) | 47% (3.0) | match |
| kor_Hang | lang | 3.4 | 76.9 | ×22.81 | ×1.69 | 5% (0.6) | 0% (0.0) | 33% (3.7) | 62% (7.1) | match |
| rus_Cyrl | lang | 4.3 | 98.7 | ×23.20 | ×4.38 | 7% (0.6) | 0% (0.0) | 36% (3.1) | 57% (5.0) | match |
| tam_Taml | lang | 5.4 | 126.0 | ×23.32 | ×4.35 | 9% (0.6) | 0% (0.0) | 48% (3.2) | 43% (2.9) | match |
| tha_Thai | lang | 6.0 | 105.3 | ×17.55 | ×3.72 | 7% (0.6) | 0% (0.0) | 39% (3.2) | 54% (4.4) | match |
| added_normalized_dense | modalities | 4.2 | 144.0 | ×34.43 | ×3.12 | 12% (0.7) | 0% (0.0) | 33% (2.1) | 55% (3.5) | match |
| added_normalized_sparse | modalities | 3.9 | 101.1 | ×25.99 | ×2.77 | 15% (1.4) | 0% (0.0) | 35% (3.2) | 51% (4.6) | match |
| added_special_dense | modalities | 3.3 | 75.4 | ×22.82 | ×1.38 | 40% (5.1) | 0% (0.0) | 41% (5.3) | 19% (2.4) | match |
| added_special_sparse | modalities | 3.4 | 69.2 | ×20.16 | ×2.02 | 23% (3.2) | 0% (0.0) | 43% (6.0) | 34% (4.8) | match |
| agentic-traces | modalities | 3.0 | 62.7 | ×20.77 | ×2.80 | 13% (1.9) | 0% (0.0) | 34% (5.1) | 53% (7.8) | match |
| agentic_swe | modalities | 3.5 | 82.7 | ×23.71 | ×3.85 | 12% (1.4) | 0% (0.0) | 34% (3.8) | 54% (6.0) | match |
| code_mixed | modalities | 3.4 | 75.0 | ×21.78 | ×2.54 | 14% (1.7) | 0% (0.0) | 36% (4.4) | 50% (6.2) | match |
| math_latex | modalities | 3.1 | 63.6 | ×20.61 | ×2.86 | 14% (2.0) | 0% (0.0) | 34% (4.9) | 52% (7.5) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.39 | 4.77 | 5.53 | 30.8 | 14.1 | 7.0 | 4.7 | 6.5× / 5.6× | 3.0× / 2.6× | 1.5× / 1.3× | 1.0× / 0.8× |
| arb_Arab | 1.01 | 3.00 | 3.34 | 5.33 | 35.2 | 15.7 | 7.7 | 5.0 | 10.5× / 6.6× | 4.7× / 2.9× | 2.3× / 1.4× | 1.5× / 0.9× |
| ben_Beng | 1.47 | 2.95 | 3.68 | 5.16 | 24.5 | 10.5 | 5.5 | 2.8 | 6.7× / 4.7× | 2.9× / 2.0× | 1.5× / 1.1× | 0.8× / 0.5× |
| cmn_Hani | 1.12 | 2.34 | 3.51 | 4.73 | 22.0 | 10.6 | 5.5 | 2.5 | 6.2× / 4.6× | 3.0× / 2.2× | 1.6× / 1.2× | 0.7× / 0.5× |
| ell_Grek | 0.58 | 3.14 | 3.22 | 5.77 | 31.0 | 14.8 | 7.0 | 5.0 | 9.6× / 5.4× | 4.6× / 2.6× | 2.2× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.10 | 1.45 | 4.69 | 6.04 | 45.9 | 28.4 | 13.5 | 4.2 | 9.8× / 7.6× | 6.0× / 4.7× | 2.9× / 2.2× | 0.9× / 0.7× |
| heb_Hebr | 1.01 | 3.16 | 3.40 | 5.55 | 34.6 | 16.9 | 8.1 | 2.9 | 10.2× / 6.2× | 5.0× / 3.0× | 2.4× / 1.5× | 0.8× / 0.5× |
| hin_Deva | 1.37 | 3.10 | 3.79 | 5.52 | 26.8 | 12.4 | 6.4 | 3.1 | 7.1× / 4.9× | 3.3× / 2.3× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.55 | 3.38 | 3.29 | 5.12 | 20.7 | 9.1 | 4.8 | 3.8 | 6.3× / 4.0× | 2.8× / 1.8× | 1.4× / 0.9× | 1.1× / 0.7× |
| kat_Geor | 1.39 | 2.56 | 2.82 | 3.98 | 19.1 | 9.8 | 4.6 | 2.2 | 6.8× / 4.8× | 3.5× / 2.5× | 1.6× / 1.2× | 0.8× / 0.6× |
| kor_Hang | 1.10 | 2.72 | 3.74 | 5.36 | 34.2 | 18.6 | 9.0 | 3.6 | 9.1× / 6.4× | 5.0× / 3.5× | 2.4× / 1.7× | 1.0× / 0.7× |
| rus_Cyrl | 1.02 | 3.01 | 3.09 | 5.09 | 29.7 | 14.4 | 6.7 | 4.8 | 9.6× / 5.8× | 4.7× / 2.8× | 2.2× / 1.3× | 1.6× / 0.9× |
| tam_Taml | 0.92 | 2.94 | 3.21 | 5.23 | 19.5 | 8.5 | 4.3 | 2.9 | 6.1× / 3.7× | 2.6× / 1.6× | 1.3× / 0.8× | 0.9× / 0.6× |
| tha_Thai | 1.37 | 2.55 | 3.23 | 4.42 | 13.3 | 5.5 | 2.8 | 2.3 | 4.1× / 3.0× | 1.7× / 1.2× | 0.9× / 0.6× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.47 | 2.10 | 3.52 | 35.3 | 17.1 | 11.2 | 2.2 | 16.8× / 10.0× | 8.1× / 4.9× | 5.3× / 3.2× | 1.1× / 0.6× |
| added_normalized_sparse | 0.06 | 1.48 | 3.19 | 4.61 | 37.6 | 20.2 | 11.5 | 2.9 | 11.8× / 8.2× | 6.3× / 4.4× | 3.6× / 2.5× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.47 | 5.29 | 6.71 | 92.0 | 66.3 | 23.8 | 3.2 | 17.4× / 13.7× | 12.5× / 9.9× | 4.5× / 3.6× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 6.01 | 7.43 | 61.3 | 40.6 | 16.8 | 3.8 | 10.2× / 8.3× | 6.8× / 5.5× | 2.8× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.58 | 1.48 | 5.10 | 6.00 | 55.9 | 40.7 | 16.7 | 4.9 | 11.0× / 9.3× | 8.0× / 6.8× | 3.3× / 2.8× | 1.0× / 0.8× |
| agentic_swe | 0.52 | 1.45 | 3.77 | 4.69 | 56.6 | 47.5 | 17.0 | 3.6 | 15.0× / 12.1× | 12.6× / 10.1× | 4.5× / 3.6× | 0.9× / 0.8× |
| code_mixed | 0.08 | 1.45 | 4.44 | 5.80 | 55.7 | 45.5 | 16.9 | 4.3 | 12.5× / 9.6× | 10.3× / 7.8× | 3.8× / 2.9× | 1.0× / 0.7× |
| math_latex | 0.57 | 1.48 | 4.91 | 5.82 | 52.7 | 35.2 | 15.6 | 4.5 | 10.7× / 9.1× | 7.2× / 6.0× | 3.2× / 2.7× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×24.97 vs v0.23.1 · ×1.97 vs base</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-glm-5-2-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 4+11 (peak 15) · Pipeline 5+2 (peak 6)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.8 | 99.3 | ×20.75 | ×1.60 | 13% (1.2) | 0% (0.0) | 39% (3.7) | 48% (4.5) | match |
| arb_Arab | lang | 4.2 | 100.6 | ×24.15 | ×1.42 | 13% (1.2) | 0% (0.0) | 26% (2.3) | 61% (5.4) | match |
| ben_Beng | lang | 3.4 | 94.2 | ×27.34 | ×1.36 | 12% (1.2) | 0% (0.0) | 32% (3.1) | 56% (5.4) | match |
| cmn_Hani | lang | 4.6 | 110.4 | ×23.92 | ×1.61 | 16% (1.2) | 0% (0.0) | 32% (2.4) | 52% (3.8) | match |
| ell_Grek | lang | 4.1 | 117.1 | ×28.66 | ×1.59 | 15% (1.2) | 0% (0.0) | 28% (2.2) | 57% (4.5) | match |
| eng_Latn | lang | 3.6 | 70.7 | ×19.54 | ×3.12 | 21% (2.7) | 1% (0.1) | 24% (3.1) | 55% (7.0) | match |
| heb_Hebr | lang | 3.9 | 106.1 | ×27.19 | ×1.61 | 13% (1.2) | 0% (0.0) | 26% (2.3) | 61% (5.4) | match |
| hin_Deva | lang | 3.2 | 93.6 | ×29.52 | ×1.49 | 11% (1.2) | 0% (0.0) | 31% (3.2) | 58% (5.9) | match |
| jpn_Jpan | lang | 4.8 | 145.5 | ×30.24 | ×1.96 | 19% (1.2) | 0% (0.0) | 35% (2.2) | 47% (2.9) | match |
| kat_Geor | lang | 4.6 | 152.0 | ×33.07 | ×1.89 | 17% (1.2) | 0% (0.0) | 31% (2.1) | 52% (3.5) | match |
| kor_Hang | lang | 3.5 | 93.4 | ×26.37 | ×1.42 | 12% (1.2) | 0% (0.0) | 25% (2.5) | 63% (6.3) | match |
| rus_Cyrl | lang | 4.1 | 115.4 | ×28.20 | ×2.87 | 14% (1.2) | 0% (0.0) | 26% (2.2) | 59% (4.9) | match |
| tam_Taml | lang | 3.2 | 107.0 | ×32.96 | ×1.51 | 13% (1.2) | 0% (0.0) | 29% (2.6) | 58% (5.4) | match |
| tha_Thai | lang | 3.9 | 103.2 | ×26.34 | ×1.41 | 14% (1.2) | 0% (0.0) | 31% (2.5) | 55% (4.5) | match |
| added_normalized_dense | modalities | 4.6 | 157.4 | ×34.04 | ×3.44 | 24% (1.3) | 0% (0.0) | 20% (1.1) | 56% (3.1) | match |
| added_normalized_sparse | modalities | 4.1 | 111.3 | ×26.86 | ×2.91 | 22% (1.9) | 0% (0.0) | 26% (2.2) | 52% (4.4) | match |
| added_special_dense | modalities | 3.3 | 49.9 | ×14.97 | ×1.23 | 60% (11.8) | 0% (0.0) | 28% (5.5) | 12% (2.3) | match |
| added_special_sparse | modalities | 3.5 | 58.3 | ×16.87 | ×1.73 | 40% (6.8) | 0% (0.1) | 33% (5.4) | 27% (4.5) | match |
| agentic-traces | modalities | 3.2 | 65.9 | ×20.48 | ×2.80 | 19% (2.6) | 0% (0.0) | 27% (3.7) | 54% (7.4) | match |
| agentic_swe | modalities | 3.5 | 84.6 | ×24.52 | ×3.84 | 19% (2.0) | 0% (0.0) | 27% (2.9) | 54% (5.8) | match |
| code_mixed | modalities | 3.4 | 78.9 | ×23.45 | ×2.56 | 20% (2.3) | 0% (0.0) | 29% (3.3) | 51% (5.8) | match |
| math_latex | modalities | 3.1 | 67.3 | ×21.38 | ×2.82 | 20% (2.6) | 0% (0.0) | 26% (3.5) | 54% (7.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.42 | 3.72 | 4.50 | 26.7 | 16.3 | 5.9 | 4.8 | 7.2× / 5.9× | 4.4× / 3.6× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 3.07 | 2.31 | 4.38 | 32.7 | 19.7 | 6.8 | 5.3 | 14.1× / 7.5× | 8.5× / 4.5× | 2.9× / 1.5× | 2.3× / 1.2× |
| ben_Beng | 1.47 | 3.03 | 3.08 | 4.64 | 44.1 | 28.0 | 10.1 | 3.6 | 14.3× / 9.5× | 9.1× / 6.0× | 3.3× / 2.2× | 1.2× / 0.8× |
| cmn_Hani | 1.13 | 2.32 | 2.36 | 3.56 | 18.9 | 11.7 | 4.7 | 2.4 | 8.0× / 5.3× | 4.9× / 3.3× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.19 | 2.21 | 4.82 | 27.7 | 17.4 | 6.1 | 4.8 | 12.5× / 5.8× | 7.9× / 3.6× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.48 | 3.06 | 4.44 | 42.3 | 32.9 | 12.2 | 3.8 | 13.9× / 9.5× | 10.8× / 7.4× | 4.0× / 2.7× | 1.2× / 0.8× |
| heb_Hebr | 1.01 | 3.13 | 2.34 | 4.45 | 30.2 | 19.8 | 6.9 | 3.0 | 12.9× / 6.8× | 8.5× / 4.4× | 3.0× / 1.5× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 3.13 | 3.22 | 4.97 | 46.6 | 30.9 | 11.2 | 3.9 | 14.5× / 9.4× | 9.6× / 6.2× | 3.5× / 2.2× | 1.2× / 0.8× |
| jpn_Jpan | 1.56 | 3.40 | 2.17 | 4.02 | 17.8 | 10.1 | 4.1 | 3.8 | 8.2× / 4.4× | 4.6× / 2.5× | 1.9× / 1.0× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.62 | 2.10 | 3.32 | 16.6 | 11.2 | 4.2 | 1.9 | 7.9× / 5.0× | 5.3× / 3.4× | 2.0× / 1.3× | 0.9× / 0.6× |
| kor_Hang | 1.21 | 2.73 | 2.53 | 4.04 | 30.3 | 21.8 | 7.3 | 3.7 | 12.0× / 7.5× | 8.6× / 5.4× | 2.9× / 1.8× | 1.4× / 0.9× |
| rus_Cyrl | 1.02 | 3.03 | 2.17 | 4.19 | 26.2 | 16.6 | 6.0 | 2.4 | 12.1× / 6.3× | 7.7× / 4.0× | 2.7× / 1.4× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.94 | 2.64 | 4.65 | 43.3 | 27.1 | 9.8 | 3.3 | 16.4× / 9.3× | 10.3× / 5.8× | 3.7× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.36 | 2.66 | 2.54 | 3.84 | 27.6 | 16.4 | 6.7 | 3.0 | 10.9× / 7.2× | 6.4× / 4.3× | 2.6× / 1.7× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.13 | 2.55 | 23.1 | 17.1 | 6.4 | 1.9 | 20.5× / 9.1× | 15.2× / 6.7× | 5.6× / 2.5× | 1.7× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 2.17 | 3.58 | 30.1 | 23.2 | 8.8 | 2.6 | 13.9× / 8.4× | 10.7× / 6.5× | 4.1× / 2.5× | 1.2× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 5.45 | 6.87 | 91.2 | 74.2 | 20.9 | 3.2 | 16.7× / 13.3× | 13.6× / 10.8× | 3.8× / 3.0× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.44 | 6.86 | 59.0 | 46.4 | 14.9 | 3.5 | 10.8× / 8.6× | 8.5× / 6.8× | 2.7× / 2.2× | 0.6× / 0.5× |
| agentic-traces | 0.72 | 1.50 | 3.74 | 4.52 | 51.2 | 43.8 | 15.3 | 4.6 | 13.7× / 11.3× | 11.7× / 9.7× | 4.1× / 3.4× | 1.2× / 1.0× |
| agentic_swe | 0.54 | 1.47 | 2.88 | 3.80 | 53.7 | 50.6 | 15.7 | 3.4 | 18.7× / 14.1× | 17.6× / 13.3× | 5.5× / 4.1× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.47 | 3.26 | 4.67 | 51.1 | 49.3 | 14.9 | 4.0 | 15.7× / 11.0× | 15.1× / 10.6× | 4.6× / 3.2× | 1.2× / 0.9× |
| math_latex | 0.56 | 1.50 | 3.49 | 4.43 | 49.3 | 38.5 | 13.9 | 4.2 | 14.1× / 11.1× | 11.0× / 8.7× | 4.0× / 3.1× | 1.2× / 0.9× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.74 vs v0.23.1 · ×1.16 vs base</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-llama-2-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 23) · Pipeline 22+0 (peak 21)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.7 | 45.2 | ×7.95 | ×0.99 | 0% (0.0) | 13% (2.7) | 0% (0.0) | 87% (19.0) | match |
| arb_Arab | lang | 12.4 | 54.8 | ×4.41 | ×1.04 | 0% (0.0) | 18% (3.2) | 0% (0.0) | 82% (14.9) | match |
| ben_Beng | lang | 13.6 | 93.3 | ×6.87 | ×1.07 | 0% (0.0) | 20% (2.1) | 0% (0.0) | 79% (8.4) | match |
| cmn_Hani | lang | 11.3 | 74.0 | ×6.56 | ×1.09 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 96% (12.6) | match |
| ell_Grek | lang | 12.7 | 64.9 | ×5.10 | ×1.09 | 0% (0.0) | 20% (3.1) | 0% (0.0) | 79% (12.2) | match |
| eng_Latn | lang | 4.4 | 6.6 | ×1.50 | ×1.07 | 0% (0.0) | 4% (6.8) | 0% (0.0) | 96% (147.9) | match |
| heb_Hebr | lang | 12.4 | 68.8 | ×5.53 | ×1.08 | 0% (0.0) | 23% (3.3) | 0% (0.0) | 77% (10.9) | match |
| hin_Deva | lang | 14.8 | 84.2 | ×5.71 | ×1.00 | 0% (0.0) | 24% (2.8) | 0% (0.0) | 76% (9.0) | match |
| jpn_Jpan | lang | 15.6 | 94.7 | ×6.06 | ×1.09 | 1% (0.1) | 3% (0.3) | 0% (0.0) | 96% (9.8) | match |
| kat_Geor | lang | 17.5 | 104.6 | ×5.97 | ×1.11 | 1% (0.0) | 20% (1.9) | 0% (0.0) | 80% (7.6) | match |
| kor_Hang | lang | 8.6 | 57.3 | ×6.67 | ×1.06 | 0% (0.1) | 19% (3.3) | 0% (0.0) | 81% (13.9) | match |
| rus_Cyrl | lang | 8.8 | 16.9 | ×1.91 | ×1.03 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (56.0) | match |
| tam_Taml | lang | 15.6 | 101.8 | ×6.51 | ×1.08 | 0% (0.0) | 18% (1.7) | 0% (0.0) | 82% (8.0) | match |
| tha_Thai | lang | 19.6 | 96.5 | ×4.92 | ×1.06 | 0% (0.0) | 9% (0.9) | 0% (0.0) | 91% (9.2) | match |
| added_normalized_dense | modalities | 6.0 | 8.9 | ×1.47 | ×1.02 | 0% (0.1) | 3% (3.8) | 0% (0.0) | 97% (109.6) | match |
| added_normalized_sparse | modalities | 5.2 | 7.9 | ×1.50 | ×1.05 | 0% (0.1) | 5% (5.9) | 0% (0.1) | 95% (123.7) | match |
| added_special_dense | modalities | 5.3 | 39.7 | ×7.51 | ×2.01 | 21% (5.1) | 66% (15.8) | 6% (1.4) | 7% (1.7) | match |
| added_special_sparse | modalities | 7.5 | 47.4 | ×6.35 | ×4.60 | 12% (2.1) | 77% (13.9) | 1% (0.3) | 10% (1.8) | match |
| agentic-traces | modalities | 4.7 | 7.4 | ×1.57 | ×1.04 | 0% (0.1) | 5% (6.1) | 0% (0.0) | 95% (128.5) | match |
| agentic_swe | modalities | 4.4 | 7.7 | ×1.76 | ×1.03 | 0% (0.0) | 7% (9.7) | 0% (0.0) | 93% (122.1) | match |
| code_mixed | modalities | 4.5 | 7.5 | ×1.67 | ×1.04 | 0% (0.0) | 6% (7.9) | 0% (0.0) | 94% (128.1) | match |
| math_latex | modalities | 4.6 | 6.9 | ×1.50 | ×1.04 | 0% (0.1) | 4% (6.3) | 0% (0.0) | 96% (136.5) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×21.78 vs v0.23.1 · ×3.54 vs base</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-llama-3-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 143+0 (peak 199) · Pipeline 144+0 (peak 200)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.8 | 103.0 | ×21.60 | ×2.01 | 7% (0.7) | 0% (0.0) | 41% (3.7) | 52% (4.6) | match |
| arb_Arab | lang | 5.1 | 115.5 | ×22.83 | ×6.61 | 7% (0.6) | 0% (0.0) | 28% (2.3) | 64% (5.2) | match |
| ben_Beng | lang | 4.3 | 108.2 | ×24.93 | ×3.42 | 7% (0.6) | 0% (0.0) | 34% (3.1) | 59% (5.3) | match |
| cmn_Hani | lang | 5.5 | 106.1 | ×19.27 | ×6.79 | 7% (0.6) | 0% (0.0) | 26% (2.4) | 67% (6.0) | match |
| ell_Grek | lang | 5.6 | 136.1 | ×24.37 | ×6.93 | 9% (0.6) | 0% (0.0) | 31% (2.2) | 60% (4.2) | match |
| eng_Latn | lang | 4.5 | 88.4 | ×19.51 | ×2.62 | 20% (2.1) | 0% (0.0) | 31% (3.1) | 49% (5.0) | match |
| heb_Hebr | lang | 4.6 | 109.2 | ×23.61 | ×4.02 | 7% (0.6) | 0% (0.0) | 27% (2.3) | 66% (5.6) | match |
| hin_Deva | lang | 4.7 | 130.2 | ×27.69 | ×1.72 | 8% (0.6) | 0% (0.0) | 44% (3.2) | 47% (3.4) | match |
| jpn_Jpan | lang | 6.2 | 134.8 | ×21.59 | ×8.52 | 10% (0.6) | 0% (0.0) | 35% (2.2) | 55% (3.3) | match |
| kat_Geor | lang | 6.0 | 165.4 | ×27.76 | ×4.15 | 11% (0.6) | 0% (0.0) | 37% (2.1) | 52% (2.9) | match |
| kor_Hang | lang | 4.4 | 76.8 | ×17.36 | ×4.28 | 5% (0.6) | 0% (0.0) | 22% (2.5) | 73% (8.4) | match |
| rus_Cyrl | lang | 5.6 | 125.3 | ×22.54 | ×7.89 | 8% (0.6) | 0% (0.0) | 29% (2.1) | 63% (4.7) | match |
| tam_Taml | lang | 4.4 | 113.4 | ×25.87 | ×3.21 | 7% (0.6) | 0% (0.0) | 32% (2.7) | 61% (5.1) | match |
| tha_Thai | lang | 5.8 | 120.0 | ×20.66 | ×5.91 | 14% (1.2) | 0% (0.0) | 31% (2.5) | 62% (5.1) | match |
| added_normalized_dense | modalities | 6.5 | 198.3 | ×30.37 | ×7.18 | 18% (0.8) | 0% (0.0) | 27% (1.1) | 56% (2.4) | match |
| added_normalized_sparse | modalities | 6.0 | 144.7 | ×24.17 | ×3.35 | 21% (1.3) | 0% (0.0) | 33% (2.0) | 47% (2.9) | match |
| added_special_dense | modalities | 4.6 | 79.3 | ×17.36 | ×1.14 | 33% (5.6) | 1% (0.1) | 35% (6.1) | 31% (5.4) | match |
| added_special_sparse | modalities | 4.8 | 83.6 | ×17.44 | ×1.20 | 25% (3.3) | 7% (0.9) | 40% (5.2) | 27% (3.6) | match |
| agentic-traces | modalities | 4.1 | 73.0 | ×17.96 | ×2.43 | 17% (1.9) | 0% (0.0) | 32% (3.7) | 51% (5.8) | match |
| agentic_swe | modalities | 4.4 | 92.1 | ×20.80 | ×3.62 | 16% (1.4) | 0% (0.0) | 32% (2.9) | 52% (4.6) | match |
| code_mixed | modalities | 4.4 | 86.2 | ×19.80 | ×2.12 | 18% (1.7) | 0% (0.0) | 35% (3.3) | 47% (4.4) | match |
| math_latex | modalities | 3.9 | 70.9 | ×18.07 | ×2.21 | 19% (2.1) | 0% (0.0) | 32% (3.5) | 50% (5.4) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.70 | 3.46 | 3.68 | 4.44 | 27.4 | 16.3 | 5.9 | 4.8 | 7.5× / 6.2× | 4.4× / 3.7× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 3.06 | 2.30 | 4.36 | 30.9 | 19.2 | 6.8 | 5.2 | 13.4× / 7.1× | 8.3× / 4.4× | 2.9× / 1.6× | 2.3× / 1.2× |
| ben_Beng | 1.46 | 2.93 | 3.06 | 4.52 | 45.4 | 29.5 | 10.3 | 3.6 | 14.8× / 10.0× | 9.6× / 6.5× | 3.4× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.14 | 2.34 | 2.35 | 3.55 | 19.7 | 11.8 | 4.8 | 2.4 | 8.4× / 5.5× | 5.0× / 3.3× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.99 | 2.19 | 4.59 | 28.3 | 17.2 | 6.2 | 4.8 | 13.0× / 6.2× | 7.9× / 3.7× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.47 | 3.14 | 4.51 | 43.9 | 32.8 | 12.4 | 3.8 | 14.0× / 9.7× | 10.5× / 7.3× | 4.0× / 2.8× | 1.2× / 0.8× |
| heb_Hebr | 1.01 | 3.12 | 2.30 | 4.41 | 30.9 | 19.7 | 6.9 | 3.0 | 13.5× / 7.0× | 8.6× / 4.5× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 3.10 | 3.19 | 4.93 | 47.9 | 31.7 | 11.0 | 3.9 | 15.0× / 9.7× | 9.9× / 6.4× | 3.5× / 2.2× | 1.2× / 0.8× |
| jpn_Jpan | 1.56 | 3.36 | 2.15 | 3.96 | 18.0 | 9.8 | 4.1 | 3.8 | 8.4× / 4.6× | 4.6× / 2.5× | 1.9× / 1.0× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.55 | 2.08 | 3.23 | 16.9 | 11.1 | 4.1 | 2.0 | 8.1× / 5.2× | 5.3× / 3.4× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.08 | 2.77 | 2.50 | 4.18 | 31.1 | 21.9 | 7.4 | 3.7 | 12.4× / 7.4× | 8.8× / 5.2× | 3.0× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.97 | 2.13 | 4.09 | 27.6 | 16.3 | 5.8 | 2.5 | 12.9× / 6.7× | 7.7× / 4.0× | 2.7× / 1.4× | 1.2× / 0.6× |
| tam_Taml | 0.92 | 2.94 | 2.65 | 4.67 | 44.3 | 26.4 | 9.9 | 3.5 | 16.7× / 9.5× | 10.0× / 5.7× | 3.8× / 2.1× | 1.3× / 0.8× |
| tha_Thai | 1.36 | 2.61 | 2.53 | 3.79 | 32.8 | 20.3 | 6.6 | 3.0 | 12.9× / 8.7× | 8.0× / 5.4× | 2.6× / 1.7× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.15 | 2.57 | 23.8 | 17.1 | 6.6 | 1.9 | 20.7× / 9.3× | 14.8× / 6.6× | 5.7× / 2.6× | 1.7× / 0.8× |
| added_normalized_sparse | 0.06 | 1.48 | 2.03 | 3.46 | 31.3 | 29.5 | 11.1 | 2.9 | 15.4× / 9.1× | 14.5× / 8.5× | 5.4× / 3.2× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 2.67 | 6.08 | 8.68 | 94.9 | 102.1 | 22.2 | 3.5 | 15.6× / 10.9× | 16.8× / 11.8× | 3.7× / 2.6× | 0.6× / 0.4× |
| added_special_sparse | 0.06 | 1.68 | 5.24 | 6.86 | 61.0 | 48.0 | 15.5 | 3.5 | 11.7× / 8.9× | 9.2× / 7.0× | 3.0× / 2.3× | 0.7× / 0.5× |
| agentic-traces | 0.57 | 1.50 | 3.71 | 4.64 | 52.9 | 44.7 | 15.2 | 4.6 | 14.2× / 11.4× | 12.0× / 9.6× | 4.1× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.53 | 1.48 | 2.86 | 3.81 | 55.5 | 51.0 | 15.6 | 3.4 | 19.4× / 14.6× | 17.9× / 13.4× | 5.5× / 4.1× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.45 | 3.27 | 4.66 | 53.2 | 50.7 | 15.2 | 4.0 | 16.2× / 11.4× | 15.5× / 10.9× | 4.7× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.71 | 1.49 | 3.48 | 4.26 | 51.0 | 39.4 | 14.8 | 4.2 | 14.7× / 12.0× | 11.3× / 9.2× | 4.3× / 3.5× | 1.2× / 1.0× |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-29913446346-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
