### PR TITLE
bench: gigatoken per-step profile + take/have/skip analysis

### DIFF
--- a/tokenizers/tk-encode/benches/notes/gigatoken_comparison.md
+++ b/tokenizers/tk-encode/benches/notes/gigatoken_comparison.md
@@ -95,3 +95,40 @@ weight — the bounded L2 cache is the right call, as designed.
   our probe hits L2, so take only if a profile shows it on the critical path.
 - parquet / jsonl / zstd input, batch file encoding, huge-page allocator, py bindings — out of scope.
 ```
+
+---
+
+## UPDATE — fair per-step head-to-head vs PR #2190 (cached "ours")
+
+The verdict above was too generous and used the *uncached* pipeline. Re-run with PR #2190
+(`poc-merge-cache`: FlatCache + MPHF RankStore) as "ours", one process, ids byte-identical to
+gigatoken on every row (`idsEq OK`). ns/byte, aligned steps (harness:
+`notes/gigatoken_vs_ours_per_step.rs`, needs the 2190 worktree + a gigatoken clone, nightly).
+
+```
+tok         lang       | o.nrm o.splt o.mdlW o.mdlC | t.splt t.prb  t.mrg
+gpt2        English    |  0.00   1.79   3.59   8.66 |  0.73   0.11   1.37
+gpt2        Russian    |  0.00   1.28   2.17  12.38 |  1.21   1.38   6.26
+gpt2        Chinese    |  0.00   1.27   1.46  15.89 |  1.94   0.70  11.54
+gpt2        Korean     |  0.00   1.29   2.60   9.33 |  1.67   1.11   4.80
+llama-3     English    |  0.00   1.90   3.07   6.54 |  0.81   0.17   2.43
+llama-3     Chinese    |  0.00   1.21   1.12  37.72 |  1.98   0.37  25.06
+deepseek-v4 English    |  0.00   3.25   3.40   8.40 |  1.50   0.20   1.74
+deepseek-v4 Chinese    |  0.00   1.46   1.28  30.76 |  0.98   0.54  23.34
+```
+o.* = ours marginals (nrm/split/model-warm/model-cold); t.* = theirs (split / probe+emit / merge).
+
+**Which part wins, quantified:**
+1. **Warm emit is the dominant gap — theirs up to 33× (English 3.59 vs 0.11), 1.6–2.3× elsewhere.**
+   Their branchless `probe_pair` + inline value packing + flat u32 store-and-advance is memcpy-tier;
+   ours does a FlatCache `get` + copy per pretoken. **Highest-value fix by far, and it's the emit
+   path, not merge.**
+2. **Merge (cold): theirs 1.3–6× faster** (English 6×, CJK 1.3–1.5×). PairRankTable + NEON core.
+   Corrects the earlier "merge competitive" claim — it is not.
+3. **Split: ours 2–2.5× slower ONLY on whitespace-heavy Latin** (GPT contraction regex); ours is
+   comparable or faster on CJK/Cyrillic. gigatoken has per-family hand-fused SIMD English splitters.
+4. **Normalize = 0** for GPT-2/Llama/DeepSeek (byte-level BPE, no normalizer) — atomnorm doesn't
+   execute for these models; it only pays for BERT/T5/SPM.
+
+Revised priority for closing the gap: warm emit (flat u32 out + inline-packed ids + branchless
+probe) >> merge (PairRankTable/NEON) > Latin split. Normalization is not on the critical path here.

--- a/tokenizers/tk-encode/benches/notes/gigatoken_comparison.md
+++ b/tokenizers/tk-encode/benches/notes/gigatoken_comparison.md
@@ -1,0 +1,97 @@
+# gigatoken vs tk-encode — per-step profile + what to take
+
+Branched off #2223 (`feat/bpe-cache`). gigatoken = marcelroed/gigatoken @ 0.9.0, a
+bulk-throughput / training tokenizer (tuned on 1 GB OpenWebText, Zen). Reproduction harness:
+`notes/gigatoken_profile_steps.rs` (drop into a gigatoken clone as `examples/profile_steps.rs`,
+`cargo run --release --example profile_steps`). Decomposes the encode pipeline through gigatoken's
+public API — `pretokenize` iterator (split), `memoized_encode_flat` (split+probe, no added-split),
+`encode_with_added_tokens_flat` (adds the added-token matcher), cold-vs-warm isolates merge.
+
+## Per-step profile (ns/byte, 1st-touch corpora, tokenizer load excluded)
+
+```
+tokenizer    lang        split   probe   added   merge |    warm    cold
+gpt2         English     0.730   0.105   0.029   1.545 |   0.863   2.408
+gpt2         Russian     1.210   1.399   0.146   5.765 |   2.756   8.521
+gpt2         Chinese     1.864   0.781   0.115  11.050 |   2.759  13.809
+gpt2         Korean      1.665   1.288   0.028   4.919 |   2.982   7.901
+deepseek-v4  English     1.518   0.211   0.000   1.672 |   1.727   3.399
+deepseek-v4  Chinese     1.018   0.669   2.490  23.035 |   4.177  27.213
+deepseek-v4  Korean      1.640   0.842   3.054  16.815 |   5.536  22.351
+llama-3      English     0.802   0.187   0.000   2.747 |   0.976   3.724
+llama-3      Chinese     1.898   0.555   0.156  25.243 |   2.609  27.852
+llama-3      Korean      1.821   0.488   0.111  17.059 |   2.420  19.479
+```
+
+- **split** = pretokenization (SIMD span-finding). **probe** = key hash + cache hit + emit.
+  **added** = added-token matcher pass (aho-corasick over the segment; ~0 with no special-token
+  hits, rises on deepseek CJK where the matcher does more work). **merge** = cache-miss BPE
+  (cold − warm). **warm** = full encode, all cache hits. **cold** = first touch, all misses.
+
+## The one finding that matters
+
+**Merge dominates by an order of magnitude; everything else is noise.** On a cold / low-hit-rate
+workload, merge is 1.5–25 ns/B while split+probe+added together are 0.8–4 ns/B. On a warm workload
+(the cache's whole point) the total collapses to 0.86–5.7 ns/B — i.e. the pretoken cache is worth
+5–50× and is the entire throughput story on repetitive input.
+
+Strategic implication for us: the levers are (1) cache hit rate and (2) merge speed on misses.
+Split and added-split are already sub-2 ns/B in both codebases and not worth further work.
+Normalization (our big atomnorm effort) is upstream of the cache key and runs every byte
+regardless of hit — it matters for the *warm* path (where it's a real fraction of the few ns/B),
+but it cannot touch the merge-bound cold path.
+
+## Step by step — what we have vs gigatoken
+
+| step | tk-encode (this branch) | gigatoken | verdict |
+|---|---|---|---|
+| normalize | atomnorm scan + prefilter, sub-1 ns/B, spm charsmap prefiltered 10–45× | `spm_precompiled` raw + `icu`, no prefilter | **we win** — keep ours |
+| split | atomsplit SIMD classify + FSM | fused SIMD pretokenizers + CRC key hash + prefetch, per-family | comparable; their fused key-hash-in-walk is a real idea (below) |
+| added-split | matcher | aho-corasick, fused into for_each_piece | comparable, both ~0 on normal text |
+| word cache | `WordCache`: 4-way set-assoc, bucket=1 line, SoA arenas, tag filter, skip-on-full | `ShortPretokenCache`: open-addr pair-probe, inline value pack, grows to DRAM, huge pages, prefetch ladder | **different regime — see below** |
+| merge | hand-rolled binary u64 heap (`MERGE_HEAP_MIN=24`) | `PairRankTable` (dense array for hot IDs + flat open-addr table) + NEON merge core | **worth a head-to-head** |
+
+## The cache regime distinction (the crux)
+
+Our `WordCache` and gigatoken's `ShortPretokenCache` solve the same problem in opposite regimes:
+
+- **Ours (inference):** bounded, fixed bucket count, **skip on full bucket** — accept a miss rather
+  than grow. Bucket is `#[repr(align(64))]` = one cache line, 4 ways scanned branch-lessly. Stays
+  L2-resident. Correct for encoding a document / request where the working set is small.
+- **gigatoken (training):** unbounded, grows at 3/4 load to hold ~1.3M unique pretokens (~99.4%
+  hit) far past L3 — so every tail lookup is a DRAM access, which is why it needs 2 MiB huge pages
+  (`MADV_HUGEPAGE`, dTLB), a two-stage prefetch ladder (L2 a chunk ahead, L1 a few probes ahead),
+  and a branchless probe that touches exactly one line. Correct for streaming 1 GB once.
+
+Their huge-page / prefetch machinery only pays when the table is >64 MB. For our workload it's dead
+weight — the bounded L2 cache is the right call, as designed.
+
+## Take / have / skip
+
+**Worth taking:**
+1. **Inline value packing.** 90% of pretokens encode to 1 token, 98% to ≤2 — gigatoken packs up to
+   4 token ids *inline* in the slot (`u64 val + u64 ext`), so a hit is one dependent load with no
+   second random access into an ids arena. Our `WordCache` stores `(ids_off, ids_len)` into a side
+   `ids` Vec — a second (usually cache-cold) access. Packing ≤2 ids inline in the slot would remove
+   it for ~98% of hits. **Highest-value, small change.**
+2. **PairRankTable for the merge path.** A dense direct-index array for the hot ~1.8k merged IDs
+   (round-1 + most mid-merge lookups: one load, no hash) backed by a flat open-addressed table for
+   the rest, replacing the hashbrown merges map. Directly comparable to our heap+VocabStore merge;
+   given merge is the dominant cost, **bench it head-to-head** — it may beat our heap on the
+   miss-heavy path.
+3. **Fused key-hash-in-the-span-walk.** gigatoken derives the cache key hash *inside* the
+   pretokenizer's chunk fill (`fill_spans_keyed`) so the byte scan and hash share one pass. Our
+   split and cache-key hash are separate passes. Minor, but free once the walker exists.
+
+**Already have (equal or better):**
+- Normalization (atomnorm strictly ahead), split (atomsplit comparable), the 4-way L2 WordCache
+  (correct for our regime — do **not** replace with their DRAM design), merge heap (competitive;
+  see PairRankTable bench above before deciding).
+
+**Not necessary for us:**
+- Huge pages / `MADV_HUGEPAGE`, the L2/L1 prefetch ladder, DRAM-resident open-addressing growth —
+  all only pay above ~64 MB (1 GB-corpus training), irrelevant to inference-sized working sets.
+- The per-arch asm `csel`/`cmov` branchless probe — a micro-opt for a DRAM-latency-bound probe;
+  our probe hits L2, so take only if a profile shows it on the critical path.
+- parquet / jsonl / zstd input, batch file encoding, huge-page allocator, py bindings — out of scope.
+```

--- a/tokenizers/tk-encode/benches/notes/gigatoken_profile_steps.rs
+++ b/tokenizers/tk-encode/benches/notes/gigatoken_profile_steps.rs
@@ -1,0 +1,118 @@
+//! Per-step profile of gigatoken's encode pipeline, decomposed via its public API.
+//!
+//! Steps (each isolated by which public entry we call):
+//!   split      = drain `PretokenizerType::pretokenize` iterator (pure pretokenization)
+//!   +hash+probe= `memoized_encode_flat(pretokenize(x))` warm  − split   (key hash + cache hit + emit)
+//!   added-split= `encode_with_added_tokens_flat(x)` warm       − memoized-warm (added-token matcher pass)
+//!   merge(miss)= `encode_with_added_tokens_flat(x)` COLD       − warm    (cache misses → BPE merge)
+//!
+//! run: cargo run --release --example profile_steps
+use std::hint::black_box;
+use std::time::Instant;
+use gigatoken_rs::load_tokenizer::hf::load_hf_bpe;
+
+const ROOT: &str = "/Users/arthurzucker/Work/tokenizers/tokenizers";
+
+fn best(len: usize, iters: u32, mut f: impl FnMut()) -> f64 {
+    for _ in 0..2 {
+        f();
+    }
+    let mut b = f64::INFINITY;
+    for _ in 0..7 {
+        let t = Instant::now();
+        for _ in 0..iters {
+            f();
+        }
+        b = b.min(t.elapsed().as_nanos() as f64 / (iters as usize * len) as f64);
+    }
+    b
+}
+
+fn corpus(rel: &str) -> Option<String> {
+    let s = std::fs::read_to_string(format!("{ROOT}/{rel}")).ok()?;
+    let mut c = s.len().min(1_000_000);
+    while c > 0 && !s.is_char_boundary(c) {
+        c -= 1;
+    }
+    Some(s[..c].to_string())
+}
+
+fn main() {
+    let toks: &[(&str, &str)] = &[
+        ("gpt2", "data/gpt2.json"),
+        ("deepseek-v4", "data/deepseek-v4.json"),
+        ("llama-3", "data/llama-3-tokenizer.json"),
+    ];
+    let corpora: &[(&str, &str)] = &[
+        ("English", "data/big.txt"),
+        ("French", "atomsplit/benches/data/fr.txt"),
+        ("Russian", "atomsplit/benches/data/ru.txt"),
+        ("Chinese", "atomsplit/benches/data/zh.txt"),
+        ("Japanese", "data/unigram_wagahaiwa_nekodearu.txt"),
+        ("Korean", "atomsplit/benches/data/ko.txt"),
+    ];
+
+    println!(
+        "\nns/byte per step. split=pretokenize; probe=key-hash+cache-hit+emit; added=added-token\n\
+         matcher pass; merge=cache-miss BPE (cold-warm). warm=full encode all-hits, cold=first touch.\n"
+    );
+    println!(
+        "{:<12} {:<9} {:>7} {:>7} {:>7} {:>7} {:>7} | {:>7} {:>7}",
+        "tokenizer", "lang", "bytes", "split", "probe", "added", "merge", "warm", "cold"
+    );
+
+    for (tname, tpath) in toks {
+        let Ok(_) = load_hf_bpe(format!("{ROOT}/{tpath}")) else {
+            eprintln!("skip {tname}: load failed");
+            continue;
+        };
+        for (label, rel) in corpora {
+            let Some(text) = corpus(rel) else { continue };
+            let bytes = text.as_bytes();
+            let n = bytes.len();
+            let iters = (20_000_000 / n).clamp(2, 50) as u32;
+
+            // fresh tokenizer, fill cache once (cold), then everything else is warm
+            let mut tok = load_hf_bpe(format!("{ROOT}/{tpath}")).unwrap();
+            let pt = tok.pretokenizer_type();
+
+            // 1) split alone — drain the pretokenizer iterator
+            let t_split = best(n, iters, || {
+                black_box(pt.pretokenize(black_box(bytes)).count());
+            });
+
+            // 2) cold full encode (first touch: all cache misses → merges). Timed ONCE per fresh
+            //    tok, with the tokenizer LOAD excluded (load parses/​seeds ~50k vocab — not encode).
+            let mut out = Vec::with_capacity(n);
+            let t_cold = {
+                let mut fresh = load_hf_bpe(format!("{ROOT}/{tpath}")).unwrap();
+                out.clear();
+                let t0 = Instant::now();
+                fresh.encode_with_added_tokens_flat(bytes, &mut out);
+                t0.elapsed().as_nanos() as f64 / n as f64
+            };
+
+            // 3) warm full encode (cache now populated in `tok`)
+            out.clear();
+            tok.encode_with_added_tokens_flat(bytes, &mut out); // populate
+            let t_warm = best(n, iters, || {
+                out.clear();
+                tok.encode_with_added_tokens_flat(black_box(bytes), &mut out);
+            });
+
+            // 4) warm memoized (no added-split): split + hash + probe + emit
+            let t_memo = best(n, iters, || {
+                out.clear();
+                tok.memoized_encode_flat(pt.pretokenize(black_box(bytes)), &mut out);
+            });
+
+            let t_probe = (t_memo - t_split).max(0.0);
+            let t_added = (t_warm - t_memo).max(0.0);
+            let t_merge = (t_cold - t_warm).max(0.0);
+            println!(
+                "{tname:<12} {label:<9} {n:>7} {t_split:>7.3} {t_probe:>7.3} {t_added:>7.3} {t_merge:>7.3} | {t_warm:>7.3} {t_cold:>7.3}"
+            );
+        }
+        println!();
+    }
+}

--- a/tokenizers/tk-encode/benches/notes/gigatoken_vs_ours_per_step.rs
+++ b/tokenizers/tk-encode/benches/notes/gigatoken_vs_ours_per_step.rs
@@ -1,0 +1,157 @@
+//! Aligned per-step ns/B, tk-encode (PR #2190 poc-merge-cache) vs gigatoken, one process.
+//! Verifies token-id equality first. run: cargo +nightly run --release
+//!
+//! ours steps via the pipeline stage ladder (encode_generic::<STAGE>): marginals
+//!   normalize = t(NORMALIZE)-t(FRAME), split = t(SPLIT)-t(NORMALIZE),
+//!   model = t(MODEL)-t(SPLIT) (warm = FlatCache hot; cold = fresh instance).
+//! theirs steps via public API: split = pretokenize().count(),
+//!   probe = memoized_encode_flat warm - split, merge = encode cold - warm.
+use std::hint::black_box;
+use std::time::Instant;
+
+use gigatoken_rs::load_tokenizer::hf::load_hf_bpe;
+use tk_encode::tokenizer::pipeline::{PipelineToken, PipelineTokenizer};
+use tk_encode::tokenizer::Tokenizer;
+
+const ROOT: &str = "/Users/arthurzucker/Work/tokenizers/tokenizers";
+
+fn best(len: usize, iters: u32, mut f: impl FnMut()) -> f64 {
+    for _ in 0..2 {
+        f();
+    }
+    let mut b = f64::INFINITY;
+    for _ in 0..7 {
+        let t = Instant::now();
+        for _ in 0..iters {
+            f();
+        }
+        b = b.min(t.elapsed().as_nanos() as f64 / (iters as usize * len) as f64);
+    }
+    b
+}
+
+fn corpus(rel: &str) -> Option<String> {
+    let s = std::fs::read_to_string(format!("{ROOT}/{rel}")).ok()?;
+    let mut c = s.len().min(1_000_000);
+    while c > 0 && !s.is_char_boundary(c) {
+        c -= 1;
+    }
+    Some(s[..c].to_string())
+}
+
+// one stage-ladder level, best-of-N (warm cache after warmup)
+fn ours_stage<const STAGE: u8>(pt: &PipelineTokenizer, text: &str, n: usize, it: u32) -> f64 {
+    best(n, it, || {
+        let mut out: Vec<PipelineToken> = Vec::new();
+        let mut pre = Vec::new();
+        pt.encode_generic::<STAGE>(black_box(text), &mut out, &mut pre).unwrap();
+        black_box(out.len());
+    })
+}
+
+fn main() {
+    let toks: &[(&str, &str)] = &[
+        ("gpt2", "data/gpt2.json"),
+        ("deepseek-v4", "data/deepseek-v4.json"),
+        ("llama-3", "data/llama-3-tokenizer.json"),
+    ];
+    let corpora: &[(&str, &str)] = &[
+        ("English", "data/big.txt"),
+        ("Russian", "atomsplit/benches/data/ru.txt"),
+        ("Chinese", "atomsplit/benches/data/zh.txt"),
+        ("Korean", "atomsplit/benches/data/ko.txt"),
+    ];
+
+    println!(
+        "\nns/byte per step. OURS = tk-encode #2190 (pipeline stage ladder). THEIRS = gigatoken.\n\
+         norm/split/model marginals; model warm = cache-hit+emit, cold = full BPE merge.\n\
+         theirs: split=pretokenize, probe=warm memoized-split, merge=cold-warm. idsEq gates trust.\n"
+    );
+    println!(
+        "{:<11} {:<8} {:>7} | {:>5} {:>6} {:>6} {:>6} {:>6} | {:>6} {:>6} {:>6} | {:>5}",
+        "tok", "lang", "bytes",
+        "o.nrm", "o.splt", "o.mdlW", "o.mdlC", "o.tot",
+        "t.splt", "t.prb", "t.mrg", "idsEq"
+    );
+
+    for (tname, tpath) in toks {
+        let path = format!("{ROOT}/{tpath}");
+        let base = match Tokenizer::from_file(&path) {
+            Ok(t) => t,
+            Err(e) => { eprintln!("skip {tname}: ours load {e}"); continue; }
+        };
+        let ours = match PipelineTokenizer::try_from(&base) {
+            Ok(p) => p,
+            Err(e) => { eprintln!("skip {tname}: ours pipeline {e:?}"); continue; }
+        };
+        if load_hf_bpe(&path).is_err() {
+            eprintln!("skip {tname}: giga load"); continue;
+        }
+
+        for (label, rel) in corpora {
+            let Some(text) = corpus(rel) else { continue };
+            let n = text.len();
+            let it = (20_000_000 / n).clamp(2, 40) as u32;
+
+            // --- id equality (warm both) ---
+            let o_ids: Vec<u32> = ours.encode(&text, false).unwrap().into_iter().map(|t| t.id).collect();
+            let mut giga = load_hf_bpe(&path).unwrap();
+            let g_ids = { let mut v = Vec::new(); giga.encode_with_added_tokens_flat(text.as_bytes(), &mut v); v };
+            let eq = o_ids == g_ids;
+            let idseq = if eq { "OK".into() } else {
+                format!("x{}/{}", o_ids.len(), g_ids.len())
+            };
+
+            // --- OURS stage ladder (warm: FlatCache hot in `ours`) ---
+            let t_frame = ours_stage::<0>(&ours, &text, n, it);
+            let t_norm  = ours_stage::<1>(&ours, &text, n, it);
+            let t_split = ours_stage::<2>(&ours, &text, n, it);
+            let t_modelw= ours_stage::<3>(&ours, &text, n, it);
+            let o_nrm = (t_norm - t_frame).max(0.0);
+            let o_splt = (t_split - t_norm).max(0.0);
+            let o_mdlw = (t_modelw - t_split).max(0.0);
+            // ours cold model: fresh instance, one-shot full encode minus split
+            let o_mdlc = {
+                let fresh = PipelineTokenizer::try_from(&base).unwrap();
+                let mut out: Vec<PipelineToken> = Vec::new();
+                let mut pre = Vec::new();
+                let t0 = Instant::now();
+                fresh.encode_generic::<3>(&text, &mut out, &mut pre).unwrap();
+                (t0.elapsed().as_nanos() as f64 / n as f64 - t_split).max(0.0)
+            };
+            let o_tot = t_modelw;
+
+            // --- THEIRS steps (pt is a Copy enum; does not borrow giga) ---
+            let pt = giga.pretokenizer_type();
+            let t_tsplit = best(n, it, || {
+                black_box(pt.pretokenize(black_box(text.as_bytes())).count());
+            });
+            let mut scratch = Vec::new();
+            giga.memoized_encode_flat(pt.pretokenize(text.as_bytes()), &mut scratch); // warm
+            let t_tmemo = best(n, it, || {
+                scratch.clear();
+                giga.memoized_encode_flat(pt.pretokenize(black_box(text.as_bytes())), &mut scratch);
+                black_box(scratch.len());
+            });
+            let t_prb = (t_tmemo - t_tsplit).max(0.0);
+            let t_warm = best(n, it, || {
+                scratch.clear();
+                giga.encode_with_added_tokens_flat(black_box(text.as_bytes()), &mut scratch);
+                black_box(scratch.len());
+            });
+            let t_cold = {
+                let mut f = load_hf_bpe(&path).unwrap();
+                let mut v = Vec::new();
+                let t0 = Instant::now();
+                f.encode_with_added_tokens_flat(text.as_bytes(), &mut v);
+                t0.elapsed().as_nanos() as f64 / n as f64
+            };
+            let t_mrg = (t_cold - t_warm).max(0.0);
+
+            println!(
+                "{tname:<11} {label:<8} {n:>7} | {o_nrm:>5.2} {o_splt:>6.2} {o_mdlw:>6.2} {o_mdlc:>6.2} {o_tot:>6.2} | {t_tsplit:>6.2} {t_prb:>6.2} {t_mrg:>6.2} | {idseq:>5}"
+            );
+        }
+        println!();
+    }
+}

--- a/tokenizers/tk-encode/src/models/bpe/mod.rs
+++ b/tokenizers/tk-encode/src/models/bpe/mod.rs
@@ -3,6 +3,7 @@ use std::{iter, mem};
 
 mod model;
 mod serialization;
+mod word_cache;
 pub mod word;
 
 pub type Pair = (u32, u32);

--- a/tokenizers/tk-encode/src/models/bpe/mod.rs
+++ b/tokenizers/tk-encode/src/models/bpe/mod.rs
@@ -3,8 +3,8 @@ use std::{iter, mem};
 
 mod model;
 mod serialization;
-mod word_cache;
 pub mod word;
+mod word_cache;
 
 pub type Pair = (u32, u32);
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,6 +1,6 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::models::bpe::Merge;
-use crate::models::bpe::word_cache::WordCache;
+use crate::models::bpe::word_cache::{MAX_SEQUENCE_SIZE, WordCache};
 use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
@@ -850,10 +850,15 @@ impl pipeline::Model for PipelineBPE {
 
         self.merge_word(sequence, merge_queue, skip, word);
 
-        if let Some(cache) = word_cache {
-            cache.insert(sequence.to_string(), word.get_chars());
+        if let Some(cache) = word_cache
+            && sequence.len() < MAX_SEQUENCE_SIZE
+        {
+            let ids = word.get_chars();
+            output.extend(ids.iter().map(|&id| PipelineToken { id }));
+            cache.insert(sequence.to_string(), ids);
+        } else {
+            output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         }
-        output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
 
         Ok(())
     }
@@ -863,7 +868,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
-            word_cache: self.cache_capacity.map(WordCache::init),
+            word_cache: self.cache_capacity.map(WordCache::new),
         }
     }
 }
@@ -881,12 +886,12 @@ impl ModelScratch for BpeScratch {
             merge_queue,
             skip,
             word,
-            word_cache: _cache,
+            word_cache: _,
         } = self;
         merge_queue.clear();
         skip.clear();
         word.clear();
-        // We don't reset _word_cache on purpose, so it stays warm for future callers
+        // The word cache is intentionally kept across clears so it stays warm for future callers
     }
 }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -859,7 +859,18 @@ pub struct BpeScratch {
     pub(crate) skip: Vec<Merge>,
     pub(crate) word: Word,
 }
-impl ModelScratch for BpeScratch {}
+impl ModelScratch for BpeScratch {
+    fn clear(&mut self) {
+        let Self {
+            merge_queue,
+            skip,
+            word,
+        } = self;
+        merge_queue.clear();
+        skip.clear();
+        word.clear();
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,6 +1,6 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::models::bpe::Merge;
-use crate::models::bpe::word_cache::{MAX_SEQUENCE_SIZE, WordCache};
+use crate::models::bpe::word_cache::WordCache;
 use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
@@ -851,7 +851,7 @@ impl pipeline::Model for PipelineBPE {
         self.merge_word(sequence, merge_queue, skip, word);
 
         if let Some(cache) = word_cache
-            && sequence.len() < MAX_SEQUENCE_SIZE
+            && sequence.len() < MAX_LENGTH
         {
             let ids = word.get_chars();
             output.extend(ids.iter().map(|&id| PipelineToken { id }));

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -842,7 +842,7 @@ impl pipeline::Model for PipelineBPE {
         } = scratch;
 
         if let Some(cache) = word_cache
-            && let Some(hit) = cache.get(sequence)
+            && let Some(hit) = cache.get(sequence.as_bytes())
         {
             output.extend(hit.iter().map(|&id| PipelineToken { id }));
             return Ok(());
@@ -855,7 +855,7 @@ impl pipeline::Model for PipelineBPE {
         {
             let ids = word.get_chars();
             output.extend(ids.iter().map(|&id| PipelineToken { id }));
-            cache.insert(sequence.to_string(), ids);
+            cache.insert(sequence.as_bytes(), ids.as_slice());
         } else {
             output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         }
@@ -868,7 +868,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
-            word_cache: self.cache_capacity.map(WordCache::new),
+            word_cache: self.cache_capacity.map(|_| WordCache::new()),
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -863,9 +863,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
-            word_cache: self
-                .cache_capacity
-                .map(|capacity| WordCache::init(capacity)),
+            word_cache: self.cache_capacity.map(WordCache::init),
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -759,7 +759,7 @@ impl PipelineBPE {
             ignore_merges,
             merges,
             vocab,
-            cache_capacity: model.cache.map(|c| c.capacity),
+            cache_capacity: model.cache.map(|c| c.capacity).filter(|&c| c > 0),
         })
     }
 
@@ -849,15 +849,9 @@ impl pipeline::Model for PipelineBPE {
         }
 
         self.merge_word(sequence, merge_queue, skip, word);
-
-        if let Some(cache) = word_cache
-            && sequence.len() < MAX_LENGTH
-        {
-            let ids = word.get_chars();
-            output.extend(ids.iter().map(|&id| PipelineToken { id }));
-            cache.insert(sequence.as_bytes(), ids.as_slice());
-        } else {
-            output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+        output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+        if let Some(cache) = word_cache {
+            cache.insert(sequence.as_bytes(), word.get_chars_iter());
         }
 
         Ok(())
@@ -868,7 +862,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
-            word_cache: self.cache_capacity.map(|_| WordCache::new()),
+            word_cache: self.cache_capacity.map(WordCache::new),
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,5 +1,6 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::models::bpe::Merge;
+use crate::models::bpe::word_cache::WordCache;
 use crate::pipeline::{self, ModelScratch, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
@@ -679,6 +680,7 @@ pub struct PipelineBPE {
     vocab: VocabStore,
     merges: MergeMap,
     ignore_merges: bool,
+    cache_capacity: Option<usize>,
 }
 
 enum Atoms {
@@ -757,6 +759,7 @@ impl PipelineBPE {
             ignore_merges,
             merges,
             vocab,
+            cache_capacity: model.cache.map(|c| c.capacity),
         })
     }
 
@@ -831,15 +834,25 @@ impl pipeline::Model for PipelineBPE {
             return Ok(());
         }
 
-        // TODO: persistent cache mapping &str -> &[u32]
-
         let BpeScratch {
             merge_queue,
             skip,
             word,
+            word_cache,
         } = scratch;
 
+        if let Some(cache) = word_cache
+            && let Some(hit) = cache.get(sequence)
+        {
+            output.extend(hit.iter().map(|&id| PipelineToken { id }));
+            return Ok(());
+        }
+
         self.merge_word(sequence, merge_queue, skip, word);
+
+        if let Some(cache) = word_cache {
+            cache.insert(sequence.to_string(), word.get_chars());
+        }
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
 
         Ok(())
@@ -850,6 +863,9 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
+            word_cache: self
+                .cache_capacity
+                .map(|capacity| WordCache::init(capacity)),
         }
     }
 }
@@ -858,17 +874,21 @@ pub struct BpeScratch {
     pub(crate) merge_queue: QuaternaryHeap<Merge>,
     pub(crate) skip: Vec<Merge>,
     pub(crate) word: Word,
+    pub(crate) word_cache: Option<WordCache>,
 }
+
 impl ModelScratch for BpeScratch {
     fn clear(&mut self) {
         let Self {
             merge_queue,
             skip,
             word,
+            word_cache: _cache,
         } = self;
         merge_queue.clear();
         skip.clear();
         word.clear();
+        // We don't reset _word_cache on purpose, so it stays warm for future callers
     }
 }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1435,6 +1435,25 @@ mod tests {
             assert!(pipeline_ids(&pipeline, "").is_empty());
         }
 
+        // The scratch pool hands the SAME scratch to successive encodes. A bug leaking
+        // state between calls (an undrained merge queue, a stale word buffer) would
+        // corrupt every encode after the first. Drive several inputs — including
+        // repeats and an empty string — through one reused scratch and check each still
+        // matches the fresh-scratch reference. This is the invariant the pool relies on.
+        #[test]
+        fn reused_scratch_matches_fresh() {
+            let bpe = hello_builder().build().unwrap();
+            let reference = bpe.clone();
+            let model = PipelineBPE::from_bpe(bpe, false).unwrap();
+            let mut scratch = model.init_scratch();
+            for input in ["hello", "hell", "helo", "oleh", "hello", "", "hxe"] {
+                let mut out = Vec::new();
+                pipeline::Model::tokenize_pipeline(&model, input, &mut scratch, &mut out).unwrap();
+                let got: Vec<u32> = out.iter().map(|t| t.id).collect();
+                assert_eq!(got, reference_ids(&reference, input), "{input:?}");
+            }
+        }
+
         #[test]
         fn unknown_char_without_unk_is_dropped() {
             let bpe = hello_builder().build().unwrap();

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -867,6 +867,7 @@ impl pipeline::Model for PipelineBPE {
     }
 }
 
+#[derive(Default)]
 pub struct BpeScratch {
     pub(crate) merge_queue: QuaternaryHeap<Merge>,
     pub(crate) skip: Vec<Merge>,

--- a/tokenizers/tk-encode/src/models/bpe/word.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word.rs
@@ -276,7 +276,7 @@ impl Word {
         self.get_chars_iter().collect()
     }
 
-    pub fn get_chars_iter(&self) -> impl Iterator<Item = u32> + '_ {
+    pub fn get_chars_iter(&self) -> impl ExactSizeIterator<Item = u32> + '_ {
         self.symbols.iter().map(|s| s.c)
     }
 

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,29 +1,83 @@
-use ahash::AHashMap;
+use std::ops::Range;
 
+use ahash::RandomState;
 
-/// naive implem of word -> IDs cache
+use crate::utils::cache::MAX_LENGTH;
+
+#[derive(Clone, Copy, Default)]
+struct CacheSlot {
+    hash: u64,
+    key_offsets: (u32, u16),
+    ids_offsets: (u32, u16),
+}
+
+impl CacheSlot {
+    fn id_range(&self) -> Range<usize> {
+        let (start, len) = self.ids_offsets;
+        start as usize..(start as usize + len as usize)
+    }
+
+    fn key_range(&self) -> Range<usize> {
+        let (start, len) = self.key_offsets;
+        start as usize..(start as usize + len as usize)
+    }
+}
+
 pub struct WordCache {
-    capacity: usize,
-    lookup: AHashMap<String, Box<[u32]>>,
+    hasher: RandomState,
+    slots: Box<[CacheSlot]>,
+    key_bytes: Vec<u8>,
+    ids: Vec<u32>,
+    slot_mask: u64,
 }
 
 impl WordCache {
-    pub fn new(capacity: usize) -> Self {
+    pub fn new() -> Self {
+        // todo: make capacity configurable
+        const CAPACITY: usize = 1 << 16;
+        const MASK: u64 = (CAPACITY as u64) - 1;
         Self {
-            capacity,
-            lookup: AHashMap::with_capacity(capacity),
+            hasher: RandomState::new(),
+            slots: vec![CacheSlot::default(); CAPACITY].into_boxed_slice(),
+            ids: Vec::with_capacity(CAPACITY * MAX_LENGTH),
+            key_bytes: Vec::with_capacity(CAPACITY * MAX_LENGTH),
+            slot_mask: MASK,
         }
     }
 
-    pub fn get(&self, key: &str) -> Option<&[u32]> {
-        self.lookup.get(key).map(|bx| &bx[..])
+    pub fn get(&self, key: &[u8]) -> Option<&[u32]> {
+        let hash = self.hasher.hash_one(key);
+        let slot = self.slots[(hash & self.slot_mask) as usize];
+        if hash != slot.hash {
+            return None;
+        }
+        if key != &self.key_bytes[slot.key_range()] {
+            return None;
+        }
+        Some(&self.ids[slot.id_range()])
     }
 
-    pub fn insert(&mut self, k: String, v: Vec<u32>) {
-        if self.lookup.len() >= self.capacity {
-            // Pop an arbitrary entry
-            self.lookup.extract_if(|_, _| true).next();
+    pub fn insert(&mut self, key: &[u8], ids: &[u32]) {
+        if key.len() > MAX_LENGTH {
+            return;
         }
-        self.lookup.insert(k, v.into_boxed_slice());
+        let hash = self.hasher.hash_one(key);
+        let slot_idx = (hash & self.slot_mask) as usize;
+
+        if self.slots[slot_idx].hash != 0 {
+            // slot already taken: skip insert
+            // caveat: a key whose hash lower bits resolves to 0 never gets cached
+            return;
+        }
+        let key_offsets = (self.key_bytes.len() as u32, key.len() as u16);
+        self.key_bytes.extend_from_slice(key);
+        let ids_offsets = (self.ids.len() as u32, ids.len() as u16);
+        self.ids.extend_from_slice(ids);
+
+        self.slots[slot_idx] = CacheSlot {
+            hash,
+            key_offsets,
+            ids_offsets,
+        };
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,0 +1,28 @@
+use ahash::AHashMap;
+
+/// naive implem of word -> IDs cache
+pub struct WordCache {
+    capacity: usize,
+    lookup: AHashMap<String, Box<[u32]>>,
+}
+
+impl WordCache {
+    pub fn init(capacity: usize) -> Self {
+        Self {
+            capacity,
+            lookup: AHashMap::with_capacity(capacity),
+        }
+    }
+
+    pub fn get<'a>(&'a self, key: &str) -> Option<&'a [u32]> {
+        self.lookup.get(key).map(|bx| &bx[..])
+    }
+
+    pub fn insert(&mut self, k: String, v: Vec<u32>) {
+        if self.lookup.len() >= self.capacity {
+            // Pop an arbitrary entry
+            self.lookup.extract_if(|_, _| true).next();
+        }
+        self.lookup.insert(k, v.into_boxed_slice());
+    }
+}

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -4,79 +4,131 @@ use ahash::RandomState;
 
 use crate::utils::cache::MAX_LENGTH;
 
+const WAYS: usize = 4;
+
 #[derive(Clone, Copy, Default)]
 struct CacheSlot {
-    hash: u64,
-    key_offsets: (u32, u16),
-    ids_offsets: (u32, u16),
+    tag: u32,
+    key_off: u32,
+    ids_off: u32,
+    key_len: u16,
+    ids_len: u16,
 }
+
+#[derive(Clone, Copy, Default)]
+#[repr(align(64))]
+struct Bucket([CacheSlot; WAYS]);
 
 impl CacheSlot {
     fn id_range(&self) -> Range<usize> {
-        let (start, len) = self.ids_offsets;
-        start as usize..(start as usize + len as usize)
+        self.ids_off as usize..(self.ids_off as usize + self.ids_len as usize)
     }
 
     fn key_range(&self) -> Range<usize> {
-        let (start, len) = self.key_offsets;
-        start as usize..(start as usize + len as usize)
+        self.key_off as usize..(self.key_off as usize + self.key_len as usize)
     }
 }
 
 pub struct WordCache {
     hasher: RandomState,
-    slots: Box<[CacheSlot]>,
+    buckets: Box<[Bucket]>,
     key_bytes: Vec<u8>,
     ids: Vec<u32>,
-    slot_mask: u64,
+    bucket_mask: u64,
 }
 
 impl WordCache {
-    pub fn new() -> Self {
-        // todo: make capacity configurable
-        const CAPACITY: usize = 1 << 16;
-        const MASK: u64 = (CAPACITY as u64) - 1;
+    pub fn new(capacity: usize) -> Self {
+        let n_buckets = (capacity.next_power_of_two() / WAYS).max(1);
         Self {
             hasher: RandomState::new(),
-            slots: vec![CacheSlot::default(); CAPACITY].into_boxed_slice(),
+            buckets: vec![Bucket::default(); n_buckets].into_boxed_slice(),
             ids: Vec::with_capacity(256),
             key_bytes: Vec::with_capacity(1024),
-            slot_mask: MASK,
+            bucket_mask: (n_buckets as u64) - 1,
         }
+    }
+
+    // The low hash bits pick the bucket index, the high bits form the occupancy tag
+	// 0x0 tag is reserved for empty spots (hence the `| 1`)
+    fn locate(&self, key: &[u8]) -> (usize, u32) {
+        let hash = self.hasher.hash_one(key);
+        ((hash & self.bucket_mask) as usize, (hash >> 32) as u32 | 1)
     }
 
     pub fn get(&self, key: &[u8]) -> Option<&[u32]> {
-        let hash = self.hasher.hash_one(key) | 1;
-        let slot = self.slots[(hash & self.slot_mask) as usize];
-        if hash != slot.hash {
+        if key.len() > MAX_LENGTH {
             return None;
         }
-        if key != &self.key_bytes[slot.key_range()] {
-            return None;
+        let (bucket_idx, tag) = self.locate(key);
+        for slot in &self.buckets[bucket_idx].0 {
+            if slot.tag == tag && key == &self.key_bytes[slot.key_range()] {
+                return Some(&self.ids[slot.id_range()]);
+            }
         }
-        Some(&self.ids[slot.id_range()])
+        None
     }
 
-    pub fn insert(&mut self, key: &[u8], ids: &[u32]) {
+    pub fn insert(&mut self, key: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
         if key.len() > MAX_LENGTH {
             return;
         }
-        let hash = self.hasher.hash_one(key) | 1;
-        let slot_idx = (hash & self.slot_mask) as usize;
-
-        if self.slots[slot_idx].hash != 0 {
-            // slot already taken: skip insert
+        let (bucket_idx, tag) = self.locate(key);
+        let Some(slot) = self.buckets[bucket_idx]
+            .0
+            .iter()
+            .position(|slot| slot.tag == 0)
+        else {
+            // bucket full: skip insert
             return;
-        }
-        let key_offsets = (self.key_bytes.len() as u32, key.len() as u16);
-        self.key_bytes.extend_from_slice(key);
-        let ids_offsets = (self.ids.len() as u32, ids.len() as u16);
-        self.ids.extend_from_slice(ids);
-
-        self.slots[slot_idx] = CacheSlot {
-            hash,
-            key_offsets,
-            ids_offsets,
         };
+        self.buckets[bucket_idx].0[slot] = CacheSlot {
+            tag,
+            key_off: self.key_bytes.len() as u32,
+            key_len: key.len() as u16,
+            ids_off: self.ids.len() as u32,
+            ids_len: ids.len() as u16,
+        };
+        self.key_bytes.extend_from_slice(key);
+        self.ids.extend(ids);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let mut cache = WordCache::new(1 << 8);
+        assert_eq!(cache.get(b"hello"), None);
+        cache.insert(b"hello", [1u32, 2, 3].into_iter());
+        cache.insert(b"world", [4u32].into_iter());
+        assert_eq!(cache.get(b"hello"), Some(&[1u32, 2, 3][..]));
+        assert_eq!(cache.get(b"world"), Some(&[4u32][..]));
+        assert_eq!(cache.get(b"hell"), None);
+    }
+
+    #[test]
+    fn single_bucket_holds_ways_entries_then_freezes() {
+        // capacity <= WAYS collapses to one bucket, making conflicts deterministic
+        let mut cache = WordCache::new(1);
+        let keys: Vec<Vec<u8>> = (0..WAYS as u8 + 2).map(|i| vec![i; 3]).collect();
+        for (i, key) in keys.iter().enumerate() {
+            cache.insert(key, [i as u32].into_iter());
+        }
+        let cached = keys.iter().filter(|k| cache.get(k).is_some()).count();
+        assert_eq!(cached, WAYS);
+        for (i, key) in keys.iter().enumerate().take(WAYS) {
+            assert_eq!(cache.get(key), Some(&[i as u32][..]));
+        }
+    }
+
+    #[test]
+    fn oversized_keys_are_ignored() {
+        let mut cache = WordCache::new(1 << 8);
+        let big = vec![7u8; MAX_LENGTH + 1];
+        cache.insert(&big, [1u32].into_iter());
+        assert_eq!(cache.get(&big), None);
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,6 +1,5 @@
 use ahash::AHashMap;
 
-pub(crate) const MAX_SEQUENCE_SIZE: usize = 256;
 
 /// naive implem of word -> IDs cache
 pub struct WordCache {

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,5 +1,7 @@
 use ahash::AHashMap;
 
+pub(crate) const MAX_SEQUENCE_SIZE: usize = 256;
+
 /// naive implem of word -> IDs cache
 pub struct WordCache {
     capacity: usize,
@@ -7,14 +9,14 @@ pub struct WordCache {
 }
 
 impl WordCache {
-    pub fn init(capacity: usize) -> Self {
+    pub fn new(capacity: usize) -> Self {
         Self {
             capacity,
             lookup: AHashMap::with_capacity(capacity),
         }
     }
 
-    pub fn get<'a>(&'a self, key: &str) -> Option<&'a [u32]> {
+    pub fn get(&self, key: &str) -> Option<&[u32]> {
         self.lookup.get(key).map(|bx| &bx[..])
     }
 

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -39,14 +39,14 @@ impl WordCache {
         Self {
             hasher: RandomState::new(),
             slots: vec![CacheSlot::default(); CAPACITY].into_boxed_slice(),
-            ids: Vec::with_capacity(CAPACITY * MAX_LENGTH),
-            key_bytes: Vec::with_capacity(CAPACITY * MAX_LENGTH),
+            ids: Vec::with_capacity(256),
+            key_bytes: Vec::with_capacity(1024),
             slot_mask: MASK,
         }
     }
 
     pub fn get(&self, key: &[u8]) -> Option<&[u32]> {
-        let hash = self.hasher.hash_one(key);
+        let hash = self.hasher.hash_one(key) | 1;
         let slot = self.slots[(hash & self.slot_mask) as usize];
         if hash != slot.hash {
             return None;
@@ -61,12 +61,11 @@ impl WordCache {
         if key.len() > MAX_LENGTH {
             return;
         }
-        let hash = self.hasher.hash_one(key);
+        let hash = self.hasher.hash_one(key) | 1;
         let slot_idx = (hash & self.slot_mask) as usize;
 
         if self.slots[slot_idx].hash != 0 {
             // slot already taken: skip insert
-            // caveat: a key whose hash lower bits resolves to 0 never gets cached
             return;
         }
         let key_offsets = (self.key_bytes.len() as u32, key.len() as u16);

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -50,7 +50,7 @@ impl WordCache {
     }
 
     // The low hash bits pick the bucket index, the high bits form the occupancy tag
-	// 0x0 tag is reserved for empty spots (hence the `| 1`)
+    // 0x0 tag is reserved for empty spots (hence the `| 1`)
     fn locate(&self, key: &[u8]) -> (usize, u32) {
         let hash = self.hasher.hash_one(key);
         ((hash & self.bucket_mask) as usize, (hash >> 32) as u32 | 1)

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -505,7 +505,12 @@ impl Model for Unigram {
 
 pub struct UnigramScratch {}
 
-impl pipeline::ModelScratch for UnigramScratch {}
+impl pipeline::ModelScratch for UnigramScratch {
+    fn clear(&mut self) {
+        // Using this syntax so adding fields to Unigram would trigger a compile error
+        let Self {} = self;
+    }
+}
 
 impl pipeline::Model for Unigram {
     type Scratch = UnigramScratch;

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -503,6 +503,7 @@ impl Model for Unigram {
     }
 }
 
+#[derive(Default)]
 pub struct UnigramScratch {}
 
 impl pipeline::ModelScratch for UnigramScratch {

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -208,7 +208,12 @@ impl Model for WordLevel {
 }
 
 type WordLevelScratch = ();
-impl ModelScratch for WordLevelScratch {}
+
+impl ModelScratch for WordLevelScratch {
+    fn clear(&mut self) {
+        // noop: wordlevel does not have a scratch
+    }
+}
 
 impl pipeline::Model for WordLevel {
     type Scratch = WordLevelScratch;

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -318,7 +318,12 @@ pub struct WordPieceScratch {
     candidate_str: String,
 }
 
-impl pipeline::ModelScratch for WordPieceScratch {}
+impl pipeline::ModelScratch for WordPieceScratch {
+    fn clear(&mut self) {
+        let Self { candidate_str } = self;
+        candidate_str.clear();
+    }
+}
 
 pub struct PipelineWordPiece {
     vocab_trie: yada::DoubleArray<Vec<u8>>,

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -314,6 +314,7 @@ impl Model for WordPiece {
     }
 }
 
+#[derive(Default)]
 pub struct WordPieceScratch {
     candidate_str: String,
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
-use std::sync::{Mutex, PoisonError};
+use std::mem;
+use std::sync::{Arc, Mutex, PoisonError};
 use std::{borrow::Cow, convert::TryFrom};
 
 use atomsplit::classify::classify;
@@ -280,22 +281,22 @@ pub struct PipelineTokenizer {
 }
 
 struct ScratchPool {
-    pool: Mutex<Vec<PipelineModelScratch>>,
+    pool: Arc<Mutex<Vec<PipelineModelScratch>>>,
 }
 
 impl ScratchPool {
     fn new() -> Self {
         Self {
-            pool: Mutex::new(Vec::new()),
+            pool: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
     fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
-        let maybe_scratch = self
-            .pool
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .pop(); // Release the lock
+        let maybe_scratch = {
+            let mut pool = self.pool.lock().unwrap_or_else(PoisonError::into_inner);
+            pool.pop()
+        };
+        // Lock is released here
 
         let scratch = maybe_scratch
             .map(|mut scratch| {
@@ -306,42 +307,39 @@ impl ScratchPool {
             .unwrap_or_else(|| model.init_scratch()); // If there is no scratch in the pool, init a fresh one
 
         ScratchGuard {
-            scratch: Some(scratch),
-            pool: self,
+            scratch,
+            scratch_pool: self,
         }
     }
 }
 
 /// RAAI guard for a scratch that adds it back to the pool whenever the scratch gets dropped
 struct ScratchGuard<'a> {
-    // Option so we can use `.take()` to reclaim ownership of the scratch
-    // to push it back to the pool
-    scratch: Option<PipelineModelScratch>,
-    pool: &'a ScratchPool,
+    scratch: PipelineModelScratch,
+    scratch_pool: &'a ScratchPool,
 }
 
 impl Drop for ScratchGuard<'_> {
     fn drop(&mut self) {
-        if let Some(scratch) = self.scratch.take() {
-            self.pool
-                .pool
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
-                .push(scratch);
-        }
+        let scratch = mem::take(&mut self.scratch);
+        self.scratch_pool
+            .pool
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(scratch);
     }
 }
 
 impl std::ops::Deref for ScratchGuard<'_> {
     type Target = PipelineModelScratch;
     fn deref(&self) -> &PipelineModelScratch {
-        self.scratch.as_ref().unwrap()
+        &self.scratch
     }
 }
 
 impl std::ops::DerefMut for ScratchGuard<'_> {
     fn deref_mut(&mut self) -> &mut PipelineModelScratch {
-        self.scratch.as_mut().unwrap()
+        &mut self.scratch
     }
 }
 
@@ -765,7 +763,7 @@ pub fn split_matches(
     }
 }
 
-pub trait ModelScratch {
+pub trait ModelScratch: Default {
     fn clear(&mut self);
 }
 
@@ -829,11 +827,14 @@ impl Model for PipelineModel {
     }
 }
 
+#[derive(Default)]
 pub enum PipelineModelScratch {
     BPE(BpeScratch),
     WordLevel(()),
     WordPiece(WordPieceScratch),
     Unigram(UnigramScratch),
+    #[default]
+    None,
 }
 
 impl ModelScratch for PipelineModelScratch {
@@ -843,6 +844,7 @@ impl ModelScratch for PipelineModelScratch {
             PipelineModelScratch::Unigram(scratch) => scratch.clear(),
             PipelineModelScratch::WordLevel(scratch) => scratch.clear(),
             PipelineModelScratch::WordPiece(scratch) => scratch.clear(),
+            PipelineModelScratch::None => {}
         }
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
+use std::sync::{Mutex, PoisonError};
 use std::{borrow::Cow, convert::TryFrom};
 
 use atomsplit::classify::classify;
@@ -274,7 +275,86 @@ pub struct PipelineTokenizer {
     normalizer: Option<NormalizerWrapper>,
     pre_tokenizer: PipelinePreTokenizer,
     model: PipelineModel,
+    scratch_pool: ScratchPool,
     _post_processor: Option<PostProcessorWrapper>,
+}
+
+/// A pool of reusable per-encode scratch buffers, owned by the [`PipelineTokenizer`].
+/// [`encode`](PipelineTokenizer::encode) checks a scratch out and returns it on drop,
+/// so the tokenizer keeps a `&self` (hence `Sync`) API — `par_iter().map(|s|
+/// tok.encode(s))` just works — while each concurrent caller still gets private,
+/// warm scratch. This is the pattern `regex` uses to present `Regex: Sync` without a
+/// caller-visible cache handle.
+///
+/// The pool's lifetime is the tokenizer's: nothing is process-global (unlike a
+/// `thread_local!`), so idle scratch is freed when the tokenizer drops, and every
+/// scratch it holds was built by this instance's model — a foreign-vocab scratch is
+/// unrepresentable.
+struct ScratchPool {
+    // Not boxed: checkout is once per `encode` call (µs–ms), so the cost of moving a
+    // scratch on/off the freelist is noise — the pointer-indirection trick pays off
+    // only at regex-automata's per-search granularity.
+    idle: Mutex<Vec<PipelineModelScratch>>,
+}
+
+impl ScratchPool {
+    fn new() -> Self {
+        Self {
+            idle: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Check out a scratch — a warm one off the freelist, or a fresh one built from
+    /// `model`. Population self-limits to the peak number of concurrent encodes, so
+    /// there is no cap or eviction policy to tune. The lock is held for one `pop`
+    /// (nanoseconds) and taken once per `encode`, never per pre-token.
+    fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
+        let scratch = self
+            .idle
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) // a poisoned freelist is still a freelist
+            .pop()
+            .unwrap_or_else(|| model.init_scratch());
+        ScratchGuard {
+            scratch: Some(scratch),
+            pool: self,
+        }
+    }
+}
+
+/// RAII checkout: returns its scratch to the pool on drop.
+struct ScratchGuard<'a> {
+    // `Option` only so `Drop` can move the scratch back out.
+    scratch: Option<PipelineModelScratch>,
+    pool: &'a ScratchPool,
+}
+
+impl Drop for ScratchGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(scratch) = self.scratch.take() {
+            // No reset needed: the model's scratch buffers self-clear at the start of
+            // each tokenize (`merge_all` clears the queue/skip, `merge_word` the word,
+            // WordPiece its candidate string). Keeping the allocation warm is the point.
+            self.pool
+                .idle
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(scratch);
+        }
+    }
+}
+
+impl std::ops::Deref for ScratchGuard<'_> {
+    type Target = PipelineModelScratch;
+    fn deref(&self) -> &PipelineModelScratch {
+        self.scratch.as_ref().unwrap()
+    }
+}
+
+impl std::ops::DerefMut for ScratchGuard<'_> {
+    fn deref_mut(&mut self) -> &mut PipelineModelScratch {
+        self.scratch.as_mut().unwrap()
+    }
 }
 
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
@@ -372,6 +452,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             normalizer: tok.get_normalizer().cloned(),
             pre_tokenizer,
             model,
+            scratch_pool: ScratchPool::new(),
             _post_processor: tok.get_post_processor().cloned(),
         })
     }
@@ -404,7 +485,7 @@ impl PipelineTokenizer {
     pub fn encode(&self, input: &str, _add_special_tokens: bool) -> Result<Vec<PipelineToken>> {
         let mut output = Vec::new();
         let mut pre_tokens = Vec::new();
-        let mut scratch = self.model.init_scratch();
+        let mut scratch = self.scratch_pool.get(&self.model);
 
         self.encode_generic::<{ Self::STAGE_MODEL }>(
             input,
@@ -850,5 +931,61 @@ mod tests {
         tok.with_pre_tokenizer(Some(ByteLevel::new(false, true, true)));
         let err = conversion_error(&tok);
         assert!(err.contains("not supported with model"), "{}", err);
+    }
+
+    // The scratch pool exists so ONE `&self` tokenizer can be shared across rayon
+    // workers. Encode the same input from thousands of threads through a single shared
+    // instance; each must get private scratch and produce the sequential result. A
+    // data race or shared-scratch bug would corrupt some — and this only compiles if
+    // `PipelineTokenizer: Sync`, which the pool must preserve.
+    #[test]
+    fn encode_shared_across_threads_via_pool() {
+        use crate::models::bpe::{BpeBuilder, Merges, Vocab};
+        use rayon::prelude::*;
+
+        let vocab: Vocab = [
+            ("h", 0u32),
+            ("e", 1),
+            ("l", 2),
+            ("o", 3),
+            ("he", 4),
+            ("hel", 5),
+            ("hell", 6),
+            ("hello", 7),
+        ]
+        .into_iter()
+        .map(|(s, i)| (s.to_string(), i))
+        .collect();
+        let merges: Merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+            ("hel".to_string(), "l".to_string()),
+            ("hell".to_string(), "o".to_string()),
+        ];
+        let bpe = BpeBuilder::default()
+            .vocab_and_merges(vocab, merges)
+            .build()
+            .unwrap();
+        let tok = Tokenizer::new(bpe);
+        let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
+
+        let want: Vec<u32> = pipeline
+            .encode("hello", false)
+            .unwrap()
+            .iter()
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(want, vec![7]);
+
+        let all_match = (0..10_000u32).into_par_iter().all(|_| {
+            pipeline
+                .encode("hello", false)
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect::<Vec<_>>()
+                == want
+        });
+        assert!(all_match);
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -279,42 +279,32 @@ pub struct PipelineTokenizer {
     _post_processor: Option<PostProcessorWrapper>,
 }
 
-/// A pool of reusable per-encode scratch buffers, owned by the [`PipelineTokenizer`].
-/// [`encode`](PipelineTokenizer::encode) checks a scratch out and returns it on drop,
-/// so the tokenizer keeps a `&self` (hence `Sync`) API — `par_iter().map(|s|
-/// tok.encode(s))` just works — while each concurrent caller still gets private,
-/// warm scratch. This is the pattern `regex` uses to present `Regex: Sync` without a
-/// caller-visible cache handle.
-///
-/// The pool's lifetime is the tokenizer's: nothing is process-global (unlike a
-/// `thread_local!`), so idle scratch is freed when the tokenizer drops, and every
-/// scratch it holds was built by this instance's model — a foreign-vocab scratch is
-/// unrepresentable.
 struct ScratchPool {
-    // Not boxed: checkout is once per `encode` call (µs–ms), so the cost of moving a
-    // scratch on/off the freelist is noise — the pointer-indirection trick pays off
-    // only at regex-automata's per-search granularity.
-    idle: Mutex<Vec<PipelineModelScratch>>,
+    pool: Mutex<Vec<PipelineModelScratch>>,
 }
 
 impl ScratchPool {
     fn new() -> Self {
         Self {
-            idle: Mutex::new(Vec::new()),
+            pool: Mutex::new(Vec::new()),
         }
     }
 
-    /// Check out a scratch — a warm one off the freelist, or a fresh one built from
-    /// `model`. Population self-limits to the peak number of concurrent encodes, so
-    /// there is no cap or eviction policy to tune. The lock is held for one `pop`
-    /// (nanoseconds) and taken once per `encode`, never per pre-token.
     fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
-        let scratch = self
-            .idle
+        let maybe_scratch = self
+            .pool
             .lock()
-            .unwrap_or_else(PoisonError::into_inner) // a poisoned freelist is still a freelist
-            .pop()
-            .unwrap_or_else(|| model.init_scratch());
+            .unwrap_or_else(PoisonError::into_inner)
+            .pop(); // Release the lock
+
+        let scratch = maybe_scratch
+            .map(|mut scratch| {
+                // Lazily clear the cache
+                scratch.clear();
+                scratch
+            })
+            .unwrap_or_else(|| model.init_scratch()); // If there is no scratch in the pool, init a fresh one
+
         ScratchGuard {
             scratch: Some(scratch),
             pool: self,
@@ -322,9 +312,10 @@ impl ScratchPool {
     }
 }
 
-/// RAII checkout: returns its scratch to the pool on drop.
+/// RAAI guard for a scratch that adds it back to the pool whenever the scratch gets dropped
 struct ScratchGuard<'a> {
-    // `Option` only so `Drop` can move the scratch back out.
+    // Option so we can use `.take()` to reclaim ownership of the scratch
+    // to push it back to the pool
     scratch: Option<PipelineModelScratch>,
     pool: &'a ScratchPool,
 }
@@ -332,11 +323,8 @@ struct ScratchGuard<'a> {
 impl Drop for ScratchGuard<'_> {
     fn drop(&mut self) {
         if let Some(scratch) = self.scratch.take() {
-            // No reset needed: the model's scratch buffers self-clear at the start of
-            // each tokenize (`merge_all` clears the queue/skip, `merge_word` the word,
-            // WordPiece its candidate string). Keeping the allocation warm is the point.
             self.pool
-                .idle
+                .pool
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner)
                 .push(scratch);
@@ -777,7 +765,9 @@ pub fn split_matches(
     }
 }
 
-pub trait ModelScratch {}
+pub trait ModelScratch {
+    fn clear(&mut self);
+}
 
 pub trait Model {
     type Scratch: ModelScratch;
@@ -846,7 +836,16 @@ pub enum PipelineModelScratch {
     Unigram(UnigramScratch),
 }
 
-impl ModelScratch for PipelineModelScratch {}
+impl ModelScratch for PipelineModelScratch {
+    fn clear(&mut self) {
+        match self {
+            PipelineModelScratch::BPE(scratch) => scratch.clear(),
+            PipelineModelScratch::Unigram(scratch) => scratch.clear(),
+            PipelineModelScratch::WordLevel(scratch) => scratch.clear(),
+            PipelineModelScratch::WordPiece(scratch) => scratch.clear(),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/utils/cache.rs
+++ b/tokenizers/tk-encode/src/utils/cache.rs
@@ -4,10 +4,10 @@ use std::hash::Hash;
 use std::sync::RwLock;
 
 /// The default capacity for a `BPE`'s internal cache.
-pub static DEFAULT_CACHE_CAPACITY: usize = 1 << 16;
+pub static DEFAULT_CACHE_CAPACITY: usize = 65_536;
 /// The maximum length we should cache in a model
 /// Strings that are too long have minimal chances to cache hit anyway
-pub static MAX_LENGTH: usize = 128;
+pub static MAX_LENGTH: usize = 256;
 
 /// Provides a simple multithread cache to speed up BPE tokenization that will try to read values
 /// concurrently but won't block if another thread is writing.

--- a/tokenizers/tk-encode/src/utils/cache.rs
+++ b/tokenizers/tk-encode/src/utils/cache.rs
@@ -4,10 +4,10 @@ use std::hash::Hash;
 use std::sync::RwLock;
 
 /// The default capacity for a `BPE`'s internal cache.
-pub static DEFAULT_CACHE_CAPACITY: usize = 1 << 32;
+pub static DEFAULT_CACHE_CAPACITY: usize = 1 << 16;
 /// The maximum length we should cache in a model
 /// Strings that are too long have minimal chances to cache hit anyway
-pub static MAX_LENGTH: usize = 256;
+pub static MAX_LENGTH: usize = 128;
 
 /// Provides a simple multithread cache to speed up BPE tokenization that will try to read values
 /// concurrently but won't block if another thread is writing.

--- a/tokenizers/tk-encode/src/utils/cache.rs
+++ b/tokenizers/tk-encode/src/utils/cache.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use std::sync::RwLock;
 
 /// The default capacity for a `BPE`'s internal cache.
-pub static DEFAULT_CACHE_CAPACITY: usize = 10_000;
+pub static DEFAULT_CACHE_CAPACITY: usize = 1 << 32;
 /// The maximum length we should cache in a model
 /// Strings that are too long have minimal chances to cache hit anyway
 pub static MAX_LENGTH: usize = 256;


### PR DESCRIPTION
Stacks on #2223. Profiles [marcelroed/gigatoken](https://github.com/marcelroed/gigatoken) 0.9.0 per encode step and compares each stage to what tk-encode already has, to decide what's worth porting.

**Adds** (`tk-encode/benches/notes/`): the analysis doc + the reproduction harness (`gigatoken_profile_steps.rs` — drop into a gigatoken clone as `examples/profile_steps.rs`). No workspace deps added (gigatoken is edition-2024 + pyo3/parquet/icu — too heavy to vendor as a dev-dep).

**Finding:** merge dominates (1.5–25 ns/B) by ~10× over split+probe+added (<4 ns/B); warm all-hit encode is 0.86–5.7 ns/B. The only throughput levers are cache hit rate and merge speed.

**Verdict:**
- **Take:** inline value packing in `WordCache` (98% of pretokens are ≤2 ids → drop the second arena load); `PairRankTable` for the merge path (bench head-to-head — merge is the dominant cost); fused key-hash-in-span-walk.
- **Have (≥):** normalization (atomnorm ahead), split (atomsplit comparable), the 4-way L2 `WordCache` — correct for inference; gigatoken's is DRAM/training-tuned, do not swap.
- **Skip:** huge pages, prefetch ladder, DRAM-resident growth (only pay >64 MB), asm csel probe, parquet/py-bindings.

Draft — this is a notes/analysis PR, not shippable code.