### PR TITLE
implement ultra-basic, erroneous decode

### DIFF
--- a/bindings/node/src/decoders.rs
+++ b/bindings/node/src/decoders.rs
@@ -1,4 +1,5 @@
 use crate::arc_rwlock_serde;
+use ahash::AHashMap;
 use serde::{Deserialize, Serialize};
 extern crate tokenizers as tk;
 use napi::bindgen_prelude::*;
@@ -58,7 +59,7 @@ pub fn bpe_decoder(suffix: Option<String>) -> Decoder {
 pub fn byte_fallback_decoder() -> Decoder {
   Decoder {
     decoder: Some(Arc::new(RwLock::new(
-      tk::decoders::byte_fallback::ByteFallback::new().into(),
+      tk::decoders::byte_fallback::ByteFallback::new(AHashMap::new()).into(),
     ))),
   }
 }

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, RwLock};
 use crate::pre_tokenizers::from_string;
 use crate::tokenizer::PyTokenizer;
 use crate::utils::PyPattern;
+use ahash::AHashMap;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::*;
@@ -299,7 +300,7 @@ impl PyByteFallbackDec {
     #[new]
     #[pyo3(signature = (), text_signature = "(self)")]
     fn new() -> PyClassInitializer<Self> {
-        PyClassInitializer::<PyDecoder>::from(PyDecoder::from(ByteFallback::new()))
+        PyClassInitializer::<PyDecoder>::from(PyDecoder::from(ByteFallback::new(AHashMap::new())))
             .add_subclass(PyByteFallbackDec {})
     }
 }

--- a/tokenizers/benches/ci_benchmark.rs
+++ b/tokenizers/benches/ci_benchmark.rs
@@ -267,7 +267,7 @@ fn bench_decode(c: &mut Criterion) {
     let mut sp_chain = Tokenizer::from_file("data/albert-base-v1-tokenizer.json").unwrap();
     sp_chain.with_decoder(Some(Sequence::new(vec![
         Replace::new("▁", " ").unwrap().into(),
-        ByteFallback::new().into(),
+        ByteFallback::default().into(),
         Fuse::new().into(),
     ])));
     let lines = encode_lines(&sp_chain, &data);

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -670,7 +670,9 @@ fn bench_threads(
 // release. No released baseline → no decode oracle, so the whole phase is null.
 // `pipeline_ok` is the once-probed "can the pipeline decode yet" flag: while
 // `PipelineTokenizer::decode` is a loud stub it is false, so the pipeline series
-// is `null` (rendered "pending") and only the baseline bar is drawn.
+// is `null` (rendered "pending") and only the baseline bar is drawn. A decoder
+// that passes that probe but `Err`s on real ids fails `text_match` and nulls
+// its series for the affected fixtures/sweep — it never aborts the run.
 
 /// Encode every chunk with the released crate into its id stream (untimed input;
 /// specials included, so decode sees the frame tokens a real stream carries).
@@ -724,22 +726,28 @@ fn bench_decode(
     };
     let mbps = |secs: f64| dec_bytes as f64 / secs / 1e6;
 
+    // The `main` probe only decodes `[0]`, so a partial decoder can still `Err`
+    // on this fixture's real id streams — that fails the `text_match` gate and
+    // skips the pipeline timing (series stays null) instead of aborting the run.
+    let pipe_ok = pipeline_ok && ids.iter().all(|i| pipeline.decode(i, false).is_ok());
     // Correctness gate (first 3 chunks): pipeline decode == released decode.
     let text_match = pipeline_ok.then(|| {
-        ids.iter()
-            .take(3)
-            .all(|i| pipeline.decode(i, false).unwrap() == baseline.decode(i, false).unwrap())
+        pipe_ok
+            && ids
+                .iter()
+                .take(3)
+                .all(|i| pipeline.decode(i, false).unwrap() == baseline.decode(i, false).unwrap())
     });
 
     // Interleaved warm-up + REPS so thermal drift hits both equally.
     one_pass(&|i| baseline.decode(i, false).unwrap().len());
-    if pipeline_ok {
+    if pipe_ok {
         one_pass(&|i| pipeline.decode(i, false).unwrap().len());
     }
     let (mut base_s, mut pipe_s) = (Vec::new(), Vec::new());
     for _ in 0..REPS {
         base_s.push(one_pass(&|i| baseline.decode(i, false).unwrap().len()));
-        if pipeline_ok {
+        if pipe_ok {
             pipe_s.push(one_pass(&|i| pipeline.decode(i, false).unwrap().len()));
         }
     }
@@ -793,11 +801,14 @@ fn bench_decode_threads(
         .iter()
         .map(|i| baseline.decode(i, false).unwrap().len())
         .sum();
+    // Same tolerance as `bench_decode`: any `Err` over the corpus drops the
+    // pipeline series to null instead of panicking mid-sweep.
+    let pipe_ok = pipeline_ok && ids.iter().all(|i| pipeline.decode(i, false).is_ok());
     let counts = thread_counts();
     let (mut pipe, mut base) = (Vec::new(), Vec::new());
     for &n in &counts {
         let b = par_decode_mbps(|i| baseline.decode(i, false).unwrap().len(), &ids, bytes, n);
-        let p = pipeline_ok
+        let p = pipe_ok
             .then(|| par_decode_mbps(|i| pipeline.decode(i, false).unwrap().len(), &ids, bytes, n));
         eprintln!(
             "    decode {n} thread(s): pipeline {}, baseline {b:.1} MB/s",

--- a/tokenizers/tk-encode/src/decoders/byte_fallback.rs
+++ b/tokenizers/tk-encode/src/decoders/byte_fallback.rs
@@ -15,8 +15,10 @@ use serde::{Deserialize, Serialize};
 pub struct ByteFallback {
     #[serde(rename = "type")]
     type_: MustBe!("ByteFallback"),
-    /// Lookup mapping a token id to the raw byte it represents
+    /// Lookup mapping a token id to the raw byte it represents. Built from
+    /// the model when the pipeline is assembled, never part of tokenizer.json.
     /// todo: closed-addressing, can use ptrhash
+    #[serde(skip)]
     fallback_lookup: AHashMap<u32, u8>,
 }
 
@@ -26,6 +28,18 @@ impl ByteFallback {
             type_: MustBe!("ByteFallback"),
             fallback_lookup,
         }
+    }
+
+    /// Invert the model's encode-time byte -> id table into the id -> byte
+    /// lookup decoding needs.
+    pub(crate) fn from_byte_to_id(byte_to_id: &[u32; 256]) -> Self {
+        Self::new(
+            byte_to_id
+                .iter()
+                .enumerate()
+                .map(|(byte, &id)| (id, byte as u8))
+                .collect(),
+        )
     }
 }
 
@@ -88,8 +102,18 @@ impl pipeline::Decoder for ByteFallback {
     }
 
     fn flush(&self, state: &mut DecoderState, decoded: &mut Vec<u8>) -> Result<()> {
-        if state.pending_buffer.len() > 0 {
+        if state.pending_buffer.is_empty() {
+            return Ok(());
+        }
+        if std::str::from_utf8(&state.pending_buffer).is_ok() {
             decoded.append(&mut state.pending_buffer);
+        } else {
+            // one '�' per byte token, like `decode_chain` above — not
+            // from_utf8_lossy, which merges maximal invalid subparts
+            for _ in 0..state.pending_buffer.len() {
+                decoded.extend_from_slice("�".as_bytes());
+            }
+            state.pending_buffer.clear();
         }
         Ok(())
     }

--- a/tokenizers/tk-encode/src/decoders/byte_fallback.rs
+++ b/tokenizers/tk-encode/src/decoders/byte_fallback.rs
@@ -1,4 +1,8 @@
-use crate::tokenizer::{Decoder, Result};
+use crate::{
+    pipeline::{self, DecoderState},
+    tokenizer::{Decoder, Result},
+};
+use ahash::AHashMap;
 use monostate::MustBe;
 
 use serde::{Deserialize, Serialize};
@@ -11,12 +15,16 @@ use serde::{Deserialize, Serialize};
 pub struct ByteFallback {
     #[serde(rename = "type")]
     type_: MustBe!("ByteFallback"),
+    /// Lookup mapping a token id to the raw byte it represents
+    /// todo: closed-addressing, can use ptrhash
+    fallback_lookup: AHashMap<u32, u8>,
 }
 
 impl ByteFallback {
-    pub fn new() -> Self {
+    pub fn new(fallback_lookup: AHashMap<u32, u8>) -> Self {
         Self {
             type_: MustBe!("ByteFallback"),
+            fallback_lookup,
         }
     }
 }
@@ -62,13 +70,38 @@ impl Decoder for ByteFallback {
     }
 }
 
+impl pipeline::Decoder for ByteFallback {
+    fn decode_token(
+        &self,
+        state: &mut pipeline::DecoderState,
+        token_id: u32,
+        token_bytes: &[u8],
+        decoded: &mut Vec<u8>,
+    ) -> Result<()> {
+        if let Some(&raw_byte) = self.fallback_lookup.get(&token_id) {
+            state.pending_buffer.push(raw_byte);
+            return Ok(());
+        }
+        self.flush(state, decoded)?;
+        decoded.extend_from_slice(token_bytes);
+        Ok(())
+    }
+
+    fn flush(&self, state: &mut DecoderState, decoded: &mut Vec<u8>) -> Result<()> {
+        if state.pending_buffer.len() > 0 {
+            decoded.append(&mut state.pending_buffer);
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn decode() {
-        let decoder = ByteFallback::new();
+        let decoder = ByteFallback::new(AHashMap::new());
         let res = decoder
             .decode_chain(vec!["Hey".into(), "friend!".into()])
             .unwrap();

--- a/tokenizers/tk-encode/src/decoders/strip.rs
+++ b/tokenizers/tk-encode/src/decoders/strip.rs
@@ -1,4 +1,7 @@
-use crate::tokenizer::{Decoder, Result};
+use crate::{
+    pipeline,
+    tokenizer::{Decoder, Result},
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -56,6 +59,34 @@ impl Decoder for Strip {
                 new_token
             })
             .collect())
+    }
+}
+
+impl pipeline::Decoder for Strip {
+    fn decode_token(
+        &self,
+        _state: &mut pipeline::DecoderState,
+        _token_id: u32,
+        token_bytes: &[u8],
+        decoded: &mut Vec<u8>,
+    ) -> Result<()> {
+        let mut pat_buf = [0u8; 4];
+        let pat = self.content.encode_utf8(&mut pat_buf).as_bytes();
+        let mut token = token_bytes;
+        for _ in 0..self.start {
+            match token.strip_prefix(pat) {
+                Some(rest) => token = rest,
+                None => break,
+            }
+        }
+        for _ in 0..self.stop {
+            match token.strip_suffix(pat) {
+                Some(rest) => token = rest,
+                None => break,
+            }
+        }
+        decoded.extend_from_slice(token);
+        Ok(())
     }
 }
 

--- a/tokenizers/tk-encode/src/decoders/wordpiece.rs
+++ b/tokenizers/tk-encode/src/decoders/wordpiece.rs
@@ -1,5 +1,7 @@
+use std::mem::replace;
+
 use crate::{
-    pipeline,
+    pipeline::{self, DecoderState},
     tokenizer::{Decoder, Result},
 };
 
@@ -72,25 +74,21 @@ const CLEANUP_LIST: [&[u8]; 10] = [
 impl pipeline::Decoder for WordPiece {
     fn decode_token(
         &self,
+        state: &mut DecoderState,
+        _token_id: u32,
         token_bytes: &[u8],
-        token_index: usize,
         decoded: &mut Vec<u8>,
     ) -> Result<()> {
-        if token_index == 0 {
-            decoded.extend_from_slice(token_bytes);
-            return Ok(());
-        }
-
-        if token_bytes.starts_with(self.prefix.as_bytes()) {
-            // trim prefix
+        if !replace(&mut state.started, true) {
+            decoded.extend(token_bytes)
+        } else if token_bytes.starts_with(self.prefix.as_bytes()) {
             decoded.extend_from_slice(&token_bytes[self.prefix.len()..]);
+        } else if self.cleanup && CLEANUP_LIST.contains(&token_bytes) {
+            decoded.extend(token_bytes);
         } else {
-            if !self.cleanup || !CLEANUP_LIST.contains(&token_bytes) {
-                decoded.push(b' ');
-            }
-            decoded.extend_from_slice(token_bytes);
+            decoded.push(b' ');
+            decoded.extend(token_bytes);
         }
-
         Ok(())
     }
 }

--- a/tokenizers/tk-encode/src/decoders/wordpiece.rs
+++ b/tokenizers/tk-encode/src/decoders/wordpiece.rs
@@ -65,8 +65,8 @@ impl Decoder for WordPiece {
     }
 }
 
-const CLEANUP_LIST: [&'static [u8]; 10] = [
-    b".", b"?", b"!", b",", b"n't", b"'m", b"do not", b"'s", b"'ve", b"'re"
+const CLEANUP_LIST: [&[u8]; 10] = [
+    b".", b"?", b"!", b",", b"n't", b"'m", b"do not", b"'s", b"'ve", b"'re",
 ];
 
 impl pipeline::Decoder for WordPiece {

--- a/tokenizers/tk-encode/src/decoders/wordpiece.rs
+++ b/tokenizers/tk-encode/src/decoders/wordpiece.rs
@@ -1,4 +1,7 @@
-use crate::tokenizer::{Decoder, Result};
+use crate::{
+    pipeline,
+    tokenizer::{Decoder, Result},
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -28,6 +31,7 @@ impl Default for WordPiece {
         }
     }
 }
+
 pub fn cleanup(dirty_input: &str) -> String {
     dirty_input
         .replace(" .", ".")
@@ -58,6 +62,36 @@ impl Decoder for WordPiece {
             }
         }
         Ok(tokens)
+    }
+}
+
+const CLEANUP_LIST: [&'static [u8]; 10] = [
+    b".", b"?", b"!", b",", b"n't", b"'m", b"do not", b"'s", b"'ve", b"'re"
+];
+
+impl pipeline::Decoder for WordPiece {
+    fn decode_token(
+        &self,
+        token_bytes: &[u8],
+        token_index: usize,
+        decoded: &mut Vec<u8>,
+    ) -> Result<()> {
+        if token_index == 0 {
+            decoded.extend_from_slice(token_bytes);
+            return Ok(());
+        }
+
+        if token_bytes.starts_with(self.prefix.as_bytes()) {
+            // trim prefix
+            decoded.extend_from_slice(&token_bytes[self.prefix.len()..]);
+        } else {
+            if !self.cleanup || !CLEANUP_LIST.contains(&token_bytes) {
+                decoded.push(b' ');
+            }
+            decoded.extend_from_slice(token_bytes);
+        }
+
+        Ok(())
     }
 }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -856,8 +856,8 @@ impl pipeline::Model for PipelineBPE {
         }
     }
 
-    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]> {
-        self.vocab.id_to_token_bytes(id.id)
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+        self.vocab.id_to_token_bytes(id)
     }
 }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -763,6 +763,19 @@ impl PipelineBPE {
         })
     }
 
+    /// The `<0xHH>` token ids indexed by byte, when this model encodes with
+    /// byte fallback. `Atoms::Bytes` also holds a byte -> id table, but it
+    /// maps byte-level atoms, not `<0xHH>` tokens, so it is not exposed here.
+    pub(crate) fn byte_fallback_ids(&self) -> Option<&[u32; 256]> {
+        match &self.atoms {
+            Atoms::Chars {
+                byte_fallback: Some(table),
+                ..
+            } => Some(table),
+            _ => None,
+        }
+    }
+
     fn merge_word(
         &self,
         sequence: &str,

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -855,6 +855,10 @@ impl pipeline::Model for PipelineBPE {
             skip: Vec::new(),
         }
     }
+
+    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]> {
+        self.vocab.id_to_token_bytes(id.id)
+    }
 }
 
 pub struct BpeScratch {

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -549,6 +549,10 @@ impl pipeline::Model for Unigram {
         }
         Ok(())
     }
+
+    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]> {
+        self.token_to_ids.id_to_token_bytes(id.id)
+    }
 }
 
 #[cfg(test)]

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -550,8 +550,8 @@ impl pipeline::Model for Unigram {
         Ok(())
     }
 
-    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]> {
-        self.token_to_ids.id_to_token_bytes(id.id)
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+        self.token_to_ids.id_to_token_bytes(id)
     }
 }
 

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -228,6 +228,10 @@ impl pipeline::Model for WordLevel {
         }
         Ok(())
     }
+
+    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]> {
+        self.vocab_r.get(&id.id).map(|s| s.as_bytes())
+    }
 }
 
 #[cfg(test)]

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -229,8 +229,8 @@ impl pipeline::Model for WordLevel {
         Ok(())
     }
 
-    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]> {
-        self.vocab_r.get(&id.id).map(|s| s.as_bytes())
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+        self.vocab_r.get(&id).map(|s| s.as_bytes())
     }
 }
 

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -322,6 +322,11 @@ impl pipeline::ModelScratch for WordPieceScratch {}
 
 pub struct PipelineWordPiece {
     vocab_trie: yada::DoubleArray<Vec<u8>>,
+    // Token bytes for decoding. The trie can't hand its keys back, so we keep
+    // a second copy; ids are dense line indices, so a flat arena indexed by id
+    // is cheaper than a hashmap. Token `id` is `vocab_r[offs[id]..offs[id + 1]]`.
+    vocab_r: Box<[u8]>,
+    vocab_r_offsets: Box<[u32]>,
     unk_token: Option<u32>,
     continuing_subword_prefix: String,
     max_input_chars_per_word: usize,
@@ -344,11 +349,31 @@ impl TryFrom<WordPiece> for PipelineWordPiece {
         keyset.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
         let vocab_trie = DoubleArray::new(DoubleArrayBuilder::build(&keyset)?)?;
 
+        let vocab_size = keyset
+            .iter()
+            .map(|(_, id)| *id as usize + 1)
+            .max()
+            .unwrap_or(0);
+        let mut vocab_r_offsets = vec![0u32; vocab_size + 1];
+        for (token, id) in &keyset {
+            vocab_r_offsets[*id as usize + 1] = token.len() as u32;
+        }
+        for i in 1..vocab_r_offsets.len() {
+            vocab_r_offsets[i] += vocab_r_offsets[i - 1];
+        }
+        let mut vocab_r = vec![0u8; vocab_r_offsets[vocab_size] as usize];
+        for (token, id) in &keyset {
+            let start = vocab_r_offsets[*id as usize] as usize;
+            vocab_r[start..start + token.len()].copy_from_slice(token.as_bytes());
+        }
+
         Ok(Self {
             continuing_subword_prefix,
             max_input_chars_per_word,
             unk_token,
             vocab_trie,
+            vocab_r: vocab_r.into_boxed_slice(),
+            vocab_r_offsets: vocab_r_offsets.into_boxed_slice(),
         })
     }
 }
@@ -409,6 +434,13 @@ impl pipeline::Model for PipelineWordPiece {
         }
         Ok(())
     }
+
+    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]> {
+        let i = id.id as usize;
+        let start = *self.vocab_r_offsets.get(i)? as usize;
+        let end = *self.vocab_r_offsets.get(i + 1)? as usize;
+        Some(&self.vocab_r[start..end])
+    }
 }
 
 #[cfg(test)]
@@ -418,5 +450,26 @@ mod tests {
     #[test]
     fn test_error_display() {
         assert!(format!("{}", Error::MissingUnkToken).contains("Missing [UNK] token"));
+    }
+
+    #[test]
+    fn id_to_token_bytes_round_trips() {
+        use crate::pipeline::{Model as _, PipelineToken};
+
+        let vocab: Vocab = [
+            ("[UNK]".to_string(), 0),
+            ("hello".to_string(), 1),
+            ("##world".to_string(), 2),
+        ]
+        .into_iter()
+        .collect();
+        let wp = WordPiece::builder().vocab(vocab).build().unwrap();
+        let model = PipelineWordPiece::try_from(wp).unwrap();
+
+        for (token, id) in [("[UNK]", 0), ("hello", 1), ("##world", 2)] {
+            let bytes = model.id_to_token_bytes(&PipelineToken { id }).unwrap();
+            assert_eq!(bytes, token.as_bytes());
+        }
+        assert_eq!(model.id_to_token_bytes(&PipelineToken { id: 3 }), None);
     }
 }

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -435,8 +435,8 @@ impl pipeline::Model for PipelineWordPiece {
         Ok(())
     }
 
-    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]> {
-        let i = id.id as usize;
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+        let i = id as usize;
         let start = *self.vocab_r_offsets.get(i)? as usize;
         let end = *self.vocab_r_offsets.get(i + 1)? as usize;
         Some(&self.vocab_r[start..end])
@@ -454,7 +454,7 @@ mod tests {
 
     #[test]
     fn id_to_token_bytes_round_trips() {
-        use crate::pipeline::{Model as _, PipelineToken};
+        use crate::pipeline::Model as _;
 
         let vocab: Vocab = [
             ("[UNK]".to_string(), 0),
@@ -467,9 +467,9 @@ mod tests {
         let model = PipelineWordPiece::try_from(wp).unwrap();
 
         for (token, id) in [("[UNK]", 0), ("hello", 1), ("##world", 2)] {
-            let bytes = model.id_to_token_bytes(&PipelineToken { id }).unwrap();
+            let bytes = model.id_to_token_bytes(id).unwrap();
             assert_eq!(bytes, token.as_bytes());
         }
-        assert_eq!(model.id_to_token_bytes(&PipelineToken { id: 3 }), None);
+        assert_eq!(model.id_to_token_bytes(3), None);
     }
 }

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -131,6 +131,22 @@ impl Decoder for Replace {
     }
 }
 
+impl pipeline::Decoder for Replace {
+    fn decode_token(
+        &self,
+        state: &mut pipeline::DecoderState,
+        token_id: u32,
+        token_bytes: &[u8],
+        decoded: &mut Vec<u8>,
+    ) -> Result<()> {
+        match &self.pattern {
+            ReplacePattern::String(string) => {}
+            ReplacePattern::Regex(_) => {}
+        }
+        Ok(())
+    }
+}
+
 // `Replace` needs a system-regex backend (SysRegex) for every test here.
 #[cfg(all(test, feature = "fancy-regex"))]
 mod tests {

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -134,16 +134,39 @@ impl Decoder for Replace {
 impl pipeline::Decoder for Replace {
     fn decode_token(
         &self,
-        state: &mut pipeline::DecoderState,
-        token_id: u32,
+        _state: &mut pipeline::DecoderState,
+        _token_id: u32,
         token_bytes: &[u8],
         decoded: &mut Vec<u8>,
     ) -> Result<()> {
         match &self.pattern {
-            ReplacePattern::String(string) => {}
-            ReplacePattern::Regex(_) => {}
+            // Plain byte search: no regex machinery on the hot path, and raw
+            // (non-UTF-8) token bytes pass through unharmed.
+            ReplacePattern::String(pattern) if !pattern.is_empty() => {
+                let pat = pattern.as_bytes();
+                let mut rest = token_bytes;
+                while let Some(pos) = rest.windows(pat.len()).position(|window| window == pat) {
+                    decoded.extend_from_slice(&rest[..pos]);
+                    decoded.extend_from_slice(self.content.as_bytes());
+                    rest = &rest[pos + pat.len()..];
+                }
+                decoded.extend_from_slice(rest);
+                Ok(())
+            }
+            _ => {
+                let token = std::str::from_utf8(token_bytes).map_err(
+                    |_| "Replace decoder with a regex pattern requires valid UTF-8 tokens",
+                )?;
+                let mut last_end = 0;
+                for (start, end) in self.regex.find_iter(token) {
+                    decoded.extend_from_slice(&token.as_bytes()[last_end..start]);
+                    decoded.extend_from_slice(self.content.as_bytes());
+                    last_end = end;
+                }
+                decoded.extend_from_slice(&token.as_bytes()[last_end..]);
+                Ok(())
+            }
         }
-        Ok(())
     }
 }
 
@@ -198,6 +221,40 @@ mod tests {
             replace.decode_chain(original).unwrap(),
             vec!["hello", " hello"]
         );
+    }
+
+    #[test]
+    fn pipeline_decode_token_matches_decode_chain() {
+        let cases = vec![
+            (
+                Replace::new("▁", " ").unwrap(),
+                vec!["▁Hey", "▁▁friend", "no_meta", "▁", ""],
+            ),
+            (Replace::new("ab", "X").unwrap(), vec!["aabb", "abab", "b"]),
+            (
+                Replace::new(ReplacePattern::Regex(r"\s+".into()), " ").unwrap(),
+                vec!["a   b", " x ", "y"],
+            ),
+        ];
+        for (replace, tokens) in cases {
+            let expected = replace
+                .decode_chain(tokens.iter().map(|t| t.to_string()).collect())
+                .unwrap()
+                .concat();
+            let mut state = pipeline::DecoderState::default();
+            let mut out = Vec::new();
+            for token in &tokens {
+                pipeline::Decoder::decode_token(
+                    &replace,
+                    &mut state,
+                    0,
+                    token.as_bytes(),
+                    &mut out,
+                )
+                .unwrap();
+            }
+            assert_eq!(out, expected.as_bytes(), "pattern {:?}", replace.pattern);
+        }
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
@@ -1,4 +1,7 @@
-use crate::tokenizer::{Decoder, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
+use crate::{
+    pipeline,
+    tokenizer::{Decoder, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior},
+};
 use serde::{Deserialize, Deserializer, Serialize, de};
 
 /// Enum representing options for the metaspace prepending scheme.
@@ -169,6 +172,25 @@ impl Decoder for Metaspace {
                     .collect::<String>()
             })
             .collect())
+    }
+}
+
+impl pipeline::Decoder for Metaspace {
+    fn decode_token(
+        &self,
+        token_bytes: &[u8],
+        token_index: usize,
+        decoded: &mut Vec<u8>,
+    ) -> Result<()> {
+        if token_bytes.starts_with(self.str_rep.as_bytes()) {
+            if token_index == 0 && self.prepend_scheme != PrependScheme::Never {
+                decoded.push(b' ');
+            }
+            decoded.extend_from_slice(&token_bytes[self.replacement.len_utf8()..]);
+        } else {
+            decoded.extend_from_slice(token_bytes);
+        }
+        Ok(())
     }
 }
 

--- a/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
@@ -185,14 +185,20 @@ impl pipeline::Decoder for Metaspace {
         token_bytes: &[u8],
         decoded: &mut Vec<u8>,
     ) -> Result<()> {
-        if token_bytes.starts_with(self.str_rep.as_bytes()) {
-            if !replace(&mut state.started, true) && self.prepend_scheme != PrependScheme::Never {
+        // Every replacement char becomes ' ', except in the first token where
+        // prepend_scheme != Never drops it (it was prepended at encode time).
+        let first = !replace(&mut state.started, true);
+        let drop_replacement = first && self.prepend_scheme != PrependScheme::Never;
+        let pat = self.str_rep.as_bytes();
+        let mut rest = token_bytes;
+        while let Some(pos) = rest.windows(pat.len()).position(|window| window == pat) {
+            decoded.extend_from_slice(&rest[..pos]);
+            if !drop_replacement {
                 decoded.push(b' ');
             }
-            decoded.extend_from_slice(&token_bytes[self.replacement.len_utf8()..]);
-        } else {
-            decoded.extend_from_slice(token_bytes);
+            rest = &rest[pos + pat.len()..];
         }
+        decoded.extend_from_slice(rest);
         Ok(())
     }
 }
@@ -203,6 +209,35 @@ mod tests {
 
     use super::*;
     use crate::{OffsetReferential, OffsetType};
+
+    #[test]
+    fn pipeline_decode_token_matches_decode_chain() {
+        let tokens = ["▁Hey", "▁▁friend", "▁", "what", "▁▁"];
+        for scheme in [
+            PrependScheme::Always,
+            PrependScheme::First,
+            PrependScheme::Never,
+        ] {
+            let decoder = Metaspace::new('▁', scheme, true);
+            let expected = decoder
+                .decode_chain(tokens.iter().map(|t| t.to_string()).collect())
+                .unwrap()
+                .concat();
+            let mut state = DecoderState::default();
+            let mut out = Vec::new();
+            for token in tokens {
+                pipeline::Decoder::decode_token(
+                    &decoder,
+                    &mut state,
+                    0,
+                    token.as_bytes(),
+                    &mut out,
+                )
+                .unwrap();
+            }
+            assert_eq!(out, expected.as_bytes(), "prepend_scheme {scheme:?}");
+        }
+    }
 
     #[test]
     fn serialization() {

--- a/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
@@ -1,5 +1,7 @@
+use std::mem::replace;
+
 use crate::{
-    pipeline,
+    pipeline::{self, DecoderState},
     tokenizer::{Decoder, PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior},
 };
 use serde::{Deserialize, Deserializer, Serialize, de};
@@ -178,12 +180,13 @@ impl Decoder for Metaspace {
 impl pipeline::Decoder for Metaspace {
     fn decode_token(
         &self,
+        state: &mut DecoderState,
+        _token_id: u32,
         token_bytes: &[u8],
-        token_index: usize,
         decoded: &mut Vec<u8>,
     ) -> Result<()> {
         if token_bytes.starts_with(self.str_rep.as_bytes()) {
-            if token_index == 0 && self.prepend_scheme != PrependScheme::Never {
+            if !replace(&mut state.started, true) && self.prepend_scheme != PrependScheme::Never {
                 decoded.push(b' ');
             }
             decoded.extend_from_slice(&token_bytes[self.replacement.len_utf8()..]);

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -271,14 +271,7 @@ impl TryFrom<&PostProcessorWrapper> for PipelinePostProcessor {
 /// [`PipelineDecoder`] is responsible for turning a chunk of token ids back into human-readable text
 #[derive(Debug, Default)]
 pub enum PipelineDecoder {
-    WordPiece {
-        /// Tokens that are inside a word start with this prefix.
-        /// For example for bert, it's "##": "tokenization" would be tokenized as ["tok", "##eni", "##z", "##ation"]
-        /// To reconstruct the text from the tokens, we need to strip that prefix for every token
-        word_continuation_prefix: String,
-        /// Whether to perform a cleanup phase (see implementation for details)
-        cleanup: bool,
-    },
+    WordPiece(WordPiece),
     #[default]
     None,
 }
@@ -288,24 +281,33 @@ pub trait Decoder {
         &self,
         model: &PipelineModel,
         added_vocabulary: &BucketAddedVocabulary,
-        token_id: u32,
-        decoded: &mut Vec<u8>,
         skip_special_tokens: bool,
+        ids: &[u32],
+        decoded: &mut Vec<u8>,
     ) -> Result<()> {
-        if let Some(special_token) = added_vocabulary.simple_id_to_token_bytes(token_id) {
-            if !skip_special_tokens {
-                decoded.extend_from_slice(special_token);
+        let mut token_index = 0;
+        for &token_id in ids {
+            if let Some(special) = added_vocabulary.simple_id_to_token_bytes(token_id) {
+                if skip_special_tokens {
+                    continue;
+                }
+                self.decode_token(special, token_index, decoded)?;
+            } else {
+                let token_bytes = model
+                    .id_to_token_bytes(token_id)
+                    .ok_or::<crate::Error>(format!("Invalid token id: {token_id}").into())?;
+
+                self.decode_token(token_bytes, token_index, decoded)?;
             }
-            return Ok(());
+            token_index += 1;
         }
-        self.decode_token(model, token_id, decoded)?;
         Ok(())
     }
 
     fn decode_token(
         &self,
-        model: &PipelineModel,
-        token_id: u32,
+        token_bytes: &[u8],
+        token_index: usize,
         decoded: &mut Vec<u8>,
     ) -> Result<()>;
 }
@@ -313,31 +315,20 @@ pub trait Decoder {
 impl Decoder for PipelineDecoder {
     fn decode_token(
         &self,
-        model: &PipelineModel,
-        token_id: u32,
+        token_bytes: &[u8],
+        token_index: usize,
         decoded: &mut Vec<u8>,
     ) -> Result<()> {
-        let bytes = model
-            .id_to_token_bytes(token_id)
-            .ok_or::<crate::Error>(format!("Invalid token id: {token_id}").into())?;
         match self {
             Self::None => {
-                decoded.extend_from_slice(bytes);
+                if token_index != 0 {
+                    decoded.push(b' ');
+                }
+                decoded.extend_from_slice(token_bytes);
                 Ok(())
             }
-            PipelineDecoder::WordPiece {
-                word_continuation_prefix,
-                ..
-            } => {
-                if bytes.starts_with(word_continuation_prefix.as_bytes()) {
-                    // trim prefix
-                    decoded.extend_from_slice(&bytes[word_continuation_prefix.len()..]);
-                } else {
-                    decoded.push(b' ');
-                    decoded.extend_from_slice(bytes);
-                }
-                // todo: cleanup phase
-                Ok(())
+            PipelineDecoder::WordPiece(decoder) => {
+                decoder.decode_token(token_bytes, token_index, decoded)
             }
         }
     }
@@ -350,10 +341,7 @@ impl TryFrom<&DecoderWrapper> for PipelineDecoder {
         match value {
             // ByteLevel decoder is no longer needed as the vocabulary is stored as raw bytes
             DecoderWrapper::ByteLevel(_) => Ok(Self::None),
-            DecoderWrapper::WordPiece(WordPiece { cleanup, prefix }) => Ok(Self::WordPiece {
-                word_continuation_prefix: prefix.clone(),
-                cleanup: *cleanup,
-            }),
+            DecoderWrapper::WordPiece(decoder) => Ok(Self::WordPiece(decoder.clone())),
             DecoderWrapper::BPE(decoder) => {
                 Err(format!("Decoder {:?} not supported yet", decoder).into())
             }
@@ -659,17 +647,14 @@ impl PipelineTokenizer {
 
     /// Decode token ids back to a `String`.
     pub fn decode(&self, ids: &[u32], skip_special_tokens: bool) -> Result<String> {
-        let mut output = Vec::with_capacity(2 * ids.len());
-
-        for &id in ids {
-            self.decoder.decode(
-                &self.model,
-                &self.added_vocabulary,
-                id,
-                &mut output,
-                skip_special_tokens,
-            )?;
-        }
+        let mut output = Vec::with_capacity(4 * ids.len());
+        self.decoder.decode(
+            &self.model,
+            &self.added_vocabulary,
+            skip_special_tokens,
+            ids,
+            &mut output,
+        )?;
         Ok(String::from_utf8(output)?)
     }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -436,6 +436,7 @@ impl PipelineDecoder {
             DecoderWrapper::ByteLevel(_) => Ok(Self::None),
             DecoderWrapper::WordPiece(decoder) => Ok(Self::WordPiece(decoder.clone())),
             DecoderWrapper::Metaspace(decoder) => Ok(Self::MetaSpace(decoder.clone())),
+            DecoderWrapper::Replace(decoder) => Ok(Self::Replace(decoder.clone())),
             DecoderWrapper::ByteFallback(_) => {
                 let byte_to_id = model.byte_fallback_ids().ok_or(
                     "ByteFallback decoder requires a model byte fallback table to map \
@@ -1394,6 +1395,23 @@ mod tests {
         }
         decoder.flush(&mut state, &mut out).unwrap();
         assert_eq!(out, b"hey you");
+    }
+
+    // llama-2's chain in miniature: Replace rewrites plain tokens, ByteFallback
+    // holds byte runs, and the run flushes through the rest of the chain.
+    #[cfg(feature = "fancy-regex")]
+    #[test]
+    fn sequence_replace_then_byte_fallback_decodes() {
+        let mut tok = byte_fallback_tokenizer(true);
+        tok.with_decoder(Some(crate::decoders::sequence::Sequence::new(vec![
+            DecoderWrapper::Replace(crate::normalizers::Replace::new("h", "H").unwrap()),
+            DecoderWrapper::ByteFallback(crate::decoders::byte_fallback::ByteFallback::default()),
+        ])));
+        let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
+        assert_eq!(
+            pipeline.decode(&[300, 0xE5, 0x8F, 0xAB], false).unwrap(),
+            "H叫"
+        );
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -332,7 +332,7 @@ pub trait Decoder {
     ) -> Result<()>;
 
     fn flush(&self, _state: &mut DecoderState, _decoded: &mut Vec<u8>) -> Result<()> {
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -451,15 +451,9 @@ impl PipelineDecoder {
                     .get_decoders()
                     .iter()
                     .map(|decoder| Self::from_decoder(decoder, model))
-                    .filter(|maybe_decoder| {
-                        if let Ok(Self::None) = maybe_decoder {
-                            false
-                        } else {
-                            true
-                        }
-                    })
+                    .filter(|maybe_decoder| !matches!(maybe_decoder, Ok(Self::None)))
                     .collect::<Result<Vec<_>>>()?;
-                if decoders.len() == 0 {
+                if decoders.is_empty() {
                     return Ok(Self::default());
                 }
                 if decoders.len() == 1 {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -272,6 +272,7 @@ impl TryFrom<&PostProcessorWrapper> for PipelinePostProcessor {
 /// [`PipelineDecoder`] is responsible for turning a chunk of token ids back into human-readable text
 #[derive(Debug, Default)]
 pub enum PipelineDecoder {
+    Sequence(Vec<Self>),
     WordPiece(WordPiece),
     MetaSpace(Metaspace),
     None,
@@ -357,6 +358,22 @@ impl TryFrom<&DecoderWrapper> for PipelineDecoder {
             DecoderWrapper::ByteLevel(_) => Ok(Self::None),
             DecoderWrapper::WordPiece(decoder) => Ok(Self::WordPiece(decoder.clone())),
             DecoderWrapper::Metaspace(decoder) => Ok(Self::MetaSpace(decoder.clone())),
+            DecoderWrapper::Sequence(sequence) => {
+                let decoders = sequence.get_decoders();
+                if decoders.len() == 0 {
+                    return Ok(Self::default());
+                }
+                if decoders.len() == 1 {
+                    // SAFETY: safe to .unwrap() as the len is asserted to be 1
+                    return Self::try_from(decoders.first().unwrap());
+                }
+                Ok(Self::Sequence(
+                    decoders
+                        .into_iter()
+                        .map(Self::try_from)
+                        .collect::<Result<Vec<_>>>()?,
+                ))
+            }
             decoder => Err(format!("Decoder {:?} not supported yet", decoder).into()),
         }
     }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -542,8 +542,16 @@ impl PipelineTokenizer {
     /// test and the comparative benchmark report decode as *pending* instead of
     /// silently validating garbage. Implementing this flips the ignored
     /// `pipeline_decode_oracle` test on and lights up the decode charts.
-    pub fn decode(&self, _ids: &[u32], _skip_special_tokens: bool) -> Result<String> {
-        Err("PipelineTokenizer::decode is not implemented yet".into())
+    pub fn decode(&self, ids: &[PipelineToken], _skip_special_tokens: bool) -> Result<String> {
+        let mut output = Vec::with_capacity(ids.len());
+        for id in ids {
+            let slice = self
+                .model
+                .id_to_token_bytes(id)
+                .ok_or::<crate::Error>(format!("Invalid token id: {}", id.id).into())?;
+            output.extend_from_slice(slice);
+        }
+        Ok(String::from_utf8(output)?)
     }
 
     /// Decode several id sequences at once, one `String` per input. Mirrors the
@@ -923,6 +931,8 @@ pub trait Model {
     ) -> Result<()>;
 
     fn init_scratch(&self) -> Self::Scratch;
+
+    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]>;
 }
 
 #[allow(
@@ -968,6 +978,15 @@ impl Model for PipelineModel {
             Self::WordLevel(_) => Self::Scratch::WordLevel(()),
             Self::WordPiece(wordpiece) => Self::Scratch::WordPiece(wordpiece.init_scratch()),
             Self::Unigram(unigram) => Self::Scratch::Unigram(unigram.init_scratch()),
+        }
+    }
+
+    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]> {
+        match self {
+            Self::BPE(model) => model.id_to_token_bytes(id),
+            Self::WordLevel(model) => model.id_to_token_bytes(id),
+            Self::WordPiece(model) => model.id_to_token_bytes(id),
+            Self::Unigram(model) => model.id_to_token_bytes(id),
         }
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -283,10 +283,10 @@ pub enum PipelineDecoder {
     None,
 }
 
-pub trait Decoder<'a> {
+pub trait Decoder {
     fn decode(
-        &'a self,
-        model: &'a PipelineModel,
+        &self,
+        model: &PipelineModel,
         added_vocabulary: &BucketAddedVocabulary,
         token_id: u32,
         decoded: &mut Vec<u8>,
@@ -298,36 +298,46 @@ pub trait Decoder<'a> {
             }
             return Ok(());
         }
-        let slice = self.decode_token_to_slice(model, token_id)?;
-        decoded.extend_from_slice(slice);
+        self.decode_token(model, token_id, decoded)?;
         Ok(())
     }
 
-    fn decode_token_to_slice(&'a self, model: &'a PipelineModel, token_id: u32)
-    -> Result<&'a [u8]>;
+    fn decode_token(
+        &self,
+        model: &PipelineModel,
+        token_id: u32,
+        decoded: &mut Vec<u8>,
+    ) -> Result<()>;
 }
 
-impl<'a> Decoder<'a> for PipelineDecoder {
-    fn decode_token_to_slice(
-        &'a self,
-        model: &'a PipelineModel,
+impl Decoder for PipelineDecoder {
+    fn decode_token(
+        &self,
+        model: &PipelineModel,
         token_id: u32,
-    ) -> Result<&'a [u8]> {
-        let mut bytes = model
+        decoded: &mut Vec<u8>,
+    ) -> Result<()> {
+        let bytes = model
             .id_to_token_bytes(token_id)
             .ok_or::<crate::Error>(format!("Invalid token id: {token_id}").into())?;
         match self {
-            Self::None => Ok(bytes),
+            Self::None => {
+                decoded.extend_from_slice(bytes);
+                Ok(())
+            }
             PipelineDecoder::WordPiece {
                 word_continuation_prefix,
                 ..
             } => {
                 if bytes.starts_with(word_continuation_prefix.as_bytes()) {
                     // trim prefix
-                    bytes = &bytes[word_continuation_prefix.len()..];
+                    decoded.extend_from_slice(&bytes[word_continuation_prefix.len()..]);
+                } else {
+                    decoded.push(b' ');
+                    decoded.extend_from_slice(bytes);
                 }
-                // todo: cleanup
-                Ok(bytes)
+                // todo: cleanup phase
+                Ok(())
             }
         }
     }
@@ -649,7 +659,7 @@ impl PipelineTokenizer {
 
     /// Decode token ids back to a `String`.
     pub fn decode(&self, ids: &[u32], skip_special_tokens: bool) -> Result<String> {
-        let mut output = Vec::with_capacity(ids.len());
+        let mut output = Vec::with_capacity(2 * ids.len());
 
         for &id in ids {
             self.decoder.decode(

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -10,11 +10,13 @@ use atomsplit::classify::classify;
 use crate::DecoderWrapper;
 use crate::decoders::byte_fallback::ByteFallback;
 use crate::decoders::metaspace::Metaspace;
+use crate::decoders::strip::Strip;
 use crate::decoders::wordpiece::WordPiece;
 use crate::models::bpe::{BpeScratch, PipelineBPE};
 use crate::models::unigram::{Unigram, UnigramScratch};
 use crate::models::wordlevel::WordLevel;
 use crate::models::wordpiece::{PipelineWordPiece, WordPieceScratch};
+use crate::normalizers::Replace;
 use crate::processors::bert::BertProcessing;
 use crate::processors::roberta::RobertaProcessing;
 use crate::utils::byte_level::GPT2_REGEX_STR;
@@ -280,6 +282,8 @@ pub enum PipelineDecoder {
     WordPiece(WordPiece),
     MetaSpace(Metaspace),
     ByteFallback(ByteFallback),
+    Replace(Replace),
+    Strip(Strip),
     None,
     #[default]
     JoinWithSpaces,
@@ -305,7 +309,9 @@ pub trait Decoder {
         let mut state = DecoderState::default();
         for &token_id in ids {
             let token_bytes = match added_vocabulary.simple_id_to_token_bytes(token_id) {
-                Some(_) if skip_special_tokens => continue,
+                Some(_) if skip_special_tokens && added_vocabulary.is_special(token_id) => {
+                    continue;
+                }
                 Some(bytes) => bytes,
                 None => model
                     .id_to_token_bytes(token_id)
@@ -350,6 +356,8 @@ impl Decoder for PipelineDecoder {
                 decoded.extend_from_slice(token_bytes);
                 Ok(())
             }
+            Self::Strip(decoder) => decoder.decode_token(state, token_id, token_bytes, decoded),
+            Self::Replace(decoder) => decoder.decode_token(state, token_id, token_bytes, decoded),
             Self::WordPiece(decoder) => decoder.decode_token(state, token_id, token_bytes, decoded),
             Self::MetaSpace(decoder) => decoder.decode_token(state, token_id, token_bytes, decoded),
             Self::ByteFallback(decoder) => {
@@ -365,7 +373,8 @@ impl Decoder for PipelineDecoder {
                 if members.is_empty() {
                     members.resize_with(stages.len(), Default::default);
                 }
-                a.copy_from_slice(token_bytes);
+                a.clear();
+                a.extend_from_slice(token_bytes);
                 for (stage, member_state) in zip(stages, members) {
                     b.clear();
                     stage.decode_token(member_state, token_id, a, b)?;
@@ -394,7 +403,8 @@ impl Decoder for PipelineDecoder {
                     if a.is_empty() {
                         continue;
                     }
-                    for (stage, member_state) in stages.iter().zip(members.iter_mut()).skip(i) {
+                    // stage i's flush is one token for the stages after it
+                    for (stage, member_state) in stages.iter().zip(members.iter_mut()).skip(i + 1) {
                         b.clear();
                         stage.decode_token(member_state, u32::MAX, a, b)?;
                         if b.is_empty() {
@@ -406,25 +416,40 @@ impl Decoder for PipelineDecoder {
                 }
                 Ok(())
             }
-            decoder => decoder.flush(state, decoded),
+            Self::Strip(decoder) => decoder.flush(state, decoded),
+            Self::Replace(decoder) => decoder.flush(state, decoded),
+            Self::WordPiece(decoder) => decoder.flush(state, decoded),
+            Self::MetaSpace(decoder) => decoder.flush(state, decoded),
+            Self::ByteFallback(decoder) => decoder.flush(state, decoded),
+            Self::None | Self::JoinWithSpaces => Ok(()),
         }
     }
 }
 
-impl TryFrom<&DecoderWrapper> for PipelineDecoder {
-    type Error = crate::Error;
-
-    fn try_from(value: &DecoderWrapper) -> std::prelude::v1::Result<Self, Self::Error> {
+impl PipelineDecoder {
+    /// Build from a legacy decoder. Takes the already-built `model` because
+    /// ByteFallback recognizes byte tokens by id, through the model's byte
+    /// fallback table.
+    fn from_decoder(value: &DecoderWrapper, model: &PipelineModel) -> Result<Self> {
         match value {
             // ByteLevel decoder is no longer needed as the vocabulary is stored as raw bytes
             DecoderWrapper::ByteLevel(_) => Ok(Self::None),
             DecoderWrapper::WordPiece(decoder) => Ok(Self::WordPiece(decoder.clone())),
             DecoderWrapper::Metaspace(decoder) => Ok(Self::MetaSpace(decoder.clone())),
+            DecoderWrapper::ByteFallback(_) => {
+                let byte_to_id = model.byte_fallback_ids().ok_or(
+                    "ByteFallback decoder requires a model byte fallback table to map \
+                     token ids to bytes; only BPE models with `byte_fallback: true` build one",
+                )?;
+                Ok(Self::ByteFallback(ByteFallback::from_byte_to_id(
+                    byte_to_id,
+                )))
+            }
             DecoderWrapper::Sequence(sequence) => {
                 let mut decoders = sequence
                     .get_decoders()
-                    .into_iter()
-                    .map(Self::try_from)
+                    .iter()
+                    .map(|decoder| Self::from_decoder(decoder, model))
                     .filter(|maybe_decoder| {
                         if let Ok(Self::None) = maybe_decoder {
                             false
@@ -666,6 +691,12 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             ModelWrapper::WordPiece(model) => PipelineModel::WordPiece(model.try_into()?),
         };
 
+        let decoder = tok
+            .get_decoder()
+            .map(|decoder| PipelineDecoder::from_decoder(decoder, &model))
+            .transpose()?
+            .unwrap_or_default();
+
         Ok(Self {
             added_vocabulary,
             normalizer: tok.get_normalizer().cloned(),
@@ -676,11 +707,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
                 .map(PipelinePostProcessor::try_from)
                 .transpose()?
                 .unwrap_or_default(),
-            decoder: tok
-                .get_decoder()
-                .map(PipelineDecoder::try_from)
-                .transpose()?
-                .unwrap_or_default(),
+            decoder,
         })
     }
 }
@@ -733,7 +760,13 @@ impl PipelineTokenizer {
             ids,
             &mut output,
         )?;
-        Ok(String::from_utf8(output)?)
+        // A byte-level id sequence can end mid-character (a decode_stream
+        // prefix does constantly); the released ByteLevel decoder is lossy
+        // there, so match it instead of erroring.
+        Ok(match String::from_utf8(output) {
+            Ok(text) => text,
+            Err(err) => String::from_utf8_lossy(err.as_bytes()).into_owned(),
+        })
     }
 
     /// Decode several id sequences at once, one `String` per input. Mirrors the
@@ -1173,6 +1206,17 @@ impl Model for PipelineModel {
     }
 }
 
+impl PipelineModel {
+    /// The model's encode-time byte fallback table (`<0xHH>` token ids indexed
+    /// by byte), when it has one.
+    fn byte_fallback_ids(&self) -> Option<&[u32; 256]> {
+        match self {
+            Self::BPE(model) => model.byte_fallback_ids(),
+            _ => None,
+        }
+    }
+}
+
 pub enum PipelineModelScratch {
     BPE(BpeScratch),
     WordLevel(()),
@@ -1265,6 +1309,111 @@ mod tests {
         tok.with_pre_tokenizer(Some(ByteLevel::new(false, true, true)));
         let err = conversion_error(&tok);
         assert!(err.contains("not supported with model"), "{}", err);
+    }
+
+    /// "h" and "e" plus all 256 `<0xHH>` tokens, each byte token's id being
+    /// its byte value.
+    fn byte_fallback_tokenizer(byte_fallback: bool) -> Tokenizer {
+        use crate::decoders::byte_fallback::ByteFallback;
+        use crate::models::bpe::{BpeBuilder, Vocab};
+
+        let mut vocab: Vocab = [("h".to_string(), 300), ("e".to_string(), 301)]
+            .into_iter()
+            .collect();
+        vocab.extend((0..=255u8).map(|b| (format!("<0x{b:02X}>"), u32::from(b))));
+        let bpe = BpeBuilder::default()
+            .vocab_and_merges(vocab, vec![])
+            .byte_fallback(byte_fallback)
+            .build()
+            .unwrap();
+        let mut tok = Tokenizer::new(bpe);
+        tok.with_decoder(Some(ByteFallback::default()));
+        tok
+    }
+
+    #[test]
+    fn byte_fallback_decoder_decodes_byte_tokens_by_id() {
+        let pipeline = PipelineTokenizer::try_from(&byte_fallback_tokenizer(true)).unwrap();
+        // 0xE5 0x8F 0xAB is the UTF-8 encoding of '叫'; the trailing byte run
+        // exercises the end-of-ids flush
+        assert_eq!(
+            pipeline
+                .decode(&[300, 301, 0xE5, 0x8F, 0xAB], false)
+                .unwrap(),
+            "he叫"
+        );
+    }
+
+    #[test]
+    fn conversion_rejects_byte_fallback_decoder_without_model_table() {
+        let err = conversion_error(&byte_fallback_tokenizer(false));
+        assert!(err.contains("byte fallback table"), "{}", err);
+    }
+
+    #[test]
+    fn byte_fallback_decoder_replaces_invalid_byte_runs() {
+        let pipeline = PipelineTokenizer::try_from(&byte_fallback_tokenizer(true)).unwrap();
+        // 0xE5 0x8F alone is an incomplete UTF-8 sequence; legacy emits one
+        // '�' per byte token of the run
+        assert_eq!(pipeline.decode(&[0xE5, 0x8F, 300], false).unwrap(), "��h");
+        assert_eq!(pipeline.decode(&[300, 0xE5, 0x8F], false).unwrap(), "h��");
+    }
+
+    #[test]
+    fn skip_special_tokens_keeps_non_special_added_tokens() {
+        let mut tok = byte_fallback_tokenizer(true);
+        tok.add_tokens([crate::AddedToken::from("<think>", false)])
+            .unwrap();
+        tok.add_special_tokens([crate::AddedToken::from("<end>", true)])
+            .unwrap();
+        let think = tok.token_to_id("<think>").unwrap();
+        let end = tok.token_to_id("<end>").unwrap();
+        let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
+        assert_eq!(
+            pipeline.decode(&[think, end, 300], false).unwrap(),
+            "<think><end>h"
+        );
+        assert_eq!(
+            pipeline.decode(&[think, end, 300], true).unwrap(),
+            "<think>h"
+        );
+    }
+
+    #[test]
+    fn sequence_decoder_chains_stages_per_token() {
+        let decoder = PipelineDecoder::Sequence(vec![
+            PipelineDecoder::Strip(Strip::new('#', 1, 0)),
+            PipelineDecoder::JoinWithSpaces,
+        ]);
+        let mut state = DecoderState::default();
+        let mut out = Vec::new();
+        for token in [b"#hey".as_slice(), b"#you"] {
+            decoder
+                .decode_token(&mut state, 0, token, &mut out)
+                .unwrap();
+        }
+        decoder.flush(&mut state, &mut out).unwrap();
+        assert_eq!(out, b"hey you");
+    }
+
+    #[test]
+    fn sequence_flushes_held_byte_run_through_later_stages() {
+        let mut lookup = ahash::AHashMap::new();
+        lookup.insert(7u32, b'a');
+        let decoder = PipelineDecoder::Sequence(vec![
+            PipelineDecoder::ByteFallback(ByteFallback::new(lookup)),
+            PipelineDecoder::JoinWithSpaces,
+        ]);
+        let mut state = DecoderState::default();
+        let mut out = Vec::new();
+        decoder
+            .decode_token(&mut state, 1, b"hey", &mut out)
+            .unwrap();
+        decoder
+            .decode_token(&mut state, 7, b"<0x61>", &mut out)
+            .unwrap();
+        decoder.flush(&mut state, &mut out).unwrap();
+        assert_eq!(out, b"hey a");
     }
 
     fn wordlevel_tokenizer(

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,10 +1,14 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
+use std::iter::zip;
+use std::mem::{replace, swap};
+use std::u32;
 use std::{borrow::Cow, convert::TryFrom};
 
 use atomsplit::classify::classify;
 
 use crate::DecoderWrapper;
+use crate::decoders::byte_fallback::ByteFallback;
 use crate::decoders::metaspace::Metaspace;
 use crate::decoders::wordpiece::WordPiece;
 use crate::models::bpe::{BpeScratch, PipelineBPE};
@@ -275,9 +279,18 @@ pub enum PipelineDecoder {
     Sequence(Vec<Self>),
     WordPiece(WordPiece),
     MetaSpace(Metaspace),
+    ByteFallback(ByteFallback),
     None,
     #[default]
     JoinWithSpaces,
+}
+
+#[derive(Default)]
+pub struct DecoderState {
+    pub(crate) pending_buffer: Vec<u8>,
+    pub(crate) swap_buffers: [Vec<u8>; 2],
+    pub(crate) started: bool,
+    pub(crate) members: Vec<Self>,
 }
 
 pub trait Decoder {
@@ -288,39 +301,41 @@ pub trait Decoder {
         skip_special_tokens: bool,
         ids: &[u32],
         decoded: &mut Vec<u8>,
-    ) -> Result<()> {
-        let mut token_index = 0;
+    ) -> crate::Result<()> {
+        let mut state = DecoderState::default();
         for &token_id in ids {
-            if let Some(special) = added_vocabulary.simple_id_to_token_bytes(token_id) {
-                if skip_special_tokens {
-                    continue;
-                }
-                self.decode_token(special, token_index, decoded)?;
-            } else {
-                let token_bytes = model
+            let token_bytes = match added_vocabulary.simple_id_to_token_bytes(token_id) {
+                Some(_) if skip_special_tokens => continue,
+                Some(bytes) => bytes,
+                None => model
                     .id_to_token_bytes(token_id)
-                    .ok_or::<crate::Error>(format!("Invalid token id: {token_id}").into())?;
-
-                self.decode_token(token_bytes, token_index, decoded)?;
-            }
-            token_index += 1;
+                    .ok_or(format!("Invalid token id: {token_id}"))?,
+            };
+            self.decode_token(&mut state, token_id, token_bytes, decoded)?;
         }
+        self.flush(&mut state, decoded)?;
         Ok(())
     }
 
     fn decode_token(
         &self,
+        state: &mut DecoderState,
+        token_id: u32,
         token_bytes: &[u8],
-        token_index: usize,
         decoded: &mut Vec<u8>,
     ) -> Result<()>;
+
+    fn flush(&self, _state: &mut DecoderState, _decoded: &mut Vec<u8>) -> Result<()> {
+        return Ok(());
+    }
 }
 
 impl Decoder for PipelineDecoder {
     fn decode_token(
         &self,
+        state: &mut DecoderState,
+        token_id: u32,
         token_bytes: &[u8],
-        token_index: usize,
         decoded: &mut Vec<u8>,
     ) -> Result<()> {
         match self {
@@ -329,22 +344,69 @@ impl Decoder for PipelineDecoder {
                 Ok(())
             }
             Self::JoinWithSpaces => {
-                if token_index != 0 {
+                if replace(&mut state.started, true) {
                     decoded.push(b' ');
                 }
                 decoded.extend_from_slice(token_bytes);
                 Ok(())
             }
-            Self::WordPiece(decoder) => {
-                decoder.decode_token(token_bytes, token_index, decoded)?;
-                if let Some(&last) = decoded.last()
-                    && last == b' '
-                {
-                    decoded.pop();
+            Self::WordPiece(decoder) => decoder.decode_token(state, token_id, token_bytes, decoded),
+            Self::MetaSpace(decoder) => decoder.decode_token(state, token_id, token_bytes, decoded),
+            Self::ByteFallback(decoder) => {
+                decoder.decode_token(state, token_id, token_bytes, decoded)
+            }
+
+            Self::Sequence(stages) => {
+                let DecoderState {
+                    swap_buffers: [a, b],
+                    members,
+                    ..
+                } = state;
+                if members.is_empty() {
+                    members.resize_with(stages.len(), Default::default);
+                }
+                a.copy_from_slice(token_bytes);
+                for (stage, member_state) in zip(stages, members) {
+                    b.clear();
+                    stage.decode_token(member_state, token_id, a, b)?;
+                    if b.is_empty() {
+                        return Ok(());
+                    }
+                    swap(a, b);
+                }
+                decoded.extend_from_slice(a);
+                Ok(())
+            }
+        }
+    }
+
+    fn flush(&self, state: &mut DecoderState, decoded: &mut Vec<u8>) -> Result<()> {
+        match self {
+            Self::Sequence(stages) => {
+                let DecoderState {
+                    swap_buffers: [a, b],
+                    members,
+                    ..
+                } = state;
+                for i in 0..stages.len() {
+                    a.clear();
+                    stages[i].flush(&mut members[i], a)?;
+                    if a.is_empty() {
+                        continue;
+                    }
+                    for (stage, member_state) in stages.iter().zip(members.iter_mut()).skip(i) {
+                        b.clear();
+                        stage.decode_token(member_state, u32::MAX, a, b)?;
+                        if b.is_empty() {
+                            return Ok(());
+                        }
+                        std::mem::swap(a, b);
+                    }
+                    decoded.extend_from_slice(a);
                 }
                 Ok(())
             }
-            Self::MetaSpace(decoder) => decoder.decode_token(token_bytes, token_index, decoded),
+            decoder => decoder.flush(state, decoded),
         }
     }
 }
@@ -359,20 +421,27 @@ impl TryFrom<&DecoderWrapper> for PipelineDecoder {
             DecoderWrapper::WordPiece(decoder) => Ok(Self::WordPiece(decoder.clone())),
             DecoderWrapper::Metaspace(decoder) => Ok(Self::MetaSpace(decoder.clone())),
             DecoderWrapper::Sequence(sequence) => {
-                let decoders = sequence.get_decoders();
+                let mut decoders = sequence
+                    .get_decoders()
+                    .into_iter()
+                    .map(Self::try_from)
+                    .filter(|maybe_decoder| {
+                        if let Ok(Self::None) = maybe_decoder {
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                    .collect::<Result<Vec<_>>>()?;
                 if decoders.len() == 0 {
                     return Ok(Self::default());
                 }
                 if decoders.len() == 1 {
                     // SAFETY: safe to .unwrap() as the len is asserted to be 1
-                    return Self::try_from(decoders.first().unwrap());
+                    let first = decoders.pop().unwrap();
+                    return Ok(first);
                 }
-                Ok(Self::Sequence(
-                    decoders
-                        .into_iter()
-                        .map(Self::try_from)
-                        .collect::<Result<Vec<_>>>()?,
-                ))
+                Ok(Self::Sequence(decoders))
             }
             decoder => Err(format!("Decoder {:?} not supported yet", decoder).into()),
         }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::convert::TryInto;
 use std::iter::zip;
 use std::mem::{replace, swap};
-use std::u32;
 use std::{borrow::Cow, convert::TryFrom};
 
 use atomsplit::classify::classify;
@@ -283,7 +282,13 @@ pub enum PipelineDecoder {
     MetaSpace(Metaspace),
     ByteFallback(ByteFallback),
     Replace(Replace),
-    Strip(Strip),
+    /// A `Strip` with no `Fuse` before it: strips each token.
+    StripToken(Strip),
+    /// A `Strip` after a `Fuse` (llama-2 style): `Fuse` concatenates all
+    /// tokens into one, so the strip applies once to the whole decoded output,
+    /// in [`decode_whole`](Decoder::decode_whole). `decode_token` passes bytes
+    /// through untouched.
+    StripWhole(Strip),
     None,
     #[default]
     JoinWithSpaces,
@@ -309,7 +314,7 @@ pub trait Decoder {
         let mut state = DecoderState::default();
         for &token_id in ids {
             let token_bytes = match added_vocabulary.simple_id_to_token_bytes(token_id) {
-                Some(_) if skip_special_tokens && added_vocabulary.is_special(token_id) => {
+                Some(_) if skip_special_tokens && added_vocabulary.skip_on_decode(token_id) => {
                     continue;
                 }
                 Some(bytes) => bytes,
@@ -320,6 +325,7 @@ pub trait Decoder {
             self.decode_token(&mut state, token_id, token_bytes, decoded)?;
         }
         self.flush(&mut state, decoded)?;
+        self.decode_whole(&mut state, decoded)?;
         Ok(())
     }
 
@@ -334,6 +340,13 @@ pub trait Decoder {
     fn flush(&self, _state: &mut DecoderState, _decoded: &mut Vec<u8>) -> Result<()> {
         Ok(())
     }
+
+    /// Runs once at the end of `decode`, on the fully decoded output. This is
+    /// where stages placed after a `Fuse` apply: `Fuse` concatenates all
+    /// tokens into one, so later stages see the whole text as one token.
+    fn decode_whole(&self, _state: &mut DecoderState, _decoded: &mut Vec<u8>) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl Decoder for PipelineDecoder {
@@ -345,7 +358,7 @@ impl Decoder for PipelineDecoder {
         decoded: &mut Vec<u8>,
     ) -> Result<()> {
         match self {
-            Self::None => {
+            Self::None | Self::StripWhole(_) => {
                 decoded.extend_from_slice(token_bytes);
                 Ok(())
             }
@@ -356,7 +369,9 @@ impl Decoder for PipelineDecoder {
                 decoded.extend_from_slice(token_bytes);
                 Ok(())
             }
-            Self::Strip(decoder) => decoder.decode_token(state, token_id, token_bytes, decoded),
+            Self::StripToken(decoder) => {
+                decoder.decode_token(state, token_id, token_bytes, decoded)
+            }
             Self::Replace(decoder) => decoder.decode_token(state, token_id, token_bytes, decoded),
             Self::WordPiece(decoder) => decoder.decode_token(state, token_id, token_bytes, decoded),
             Self::MetaSpace(decoder) => decoder.decode_token(state, token_id, token_bytes, decoded),
@@ -397,6 +412,9 @@ impl Decoder for PipelineDecoder {
                     members,
                     ..
                 } = state;
+                if members.is_empty() {
+                    members.resize_with(stages.len(), Default::default);
+                }
                 for i in 0..stages.len() {
                     a.clear();
                     stages[i].flush(&mut members[i], a)?;
@@ -416,12 +434,31 @@ impl Decoder for PipelineDecoder {
                 }
                 Ok(())
             }
-            Self::Strip(decoder) => decoder.flush(state, decoded),
+            Self::StripToken(decoder) => decoder.flush(state, decoded),
             Self::Replace(decoder) => decoder.flush(state, decoded),
             Self::WordPiece(decoder) => decoder.flush(state, decoded),
             Self::MetaSpace(decoder) => decoder.flush(state, decoded),
             Self::ByteFallback(decoder) => decoder.flush(state, decoded),
-            Self::None | Self::JoinWithSpaces => Ok(()),
+            Self::None | Self::StripWhole(_) | Self::JoinWithSpaces => Ok(()),
+        }
+    }
+
+    fn decode_whole(&self, state: &mut DecoderState, decoded: &mut Vec<u8>) -> Result<()> {
+        match self {
+            Self::Sequence(stages) => {
+                for stage in stages {
+                    stage.decode_whole(state, decoded)?;
+                }
+                Ok(())
+            }
+            Self::StripWhole(strip) => {
+                let [scratch, _] = &mut state.swap_buffers;
+                scratch.clear();
+                strip.decode_token(&mut DecoderState::default(), u32::MAX, decoded, scratch)?;
+                swap(decoded, scratch);
+                Ok(())
+            }
+            _ => Ok(()),
         }
     }
 }
@@ -432,8 +469,10 @@ impl PipelineDecoder {
     /// fallback table.
     fn from_decoder(value: &DecoderWrapper, model: &PipelineModel) -> Result<Self> {
         match value {
-            // ByteLevel decoder is no longer needed as the vocabulary is stored as raw bytes
-            DecoderWrapper::ByteLevel(_) => Ok(Self::None),
+            // ByteLevel is not needed as the vocabulary is stored as raw bytes;
+            // a standalone Fuse only concatenates, which decoding does anyway
+            DecoderWrapper::ByteLevel(_) | DecoderWrapper::Fuse(_) => Ok(Self::None),
+            DecoderWrapper::Strip(decoder) => Ok(Self::StripToken(decoder.clone())),
             DecoderWrapper::WordPiece(decoder) => Ok(Self::WordPiece(decoder.clone())),
             DecoderWrapper::Metaspace(decoder) => Ok(Self::MetaSpace(decoder.clone())),
             DecoderWrapper::Replace(decoder) => Ok(Self::Replace(decoder.clone())),
@@ -447,21 +486,35 @@ impl PipelineDecoder {
                 )))
             }
             DecoderWrapper::Sequence(sequence) => {
-                let mut decoders = sequence
-                    .get_decoders()
-                    .iter()
-                    .map(|decoder| Self::from_decoder(decoder, model))
-                    .filter(|maybe_decoder| !matches!(maybe_decoder, Ok(Self::None)))
-                    .collect::<Result<Vec<_>>>()?;
-                if decoders.is_empty() {
-                    return Ok(Self::default());
+                // Fuse concatenates all tokens into one, so a Strip after it
+                // strips the whole decoded output, not each token. No other
+                // decoder is supported after a Fuse yet.
+                let mut fused = false;
+                let mut decoders = Vec::new();
+                for stage in sequence.get_decoders() {
+                    let decoder = match stage {
+                        DecoderWrapper::Fuse(_) => {
+                            fused = true;
+                            continue;
+                        }
+                        DecoderWrapper::Strip(strip) if fused => Self::StripWhole(strip.clone()),
+                        _ if fused => {
+                            return Err(format!(
+                                "only Strip decoders may follow Fuse, got {stage:?}"
+                            )
+                            .into());
+                        }
+                        _ => Self::from_decoder(stage, model)?,
+                    };
+                    if !matches!(decoder, Self::None) {
+                        decoders.push(decoder);
+                    }
                 }
-                if decoders.len() == 1 {
-                    // SAFETY: safe to .unwrap() as the len is asserted to be 1
-                    let first = decoders.pop().unwrap();
-                    return Ok(first);
+                match decoders.len() {
+                    0 => Ok(Self::None),
+                    1 => Ok(decoders.pop().unwrap()),
+                    _ => Ok(Self::Sequence(decoders)),
                 }
-                Ok(Self::Sequence(decoders))
             }
             decoder => Err(format!("Decoder {:?} not supported yet", decoder).into()),
         }
@@ -609,7 +662,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
         let pre_tokenizer: PipelinePreTokenizer = tok
             .get_pre_tokenizer()
             .cloned()
-            .map(TryInto::try_into)
+            .map(PipelinePreTokenizer::try_from)
             .transpose()?
             .unwrap_or(PipelinePreTokenizer::None);
 
@@ -1375,9 +1428,25 @@ mod tests {
     }
 
     #[test]
+    fn skip_special_tokens_keeps_specials_rewritten_by_normalization() {
+        use crate::normalizers::prepend::Prepend;
+
+        let mut tok = byte_fallback_tokenizer(true);
+        tok.with_normalizer(Some(Prepend::new("▁".into()))).unwrap();
+        tok.add_special_tokens([crate::AddedToken::from("<end>", true).normalized(true)])
+            .unwrap();
+        let end = tok.token_to_id("<end>").unwrap();
+        let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
+        // The released crate compares the decode-time (normalized) string
+        // against raw special contents: "▁<end>" never matches "<end>", so the
+        // special survives the skip — llama-2's `<s>` under `Prepend("▁")`.
+        assert_eq!(pipeline.decode(&[end, 300], true).unwrap(), "▁<end>h");
+    }
+
+    #[test]
     fn sequence_decoder_chains_stages_per_token() {
         let decoder = PipelineDecoder::Sequence(vec![
-            PipelineDecoder::Strip(Strip::new('#', 1, 0)),
+            PipelineDecoder::StripToken(Strip::new('#', 1, 0)),
             PipelineDecoder::JoinWithSpaces,
         ]);
         let mut state = DecoderState::default();
@@ -1426,6 +1495,31 @@ mod tests {
             .unwrap();
         decoder.flush(&mut state, &mut out).unwrap();
         assert_eq!(out, b"hey a");
+    }
+
+    #[test]
+    fn stages_after_fuse_decode_the_whole_output() {
+        let mut tok = byte_fallback_tokenizer(true);
+        // llama-2's trailing Strip(' ', 1, 0) comes after Fuse: it must remove
+        // one leading space from the whole text, not one from every token
+        tok.with_decoder(Some(crate::decoders::sequence::Sequence::new(vec![
+            DecoderWrapper::ByteFallback(crate::decoders::byte_fallback::ByteFallback::default()),
+            DecoderWrapper::Fuse(crate::decoders::fuse::Fuse::new()),
+            DecoderWrapper::Strip(Strip::new(' ', 1, 0)),
+        ])));
+        let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
+        assert_eq!(pipeline.decode(&[32, 300, 32, 301], false).unwrap(), "h e");
+    }
+
+    #[test]
+    fn conversion_rejects_fuse_followed_by_non_strip() {
+        let mut tok = byte_fallback_tokenizer(true);
+        tok.with_decoder(Some(crate::decoders::sequence::Sequence::new(vec![
+            DecoderWrapper::Fuse(crate::decoders::fuse::Fuse::new()),
+            DecoderWrapper::WordPiece(crate::decoders::wordpiece::WordPiece::default()),
+        ])));
+        let err = conversion_error(&tok);
+        assert!(err.contains("follow Fuse"), "{}", err);
     }
 
     fn wordlevel_tokenizer(

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -4,6 +4,8 @@ use std::{borrow::Cow, convert::TryFrom};
 
 use atomsplit::classify::classify;
 
+use crate::DecoderWrapper;
+use crate::decoders::wordpiece::WordPiece;
 use crate::models::bpe::{BpeScratch, PipelineBPE};
 use crate::models::unigram::{Unigram, UnigramScratch};
 use crate::models::wordlevel::WordLevel;
@@ -14,7 +16,6 @@ use crate::utils::byte_level::GPT2_REGEX_STR;
 use crate::vocab::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
-use crate::{Decoder, DecoderWrapper};
 use crate::{
     ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer,
     normalizers::NormalizerWrapper,
@@ -267,10 +268,69 @@ impl TryFrom<&PostProcessorWrapper> for PipelinePostProcessor {
     }
 }
 
+/// [`PipelineDecoder`] is responsible for turning a chunk of token ids back into human-readable text
 #[derive(Debug, Default)]
 pub enum PipelineDecoder {
+    WordPiece {
+        /// Tokens that are inside a word start with this prefix.
+        /// For example for bert, it's "##": "tokenization" would be tokenized as ["tok", "##eni", "##z", "##ation"]
+        /// To reconstruct the text from the tokens, we need to strip that prefix for every token
+        word_continuation_prefix: String,
+        /// Whether to perform a cleanup phase (see implementation for details)
+        cleanup: bool,
+    },
     #[default]
     None,
+}
+
+pub trait Decoder<'a> {
+    fn decode(
+        &'a self,
+        model: &'a PipelineModel,
+        added_vocabulary: &BucketAddedVocabulary,
+        token_id: u32,
+        decoded: &mut Vec<u8>,
+        skip_special_tokens: bool,
+    ) -> Result<()> {
+        if let Some(special_token) = added_vocabulary.simple_id_to_token_bytes(token_id) {
+            if !skip_special_tokens {
+                decoded.extend_from_slice(special_token);
+            }
+            return Ok(());
+        }
+        let slice = self.decode_token_to_slice(model, token_id)?;
+        decoded.extend_from_slice(slice);
+        Ok(())
+    }
+
+    fn decode_token_to_slice(&'a self, model: &'a PipelineModel, token_id: u32)
+    -> Result<&'a [u8]>;
+}
+
+impl<'a> Decoder<'a> for PipelineDecoder {
+    fn decode_token_to_slice(
+        &'a self,
+        model: &'a PipelineModel,
+        token_id: u32,
+    ) -> Result<&'a [u8]> {
+        let mut bytes = model
+            .id_to_token_bytes(token_id)
+            .ok_or::<crate::Error>(format!("Invalid token id: {token_id}").into())?;
+        match self {
+            Self::None => Ok(bytes),
+            PipelineDecoder::WordPiece {
+                word_continuation_prefix,
+                ..
+            } => {
+                if bytes.starts_with(word_continuation_prefix.as_bytes()) {
+                    // trim prefix
+                    bytes = &bytes[word_continuation_prefix.len()..];
+                }
+                // todo: cleanup
+                Ok(bytes)
+            }
+        }
+    }
 }
 
 impl TryFrom<&DecoderWrapper> for PipelineDecoder {
@@ -278,13 +338,16 @@ impl TryFrom<&DecoderWrapper> for PipelineDecoder {
 
     fn try_from(value: &DecoderWrapper) -> std::prelude::v1::Result<Self, Self::Error> {
         match value {
+            // ByteLevel decoder is no longer needed as the vocabulary is stored as raw bytes
+            DecoderWrapper::ByteLevel(_) => Ok(Self::None),
+            DecoderWrapper::WordPiece(WordPiece { cleanup, prefix }) => Ok(Self::WordPiece {
+                word_continuation_prefix: prefix.clone(),
+                cleanup: *cleanup,
+            }),
             DecoderWrapper::BPE(decoder) => {
                 Err(format!("Decoder {:?} not supported yet", decoder).into())
             }
             DecoderWrapper::ByteFallback(decoder) => {
-                Err(format!("Decoder {:?} not supported yet", decoder).into())
-            }
-            DecoderWrapper::ByteLevel(decoder) => {
                 Err(format!("Decoder {:?} not supported yet", decoder).into())
             }
             DecoderWrapper::CTC(decoder) => {
@@ -303,9 +366,6 @@ impl TryFrom<&DecoderWrapper> for PipelineDecoder {
                 Err(format!("Decoder {:?} not supported yet", decoder).into())
             }
             DecoderWrapper::Strip(decoder) => {
-                Err(format!("Decoder {:?} not supported yet", decoder).into())
-            }
-            DecoderWrapper::WordPiece(decoder) => {
                 Err(format!("Decoder {:?} not supported yet", decoder).into())
             }
         }
@@ -590,18 +650,15 @@ impl PipelineTokenizer {
     /// Decode token ids back to a `String`.
     pub fn decode(&self, ids: &[u32], skip_special_tokens: bool) -> Result<String> {
         let mut output = Vec::with_capacity(ids.len());
+
         for &id in ids {
-            if let Some(special_token) = self.added_vocabulary.simple_id_to_token_bytes(id) {
-                if !skip_special_tokens {
-                    output.extend_from_slice(special_token);
-                }
-                continue;
-            }
-            let slice = self
-                .model
-                .id_to_token_bytes(id)
-                .ok_or::<crate::Error>(format!("Invalid token id: {id}").into())?;
-            output.extend_from_slice(slice);
+            self.decoder.decode(
+                &self.model,
+                &self.added_vocabulary,
+                id,
+                &mut output,
+                skip_special_tokens,
+            )?;
         }
         Ok(String::from_utf8(output)?)
     }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -537,18 +537,16 @@ impl PipelineTokenizer {
 
     /// Decode token ids back to a `String`.
     ///
-    /// Not implemented yet — the pipeline decode path is being built. It fails
-    /// loud (rather than returning a plausible-but-wrong string) so the oracle
-    /// test and the comparative benchmark report decode as *pending* instead of
-    /// silently validating garbage. Implementing this flips the ignored
-    /// `pipeline_decode_oracle` test on and lights up the decode charts.
-    pub fn decode(&self, ids: &[PipelineToken], _skip_special_tokens: bool) -> Result<String> {
+    /// Incomplete: it concatenates raw token bytes only. No decoder, no added-
+    /// vocab lookup, no `skip_special_tokens` — so the `pipeline_decode_oracle`
+    /// test fails on purpose until those land.
+    pub fn decode(&self, ids: &[u32], _skip_special_tokens: bool) -> Result<String> {
         let mut output = Vec::with_capacity(ids.len());
-        for id in ids {
+        for &id in ids {
             let slice = self
                 .model
                 .id_to_token_bytes(id)
-                .ok_or::<crate::Error>(format!("Invalid token id: {}", id.id).into())?;
+                .ok_or::<crate::Error>(format!("Invalid token id: {id}").into())?;
             output.extend_from_slice(slice);
         }
         Ok(String::from_utf8(output)?)
@@ -932,7 +930,7 @@ pub trait Model {
 
     fn init_scratch(&self) -> Self::Scratch;
 
-    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]>;
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]>;
 }
 
 #[allow(
@@ -981,7 +979,7 @@ impl Model for PipelineModel {
         }
     }
 
-    fn id_to_token_bytes(&self, id: &PipelineToken) -> Option<&[u8]> {
+    fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
         match self {
             Self::BPE(model) => model.id_to_token_bytes(id),
             Self::WordLevel(model) => model.id_to_token_bytes(id),

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -14,6 +14,7 @@ use crate::utils::byte_level::GPT2_REGEX_STR;
 use crate::vocab::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
+use crate::{Decoder, DecoderWrapper};
 use crate::{
     ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer,
     normalizers::NormalizerWrapper,
@@ -266,6 +267,51 @@ impl TryFrom<&PostProcessorWrapper> for PipelinePostProcessor {
     }
 }
 
+#[derive(Debug, Default)]
+pub enum PipelineDecoder {
+    #[default]
+    None,
+}
+
+impl TryFrom<&DecoderWrapper> for PipelineDecoder {
+    type Error = crate::Error;
+
+    fn try_from(value: &DecoderWrapper) -> std::prelude::v1::Result<Self, Self::Error> {
+        match value {
+            DecoderWrapper::BPE(decoder) => {
+                Err(format!("Decoder {:?} not supported yet", decoder).into())
+            }
+            DecoderWrapper::ByteFallback(decoder) => {
+                Err(format!("Decoder {:?} not supported yet", decoder).into())
+            }
+            DecoderWrapper::ByteLevel(decoder) => {
+                Err(format!("Decoder {:?} not supported yet", decoder).into())
+            }
+            DecoderWrapper::CTC(decoder) => {
+                Err(format!("Decoder {:?} not supported yet", decoder).into())
+            }
+            DecoderWrapper::Fuse(decoder) => {
+                Err(format!("Decoder {:?} not supported yet", decoder).into())
+            }
+            DecoderWrapper::Metaspace(decoder) => {
+                Err(format!("Decoder {:?} not supported yet", decoder).into())
+            }
+            DecoderWrapper::Replace(decoder) => {
+                Err(format!("Decoder {:?} not supported yet", decoder).into())
+            }
+            DecoderWrapper::Sequence(decoder) => {
+                Err(format!("Decoder {:?} not supported yet", decoder).into())
+            }
+            DecoderWrapper::Strip(decoder) => {
+                Err(format!("Decoder {:?} not supported yet", decoder).into())
+            }
+            DecoderWrapper::WordPiece(decoder) => {
+                Err(format!("Decoder {:?} not supported yet", decoder).into())
+            }
+        }
+    }
+}
+
 /// An output token. Carries only the vocabulary `id` — offsets and the token
 /// string are dropped, which is all an encode-only caller needs.
 #[derive(Debug, Clone, Copy)]
@@ -391,6 +437,7 @@ pub struct PipelineTokenizer {
     pre_tokenizer: PipelinePreTokenizer,
     model: PipelineModel,
     post_processor: PipelinePostProcessor,
+    decoder: PipelineDecoder,
 }
 
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
@@ -493,6 +540,11 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
                 .map(PipelinePostProcessor::try_from)
                 .transpose()?
                 .unwrap_or_default(),
+            decoder: tok
+                .get_decoder()
+                .map(PipelineDecoder::try_from)
+                .transpose()?
+                .unwrap_or_default(),
         })
     }
 }
@@ -536,10 +588,6 @@ impl PipelineTokenizer {
     }
 
     /// Decode token ids back to a `String`.
-    ///
-    /// Incomplete: it concatenates raw token bytes only. No decoder, no added-
-    /// vocab lookup, no `skip_special_tokens` — so the `pipeline_decode_oracle`
-    /// test fails on purpose until those land.
     pub fn decode(&self, ids: &[u32], skip_special_tokens: bool) -> Result<String> {
         let mut output = Vec::with_capacity(ids.len());
         for &id in ids {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -540,9 +540,15 @@ impl PipelineTokenizer {
     /// Incomplete: it concatenates raw token bytes only. No decoder, no added-
     /// vocab lookup, no `skip_special_tokens` — so the `pipeline_decode_oracle`
     /// test fails on purpose until those land.
-    pub fn decode(&self, ids: &[u32], _skip_special_tokens: bool) -> Result<String> {
+    pub fn decode(&self, ids: &[u32], skip_special_tokens: bool) -> Result<String> {
         let mut output = Vec::with_capacity(ids.len());
         for &id in ids {
+            if let Some(special_token) = self.added_vocabulary.simple_id_to_token_bytes(id) {
+                if !skip_special_tokens {
+                    output.extend_from_slice(special_token);
+                }
+                continue;
+            }
             let slice = self
                 .model
                 .id_to_token_bytes(id)

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -5,6 +5,7 @@ use std::{borrow::Cow, convert::TryFrom};
 use atomsplit::classify::classify;
 
 use crate::DecoderWrapper;
+use crate::decoders::metaspace::Metaspace;
 use crate::decoders::wordpiece::WordPiece;
 use crate::models::bpe::{BpeScratch, PipelineBPE};
 use crate::models::unigram::{Unigram, UnigramScratch};
@@ -272,6 +273,7 @@ impl TryFrom<&PostProcessorWrapper> for PipelinePostProcessor {
 #[derive(Debug, Default)]
 pub enum PipelineDecoder {
     WordPiece(WordPiece),
+    MetaSpace(Metaspace),
     None,
     #[default]
     JoinWithSpaces,
@@ -332,9 +334,16 @@ impl Decoder for PipelineDecoder {
                 decoded.extend_from_slice(token_bytes);
                 Ok(())
             }
-            PipelineDecoder::WordPiece(decoder) => {
-                decoder.decode_token(token_bytes, token_index, decoded)
+            Self::WordPiece(decoder) => {
+                decoder.decode_token(token_bytes, token_index, decoded)?;
+                if let Some(&last) = decoded.last()
+                    && last == b' '
+                {
+                    decoded.pop();
+                }
+                Ok(())
             }
+            Self::MetaSpace(decoder) => decoder.decode_token(token_bytes, token_index, decoded),
         }
     }
 }
@@ -347,30 +356,8 @@ impl TryFrom<&DecoderWrapper> for PipelineDecoder {
             // ByteLevel decoder is no longer needed as the vocabulary is stored as raw bytes
             DecoderWrapper::ByteLevel(_) => Ok(Self::None),
             DecoderWrapper::WordPiece(decoder) => Ok(Self::WordPiece(decoder.clone())),
-            DecoderWrapper::BPE(decoder) => {
-                Err(format!("Decoder {:?} not supported yet", decoder).into())
-            }
-            DecoderWrapper::ByteFallback(decoder) => {
-                Err(format!("Decoder {:?} not supported yet", decoder).into())
-            }
-            DecoderWrapper::CTC(decoder) => {
-                Err(format!("Decoder {:?} not supported yet", decoder).into())
-            }
-            DecoderWrapper::Fuse(decoder) => {
-                Err(format!("Decoder {:?} not supported yet", decoder).into())
-            }
-            DecoderWrapper::Metaspace(decoder) => {
-                Err(format!("Decoder {:?} not supported yet", decoder).into())
-            }
-            DecoderWrapper::Replace(decoder) => {
-                Err(format!("Decoder {:?} not supported yet", decoder).into())
-            }
-            DecoderWrapper::Sequence(decoder) => {
-                Err(format!("Decoder {:?} not supported yet", decoder).into())
-            }
-            DecoderWrapper::Strip(decoder) => {
-                Err(format!("Decoder {:?} not supported yet", decoder).into())
-            }
+            DecoderWrapper::Metaspace(decoder) => Ok(Self::MetaSpace(decoder.clone())),
+            decoder => Err(format!("Decoder {:?} not supported yet", decoder).into()),
         }
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -272,8 +272,9 @@ impl TryFrom<&PostProcessorWrapper> for PipelinePostProcessor {
 #[derive(Debug, Default)]
 pub enum PipelineDecoder {
     WordPiece(WordPiece),
-    #[default]
     None,
+    #[default]
+    JoinWithSpaces,
 }
 
 pub trait Decoder {
@@ -321,6 +322,10 @@ impl Decoder for PipelineDecoder {
     ) -> Result<()> {
         match self {
             Self::None => {
+                decoded.extend_from_slice(token_bytes);
+                Ok(())
+            }
+            Self::JoinWithSpaces => {
                 if token_index != 0 {
                     decoded.push(b' ');
                 }

--- a/tokenizers/tk-encode/src/vocab/bucket_added_vocabulary.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_added_vocabulary.rs
@@ -249,10 +249,17 @@ impl AddedVocabulary {
     /// this returns the cached normalized form so that the configured `Decoder` can
     /// invert the transformation correctly. For all other tokens, the original
     /// `content` is returned.
-    pub fn simple_id_to_token(&self, _id: u32) -> Option<String> {
+    pub fn simple_id_to_token(&self, id: u32) -> Option<String> {
         self.vocab
-            .id_to_token(_id)
-            .or_else(|| self.normalized_vocab.id_to_token(_id))
+            .id_to_token(id)
+            .or_else(|| self.normalized_vocab.id_to_token(id))
+    }
+
+    /// todo: docs
+    pub fn simple_id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+        self.vocab
+            .id_to_token_bytes(id)
+            .or_else(|| self.normalized_vocab.id_to_token_bytes(id))
     }
 
     //

--- a/tokenizers/tk-encode/src/vocab/bucket_added_vocabulary.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_added_vocabulary.rs
@@ -262,6 +262,14 @@ impl AddedVocabulary {
             .or_else(|| self.normalized_vocab.id_to_token_bytes(id))
     }
 
+    /// Whether `id` is a *special* added token — the kind `skip_special_tokens`
+    /// drops at decode time, as opposed to user-added regular tokens.
+    pub fn is_special(&self, id: u32) -> bool {
+        self.token_metadata
+            .get(id as usize)
+            .is_some_and(|metadata| metadata.special)
+    }
+
     //
     pub fn set_encode_special_tokens(&mut self, value: bool) {
         self.encode_special_tokens = value;

--- a/tokenizers/tk-encode/src/vocab/bucket_added_vocabulary.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_added_vocabulary.rs
@@ -134,6 +134,7 @@ impl From<&AddedToken> for AddedTokenFlags {
             single_word: token.single_word,
             lstrip: token.lstrip,
             rstrip: token.rstrip,
+            skip_on_decode: false,
         }
     }
 }
@@ -262,12 +263,12 @@ impl AddedVocabulary {
             .or_else(|| self.normalized_vocab.id_to_token_bytes(id))
     }
 
-    /// Whether `id` is a *special* added token — the kind `skip_special_tokens`
-    /// drops at decode time, as opposed to user-added regular tokens.
-    pub fn is_special(&self, id: u32) -> bool {
+    /// Whether `skip_special_tokens` drops `id` at decode time — see
+    /// [`AddedTokenFlags::skip_on_decode`] for why this is not `special`.
+    pub fn skip_on_decode(&self, id: u32) -> bool {
         self.token_metadata
             .get(id as usize)
-            .is_some_and(|metadata| metadata.special)
+            .is_some_and(|metadata| metadata.skip_on_decode)
     }
 
     //
@@ -332,7 +333,7 @@ impl AddedVocabulary {
                 ignored += 1;
                 continue;
             }
-            let flags = AddedTokenFlags::from(&token);
+            let mut flags = AddedTokenFlags::from(&token);
             let is_norm = flags.normalized;
             let norm_form: String = match normalizer {
                 Some(n) => {
@@ -343,6 +344,9 @@ impl AddedVocabulary {
                 }
                 None => token.content.clone(),
             };
+            // a special is skipped only if normalization left its content
+            // unchanged — see `AddedTokenFlags::skip_on_decode`
+            flags.skip_on_decode = flags.special && (!is_norm || norm_form == token.content);
             let form = if is_norm {
                 norm_form.clone().into_bytes()
             } else {

--- a/tokenizers/tk-encode/src/vocab/buckets.rs
+++ b/tokenizers/tk-encode/src/vocab/buckets.rs
@@ -7,6 +7,11 @@ pub struct AddedTokenFlags {
     pub single_word: bool,
     pub lstrip: bool,
     pub rstrip: bool,
+    /// Whether `skip_special_tokens` drops this token. Not the same as
+    /// `special`: `Tokenizer::decode` compares the decode-time (normalized)
+    /// string against raw special contents, so a special whose content the
+    /// normalizer rewrote (llama-2's `<s>`, stored as `▁<s>`) survives the skip.
+    pub skip_on_decode: bool,
 }
 
 /// The key to have a fast byte matching alrogithm is to skip failures fast and reject quickly

--- a/tokenizers/tk-encode/src/vocab/buckets.rs
+++ b/tokenizers/tk-encode/src/vocab/buckets.rs
@@ -443,6 +443,9 @@ impl Buckets {
     pub fn id_to_token(&self, id: u32) -> Option<String> {
         self.vocab.id_to_token(id)
     }
+    pub fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+        self.vocab.id_to_token_bytes(id)
+    }
 }
 
 impl Default for Buckets {

--- a/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
@@ -113,12 +113,18 @@ fn check_model(tok_file: &str) {
                         );
                         match pipeline.decode(&ids, skip_special_tokens) {
                             Ok(got) if got == expected => {}
-                            Ok(_) => failures.push(format!("{ctx}: decode mismatch")),
+                            Ok(got) => failures.push(format!(
+                                "{ctx}: decode mismatch, {}",
+                                divergence(&expected, &got)
+                            )),
                             Err(e) => failures.push(format!("{ctx}: decode error: {e}")),
                         }
                         match stream_decode(&pipeline, &ids, skip_special_tokens) {
                             Ok(got) if got == expected => {}
-                            Ok(_) => failures.push(format!("{ctx}: decode_stream mismatch")),
+                            Ok(got) => failures.push(format!(
+                                "{ctx}: decode_stream mismatch, {}",
+                                divergence(&expected, &got)
+                            )),
                             Err(e) => failures.push(format!("{ctx}: decode_stream error: {e}")),
                         }
                     }
@@ -134,7 +140,13 @@ fn check_model(tok_file: &str) {
         let expected = released.decode_batch(&sentences, false).unwrap();
         match pipeline.decode_batch(&sentences, false) {
             Ok(got) if got == expected => {}
-            Ok(_) => failures.push("decode_batch mismatch".into()),
+            Ok(got) => {
+                let i = expected.iter().zip(&got).position(|(e, g)| e != g).unwrap();
+                failures.push(format!(
+                    "decode_batch mismatch at sentence {i}, {}",
+                    divergence(&expected[i], &got[i])
+                ));
+            }
             Err(e) => failures.push(format!("decode_batch error: {e}")),
         }
     }
@@ -147,6 +159,35 @@ fn check_model(tok_file: &str) {
         shown.len(),
         shown.join("\n"),
     );
+}
+
+/// Show where `got` first diverges from `expected`, with nearby text from both
+/// sides — fixture windows are kilobytes, so printing whole strings would bury
+/// the interesting byte.
+fn divergence(expected: &str, got: &str) -> String {
+    let byte = expected
+        .bytes()
+        .zip(got.bytes())
+        .position(|(e, g)| e != g)
+        .unwrap_or_else(|| expected.len().min(got.len()));
+    let excerpt = |s: &str| {
+        let mut start = byte.saturating_sub(40);
+        while !s.is_char_boundary(start) {
+            start -= 1;
+        }
+        let mut end = (byte + 40).min(s.len());
+        while !s.is_char_boundary(end) {
+            end += 1;
+        }
+        format!("…{:?}…", &s[start..end])
+    };
+    format!(
+        "first divergence at byte {byte}\n  expected ({} B): {}\n  got      ({} B): {}",
+        expected.len(),
+        excerpt(expected),
+        got.len(),
+        excerpt(got),
+    )
 }
 
 /// Feed `ids` through [`PipelineTokenizer::decode_stream`] one at a time and


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**7 / 8 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`6810fa505 · 2026-07-27 10:26 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-overview.png" width="860">

**vs base branch** (`8abd11215`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.87 vs v0.23.1 · ×1.04 vs base · decode ×14.56</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 12) · Pipeline 17+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 27.5 | ×3.49 | ×1.02 | 3% (1.2) | 75% (27.1) | 13% (4.8) | 8% (3.0) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 24.9 | ×5.87 | ×1.03 | 3% (1.2) | 68% (27.5) | 8% (3.3) | 21% (8.3) | 0% (0.0) | match |
| ben_Beng | lang | 6.1 | 34.8 | ×5.74 | ×1.03 | 4% (1.2) | 66% (19.1) | 10% (2.9) | 20% (5.6) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 18.9 | ×4.84 | ×1.05 | 2% (1.2) | 70% (37.5) | 11% (5.8) | 17% (9.0) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 23.7 | ×6.18 | ×1.03 | 3% (1.2) | 68% (28.7) | 8% (3.4) | 21% (9.0) | 0% (0.0) | match |
| eng_Latn | lang | 4.6 | 18.4 | ×4.02 | ×1.08 | 5% (2.5) | 69% (38.7) | 8% (4.4) | 19% (10.7) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 19.9 | ×4.70 | ×1.03 | 2% (1.2) | 75% (37.5) | 7% (3.7) | 16% (8.0) | 0% (0.0) | match |
| hin_Deva | lang | 6.6 | 27.4 | ×4.17 | ×1.03 | 3% (1.2) | 74% (27.0) | 9% (3.2) | 14% (5.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.4 | 27.4 | ×6.29 | ×1.02 | 3% (1.2) | 64% (23.2) | 13% (4.6) | 20% (7.4) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 28.0 | ×4.49 | ×1.02 | 3% (1.2) | 74% (26.5) | 9% (3.1) | 14% (4.8) | 0% (0.0) | match |
| kor_Hang | lang | 2.5 | 17.7 | ×7.18 | ×1.01 | 2% (1.2) | 62% (35.1) | 13% (7.3) | 23% (12.8) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.7 | 23.7 | ×6.39 | ×1.03 | 3% (1.2) | 65% (27.4) | 7% (3.2) | 25% (10.5) | 0% (0.1) | match |
| tam_Taml | lang | 7.1 | 38.3 | ×5.40 | ×1.03 | 4% (1.2) | 71% (18.6) | 10% (2.6) | 15% (3.8) | 0% (0.0) | match |
| tha_Thai | lang | 8.5 | 32.9 | ×3.85 | ×1.02 | 4% (1.2) | 82% (24.9) | 8% (2.5) | 5% (1.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.8 | 19.7 | ×2.91 | ×1.08 | 3% (1.3) | 78% (40.8) | 13% (6.7) | 6% (3.3) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 18.4 | ×3.45 | ×1.07 | 3% (1.8) | 72% (40.0) | 13% (7.0) | 12% (6.8) | 0% (0.0) | match |
| added_special_dense | modalities | 5.4 | 38.4 | ×7.17 | ×1.00 | 22% (5.4) | 36% (8.9) | 35% (8.6) | 7% (1.9) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 21.2 | ×5.30 | ×1.02 | 8% (3.7) | 59% (28.1) | 18% (8.6) | 14% (6.7) | 0% (0.2) | match |
| agentic-traces | modalities | 3.9 | 18.2 | ×4.69 | ×1.07 | 4% (2.3) | 68% (38.4) | 9% (4.9) | 19% (11.0) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 19.5 | ×4.65 | ×1.08 | 4% (1.9) | 73% (38.6) | 7% (3.7) | 17% (9.0) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 19.0 | ×4.76 | ×1.07 | 4% (2.1) | 71% (38.5) | 8% (4.2) | 18% (9.6) | 0% (0.0) | match |
| math_latex | modalities | 4.1 | 18.2 | ×4.42 | ×1.07 | 4% (2.5) | 68% (38.6) | 8% (4.7) | 19% (10.8) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×4.08 vs v0.23.1 · ×1.00 vs base · decode ×3.14</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 67) · Pipeline 82+0 (peak 82)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 33.2 | ×7.62 | ×0.98 | 2% (0.7) | 0% (0.0) | 17% (4.8) | 81% (23.5) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 16.4 | ×3.76 | ×1.02 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (55.2) | 0% (0.0) | match |
| ben_Beng | lang | 6.3 | 17.9 | ×2.83 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (3.1) | 93% (51.4) | 0% (0.0) | match |
| cmn_Hani | lang | 3.7 | 16.5 | ×4.42 | ×1.00 | 1% (0.8) | 0% (0.0) | 5% (3.1) | 94% (53.9) | 0% (0.0) | match |
| ell_Grek | lang | 4.7 | 17.8 | ×3.77 | ×0.99 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (50.9) | 0% (0.0) | match |
| eng_Latn | lang | 3.1 | 12.9 | ×4.11 | ×1.00 | 3% (2.0) | 0% (0.0) | 7% (5.0) | 90% (68.0) | 1% (0.7) | match |
| heb_Hebr | lang | 4.1 | 13.0 | ×3.21 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (3.5) | 94% (71.5) | 0% (0.2) | match |
| hin_Deva | lang | 5.9 | 20.9 | ×3.52 | ×0.99 | 1% (0.6) | 0% (0.0) | 7% (3.3) | 91% (42.9) | 0% (0.1) | match |
| jpn_Jpan | lang | 4.3 | 17.7 | ×4.08 | ×1.01 | 1% (0.7) | 0% (0.0) | 5% (3.0) | 93% (50.6) | 0% (0.0) | match |
| kat_Geor | lang | 6.0 | 17.9 | ×2.95 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (2.9) | 94% (51.7) | 0% (0.0) | match |
| kor_Hang | lang | 3.8 | 19.6 | ×5.20 | ×0.99 | 1% (0.6) | 0% (0.0) | 7% (3.7) | 92% (45.6) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.4 | 14.2 | ×3.21 | ×0.98 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 94% (64.9) | 1% (0.6) | match |
| tam_Taml | lang | 6.3 | 17.6 | ×2.81 | ×1.01 | 1% (0.6) | 0% (0.0) | 5% (2.7) | 94% (52.6) | 0% (0.1) | match |
| tha_Thai | lang | 7.1 | 14.3 | ×2.02 | ×1.00 | 1% (0.6) | 0% (0.0) | 3% (2.2) | 96% (65.7) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.0 | 23.3 | ×3.85 | ×1.00 | 2% (0.7) | 0% (0.0) | 6% (2.7) | 92% (38.8) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 19.4 | ×3.62 | ×0.99 | 3% (1.3) | 0% (0.0) | 7% (3.8) | 90% (45.5) | 0% (0.0) | match |
| added_special_dense | modalities | 3.6 | 36.3 | ×10.09 | ×0.99 | 25% (6.5) | 2% (0.6) | 25% (6.6) | 48% (12.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 20.5 | ×5.13 | ×0.99 | 8% (3.9) | 0% (0.2) | 14% (6.9) | 76% (36.7) | 1% (0.5) | match |
| agentic-traces | modalities | 3.0 | 14.2 | ×4.81 | ×1.00 | 3% (1.8) | 0% (0.0) | 8% (5.4) | 90% (61.2) | 0% (0.0) | match |
| agentic_swe | modalities | 3.0 | 14.9 | ×4.96 | ×1.00 | 2% (1.3) | 0% (0.0) | 6% (3.8) | 92% (59.8) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 15.4 | ×4.42 | ×0.99 | 2% (1.6) | 0% (0.0) | 7% (4.6) | 93% (58.4) | 0% (0.0) | match |
| math_latex | modalities | 2.8 | 13.8 | ×4.88 | ×0.99 | 3% (1.9) | 0% (0.0) | 8% (5.3) | 90% (62.3) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.43 | 4.79 | 5.43 | 41.4 | 19.9 | 9.1 | — | 8.6× / 7.6× | 4.2× / 3.7× | 1.9× / 1.7× | — |
| arb_Arab | 1.15 | 2.97 | 3.37 | 5.19 | 47.7 | 22.6 | 10.2 | — | 14.2× / 9.2× | 6.7× / 4.4× | 3.0× / 2.0× | — |
| ben_Beng | 1.62 | 2.89 | 3.15 | 4.42 | 35.5 | 16.0 | 7.5 | — | 11.3× / 8.0× | 5.1× / 3.6× | 2.4× / 1.7× | — |
| cmn_Hani | 1.12 | 2.24 | 3.14 | 4.26 | 58.7 | 33.7 | 14.2 | — | 18.7× / 13.8× | 10.7× / 7.9× | 4.5× / 3.3× | — |
| ell_Grek | 0.59 | 2.99 | 3.39 | 5.79 | 48.2 | 20.8 | 9.6 | — | 14.2× / 8.3× | 6.1× / 3.6× | 2.8× / 1.7× | — |
| eng_Latn | 0.10 | 1.46 | 5.02 | 6.39 | 63.6 | 38.8 | 16.1 | — | 12.7× / 10.0× | 7.7× / 6.1× | 3.2× / 2.5× | — |
| heb_Hebr | 1.15 | 3.00 | 3.50 | 5.36 | 49.9 | 23.8 | 10.6 | — | 14.2× / 9.3× | 6.8× / 4.4× | 3.0× / 2.0× | — |
| hin_Deva | 1.51 | 3.09 | 3.31 | 4.90 | 37.3 | 18.5 | 8.5 | — | 11.3× / 7.6× | 5.6× / 3.8× | 2.6× / 1.7× | — |
| jpn_Jpan | 1.70 | 3.36 | 2.96 | 4.62 | 51.3 | 27.0 | 11.7 | — | 17.3× / 11.1× | 9.1× / 5.8× | 4.0× / 2.5× | — |
| kat_Geor | 1.54 | 2.57 | 2.93 | 3.97 | 31.5 | 15.0 | 7.2 | — | 10.7× / 7.9× | 5.1× / 3.8× | 2.4× / 1.8× | — |
| kor_Hang | 1.23 | 2.70 | 3.68 | 5.15 | 48.6 | 26.7 | 11.9 | — | 13.2× / 9.4× | 7.3× / 5.2× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.16 | 2.88 | 3.26 | 4.99 | 45.7 | 20.8 | 9.5 | — | 14.0× / 9.2× | 6.4× / 4.2× | 2.9× / 1.9× | — |
| tam_Taml | 0.93 | 2.98 | 2.69 | 4.74 | 31.3 | 13.5 | 6.6 | — | 11.7× / 6.6× | 5.0× / 2.8× | 2.4× / 1.4× | — |
| tha_Thai | 1.51 | 2.57 | 2.18 | 3.24 | 27.0 | 10.1 | 5.2 | — | 12.4× / 8.3× | 4.6× / 3.1× | 2.4× / 1.6× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.74 | 4.16 | 41.4 | 20.0 | 9.0 | — | 15.1× / 10.0× | 7.3× / 4.8× | 3.3× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.78 | 5.20 | 47.7 | 25.8 | 11.3 | — | 12.6× / 9.2× | 6.8× / 5.0× | 3.0× / 2.2× | — |
| added_special_dense | 0.06 | 1.47 | 6.65 | 8.06 | 167.2 | 97.1 | 38.0 | — | 25.2× / 20.7× | 14.6× / 12.0× | 5.7× / 4.7× | — |
| added_special_sparse | 0.06 | 1.48 | 6.95 | 8.37 | 99.1 | 56.7 | 23.8 | — | 14.3× / 11.9× | 8.2× / 6.8× | 3.4× / 2.8× | — |
| agentic-traces | 0.73 | 1.48 | 5.37 | 6.12 | 78.5 | 53.0 | 19.9 | — | 14.6× / 12.8× | 9.9× / 8.6× | 3.7× / 3.2× | — |
| agentic_swe | 0.68 | 1.44 | 3.82 | 4.58 | 92.9 | 65.3 | 23.2 | — | 24.3× / 20.3× | 17.1× / 14.2× | 6.1× / 5.1× | — |
| code_mixed | 0.07 | 1.44 | 4.56 | 5.93 | 72.0 | 53.4 | 18.3 | — | 15.8× / 12.2× | 11.7× / 9.0× | 4.0× / 3.1× | — |
| math_latex | 0.71 | 1.48 | 5.28 | 6.05 | 76.1 | 47.4 | 19.2 | — | 14.4× / 12.6× | 9.0× / 7.8× | 3.6× / 3.2× | — |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×7.55 vs v0.23.1 · ×0.99 vs base · decode ×3.40</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 28+0 (peak 28)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 50.0 | ×11.28 | ×0.98 | 3% (0.7) | 0% (0.0) | 19% (3.6) | 78% (14.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 25.6 | ×6.04 | ×0.99 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 93% (35.5) | 0% (0.0) | match |
| ben_Beng | lang | 3.2 | 43.9 | ×13.54 | ×0.94 | 3% (0.6) | 0% (0.0) | 13% (3.0) | 84% (19.0) | 0% (0.0) | match |
| cmn_Hani | lang | 4.0 | 28.3 | ×7.09 | ×0.96 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 92% (31.4) | 0% (0.0) | match |
| ell_Grek | lang | 4.6 | 28.8 | ×6.28 | ×1.02 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 92% (31.4) | 0% (0.0) | match |
| eng_Latn | lang | 3.8 | 13.9 | ×3.68 | ×0.99 | 3% (2.0) | 0% (0.0) | 4% (2.9) | 93% (65.8) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 28.7 | ×6.97 | ×1.01 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 92% (31.3) | 0% (0.0) | match |
| hin_Deva | lang | 3.3 | 40.6 | ×12.42 | ×1.00 | 2% (0.6) | 0% (0.0) | 13% (3.1) | 85% (20.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.6 | 21.0 | ×4.57 | ×0.95 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (43.9) | 0% (0.0) | match |
| kat_Geor | lang | 4.9 | 70.0 | ×14.41 | ×1.02 | 4% (0.6) | 0% (0.0) | 14% (2.1) | 82% (11.8) | 0% (0.0) | match |
| kor_Hang | lang | 3.5 | 41.8 | ×12.01 | ×0.96 | 3% (0.6) | 0% (0.0) | 10% (2.4) | 86% (20.1) | 1% (0.2) | match |
| rus_Cyrl | lang | 4.2 | 27.4 | ×6.51 | ×0.95 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 93% (33.2) | 0% (0.0) | match |
| tam_Taml | lang | 2.7 | 72.6 | ×27.34 | ×1.06 | 4% (0.6) | 0% (0.0) | 20% (2.6) | 76% (10.2) | 0% (0.0) | match |
| tha_Thai | lang | 3.6 | 38.4 | ×10.55 | ×1.03 | 2% (0.6) | 0% (0.0) | 10% (2.5) | 88% (22.0) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.0 | 25.3 | ×4.20 | ×1.00 | 2% (0.7) | 0% (0.0) | 3% (1.1) | 95% (36.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 21.4 | ×4.14 | ×1.00 | 3% (1.3) | 0% (0.0) | 4% (1.9) | 93% (42.8) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 47.4 | ×11.47 | ×0.99 | 25% (5.0) | 0% (0.0) | 20% (4.0) | 55% (11.0) | 0% (0.1) | match |
| added_special_sparse | modalities | 4.3 | 23.6 | ×5.47 | ×0.98 | 8% (3.1) | 0% (0.1) | 10% (4.1) | 82% (33.6) | 1% (0.2) | match |
| agentic-traces | modalities | 3.2 | 16.2 | ×5.00 | ×1.00 | 3% (1.8) | 0% (0.0) | 6% (3.5) | 92% (55.6) | 0% (0.0) | match |
| agentic_swe | modalities | 3.4 | 24.6 | ×7.17 | ×0.98 | 3% (1.3) | 0% (0.0) | 6% (2.4) | 91% (36.0) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 20.5 | ×5.82 | ×0.98 | 3% (1.6) | 0% (0.0) | 6% (2.9) | 90% (43.4) | 1% (0.2) | match |
| math_latex | modalities | 3.2 | 15.2 | ×4.69 | ×0.99 | 3% (1.9) | 0% (0.0) | 5% (3.2) | 92% (60.0) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.43 | 3.64 | 4.28 | 26.0 | 21.3 | 5.7 | 4.8 | 7.1× / 6.1× | 5.8× / 5.0× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.96 | 2.25 | 4.06 | 30.2 | 25.9 | 6.7 | 5.1 | 13.4× / 7.4× | 11.5× / 6.4× | 3.0× / 1.7× | 2.3× / 1.3× |
| ben_Beng | 1.85 | 2.93 | 2.98 | 4.06 | 62.0 | 57.1 | 13.6 | 4.0 | 20.8× / 15.3× | 19.1× / 14.1× | 4.5× / 3.3× | 1.3× / 1.0× |
| cmn_Hani | 1.12 | 2.23 | 2.32 | 3.43 | 24.9 | 21.4 | 5.9 | 2.4 | 10.8× / 7.3× | 9.2× / 6.2× | 2.5× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 1.15 | 2.95 | 2.14 | 3.95 | 26.8 | 21.9 | 5.9 | 4.8 | 12.5× / 6.8× | 10.2× / 5.6× | 2.7× / 1.5× | 2.2× / 1.2× |
| eng_Latn | 0.10 | 1.46 | 2.88 | 4.25 | 41.0 | 42.5 | 11.7 | 3.8 | 14.2× / 9.7× | 14.8× / 10.0× | 4.1× / 2.7× | 1.3× / 0.9× |
| heb_Hebr | 1.14 | 3.03 | 2.25 | 4.14 | 29.8 | 26.2 | 6.8 | 3.0 | 13.2× / 7.2× | 11.6× / 6.3× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.14 | 3.06 | 4.69 | 57.8 | 54.5 | 13.3 | 4.2 | 18.9× / 12.3× | 17.8× / 11.6× | 4.4× / 2.8× | 1.4× / 0.9× |
| jpn_Jpan | 1.70 | 3.35 | 2.10 | 3.76 | 22.3 | 17.8 | 4.9 | 3.9 | 10.6× / 5.9× | 8.4× / 4.7× | 2.3× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.54 | 2.51 | 2.06 | 3.03 | 16.5 | 14.3 | 4.1 | 1.9 | 8.0× / 5.5× | 7.0× / 4.7× | 2.0× / 1.4× | 0.9× / 0.6× |
| kor_Hang | 1.23 | 2.73 | 2.42 | 3.92 | 30.3 | 28.7 | 7.4 | 3.7 | 12.5× / 7.7× | 11.9× / 7.3× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.93 | 2.08 | 3.84 | 25.6 | 21.0 | 5.7 | 2.5 | 12.3× / 6.7× | 10.1× / 5.5× | 2.8× / 1.5× | 1.2× / 0.7× |
| tam_Taml | 0.93 | 2.92 | 2.64 | 4.64 | 65.3 | 58.6 | 14.1 | 3.8 | 24.7× / 14.1× | 22.2× / 12.6× | 5.3× / 3.0× | 1.4× / 0.8× |
| tha_Thai | 1.52 | 2.57 | 2.48 | 3.54 | 38.3 | 31.7 | 8.7 | 3.2 | 15.4× / 10.8× | 12.8× / 9.0× | 3.5× / 2.5× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.48 | 1.10 | 2.52 | 22.2 | 22.8 | 6.3 | 1.9 | 20.1× / 8.8× | 20.7× / 9.0× | 5.7× / 2.5× | 1.8× / 0.8× |
| added_normalized_sparse | 0.06 | 1.48 | 1.91 | 3.33 | 29.3 | 31.4 | 8.3 | 2.7 | 15.3× / 8.8× | 16.4× / 9.4× | 4.3× / 2.5× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.00 | 5.42 | 89.0 | 98.4 | 19.7 | 2.8 | 22.2× / 16.4× | 24.6× / 18.2× | 4.9× / 3.6× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 4.15 | 5.86 | 57.7 | 61.2 | 14.1 | 3.4 | 13.9× / 9.9× | 14.8× / 10.5× | 3.4× / 2.4× | 0.8× / 0.6× |
| agentic-traces | 0.74 | 1.48 | 3.46 | 4.20 | 54.9 | 61.3 | 15.1 | 4.6 | 15.9× / 13.1× | 17.7× / 14.6× | 4.4× / 3.6× | 1.3× / 1.1× |
| agentic_swe | 0.66 | 1.45 | 2.42 | 3.21 | 56.3 | 69.5 | 14.4 | 3.5 | 23.2× / 17.5× | 28.7× / 21.6× | 5.9× / 4.5× | 1.4× / 1.1× |
| code_mixed | 0.10 | 1.44 | 2.91 | 4.25 | 55.4 | 68.0 | 14.8 | 4.1 | 19.0× / 13.0× | 23.4× / 16.0× | 5.1× / 3.5× | 1.4× / 1.0× |
| math_latex | 0.71 | 1.47 | 3.22 | 3.99 | 48.9 | 51.1 | 13.8 | 4.2 | 15.2× / 12.3× | 15.8× / 12.8× | 4.3× / 3.4× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×7.59 vs v0.23.1 · ×1.00 vs base · decode ×3.39</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 5+12 (peak 17) · Pipeline 7+0 (peak 7)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.1 | 62.1 | ×20.19 | ×1.06 | 4% (0.7) | 0% (0.0) | 32% (5.0) | 64% (9.8) | 0% (0.0) | match |
| arb_Arab | lang | 3.7 | 24.7 | ×6.66 | ×0.98 | 2% (0.6) | 0% (0.0) | 10% (3.8) | 89% (35.3) | 0% (0.0) | match |
| ben_Beng | lang | 5.1 | 27.2 | ×5.37 | ×0.99 | 2% (0.6) | 0% (0.0) | 11% (3.9) | 87% (31.4) | 0% (0.0) | match |
| cmn_Hani | lang | 4.1 | 38.5 | ×9.44 | ×1.00 | 2% (0.6) | 0% (0.0) | 13% (3.3) | 84% (21.3) | 0% (0.0) | match |
| ell_Grek | lang | 4.0 | 31.5 | ×7.92 | ×1.01 | 2% (0.6) | 0% (0.0) | 11% (3.3) | 87% (27.0) | 0% (0.0) | match |
| eng_Latn | lang | 3.1 | 21.3 | ×6.86 | ×0.99 | 4% (2.0) | 0% (0.0) | 10% (4.6) | 86% (39.9) | 0% (0.0) | match |
| heb_Hebr | lang | 3.7 | 26.7 | ×7.18 | ×0.95 | 2% (0.6) | 0% (0.0) | 10% (3.9) | 89% (32.8) | 0% (0.0) | match |
| hin_Deva | lang | 5.0 | 23.7 | ×4.78 | ×1.01 | 1% (0.6) | 0% (0.0) | 10% (4.0) | 89% (36.7) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.7 | 36.8 | ×7.82 | ×0.98 | 2% (0.6) | 0% (0.0) | 12% (3.1) | 86% (22.6) | 0% (0.0) | match |
| kat_Geor | lang | 5.5 | 26.2 | ×4.72 | ×1.05 | 2% (0.6) | 0% (0.0) | 8% (2.9) | 91% (34.1) | 0% (0.0) | match |
| kor_Hang | lang | 3.5 | 47.9 | ×13.77 | ×1.02 | 3% (0.6) | 0% (0.0) | 19% (3.9) | 78% (15.8) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.4 | 22.4 | ×5.03 | ×0.99 | 1% (0.6) | 0% (0.0) | 7% (3.2) | 94% (41.0) | 0% (0.0) | match |
| tam_Taml | lang | 5.5 | 28.8 | ×5.20 | ×1.00 | 2% (0.6) | 0% (0.0) | 10% (3.4) | 88% (29.9) | 0% (0.0) | match |
| tha_Thai | lang | 6.3 | 26.7 | ×4.24 | ×0.99 | 2% (0.6) | 0% (0.0) | 9% (3.4) | 89% (32.1) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.7 | 45.2 | ×9.67 | ×0.99 | 3% (0.7) | 0% (0.0) | 11% (2.3) | 86% (18.9) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.2 | 36.1 | ×8.52 | ×0.98 | 5% (1.3) | 0% (0.0) | 12% (3.2) | 84% (22.9) | 0% (0.0) | match |
| added_special_dense | modalities | 3.7 | 55.5 | ×14.86 | ×1.02 | 30% (5.0) | 0% (0.1) | 28% (4.8) | 42% (7.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.8 | 34.0 | ×9.06 | ×0.98 | 11% (3.2) | 0% (0.0) | 20% (5.7) | 68% (19.3) | 0% (0.0) | match |
| agentic-traces | modalities | 3.1 | 22.5 | ×7.21 | ×0.98 | 4% (1.8) | 0% (0.0) | 11% (5.0) | 85% (36.7) | 0% (0.0) | match |
| agentic_swe | modalities | 3.4 | 21.7 | ×6.32 | ×0.99 | 3% (1.3) | 0% (0.0) | 8% (3.8) | 89% (40.1) | 0% (0.0) | match |
| code_mixed | modalities | 3.4 | 29.6 | ×8.81 | ×1.00 | 5% (1.6) | 0% (0.0) | 13% (4.4) | 85% (28.3) | 0% (0.0) | match |
| math_latex | modalities | 3.1 | 22.4 | ×7.29 | ×0.99 | 4% (1.9) | 0% (0.0) | 11% (4.8) | 85% (36.7) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.43 | 4.95 | 5.60 | 36.3 | 14.2 | 6.9 | 4.7 | 7.3× / 6.5× | 2.9× / 2.5× | 1.4× / 1.2× | 1.0× / 0.8× |
| arb_Arab | 1.15 | 3.00 | 3.77 | 5.63 | 41.8 | 16.2 | 7.5 | 5.1 | 11.1× / 7.4× | 4.3× / 2.9× | 2.0× / 1.3× | 1.4× / 0.9× |
| ben_Beng | 1.84 | 2.98 | 3.90 | 5.05 | 28.7 | 11.0 | 5.5 | 2.7 | 7.4× / 5.7× | 2.8× / 2.2× | 1.4× / 1.1× | 0.7× / 0.5× |
| cmn_Hani | 1.11 | 2.25 | 3.30 | 4.44 | 25.6 | 10.8 | 5.5 | 2.5 | 7.7× / 5.8× | 3.3× / 2.4× | 1.7× / 1.2× | 0.8× / 0.6× |
| ell_Grek | 1.15 | 2.95 | 3.28 | 5.08 | 37.1 | 15.0 | 6.9 | 5.1 | 11.3× / 7.3× | 4.6× / 3.0× | 2.1× / 1.4× | 1.6× / 1.0× |
| eng_Latn | 0.10 | 1.45 | 4.61 | 5.96 | 58.3 | 29.2 | 13.4 | 4.1 | 12.7× / 9.8× | 6.3× / 4.9× | 2.9× / 2.2× | 0.9× / 0.7× |
| heb_Hebr | 1.14 | 3.02 | 3.87 | 5.75 | 42.0 | 17.1 | 8.3 | 2.8 | 10.8× / 7.3× | 4.4× / 3.0× | 2.1× / 1.4× | 0.7× / 0.5× |
| hin_Deva | 1.54 | 3.06 | 4.02 | 5.55 | 32.1 | 13.3 | 6.3 | 3.1 | 8.0× / 5.8× | 3.3× / 2.4× | 1.6× / 1.1× | 0.8× / 0.6× |
| jpn_Jpan | 1.70 | 3.36 | 3.06 | 4.72 | 23.4 | 9.2 | 4.8 | 3.8 | 7.7× / 5.0× | 3.0× / 1.9× | 1.6× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.54 | 2.55 | 2.92 | 3.93 | 22.9 | 10.3 | 4.6 | 2.1 | 7.8× / 5.8× | 3.5× / 2.6× | 1.6× / 1.2× | 0.7× / 0.5× |
| kor_Hang | 1.23 | 2.74 | 3.87 | 5.38 | 42.0 | 18.6 | 8.7 | 3.5 | 10.9× / 7.8× | 4.8× / 3.5× | 2.3× / 1.6× | 0.9× / 0.7× |
| rus_Cyrl | 1.16 | 2.90 | 3.18 | 4.92 | 35.5 | 14.8 | 6.7 | 4.8 | 11.1× / 7.2× | 4.7× / 3.0× | 2.1× / 1.4× | 1.5× / 1.0× |
| tam_Taml | 0.93 | 2.94 | 3.44 | 5.45 | 22.7 | 8.7 | 4.2 | 2.9 | 6.6× / 4.2× | 2.5× / 1.6× | 1.2× / 0.8× | 0.8× / 0.5× |
| tha_Thai | 1.53 | 2.58 | 3.42 | 4.48 | 14.8 | 5.7 | 2.8 | 2.2 | 4.3× / 3.3× | 1.7× / 1.3× | 0.8× / 0.6× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.47 | 2.33 | 3.74 | 42.3 | 17.1 | 11.3 | 2.2 | 18.2× / 11.3× | 7.3× / 4.6× | 4.9× / 3.0× | 0.9× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.15 | 4.57 | 47.3 | 20.6 | 11.5 | 2.9 | 15.0× / 10.3× | 6.5× / 4.5× | 3.6× / 2.5× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.47 | 4.82 | 6.24 | 116.9 | 67.6 | 23.8 | 3.1 | 24.3× / 18.7× | 14.0× / 10.8× | 4.9× / 3.8× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 5.74 | 7.16 | 77.7 | 41.7 | 16.8 | 3.6 | 13.6× / 10.9× | 7.3× / 5.8× | 2.9× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.72 | 1.48 | 4.99 | 5.76 | 69.3 | 40.7 | 16.5 | 4.8 | 13.9× / 12.0× | 8.2× / 7.1× | 3.3× / 2.9× | 1.0× / 0.8× |
| agentic_swe | 0.66 | 1.46 | 3.75 | 4.56 | 70.4 | 48.7 | 17.1 | 3.6 | 18.8× / 15.4× | 13.0× / 10.7× | 4.6× / 3.7× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.44 | 4.36 | 5.73 | 69.6 | 47.3 | 16.8 | 4.3 | 16.0× / 12.2× | 10.9× / 8.3× | 3.8× / 2.9× | 1.0× / 0.7× |
| math_latex | 0.74 | 1.49 | 4.84 | 5.59 | 67.3 | 35.2 | 15.4 | 4.4 | 13.9× / 12.0× | 7.3× / 6.3× | 3.2× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×12.88 vs v0.23.1 · ×1.00 vs base · decode ×3.54</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 4+12 (peak 17) · Pipeline 6+0 (peak 6)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.6 | 57.7 | ×12.52 | ×0.94 | 7% (1.2) | 0% (0.0) | 22% (3.7) | 70% (11.8) | 0% (0.1) | match |
| arb_Arab | lang | 4.1 | 72.6 | ×17.61 | ×1.27 | 9% (1.2) | 0% (0.0) | 17% (2.3) | 74% (10.0) | 0% (0.0) | match |
| ben_Beng | lang | 3.4 | 71.0 | ×21.04 | ×1.02 | 8% (1.2) | 0% (0.0) | 23% (3.1) | 68% (9.4) | 0% (0.0) | match |
| cmn_Hani | lang | 4.7 | 69.0 | ×14.64 | ×1.03 | 8% (1.2) | 0% (0.0) | 17% (2.4) | 74% (10.4) | 0% (0.0) | match |
| ell_Grek | lang | 4.0 | 71.3 | ×17.75 | ×0.99 | 9% (1.2) | 0% (0.0) | 16% (2.2) | 75% (10.2) | 0% (0.0) | match |
| eng_Latn | lang | 3.5 | 22.7 | ×6.48 | ×0.99 | 6% (2.5) | 0% (0.0) | 7% (3.0) | 87% (37.9) | 0% (0.0) | match |
| heb_Hebr | lang | 3.7 | 69.7 | ×18.78 | ×0.94 | 8% (1.2) | 0% (0.0) | 17% (2.3) | 75% (10.5) | 0% (0.0) | match |
| hin_Deva | lang | 3.1 | 64.7 | ×20.98 | ×0.95 | 8% (1.2) | 0% (0.0) | 21% (3.2) | 71% (10.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.7 | 74.2 | ×15.85 | ×1.05 | 9% (1.2) | 0% (0.0) | 17% (2.2) | 74% (9.6) | 0% (0.0) | match |
| kat_Geor | lang | 4.4 | 78.7 | ×17.71 | ×0.93 | 9% (1.2) | 0% (0.0) | 17% (2.1) | 73% (8.9) | 0% (0.0) | match |
| kor_Hang | lang | 3.5 | 70.5 | ×20.43 | ×1.04 | 9% (1.2) | 0% (0.0) | 18% (2.5) | 73% (10.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.0 | 40.9 | ×10.29 | ×1.02 | 5% (1.2) | 0% (0.0) | 9% (2.2) | 86% (20.8) | 1% (0.1) | match |
| tam_Taml | lang | 3.2 | 75.0 | ×23.75 | ×1.04 | 9% (1.2) | 0% (0.0) | 21% (2.7) | 70% (9.1) | 0% (0.0) | match |
| tha_Thai | lang | 3.9 | 72.0 | ×18.43 | ×1.00 | 9% (1.2) | 0% (0.0) | 19% (2.6) | 72% (9.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.6 | 45.8 | ×9.92 | ×0.99 | 6% (1.3) | 0% (0.0) | 5% (1.1) | 89% (18.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.1 | 39.0 | ×9.43 | ×0.97 | 8% (1.8) | 0% (0.0) | 9% (2.1) | 85% (20.5) | 0% (0.0) | match |
| added_special_dense | modalities | 3.4 | 40.5 | ×11.99 | ×1.00 | 53% (12.7) | 1% (0.2) | 20% (4.8) | 25% (5.9) | 1% (0.3) | match |
| added_special_sparse | modalities | 3.5 | 33.8 | ×9.78 | ×0.99 | 25% (7.1) | 0% (0.0) | 16% (4.5) | 59% (16.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.2 | 23.8 | ×7.39 | ×0.99 | 6% (2.5) | 0% (0.0) | 9% (3.7) | 85% (35.2) | 0% (0.0) | match |
| agentic_swe | modalities | 3.6 | 22.2 | ×6.16 | ×0.99 | 4% (1.9) | 0% (0.0) | 7% (2.9) | 89% (39.6) | 0% (0.0) | match |
| code_mixed | modalities | 3.6 | 31.0 | ×8.71 | ×0.99 | 7% (2.2) | 0% (0.0) | 10% (3.3) | 83% (26.3) | 0% (0.0) | match |
| math_latex | modalities | 3.2 | 24.1 | ×7.54 | ×0.99 | 6% (2.5) | 0% (0.0) | 8% (3.4) | 86% (34.9) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.41 | 3.70 | 4.32 | 26.2 | 15.9 | 5.8 | 4.8 | 7.1× / 6.1× | 4.3× / 3.7× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.96 | 2.32 | 4.13 | 29.6 | 19.5 | 6.7 | 5.2 | 12.8× / 7.2× | 8.4× / 4.7× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.61 | 2.91 | 3.14 | 4.44 | 43.5 | 27.7 | 10.1 | 3.7 | 13.8× / 9.8× | 8.8× / 6.2× | 3.2× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.11 | 2.22 | 2.39 | 3.50 | 18.7 | 11.6 | 4.7 | 2.4 | 7.8× / 5.3× | 4.9× / 3.3× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 2.97 | 2.21 | 4.59 | 27.1 | 17.0 | 6.1 | 4.7 | 12.3× / 5.9× | 7.7× / 3.7× | 2.7× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.11 | 1.46 | 3.01 | 4.37 | 41.5 | 32.7 | 12.0 | 3.7 | 13.8× / 9.5× | 10.8× / 7.5× | 4.0× / 2.8× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.06 | 2.32 | 4.24 | 29.6 | 19.8 | 6.9 | 3.0 | 12.7× / 7.0× | 8.5× / 4.7× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.52 | 3.12 | 3.22 | 4.82 | 46.1 | 30.2 | 11.0 | 4.0 | 14.3× / 9.6× | 9.4× / 6.3× | 3.4× / 2.3× | 1.3× / 0.8× |
| jpn_Jpan | 1.69 | 3.33 | 2.20 | 3.84 | 17.5 | 9.9 | 4.0 | 3.7 | 8.0× / 4.6× | 4.5× / 2.6× | 1.8× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.55 | 2.49 | 2.10 | 3.04 | 16.8 | 11.3 | 4.2 | 2.0 | 8.0× / 5.5× | 5.4× / 3.7× | 2.0× / 1.4× | 1.0× / 0.7× |
| kor_Hang | 1.23 | 2.72 | 2.52 | 4.00 | 29.4 | 21.0 | 7.3 | 3.7 | 11.7× / 7.3× | 8.3× / 5.2× | 2.9× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.90 | 2.15 | 3.89 | 25.6 | 16.6 | 5.9 | 2.5 | 11.9× / 6.6× | 7.7× / 4.3× | 2.7× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.93 | 2.94 | 2.72 | 4.74 | 42.4 | 26.6 | 9.6 | 3.4 | 15.6× / 8.9× | 9.8× / 5.6× | 3.5× / 2.0× | 1.3× / 0.7× |
| tha_Thai | 1.53 | 2.59 | 2.62 | 3.67 | 27.2 | 16.1 | 6.6 | 3.0 | 10.4× / 7.4× | 6.2× / 4.4× | 2.5× / 1.8× | 1.1× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.12 | 2.53 | 22.5 | 17.1 | 6.5 | 1.8 | 20.2× / 8.9× | 15.3× / 6.8× | 5.8× / 2.6× | 1.6× / 0.7× |
| added_normalized_sparse | 0.06 | 1.77 | 2.07 | 3.77 | 30.0 | 22.8 | 8.9 | 2.5 | 14.5× / 7.9× | 11.1× / 6.0× | 4.3× / 2.4× | 1.2× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 4.77 | 6.19 | 90.5 | 74.5 | 20.9 | 3.1 | 19.0× / 14.6× | 15.6× / 12.0× | 4.4× / 3.4× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 4.54 | 6.25 | 58.3 | 46.8 | 15.0 | 3.6 | 12.8× / 9.3× | 10.3× / 7.5× | 3.3× / 2.4× | 0.8× / 0.6× |
| agentic-traces | 0.71 | 1.47 | 3.72 | 4.48 | 49.9 | 43.5 | 14.6 | 4.5 | 13.4× / 11.1× | 11.7× / 9.7× | 3.9× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.66 | 1.45 | 2.88 | 3.67 | 52.8 | 51.7 | 15.5 | 3.4 | 18.3× / 14.4× | 17.9× / 14.1× | 5.4× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.28 | 4.65 | 50.4 | 48.9 | 14.9 | 4.0 | 15.3× / 10.8× | 14.9× / 10.5× | 4.5× / 3.2× | 1.2× / 0.9× |
| math_latex | 0.72 | 1.48 | 3.44 | 4.20 | 48.2 | 38.9 | 14.1 | 4.1 | 14.0× / 11.5× | 11.3× / 9.3× | 4.1× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.16 vs v0.23.1 · ×1.02 vs base · decode ×2.84</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 18+0 (peak 23) · Pipeline 24+0 (peak 24)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.6 | 41.7 | ×7.47 | ×0.99 | 0% (0.0) | 12% (2.7) | 0% (0.0) | 88% (18.9) | 0% (0.0) | match |
| arb_Arab | lang | 12.3 | 49.4 | ×4.02 | ×1.02 | 0% (0.0) | 16% (3.1) | 0% (0.0) | 84% (15.9) | 0% (0.0) | match |
| ben_Beng | lang | 13.5 | 81.2 | ×6.02 | ×1.02 | 0% (0.0) | 19% (2.1) | 0% (0.0) | 81% (9.2) | 0% (0.0) | match |
| cmn_Hani | lang | 11.3 | 65.9 | ×5.83 | ×1.05 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 97% (13.5) | 0% (0.0) | match |
| ell_Grek | lang | 12.6 | 57.8 | ×4.58 | ×1.02 | 0% (0.0) | 19% (3.1) | 0% (0.0) | 81% (13.4) | 0% (0.0) | match |
| eng_Latn | lang | 4.5 | 6.5 | ×1.44 | ×1.01 | 0% (0.1) | 4% (6.7) | 0% (0.0) | 95% (143.4) | 0% (0.3) | match |
| heb_Hebr | lang | 12.3 | 60.5 | ×4.91 | ×1.02 | 0% (0.0) | 21% (3.2) | 0% (0.0) | 79% (12.1) | 0% (0.0) | match |
| hin_Deva | lang | 14.4 | 78.7 | ×5.45 | ×1.05 | 0% (0.0) | 24% (2.8) | 0% (0.0) | 77% (9.0) | 0% (0.0) | match |
| jpn_Jpan | lang | 15.7 | 82.3 | ×5.24 | ×1.01 | 0% (0.0) | 3% (0.3) | 0% (0.0) | 97% (10.3) | 0% (0.0) | match |
| kat_Geor | lang | 17.3 | 91.6 | ×5.28 | ×1.04 | 0% (0.0) | 18% (1.8) | 0% (0.0) | 81% (8.3) | 0% (0.0) | match |
| kor_Hang | lang | 8.6 | 50.2 | ×5.86 | ×1.00 | 0% (0.1) | 17% (3.2) | 0% (0.0) | 82% (15.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 8.9 | 16.2 | ×1.81 | ×1.01 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (57.6) | 0% (0.2) | match |
| tam_Taml | lang | 15.3 | 89.1 | ×5.81 | ×1.05 | 0% (0.0) | 17% (1.7) | 0% (0.0) | 83% (8.5) | 0% (0.0) | match |
| tha_Thai | lang | 19.4 | 87.4 | ×4.51 | ×1.05 | 0% (0.0) | 9% (0.9) | 0% (0.0) | 91% (9.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 8.6 | ×1.40 | ×0.99 | 0% (0.1) | 3% (3.7) | 0% (0.0) | 98% (109.9) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 7.4 | ×1.42 | ×1.01 | 0% (0.0) | 5% (6.0) | 0% (0.0) | 96% (122.3) | 0% (0.0) | match |
| added_special_dense | modalities | 5.3 | 20.1 | ×3.80 | ×1.01 | 11% (5.2) | 32% (15.6) | 2% (1.2) | 54% (26.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 7.7 | 10.3 | ×1.34 | ×1.01 | 2% (2.2) | 14% (13.7) | 0% (0.5) | 83% (79.8) | 0% (0.0) | match |
| agentic-traces | modalities | 4.7 | 7.2 | ×1.52 | ×1.02 | 0% (0.1) | 4% (6.1) | 0% (0.0) | 95% (129.4) | 0% (0.4) | match |
| agentic_swe | modalities | 4.2 | 7.6 | ×1.80 | ×1.01 | 0% (0.0) | 7% (9.7) | 0% (0.0) | 93% (120.6) | 0% (0.0) | match |
| code_mixed | modalities | 4.4 | 7.2 | ×1.64 | ×1.01 | 0% (0.0) | 6% (7.9) | 0% (0.0) | 95% (127.2) | 0% (0.0) | match |
| math_latex | modalities | 4.6 | 6.8 | ×1.46 | ×0.99 | 0% (0.1) | 4% (6.2) | 0% (0.0) | 95% (136.5) | 0% (0.5) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×7.00 vs v0.23.1 · ×0.98 vs base · decode ×3.30</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 143+0 (peak 199) · Pipeline 145+0 (peak 200)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 50.9 | ×11.67 | ×0.96 | 4% (0.7) | 0% (0.0) | 22% (3.7) | 75% (12.7) | 0% (0.0) | match |
| arb_Arab | lang | 4.9 | 17.6 | ×3.63 | ×0.95 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 95% (51.4) | 0% (0.0) | match |
| ben_Beng | lang | 4.1 | 31.1 | ×7.52 | ×0.97 | 2% (0.6) | 0% (0.0) | 10% (3.1) | 88% (27.4) | 0% (0.0) | match |
| cmn_Hani | lang | 5.2 | 16.4 | ×3.16 | ×0.95 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 96% (52.9) | 0% (0.0) | match |
| ell_Grek | lang | 5.3 | 19.3 | ×3.68 | ×0.98 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 96% (47.1) | 0% (0.0) | match |
| eng_Latn | lang | 4.0 | 45.0 | ×11.30 | ×0.89 | 11% (2.0) | 0% (0.0) | 16% (3.0) | 73% (13.3) | 0% (0.0) | match |
| heb_Hebr | lang | 4.4 | 25.9 | ×5.92 | ×1.01 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 92% (33.6) | 0% (0.0) | match |
| hin_Deva | lang | 4.5 | 76.0 | ×17.03 | ×0.99 | 5% (0.6) | 0% (0.0) | 27% (3.2) | 68% (7.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.8 | 16.2 | ×2.76 | ×0.99 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 91% (53.9) | 4% (2.3) | match |
| kat_Geor | lang | 5.5 | 38.3 | ×6.95 | ×1.10 | 2% (0.6) | 0% (0.0) | 9% (2.1) | 89% (21.6) | 0% (0.0) | match |
| kor_Hang | lang | 4.1 | 19.0 | ×4.61 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 93% (45.6) | 0% (0.2) | match |
| rus_Cyrl | lang | 5.1 | 16.5 | ×3.22 | ×0.97 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (55.7) | 1% (0.4) | match |
| tam_Taml | lang | 4.0 | 35.8 | ×9.04 | ×1.02 | 2% (0.6) | 0% (0.0) | 10% (2.8) | 88% (24.1) | 0% (0.0) | match |
| tha_Thai | lang | 5.3 | 20.0 | ×3.76 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (2.6) | 95% (45.7) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 26.8 | ×4.38 | ×0.98 | 2% (0.7) | 0% (0.0) | 3% (1.2) | 95% (35.3) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 42.6 | ×7.95 | ×0.99 | 6% (1.3) | 0% (0.0) | 8% (1.9) | 87% (20.0) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 75.7 | ×18.35 | ×1.01 | 39% (5.0) | 1% (0.1) | 36% (4.6) | 24% (3.0) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 72.8 | ×16.64 | ×0.99 | 25% (3.2) | 0% (0.0) | 37% (4.7) | 38% (5.0) | 0% (0.1) | match |
| agentic-traces | modalities | 3.5 | 37.4 | ×10.55 | ×0.99 | 7% (1.8) | 0% (0.0) | 15% (3.7) | 79% (18.9) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 28.7 | ×7.05 | ×1.00 | 4% (1.3) | 0% (0.0) | 9% (2.9) | 88% (28.8) | 0% (0.0) | match |
| code_mixed | modalities | 4.1 | 46.7 | ×11.39 | ×0.98 | 8% (1.6) | 0% (0.0) | 17% (3.3) | 75% (14.1) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 40.6 | ×10.74 | ×0.98 | 9% (1.9) | 0% (0.0) | 16% (3.4) | 79% (17.0) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.43 | 3.68 | 4.34 | 27.6 | 16.2 | 5.9 | 4.8 | 7.5× / 6.4× | 4.4× / 3.7× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.96 | 2.32 | 4.13 | 31.5 | 19.3 | 6.8 | 5.2 | 13.6× / 7.6× | 8.3× / 4.7× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.62 | 2.93 | 3.11 | 4.43 | 46.0 | 27.5 | 10.2 | 3.7 | 14.8× / 10.4× | 8.8× / 6.2× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.27 | 2.37 | 3.52 | 19.5 | 11.7 | 4.7 | 2.3 | 8.2× / 5.5× | 4.9× / 3.3× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 2.96 | 2.20 | 4.58 | 28.8 | 17.2 | 6.2 | 4.8 | 13.1× / 6.3× | 7.8× / 3.7× | 2.8× / 1.4× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.45 | 3.00 | 4.36 | 44.9 | 32.7 | 12.3 | 3.7 | 15.0× / 10.3× | 10.9× / 7.5× | 4.1× / 2.8× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.00 | 2.31 | 4.17 | 31.6 | 19.7 | 6.9 | 3.0 | 13.7× / 7.6× | 8.5× / 4.7× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.11 | 3.21 | 4.80 | 48.9 | 30.5 | 11.1 | 4.0 | 15.3× / 10.2× | 9.5× / 6.4× | 3.5× / 2.3× | 1.3× / 0.8× |
| jpn_Jpan | 1.69 | 3.41 | 2.18 | 3.90 | 18.2 | 9.9 | 4.0 | 3.7 | 8.4× / 4.7× | 4.6× / 2.5× | 1.9× / 1.0× | 1.7× / 0.9× |
| kat_Geor | 1.54 | 2.55 | 2.09 | 3.10 | 17.5 | 11.3 | 4.2 | 2.0 | 8.4× / 5.6× | 5.4× / 3.7× | 2.0× / 1.4× | 1.0× / 0.6× |
| kor_Hang | 1.23 | 2.73 | 2.51 | 4.02 | 31.8 | 21.2 | 7.5 | 3.7 | 12.7× / 7.9× | 8.5× / 5.3× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.93 | 2.15 | 3.92 | 27.3 | 17.0 | 5.9 | 2.5 | 12.7× / 7.0× | 7.9× / 4.3× | 2.8× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.96 | 2.75 | 4.79 | 45.0 | 27.0 | 9.9 | 3.4 | 16.3× / 9.4× | 9.8× / 5.6× | 3.6× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.52 | 2.59 | 2.60 | 3.67 | 28.6 | 16.6 | 6.7 | 3.0 | 11.0× / 7.8× | 6.4× / 4.5× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.48 | 1.20 | 2.62 | 24.1 | 16.8 | 6.4 | 1.8 | 20.1× / 9.2× | 14.0× / 6.4× | 5.4× / 2.5× | 1.5× / 0.7× |
| added_normalized_sparse | 0.06 | 1.77 | 1.92 | 3.63 | 31.9 | 22.5 | 8.8 | 2.6 | 16.6× / 8.8× | 11.7× / 6.2× | 4.6× / 2.4× | 1.3× / 0.7× |
| added_special_dense | 0.06 | 1.48 | 4.56 | 5.98 | 97.1 | 73.3 | 20.9 | 3.2 | 21.3× / 16.2× | 16.1× / 12.3× | 4.6× / 3.5× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 4.73 | 6.15 | 62.0 | 45.4 | 15.1 | 3.3 | 13.1× / 10.1× | 9.6× / 7.4× | 3.2× / 2.5× | 0.7× / 0.5× |
| agentic-traces | 0.74 | 1.54 | 3.70 | 4.51 | 54.2 | 44.5 | 15.1 | 4.5 | 14.6× / 12.0× | 12.0× / 9.9× | 4.1× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.68 | 1.46 | 2.87 | 3.66 | 56.9 | 53.0 | 16.1 | 3.4 | 19.8× / 15.5× | 18.5× / 14.5× | 5.6× / 4.4× | 1.2× / 0.9× |
| code_mixed | 0.10 | 1.45 | 3.27 | 4.63 | 54.0 | 50.8 | 15.5 | 3.9 | 16.5× / 11.7× | 15.5× / 11.0× | 4.7× / 3.4× | 1.2× / 0.8× |
| math_latex | 0.71 | 1.48 | 3.42 | 4.20 | 52.1 | 40.2 | 14.1 | 4.1 | 15.2× / 12.4× | 11.7× / 9.6× | 4.1× / 3.4× | 1.2× / 1.0× |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257495024-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->




