### PR TITLE
feat(pipeline): Decode benches and stub

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Render the fixture_bench JSON as charts + a markdown PR report.
 
-Two series: `baseline` (the latest released `tokenizers` crate — the bar to beat,
-drawn gray; the in-tree `Tokenizer` isn't benched, it's only the id oracle behind
-`ids_match`) and `pipeline` (the experimental PipelineTokenizer, blue). Leads with
+Two series: `baseline` (the latest released `tokenizers` crate — the bar to beat
+AND the correctness reference, drawn gray; the in-tree `Tokenizer`, being removed,
+only builds the pipeline) and `pipeline` (the experimental PipelineTokenizer,
+blue). `ids_match`/`text_match` compare the pipeline against the release. Leads with
 three always-visible charts — per-model geomean ×speedup, memory footprint, binary
 size — then one collapsed <details> per model (per-fixture speedup, thread scaling,
 stage mix, numbers table). Models the pipeline can't build yet render as "not
@@ -105,6 +106,23 @@ def speedup(row):
 
 def model_speedups(model):
     return [v for v in (speedup(r) for r in model["results"]) if v]
+
+
+def decode_speedup(row):
+    m = row.get("decode_mbps") or {}
+    b, p = m.get("baseline"), m.get("pipeline")
+    return p / b if b and p else None
+
+
+def decode_model_speedups(model):
+    return [v for v in (decode_speedup(r) for r in model["results"]) if v]
+
+
+def has_decode_baseline(model):
+    """True once any fixture carries a released-crate decode number — the decode
+    section renders (baseline bar + pipeline 'pending') even before the pipeline
+    can decode."""
+    return any((r.get("decode_mbps") or {}).get("baseline") for r in model["results"])
 
 
 def base_speedup(row, base_lookup, model_name):
@@ -287,9 +305,13 @@ def overview_svg(models, subtitle_base, meta, lo, hi, baseline_label,
     return svg_doc(ink, height, title, subtitle, axis + "".join(body) + legend, meta)
 
 
-def memory_svg(models, meta, baseline_label):
+def memory_svg(models, meta, baseline_label, pass_key="encode_bytes",
+               pass_label="encode", title="Memory footprint"):
     """Per model: resident-set delta of each implementation — load footprint plus
-    the encode-pass delta as stacked segments, peak RSS as a tick."""
+    the `pass_key`-pass delta as stacked segments, peak RSS as a tick. `pass_key`
+    selects the encode-pass or the decode-pass delta (same chart, both directions).
+    A model with no `pass_key` data for either impl is dropped (e.g. decode while
+    the pipeline stub means only the baseline bar is drawn)."""
     ink, sink = INK, SERIES_INK
     models = [m for m in models if isinstance(m.get("memory"), dict)]
 
@@ -297,19 +319,25 @@ def memory_svg(models, meta, baseline_label):
         d = m["memory"].get(impl)
         if not isinstance(d, dict):
             return None
-        return {k: max(0, d[k]) / 1e6 if d.get(k) is not None else None
-                for k in ("load_bytes", "encode_bytes", "peak_bytes")}
+        pick = {"load_bytes": "load_bytes", "pass": pass_key, "peak_bytes": "peak_bytes"}
+        return {k: max(0, d[src]) / 1e6 if d.get(src) is not None else None
+                for k, src in pick.items()}
+
+    models = [m for m in models
+              if any((mem(m, impl) or {}).get("pass") is not None
+                     or (mem(m, impl) or {}).get("load_bytes") is not None
+                     for impl in ("baseline", "pipeline"))]
 
     vals = []
     for m in models:
         for impl in ("baseline", "pipeline"):
             d = mem(m, impl)
-            if d:
-                vals.append((d["load_bytes"] or 0) + (d["encode_bytes"] or 0))
+            if d and d["load_bytes"] is not None:
+                vals.append((d["load_bytes"] or 0) + (d["pass"] or 0))
                 if d["peak_bytes"]:
                     vals.append(d["peak_bytes"])
     if not vals:
-        return svg_doc(ink, 120, "Memory footprint", "no data", "", meta)
+        return svg_doc(ink, 120, title, "no data", "", meta)
     max_mb = max(vals) * 1.05
 
     def x(v):
@@ -320,7 +348,7 @@ def memory_svg(models, meta, baseline_label):
     body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
             f'text-anchor="end">MB: {escape(baseline_label)} → Pipeline</text>',
             f'<text x="{OV_GUTTER}" y="{top - 14}" fill="{ink["muted"]}" font-size="11">'
-            f'smaller is better · solid: after load · translucent: encode-pass delta</text>']
+            f'smaller is better · solid: after load · translucent: {escape(pass_label)}-pass delta</text>']
     y = top
     for m in models:
         cy = y + row_h / 2
@@ -330,11 +358,11 @@ def memory_svg(models, meta, baseline_label):
         by = y + 8
         for impl in ("baseline", "pipeline"):
             d = mem(m, impl)
-            if not d:
+            if not d or d["load_bytes"] is None:
                 totals.append(None)
                 by += bar_h + 3
                 continue
-            load, enc = d["load_bytes"] or 0, d["encode_bytes"] or 0
+            load, enc = d["load_bytes"] or 0, d["pass"] or 0
             totals.append(load + enc)
             body.append(f'<rect x="{x(0):.1f}" y="{by:.1f}" width="{max(1.5, x(load) - x(0)):.1f}" '
                         f'height="{bar_h}" rx="2" fill="{sink[impl]}"/>')
@@ -360,9 +388,8 @@ def memory_svg(models, meta, baseline_label):
         ("tick", ink["primary"], "peak RSS (VmHWM)"),
     ])
     height = y + 34
-    subtitle = "resident-set delta per implementation, one process each · load + encode pass"
-    return svg_doc(ink, height, "Memory footprint",
-                   subtitle, grid + "".join(body) + legend, meta)
+    subtitle = f"resident-set delta per implementation, one process each · load + {pass_label} pass"
+    return svg_doc(ink, height, title, subtitle, grid + "".join(body) + legend, meta)
 
 
 def chart_svg(model, subtitle_base, meta, lo, hi, baseline_label):
@@ -378,7 +405,6 @@ def chart_svg(model, subtitle_base, meta, lo, hi, baseline_label):
     body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
             f'text-anchor="end">MB/s: {escape(baseline_label)} → Pipeline</text>']
     y = top
-    baseline_id_note = False
     for key, title in GROUPS:
         # stable order (alphabetical) so a fixture keeps its row across runs and
         # lines up with the stage chart — not sorted by the (run-varying) speedup.
@@ -390,12 +416,8 @@ def chart_svg(model, subtitle_base, meta, lo, hi, baseline_label):
                     f'font-weight="600" letter-spacing="1.2" text-anchor="end" dx="-10">{title.upper()}</text>')
         y += 22
         for r in group_rows:
-            label = r["fixture"]
-            if r.get("ids_match_baseline") is False:
-                label += " †"
-                baseline_id_note = True
             body.append(f'<text x="{GUTTER - 10}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
-                        f'font-size="12.5" text-anchor="end">{escape(label)}</text>')
+                        f'font-size="12.5" text-anchor="end">{escape(r["fixture"])}</text>')
             v = speedup(r)
             by = y + (ROW_H - BAR_H) / 2
             if v:
@@ -434,9 +456,145 @@ def chart_svg(model, subtitle_base, meta, lo, hi, baseline_label):
         parts.append(f"geomean ×{geomean(vals):.2f} vs {baseline_label}")
     else:
         parts.append(f"{baseline_label} can’t load this model — no comparison")
-    if baseline_id_note:
-        parts.append(f"† ids differ from {baseline_label}")
     return svg_doc(ink, height, f'{model["model"]} — PipelineTokenizer encode throughput',
+                   " · ".join(parts), axis + "".join(body) + legend, meta, subtitle_base)
+
+
+def decode_overview_svg(models, subtitle_base, meta, lo, hi, baseline_label):
+    """Headline decode chart, twin of `overview_svg`: per-model geomean ×speedup of
+    pipeline decode vs the released crate (×1.0), min–max whisker across fixtures.
+    Same row set as the encode overview — models whose decode isn't implemented yet
+    show a muted 'pending' row, ones the pipeline can't build show 'not supported'."""
+    ink, sink = INK, SERIES_INK
+    title = "PipelineTokenizer vs latest release — decode throughput"
+    x = log_x(OV_GUTTER, OV_PLOT, lo, hi)
+    ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x, min_px=34, keep=1.0)
+
+    top, row_h = 74, 40
+    col_x = CHART_W - 16
+    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+            f'text-anchor="end">fixtures · text</text>']
+    y = top
+    for m in models:
+        cy = y + row_h / 2
+        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy - 3:.1f}" fill="{ink["primary"]}" '
+                    f'font-size="12.5" font-weight="600" text-anchor="end">{escape(m["model"])}</text>')
+        desc = m.get("desc") or m["shape"]
+        body.append(f'<text x="{OV_GUTTER - 14}" y="{cy + 11:.1f}" fill="{ink["muted"]}" '
+                    f'font-size="10.5" text-anchor="end">{escape(desc)}</text>')
+        vals = decode_model_speedups(m)
+        if vals:
+            g, mn, mx = geomean(vals), min(vals), max(vals)
+            body.append(hbar(x(1.0), x(g), cy - 7, 14, sink["pipeline"]))
+            body.append(f'<line x1="{x(mn):.1f}" y1="{cy:.1f}" x2="{x(mx):.1f}" y2="{cy:.1f}" '
+                        f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
+            for v in (mn, mx):
+                body.append(f'<line x1="{x(v):.1f}" y1="{cy - 4:.1f}" x2="{x(v):.1f}" y2="{cy + 4:.1f}" '
+                            f'stroke="{ink["secondary"]}" stroke-width="1.5"/>')
+            anchor, lx = (("start", max(x(mx), x(1.0)) + 8) if g >= 1
+                          else ("end", min(x(mn), x(1.0)) - 8))
+            if anchor == "end" and lx - 40 < OV_GUTTER + 4:
+                anchor, lx = "start", max(x(mx), x(1.0)) + 8
+            body.append(f'<text x="{lx:.1f}" y="{cy + 4:.1f}" fill="{ink["primary"]}" font-size="12" '
+                        f'font-weight="600" text-anchor="{anchor}" '
+                        f'style="font-variant-numeric:tabular-nums">×{g:.2f}</text>')
+            bad = sum(1 for r in m["results"] if r.get("text_match") is False)
+            right, fill = ((f"⚠ {bad} differ", ink["critical"]) if bad
+                           else (f'{len(m["results"])} · text ok', ink["secondary"]))
+            body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{fill}" font-size="12" '
+                        f'text-anchor="end" style="font-variant-numeric:tabular-nums">{right}</text>')
+        elif not m["results"]:
+            pretok = m["shape"].split("·")[-1].strip()
+            why = (m.get("reason") or f"no {pretok} pre-tokenizer")
+            body.append(f'<text x="{x(1.0) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["muted"]}" '
+                        f'font-size="11.5" font-style="italic">not supported — {escape(why)}</text>')
+            body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{ink["muted"]}" font-size="12" '
+                        f'text-anchor="end">—</text>')
+        elif m.get("decode_reason"):
+            body.append(f'<text x="{x(1.0) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["muted"]}" '
+                        f'font-size="11.5" font-style="italic">decode pending — not implemented yet</text>')
+            body.append(f'<text x="{col_x}" y="{cy + 4:.1f}" fill="{ink["muted"]}" font-size="12" '
+                        f'text-anchor="end">—</text>')
+        else:
+            msg = f"{baseline_label} can’t decode this model — no comparison"
+            body.append(f'<text x="{x(1.0) + 8:.1f}" y="{cy + 4:.1f}" fill="{ink["muted"]}" '
+                        f'font-size="11.5" font-style="italic">{escape(msg)}</text>')
+        y += row_h
+
+    axis = speedup_axis(ink, x, ticks, top, y + 4)
+    y += 30
+    legend = legend_row(ink, sink, y, [
+        ("swatch", "pipeline", "PipelineTokenizer decode"),
+        ("tick", ink["baseline"], f"×1.0 = {baseline_label}"),
+    ])
+    height = y + 34
+    subtitle = (f"geomean ×speedup per model vs {baseline_label} · "
+                f"whisker: min–max across fixtures · {subtitle_base}")
+    return svg_doc(ink, height, title, subtitle, axis + "".join(body) + legend, meta)
+
+
+def decode_chart_svg(model, subtitle_base, meta, lo, hi, baseline_label):
+    """Per-fixture decode ×speedup vs the release, twin of `chart_svg`. Rows with no
+    pipeline decode yet show the baseline number and a blank (pending) bar."""
+    ink, sink = INK, SERIES_INK
+    rows = model["results"]
+    x = log_x(GUTTER, PLOT_W, lo, hi)
+    ticks = thin_ticks([t for t in TICKS if lo <= t <= hi], x, min_px=34, keep=1.0)
+
+    top = 74
+    col_x = GUTTER + PLOT_W + PAD_R + COL_W - 16
+    body = [f'<text x="{col_x}" y="{top - 14}" fill="{ink["muted"]}" font-size="11" '
+            f'text-anchor="end">MB/s: {escape(baseline_label)} → Pipeline</text>']
+    y = top
+    for key, gtitle in GROUPS:
+        group_rows = sorted((r for r in rows if r["group"] == key), key=lambda r: r["fixture"])
+        if not group_rows:
+            continue
+        body.append(f'<text x="{GUTTER}" y="{y + 12}" fill="{ink["secondary"]}" font-size="11" '
+                    f'font-weight="600" letter-spacing="1.2" text-anchor="end" dx="-10">{gtitle.upper()}</text>')
+        y += 22
+        for r in group_rows:
+            body.append(f'<text x="{GUTTER - 10}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
+                        f'font-size="12.5" text-anchor="end">{escape(r["fixture"])}</text>')
+            v = decode_speedup(r)
+            by = y + (ROW_H - BAR_H) / 2
+            if v:
+                body.append(hbar(x(1.0), x(v), by, BAR_H, sink["pipeline"]))
+                txt = f"×{v:.2f}"
+                fill = ink["primary"]
+                if r.get("text_match") is False:
+                    txt += "  ⚠ text differs"
+                    fill = ink["critical"]
+                anchor, lx = ("start", max(x(1.0), x(v)) + 6) if v >= 1 else ("end", min(x(1.0), x(v)) - 6)
+                if anchor == "end" and lx - len(txt) * 6.7 < GUTTER + 4:
+                    anchor, lx = "start", x(1.0) + 6
+                body.append(f'<text x="{lx:.1f}" y="{y + ROW_H / 2 + 4}" fill="{fill}" '
+                            f'font-size="12" font-weight="600" text-anchor="{anchor}" '
+                            f'style="font-variant-numeric:tabular-nums">{txt}</text>')
+            mb = r.get("decode_mbps") or {}
+            body.append(f'<text x="{col_x}" y="{y + ROW_H / 2 + 4}" fill="{ink["secondary"]}" '
+                        f'font-size="12" text-anchor="end" style="font-variant-numeric:tabular-nums">'
+                        f'{chain([mb.get("baseline"), mb.get("pipeline")])}</text>')
+            y += ROW_H
+        y += 10
+
+    axis = speedup_axis(ink, x, ticks, top, y)
+    y += 26
+    legend = legend_row(ink, sink, y, [
+        ("swatch", "pipeline", "PipelineTokenizer decode"),
+        ("tick", ink["baseline"], f"×1.0 = {baseline_label}"),
+    ])
+    height = y + 44
+
+    parts = [model["shape"]]
+    vals = decode_model_speedups(model)
+    if vals:
+        parts.append(f"geomean ×{geomean(vals):.2f} vs {baseline_label}")
+    elif model.get("decode_reason"):
+        parts.append("decode pending — not implemented yet")
+    else:
+        parts.append(f"{baseline_label} can’t decode this model — no comparison")
+    return svg_doc(ink, height, f'{model["model"]} — PipelineTokenizer decode throughput',
                    " · ".join(parts), axis + "".join(body) + legend, meta, subtitle_base)
 
 
@@ -647,18 +805,20 @@ def binsize_svg(sizes, meta, baseline_label):
                    subtitle, grid + "".join(body), meta)
 
 
-def has_threads(m):
-    t = m.get("threads")
+def has_threads(m, key="threads"):
+    t = m.get(key)
     return isinstance(t, dict) and bool(t.get("counts"))
 
 
-def threads_svg(model, meta, baseline_label):
-    """Per model: encode throughput (MB/s) at 1/2/4/8/device-max threads — pipeline
-    vs the release — with a per-row *ideal linear* tick (single-thread × N) on the
+def threads_svg(model, meta, baseline_label, threads_key="threads", title="Thread scaling"):
+    """Per model: throughput (MB/s) at 1/2/4/8/device-max threads — pipeline vs the
+    release — with a per-row *ideal linear* tick (single-thread × N) on the
     pipeline bar, so linear vs sub-linear scaling is visible at a glance alongside
-    the pipeline↔release gap; the right column carries self-scaling % of linear."""
+    the pipeline↔release gap; the right column carries self-scaling % of linear.
+    `threads_key` selects the encode (`threads`) or decode (`decode_threads`) sweep;
+    a `null` pipeline series (decode while stubbed) draws baseline-only."""
     ink, sink = INK, SERIES_INK
-    t = model["threads"]
+    t = model[threads_key]
     counts, pipe, base = t["counts"], t["pipeline_mbps"], t["baseline_mbps"]
     p1 = pipe[0] if pipe and pipe[0] else None  # single-thread anchor for the linear reference
     ideal = [p1 * n for n in counts] if p1 else []
@@ -715,7 +875,7 @@ def threads_svg(model, meta, baseline_label):
         sc = pipe[-1] / p1
         scaling = f" · pipeline {sc:.1f}× on {counts[-1]} threads ({sc / counts[-1] * 100:.0f}% of linear)"
     subtitle = f"throughput at N threads vs {baseline_label}; tick = perfect linear scaling{scaling}"
-    return svg_doc(ink, height, "Thread scaling",
+    return svg_doc(ink, height, title,
                    subtitle, grid + "".join(body) + legend, meta)
 
 
@@ -766,8 +926,8 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
     unsupported = [m for m in models if not m["results"]]
     mismatches = [f"{m['model']}/{r['fixture']}"
                   for m in benched for r in m["results"] if r["ids_match"] is False]
-    base_mismatch = sorted({m["model"] for m in benched
-                            for r in m["results"] if r.get("ids_match_baseline") is False})
+    text_mismatches = [f"{m['model']}/{r['fixture']}"
+                       for m in benched for r in m["results"] if r.get("text_match") is False]
 
     md = ["## PipelineTokenizer benchmark", "",
           f"**{len(benched)} / {len(models)} models supported** — PipelineTokenizer vs "
@@ -782,13 +942,18 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
     if sizes:
         md += [picture(base, run_id, "binsize", "Minimal encode binary size", 860), ""]
 
+    md += ["### Decode", "",
+           picture(base, run_id, "decode-overview",
+                   "Per-model decode throughput vs latest release", 860), ""]
+    if any(has_decode_baseline(m) for m in benched):
+        md += [picture(base, run_id, "decode-memory", "Per-model decode memory footprint", 860), ""]
+
     if mismatches:
-        md += [f"> ⚠️ **Pipeline token ids diverge from this tree's Tokenizer on: "
+        md += [f"> ⚠️ **Pipeline token ids diverge from `tokenizers` {baseline_label} on: "
                f"{', '.join(mismatches)}** — speedups there are meaningless until fixed.", ""]
-    if base_mismatch:
-        md += [f"> ℹ️ Token ids differ from {baseline_label} on: {', '.join(base_mismatch)} "
-               f"(† in the per-model charts) — expected when this branch fixes encode bugs, "
-               f"but worth a look.", ""]
+    if text_mismatches:
+        md += [f"> ⚠️ **Pipeline decode diverges from `tokenizers` {baseline_label} on: "
+               f"{', '.join(text_mismatches)}** — decode speedups there are meaningless until fixed.", ""]
 
     for m in benched:
         slug = slugify(m["model"])
@@ -800,7 +965,14 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
             bvals = base_model_speedups(m, base_lookup)
             if bvals:
                 summary += f" · ×{geomean(bvals):.2f} vs base"
+        dvals = decode_model_speedups(m)
+        if dvals:
+            summary += f" · decode ×{geomean(dvals):.2f}"
+        elif m.get("decode_reason"):
+            summary += " · decode pending"
         flag = " · ⚠ ids differ" if any(r["ids_match"] is False for r in m["results"]) else ""
+        if any(r.get("text_match") is False for r in m["results"]):
+            flag += " · ⚠ decode differs"
         md += [f"<details><summary><b>{escape(m['model'])}</b> — {escape(desc)} · "
                f"{summary}{flag}</summary>", ""]
         md += [picture(base, run_id, slug, f"{m['model']} speedup", 860), ""]
@@ -810,6 +982,11 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
         if has_threads(m):
             md += [picture(base, run_id, f"{slug}-threads",
                            f"{m['model']} thread scaling", 860), ""]
+        md += [picture(base, run_id, f"{slug}-decode",
+                       f"{m['model']} decode speedup", 860), ""]
+        if has_threads(m, "decode_threads"):
+            md += [picture(base, run_id, f"{slug}-decode-threads",
+                           f"{m['model']} decode thread scaling", 860), ""]
         md += [mem_line(m, baseline_label), ""]
         # Per-stage columns carry each split's share of the pipeline's own encode
         # time with the ns/byte alongside — `share% (ns/B)` — readable as text
@@ -823,12 +1000,7 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
                f"|---|---|---:|---:|---:|{base_sep}{stage_sep}:--|"]
         for r in sorted(m["results"], key=lambda r: (r["group"], r["fixture"])):
             mb = r["mbps"]
-            flags = []
-            if r["ids_match"] is False:
-                flags.append("⚠️ ≠ tree")
-            if r.get("ids_match_baseline") is False:
-                flags.append(f"≠ {baseline_label}")
-            ids = " · ".join(flags) if flags else "match"
+            ids = "⚠️ ≠ release" if r["ids_match"] is False else "match"
             s = r.get("stage_ns_per_byte")
             stages = " ".join(f"| {stage_cell(s, k)}" for k, _ in STAGES)
             base_cell = (f"| {fnum(base_speedup(r, base_lookup, m['model']), '×{:.2f}')} "
@@ -917,6 +1089,18 @@ def main():
     if sizes:
         (out / "pipeline_bench_binsize.svg").write_text(
             binsize_svg(sizes, meta, baseline_label))
+
+    # Decode: shares the id-correctness/perf story with encode but its own scale.
+    # The overview always renders (pending rows while the pipeline stub stands);
+    # decode memory only when a released decode number exists to draw against.
+    dlo, dhi = scale(benched, decode_model_speedups)
+    (out / "pipeline_bench_decode-overview.svg").write_text(
+        decode_overview_svg(models, args.subtitle, meta, dlo, dhi, baseline_label))
+    if any(has_decode_baseline(m) for m in benched):
+        (out / "pipeline_bench_decode-memory.svg").write_text(
+            memory_svg(models, meta, baseline_label, pass_key="decode_bytes",
+                       pass_label="decode", title="Memory footprint — decode"))
+
     for m in models:
         slug = slugify(m["model"])
         svg = (chart_svg(m, args.subtitle, meta, lo, hi, baseline_label)
@@ -928,6 +1112,13 @@ def main():
         if has_threads(m):
             (out / f"pipeline_bench_{slug}-threads.svg").write_text(
                 threads_svg(m, meta, baseline_label))
+        if m["results"]:
+            (out / f"pipeline_bench_{slug}-decode.svg").write_text(
+                decode_chart_svg(m, args.subtitle, meta, dlo, dhi, baseline_label))
+        if has_threads(m, "decode_threads"):
+            (out / f"pipeline_bench_{slug}-decode-threads.svg").write_text(
+                threads_svg(m, meta, baseline_label, threads_key="decode_threads",
+                            title="Thread scaling — decode"))
 
     (out / "pipeline_bench.md").write_text(
         render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes,

--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -306,12 +306,13 @@ def overview_svg(models, subtitle_base, meta, lo, hi, baseline_label,
 
 
 def memory_svg(models, meta, baseline_label, pass_key="encode_bytes",
-               pass_label="encode", title="Memory footprint"):
+               pass_label="encode", title="Memory footprint", subtitle_base=""):
     """Per model: resident-set delta of each implementation — load footprint plus
     the `pass_key`-pass delta as stacked segments, peak RSS as a tick. `pass_key`
     selects the encode-pass or the decode-pass delta (same chart, both directions).
-    A model with no `pass_key` data for either impl is dropped (e.g. decode while
-    the pipeline stub means only the baseline bar is drawn)."""
+    An impl that didn't run the pass draws no bar and totals "—" (decode while the
+    pipeline is a stub → baseline-only rows); a model where neither impl ran it is
+    dropped."""
     ink, sink = INK, SERIES_INK
     models = [m for m in models if isinstance(m.get("memory"), dict)]
 
@@ -325,15 +326,14 @@ def memory_svg(models, meta, baseline_label, pass_key="encode_bytes",
 
     models = [m for m in models
               if any((mem(m, impl) or {}).get("pass") is not None
-                     or (mem(m, impl) or {}).get("load_bytes") is not None
                      for impl in ("baseline", "pipeline"))]
 
     vals = []
     for m in models:
         for impl in ("baseline", "pipeline"):
             d = mem(m, impl)
-            if d and d["load_bytes"] is not None:
-                vals.append((d["load_bytes"] or 0) + (d["pass"] or 0))
+            if d and d["load_bytes"] is not None and d["pass"] is not None:
+                vals.append(d["load_bytes"] + d["pass"])
                 if d["peak_bytes"]:
                     vals.append(d["peak_bytes"])
     if not vals:
@@ -358,11 +358,11 @@ def memory_svg(models, meta, baseline_label, pass_key="encode_bytes",
         by = y + 8
         for impl in ("baseline", "pipeline"):
             d = mem(m, impl)
-            if not d or d["load_bytes"] is None:
+            if not d or d["load_bytes"] is None or d["pass"] is None:
                 totals.append(None)
                 by += bar_h + 3
                 continue
-            load, enc = d["load_bytes"] or 0, d["pass"] or 0
+            load, enc = d["load_bytes"], d["pass"]
             totals.append(load + enc)
             body.append(f'<rect x="{x(0):.1f}" y="{by:.1f}" width="{max(1.5, x(load) - x(0)):.1f}" '
                         f'height="{bar_h}" rx="2" fill="{sink[impl]}"/>')
@@ -389,7 +389,8 @@ def memory_svg(models, meta, baseline_label, pass_key="encode_bytes",
     ])
     height = y + 34
     subtitle = f"resident-set delta per implementation, one process each · load + {pass_label} pass"
-    return svg_doc(ink, height, title, subtitle, grid + "".join(body) + legend, meta)
+    return svg_doc(ink, height, title, subtitle, grid + "".join(body) + legend, meta,
+                   subtitle_base)
 
 
 def chart_svg(model, subtitle_base, meta, lo, hi, baseline_label):
@@ -529,7 +530,8 @@ def decode_overview_svg(models, subtitle_base, meta, lo, hi, baseline_label):
     ])
     height = y + 34
     subtitle = (f"geomean ×speedup per model vs {baseline_label} · "
-                f"whisker: min–max across fixtures · {subtitle_base}")
+                f"whisker: min–max across fixtures · both decode the same "
+                f"{baseline_label}-encoded ids · {subtitle_base}")
     return svg_doc(ink, height, title, subtitle, axis + "".join(body) + legend, meta)
 
 
@@ -594,6 +596,7 @@ def decode_chart_svg(model, subtitle_base, meta, lo, hi, baseline_label):
         parts.append("decode pending — not implemented yet")
     else:
         parts.append(f"{baseline_label} can’t decode this model — no comparison")
+    parts.append("MB/s = decoded text bytes/s, same ids to both")
     return svg_doc(ink, height, f'{model["model"]} — PipelineTokenizer decode throughput',
                    " · ".join(parts), axis + "".join(body) + legend, meta, subtitle_base)
 
@@ -810,7 +813,8 @@ def has_threads(m, key="threads"):
     return isinstance(t, dict) and bool(t.get("counts"))
 
 
-def threads_svg(model, meta, baseline_label, threads_key="threads", title="Thread scaling"):
+def threads_svg(model, meta, baseline_label, threads_key="threads", title="Thread scaling",
+                subtitle_base=""):
     """Per model: throughput (MB/s) at 1/2/4/8/device-max threads — pipeline vs the
     release — with a per-row *ideal linear* tick (single-thread × N) on the
     pipeline bar, so linear vs sub-linear scaling is visible at a glance alongside
@@ -876,7 +880,7 @@ def threads_svg(model, meta, baseline_label, threads_key="threads", title="Threa
         scaling = f" · pipeline {sc:.1f}× on {counts[-1]} threads ({sc / counts[-1] * 100:.0f}% of linear)"
     subtitle = f"throughput at N threads vs {baseline_label}; tick = perfect linear scaling{scaling}"
     return svg_doc(ink, height, title,
-                   subtitle, grid + "".join(body) + legend, meta)
+                   subtitle, grid + "".join(body) + legend, meta, subtitle_base)
 
 
 def pretok_compare_md(model):
@@ -943,6 +947,10 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
         md += [picture(base, run_id, "binsize", "Minimal encode binary size", 860), ""]
 
     md += ["### Decode", "",
+           f"Round-trip: {baseline_label} `encode_fast` produces the id streams "
+           "(same fixtures, `add_special_tokens=true`); both implementations decode "
+           "those SAME ids with `skip_special_tokens=false`. MB/s counts decoded "
+           "text bytes.", "",
            picture(base, run_id, "decode-overview",
                    "Per-model decode throughput vs latest release", 860), ""]
     if any(has_decode_baseline(m) for m in benched):
@@ -1032,7 +1040,7 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("results")
     ap.add_argument("--out-dir", default=".")
-    ap.add_argument("--subtitle", default="~10 kB inputs · single thread")
+    ap.add_argument("--subtitle", default="~10 kB inputs · add_special_tokens on · single thread")
     ap.add_argument("--revision", default="")
     ap.add_argument("--img-base", default="", help="base URL for uploaded PNGs")
     ap.add_argument("--run-id", default="local")
@@ -1085,7 +1093,7 @@ def main():
                          ref_label=(args.base_ref or "base branch"), mark_regressions=True,
                          no_cmp_msg="not benched on the base branch"))
     (out / "pipeline_bench_memory.svg").write_text(
-        memory_svg(models, meta, baseline_label))
+        memory_svg(models, meta, baseline_label, subtitle_base=args.subtitle))
     if sizes:
         (out / "pipeline_bench_binsize.svg").write_text(
             binsize_svg(sizes, meta, baseline_label))
@@ -1099,7 +1107,8 @@ def main():
     if any(has_decode_baseline(m) for m in benched):
         (out / "pipeline_bench_decode-memory.svg").write_text(
             memory_svg(models, meta, baseline_label, pass_key="decode_bytes",
-                       pass_label="decode", title="Memory footprint — decode"))
+                       pass_label="decode", title="Memory footprint — decode",
+                       subtitle_base=args.subtitle))
 
     for m in models:
         slug = slugify(m["model"])
@@ -1111,14 +1120,14 @@ def main():
                 stage_chart_svg(m, args.subtitle, meta, baseline_label))
         if has_threads(m):
             (out / f"pipeline_bench_{slug}-threads.svg").write_text(
-                threads_svg(m, meta, baseline_label))
+                threads_svg(m, meta, baseline_label, subtitle_base=args.subtitle))
         if m["results"]:
             (out / f"pipeline_bench_{slug}-decode.svg").write_text(
                 decode_chart_svg(m, args.subtitle, meta, dlo, dhi, baseline_label))
         if has_threads(m, "decode_threads"):
             (out / f"pipeline_bench_{slug}-decode-threads.svg").write_text(
                 threads_svg(m, meta, baseline_label, threads_key="decode_threads",
-                            title="Thread scaling — decode"))
+                            title="Thread scaling — decode", subtitle_base=args.subtitle))
 
     (out / "pipeline_bench.md").write_text(
         render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes,

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -1,10 +1,11 @@
 name: Pipeline Benchmark
 
 # Comparative benchmark: the experimental `PipelineTokenizer` vs the latest
-# *released* tokenizers crate (the baseline to beat — the in-tree legacy
-# `Tokenizer` is being phased out, so it is only the id-correctness oracle,
-# never a benched series), for every model in
-# tk-encode/examples/bench_models.json across every corpus in data/fixtures/.
+# *released* tokenizers crate — both the baseline to beat AND the correctness
+# reference (`ids_match`/`text_match`). The in-tree legacy `Tokenizer` is being
+# phased out, so it only *builds* the pipeline and is never benched or trusted as
+# an oracle. Runs for every model in tk-encode/examples/bench_models.json across
+# every corpus in data/fixtures/.
 # Measures single- and multi-thread throughput (1/2/4/8/device-max), per-
 # implementation memory footprint (RSS), and stripped minimal-binary size. The
 # release dep is behind tk-encode's `bench-baseline` feature, so production
@@ -130,6 +131,46 @@ jobs:
             tokenizers/target/release/examples/binsize_baseline
             tokenizers/target/release/examples/binsize_pipeline
           retention-days: 3
+
+  # Pipeline oracle tests: encode + decode parity of the pipeline against the
+  # released crate. They live behind `bench-baseline` (they link the released
+  # crate), so a plain `cargo test` skips them — this is where they run. Same
+  # fixtures + models as the shards; the decode oracle is #[ignore]d until
+  # PipelineTokenizer::decode lands, so only encode parity runs today.
+  oracle:
+    name: pipeline oracle tests
+    if: github.event_name != 'pull_request' || github.event.label.name == 'run-pipeline-bench'
+    runs-on:
+      group: aws-general-8-plus
+    defaults:
+      run:
+        working-directory: tokenizers
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      # onig_sys (a bench-baseline dep) generates bindings via bindgen → needs libclang.
+      - name: Install libclang (onig_sys → bindgen)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Cache fixtures + model tokenizers
+        uses: actions/cache@v4
+        with:
+          path: tokenizers/data
+          key: bench-data-${{ hashFiles('tokenizers/Makefile', 'tokenizers/tk-encode/examples/bench_models.json') }}
+
+      - name: Download fixtures and model tokenizers
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: make fixtures bench-models HF="uvx --from huggingface_hub hf"
+
+      - name: Run pipeline oracle tests (parity vs the released crate)
+        run: cargo test -p tk-encode --features bench-baseline --test pipeline_oracle --test pipeline_decode_oracle
 
   # Fan-out: each shard benches the i-th of SHARDS contiguous manifest slices on its
   # own 8-vCPU runner (isolated + parallel), running the prebuilt binary, and uploads
@@ -405,16 +446,22 @@ jobs:
           gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/run-pipeline-bench" \
             -X DELETE || true
 
-      # Pipeline ids must match this tree's Tokenizer. Baseline id mismatches
-      # (ids_match_baseline) are report-only: a branch may fix encode bugs.
-      - name: Fail on id mismatches
+      # Pipeline encode ids (`ids_match`) AND decode text (`text_match`) must match
+      # the released crate. Both are null when the release can't load a model (no
+      # reference), and `text_match` is null while decode is a stub → inert until
+      # the pipeline can decode.
+      - name: Fail on id / decode mismatches
         run: |
           python3 -c "
           import json, sys
           models = json.load(open('pipeline_bench.json'))['models']
-          bad = [f\"{m['model']}/{r['fixture']}\" for m in models
+          ids = [f\"{m['model']}/{r['fixture']}\" for m in models
                  for r in m['results'] if r.get('ids_match') is False]
-          sys.exit(f'ids diverge on: {bad}' if bad else 0)
+          text = [f\"{m['model']}/{r['fixture']}\" for m in models
+                  for r in m['results'] if r.get('text_match') is False]
+          errs = ([f'ids diverge on: {ids}'] if ids else []) + \
+                 ([f'decode diverges on: {text}'] if text else [])
+          sys.exit(' · '.join(errs) if errs else 0)
           "
 
       # Establish/refresh the base-branch baseline: on a push to

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -381,7 +381,7 @@ jobs:
           fi
           python3 ${{ github.workspace }}/.github/scripts/render_pipeline_bench.py \
             pipeline_bench.json \
-            --subtitle "~10 kB inputs · single thread + 1/2/4/8/max-thread sweep" \
+            --subtitle "~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep" \
             --revision "${{ github.event.pull_request.head.sha || github.sha }}" \
             --img-base "$base_url" \
             --run-id "${{ github.run_id }}" \

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -77,7 +77,7 @@ jobs:
           python -m venv .env
           source .env/bin/activate
           pip install -U pip
-          pip install pytest pytest-asyncio huggingface_hub setuptools_rust numpy pyarrow datasets ruff ty maturin
+          pip install pytest pytest-asyncio huggingface_hub setuptools_rust numpy pyarrow datasets ruff==0.15.22 ty maturin
           # Build via maturin so we can drop the abi3 cargo feature on
           # free-threaded Python (3.14t can't load abi3 extensions).
           # `pip install -e .` would build through maturin's PEP 660 path
@@ -159,7 +159,8 @@ jobs:
           python -m venv .env
           source .env/bin/activate
           pip install -U pip
-          pip install pytest pytest-asyncio requests setuptools_rust numpy pyarrow datasets ruff ty maturin
+          # ruff pinned: 0.16 re-lints the whole tree (637 errors); bump it together with a dedicated style pass
+          pip install pytest pytest-asyncio requests setuptools_rust numpy pyarrow datasets ruff==0.15.22 ty maturin
           maturin develop --release
 
       - name: Check style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,8 +186,8 @@ make fixtures bench-models   # needs HF_TOKEN
 # encode parity: pipeline ids == released encode_fast ids
 cargo test -p tk-encode --features bench-baseline --test pipeline_oracle
 
-# decode parity: #[ignore]d until PipelineTokenizer::decode is implemented
-cargo test -p tk-encode --features bench-baseline --test pipeline_decode_oracle -- --ignored
+# decode parity
+cargo test -p tk-encode --features bench-baseline --test pipeline_decode_oracle
 ```
 
 The comparative benchmark (throughput, thread scaling, and memory vs the release)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,3 +167,35 @@ Profile from Python to see the full stack including PyO3 overhead:
 ```bash
 samply record python my_script.py
 ```
+
+### PipelineTokenizer oracle tests & benchmark
+
+`PipelineTokenizer` (in `tk-encode`) is an experimental reimplementation of the
+encode/decode pipeline. It is checked for parity against the latest *released*
+`tokenizers` crate — same token ids on encode, same decoded string — rather than
+the in-tree `Tokenizer`, which is being retired.
+
+Those checks link the released crate, so they live behind the `bench-baseline`
+feature and a plain `cargo test` skips them. Fetch the corpora and model
+tokenizers, then run with the feature:
+
+```bash
+cd tokenizers
+make fixtures bench-models   # needs HF_TOKEN
+
+# encode parity: pipeline ids == released encode_fast ids
+cargo test -p tk-encode --features bench-baseline --test pipeline_oracle
+
+# decode parity: #[ignore]d until PipelineTokenizer::decode is implemented
+cargo test -p tk-encode --features bench-baseline --test pipeline_decode_oracle -- --ignored
+```
+
+The comparative benchmark (throughput, thread scaling, and memory vs the release)
+runs off the same data and renders to charts:
+
+```bash
+cargo run --release -p tk-encode --features bench-baseline --example fixture_bench > bench.json
+python3 ../.github/scripts/render_pipeline_bench.py bench.json
+```
+
+CI runs both in the **Pipeline Benchmark** workflow (`.github/workflows/pipeline-bench.yml`).

--- a/bindings/python/py_src/tokenizers/models.pyi
+++ b/bindings/python/py_src/tokenizers/models.pyi
@@ -287,7 +287,7 @@ class WordLevel(Model):
     Most simple tokenizer model based on mapping tokens to their corresponding id.
 
     Args:
-        vocab (:obj:`str`, `optional`):
+        vocab (:obj:`Dict[str, int]`, `optional`):
             A dictionary of string keys and their ids :obj:`{"am": 0,...}`
 
         unk_token (:obj:`str`, `optional`):

--- a/bindings/python/py_src/tokenizers/trainers.pyi
+++ b/bindings/python/py_src/tokenizers/trainers.pyi
@@ -5,7 +5,7 @@ Trainers Module
 from collections.abc import Sequence
 from typing import Any, final
 
-from tokenizers import AddedToken
+from tokenizers import AddedToken, Tokenizer
 
 @final
 class BpeTrainer(Trainer):
@@ -111,6 +111,59 @@ class BpeTrainer(Trainer):
 
 @final
 class ParityBpeTrainer:
+    """
+    Trainer for parity-aware BPE that ensures cross-lingual fairness in tokenization.
+
+    Unlike standard BPE, this trainer takes one Python iterator per language and
+    balances merge operations across languages using a development set or target
+    compression ratios. The single training entry point is
+    :meth:`train_from_iterator`, the multi-corpus analogue of
+    :meth:`tokenizers.Tokenizer.train_from_iterator`.
+
+    Args:
+        num_merges (:obj:`int`, `optional`):
+            Number of BPE merge operations to perform. Defaults to ``32000``.
+
+        variant (:obj:`str`, `optional`):
+            Algorithm variant: ``"base"`` (default) or ``"window"`` (moving-window balancing).
+
+        min_frequency (:obj:`int`, `optional`):
+            Minimum pair frequency to merge. Defaults to ``0``.
+
+        global_merges (:obj:`int`, `optional`):
+            Number of initial standard BPE merges before switching to parity mode. Defaults to ``0``.
+
+        window_size (:obj:`int`, `optional`):
+            Window size for the ``"window"`` variant. Defaults to ``100``.
+
+        alpha (:obj:`float`, `optional`):
+            Alpha parameter for the ``"window"`` variant. Defaults to ``2.0``.
+
+        total_symbols (:obj:`bool`, `optional`):
+            If True, subtract unique character count from ``num_merges``. Defaults to ``False``.
+
+    Example::
+
+        from tokenizers import Tokenizer
+        from tokenizers.models import BPE
+        from tokenizers import pre_tokenizers
+        from tokenizers.trainers import ParityBpeTrainer
+
+        tokenizer = Tokenizer(BPE())
+        tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+
+        def lines(path):
+            with open(path) as f:
+                yield from f
+
+        trainer = ParityBpeTrainer(num_merges=32000, variant="base")
+        trainer.train_from_iterator(
+            tokenizer,
+            train_iterators=[lines("train_en.txt"), lines("train_de.txt")],
+            dev_iterators=[lines("dev_en.txt"), lines("dev_de.txt")],
+        )
+        output = tokenizer.encode("Hello world")
+    """
     def __getstate__(self, /) -> Any: ...
     def __new__(
         cls,
@@ -130,16 +183,10 @@ class ParityBpeTrainer:
         continuing_subword_prefix: str | None = None,
         end_of_word_suffix: str | None = None,
         max_token_length: int | None = None,
-    ) -> ParityBpeTrainer:
-        """Create and return a new object.  See help(type) for accurate signature."""
-        ...
-    def __repr__(self, /) -> str:
-        """Return repr(self)."""
-        ...
+    ) -> ParityBpeTrainer: ...
+    def __repr__(self, /) -> str: ...
     def __setstate__(self, /, state: Any) -> None: ...
-    def __str__(self, /) -> str:
-        """Return str(self)."""
-        ...
+    def __str__(self, /) -> str: ...
     @property
     def alpha(self, /) -> float: ...
     @alpha.setter
@@ -188,6 +235,43 @@ class ParityBpeTrainer:
     def total_symbols(self, /) -> bool: ...
     @total_symbols.setter
     def total_symbols(self, /, v: bool) -> None: ...
+    def train_from_iterator(
+        self,
+        /,
+        tokenizer: Tokenizer,
+        train_iterators: Sequence[Any],
+        dev_iterators: Sequence[Any] | None = None,
+        ratio: Sequence[float] | None = None,
+    ) -> None:
+        """
+        Train a user-configured tokenizer with parity-aware BPE from per-language
+        Python iterators.
+
+        Each entry of ``train_iterators`` (and optionally ``dev_iterators``) is a
+        Python iterator yielding strings (or batches / lists of strings) for one
+        language. This is the multi-corpus analogue of
+        :meth:`~tokenizers.Tokenizer.train_from_iterator`: file I/O happens in
+        Python, so users can pull data from plain text, parquet (via ``pyarrow``),
+        ``datasets``, etc.
+
+        Args:
+            tokenizer (:class:`~tokenizers.Tokenizer`):
+                A tokenizer instance to train. Its pre-tokenizer (and optionally
+                normalizer) should already be configured.
+
+            train_iterators (:obj:`List[Iterator]`):
+                One Python iterator per language, each yielding ``str`` or
+                ``List[str]``.
+
+            dev_iterators (:obj:`List[Iterator]`, `optional`):
+                One Python iterator per language, used to drive parity-aware
+                language selection. Must have the same length as
+                ``train_iterators``.
+
+            ratio (:obj:`List[float]`, `optional`):
+                Target compression ratios per language (alternative to
+                ``dev_iterators``).
+        """
     @property
     def variant(self, /) -> str: ...
     @property

--- a/tokenizers/tk-encode/README.md
+++ b/tokenizers/tk-encode/README.md
@@ -66,42 +66,6 @@ Training lives in the companion `tk-train` crate (re-exported by the
   environment variable. As an example setting `RAYON_RS_NUM_THREADS=4` will allocate a maximum of 4 threads.
   **_Please note this behavior may evolve in the future_**
 
-## PipelineTokenizer: oracle tests & benchmark
-
-`PipelineTokenizer` is an experimental, allocation-light re-implementation of the
-encode/decode pipeline. Its correctness is judged against the **latest released
-`tokenizers` crate** (not the in-tree `Tokenizer`, which is being retired): the
-pipeline must produce identical token ids and identical decoded text.
-
-That comparison lives behind the optional `bench-baseline` feature (it links the
-released crate), so a plain `cargo test` skips it. To run it you need the fixture
-corpora and model tokenizers, then the feature flag:
-
-```bash
-# from tokenizers/ — fetches data/fixtures/ + model tokenizers (needs HF_TOKEN)
-make fixtures bench-models
-
-# encode parity (pipeline ids == released `encode_fast` ids)
-cargo test -p tk-encode --features bench-baseline --test pipeline_oracle
-
-# decode parity (pipeline decode == released `decode`) — ignored until
-# PipelineTokenizer::decode is implemented, so pass --ignored to run it
-cargo test -p tk-encode --features bench-baseline --test pipeline_decode_oracle -- --ignored
-```
-
-Both oracles sample seeded-random windows of every fixture corpus; a model whose
-tokenizer file isn't present is skipped. CI runs them in the **Pipeline
-Benchmark** workflow (`.github/workflows/pipeline-bench.yml`).
-
-The same workflow runs the comparative benchmark — throughput, thread scaling,
-memory, and binary size vs the release — and renders it to charts. To reproduce
-locally:
-
-```bash
-cargo run --release -p tk-encode --features bench-baseline --example fixture_bench > bench.json
-python3 ../.github/scripts/render_pipeline_bench.py bench.json   # writes SVGs + pipeline_bench.md
-```
-
 ## Features
 
 - **progressbar**: The progress bar visualization is enabled by default. It might be disabled if

--- a/tokenizers/tk-encode/README.md
+++ b/tokenizers/tk-encode/README.md
@@ -66,6 +66,42 @@ Training lives in the companion `tk-train` crate (re-exported by the
   environment variable. As an example setting `RAYON_RS_NUM_THREADS=4` will allocate a maximum of 4 threads.
   **_Please note this behavior may evolve in the future_**
 
+## PipelineTokenizer: oracle tests & benchmark
+
+`PipelineTokenizer` is an experimental, allocation-light re-implementation of the
+encode/decode pipeline. Its correctness is judged against the **latest released
+`tokenizers` crate** (not the in-tree `Tokenizer`, which is being retired): the
+pipeline must produce identical token ids and identical decoded text.
+
+That comparison lives behind the optional `bench-baseline` feature (it links the
+released crate), so a plain `cargo test` skips it. To run it you need the fixture
+corpora and model tokenizers, then the feature flag:
+
+```bash
+# from tokenizers/ — fetches data/fixtures/ + model tokenizers (needs HF_TOKEN)
+make fixtures bench-models
+
+# encode parity (pipeline ids == released `encode_fast` ids)
+cargo test -p tk-encode --features bench-baseline --test pipeline_oracle
+
+# decode parity (pipeline decode == released `decode`) — ignored until
+# PipelineTokenizer::decode is implemented, so pass --ignored to run it
+cargo test -p tk-encode --features bench-baseline --test pipeline_decode_oracle -- --ignored
+```
+
+Both oracles sample seeded-random windows of every fixture corpus; a model whose
+tokenizer file isn't present is skipped. CI runs them in the **Pipeline
+Benchmark** workflow (`.github/workflows/pipeline-bench.yml`).
+
+The same workflow runs the comparative benchmark — throughput, thread scaling,
+memory, and binary size vs the release — and renders it to charts. To reproduce
+locally:
+
+```bash
+cargo run --release -p tk-encode --features bench-baseline --example fixture_bench > bench.json
+python3 ../.github/scripts/render_pipeline_bench.py bench.json   # writes SVGs + pipeline_bench.md
+```
+
 ## Features
 
 - **progressbar**: The progress bar visualization is enabled by default. It might be disabled if

--- a/tokenizers/tk-encode/benches/pipeline_benchmark.rs
+++ b/tokenizers/tk-encode/benches/pipeline_benchmark.rs
@@ -80,7 +80,7 @@ fn bench_pipeline(c: &mut Criterion) {
                     b.iter(|| {
                         let mut n = 0usize;
                         for chunk in &chunks {
-                            n += pipeline.encode(chunk, false).unwrap().len();
+                            n += pipeline.encode(chunk, true).unwrap().len();
                         }
                         black_box(n)
                     })

--- a/tokenizers/tk-encode/benches/pipeline_benchmark.rs
+++ b/tokenizers/tk-encode/benches/pipeline_benchmark.rs
@@ -3,7 +3,7 @@
 //! ~128 B / 1 kB / 10 kB / 100 kB, sweeping from per-input-overhead-dominated
 //! to fully amortized.
 //!
-//! Correctness (id equivalence with the reference `Tokenizer`) is asserted
+//! Correctness (id equivalence with the released `tokenizers` crate) is asserted
 //! separately in `tests/pipeline_oracle.rs`.
 
 #[macro_use]

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -672,13 +672,14 @@ fn bench_threads(
 // `PipelineTokenizer::decode` is a loud stub it is false, so the pipeline series
 // is `null` (rendered "pending") and only the baseline bar is drawn.
 
-/// Encode every chunk with the released crate into its id stream (untimed input).
+/// Encode every chunk with the released crate into its id stream (untimed input;
+/// specials included, so decode sees the frame tokens a real stream carries).
 fn ids_of(baseline: &BaselineTokenizer, chunks: &[String]) -> Vec<Vec<u32>> {
     chunks
         .iter()
         .map(|c| {
             baseline
-                .encode_fast(c.as_str(), false)
+                .encode_fast(c.as_str(), true)
                 .unwrap()
                 .get_ids()
                 .to_vec()
@@ -882,7 +883,7 @@ fn memory_child(which: &str, model: &Path) {
             inject_added_tokens_baseline(&mut tok);
             let after_load = rss_now().unwrap_or(0);
             for c in &chunks {
-                let enc = tok.encode_fast(c.as_str(), false).unwrap();
+                let enc = tok.encode_fast(c.as_str(), true).unwrap();
                 n += enc.len();
                 ids.push(enc.get_ids().to_vec());
             }
@@ -903,7 +904,7 @@ fn memory_child(which: &str, model: &Path) {
             drop(tok);
             let after_load = rss_now().unwrap_or(0);
             for c in &chunks {
-                let enc = pipeline.encode(c, false).unwrap();
+                let enc = pipeline.encode(c, true).unwrap();
                 n += enc.len();
                 ids.push(enc.iter().map(|t| t.id).collect());
             }

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -6,7 +6,7 @@
 //! because the pipeline's `encode` computes no offsets either; timing the
 //! baseline's offset-tracking `encode` would flatter the pipeline.
 //!
-//! Three isolated phases per model:
+//! Four isolated phases per model:
 //!
 //! 1. **Throughput** — single-thread warm MB/s per fixture on ~10 kB inputs
 //!    (the regime where per-input overhead is amortized — see
@@ -26,16 +26,25 @@
 //!    re-spawning this binary as `--memory <impl> <model.json>` children — one
 //!    implementation per process, so allocator page reuse can't blur the
 //!    attribution.
+//! 4. **Decode** — the inverse direction, anchored on the RELEASED crate (never
+//!    the in-tree legacy `Tokenizer`, which is being removed — oracles must not
+//!    depend on it). The release's `encode_fast` produces the id stream; pipeline
+//!    and released `decode` then consume the SAME ids (single-thread throughput +
+//!    the 1/2/4/8/max sweep + a decode-pass RSS delta), gated by `text_match`
+//!    (pipeline decode == released decode). While `PipelineTokenizer::decode` is a
+//!    loud stub the pipeline decode series is `null` (rendered "pending"); the
+//!    released baseline is measured regardless. No released baseline → no decode
+//!    oracle → the phase is skipped for that model.
 //!
-//! The in-tree `Tokenizer` is *not* benched: it only builds the pipeline and
-//! serves as the id-correctness oracle (`ids_match`, which CI fails on).
-//! `ids_match_baseline` — pipeline vs the released crate — is report-only,
-//! since a branch may intentionally fix encode behavior. Models the pipeline
-//! can't build (or encode) yet are reported with empty `results` (plus the
-//! failure `reason`) and their pipeline shape rather than benched — the CI
-//! grid renders those as roadmap cards. Each manifest entry carries a `desc`:
-//! a one-line label of the workload archetype the model exercises, passed
-//! through to the report.
+//! Correctness is judged against the released crate, never the in-tree
+//! `Tokenizer` (which is being removed and only *builds* the pipeline here):
+//! `ids_match` (encode ids) and `text_match` (decode text) both compare against
+//! the release and both fail CI. They are `null` when the release can't load the
+//! model — no reference, so no gate. Models the pipeline can't build (or encode)
+//! yet are reported with empty `results` (plus the failure `reason`) and their
+//! pipeline shape rather than benched — the CI grid renders those as roadmap
+//! cards. Each manifest entry carries a `desc`: a one-line label of the workload
+//! archetype the model exercises, passed through to the report.
 //!
 //! Emits one JSON object (`{baseline, models}`) on stdout, consumed by
 //! `.github/scripts/render_pipeline_bench.py` in CI.
@@ -237,19 +246,12 @@ fn bench_throughput(
             .map(|t| t.id)
             .collect()
     };
-    // The correctness gate CI fails on: pipeline vs this tree's Tokenizer, both flags
-    // (add_special_tokens=true exercises the post-process prefix/suffix step).
-    let ids_match = [false, true].into_iter().all(|add_special_tokens| {
-        f.chunks.iter().take(3).all(|c| {
-            oracle
-                .encode(c.as_str(), add_special_tokens)
-                .unwrap()
-                .get_ids()
-                == pipe_ids(c, add_special_tokens)
-        })
-    });
-    // Report-only: pipeline vs the released crate (a branch may fix encode bugs).
-    let ids_match_baseline = base.as_ref().map(|b| {
+    // The correctness gate CI fails on: pipeline ids == the released crate's ids,
+    // for both `add_special_tokens` values (`true` exercises the post-process
+    // stage). The in-tree `Tokenizer` only *builds* the pipeline here — never the
+    // reference, since it is on its way out. `None` when the release can't load
+    // this model (no reference to compare against).
+    let ids_match = base.as_ref().map(|b| {
         [false, true].into_iter().all(|add_special_tokens| {
             f.chunks.iter().take(3).all(|c| {
                 b.encode_fast(c.as_str(), add_special_tokens)
@@ -286,7 +288,6 @@ fn bench_throughput(
         "group": f.group,
         "mbps": { "baseline": base_mbps, "pipeline": pipe_mbps },
         "ids_match": ids_match,
-        "ids_match_baseline": ids_match_baseline,
     })
 }
 
@@ -660,6 +661,153 @@ fn bench_threads(
     json!({ "counts": counts, "pipeline_mbps": pipe, "baseline_mbps": base })
 }
 
+// ── decode: throughput + scaling ─────────────────────────────────────────────
+// Mirror of the encode phases, over the inverse direction, anchored on the
+// RELEASED crate — never the in-tree legacy `Tokenizer` (which is being removed;
+// oracles must not depend on it). The id stream is produced by the release's
+// `encode_fast`, and both decoders — pipeline and released baseline — consume
+// those SAME ids, so decode is a clean apples-to-apples judged against the
+// release. No released baseline → no decode oracle, so the whole phase is null.
+// `pipeline_ok` is the once-probed "can the pipeline decode yet" flag: while
+// `PipelineTokenizer::decode` is a loud stub it is false, so the pipeline series
+// is `null` (rendered "pending") and only the baseline bar is drawn.
+
+/// Encode every chunk with the released crate into its id stream (untimed input).
+fn ids_of(baseline: &BaselineTokenizer, chunks: &[String]) -> Vec<Vec<u32>> {
+    chunks
+        .iter()
+        .map(|c| {
+            baseline
+                .encode_fast(c.as_str(), false)
+                .unwrap()
+                .get_ids()
+                .to_vec()
+        })
+        .collect()
+}
+
+/// Warm single-thread decode throughput + the `text_match` gate for one fixture.
+/// `text_match` = pipeline decode == released decode (the gate CI fails on). All
+/// null when there is no released baseline to judge against.
+fn bench_decode(
+    baseline: Option<&BaselineTokenizer>,
+    pipeline: &PipelineTokenizer,
+    f: &Fixture,
+    pipeline_ok: bool,
+) -> Value {
+    let null = json!({
+        "decode_mbps": { "baseline": Value::Null, "pipeline": Value::Null },
+        "text_match": Value::Null,
+    });
+    let Some(baseline) = baseline else {
+        return null;
+    };
+    let ids = ids_of(baseline, &f.chunks);
+    // Throughput basis: bytes of text decode emits, measured once via the release.
+    let dec_bytes: usize = ids
+        .iter()
+        .map(|i| baseline.decode(i, false).unwrap().len())
+        .sum();
+    if dec_bytes == 0 {
+        return null;
+    }
+
+    let one_pass = |dec: &dyn Fn(&[u32]) -> usize| -> f64 {
+        let start = Instant::now();
+        let mut n = 0usize;
+        for i in &ids {
+            n += dec(i);
+        }
+        black_box(n);
+        start.elapsed().as_secs_f64()
+    };
+    let mbps = |secs: f64| dec_bytes as f64 / secs / 1e6;
+
+    // Correctness gate (first 3 chunks): pipeline decode == released decode.
+    let text_match = pipeline_ok.then(|| {
+        ids.iter()
+            .take(3)
+            .all(|i| pipeline.decode(i, false).unwrap() == baseline.decode(i, false).unwrap())
+    });
+
+    // Interleaved warm-up + REPS so thermal drift hits both equally.
+    one_pass(&|i| baseline.decode(i, false).unwrap().len());
+    if pipeline_ok {
+        one_pass(&|i| pipeline.decode(i, false).unwrap().len());
+    }
+    let (mut base_s, mut pipe_s) = (Vec::new(), Vec::new());
+    for _ in 0..REPS {
+        base_s.push(one_pass(&|i| baseline.decode(i, false).unwrap().len()));
+        if pipeline_ok {
+            pipe_s.push(one_pass(&|i| pipeline.decode(i, false).unwrap().len()));
+        }
+    }
+    let base_mbps = mbps(median_secs(base_s));
+    let pipe_mbps = (!pipe_s.is_empty()).then(|| mbps(median_secs(pipe_s)));
+
+    eprintln!(
+        "  {} decode: baseline {base_mbps:.1} MB/s, pipeline {}",
+        f.name,
+        pipe_mbps.map_or("pending".into(), |v: f64| format!("{v:.1} MB/s")),
+    );
+
+    json!({
+        "decode_mbps": { "baseline": base_mbps, "pipeline": pipe_mbps },
+        "text_match": text_match,
+    })
+}
+
+/// Median MB/s of decoding `ids` across `n` threads in a private rayon pool.
+fn par_decode_mbps(
+    decode: impl Fn(&[u32]) -> usize + Sync,
+    ids: &[Vec<u32>],
+    bytes: usize,
+    n: usize,
+) -> f64 {
+    let pool = ThreadPoolBuilder::new().num_threads(n).build().unwrap();
+    let run = || pool.install(|| ids.par_iter().map(|i| decode(i.as_slice())).sum::<usize>());
+    black_box(run());
+    let mut samples = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let t = Instant::now();
+        black_box(run());
+        samples.push(t.elapsed().as_secs_f64());
+    }
+    bytes as f64 / median_secs(samples) / 1e6
+}
+
+/// Multi-thread decode throughput sweep — pipeline vs the released crate at
+/// 1/2/4/8/max threads over the whole fixture corpus's id stream (release-produced).
+fn bench_decode_threads(
+    baseline: Option<&BaselineTokenizer>,
+    pipeline: &PipelineTokenizer,
+    all_chunks: &[String],
+    pipeline_ok: bool,
+) -> Value {
+    let Some(baseline) = baseline else {
+        return json!({ "counts": [], "pipeline_mbps": [], "baseline_mbps": [] });
+    };
+    let ids = ids_of(baseline, all_chunks);
+    let bytes: usize = ids
+        .iter()
+        .map(|i| baseline.decode(i, false).unwrap().len())
+        .sum();
+    let counts = thread_counts();
+    let (mut pipe, mut base) = (Vec::new(), Vec::new());
+    for &n in &counts {
+        let b = par_decode_mbps(|i| baseline.decode(i, false).unwrap().len(), &ids, bytes, n);
+        let p = pipeline_ok
+            .then(|| par_decode_mbps(|i| pipeline.decode(i, false).unwrap().len(), &ids, bytes, n));
+        eprintln!(
+            "    decode {n} thread(s): pipeline {}, baseline {b:.1} MB/s",
+            p.map_or("pending".into(), |v: f64| format!("{v:.1} MB/s")),
+        );
+        pipe.push(p);
+        base.push(b);
+    }
+    json!({ "counts": counts, "pipeline_mbps": pipe, "baseline_mbps": base })
+}
+
 /// Resident set size in bytes. Exact on Linux (`/proc`); on macOS a `ps`
 /// fallback good enough for local iteration — CI runs on Linux.
 fn rss_now() -> Option<i64> {
@@ -718,22 +866,32 @@ fn memory_sample() -> Vec<String> {
 }
 
 /// `--memory <impl> <model.json>` child entry: load one implementation, encode a
-/// capped pass over the fixtures, print `{load_bytes, encode_bytes, peak_bytes}`.
-/// One implementation per process so the deltas attribute cleanly.
+/// capped pass over the fixtures, then decode that pass's ids, printing
+/// `{load_bytes, encode_bytes, decode_bytes, peak_bytes}`. One implementation per
+/// process so the deltas attribute cleanly. `decode_bytes` is `null` when the
+/// implementation can't decode yet (the pipeline's loud stub).
 fn memory_child(which: &str, model: &Path) {
     let chunks = memory_sample();
 
     let rss0 = rss_now().unwrap_or(0);
     let mut n = 0usize;
-    let (after_load, after_encode) = match which {
+    let mut ids: Vec<Vec<u32>> = Vec::new();
+    let (after_load, after_encode, decode_bytes) = match which {
         "baseline" => {
             let mut tok = BaselineTokenizer::from_file(model).unwrap();
             inject_added_tokens_baseline(&mut tok);
             let after_load = rss_now().unwrap_or(0);
             for c in &chunks {
-                n += tok.encode_fast(c.as_str(), true).unwrap().len();
+                let enc = tok.encode_fast(c.as_str(), false).unwrap();
+                n += enc.len();
+                ids.push(enc.get_ids().to_vec());
             }
-            (after_load, rss_now().unwrap_or(0))
+            let after_encode = rss_now().unwrap_or(0);
+            for i in &ids {
+                n += tok.decode(i, false).map(|s| s.len()).unwrap_or(0);
+            }
+            let decode_bytes = rss_now().unwrap_or(0) - after_encode;
+            (after_load, after_encode, Some(decode_bytes))
         }
         "pipeline" => {
             let mut tok = Tokenizer::from_file(model).unwrap();
@@ -745,9 +903,25 @@ fn memory_child(which: &str, model: &Path) {
             drop(tok);
             let after_load = rss_now().unwrap_or(0);
             for c in &chunks {
-                n += pipeline.encode(c, true).unwrap().len();
+                let enc = pipeline.encode(c, false).unwrap();
+                n += enc.len();
+                ids.push(enc.iter().map(|t| t.id).collect());
             }
-            (after_load, rss_now().unwrap_or(0))
+            let after_encode = rss_now().unwrap_or(0);
+            // Decode is a loud stub today → skip the pass and report null, so the
+            // decode memory bar reads "pending" rather than a bogus 0.
+            let decode_bytes = if ids
+                .first()
+                .is_some_and(|i| pipeline.decode(i, false).is_ok())
+            {
+                for i in &ids {
+                    n += pipeline.decode(i, false).map(|s| s.len()).unwrap_or(0);
+                }
+                Some(rss_now().unwrap_or(0) - after_encode)
+            } else {
+                None
+            };
+            (after_load, after_encode, decode_bytes)
         }
         other => panic!("unknown impl {:?}", other),
     };
@@ -758,6 +932,7 @@ fn memory_child(which: &str, model: &Path) {
         json!({
             "load_bytes": after_load - rss0,
             "encode_bytes": after_encode - after_load,
+            "decode_bytes": decode_bytes,
             "peak_bytes": rss_peak().map(|p| p - rss0),
         })
     );
@@ -987,12 +1162,33 @@ fn main() {
             row.insert("stage_ns_per_byte".into(), stages);
             row.insert("pretok_vs_regex".into(), pretok);
         }
+        // Decode: probe once whether the pipeline can decode yet (a loud stub
+        // today → the pipeline decode series is `null`, rendered "pending"). The
+        // probe uses a bare id slice so it never touches the legacy encode path.
+        let (decode_ok, decode_reason) = match pipeline.decode(&[0], false) {
+            Ok(_) => (true, None),
+            Err(e) => {
+                eprintln!("  pipeline decode pending ({shape}): {e}");
+                (false, Some(format!("{e}")))
+            }
+        };
+        for (row, f) in rows.iter_mut().zip(&fixtures) {
+            let dec = bench_decode(baseline.as_ref(), &pipeline, f, decode_ok);
+            let row = row.as_object_mut().unwrap();
+            for (k, v) in dec.as_object().unwrap() {
+                row.insert(k.clone(), v.clone());
+            }
+        }
+        let decode_threads =
+            bench_decode_threads(baseline.as_ref(), &pipeline, &all_chunks, decode_ok);
+
         let memory = measure_memory(&path, baseline.is_some());
         let threads = bench_threads(baseline.as_ref(), &pipeline, &all_chunks);
 
         models.push(json!({
             "model": name, "desc": desc, "shape": shape,
             "results": rows, "memory": memory, "threads": threads,
+            "decode_threads": decode_threads, "decode_reason": decode_reason,
         }));
     }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -533,6 +533,17 @@ impl PipelineTokenizer {
         Ok(output)
     }
 
+    /// Decode token ids back to a `String`.
+    ///
+    /// Not implemented yet — the pipeline decode path is being built. It fails
+    /// loud (rather than returning a plausible-but-wrong string) so the oracle
+    /// test and the comparative benchmark report decode as *pending* instead of
+    /// silently validating garbage. Implementing this flips the ignored
+    /// `pipeline_decode_oracle` test on and lights up the decode charts.
+    pub fn decode(&self, _ids: &[u32], _skip_special_tokens: bool) -> Result<String> {
+        Err("PipelineTokenizer::decode is not implemented yet".into())
+    }
+
     /// Single source of truth for the encode pipeline, generic over how many stages
     /// run. `STAGE` is a **const generic**, so `if STAGE >= …` folds at compile time and
     /// the disabled stages are compiled out — the full specialization

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -158,6 +158,7 @@ impl TryFrom<PreTokenizerWrapper> for PipelinePreTokenizer {
 /// Processors that don't reduce to such a frame are rejected at conversion.
 ///
 /// Example:
+/// ```text
 ///     PipelinePostProcessor {
 ///         prefix: vec![100].into_boxed_slice(),
 ///         suffix: vec![101, 102].into_boxed_slice()
@@ -166,6 +167,7 @@ impl TryFrom<PreTokenizerWrapper> for PipelinePreTokenizer {
 ///     [CLS] The quick Brown fox  [SEP]
 ///     <100>|  <3> <4> <19> <67> | <101> <102>
 ///   prefix |  sequence encoding | suffix
+/// ```
 ///
 #[derive(Debug, Default)]
 pub struct PipelinePostProcessor {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -544,6 +544,33 @@ impl PipelineTokenizer {
         Err("PipelineTokenizer::decode is not implemented yet".into())
     }
 
+    /// Decode several id sequences at once, one `String` per input. Mirrors the
+    /// released `decode_batch`; sequential (KISS) — behavior-identical to a
+    /// parallel map, since each [`decode`](Self::decode) is independent.
+    pub fn decode_batch(
+        &self,
+        sentences: &[&[u32]],
+        skip_special_tokens: bool,
+    ) -> Result<Vec<String>> {
+        sentences
+            .iter()
+            .map(|ids| self.decode(ids, skip_special_tokens))
+            .collect()
+    }
+
+    /// Incremental decode: feed ids one at a time via [`PipelineDecodeStream::step`].
+    /// Same prefix-tracking scheme as the released `DecodeStream`, built on
+    /// [`decode`](Self::decode) — so it is correct exactly where `decode` is.
+    pub fn decode_stream(&self, skip_special_tokens: bool) -> PipelineDecodeStream<'_> {
+        PipelineDecodeStream {
+            tokenizer: self,
+            ids: Vec::new(),
+            skip_special_tokens,
+            prefix: String::new(),
+            prefix_index: 0,
+        }
+    }
+
     /// Single source of truth for the encode pipeline, generic over how many stages
     /// run. `STAGE` is a **const generic**, so `if STAGE >= …` folds at compile time and
     /// the disabled stages are compiled out — the full specialization
@@ -624,6 +651,51 @@ impl PipelineTokenizer {
             output.extend_from_slice(suffix);
         }
         Ok(())
+    }
+}
+
+/// Streaming decoder over a [`PipelineTokenizer`]; see [`PipelineTokenizer::decode_stream`].
+pub struct PipelineDecodeStream<'tok> {
+    tokenizer: &'tok PipelineTokenizer,
+    ids: Vec<u32>,
+    skip_special_tokens: bool,
+    prefix: String,
+    prefix_index: usize,
+}
+
+impl PipelineDecodeStream<'_> {
+    /// Push one id and return the text it completes, or `None` while a multi-token
+    /// (or multi-byte) unit is still forming. Ids past the emitted prefix are kept
+    /// as decode context so cross-token decoders (byte-level, WordPiece `##`, …)
+    /// see the same input a one-shot [`decode`](PipelineTokenizer::decode) would.
+    pub fn step(&mut self, id: u32) -> Result<Option<String>> {
+        if self.prefix.is_empty() && !self.ids.is_empty() {
+            let new_prefix = self.tokenizer.decode(&self.ids, self.skip_special_tokens)?;
+            if !new_prefix.ends_with('\u{fffd}') {
+                self.prefix = new_prefix;
+                self.prefix_index = self.ids.len();
+            }
+        }
+
+        self.ids.push(id);
+        let string = self.tokenizer.decode(&self.ids, self.skip_special_tokens)?;
+        if string.len() > self.prefix.len() && !string.ends_with('\u{fffd}') {
+            if !string.starts_with(&self.prefix) {
+                return Err(format!(
+                    "decode stream: {string:?} does not extend prefix {:?}",
+                    self.prefix
+                )
+                .into());
+            }
+            let new_text = string[self.prefix.len()..].to_string();
+            let new_prefix_index = self.ids.len() - self.prefix_index;
+            self.ids = self.ids.split_off(self.prefix_index);
+            self.prefix = self.tokenizer.decode(&self.ids, self.skip_special_tokens)?;
+            self.prefix_index = new_prefix_index;
+            Ok(Some(new_text))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/tokenizers/tk-encode/tests/common/mod.rs
+++ b/tokenizers/tk-encode/tests/common/mod.rs
@@ -2,8 +2,8 @@
 //! judged over the same inputs: seeded-random windows of the real fixture corpora
 //! (`data/fixtures/{lang,modalities}` — 14 languages + code/math/agentic). Random
 //! for coverage across varied text, seeded so any failure reproduces exactly.
-
-use std::path::{Path, PathBuf};
+//! Both oracles generate one `#[test]` per fixture via [`for_each_fixture`], so a
+//! red run names the exact model and language/modality that broke.
 
 /// Test-data root, shared with the benchmark harness (populated by `make fixtures`).
 pub const DATA: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
@@ -19,22 +19,12 @@ pub fn splitmix64(seed: u64) -> u64 {
     z ^ (z >> 31)
 }
 
-/// Existing `.txt` fixtures under `data/fixtures/{lang,modalities}`, sorted. Empty
-/// when fixtures haven't been fetched — callers skip rather than fail.
-pub fn fixture_files() -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    for group in ["lang", "modalities"] {
-        let dir = Path::new(DATA).join("fixtures").join(group);
-        if let Ok(entries) = std::fs::read_dir(&dir) {
-            let mut paths: Vec<PathBuf> = entries
-                .filter_map(|e| e.ok().map(|e| e.path()))
-                .filter(|p| p.extension().is_some_and(|x| x == "txt"))
-                .collect();
-            paths.sort();
-            out.extend(paths);
-        }
-    }
-    out
+/// Deterministic per-fixture seed — FNV-1a of the stem, so each fixture samples a
+/// different slice of its corpus while any failure still reproduces exactly.
+pub fn stem_seed(stem: &str) -> u64 {
+    stem.bytes().fold(0xcbf2_9ce4_8422_2325u64, |h, b| {
+        (h ^ b as u64).wrapping_mul(0x0100_0000_01b3)
+    })
 }
 
 /// A `window`-byte slice of `text` from a seeded offset, snapped to char boundaries.
@@ -53,3 +43,47 @@ pub fn random_chunk(text: &str, window: usize, seed: u64) -> &str {
     }
     &text[start..end]
 }
+
+/// One `#[test]` per fixture: expands `$cb($($extra,)* group, stem)` for every
+/// fixture in `data/fixtures/{lang,modalities}`. The list mirrors the Makefile's
+/// `FIXTURE_LANGS`/`FIXTURE_MODALITIES`; absent files skip inside the callback.
+/// `ident = "stem"` overrides the file stem when it isn't a valid identifier.
+macro_rules! for_each_fixture {
+    ($cb:path $(, $extra:expr)* $(,)?) => {
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", amh_Ethi);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", arb_Arab);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", ben_Beng);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", cmn_Hani);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", ell_Grek);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", eng_Latn);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", heb_Hebr);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", hin_Deva);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", jpn_Jpan);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", kat_Geor);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", kor_Hang);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", rus_Cyrl);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", tam_Taml);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", tha_Thai);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", added_normalized_dense);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", added_normalized_sparse);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", added_special_dense);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", added_special_sparse);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", agentic_swe);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", agentic_traces = "agentic-traces");
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", code_mixed);
+        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", math_latex);
+    };
+    (@one $cb:path, ($($extra:expr),*), $group:literal, $name:ident) => {
+        #[test]
+        fn $name() {
+            $cb($($extra,)* $group, stringify!($name));
+        }
+    };
+    (@one $cb:path, ($($extra:expr),*), $group:literal, $name:ident = $stem:literal) => {
+        #[test]
+        fn $name() {
+            $cb($($extra,)* $group, $stem);
+        }
+    };
+}
+pub(crate) use for_each_fixture;

--- a/tokenizers/tk-encode/tests/common/mod.rs
+++ b/tokenizers/tk-encode/tests/common/mod.rs
@@ -1,0 +1,55 @@
+//! Shared setup for the pipeline oracle tests. Encode and decode parity are
+//! judged over the same inputs: seeded-random windows of the real fixture corpora
+//! (`data/fixtures/{lang,modalities}` — 14 languages + code/math/agentic). Random
+//! for coverage across varied text, seeded so any failure reproduces exactly.
+
+use std::path::{Path, PathBuf};
+
+/// Test-data root, shared with the benchmark harness (populated by `make fixtures`).
+pub const DATA: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
+
+/// Window sizes sampled per fixture: one per-input-overhead-sized, one amortized.
+pub const WINDOWS: &[usize] = &[1024, 8 * 1024];
+
+/// splitmix64 — a tiny deterministic PRNG so the "random" offsets stay reproducible.
+pub fn splitmix64(seed: u64) -> u64 {
+    let mut z = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Existing `.txt` fixtures under `data/fixtures/{lang,modalities}`, sorted. Empty
+/// when fixtures haven't been fetched — callers skip rather than fail.
+pub fn fixture_files() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for group in ["lang", "modalities"] {
+        let dir = Path::new(DATA).join("fixtures").join(group);
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            let mut paths: Vec<PathBuf> = entries
+                .filter_map(|e| e.ok().map(|e| e.path()))
+                .filter(|p| p.extension().is_some_and(|x| x == "txt"))
+                .collect();
+            paths.sort();
+            out.extend(paths);
+        }
+    }
+    out
+}
+
+/// A `window`-byte slice of `text` from a seeded offset, snapped to char boundaries.
+pub fn random_chunk(text: &str, window: usize, seed: u64) -> &str {
+    let len = text.len();
+    if len <= window {
+        return text;
+    }
+    let mut start = splitmix64(seed) as usize % (len - window);
+    while !text.is_char_boundary(start) {
+        start += 1;
+    }
+    let mut end = (start + window).min(len);
+    while end < len && !text.is_char_boundary(end) {
+        end += 1;
+    }
+    &text[start..end]
+}

--- a/tokenizers/tk-encode/tests/common/mod.rs
+++ b/tokenizers/tk-encode/tests/common/mod.rs
@@ -1,89 +1,53 @@
 //! Shared setup for the pipeline oracle tests. Encode and decode parity are
-//! judged over the same inputs: seeded-random windows of the real fixture corpora
-//! (`data/fixtures/{lang,modalities}` — 14 languages + code/math/agentic). Random
-//! for coverage across varied text, seeded so any failure reproduces exactly.
-//! Both oracles generate one `#[test]` per fixture via [`for_each_fixture`], so a
-//! red run names the exact model and language/modality that broke.
+//! judged over the same inputs: fixed-size windows of the real fixture corpora
+//! (`data/fixtures/{lang,modalities}` — 14 languages + code/math/agentic).
 
 /// Test-data root, shared with the benchmark harness (populated by `make fixtures`).
 pub const DATA: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
 
-/// Window sizes sampled per fixture: one per-input-overhead-sized, one amortized.
+/// Window sizes taken per fixture, consecutively from the start of the file:
+/// one per-input-overhead-sized, one amortized.
 pub const WINDOWS: &[usize] = &[1024, 8 * 1024];
 
-/// splitmix64 — a tiny deterministic PRNG so the "random" offsets stay reproducible.
-pub fn splitmix64(seed: u64) -> u64 {
-    let mut z = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
-    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-    z ^ (z >> 31)
-}
+/// Every fixture `make fixtures` fetches, as `(group, file stem)` — mirrors the
+/// Makefile's `FIXTURE_LANGS`/`FIXTURE_MODALITIES`. Absent files skip at run time.
+pub const FIXTURES: &[(&str, &str)] = &[
+    ("lang", "amh_Ethi"),
+    ("lang", "arb_Arab"),
+    ("lang", "ben_Beng"),
+    ("lang", "cmn_Hani"),
+    ("lang", "ell_Grek"),
+    ("lang", "eng_Latn"),
+    ("lang", "heb_Hebr"),
+    ("lang", "hin_Deva"),
+    ("lang", "jpn_Jpan"),
+    ("lang", "kat_Geor"),
+    ("lang", "kor_Hang"),
+    ("lang", "rus_Cyrl"),
+    ("lang", "tam_Taml"),
+    ("lang", "tha_Thai"),
+    ("modalities", "added_normalized_dense"),
+    ("modalities", "added_normalized_sparse"),
+    ("modalities", "added_special_dense"),
+    ("modalities", "added_special_sparse"),
+    ("modalities", "agentic_swe"),
+    ("modalities", "agentic-traces"),
+    ("modalities", "code_mixed"),
+    ("modalities", "math_latex"),
+];
 
-/// Deterministic per-fixture seed — FNV-1a of the stem, so each fixture samples a
-/// different slice of its corpus while any failure still reproduces exactly.
-pub fn stem_seed(stem: &str) -> u64 {
-    stem.bytes().fold(0xcbf2_9ce4_8422_2325u64, |h, b| {
-        (h ^ b as u64).wrapping_mul(0x0100_0000_01b3)
-    })
-}
-
-/// A `window`-byte slice of `text` from a seeded offset, snapped to char boundaries.
-pub fn random_chunk(text: &str, window: usize, seed: u64) -> &str {
-    let len = text.len();
-    if len <= window {
-        return text;
+/// `len` bytes of `text` from `start`, both ends snapped to char boundaries.
+pub fn window(text: &str, start: usize, len: usize) -> &str {
+    if start >= text.len() {
+        return "";
     }
-    let mut start = splitmix64(seed) as usize % (len - window);
-    while !text.is_char_boundary(start) {
-        start += 1;
+    let mut s = start;
+    while !text.is_char_boundary(s) {
+        s += 1;
     }
-    let mut end = (start + window).min(len);
-    while end < len && !text.is_char_boundary(end) {
-        end += 1;
+    let mut e = (s + len).min(text.len());
+    while e < text.len() && !text.is_char_boundary(e) {
+        e += 1;
     }
-    &text[start..end]
+    &text[s..e]
 }
-
-/// One `#[test]` per fixture: expands `$cb($($extra,)* group, stem)` for every
-/// fixture in `data/fixtures/{lang,modalities}`. The list mirrors the Makefile's
-/// `FIXTURE_LANGS`/`FIXTURE_MODALITIES`; absent files skip inside the callback.
-/// `ident = "stem"` overrides the file stem when it isn't a valid identifier.
-macro_rules! for_each_fixture {
-    ($cb:path $(, $extra:expr)* $(,)?) => {
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", amh_Ethi);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", arb_Arab);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", ben_Beng);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", cmn_Hani);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", ell_Grek);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", eng_Latn);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", heb_Hebr);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", hin_Deva);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", jpn_Jpan);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", kat_Geor);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", kor_Hang);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", rus_Cyrl);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", tam_Taml);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"lang", tha_Thai);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", added_normalized_dense);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", added_normalized_sparse);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", added_special_dense);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", added_special_sparse);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", agentic_swe);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", agentic_traces = "agentic-traces");
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", code_mixed);
-        crate::common::for_each_fixture!(@one $cb, ($($extra),*),"modalities", math_latex);
-    };
-    (@one $cb:path, ($($extra:expr),*), $group:literal, $name:ident) => {
-        #[test]
-        fn $name() {
-            $cb($($extra,)* $group, stringify!($name));
-        }
-    };
-    (@one $cb:path, ($($extra:expr),*), $group:literal, $name:ident = $stem:literal) => {
-        #[test]
-        fn $name() {
-            $cb($($extra,)* $group, $stem);
-        }
-    };
-}
-pub(crate) use for_each_fixture;

--- a/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
@@ -87,7 +87,6 @@ macro_rules! decode_tests {
     ($($name:ident => $tok:literal),* $(,)?) => {
         $(
             #[test]
-            #[ignore = "un-ignore once PipelineTokenizer::decode is implemented"]
             fn $name() {
                 check($tok);
             }

--- a/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
@@ -2,28 +2,21 @@
 //! latest *released* `tokenizers` crate — not the in-tree legacy `Tokenizer`,
 //! which is being removed (oracles must not depend on it).
 //!
-//! Round-trip: encode a fixture window with the release's `encode_fast`, then
+//! Round-trip: encode fixture windows with the release's `encode_fast`, then
 //! decode those ids with both the released `decode` and
 //! `PipelineTokenizer::decode` and require byte-identical output. Feeding the
 //! release's own ids keeps this honest even where the pipeline's *encode*
 //! legitimately diverges — decode is judged on decode alone. (0.23.1 has no
 //! `decode_fast`; switch to it if a future release adds one.)
 //!
-//! One test per `model::{single,pair}::fixture` — so a red run names the exact
-//! model, input kind, and language/modality that broke, instead of one giant
-//! per-model test that stops at its first mismatch. Inside each, the window ×
-//! `add_special_tokens` × `skip_special_tokens` sweep runs, comparing the pipeline
-//! to the release three ways: one-shot `decode`, chunk-by-chunk `decode_stream`,
-//! and `decode_batch` over the fixture's windows. Together they exercise:
-//!   - the per-model **decoder** — one model per `DecoderWrapper` a fixture reaches
-//!     (see the `decode_tests!` set below);
-//!   - **special tokens** in the stream — `add_special_tokens = true` injects the
-//!     model's specials ([CLS]/[SEP], <|begin_of_text|>, …); `pair` adds the pair
-//!     template's extras (second [SEP], type ids). Single-sequence models have no
-//!     pair template, so their `pair` tests skip;
-//!   - **`skip_special_tokens`** — both keeping and dropping those ids;
-//!   - the multibyte paths (byte-fallback `<0xNN>`, Metaspace) that only fire on the
-//!     non-ASCII language fixtures — run `make fixtures` or every fixture skips.
+//! One test per model; a failure lists every diverging (fixture, window, flags)
+//! case instead of stopping at the first. Each case sweeps single and pair inputs
+//! (pair drives the pair template's extras — second [SEP], type ids; models
+//! without a pair template only run single), `add_special_tokens` ×
+//! `skip_special_tokens`, and compares one-shot `decode`, chunk-by-chunk
+//! `decode_stream`, and `decode_batch`. The multibyte paths (byte-fallback
+//! `<0xNN>`, Metaspace) only fire on the non-ASCII language fixtures — run
+//! `make fixtures` or every fixture skips.
 //!
 //! `non_special_added_token_survives_skip` covers the one case the corpus can't: a
 //! *non-special* added token (every fixture's added tokens are `special: true`) must
@@ -42,15 +35,12 @@ mod common;
 use std::convert::TryFrom;
 use std::path::Path;
 
-use common::{DATA, WINDOWS, random_chunk, stem_seed};
+use common::{DATA, FIXTURES, WINDOWS, window};
 use tk_encode::Tokenizer;
 use tk_encode::pipeline::PipelineTokenizer;
 use tokenizers_release::Tokenizer as Released;
 
-/// One (model, input-kind, fixture) case: decode every window of `data/fixtures/
-/// {group}/{stem}.txt` and require pipeline == release for one-shot, streaming, and
-/// batch decode across the `add_special_tokens × skip_special_tokens` sweep.
-fn check_one(tok_file: &str, pair: bool, group: &str, stem: &str) {
+fn check_model(tok_file: &str) {
     let path = Path::new(DATA).join(tok_file);
     // The legacy `Tokenizer` only *builds* the pipeline (its sole constructor
     // today); it is never a decode reference. Drops out once a direct loader exists.
@@ -70,90 +60,111 @@ fn check_one(tok_file: &str, pair: bool, group: &str, stem: &str) {
         }
     };
     // Single-sequence tokenizers have no pair template and error on a pair input.
-    if pair && released.encode_fast(("a", "b"), false).is_err() {
-        eprintln!("skip {tok_file} [{group}/{stem}] pair: model has no pair template");
-        return;
-    }
-
-    let fixture = Path::new(DATA)
-        .join("fixtures")
-        .join(group)
-        .join(format!("{stem}.txt"));
-    let Ok(text) = std::fs::read_to_string(&fixture) else {
-        eprintln!(
-            "skip {}: fixture absent (run `make fixtures`)",
-            fixture.display()
-        );
-        return;
+    let pair_kinds: &[bool] = if released.encode_fast(("a", "b"), false).is_ok() {
+        &[false, true]
+    } else {
+        &[false]
     };
-    if text.is_empty() {
-        return;
-    }
 
+    let mut failures = Vec::new();
     let mut batch: Vec<Vec<u32>> = Vec::new();
-    for (w, &window) in WINDOWS.iter().enumerate() {
-        let seed = stem_seed(stem) ^ w as u64;
-        let chunk = random_chunk(&text, window, seed);
-        if chunk.is_empty() {
+    for &(group, stem) in FIXTURES {
+        let fixture = Path::new(DATA)
+            .join("fixtures")
+            .join(group)
+            .join(format!("{stem}.txt"));
+        let Ok(text) = std::fs::read_to_string(&fixture) else {
+            eprintln!(
+                "skip {}: fixture absent (run `make fixtures`)",
+                fixture.display()
+            );
             continue;
-        }
-        for add_special_tokens in [false, true] {
-            let ids = if pair {
-                // A second, disjoint-seeded slice so the pair drives the
-                // post-processor's pair template into the decoded id stream.
-                let second = random_chunk(&text, window, seed ^ 0xA5A5_A5A5);
-                match released.encode_fast((chunk, second), add_special_tokens) {
-                    Ok(enc) => enc.get_ids().to_vec(),
-                    Err(_) => continue,
-                }
-            } else {
-                released
-                    .encode_fast(chunk, add_special_tokens)
-                    .unwrap()
-                    .get_ids()
-                    .to_vec()
-            };
-
-            for skip_special_tokens in [false, true] {
-                let expected = released.decode(&ids, skip_special_tokens).unwrap();
-                let one_shot = pipeline.decode(&ids, skip_special_tokens).unwrap();
-                let streamed = stream_decode(&pipeline, &ids, skip_special_tokens);
-                let ctx = format!(
-                    "{tok_file} [{group}/{stem}] (pair={pair}, \
-                     add_special_tokens={add_special_tokens}, \
-                     skip_special_tokens={skip_special_tokens}) @ {:?}",
-                    chunk.chars().take(60).collect::<String>(),
-                );
-                assert_eq!(expected, one_shot, "decode mismatch on {ctx}");
-                assert_eq!(expected, streamed, "decode_stream mismatch on {ctx}");
+        };
+        let mut start = 0;
+        for &w in WINDOWS {
+            let chunk = window(&text, start, w);
+            // The pair's second sequence: the bytes right after `chunk`.
+            let second = window(&text, start + w, w);
+            start += w;
+            if chunk.is_empty() {
+                continue;
             }
-            batch.push(ids);
+            for &pair in pair_kinds {
+                for add_special_tokens in [false, true] {
+                    let ids = if pair {
+                        released
+                            .encode_fast((chunk, second), add_special_tokens)
+                            .unwrap()
+                            .get_ids()
+                            .to_vec()
+                    } else {
+                        released
+                            .encode_fast(chunk, add_special_tokens)
+                            .unwrap()
+                            .get_ids()
+                            .to_vec()
+                    };
+                    for skip_special_tokens in [false, true] {
+                        let expected = released.decode(&ids, skip_special_tokens).unwrap();
+                        let ctx = format!(
+                            "{group}/{stem} ({w} B window, pair={pair}, \
+                             add_special_tokens={add_special_tokens}, \
+                             skip_special_tokens={skip_special_tokens})"
+                        );
+                        match pipeline.decode(&ids, skip_special_tokens) {
+                            Ok(got) if got == expected => {}
+                            Ok(_) => failures.push(format!("{ctx}: decode mismatch")),
+                            Err(e) => failures.push(format!("{ctx}: decode error: {e}")),
+                        }
+                        match stream_decode(&pipeline, &ids, skip_special_tokens) {
+                            Ok(got) if got == expected => {}
+                            Ok(_) => failures.push(format!("{ctx}: decode_stream mismatch")),
+                            Err(e) => failures.push(format!("{ctx}: decode_stream error: {e}")),
+                        }
+                    }
+                    batch.push(ids);
+                }
+            }
         }
     }
 
-    // decode_batch must match the released batch decoder over this fixture's ids.
+    // decode_batch must match the released batch decoder over the whole id set.
     if !batch.is_empty() {
         let sentences: Vec<&[u32]> = batch.iter().map(Vec::as_slice).collect();
-        assert_eq!(
-            released.decode_batch(&sentences, false).unwrap(),
-            pipeline.decode_batch(&sentences, false).unwrap(),
-            "decode_batch mismatch for {tok_file} [{group}/{stem}] (pair={pair})",
-        );
+        let expected = released.decode_batch(&sentences, false).unwrap();
+        match pipeline.decode_batch(&sentences, false) {
+            Ok(got) if got == expected => {}
+            Ok(_) => failures.push("decode_batch mismatch".into()),
+            Err(e) => failures.push(format!("decode_batch error: {e}")),
+        }
     }
+
+    let shown: Vec<&str> = failures.iter().take(10).map(String::as_str).collect();
+    assert!(
+        failures.is_empty(),
+        "{tok_file}: {} case(s) diverge from the released crate (first {}):\n{}",
+        failures.len(),
+        shown.len(),
+        shown.join("\n"),
+    );
 }
 
 /// Feed `ids` through [`PipelineTokenizer::decode_stream`] one at a time and
 /// concatenate the emitted chunks — for a complete id sequence this must equal a
 /// one-shot `decode`, so the oracle can compare it against the release directly.
-fn stream_decode(pipeline: &PipelineTokenizer, ids: &[u32], skip_special_tokens: bool) -> String {
+fn stream_decode(
+    pipeline: &PipelineTokenizer,
+    ids: &[u32],
+    skip_special_tokens: bool,
+) -> tk_encode::Result<String> {
     let mut stream = pipeline.decode_stream(skip_special_tokens);
     let mut out = String::new();
     for &id in ids {
-        if let Some(chunk) = stream.step(id).unwrap() {
+        if let Some(chunk) = stream.step(id)? {
             out.push_str(&chunk);
         }
     }
-    out
+    Ok(out)
 }
 
 /// A non-special *added* token must survive `skip_special_tokens = true` — that
@@ -209,33 +220,39 @@ fn non_special_added_token_survives_skip() {
 // reach is exercised: byte-level (gpt2, llama-3), WordPiece (bert-base-uncased),
 // null→space-join (bert-wiki), Metaspace (t5-base, albert), and the SentencePiece
 // `Sequence[Replace, ByteFallback, Fuse, Strip]` (llama-2). Missing files or
-// unsupported models are skipped, not ignored: the decode gaps fail on purpose
-// until decode is implemented. (BPE/CTC decoders have no fixture in this set yet.)
-macro_rules! decode_tests {
-    ($($model:ident => $tok:literal),* $(,)?) => {
-        $(
-            mod $model {
-                // Fixture-derived fn names (amh_Ethi, tam_Taml, …) keep their script
-                // casing so a failure reads as the fixture, not a mangled snake_case.
-                #[allow(non_snake_case)]
-                mod single {
-                    crate::common::for_each_fixture!(crate::check_one, $tok, false);
-                }
-                #[allow(non_snake_case)]
-                mod pair {
-                    crate::common::for_each_fixture!(crate::check_one, $tok, true);
-                }
-            }
-        )*
-    };
+// unsupported models skip, not fail: the decode gaps fail on purpose until decode
+// is implemented. (BPE/CTC decoders have no fixture in this set yet.)
+#[test]
+fn bert_wiki() {
+    check_model("bert-wiki.json");
 }
 
-decode_tests! {
-    bert_wiki         => "bert-wiki.json",
-    bert_base_uncased => "bert-base-uncased.json",
-    gpt2              => "gpt2.json",
-    llama3            => "llama-3-tokenizer.json",
-    llama2            => "llama-2.json",
-    t5_base           => "t5-base.json",
-    albert            => "albert-base-v1-tokenizer.json",
+#[test]
+fn bert_base_uncased() {
+    check_model("bert-base-uncased.json");
+}
+
+#[test]
+fn gpt2() {
+    check_model("gpt2.json");
+}
+
+#[test]
+fn llama3() {
+    check_model("llama-3-tokenizer.json");
+}
+
+#[test]
+fn llama2() {
+    check_model("llama-2.json");
+}
+
+#[test]
+fn t5_base() {
+    check_model("t5-base.json");
+}
+
+#[test]
+fn albert() {
+    check_model("albert-base-v1-tokenizer.json");
 }

--- a/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
@@ -2,21 +2,38 @@
 //! latest *released* `tokenizers` crate — not the in-tree legacy `Tokenizer`,
 //! which is being removed (oracles must not depend on it).
 //!
-//! Round-trip: encode a fixture window with the release's `encode_fast`
-//! (`add_special_tokens = false`), then decode those ids with both the released
-//! `decode` and `PipelineTokenizer::decode` and require byte-identical output.
-//! Feeding the release's own ids keeps this honest even where the pipeline's
-//! *encode* legitimately diverges — decode is judged on decode alone. (0.23.1 has
-//! no `decode_fast`; switch to it if a future release adds one.)
+//! Round-trip: encode a fixture window with the release's `encode_fast`, then
+//! decode those ids with both the released `decode` and
+//! `PipelineTokenizer::decode` and require byte-identical output. Feeding the
+//! release's own ids keeps this honest even where the pipeline's *encode*
+//! legitimately diverges — decode is judged on decode alone. (0.23.1 has no
+//! `decode_fast`; switch to it if a future release adds one.)
 //!
-//! Inputs and covered tokenizers mirror the encode oracle (`pipeline_oracle.rs`):
-//! bert-wiki (WordPiece `##`) and llama-3 (byte-level) over seeded-random windows
-//! of the fixture corpora.
+//! One test per `model::{single,pair}::fixture` — so a red run names the exact
+//! model, input kind, and language/modality that broke, instead of one giant
+//! per-model test that stops at its first mismatch. Inside each, the window ×
+//! `add_special_tokens` × `skip_special_tokens` sweep runs, comparing the pipeline
+//! to the release three ways: one-shot `decode`, chunk-by-chunk `decode_stream`,
+//! and `decode_batch` over the fixture's windows. Together they exercise:
+//!   - the per-model **decoder** — one model per `DecoderWrapper` a fixture reaches
+//!     (see the `decode_tests!` set below);
+//!   - **special tokens** in the stream — `add_special_tokens = true` injects the
+//!     model's specials ([CLS]/[SEP], <|begin_of_text|>, …); `pair` adds the pair
+//!     template's extras (second [SEP], type ids). Single-sequence models have no
+//!     pair template, so their `pair` tests skip;
+//!   - **`skip_special_tokens`** — both keeping and dropping those ids;
+//!   - the multibyte paths (byte-fallback `<0xNN>`, Metaspace) that only fire on the
+//!     non-ASCII language fixtures — run `make fixtures` or every fixture skips.
 //!
-//! Behind `bench-baseline`. IGNORED until `PipelineTokenizer::decode` is
-//! implemented (a loud stub today, so these fail on `.unwrap()`); un-ignore with
-//! the impl by dropping the `#[ignore]` lines:
-//!   cargo test -p tk-encode --features bench-baseline --test pipeline_decode_oracle -- --ignored
+//! `non_special_added_token_survives_skip` covers the one case the corpus can't: a
+//! *non-special* added token (every fixture's added tokens are `special: true`) must
+//! survive `skip_special_tokens = true`. It's built by adding the same token to both
+//! sides, so it stays an honest release-vs-pipeline parity check.
+//!
+//! Behind `bench-baseline`. These FAIL until `PipelineTokenizer::decode` applies the
+//! decoder and distinguishes special from non-special added vocab — on purpose: CI
+//! stays red until decode lands, rather than hiding the gap behind a skipped test.
+//!   cargo test -p tk-encode --features bench-baseline --test pipeline_decode_oracle
 
 #![cfg(feature = "bench-baseline")]
 
@@ -25,17 +42,20 @@ mod common;
 use std::convert::TryFrom;
 use std::path::Path;
 
-use common::{DATA, WINDOWS, fixture_files, random_chunk};
+use common::{DATA, WINDOWS, random_chunk, stem_seed};
 use tk_encode::Tokenizer;
 use tk_encode::pipeline::PipelineTokenizer;
 use tokenizers_release::Tokenizer as Released;
 
-fn check(tok_file: &str) {
+/// One (model, input-kind, fixture) case: decode every window of `data/fixtures/
+/// {group}/{stem}.txt` and require pipeline == release for one-shot, streaming, and
+/// batch decode across the `add_special_tokens × skip_special_tokens` sweep.
+fn check_one(tok_file: &str, pair: bool, group: &str, stem: &str) {
     let path = Path::new(DATA).join(tok_file);
     // The legacy `Tokenizer` only *builds* the pipeline (its sole constructor
     // today); it is never a decode reference. Drops out once a direct loader exists.
     let Ok(tree) = Tokenizer::from_file(&path) else {
-        eprintln!("skip {tok_file}: not present (fetch with `make fixtures bench-models`)");
+        eprintln!("skip {tok_file}: not present (fetch with `make bench-models`)");
         return;
     };
     let Ok(pipeline) = PipelineTokenizer::try_from(&tree) else {
@@ -49,55 +69,173 @@ fn check(tok_file: &str) {
             return;
         }
     };
-    let files = fixture_files();
-    if files.is_empty() {
-        eprintln!("skip {tok_file}: no fixtures under {DATA}/fixtures — run `make fixtures`");
+    // Single-sequence tokenizers have no pair template and error on a pair input.
+    if pair && released.encode_fast(("a", "b"), false).is_err() {
+        eprintln!("skip {tok_file} [{group}/{stem}] pair: model has no pair template");
         return;
     }
 
-    for (i, f) in files.iter().enumerate() {
-        let text = std::fs::read_to_string(f).unwrap();
-        if text.is_empty() {
+    let fixture = Path::new(DATA)
+        .join("fixtures")
+        .join(group)
+        .join(format!("{stem}.txt"));
+    let Ok(text) = std::fs::read_to_string(&fixture) else {
+        eprintln!(
+            "skip {}: fixture absent (run `make fixtures`)",
+            fixture.display()
+        );
+        return;
+    };
+    if text.is_empty() {
+        return;
+    }
+
+    let mut batch: Vec<Vec<u32>> = Vec::new();
+    for (w, &window) in WINDOWS.iter().enumerate() {
+        let seed = stem_seed(stem) ^ w as u64;
+        let chunk = random_chunk(&text, window, seed);
+        if chunk.is_empty() {
             continue;
         }
-        for (w, &window) in WINDOWS.iter().enumerate() {
-            let chunk = random_chunk(&text, window, ((i as u64) << 8) | w as u64);
-            if chunk.is_empty() {
-                continue;
+        for add_special_tokens in [false, true] {
+            let ids = if pair {
+                // A second, disjoint-seeded slice so the pair drives the
+                // post-processor's pair template into the decoded id stream.
+                let second = random_chunk(&text, window, seed ^ 0xA5A5_A5A5);
+                match released.encode_fast((chunk, second), add_special_tokens) {
+                    Ok(enc) => enc.get_ids().to_vec(),
+                    Err(_) => continue,
+                }
+            } else {
+                released
+                    .encode_fast(chunk, add_special_tokens)
+                    .unwrap()
+                    .get_ids()
+                    .to_vec()
+            };
+
+            for skip_special_tokens in [false, true] {
+                let expected = released.decode(&ids, skip_special_tokens).unwrap();
+                let one_shot = pipeline.decode(&ids, skip_special_tokens).unwrap();
+                let streamed = stream_decode(&pipeline, &ids, skip_special_tokens);
+                let ctx = format!(
+                    "{tok_file} [{group}/{stem}] (pair={pair}, \
+                     add_special_tokens={add_special_tokens}, \
+                     skip_special_tokens={skip_special_tokens}) @ {:?}",
+                    chunk.chars().take(60).collect::<String>(),
+                );
+                assert_eq!(expected, one_shot, "decode mismatch on {ctx}");
+                assert_eq!(expected, streamed, "decode_stream mismatch on {ctx}");
             }
-            let ids = released
-                .encode_fast(chunk, false)
-                .unwrap()
-                .get_ids()
-                .to_vec();
-            let expected = released.decode(&ids, false).unwrap();
-            let got = pipeline.decode(&ids, false).unwrap();
-            assert_eq!(
-                expected,
-                got,
-                "decode mismatch on {} @ {:?}",
-                f.display(),
-                chunk.chars().take(60).collect::<String>(),
-            );
+            batch.push(ids);
         }
+    }
+
+    // decode_batch must match the released batch decoder over this fixture's ids.
+    if !batch.is_empty() {
+        let sentences: Vec<&[u32]> = batch.iter().map(Vec::as_slice).collect();
+        assert_eq!(
+            released.decode_batch(&sentences, false).unwrap(),
+            pipeline.decode_batch(&sentences, false).unwrap(),
+            "decode_batch mismatch for {tok_file} [{group}/{stem}] (pair={pair})",
+        );
     }
 }
 
+/// Feed `ids` through [`PipelineTokenizer::decode_stream`] one at a time and
+/// concatenate the emitted chunks — for a complete id sequence this must equal a
+/// one-shot `decode`, so the oracle can compare it against the release directly.
+fn stream_decode(pipeline: &PipelineTokenizer, ids: &[u32], skip_special_tokens: bool) -> String {
+    let mut stream = pipeline.decode_stream(skip_special_tokens);
+    let mut out = String::new();
+    for &id in ids {
+        if let Some(chunk) = stream.step(id).unwrap() {
+            out.push_str(&chunk);
+        }
+    }
+    out
+}
+
+/// A non-special *added* token must survive `skip_special_tokens = true` — that
+/// flag drops only tokens marked `special`. Every fixture's added tokens are
+/// `special: true`, so this can't come from the corpus: add the same non-special
+/// token to both the reference and the pipeline's source, then round-trip a string
+/// containing it. Byte-level gpt2 decodes this ASCII round-trip correctly, so the
+/// only thing under test here is the special-vs-non-special distinction.
+#[test]
+fn non_special_added_token_survives_skip() {
+    let path = Path::new(DATA).join("gpt2.json");
+    let Ok(mut tree) = Tokenizer::from_file(&path) else {
+        eprintln!("skip: gpt2.json not present (fetch with `make bench-models`)");
+        return;
+    };
+    let Ok(mut released) = Released::from_file(&path) else {
+        eprintln!("skip: released crate can't load gpt2.json");
+        return;
+    };
+
+    let content = "<|mytok|>";
+    tree.add_tokens([tk_encode::AddedToken::from(content, false)])
+        .unwrap();
+    released
+        .add_tokens([tokenizers_release::AddedToken::from(content, false)])
+        .unwrap();
+    let pipeline = PipelineTokenizer::try_from(&tree).unwrap();
+
+    let text = format!("hello {content} world");
+    let ids = released
+        .encode_fast(text.as_str(), false)
+        .unwrap()
+        .get_ids()
+        .to_vec();
+    let tok_id = released.token_to_id(content).unwrap();
+    assert!(
+        ids.contains(&tok_id),
+        "added token not present in id stream"
+    );
+
+    for skip_special_tokens in [false, true] {
+        let expected = released.decode(&ids, skip_special_tokens).unwrap();
+        let got = pipeline.decode(&ids, skip_special_tokens).unwrap();
+        assert_eq!(expected, got, "skip_special_tokens={skip_special_tokens}");
+        assert!(
+            got.contains(content),
+            "non-special added token dropped at skip_special_tokens={skip_special_tokens}: {got:?}",
+        );
+    }
+}
+
+// One model per distinct decoder so every `DecoderWrapper` variant a fixture can
+// reach is exercised: byte-level (gpt2, llama-3), WordPiece (bert-base-uncased),
+// null→space-join (bert-wiki), Metaspace (t5-base, albert), and the SentencePiece
+// `Sequence[Replace, ByteFallback, Fuse, Strip]` (llama-2). Missing files or
+// unsupported models are skipped, not ignored: the decode gaps fail on purpose
+// until decode is implemented. (BPE/CTC decoders have no fixture in this set yet.)
 macro_rules! decode_tests {
-    ($($name:ident => $tok:literal),* $(,)?) => {
+    ($($model:ident => $tok:literal),* $(,)?) => {
         $(
-            #[test]
-            fn $name() {
-                check($tok);
+            mod $model {
+                // Fixture-derived fn names (amh_Ethi, tam_Taml, …) keep their script
+                // casing so a failure reads as the fixture, not a mangled snake_case.
+                #[allow(non_snake_case)]
+                mod single {
+                    crate::common::for_each_fixture!(crate::check_one, $tok, false);
+                }
+                #[allow(non_snake_case)]
+                mod pair {
+                    crate::common::for_each_fixture!(crate::check_one, $tok, true);
+                }
             }
         )*
     };
 }
 
-// Mirrors the encode oracle's model set; missing files are skipped.
 decode_tests! {
     bert_wiki         => "bert-wiki.json",
     bert_base_uncased => "bert-base-uncased.json",
     gpt2              => "gpt2.json",
     llama3            => "llama-3-tokenizer.json",
+    llama2            => "llama-2.json",
+    t5_base           => "t5-base.json",
+    albert            => "albert-base-v1-tokenizer.json",
 }

--- a/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
@@ -1,14 +1,22 @@
-//! `PipelineTokenizer` must encode to exactly the same token ids as the latest
-//! *released* `tokenizers` crate — not the in-tree legacy `Tokenizer`, which is
-//! being removed (oracles must not depend on it). We compare against the release's
-//! `encode_fast` (its offset-free path; the pipeline computes no offsets either),
-//! over seeded-random windows of the fixture corpora.
+//! `PipelineTokenizer` must decode ids back to exactly the same string as the
+//! latest *released* `tokenizers` crate — not the in-tree legacy `Tokenizer`,
+//! which is being removed (oracles must not depend on it).
 //!
-//! Covered: bert-wiki (Whitespace + WordPiece) and llama-3 (byte-level BPE) — a
-//! model the pipeline can't build or encode yet is skipped, not failed.
+//! Round-trip: encode a fixture window with the release's `encode_fast`
+//! (`add_special_tokens = false`), then decode those ids with both the released
+//! `decode` and `PipelineTokenizer::decode` and require byte-identical output.
+//! Feeding the release's own ids keeps this honest even where the pipeline's
+//! *encode* legitimately diverges — decode is judged on decode alone. (0.23.1 has
+//! no `decode_fast`; switch to it if a future release adds one.)
 //!
-//! Behind the `bench-baseline` feature (the released crate is optional):
-//!   cargo test -p tk-encode --features bench-baseline --test pipeline_oracle
+//! Inputs and covered tokenizers mirror the encode oracle (`pipeline_oracle.rs`):
+//! bert-wiki (WordPiece `##`) and llama-3 (byte-level) over seeded-random windows
+//! of the fixture corpora.
+//!
+//! Behind `bench-baseline`. IGNORED until `PipelineTokenizer::decode` is
+//! implemented (a loud stub today, so these fail on `.unwrap()`); un-ignore with
+//! the impl by dropping the `#[ignore]` lines:
+//!   cargo test -p tk-encode --features bench-baseline --test pipeline_decode_oracle -- --ignored
 
 #![cfg(feature = "bench-baseline")]
 
@@ -22,12 +30,10 @@ use tk_encode::Tokenizer;
 use tk_encode::pipeline::PipelineTokenizer;
 use tokenizers_release::Tokenizer as Released;
 
-const PROBE: &str = "The quick brown fox jumps 123.";
-
 fn check(tok_file: &str) {
     let path = Path::new(DATA).join(tok_file);
     // The legacy `Tokenizer` only *builds* the pipeline (its sole constructor
-    // today); it is never an encode reference. Drops out once a direct loader exists.
+    // today); it is never a decode reference. Drops out once a direct loader exists.
     let Ok(tree) = Tokenizer::from_file(&path) else {
         eprintln!("skip {tok_file}: not present (fetch with `make fixtures bench-models`)");
         return;
@@ -36,11 +42,6 @@ fn check(tok_file: &str) {
         eprintln!("skip {tok_file}: not supported by PipelineTokenizer");
         return;
     };
-    // Build constraints can be met while encode is still unimplemented for this shape.
-    if pipeline.encode(PROBE, false).is_err() {
-        eprintln!("skip {tok_file}: pipeline can't encode this model yet");
-        return;
-    }
     let released = match Released::from_file(&path) {
         Ok(r) => r,
         Err(e) => {
@@ -64,21 +65,17 @@ fn check(tok_file: &str) {
             if chunk.is_empty() {
                 continue;
             }
-            let expected = released
+            let ids = released
                 .encode_fast(chunk, false)
                 .unwrap()
                 .get_ids()
                 .to_vec();
-            let got: Vec<u32> = pipeline
-                .encode(chunk, false)
-                .unwrap()
-                .iter()
-                .map(|t| t.id)
-                .collect();
+            let expected = released.decode(&ids, false).unwrap();
+            let got = pipeline.decode(&ids, false).unwrap();
             assert_eq!(
                 expected,
                 got,
-                "id mismatch on {} @ {:?}",
+                "decode mismatch on {} @ {:?}",
                 f.display(),
                 chunk.chars().take(60).collect::<String>(),
             );
@@ -86,10 +83,11 @@ fn check(tok_file: &str) {
     }
 }
 
-macro_rules! oracle_tests {
+macro_rules! decode_tests {
     ($($name:ident => $tok:literal),* $(,)?) => {
         $(
             #[test]
+            #[ignore = "un-ignore once PipelineTokenizer::decode is implemented"]
             fn $name() {
                 check($tok);
             }
@@ -97,9 +95,8 @@ macro_rules! oracle_tests {
     };
 }
 
-// Two decode/encode archetypes each; whichever files a given checkout has get run
-// (bert-wiki + llama-3 ship with `make test`; the rest with `make bench-models`).
-oracle_tests! {
+// Mirrors the encode oracle's model set; missing files are skipped.
+decode_tests! {
     bert_wiki         => "bert-wiki.json",
     bert_base_uncased => "bert-base-uncased.json",
     gpt2              => "gpt2.json",

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -2,13 +2,11 @@
 //! *released* `tokenizers` crate — not the in-tree legacy `Tokenizer`, which is
 //! being removed (oracles must not depend on it). We compare against the release's
 //! `encode_fast` (its offset-free path; the pipeline computes no offsets either),
-//! over seeded-random windows of the fixture corpora.
+//! over fixed windows of every fixture corpus, for both `add_special_tokens`
+//! values — `true` exercises the post-process frame.
 //!
-//! One test per `model::fixture` — so a red run names the exact model and
-//! language/modality that broke (same structure as `pipeline_decode_oracle.rs`; no
-//! `{single,pair}` split here because `PipelineTokenizer::encode` takes a single
-//! sequence). Every window is checked for both `add_special_tokens` values —
-//! `true` exercises the post-process frame. A model the pipeline can't build or
+//! One test per model; a failure lists every diverging (fixture, window, flags)
+//! case instead of stopping at the first. A model the pipeline can't build or
 //! encode yet is skipped, not failed; the model set mirrors the decode oracle's.
 //!
 //! Behind the `bench-baseline` feature (the released crate is optional):
@@ -21,16 +19,14 @@ mod common;
 use std::convert::TryFrom;
 use std::path::Path;
 
-use common::{DATA, WINDOWS, random_chunk, stem_seed};
+use common::{DATA, FIXTURES, WINDOWS, window};
 use tk_encode::Tokenizer;
 use tk_encode::pipeline::PipelineTokenizer;
 use tokenizers_release::Tokenizer as Released;
 
 const PROBE: &str = "The quick brown fox jumps 123.";
 
-/// One (model, fixture) case: encode every window of `data/fixtures/{group}/
-/// {stem}.txt` with both sides and require identical ids.
-fn check_one(tok_file: &str, group: &str, stem: &str) {
+fn check_model(tok_file: &str) {
     let path = Path::new(DATA).join(tok_file);
     // The legacy `Tokenizer` only *builds* the pipeline (its sole constructor
     // today); it is never an encode reference. Drops out once a direct loader exists.
@@ -55,71 +51,96 @@ fn check_one(tok_file: &str, group: &str, stem: &str) {
         }
     };
 
-    let fixture = Path::new(DATA)
-        .join("fixtures")
-        .join(group)
-        .join(format!("{stem}.txt"));
-    let Ok(text) = std::fs::read_to_string(&fixture) else {
-        eprintln!(
-            "skip {}: fixture absent (run `make fixtures`)",
-            fixture.display()
-        );
-        return;
-    };
-    if text.is_empty() {
-        return;
-    }
-
-    for (w, &window) in WINDOWS.iter().enumerate() {
-        let chunk = random_chunk(&text, window, stem_seed(stem) ^ w as u64);
-        if chunk.is_empty() {
-            continue;
-        }
-        for add_special_tokens in [false, true] {
-            let expected = released
-                .encode_fast(chunk, add_special_tokens)
-                .unwrap()
-                .get_ids()
-                .to_vec();
-            let got: Vec<u32> = pipeline
-                .encode(chunk, add_special_tokens)
-                .unwrap()
-                .iter()
-                .map(|t| t.id)
-                .collect();
-            assert_eq!(
-                expected,
-                got,
-                "id mismatch on {tok_file} [{group}/{stem}] \
-                 (add_special_tokens={add_special_tokens}) @ {:?}",
-                chunk.chars().take(60).collect::<String>(),
+    let mut failures = Vec::new();
+    for &(group, stem) in FIXTURES {
+        let fixture = Path::new(DATA)
+            .join("fixtures")
+            .join(group)
+            .join(format!("{stem}.txt"));
+        let Ok(text) = std::fs::read_to_string(&fixture) else {
+            eprintln!(
+                "skip {}: fixture absent (run `make fixtures`)",
+                fixture.display()
             );
+            continue;
+        };
+        let mut start = 0;
+        for &w in WINDOWS {
+            let chunk = window(&text, start, w);
+            start += w;
+            if chunk.is_empty() {
+                continue;
+            }
+            for add_special_tokens in [false, true] {
+                let expected = released
+                    .encode_fast(chunk, add_special_tokens)
+                    .unwrap()
+                    .get_ids()
+                    .to_vec();
+                let got: Vec<u32> = pipeline
+                    .encode(chunk, add_special_tokens)
+                    .unwrap()
+                    .iter()
+                    .map(|t| t.id)
+                    .collect();
+                if expected != got {
+                    let at = expected
+                        .iter()
+                        .zip(&got)
+                        .position(|(e, g)| e != g)
+                        .unwrap_or(expected.len().min(got.len()));
+                    failures.push(format!(
+                        "{group}/{stem} ({w} B window, add_special_tokens={add_special_tokens}): \
+                         ids diverge at {at} (expected len {}, got len {})",
+                        expected.len(),
+                        got.len(),
+                    ));
+                }
+            }
         }
     }
+    assert!(
+        failures.is_empty(),
+        "{tok_file}: {} case(s) diverge from the released crate:\n{}",
+        failures.len(),
+        failures.join("\n"),
+    );
 }
 
 // Same model set as the decode oracle (one per decoder archetype); whichever files
 // a given checkout has get run (bert-wiki + llama-3 ship with `make test`; the rest
 // with `make bench-models`). Unsupported models skip, not fail.
-macro_rules! encode_tests {
-    ($($model:ident => $tok:literal),* $(,)?) => {
-        $(
-            // Fixture-derived fn names (amh_Ethi, tam_Taml, …) keep their script
-            // casing so a failure reads as the fixture, not a mangled snake_case.
-            #[allow(non_snake_case)]
-            mod $model {
-                crate::common::for_each_fixture!(crate::check_one, $tok);
-            }
-        )*
-    };
+#[test]
+fn bert_wiki() {
+    check_model("bert-wiki.json");
 }
 
-encode_tests! {
-    bert_wiki         => "bert-wiki.json",
-    bert_base_uncased => "bert-base-uncased.json",
-    gpt2              => "gpt2.json",
-    llama3            => "llama-3-tokenizer.json",
-    llama2            => "llama-2.json",
-    t5_base           => "t5-base.json",
-    albert            => "albert-base-v1-tokenizer.json",
+#[test]
+fn bert_base_uncased() {
+    check_model("bert-base-uncased.json");
+}
+
+#[test]
+fn gpt2() {
+    check_model("gpt2.json");
+}
+
+#[test]
+fn llama3() {
+    check_model("llama-3-tokenizer.json");
+}
+
+#[test]
+fn llama2() {
+    check_model("llama-2.json");
+}
+
+#[test]
+fn t5_base() {
+    check_model("t5-base.json");
+}
+
+#[test]
+fn albert() {
+    check_model("albert-base-v1-tokenizer.json");
 }

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -4,8 +4,11 @@
 //! `encode_fast` (its offset-free path; the pipeline computes no offsets either),
 //! over seeded-random windows of the fixture corpora.
 //!
-//! Covered: bert-wiki (Whitespace + WordPiece) and llama-3 (byte-level BPE) — a
-//! model the pipeline can't build or encode yet is skipped, not failed.
+//! One test per `model::fixture` — so a red run names the exact model and
+//! language/modality that broke (same structure as `pipeline_decode_oracle.rs`; no
+//! `{single,pair}` split here because `PipelineTokenizer::encode` takes a single
+//! sequence and post-processing isn't wired). A model the pipeline can't build or
+//! encode yet is skipped, not failed; the model set mirrors the decode oracle's.
 //!
 //! Behind the `bench-baseline` feature (the released crate is optional):
 //!   cargo test -p tk-encode --features bench-baseline --test pipeline_oracle
@@ -17,19 +20,21 @@ mod common;
 use std::convert::TryFrom;
 use std::path::Path;
 
-use common::{DATA, WINDOWS, fixture_files, random_chunk};
+use common::{DATA, WINDOWS, random_chunk, stem_seed};
 use tk_encode::Tokenizer;
 use tk_encode::pipeline::PipelineTokenizer;
 use tokenizers_release::Tokenizer as Released;
 
 const PROBE: &str = "The quick brown fox jumps 123.";
 
-fn check(tok_file: &str) {
+/// One (model, fixture) case: encode every window of `data/fixtures/{group}/
+/// {stem}.txt` with both sides and require identical ids.
+fn check_one(tok_file: &str, group: &str, stem: &str) {
     let path = Path::new(DATA).join(tok_file);
     // The legacy `Tokenizer` only *builds* the pipeline (its sole constructor
     // today); it is never an encode reference. Drops out once a direct loader exists.
     let Ok(tree) = Tokenizer::from_file(&path) else {
-        eprintln!("skip {tok_file}: not present (fetch with `make fixtures bench-models`)");
+        eprintln!("skip {tok_file}: not present (fetch with `make bench-models`)");
         return;
     };
     let Ok(pipeline) = PipelineTokenizer::try_from(&tree) else {
@@ -48,60 +53,69 @@ fn check(tok_file: &str) {
             return;
         }
     };
-    let files = fixture_files();
-    if files.is_empty() {
-        eprintln!("skip {tok_file}: no fixtures under {DATA}/fixtures — run `make fixtures`");
+
+    let fixture = Path::new(DATA)
+        .join("fixtures")
+        .join(group)
+        .join(format!("{stem}.txt"));
+    let Ok(text) = std::fs::read_to_string(&fixture) else {
+        eprintln!(
+            "skip {}: fixture absent (run `make fixtures`)",
+            fixture.display()
+        );
+        return;
+    };
+    if text.is_empty() {
         return;
     }
 
-    for (i, f) in files.iter().enumerate() {
-        let text = std::fs::read_to_string(f).unwrap();
-        if text.is_empty() {
+    for (w, &window) in WINDOWS.iter().enumerate() {
+        let chunk = random_chunk(&text, window, stem_seed(stem) ^ w as u64);
+        if chunk.is_empty() {
             continue;
         }
-        for (w, &window) in WINDOWS.iter().enumerate() {
-            let chunk = random_chunk(&text, window, ((i as u64) << 8) | w as u64);
-            if chunk.is_empty() {
-                continue;
-            }
-            let expected = released
-                .encode_fast(chunk, false)
-                .unwrap()
-                .get_ids()
-                .to_vec();
-            let got: Vec<u32> = pipeline
-                .encode(chunk, false)
-                .unwrap()
-                .iter()
-                .map(|t| t.id)
-                .collect();
-            assert_eq!(
-                expected,
-                got,
-                "id mismatch on {} @ {:?}",
-                f.display(),
-                chunk.chars().take(60).collect::<String>(),
-            );
-        }
+        let expected = released
+            .encode_fast(chunk, false)
+            .unwrap()
+            .get_ids()
+            .to_vec();
+        let got: Vec<u32> = pipeline
+            .encode(chunk, false)
+            .unwrap()
+            .iter()
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(
+            expected,
+            got,
+            "id mismatch on {tok_file} [{group}/{stem}] @ {:?}",
+            chunk.chars().take(60).collect::<String>(),
+        );
     }
 }
 
-macro_rules! oracle_tests {
-    ($($name:ident => $tok:literal),* $(,)?) => {
+// Same model set as the decode oracle (one per decoder archetype); whichever files
+// a given checkout has get run (bert-wiki + llama-3 ship with `make test`; the rest
+// with `make bench-models`). Unsupported models skip, not fail.
+macro_rules! encode_tests {
+    ($($model:ident => $tok:literal),* $(,)?) => {
         $(
-            #[test]
-            fn $name() {
-                check($tok);
+            // Fixture-derived fn names (amh_Ethi, tam_Taml, …) keep their script
+            // casing so a failure reads as the fixture, not a mangled snake_case.
+            #[allow(non_snake_case)]
+            mod $model {
+                crate::common::for_each_fixture!(crate::check_one, $tok);
             }
         )*
     };
 }
 
-// Two decode/encode archetypes each; whichever files a given checkout has get run
-// (bert-wiki + llama-3 ship with `make test`; the rest with `make bench-models`).
-oracle_tests! {
+encode_tests! {
     bert_wiki         => "bert-wiki.json",
     bert_base_uncased => "bert-base-uncased.json",
     gpt2              => "gpt2.json",
     llama3            => "llama-3-tokenizer.json",
+    llama2            => "llama-2.json",
+    t5_base           => "t5-base.json",
+    albert            => "albert-base-v1-tokenizer.json",
 }

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -7,7 +7,8 @@
 //! One test per `model::fixture` — so a red run names the exact model and
 //! language/modality that broke (same structure as `pipeline_decode_oracle.rs`; no
 //! `{single,pair}` split here because `PipelineTokenizer::encode` takes a single
-//! sequence and post-processing isn't wired). A model the pipeline can't build or
+//! sequence). Every window is checked for both `add_special_tokens` values —
+//! `true` exercises the post-process frame. A model the pipeline can't build or
 //! encode yet is skipped, not failed; the model set mirrors the decode oracle's.
 //!
 //! Behind the `bench-baseline` feature (the released crate is optional):
@@ -74,23 +75,26 @@ fn check_one(tok_file: &str, group: &str, stem: &str) {
         if chunk.is_empty() {
             continue;
         }
-        let expected = released
-            .encode_fast(chunk, false)
-            .unwrap()
-            .get_ids()
-            .to_vec();
-        let got: Vec<u32> = pipeline
-            .encode(chunk, false)
-            .unwrap()
-            .iter()
-            .map(|t| t.id)
-            .collect();
-        assert_eq!(
-            expected,
-            got,
-            "id mismatch on {tok_file} [{group}/{stem}] @ {:?}",
-            chunk.chars().take(60).collect::<String>(),
-        );
+        for add_special_tokens in [false, true] {
+            let expected = released
+                .encode_fast(chunk, add_special_tokens)
+                .unwrap()
+                .get_ids()
+                .to_vec();
+            let got: Vec<u32> = pipeline
+                .encode(chunk, add_special_tokens)
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect();
+            assert_eq!(
+                expected,
+                got,
+                "id mismatch on {tok_file} [{group}/{stem}] \
+                 (add_special_tokens={add_special_tokens}) @ {:?}",
+                chunk.chars().take(60).collect::<String>(),
+            );
+        }
     }
 }
 


### PR DESCRIPTION
# TL;DR

This PR adds the scaffolding to bring `decode` to `PipleineTokenizer`, with parity tests and a comprehensive benchmark

It does **not** implement decode yet. `PipelineTokenizer::decode` is a loud stub that returns an
error. Keeping it a stub makes this PR small to review and lets the actual decode land next as a
pure, test-guarded change.

## Changing oracle reference to the latest release

The in-tree `Tokenizer` is being retired, so it can't stay the source of truth. From here on the pipeline is judged against the last published release: same token ids on encode, same string on decode.
The legacy `Tokenizer` is still used to *build* the pipeline (its only constructor today), but never as a correctness oracle.

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**7 / 8 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`e849f52be · 2026-07-24 10:30 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-overview.png" width="860">

**vs base branch** (`97c213eb4`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.87 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 11) · Pipeline 8+0 (peak 16)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 26.8 | ×3.41 | ×0.97 | 3% (1.2) | 76% (27.4) | 13% (4.7) | 7% (2.5) | 0% (0.1) | match |
| arb_Arab | lang | 4.2 | 24.3 | ×5.75 | ×0.97 | 3% (1.2) | 70% (27.7) | 8% (3.1) | 20% (7.8) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 34.2 | ×5.65 | ×0.98 | 4% (1.2) | 67% (19.1) | 10% (2.9) | 18% (5.2) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 18.6 | ×4.80 | ×0.99 | 2% (1.2) | 71% (37.5) | 11% (5.7) | 16% (8.3) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 23.2 | ×6.14 | ×0.98 | 3% (1.2) | 69% (28.6) | 8% (3.4) | 20% (8.4) | 0% (0.0) | match |
| eng_Latn | lang | 4.5 | 18.4 | ×4.07 | ×1.01 | 5% (2.5) | 72% (38.7) | 8% (4.3) | 16% (8.5) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 19.5 | ×4.63 | ×0.98 | 2% (1.2) | 75% (37.5) | 7% (3.6) | 15% (7.5) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 27.0 | ×4.17 | ×0.98 | 3% (1.2) | 75% (27.0) | 9% (3.2) | 13% (4.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 27.0 | ×6.27 | ×0.98 | 3% (1.2) | 63% (23.2) | 13% (4.7) | 21% (7.6) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 27.3 | ×4.41 | ×0.97 | 3% (1.2) | 75% (26.5) | 9% (3.1) | 13% (4.4) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 17.3 | ×7.11 | ×0.98 | 2% (1.2) | 63% (35.0) | 13% (7.3) | 22% (12.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.7 | 23.2 | ×6.33 | ×0.97 | 3% (1.2) | 66% (27.4) | 8% (3.2) | 24% (9.9) | 0% (0.0) | match |
| tam_Taml | lang | 7.0 | 37.7 | ×5.40 | ×0.99 | 4% (1.2) | 72% (18.6) | 9% (2.4) | 14% (3.5) | 0% (0.0) | match |
| tha_Thai | lang | 8.4 | 32.7 | ×3.91 | ×0.99 | 4% (1.2) | 84% (24.9) | 7% (2.2) | 4% (1.2) | 1% (0.3) | match |
| added_normalized_dense | modalities | 6.6 | 19.7 | ×2.98 | ×1.00 | 3% (1.3) | 81% (40.7) | 14% (7.1) | 2% (1.0) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 18.5 | ×3.53 | ×1.00 | 4% (1.9) | 75% (40.2) | 13% (6.7) | 8% (4.5) | 0% (0.1) | match |
| added_special_dense | modalities | 5.3 | 39.1 | ×7.33 | ×1.00 | 21% (5.2) | 37% (9.3) | 34% (8.6) | 7% (1.8) | 1% (0.3) | match |
| added_special_sparse | modalities | 4.0 | 21.4 | ×5.37 | ×1.00 | 8% (3.7) | 61% (28.1) | 18% (8.4) | 12% (5.6) | 0% (0.2) | match |
| agentic-traces | modalities | 3.8 | 18.2 | ×4.73 | ×1.00 | 4% (2.4) | 71% (38.5) | 9% (4.8) | 16% (8.8) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 19.5 | ×4.75 | ×1.00 | 4% (1.9) | 76% (38.6) | 7% (3.6) | 13% (6.8) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 19.0 | ×4.81 | ×1.00 | 4% (2.1) | 74% (38.5) | 8% (4.3) | 14% (7.4) | 0% (0.0) | match |
| math_latex | modalities | 4.1 | 18.3 | ×4.48 | ×1.01 | 5% (2.5) | 71% (38.6) | 9% (4.7) | 16% (8.7) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×3.98 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 82+0 (peak 81)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.5 | 34.7 | ×7.65 | ×1.00 | 2% (0.7) | 0% (0.0) | 17% (4.7) | 80% (22.3) | 0% (0.1) | match |
| arb_Arab | lang | 4.6 | 16.6 | ×3.65 | ×0.99 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (54.5) | 0% (0.0) | match |
| ben_Beng | lang | 6.6 | 17.8 | ×2.72 | ×0.98 | 1% (0.6) | 0% (0.0) | 6% (3.1) | 93% (50.9) | 0% (0.1) | match |
| cmn_Hani | lang | 4.0 | 17.0 | ×4.29 | ×0.99 | 1% (0.8) | 0% (0.0) | 6% (3.1) | 93% (52.8) | 0% (0.0) | match |
| ell_Grek | lang | 5.0 | 18.3 | ×3.69 | ×0.99 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 92% (49.3) | 0% (0.0) | match |
| eng_Latn | lang | 3.4 | 13.2 | ×3.90 | ×1.00 | 3% (2.0) | 0% (0.0) | 7% (5.0) | 91% (66.7) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 12.8 | ×3.02 | ×0.97 | 1% (0.6) | 0% (0.0) | 5% (3.5) | 95% (72.2) | 0% (0.0) | match |
| hin_Deva | lang | 6.2 | 21.2 | ×3.43 | ×0.97 | 1% (0.6) | 0% (0.0) | 7% (3.3) | 91% (41.5) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.5 | 18.2 | ×4.02 | ×0.99 | 1% (0.7) | 0% (0.0) | 5% (3.0) | 93% (51.5) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 18.0 | ×2.89 | ×0.97 | 1% (0.6) | 0% (0.0) | 5% (2.9) | 93% (50.9) | 0% (0.0) | match |
| kor_Hang | lang | 3.9 | 20.1 | ×5.13 | ×0.99 | 1% (0.6) | 0% (0.0) | 7% (3.7) | 91% (44.9) | 0% (0.1) | match |
| rus_Cyrl | lang | 4.7 | 14.4 | ×3.08 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 94% (63.5) | 0% (0.0) | match |
| tam_Taml | lang | 6.6 | 17.6 | ×2.68 | ×0.96 | 1% (0.6) | 0% (0.0) | 5% (2.7) | 94% (51.7) | 0% (0.0) | match |
| tha_Thai | lang | 7.3 | 14.6 | ×2.01 | ×0.98 | 1% (0.6) | 0% (0.0) | 3% (2.2) | 96% (63.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.0 | 23.5 | ×3.91 | ×1.00 | 2% (0.7) | 0% (0.0) | 7% (2.7) | 92% (38.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 19.3 | ×3.59 | ×0.98 | 3% (1.2) | 0% (0.0) | 8% (3.8) | 90% (44.4) | 0% (0.0) | match |
| added_special_dense | modalities | 3.6 | 37.5 | ×10.40 | ×1.02 | 25% (6.5) | 2% (0.5) | 23% (6.0) | 48% (12.5) | 1% (0.3) | match |
| added_special_sparse | modalities | 4.0 | 20.7 | ×5.13 | ×1.00 | 8% (3.9) | 0% (0.1) | 15% (6.8) | 77% (35.6) | 0% (0.1) | match |
| agentic-traces | modalities | 3.1 | 14.5 | ×4.69 | ×1.01 | 3% (1.8) | 0% (0.0) | 8% (5.4) | 89% (61.2) | 0% (0.1) | match |
| agentic_swe | modalities | 3.2 | 15.3 | ×4.78 | ×1.01 | 2% (1.3) | 0% (0.0) | 6% (3.8) | 92% (59.1) | 0% (0.0) | match |
| code_mixed | modalities | 3.7 | 15.8 | ×4.24 | ×1.01 | 2% (1.5) | 0% (0.0) | 7% (4.6) | 90% (56.5) | 0% (0.0) | match |
| math_latex | modalities | 3.0 | 14.1 | ×4.67 | ×0.99 | 3% (1.9) | 0% (0.0) | 8% (5.3) | 89% (61.1) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.41 | 4.69 | 5.35 | 41.2 | 20.3 | 9.1 | — | 8.8× / 7.7× | 4.3× / 3.8× | 1.9× / 1.7× | — |
| arb_Arab | 1.15 | 2.96 | 3.38 | 5.19 | 48.0 | 23.0 | 10.1 | — | 14.2× / 9.3× | 6.8× / 4.4× | 3.0× / 1.9× | — |
| ben_Beng | 1.60 | 2.93 | 3.13 | 4.47 | 35.5 | 16.0 | 7.5 | — | 11.3× / 7.9× | 5.1× / 3.6× | 2.4× / 1.7× | — |
| cmn_Hani | 1.12 | 2.26 | 3.14 | 4.28 | 59.3 | 33.9 | 14.2 | — | 18.9× / 13.9× | 10.8× / 7.9× | 4.5× / 3.3× | — |
| ell_Grek | 0.58 | 2.95 | 3.38 | 5.75 | 46.1 | 21.2 | 9.5 | — | 13.6× / 8.0× | 6.3× / 3.7× | 2.8× / 1.7× | — |
| eng_Latn | 0.09 | 1.47 | 5.01 | 6.39 | 63.1 | 39.2 | 15.8 | — | 12.6× / 9.9× | 7.8× / 6.1× | 3.2× / 2.5× | — |
| heb_Hebr | 1.14 | 3.03 | 3.51 | 5.40 | 49.8 | 23.8 | 10.5 | — | 14.2× / 9.2× | 6.8× / 4.4× | 3.0× / 1.9× | — |
| hin_Deva | 1.52 | 3.10 | 3.31 | 4.90 | 37.3 | 18.8 | 8.5 | — | 11.2× / 7.6× | 5.7× / 3.8× | 2.6× / 1.7× | — |
| jpn_Jpan | 1.69 | 3.34 | 2.97 | 4.61 | 52.1 | 27.4 | 11.8 | — | 17.6× / 11.3× | 9.2× / 5.9× | 4.0× / 2.5× | — |
| kat_Geor | 1.52 | 2.56 | 2.92 | 3.95 | 31.9 | 15.1 | 7.1 | — | 10.9× / 8.1× | 5.2× / 3.8× | 2.4× / 1.8× | — |
| kor_Hang | 1.22 | 2.71 | 3.66 | 5.15 | 49.0 | 26.8 | 11.8 | — | 13.4× / 9.5× | 7.3× / 5.2× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.16 | 2.86 | 3.26 | 4.96 | 46.1 | 20.9 | 9.4 | — | 14.2× / 9.3× | 6.4× / 4.2× | 2.9× / 1.9× | — |
| tam_Taml | 0.91 | 2.96 | 2.73 | 4.77 | 31.3 | 13.6 | 6.5 | — | 11.5× / 6.5× | 5.0× / 2.9× | 2.4× / 1.4× | — |
| tha_Thai | 1.50 | 2.58 | 2.19 | 3.27 | 26.3 | 10.1 | 5.2 | — | 12.0× / 8.1× | 4.6× / 3.1× | 2.4× / 1.6× | — |
| added_normalized_dense | 0.06 | 1.48 | 2.74 | 4.16 | 40.7 | 20.2 | 9.2 | — | 14.9× / 9.8× | 7.4× / 4.9× | 3.4× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.77 | 3.85 | 5.56 | 47.3 | 26.1 | 11.6 | — | 12.3× / 8.5× | 6.8× / 4.7× | 3.0× / 2.1× | — |
| added_special_dense | 0.06 | 1.48 | 5.97 | 7.39 | 166.7 | 100.2 | 37.7 | — | 27.9× / 22.6× | 16.8× / 13.6× | 6.3× / 5.1× | — |
| added_special_sparse | 0.06 | 1.48 | 6.75 | 8.17 | 99.1 | 58.4 | 23.3 | — | 14.7× / 12.1× | 8.6× / 7.1× | 3.5× / 2.9× | — |
| agentic-traces | 0.75 | 1.47 | 5.38 | 6.10 | 77.2 | 52.7 | 19.6 | — | 14.4× / 12.7× | 9.8× / 8.6× | 3.7× / 3.2× | — |
| agentic_swe | 0.65 | 1.45 | 3.85 | 4.65 | 91.7 | 66.0 | 23.0 | — | 23.8× / 19.7× | 17.1× / 14.2× | 6.0× / 5.0× | — |
| code_mixed | 0.06 | 1.46 | 4.56 | 5.97 | 70.8 | 53.8 | 18.2 | — | 15.5× / 11.9× | 11.8× / 9.0× | 4.0× / 3.1× | — |
| math_latex | 0.71 | 1.49 | 5.27 | 6.06 | 75.4 | 47.6 | 18.9 | — | 14.3× / 12.4× | 9.0× / 7.9× | 3.6× / 3.1× | — |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×7.58 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 28+0 (peak 28)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 45.4 | ×10.61 | ×0.92 | 3% (0.7) | 0% (0.0) | 17% (3.6) | 80% (16.7) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 25.8 | ×6.20 | ×0.95 | 2% (0.6) | 0% (0.0) | 6% (2.2) | 93% (35.0) | 0% (0.0) | match |
| ben_Beng | lang | 3.3 | 47.7 | ×14.66 | ×1.02 | 3% (0.6) | 0% (0.0) | 15% (3.0) | 82% (16.8) | 0% (0.1) | match |
| cmn_Hani | lang | 3.9 | 29.3 | ×7.47 | ×1.00 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (30.0) | 0% (0.1) | match |
| ell_Grek | lang | 4.5 | 29.3 | ×6.45 | ×1.03 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 92% (30.5) | 0% (0.1) | match |
| eng_Latn | lang | 3.7 | 13.8 | ×3.70 | ×1.00 | 3% (2.0) | 0% (0.0) | 4% (2.9) | 92% (64.7) | 1% (0.6) | match |
| heb_Hebr | lang | 4.1 | 29.3 | ×7.20 | ×1.01 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (30.7) | 0% (0.0) | match |
| hin_Deva | lang | 3.2 | 40.4 | ×12.48 | ×1.05 | 2% (0.6) | 0% (0.0) | 13% (3.0) | 86% (20.5) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.5 | 21.7 | ×4.78 | ×0.98 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (41.4) | 0% (0.1) | match |
| kat_Geor | lang | 4.8 | 72.1 | ×15.03 | ×1.05 | 4% (0.6) | 0% (0.0) | 15% (2.1) | 79% (11.0) | 1% (0.2) | match |
| kor_Hang | lang | 3.4 | 43.1 | ×12.49 | ×1.01 | 3% (0.6) | 0% (0.0) | 11% (2.4) | 86% (19.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.3 | 26.3 | ×6.08 | ×0.93 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 93% (34.4) | 0% (0.0) | match |
| tam_Taml | lang | 2.8 | 66.9 | ×23.96 | ×0.95 | 4% (0.6) | 0% (0.0) | 18% (2.6) | 78% (11.3) | 0% (0.0) | match |
| tha_Thai | lang | 3.7 | 37.9 | ×10.37 | ×1.02 | 2% (0.6) | 0% (0.0) | 10% (2.5) | 88% (22.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 25.3 | ×4.16 | ×0.99 | 2% (0.7) | 0% (0.0) | 3% (1.1) | 95% (35.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 21.7 | ×4.12 | ×1.01 | 3% (1.3) | 0% (0.0) | 4% (1.9) | 93% (41.2) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 48.0 | ×11.59 | ×1.04 | 25% (5.0) | 0% (0.0) | 20% (4.0) | 55% (10.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 24.1 | ×5.53 | ×1.03 | 8% (3.2) | 0% (0.0) | 11% (4.4) | 81% (33.0) | 0% (0.2) | match |
| agentic-traces | modalities | 3.2 | 16.4 | ×5.04 | ×1.00 | 3% (1.8) | 0% (0.0) | 6% (3.5) | 91% (54.3) | 0% (0.1) | match |
| agentic_swe | modalities | 3.4 | 24.9 | ×7.22 | ×1.03 | 3% (1.3) | 0% (0.0) | 6% (2.4) | 90% (35.0) | 0% (0.1) | match |
| code_mixed | modalities | 3.6 | 20.8 | ×5.77 | ×1.02 | 3% (1.5) | 0% (0.0) | 6% (2.9) | 90% (42.3) | 1% (0.4) | match |
| math_latex | modalities | 3.3 | 15.3 | ×4.67 | ×1.01 | 3% (1.9) | 0% (0.0) | 5% (3.2) | 92% (58.8) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.74 | 3.40 | 3.62 | 4.28 | 27.2 | 21.5 | 5.7 | 4.8 | 7.5× / 6.4× | 5.9× / 5.0× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.97 | 2.24 | 4.06 | 31.9 | 26.7 | 6.7 | 5.1 | 14.3× / 7.8× | 11.9× / 6.6× | 3.0× / 1.7× | 2.3× / 1.2× |
| ben_Beng | 1.59 | 2.95 | 2.98 | 4.34 | 65.5 | 56.7 | 13.7 | 4.0 | 22.0× / 15.1× | 19.0× / 13.1× | 4.6× / 3.2× | 1.3× / 0.9× |
| cmn_Hani | 1.12 | 2.26 | 2.31 | 3.45 | 26.2 | 21.9 | 6.0 | 2.4 | 11.4× / 7.6× | 9.5× / 6.3× | 2.6× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.97 | 2.14 | 4.53 | 27.9 | 22.5 | 5.9 | 4.8 | 13.0× / 6.2× | 10.5× / 5.0× | 2.7× / 1.3× | 2.2× / 1.1× |
| eng_Latn | 0.09 | 1.46 | 2.90 | 4.26 | 43.5 | 43.5 | 11.6 | 3.8 | 15.0× / 10.2× | 15.0× / 10.2× | 4.0× / 2.7× | 1.3× / 0.9× |
| heb_Hebr | 1.14 | 2.99 | 2.25 | 4.10 | 31.2 | 26.3 | 6.8 | 3.0 | 13.8× / 7.6× | 11.7× / 6.4× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.50 | 3.12 | 3.03 | 4.66 | 61.9 | 56.2 | 13.3 | 4.3 | 20.4× / 13.3× | 18.5× / 12.1× | 4.4× / 2.9× | 1.4× / 0.9× |
| jpn_Jpan | 1.69 | 3.35 | 2.10 | 3.76 | 23.3 | 18.1 | 5.0 | 3.9 | 11.1× / 6.2× | 8.6× / 4.8× | 2.4× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.52 | 2.56 | 2.05 | 3.09 | 17.1 | 14.6 | 4.1 | 2.0 | 8.4× / 5.6× | 7.1× / 4.7× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.22 | 2.69 | 2.43 | 3.90 | 31.8 | 28.8 | 7.4 | 3.7 | 13.1× / 8.2× | 11.9× / 7.4× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.17 | 2.94 | 2.09 | 3.86 | 26.8 | 22.0 | 5.8 | 2.5 | 12.8× / 7.0× | 10.5× / 5.7× | 2.8× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.91 | 2.94 | 2.62 | 4.65 | 68.3 | 61.0 | 14.1 | 3.8 | 26.1× / 14.7× | 23.3× / 13.1× | 5.4× / 3.0× | 1.5× / 0.8× |
| tha_Thai | 1.51 | 2.57 | 2.47 | 3.53 | 39.8 | 32.6 | 8.7 | 3.2 | 16.1× / 11.3× | 13.2× / 9.2× | 3.5× / 2.5× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.06 | 2.47 | 22.8 | 23.4 | 6.2 | 2.0 | 21.6× / 9.2× | 22.2× / 9.5× | 5.9× / 2.5× | 1.9× / 0.8× |
| added_normalized_sparse | 0.06 | 1.48 | 1.93 | 3.35 | 30.4 | 31.7 | 8.3 | 2.7 | 15.7× / 9.1× | 16.4× / 9.4× | 4.3× / 2.5× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.48 | 4.00 | 5.42 | 93.1 | 98.2 | 19.7 | 2.8 | 23.3× / 17.2× | 24.6× / 18.1× | 4.9× / 3.6× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.37 | 5.78 | 60.4 | 62.6 | 14.3 | 3.3 | 13.8× / 10.4× | 14.3× / 10.8× | 3.3× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.73 | 1.47 | 3.46 | 4.19 | 57.3 | 62.1 | 15.0 | 4.6 | 16.6× / 13.7× | 18.0× / 14.8× | 4.4× / 3.6× | 1.3× / 1.1× |
| agentic_swe | 0.65 | 1.44 | 2.40 | 3.19 | 58.3 | 70.3 | 14.4 | 3.4 | 24.2× / 18.3× | 29.3× / 22.1× | 6.0× / 4.5× | 1.4× / 1.1× |
| code_mixed | 0.07 | 1.44 | 2.90 | 4.27 | 56.7 | 67.8 | 15.3 | 4.1 | 19.6× / 13.3× | 23.4× / 15.9× | 5.3× / 3.6× | 1.4× / 0.9× |
| math_latex | 0.73 | 1.49 | 3.23 | 3.98 | 51.1 | 52.2 | 13.6 | 4.2 | 15.8× / 12.8× | 16.2× / 13.1× | 4.2× / 3.4× | 1.3× / 1.1× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×7.22 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 4+12 (peak 17) · Pipeline 7+0 (peak 7)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.5 | 62.3 | ×17.70 | ×0.99 | 4% (0.7) | 0% (0.0) | 31% (4.9) | 65% (10.2) | 0% (0.0) | match |
| arb_Arab | lang | 4.1 | 25.0 | ×6.12 | ×0.97 | 2% (0.6) | 0% (0.0) | 9% (3.7) | 89% (34.8) | 0% (0.2) | match |
| ben_Beng | lang | 5.5 | 27.0 | ×4.94 | ×0.95 | 2% (0.6) | 0% (0.0) | 11% (3.9) | 87% (31.5) | 0% (0.1) | match |
| cmn_Hani | lang | 4.3 | 38.2 | ×8.85 | ×1.00 | 2% (0.6) | 0% (0.0) | 13% (3.3) | 85% (22.0) | 0% (0.0) | match |
| ell_Grek | lang | 4.2 | 32.1 | ×7.59 | ×1.01 | 2% (0.6) | 0% (0.0) | 11% (3.3) | 87% (26.8) | 0% (0.0) | match |
| eng_Latn | lang | 3.3 | 21.4 | ×6.51 | ×1.00 | 4% (2.0) | 0% (0.0) | 10% (4.5) | 86% (39.2) | 0% (0.1) | match |
| heb_Hebr | lang | 4.0 | 28.3 | ×7.15 | ×1.00 | 2% (0.6) | 0% (0.0) | 11% (3.8) | 87% (30.2) | 1% (0.2) | match |
| hin_Deva | lang | 5.3 | 23.1 | ×4.38 | ×0.94 | 1% (0.6) | 0% (0.0) | 9% (4.0) | 89% (37.7) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.9 | 37.3 | ×7.55 | ×1.00 | 2% (0.6) | 0% (0.0) | 12% (3.1) | 86% (22.5) | 0% (0.0) | match |
| kat_Geor | lang | 5.7 | 25.1 | ×4.38 | ×0.95 | 2% (0.6) | 0% (0.0) | 8% (2.9) | 91% (35.0) | 0% (0.0) | match |
| kor_Hang | lang | 3.7 | 47.1 | ×12.82 | ×1.00 | 3% (0.7) | 0% (0.0) | 19% (3.9) | 78% (16.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.7 | 22.4 | ×4.80 | ×0.97 | 1% (0.6) | 0% (0.0) | 7% (3.2) | 91% (40.0) | 0% (0.2) | match |
| tam_Taml | lang | 5.8 | 29.5 | ×5.10 | ×0.96 | 2% (0.6) | 0% (0.0) | 11% (3.4) | 88% (28.5) | 0% (0.0) | match |
| tha_Thai | lang | 6.5 | 26.5 | ×4.11 | ×0.97 | 2% (0.6) | 0% (0.0) | 9% (3.4) | 89% (32.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.9 | 45.8 | ×9.43 | ×0.98 | 4% (0.7) | 0% (0.0) | 11% (2.4) | 85% (17.6) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.4 | 36.5 | ×8.26 | ×1.00 | 5% (1.3) | 0% (0.0) | 12% (3.1) | 83% (21.6) | 0% (0.1) | match |
| added_special_dense | modalities | 3.8 | 55.8 | ×14.57 | ×0.98 | 28% (5.0) | 0% (0.1) | 30% (5.3) | 39% (6.8) | 2% (0.4) | match |
| added_special_sparse | modalities | 3.9 | 34.6 | ×8.91 | ×1.01 | 11% (3.2) | 0% (0.1) | 21% (5.8) | 67% (18.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.3 | 22.8 | ×6.95 | ×1.00 | 4% (1.8) | 0% (0.0) | 12% (4.9) | 84% (36.1) | 0% (0.1) | match |
| agentic_swe | modalities | 3.7 | 22.0 | ×5.99 | ×1.00 | 3% (1.3) | 0% (0.0) | 8% (3.7) | 89% (40.0) | 0% (0.0) | match |
| code_mixed | modalities | 3.6 | 29.9 | ×8.41 | ×1.01 | 5% (1.5) | 0% (0.0) | 13% (4.4) | 82% (26.8) | 0% (0.0) | match |
| math_latex | modalities | 3.3 | 22.8 | ×7.01 | ×1.00 | 4% (1.9) | 0% (0.0) | 11% (4.8) | 84% (36.1) | 1% (0.2) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.46 | 4.89 | 5.59 | 29.5 | 14.1 | 6.9 | 4.7 | 6.0× / 5.3× | 2.9× / 2.5× | 1.4× / 1.2× | 1.0× / 0.8× |
| arb_Arab | 1.15 | 2.96 | 3.65 | 5.47 | 33.7 | 16.1 | 7.5 | 5.1 | 9.2× / 6.2× | 4.4× / 2.9× | 2.0× / 1.4× | 1.4× / 0.9× |
| ben_Beng | 1.60 | 2.93 | 3.89 | 5.23 | 23.6 | 10.8 | 5.4 | 2.7 | 6.1× / 4.5× | 2.8× / 2.1× | 1.4× / 1.0× | 0.7× / 0.5× |
| cmn_Hani | 1.11 | 2.26 | 3.30 | 4.45 | 21.7 | 10.8 | 5.5 | 2.5 | 6.6× / 4.9× | 3.3× / 2.4× | 1.7× / 1.2× | 0.8× / 0.6× |
| ell_Grek | 0.58 | 2.96 | 3.28 | 5.66 | 29.8 | 15.2 | 6.9 | 5.1 | 9.1× / 5.3× | 4.6× / 2.7× | 2.1× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.10 | 1.47 | 4.55 | 5.91 | 42.2 | 28.9 | 13.6 | 4.2 | 9.3× / 7.1× | 6.4× / 4.9× | 3.0× / 2.3× | 0.9× / 0.7× |
| heb_Hebr | 1.14 | 3.02 | 3.84 | 5.71 | 33.3 | 17.1 | 8.0 | 2.8 | 8.7× / 5.8× | 4.4× / 3.0× | 2.1× / 1.4× | 0.7× / 0.5× |
| hin_Deva | 1.49 | 3.06 | 4.01 | 5.58 | 25.9 | 13.1 | 6.4 | 3.2 | 6.4× / 4.6× | 3.3× / 2.3× | 1.6× / 1.1× | 0.8× / 0.6× |
| jpn_Jpan | 1.69 | 3.41 | 3.08 | 4.80 | 20.4 | 9.4 | 4.8 | 3.8 | 6.6× / 4.3× | 3.0× / 1.9× | 1.6× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.52 | 2.53 | 2.89 | 3.91 | 19.2 | 10.2 | 4.7 | 2.1 | 6.6× / 4.9× | 3.5× / 2.6× | 1.6× / 1.2× | 0.7× / 0.5× |
| kor_Hang | 1.23 | 2.73 | 3.87 | 5.37 | 33.0 | 18.8 | 8.8 | 3.6 | 8.5× / 6.2× | 4.9× / 3.5× | 2.3× / 1.6× | 0.9× / 0.7× |
| rus_Cyrl | 1.16 | 2.91 | 3.19 | 4.93 | 28.5 | 14.7 | 6.7 | 4.8 | 9.0× / 5.8× | 4.6× / 3.0× | 2.1× / 1.4× | 1.5× / 1.0× |
| tam_Taml | 0.91 | 2.96 | 3.43 | 5.47 | 19.0 | 8.6 | 4.2 | 2.9 | 5.5× / 3.5× | 2.5× / 1.6× | 1.2× / 0.8× | 0.9× / 0.5× |
| tha_Thai | 1.51 | 2.55 | 3.40 | 4.44 | 13.2 | 5.7 | 2.8 | 2.2 | 3.9× / 3.0× | 1.7× / 1.3× | 0.8× / 0.6× | 0.6× / 0.5× |
| added_normalized_dense | 0.06 | 1.48 | 2.35 | 3.77 | 32.3 | 17.6 | 11.2 | 2.2 | 13.7× / 8.5× | 7.5× / 4.7× | 4.8× / 3.0× | 0.9× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.08 | 4.50 | 34.8 | 21.1 | 11.4 | 3.0 | 11.3× / 7.7× | 6.8× / 4.7× | 3.7× / 2.5× | 1.0× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 5.30 | 6.72 | 82.5 | 69.1 | 23.8 | 3.3 | 15.6× / 12.3× | 13.0× / 10.3× | 4.5× / 3.5× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 5.82 | 7.24 | 55.9 | 41.3 | 17.0 | 3.7 | 9.6× / 7.7× | 7.1× / 5.7× | 2.9× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.71 | 1.48 | 4.94 | 5.70 | 50.7 | 41.0 | 16.7 | 4.9 | 10.3× / 8.9× | 8.3× / 7.2× | 3.4× / 2.9× | 1.0× / 0.9× |
| agentic_swe | 0.65 | 1.46 | 3.73 | 4.53 | 51.5 | 48.7 | 16.9 | 3.6 | 13.8× / 11.4× | 13.1× / 10.7× | 4.5× / 3.7× | 1.0× / 0.8× |
| code_mixed | 0.06 | 1.46 | 4.36 | 5.76 | 51.0 | 47.0 | 17.0 | 4.2 | 11.7× / 8.9× | 10.8× / 8.2× | 3.9× / 2.9× | 1.0× / 0.7× |
| math_latex | 0.72 | 1.49 | 4.79 | 5.57 | 49.0 | 35.0 | 15.7 | 4.5 | 10.2× / 8.8× | 7.3× / 6.3× | 3.3× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×12.72 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 4+12 (peak 17) · Pipeline 6+0 (peak 6)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.7 | 65.0 | ×13.72 | ×1.00 | 8% (1.2) | 0% (0.0) | 25% (3.6) | 67% (9.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.3 | 73.1 | ×17.10 | ×0.97 | 9% (1.2) | 0% (0.0) | 18% (2.3) | 73% (9.7) | 0% (0.0) | match |
| ben_Beng | lang | 3.5 | 67.5 | ×19.16 | ×0.98 | 8% (1.2) | 0% (0.0) | 22% (3.1) | 70% (10.0) | 0% (0.0) | match |
| cmn_Hani | lang | 4.7 | 67.2 | ×14.16 | ×0.98 | 8% (1.2) | 0% (0.0) | 17% (2.4) | 75% (10.8) | 0% (0.0) | match |
| ell_Grek | lang | 4.1 | 71.2 | ×17.31 | ×0.99 | 9% (1.2) | 0% (0.0) | 16% (2.2) | 75% (10.1) | 0% (0.0) | match |
| eng_Latn | lang | 3.6 | 22.8 | ×6.32 | ×1.00 | 6% (2.5) | 0% (0.0) | 7% (3.0) | 87% (38.2) | 0% (0.0) | match |
| heb_Hebr | lang | 3.9 | 78.1 | ×20.09 | ×1.03 | 9% (1.2) | 0% (0.0) | 19% (2.3) | 72% (8.9) | 0% (0.0) | match |
| hin_Deva | lang | 3.2 | 66.9 | ×21.05 | ×1.04 | 8% (1.2) | 0% (0.0) | 22% (3.2) | 70% (10.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.8 | 73.4 | ×15.44 | ×1.06 | 9% (1.2) | 0% (0.0) | 17% (2.2) | 74% (9.6) | 0% (0.0) | match |
| kat_Geor | lang | 4.6 | 81.1 | ×17.74 | ×0.99 | 10% (1.2) | 0% (0.0) | 17% (2.1) | 73% (8.7) | 0% (0.0) | match |
| kor_Hang | lang | 3.5 | 70.3 | ×19.98 | ×1.02 | 9% (1.2) | 0% (0.0) | 18% (2.5) | 73% (10.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.1 | 39.8 | ×9.81 | ×0.98 | 5% (1.2) | 0% (0.0) | 9% (2.2) | 86% (21.3) | 0% (0.0) | match |
| tam_Taml | lang | 3.2 | 69.2 | ×21.30 | ×0.97 | 8% (1.2) | 0% (0.0) | 19% (2.7) | 72% (10.1) | 0% (0.0) | match |
| tha_Thai | lang | 3.9 | 68.5 | ×17.42 | ×0.93 | 8% (1.2) | 0% (0.0) | 17% (2.6) | 75% (11.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.6 | 46.7 | ×10.08 | ×1.02 | 6% (1.3) | 0% (0.0) | 6% (1.2) | 87% (17.8) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.2 | 40.3 | ×9.63 | ×1.02 | 7% (1.8) | 0% (0.0) | 8% (2.0) | 84% (20.4) | 1% (0.2) | match |
| added_special_dense | modalities | 3.4 | 41.0 | ×12.11 | ×0.99 | 53% (12.6) | 0% (0.1) | 21% (4.9) | 26% (6.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.5 | 34.2 | ×9.76 | ×1.01 | 25% (6.9) | 0% (0.0) | 18% (5.0) | 58% (16.3) | 0% (0.0) | match |
| agentic-traces | modalities | 3.2 | 23.8 | ×7.46 | ×1.00 | 6% (2.4) | 0% (0.0) | 9% (3.7) | 85% (34.9) | 0% (0.2) | match |
| agentic_swe | modalities | 3.6 | 22.2 | ×6.13 | ×0.99 | 4% (1.9) | 0% (0.0) | 6% (2.9) | 89% (40.7) | 0% (0.1) | match |
| code_mixed | modalities | 3.6 | 31.2 | ×8.67 | ×1.01 | 7% (2.2) | 0% (0.0) | 10% (3.3) | 82% (25.8) | 0% (0.1) | match |
| math_latex | modalities | 3.2 | 24.3 | ×7.52 | ×1.00 | 6% (2.5) | 0% (0.0) | 8% (3.5) | 86% (35.3) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.41 | 3.64 | 4.30 | 26.3 | 17.2 | 5.8 | 4.8 | 7.2× / 6.1× | 4.7× / 4.0× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.14 | 2.95 | 2.33 | 4.14 | 30.2 | 19.3 | 6.9 | 5.2 | 13.0× / 7.3× | 8.3× / 4.7× | 2.9× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.60 | 2.92 | 3.11 | 4.43 | 43.3 | 27.6 | 10.2 | 3.7 | 13.9× / 9.8× | 8.9× / 6.2× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.25 | 2.40 | 3.53 | 19.2 | 11.6 | 4.7 | 2.3 | 8.0× / 5.5× | 4.9× / 3.3× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.95 | 2.21 | 4.58 | 27.3 | 17.7 | 6.0 | 4.7 | 12.4× / 6.0× | 8.0× / 3.9× | 2.7× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.10 | 1.46 | 3.02 | 4.39 | 41.9 | 32.9 | 12.1 | 3.7 | 13.9× / 9.6× | 10.9× / 7.5× | 4.0× / 2.8× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.00 | 2.30 | 4.17 | 29.6 | 20.1 | 6.8 | 3.0 | 12.9× / 7.1× | 8.7× / 4.8× | 2.9× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.50 | 3.13 | 3.20 | 4.83 | 45.5 | 30.2 | 11.0 | 4.0 | 14.2× / 9.4× | 9.5× / 6.3× | 3.4× / 2.3× | 1.3× / 0.8× |
| jpn_Jpan | 1.69 | 3.35 | 2.20 | 3.85 | 17.9 | 10.0 | 4.1 | 3.7 | 8.1× / 4.6× | 4.6× / 2.6× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.53 | 2.55 | 2.08 | 3.11 | 16.6 | 11.3 | 4.2 | 2.0 | 7.9× / 5.3× | 5.4× / 3.7× | 2.0× / 1.4× | 1.0× / 0.7× |
| kor_Hang | 1.23 | 2.68 | 2.52 | 3.97 | 29.9 | 22.0 | 7.3 | 3.7 | 11.9× / 7.5× | 8.7× / 5.5× | 2.9× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.93 | 2.17 | 3.94 | 26.2 | 16.8 | 5.9 | 2.5 | 12.1× / 6.7× | 7.7× / 4.3× | 2.7× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.91 | 2.95 | 2.70 | 4.75 | 43.0 | 27.2 | 9.7 | 3.4 | 15.9× / 9.1× | 10.1× / 5.7× | 3.6× / 2.0× | 1.2× / 0.7× |
| tha_Thai | 1.50 | 2.61 | 2.60 | 3.71 | 27.3 | 16.7 | 6.7 | 3.0 | 10.5× / 7.4× | 6.4× / 4.5× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.24 | 2.66 | 22.4 | 17.0 | 6.4 | 1.8 | 18.1× / 8.4× | 13.7× / 6.4× | 5.1× / 2.4× | 1.4× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 2.01 | 3.42 | 29.9 | 23.1 | 8.6 | 2.5 | 14.9× / 8.7× | 11.5× / 6.8× | 4.3× / 2.5× | 1.3× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 4.94 | 6.35 | 89.2 | 79.0 | 21.0 | 3.1 | 18.1× / 14.0× | 16.0× / 12.4× | 4.3× / 3.3× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.97 | 6.38 | 57.4 | 47.5 | 14.8 | 3.6 | 11.6× / 9.0× | 9.6× / 7.4× | 3.0× / 2.3× | 0.7× / 0.6× |
| agentic-traces | 0.71 | 1.48 | 3.72 | 4.49 | 50.4 | 44.2 | 14.7 | 4.6 | 13.5× / 11.2× | 11.9× / 9.9× | 3.9× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.66 | 1.44 | 2.88 | 3.66 | 52.3 | 50.6 | 15.3 | 3.4 | 18.1× / 14.3× | 17.5× / 13.8× | 5.3× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.45 | 3.29 | 4.67 | 50.2 | 50.1 | 14.8 | 4.0 | 15.3× / 10.8× | 15.2× / 10.7× | 4.5× / 3.2× | 1.2× / 0.9× |
| math_latex | 0.71 | 1.48 | 3.45 | 4.22 | 47.8 | 39.7 | 13.8 | 4.1 | 13.9× / 11.3× | 11.5× / 9.4× | 4.0× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.10 vs v0.23.1 · ×0.98 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.6 | 41.2 | ×7.33 | ×0.96 | 0% (0.0) | 12% (2.7) | 0% (0.0) | 88% (20.2) | 0% (0.0) | match |
| arb_Arab | lang | 12.3 | 49.4 | ×4.01 | ×0.96 | 0% (0.0) | 16% (3.2) | 0% (0.0) | 84% (16.4) | 0% (0.0) | match |
| ben_Beng | lang | 13.6 | 75.8 | ×5.58 | ×0.87 | 0% (0.0) | 17% (2.1) | 0% (0.0) | 82% (10.4) | 1% (0.2) | match |
| cmn_Hani | lang | 11.3 | 66.0 | ×5.83 | ×0.99 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 97% (13.7) | 0% (0.0) | match |
| ell_Grek | lang | 12.7 | 58.0 | ×4.55 | ×0.97 | 0% (0.0) | 19% (3.1) | 0% (0.0) | 81% (13.4) | 0% (0.0) | match |
| eng_Latn | lang | 4.6 | 6.4 | ×1.39 | ×1.02 | 0% (0.0) | 5% (6.9) | 0% (0.0) | 97% (145.3) | 0% (0.0) | match |
| heb_Hebr | lang | 12.5 | 61.3 | ×4.89 | ×1.00 | 0% (0.0) | 21% (3.3) | 0% (0.0) | 79% (12.6) | 0% (0.0) | match |
| hin_Deva | lang | 14.7 | 77.6 | ×5.29 | ×0.96 | 0% (0.0) | 23% (2.8) | 0% (0.0) | 77% (9.5) | 0% (0.0) | match |
| jpn_Jpan | lang | 15.9 | 85.1 | ×5.36 | ×1.01 | 0% (0.0) | 3% (0.3) | 0% (0.0) | 97% (10.6) | 0% (0.0) | match |
| kat_Geor | lang | 17.6 | 89.2 | ×5.07 | ×0.96 | 0% (0.0) | 17% (1.9) | 0% (0.0) | 82% (8.8) | 0% (0.0) | match |
| kor_Hang | lang | 8.7 | 51.7 | ×5.92 | ×0.98 | 0% (0.1) | 17% (3.2) | 0% (0.0) | 82% (15.1) | 0% (0.1) | match |
| rus_Cyrl | lang | 9.3 | 16.3 | ×1.76 | ×0.98 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (57.4) | 0% (0.0) | match |
| tam_Taml | lang | 15.3 | 86.4 | ×5.63 | ×0.92 | 0% (0.0) | 16% (1.7) | 0% (0.0) | 84% (8.9) | 0% (0.0) | match |
| tha_Thai | lang | 19.5 | 86.3 | ×4.43 | ×0.95 | 0% (0.0) | 8% (0.9) | 0% (0.0) | 92% (10.1) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 8.7 | ×1.42 | ×1.00 | 0% (0.1) | 3% (3.8) | 0% (0.0) | 97% (109.3) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 7.4 | ×1.40 | ×1.00 | 0% (0.0) | 5% (6.0) | 0% (0.0) | 95% (122.8) | 0% (0.0) | match |
| added_special_dense | modalities | 5.4 | 20.3 | ×3.76 | ×1.02 | 10% (5.0) | 34% (16.1) | 2% (1.1) | 53% (25.4) | 0% (0.2) | match |
| added_special_sparse | modalities | 7.6 | 10.3 | ×1.35 | ×1.00 | 2% (2.1) | 14% (13.9) | 0% (0.1) | 81% (79.0) | 2% (2.1) | match |
| agentic-traces | modalities | 4.9 | 7.3 | ×1.49 | ×1.02 | 0% (0.1) | 5% (6.1) | 0% (0.0) | 96% (128.4) | 0% (0.0) | match |
| agentic_swe | modalities | 4.5 | 7.6 | ×1.71 | ×1.01 | 0% (0.0) | 7% (9.7) | 0% (0.0) | 93% (120.9) | 0% (0.0) | match |
| code_mixed | modalities | 4.6 | 7.3 | ×1.59 | ×0.99 | 0% (0.0) | 6% (8.0) | 0% (0.0) | 94% (126.2) | 0% (0.3) | match |
| math_latex | modalities | 4.7 | 6.8 | ×1.44 | ×0.98 | 0% (0.1) | 4% (6.4) | 0% (0.0) | 95% (135.6) | 0% (0.1) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×7.05 vs v0.23.1 · ×1.05 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 143+0 (peak 199) · Pipeline 144+0 (peak 200)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 49.7 | ×11.57 | ×1.07 | 4% (0.7) | 0% (0.0) | 21% (3.7) | 75% (12.9) | 0% (0.0) | match |
| arb_Arab | lang | 4.9 | 18.4 | ×3.73 | ×1.05 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 94% (48.7) | 0% (0.0) | match |
| ben_Beng | lang | 4.2 | 32.1 | ×7.71 | ×1.03 | 2% (0.6) | 0% (0.0) | 10% (3.1) | 88% (26.0) | 0% (0.0) | match |
| cmn_Hani | lang | 5.2 | 17.0 | ×3.26 | ×1.03 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 94% (50.7) | 0% (0.3) | match |
| ell_Grek | lang | 5.4 | 19.7 | ×3.67 | ×1.04 | 1% (0.6) | 0% (0.0) | 5% (2.2) | 94% (45.5) | 0% (0.0) | match |
| eng_Latn | lang | 4.2 | 48.9 | ×11.78 | ×1.17 | 11% (2.0) | 0% (0.0) | 17% (3.0) | 72% (12.8) | 0% (0.0) | match |
| heb_Hebr | lang | 4.5 | 26.8 | ×5.91 | ×1.06 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 91% (32.7) | 1% (0.3) | match |
| hin_Deva | lang | 4.4 | 78.9 | ×17.78 | ×1.03 | 5% (0.6) | 0% (0.0) | 28% (3.2) | 67% (7.7) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.0 | 16.5 | ×2.76 | ×1.01 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (53.7) | 0% (0.0) | match |
| kat_Geor | lang | 5.7 | 37.2 | ×6.52 | ×1.02 | 2% (0.6) | 0% (0.0) | 8% (2.1) | 89% (21.7) | 0% (0.0) | match |
| kor_Hang | lang | 4.3 | 19.4 | ×4.56 | ×1.08 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 93% (44.3) | 0% (0.1) | match |
| rus_Cyrl | lang | 5.2 | 17.0 | ×3.25 | ×1.05 | 1% (0.6) | 0% (0.0) | 4% (2.1) | 95% (52.6) | 0% (0.1) | match |
| tam_Taml | lang | 3.9 | 35.7 | ×9.26 | ×1.01 | 2% (0.6) | 0% (0.0) | 10% (2.7) | 88% (23.4) | 0% (0.0) | match |
| tha_Thai | lang | 5.4 | 21.0 | ×3.92 | ×1.04 | 1% (0.6) | 0% (0.0) | 6% (2.6) | 93% (41.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.2 | 26.8 | ×4.36 | ×0.98 | 2% (0.7) | 0% (0.0) | 3% (1.1) | 95% (33.5) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 42.3 | ×7.94 | ×1.02 | 6% (1.3) | 0% (0.0) | 9% (2.0) | 85% (19.0) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 75.8 | ×17.78 | ×1.00 | 39% (4.9) | 1% (0.1) | 37% (4.6) | 21% (2.6) | 2% (0.2) | match |
| added_special_sparse | modalities | 4.5 | 73.7 | ×16.50 | ×1.03 | 25% (3.2) | 0% (0.1) | 37% (4.8) | 36% (4.7) | 1% (0.2) | match |
| agentic-traces | modalities | 3.7 | 38.1 | ×10.33 | ×1.04 | 8% (1.8) | 0% (0.0) | 16% (3.7) | 76% (17.8) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 29.1 | ×7.04 | ×1.09 | 4% (1.3) | 0% (0.0) | 9% (2.9) | 87% (28.0) | 0% (0.0) | match |
| code_mixed | modalities | 4.3 | 49.9 | ×11.55 | ×1.13 | 8% (1.6) | 0% (0.0) | 18% (3.3) | 74% (13.5) | 0% (0.1) | match |
| math_latex | modalities | 4.0 | 44.6 | ×11.19 | ×1.20 | 9% (1.9) | 0% (0.0) | 16% (3.4) | 74% (15.4) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.77 | 3.44 | 3.65 | 4.33 | 27.1 | 16.1 | 5.9 | 4.7 | 7.4× / 6.3× | 4.4× / 3.7× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.14 | 2.95 | 2.31 | 4.11 | 31.2 | 19.3 | 6.7 | 5.1 | 13.5× / 7.6× | 8.4× / 4.7× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.60 | 2.92 | 3.10 | 4.41 | 45.0 | 27.8 | 10.3 | 3.7 | 14.5× / 10.2× | 9.0× / 6.3× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.21 | 2.38 | 3.47 | 19.8 | 11.8 | 4.7 | 2.4 | 8.3× / 5.7× | 5.0× / 3.4× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.95 | 2.20 | 4.56 | 28.2 | 17.3 | 6.1 | 4.7 | 12.9× / 6.2× | 7.9× / 3.8× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.45 | 3.00 | 4.36 | 43.3 | 32.9 | 12.2 | 3.7 | 14.5× / 9.9× | 11.0× / 7.6× | 4.1× / 2.8× | 1.2× / 0.9× |
| heb_Hebr | 1.15 | 3.03 | 2.29 | 4.17 | 30.6 | 19.6 | 7.0 | 3.1 | 13.3× / 7.3× | 8.5× / 4.7× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.50 | 3.07 | 3.19 | 4.75 | 47.5 | 30.7 | 11.3 | 4.0 | 14.9× / 10.0× | 9.6× / 6.5× | 3.5× / 2.4× | 1.3× / 0.8× |
| jpn_Jpan | 1.69 | 3.33 | 2.17 | 3.80 | 18.4 | 10.1 | 4.1 | 3.7 | 8.5× / 4.8× | 4.6× / 2.6× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.52 | 2.57 | 2.07 | 3.13 | 17.0 | 11.2 | 4.2 | 2.0 | 8.2× / 5.4× | 5.4× / 3.6× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.23 | 2.70 | 2.52 | 3.99 | 31.0 | 21.9 | 7.6 | 3.7 | 12.3× / 7.8× | 8.7× / 5.5× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.93 | 2.14 | 3.91 | 26.8 | 16.6 | 5.9 | 2.4 | 12.5× / 6.9× | 7.7× / 4.2× | 2.8× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.91 | 2.90 | 2.68 | 4.67 | 44.3 | 27.4 | 9.9 | 3.4 | 16.5× / 9.5× | 10.2× / 5.9× | 3.7× / 2.1× | 1.3× / 0.7× |
| tha_Thai | 1.50 | 2.59 | 2.58 | 3.68 | 28.0 | 16.2 | 6.7 | 3.0 | 10.9× / 7.6× | 6.3× / 4.4× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.77 | 1.14 | 2.85 | 23.1 | 17.0 | 6.6 | 1.8 | 20.3× / 8.1× | 14.9× / 6.0× | 5.8× / 2.3× | 1.6× / 0.6× |
| added_normalized_sparse | 0.06 | 1.48 | 2.02 | 3.44 | 30.8 | 23.1 | 8.6 | 2.5 | 15.3× / 9.0× | 11.4× / 6.7× | 4.3× / 2.5× | 1.3× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 4.63 | 6.05 | 93.3 | 76.2 | 21.1 | 3.2 | 20.1× / 15.4× | 16.4× / 12.6× | 4.5× / 3.5× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.77 | 6.19 | 60.1 | 45.8 | 15.1 | 3.5 | 12.6× / 9.7× | 9.6× / 7.4× | 3.2× / 2.4× | 0.7× / 0.6× |
| agentic-traces | 0.72 | 1.47 | 3.69 | 4.45 | 51.9 | 44.1 | 14.8 | 4.6 | 14.1× / 11.7× | 11.9× / 9.9× | 4.0× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.65 | 1.44 | 2.86 | 3.64 | 54.0 | 51.9 | 15.4 | 3.4 | 18.9× / 14.8× | 18.2× / 14.3× | 5.4× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.25 | 4.63 | 51.6 | 50.1 | 15.2 | 4.0 | 15.8× / 11.1× | 15.4× / 10.8× | 4.7× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.72 | 1.63 | 3.41 | 4.33 | 50.4 | 39.0 | 14.1 | 4.2 | 14.8× / 11.6× | 11.4× / 9.0× | 4.1× / 3.2× | 1.2× / 1.0× |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30085846489-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->


