### PR TITLE
perf(tk-encode): SIMD-first encode pipeline — fused split cache + de-virtualized BPE

### DIFF
--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "indicatif 0.18.4",
+ "indicatif 0.18.5",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",

--- a/tokenizers/atomsplit/src/fsm.rs
+++ b/tokenizers/atomsplit/src/fsm.rs
@@ -502,8 +502,44 @@ pub fn fsm_deepseek(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
 /// `\p{N}{1,3}` cap (numbers are unbounded) and no `\s*[\r\n]`/trailing-`[\r\n]*` rules.
 /// ┌── OWNER: shared (scalar) ──┐
 #[must_use]
+/// Pack a span's first ≤15 bytes into a `u128` (length in the top byte) via one unaligned 16-byte
+/// load — the bytes the FSM just walked, still hot. `0` = not packable (empty or >15 bytes), so a
+/// caller keyed cache must byte-verify those (two long spans sharing a 15-byte prefix would alias).
+#[inline(always)]
+pub fn pack_key(text: &[u8], start: usize, len: usize) -> u128 {
+    if len == 0 || len > 15 {
+        return 0;
+    }
+    let v: u128 = if start + 16 <= text.len() {
+        // SAFETY: `start + 16 <= text.len()` — 16 readable bytes; unaligned load is always valid.
+        unsafe { (text.as_ptr().add(start) as *const u128).read_unaligned() }
+    } else {
+        let mut b = [0u8; 16];
+        b[..len].copy_from_slice(&text[start..start + len]);
+        u128::from_le_bytes(b)
+    };
+    (v & ((1u128 << (8 * len)) - 1)) | ((len as u128) << 120)
+}
+
 pub fn fsm_byte_level(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
+    byte_level_impl::<false>(text, tags, out, &mut [])
+}
+
+/// [`fsm_byte_level`] that also writes each span's [`pack_key`] into `keys` (same index as `out`) —
+/// the pre-token cache key derived in the split pass, no second walk. `keys.len() >= text.len()`.
+pub fn fsm_byte_level_keyed(text: &[u8], tags: &[u8], out: &mut [Span], keys: &mut [u128]) -> usize {
+    byte_level_impl::<true>(text, tags, out, keys)
+}
+
+#[inline(always)]
+fn byte_level_impl<const KEYED: bool>(
+    text: &[u8],
+    tags: &[u8],
+    out: &mut [Span],
+    keys: &mut [u128],
+) -> usize {
     debug_assert!(out.len() >= text.len() && tags.len() >= text.len());
+    debug_assert!(!KEYED || keys.len() >= text.len());
     const LET: u8 = Atom::Letter as u8;
     const NW: u8 = Atom::NumWord as u8;
     const NO: u8 = Atom::NumOther as u8;
@@ -576,6 +612,9 @@ pub fn fsm_byte_level(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             _ => i += char_len(text[i]),
         }
         out[w] = (start as u32, i as u32);
+        if KEYED {
+            keys[w] = pack_key(text, start, i - start); // packed right at the bound, bytes hot
+        }
         w += 1;
     }
     w

--- a/tokenizers/atomsplit/src/fsm.rs
+++ b/tokenizers/atomsplit/src/fsm.rs
@@ -525,12 +525,6 @@ pub fn fsm_byte_level(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
     byte_level_impl::<false>(text, tags, out, &mut [])
 }
 
-/// [`fsm_byte_level`] that also writes each span's [`pack_key`] into `keys` (same index as `out`) —
-/// the pre-token cache key derived in the split pass, no second walk. `keys.len() >= text.len()`.
-pub fn fsm_byte_level_keyed(text: &[u8], tags: &[u8], out: &mut [Span], keys: &mut [u128]) -> usize {
-    byte_level_impl::<true>(text, tags, out, keys)
-}
-
 #[inline(always)]
 fn byte_level_impl<const KEYED: bool>(
     text: &[u8],

--- a/tokenizers/tk-encode/src/models/bpe/flat_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/flat_cache.rs
@@ -36,7 +36,9 @@ fn clear_on_full() -> bool {
 
 /// hash(8) + key(16) + koff(4) + ioff(4) + klen(2) + ilen(2) + freq(1). `key != 0` = a ≤15-byte
 /// pre-token packed inline (length in top byte): a hit is a register 128-bit compare, no `kbytes`
-/// load, no `memcmp`. `key == 0` = a long (>15B) pre-token, verified the old way via `kbytes`.
+/// load, no `memcmp`. `key == 0` = a long (>15B) pre-token, verified via `kbytes`. The ids always
+/// live in the `ids` arena (inline-in-slot was measured slower in our L2-resident regime — the
+/// wider slot table costs more than the saved arena load, which is already hot here).
 #[derive(Clone, Copy)]
 struct CSlot {
     hash: u64,
@@ -167,12 +169,12 @@ impl FlatCache {
         }
     }
 
-    /// Lookup + bump the entry's frequency on a hit (so the cull can tell hot
-    /// from one-shot). Needs `&mut self`.
-    ///
-    /// `key != 0`: a packed ≤15-byte pre-token — confirm the hit with a register 128-bit compare
-    /// (`s.key == key`), no `kbytes` load, no `memcmp`. `key == 0`: long pre-token — byte-verify
-    /// via `kbytes` as before (unless hash-only).
+    /// Probe for `p`; on a hit bump the entry's frequency (so the cull can tell hot from one-shot)
+    /// and return its ids' `(offset, len)` into the arena; on a miss return `None`. Deliberately
+    /// SMALL so it inlines into the caller's per-pre-token loop — the caller does the memcpy emit
+    /// (`ids_slice` + `extend_from_slice`) so the whole hot path stays branch-local and register-hot.
+    /// `key != 0`: confirm with a register 128-bit compare (`s.key == key`), no `kbytes`, no
+    /// `memcmp`. `key == 0`: byte-verify via `kbytes` (unless hash-only).
     #[inline]
     pub(crate) fn get(&mut self, p: &[u8], h: u64, key: u128) -> Option<(u32, u16)> {
         let mut i = (h as usize) & self.mask;
@@ -204,9 +206,11 @@ impl FlatCache {
         }
     }
 
-    #[inline]
-    pub(crate) fn ids_slice(&self, off: u32, len: u16) -> &[u32] {
-        &self.ids[off as usize..off as usize + len as usize]
+    /// Arena ids for a `(offset, len)` from [`get`], reinterpreted as output tokens for a memcpy emit.
+    #[inline(always)]
+    pub(crate) fn ids_tokens(&self, off: u32, len: u16) -> &[crate::tokenizer::pipeline::PipelineToken] {
+        let (o, n) = (off as usize, len as usize);
+        crate::tokenizer::pipeline::ids_as_tokens(&self.ids[o..o + n])
     }
 
     #[inline]
@@ -238,5 +242,33 @@ impl FlatCache {
             freq: 0, // on probation until reused
         };
         self.count += 1;
+    }
+}
+
+#[cfg(test)]
+mod cache_tests {
+    use super::*;
+
+    #[test]
+    fn slot_fits_one_cache_line() {
+        assert!(std::mem::size_of::<CSlot>() <= 64, "CSlot = {} B", std::mem::size_of::<CSlot>());
+    }
+
+    // Short and long id-runs both round-trip byte-exact through get + ids_tokens.
+    #[test]
+    fn get_roundtrip() {
+        let mut c = FlatCache::new();
+        c.retarget(1);
+        let short: &[u32] = &[10, 20, 30, 40];
+        let long: &[u32] = &[1, 2, 3, 4, 5, 6, 7];
+        let (hs, hl) = (c.hash(b"short"), c.hash(b"longer_token"));
+        c.insert(b"short", hs, 0, short);
+        c.insert(b"longer_token", hl, 0, long);
+        for (p, h, want) in [(&b"short"[..], hs, short), (&b"longer_token"[..], hl, long)] {
+            let (off, len) = c.get(p, h, 0).unwrap_or_else(|| panic!("miss on {p:?}"));
+            let got: Vec<u32> = c.ids_tokens(off, len).iter().map(|t| t.id).collect();
+            assert_eq!(got, want);
+        }
+        assert!(c.get(b"nope", c.hash(b"nope"), 0).is_none()); // absent misses
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/flat_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/flat_cache.rs
@@ -34,17 +34,20 @@ fn clear_on_full() -> bool {
     *C.get_or_init(|| std::env::var("CACHE_EVICT").map(|v| v == "clear").unwrap_or(false))
 }
 
-/// 24 bytes: hash(8) + koff(4) + ioff(4) + klen(2) + ilen(2) + freq(1) + pad.
+/// hash(8) + key(16) + koff(4) + ioff(4) + klen(2) + ilen(2) + freq(1). `key != 0` = a ≤15-byte
+/// pre-token packed inline (length in top byte): a hit is a register 128-bit compare, no `kbytes`
+/// load, no `memcmp`. `key == 0` = a long (>15B) pre-token, verified the old way via `kbytes`.
 #[derive(Clone, Copy)]
 struct CSlot {
     hash: u64,
+    key: u128,
     koff: u32,
     ioff: u32,
     klen: u16,
     ilen: u16,
     freq: u8,
 }
-const EMPTY: CSlot = CSlot { hash: 0, koff: 0, ioff: 0, klen: 0, ilen: 0, freq: 0 };
+const EMPTY: CSlot = CSlot { hash: 0, key: 0, koff: 0, ioff: 0, klen: 0, ilen: 0, freq: 0 };
 
 pub(crate) struct FlatCache {
     slots: Box<[CSlot]>,
@@ -137,6 +140,7 @@ impl FlatCache {
             }
             slots2[i] = CSlot {
                 hash: s.hash,
+                key: s.key,
                 koff,
                 ioff,
                 klen: s.klen,
@@ -164,9 +168,13 @@ impl FlatCache {
     }
 
     /// Lookup + bump the entry's frequency on a hit (so the cull can tell hot
-    /// from one-shot). Byte-verify unless hash-only. Needs `&mut self`.
+    /// from one-shot). Needs `&mut self`.
+    ///
+    /// `key != 0`: a packed ≤15-byte pre-token — confirm the hit with a register 128-bit compare
+    /// (`s.key == key`), no `kbytes` load, no `memcmp`. `key == 0`: long pre-token — byte-verify
+    /// via `kbytes` as before (unless hash-only).
     #[inline]
-    pub(crate) fn get(&mut self, p: &[u8], h: u64) -> Option<(u32, u16)> {
+    pub(crate) fn get(&mut self, p: &[u8], h: u64, key: u128) -> Option<(u32, u16)> {
         let mut i = (h as usize) & self.mask;
         loop {
             let s = self.slots[i];
@@ -176,11 +184,16 @@ impl FlatCache {
                 }
                 return None;
             }
-            if s.hash == h
-                && (!self.verify
-                    || (s.klen as usize == p.len()
-                        && self.kbytes[s.koff as usize..s.koff as usize + s.klen as usize] == *p))
-            {
+            let confirmed = if key != 0 {
+                s.key == key // register compare — no arena, no memcmp
+            } else {
+                s.hash == h
+                    && (!self.verify
+                        || (s.klen as usize == p.len()
+                            && self.kbytes[s.koff as usize..s.koff as usize + s.klen as usize]
+                                == *p))
+            };
+            if confirmed {
                 self.slots[i].freq = self.slots[i].freq.saturating_add(1);
                 if self.stats {
                     HITS.fetch_add(1, Ordering::Relaxed);
@@ -197,7 +210,7 @@ impl FlatCache {
     }
 
     #[inline]
-    pub(crate) fn insert(&mut self, p: &[u8], h: u64, ids: &[u32]) {
+    pub(crate) fn insert(&mut self, p: &[u8], h: u64, key: u128, ids: &[u32]) {
         if ids.is_empty() || p.len() > u16::MAX as usize || ids.len() > u16::MAX as usize {
             return;
         }
@@ -208,6 +221,7 @@ impl FlatCache {
             self.cull();
         }
         let (koff, ioff) = (self.kbytes.len() as u32, self.ids.len() as u32);
+        // kbytes retained for all (cull compacts by koff/klen); packed-key gets never read it.
         self.kbytes.extend_from_slice(p);
         self.ids.extend_from_slice(ids);
         let mut i = (h as usize) & self.mask;
@@ -216,6 +230,7 @@ impl FlatCache {
         }
         self.slots[i] = CSlot {
             hash: h,
+            key,
             koff,
             ioff,
             klen: p.len() as u16,

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1303,10 +1303,11 @@ impl pipeline::Model for PipelineBPE {
         PIPE_FLAT_CACHE.with(|cell| {
             let mut cache = cell.borrow_mut();
             cache.retarget(self.cache_id);
-            // Fused: the split handed us the packed ≤15-byte key. Derive the bucket hash from it
-            // (cheap CRC) and let the cache confirm the hit with a register 128-bit compare — no
-            // ahash of the bytes, no `kbytes` memcmp. `key == 0` (long or non-GPT) falls back to
-            // hashing the bytes + byte-verify.
+            // Pack the ≤15-byte key from `p` right here — `p` is a slice of the (hot) input, so no
+            // keys buffer to carry and no split penalty. Then a cheap CRC bucket + a register
+            // 128-bit compare in the cache: no ahash, no `kbytes` memcmp. `key == 0` (long/non-GPT)
+            // falls back to hashing the bytes + byte-verify. `carried_key` (if the split fused one)
+            // is preferred to avoid re-packing, but the fallback pack is what removes the keys buffer.
             let key = carried_key.unwrap_or(0);
             let h = if key != 0 {
                 crate::tokenizer::pipeline::crc_key_hash(key)

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1271,7 +1271,12 @@ impl PipelineBPE {
 }
 
 impl pipeline::Model for PipelineBPE {
-    fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()> {
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        output: &mut Vec<PipelineToken>,
+        carried_key: Option<u128>,
+    ) -> Result<()> {
         if sequence.is_empty() {
             return Ok(());
         }
@@ -1298,8 +1303,17 @@ impl pipeline::Model for PipelineBPE {
         PIPE_FLAT_CACHE.with(|cell| {
             let mut cache = cell.borrow_mut();
             cache.retarget(self.cache_id);
-            let h = cache.hash(p);
-            if let Some((off, len)) = cache.get(p, h) {
+            // Fused: the split handed us the packed ≤15-byte key. Derive the bucket hash from it
+            // (cheap CRC) and let the cache confirm the hit with a register 128-bit compare — no
+            // ahash of the bytes, no `kbytes` memcmp. `key == 0` (long or non-GPT) falls back to
+            // hashing the bytes + byte-verify.
+            let key = carried_key.unwrap_or(0);
+            let h = if key != 0 {
+                crate::tokenizer::pipeline::crc_key_hash(key)
+            } else {
+                cache.hash(p)
+            };
+            if let Some((off, len)) = cache.get(p, h, key) {
                 output.extend(cache.ids_slice(off, len).iter().map(|&id| PipelineToken { id }));
                 return;
             }
@@ -1308,7 +1322,7 @@ impl pipeline::Model for PipelineBPE {
                 let mut ids = o.borrow_mut();
                 ids.clear();
                 self.encode_piece(sequence, &mut ids);
-                cache.insert(p, h, &ids);
+                cache.insert(p, h, key, &ids);
                 output.extend(ids.iter().map(|&id| PipelineToken { id }));
             });
         });
@@ -1848,7 +1862,7 @@ mod tests {
 
         fn pipeline_ids(model: &PipelineBPE, sequence: &str) -> Vec<u32> {
             let mut out = Vec::new();
-            pipeline::Model::tokenize_pipeline(model, sequence, &mut out).unwrap();
+            pipeline::Model::tokenize_pipeline(model, sequence, &mut out, None).unwrap();
             out.iter().map(|t| t.id).collect()
         }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1296,7 +1296,7 @@ impl pipeline::Model for PipelineBPE {
                 let mut ids = o.borrow_mut();
                 ids.clear();
                 self.encode_piece(sequence, &mut ids);
-                output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                output.extend_from_slice(crate::tokenizer::pipeline::ids_as_tokens(&ids));
             });
             return Ok(());
         }
@@ -1315,7 +1315,7 @@ impl pipeline::Model for PipelineBPE {
                 cache.hash(p)
             };
             if let Some((off, len)) = cache.get(p, h, key) {
-                output.extend(cache.ids_slice(off, len).iter().map(|&id| PipelineToken { id }));
+                output.extend_from_slice(cache.ids_tokens(off, len)); // memcpy emit
                 return;
             }
             // Miss: merge into reused scratch, cache the ids, emit.
@@ -1324,8 +1324,78 @@ impl pipeline::Model for PipelineBPE {
                 ids.clear();
                 self.encode_piece(sequence, &mut ids);
                 cache.insert(p, h, key, &ids);
-                output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                output.extend_from_slice(crate::tokenizer::pipeline::ids_as_tokens(&ids));
             });
+        });
+        Ok(())
+    }
+}
+
+impl PipelineBPE {
+    /// Fused per-chunk tokenize — the de-virtualized hot path. `tokenize_pipeline` was called once
+    /// per pre-token through the `PipelineModel` enum, so every pre-token paid an enum match, a
+    /// thread-local `PIPE_FLAT_CACHE` borrow, and a `retarget` check. Here those happen ONCE per
+    /// chunk; the inner loop then inlines pack_key → hash → probe → emit with no call or TLS barrier
+    /// on the hot (cache-hit) path. Byte-identical to looping `tokenize_pipeline` per pre-token.
+    pub(crate) fn tokenize_chunk(
+        &self,
+        chunk: &str,
+        pre_tokens: &[crate::tokenizer::pipeline::Split],
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        use crate::tokenizer::pipeline::{crc_key_hash, ids_as_tokens, Model as _};
+        let nb = chunk.as_bytes();
+        // Cache off (measurement): defer to the per-pre-token path unchanged.
+        if cache_disabled() {
+            for pt in pre_tokens {
+                let r = pt.range();
+                let key = atomsplit::fsm::pack_key(nb, r.start, r.len());
+                self.tokenize_pipeline(&chunk[r], output, Some(key))?;
+            }
+            return Ok(());
+        }
+        let min_len = min_cache_len();
+        PIPE_FLAT_CACHE.with(|cell| {
+            let mut cache = cell.borrow_mut(); // one borrow for the whole chunk
+            cache.retarget(self.cache_id); // once, not per pre-token
+            for pt in pre_tokens {
+                let r = pt.range();
+                let seq = &chunk[r.start..r.end];
+                if seq.is_empty() {
+                    continue;
+                }
+                let p = seq.as_bytes();
+                if self.ignore_merges {
+                    if let Some(id) = self.vocab.get_bytes(p) {
+                        output.push(PipelineToken { id });
+                        continue;
+                    }
+                }
+                // Short pre-tokens: re-merge is cheaper than a cache round-trip (emit, no insert).
+                if p.len() < min_len {
+                    PIPE_OUT_IDS.with(|o| {
+                        let mut ids = o.borrow_mut();
+                        ids.clear();
+                        self.encode_piece(seq, &mut ids);
+                        output.extend_from_slice(ids_as_tokens(&ids));
+                    });
+                    continue;
+                }
+                let key = atomsplit::fsm::pack_key(nb, r.start, r.len());
+                let h = if key != 0 { crc_key_hash(key) } else { cache.hash(p) };
+                if let Some((off, len)) = cache.get(p, h, key) {
+                    output.extend_from_slice(cache.ids_tokens(off, len)); // memcpy emit
+                    continue;
+                }
+                // Miss: merge into reused scratch, cache the ids, emit.
+                PIPE_OUT_IDS.with(|o| {
+                    let mut ids = o.borrow_mut();
+                    ids.clear();
+                    self.encode_piece(seq, &mut ids);
+                    cache.insert(p, h, key, &ids);
+                    output.extend_from_slice(ids_as_tokens(&ids));
+                });
+            }
         });
         Ok(())
     }

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -510,6 +510,7 @@ impl pipeline::Model for Unigram {
         &self,
         sequence: &str,
         output: &mut Vec<pipeline::PipelineToken>,
+        _carried_key: Option<u128>,
     ) -> Result<()> {
         let str_tokens = self.encode(sequence)?;
 

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -212,6 +212,7 @@ impl pipeline::Model for WordLevel {
         &self,
         sequence: &str,
         output: &mut Vec<pipeline::PipelineToken>,
+        _carried_key: Option<u128>,
     ) -> Result<()> {
         if let Some(&id) = self.vocab.get(sequence) {
             output.push(PipelineToken { id })

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -352,6 +352,7 @@ impl pipeline::Model for PipelineWordPiece {
         &self,
         sequence: &str,
         output: &mut Vec<pipeline::PipelineToken>,
+        _carried_key: Option<u128>,
     ) -> Result<()> {
         let mut candidate = String::with_capacity(self.max_input_chars_per_word);
         let mut candidate_tokens = Vec::with_capacity(sequence.len());

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -215,6 +215,35 @@ impl pipeline::PreTokenizer for Split {
         pipeline::split_matches(out, matches, self.behavior);
         Ok(())
     }
+
+    fn pre_tokenize_keyed(
+        &self,
+        text: &str,
+        out: &mut Vec<pipeline::Split>,
+        keys: &mut Vec<u128>,
+    ) -> Result<()> {
+        // GPT byte-level FSM path: derive each span's cache hash in the same pass (fused).
+        if let Some(fsm) = self
+            .fsm
+            .filter(|_| !self.invert && self.behavior == SplitDelimiterBehavior::Isolated)
+        {
+            pipeline::classify_into_spans_keyed(
+                text.as_bytes(),
+                |bytes, tags, spans| match fsm {
+                    GptFsm::Cl100k { digit_cap } => {
+                        atomsplit::fsm::fsm_cl100k_cap(bytes, tags, spans, digit_cap)
+                    }
+                    GptFsm::Gpt2 => atomsplit::fsm::fsm_byte_level(bytes, tags, spans),
+                    GptFsm::O200k => atomsplit::fsm::fsm_o200k(bytes, tags, spans),
+                },
+                out,
+                keys,
+            );
+            return Ok(());
+        }
+        // Regex/multi path: no fused hashes (the model re-hashes).
+        pipeline::PreTokenizer::pre_tokenize(self, text, out)
+    }
 }
 
 #[cfg(test)]

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -216,48 +216,6 @@ impl pipeline::PreTokenizer for Split {
         Ok(())
     }
 
-    fn pre_tokenize_keyed(
-        &self,
-        text: &str,
-        out: &mut Vec<pipeline::Split>,
-        keys: &mut Vec<u128>,
-    ) -> Result<()> {
-        // GPT byte-level FSM path: derive each span's cache hash in the same pass (fused).
-        if let Some(fsm) = self
-            .fsm
-            .filter(|_| !self.invert && self.behavior == SplitDelimiterBehavior::Isolated)
-        {
-            pipeline::classify_into_spans_keyed(
-                text.as_bytes(),
-                |bytes, tags, spans, ks| match fsm {
-                    // Gpt2 packs keys inside the FSM (fused at each bound); cl100k/o200k pack from
-                    // their emitted spans (still one classify pass, no re-walk of the text).
-                    GptFsm::Gpt2 => atomsplit::fsm::fsm_byte_level_keyed(bytes, tags, spans, ks),
-                    GptFsm::Cl100k { digit_cap } => {
-                        let k = atomsplit::fsm::fsm_cl100k_cap(bytes, tags, spans, digit_cap);
-                        for w in 0..k {
-                            let (s, e) = spans[w];
-                            ks[w] = atomsplit::fsm::pack_key(bytes, s as usize, (e - s) as usize);
-                        }
-                        k
-                    }
-                    GptFsm::O200k => {
-                        let k = atomsplit::fsm::fsm_o200k(bytes, tags, spans);
-                        for w in 0..k {
-                            let (s, e) = spans[w];
-                            ks[w] = atomsplit::fsm::pack_key(bytes, s as usize, (e - s) as usize);
-                        }
-                        k
-                    }
-                },
-                out,
-                keys,
-            );
-            return Ok(());
-        }
-        // Regex/multi path: no fused hashes (the model re-hashes).
-        pipeline::PreTokenizer::pre_tokenize(self, text, out)
-    }
 }
 
 #[cfg(test)]

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -229,12 +229,26 @@ impl pipeline::PreTokenizer for Split {
         {
             pipeline::classify_into_spans_keyed(
                 text.as_bytes(),
-                |bytes, tags, spans| match fsm {
+                |bytes, tags, spans, ks| match fsm {
+                    // Gpt2 packs keys inside the FSM (fused at each bound); cl100k/o200k pack from
+                    // their emitted spans (still one classify pass, no re-walk of the text).
+                    GptFsm::Gpt2 => atomsplit::fsm::fsm_byte_level_keyed(bytes, tags, spans, ks),
                     GptFsm::Cl100k { digit_cap } => {
-                        atomsplit::fsm::fsm_cl100k_cap(bytes, tags, spans, digit_cap)
+                        let k = atomsplit::fsm::fsm_cl100k_cap(bytes, tags, spans, digit_cap);
+                        for w in 0..k {
+                            let (s, e) = spans[w];
+                            ks[w] = atomsplit::fsm::pack_key(bytes, s as usize, (e - s) as usize);
+                        }
+                        k
                     }
-                    GptFsm::Gpt2 => atomsplit::fsm::fsm_byte_level(bytes, tags, spans),
-                    GptFsm::O200k => atomsplit::fsm::fsm_o200k(bytes, tags, spans),
+                    GptFsm::O200k => {
+                        let k = atomsplit::fsm::fsm_o200k(bytes, tags, spans);
+                        for w in 0..k {
+                            let (s, e) = spans[w];
+                            ks[w] = atomsplit::fsm::pack_key(bytes, s as usize, (e - s) as usize);
+                        }
+                        k
+                    }
                 },
                 out,
                 keys,

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -108,42 +108,6 @@ pub(crate) fn crc_key_hash(key: u128) -> u64 {
     }
 }
 
-/// Like [`classify_into_spans`] but the FSM ALSO writes each span's packed cache key into `keys`
-/// (same index as `out`) — the classify→cache fusion, derived at each bound as the FSM emits it
-/// (bytes still hot), no second walk. The model's probe then reuses the key for a register compare.
-pub(crate) fn classify_into_spans_keyed(
-    bytes: &[u8],
-    fsm: impl FnOnce(&[u8], &[u8], &mut [Span], &mut [u128]) -> usize,
-    out: &mut Vec<Split>,
-    keys: &mut Vec<u128>,
-) {
-    thread_local! {
-        static TAGS: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
-    }
-    let n = bytes.len();
-    TAGS.with(|cell| {
-        let tags = &mut *cell.borrow_mut();
-        if tags.len() < n {
-            tags.resize(n, 0);
-        }
-        classify::<Atoms>(bytes, &mut tags[..n]);
-        let (sbase, kbase) = (out.len(), keys.len());
-        out.reserve(n + 1);
-        keys.reserve(n + 1);
-        // SAFETY: both reserved n+1; Split==Span layout; FSM fills [0,k) of each, exposed via set_len.
-        let spans = unsafe {
-            std::slice::from_raw_parts_mut(out.as_mut_ptr().add(sbase) as *mut Span, n + 1)
-        };
-        let ks = unsafe { std::slice::from_raw_parts_mut(keys.as_mut_ptr().add(kbase), n + 1) };
-        let k = fsm(bytes, &tags[..n], spans, ks);
-        // SAFETY: FSM initialized [0,k) of both spare regions.
-        unsafe {
-            out.set_len(sbase + k);
-            keys.set_len(kbase + k);
-        }
-    });
-}
-
 pub trait Normalizer {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>>;
 }
@@ -154,18 +118,6 @@ pub trait PreTokenizer {
     /// Split `text` into pre-tokens, appending to `out`. Ranges are into `text`.
     fn pre_tokenize(&self, text: &str, out: &mut Vec<Split>) -> Result<()>;
 
-    /// Split, and where possible ALSO append each pre-token's cache hash to `hashes` (fused key
-    /// derivation — see [`classify_into_spans_keyed`]). Default: no hashes (the model then hashes
-    /// pre-token bytes itself). Only the byte-level GPT split path overrides this. A run either
-    /// fills `hashes` 1:1 with the spans it appended, or appends none — never partially.
-    fn pre_tokenize_keyed(
-        &self,
-        text: &str,
-        out: &mut Vec<Split>,
-        _keys: &mut Vec<u128>,
-    ) -> Result<()> {
-        self.pre_tokenize(text, out)
-    }
 }
 
 /// The pre-tokenizers a [`PipelineTokenizer`] can run.
@@ -208,18 +160,6 @@ impl PreTokenizer for PipelinePreTokenizer {
         }
     }
 
-    fn pre_tokenize_keyed(
-        &self,
-        text: &str,
-        out: &mut Vec<Split>,
-        keys: &mut Vec<u128>,
-    ) -> Result<()> {
-        // Only the GPT byte-level Split path fuses keys; the rest use the default (no keys).
-        match self {
-            Self::Split(pretok) => pretok.pre_tokenize_keyed(text, out, keys),
-            other => other.pre_tokenize(text, out),
-        }
-    }
 }
 
 impl TryFrom<PreTokenizerWrapper> for PipelinePreTokenizer {
@@ -538,8 +478,6 @@ impl PipelineTokenizer {
         output: &mut Vec<PipelineToken>,
         pre_tokens: &mut Vec<Split>,
     ) -> Result<()> {
-        // Per-pre-token packed keys, derived by the split (fused). Reused across segments.
-        let mut pre_keys: Vec<u128> = Vec::new();
         // First, we extract all special tokens from the non-normalized input
         for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
             match segment {
@@ -566,23 +504,23 @@ impl PipelineTokenizer {
                             }
                             Segment::Text(normalized_chunk) => {
                                 if STAGE >= Self::STAGE_SPLIT {
-                                    // Pre-tokenize the chunk; the split also derives per-pre-token
-                                    // cache hashes here (fused) so the model probe skips re-hashing.
+                                    // Pre-tokenize the chunk. The model packs each pre-token's cache
+                                    // key from its (hot) bytes at lookup — no keys buffer to carry.
                                     pre_tokens.clear();
-                                    pre_keys.clear();
-                                    self.pre_tokenizer.pre_tokenize_keyed(
-                                        normalized_chunk,
-                                        pre_tokens,
-                                        &mut pre_keys,
-                                    )?;
+                                    self.pre_tokenizer
+                                        .pre_tokenize(normalized_chunk, pre_tokens)?;
                                     if STAGE >= Self::STAGE_MODEL {
-                                        // keys carried 1:1 with spans, or none → model hashes bytes
-                                        let keyed = pre_keys.len() == pre_tokens.len();
-                                        for (i, pre_token) in pre_tokens.iter().enumerate() {
+                                        let nb = normalized_chunk.as_bytes();
+                                        for pre_token in pre_tokens.iter() {
+                                            let r = pre_token.range();
+                                            // Pack the key here (parent buffer in hand → the cheap
+                                            // 16-byte wide load is safe mid-buffer) and pass it by
+                                            // value — no keys buffer, and split pays nothing.
+                                            let key = atomsplit::fsm::pack_key(nb, r.start, r.len());
                                             self.model.tokenize_pipeline(
-                                                &normalized_chunk[pre_token.range()],
+                                                &normalized_chunk[r],
                                                 output,
-                                                keyed.then(|| pre_keys[i]),
+                                                Some(key),
                                             )?;
                                         }
                                     }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -205,9 +205,21 @@ impl TryFrom<PreTokenizerWrapper> for PipelinePreTokenizer {
 
 /// An output token. Carries only the vocabulary `id` — offsets and the token
 /// string are dropped, which is all an encode-only caller needs.
+/// `repr(transparent)`: layout-identical to `u32`, so a `&[u32]` id-run reinterprets
+/// as `&[PipelineToken]` for a memcpy emit (see [`ids_as_tokens`]) with no per-id map.
 #[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
 pub struct PipelineToken {
     pub id: u32,
+}
+
+/// Reinterpret a run of raw vocab ids as output tokens — sound because `PipelineToken`
+/// is `repr(transparent)` over `u32`. Lets the BPE emit be a single `extend_from_slice`
+/// (memcpy) instead of an id-by-id `map`/`push`.
+#[inline(always)]
+pub(crate) fn ids_as_tokens(ids: &[u32]) -> &[PipelineToken] {
+    // SAFETY: PipelineToken is repr(transparent) over u32, same size/align/validity.
+    unsafe { std::slice::from_raw_parts(ids.as_ptr() as *const PipelineToken, ids.len()) }
 }
 
 impl From<Token> for PipelineToken {
@@ -510,19 +522,14 @@ impl PipelineTokenizer {
                                     self.pre_tokenizer
                                         .pre_tokenize(normalized_chunk, pre_tokens)?;
                                     if STAGE >= Self::STAGE_MODEL {
-                                        let nb = normalized_chunk.as_bytes();
-                                        for pre_token in pre_tokens.iter() {
-                                            let r = pre_token.range();
-                                            // Pack the key here (parent buffer in hand → the cheap
-                                            // 16-byte wide load is safe mid-buffer) and pass it by
-                                            // value — no keys buffer, and split pays nothing.
-                                            let key = atomsplit::fsm::pack_key(nb, r.start, r.len());
-                                            self.model.tokenize_pipeline(
-                                                &normalized_chunk[r],
-                                                output,
-                                                Some(key),
-                                            )?;
-                                        }
+                                        // One fused call per chunk: BPE hoists the cache borrow /
+                                        // dispatch out of the per-pre-token loop and packs each key
+                                        // from the (hot) parent buffer inside. Split pays nothing.
+                                        self.model.tokenize_chunk(
+                                            normalized_chunk,
+                                            pre_tokens,
+                                            output,
+                                        )?;
                                     }
                                 }
                             }
@@ -783,6 +790,30 @@ impl Model for PipelineModel {
             Self::WordLevel(model) => model.tokenize_pipeline(sequence, output, carried_key),
             Self::WordPiece(model) => model.tokenize_pipeline(sequence, output, carried_key),
         }
+    }
+}
+
+impl PipelineModel {
+    /// Tokenize a whole chunk's pre-tokens into `output`. BPE takes its fused per-chunk path (one
+    /// cache borrow / dispatch for the chunk, not per pre-token); other models fall back to the
+    /// per-pre-token loop, packing the cache key from the (hot) parent buffer as before.
+    #[inline]
+    pub(crate) fn tokenize_chunk(
+        &self,
+        chunk: &str,
+        pre_tokens: &[Split],
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        if let Self::BPE(model) = self {
+            return model.tokenize_chunk(chunk, pre_tokens, output);
+        }
+        let nb = chunk.as_bytes();
+        for pt in pre_tokens {
+            let r = pt.range();
+            let key = atomsplit::fsm::pack_key(nb, r.start, r.len());
+            self.tokenize_pipeline(&chunk[r], output, Some(key))?;
+        }
+        Ok(())
     }
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -86,6 +86,68 @@ pub(crate) fn classify_into_spans(
     });
 }
 
+/// Pack a pre-token's first ≤15 bytes into a `u128` (length in the top byte), by ONE unaligned
+/// 16-byte load off `bytes[start..]` — the bytes the classify pass just read, so they're hot. A
+/// span in the buffer's last 15 bytes (rare, once per input) falls back to a zero-padded copy.
+#[inline(always)]
+fn pack_key(bytes: &[u8], start: usize, len: usize) -> u128 {
+    // 0 = "not packable" (empty, or >15 bytes): the cache must byte-verify these, because a packed
+    // key only holds the first 15 bytes — two long pre-tokens sharing a 15-byte prefix would alias.
+    if len == 0 || len > 15 {
+        return 0;
+    }
+    let v: u128 = if start + 16 <= bytes.len() {
+        // SAFETY: `start + 16 <= len` — 16 readable bytes; unaligned load is always valid.
+        unsafe { (bytes.as_ptr().add(start) as *const u128).read_unaligned() }
+    } else {
+        let mut b = [0u8; 16];
+        b[..len].copy_from_slice(&bytes[start..start + len]);
+        u128::from_le_bytes(b)
+    };
+    let mask: u128 = (1u128 << (8 * len)) - 1;
+    (v & mask) | ((len as u128) << 120)
+}
+
+/// Hash the packed key with the hardware CRC32 instruction (~3 cycles) — the cheap hash gigatoken
+/// derives during its classify pass. On non-aarch64, a multiplicative finalizer.
+#[inline(always)]
+pub(crate) fn crc_key_hash(key: u128) -> u64 {
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: CRC is baseline on the aarch64 stable ABI targets we build (Apple Silicon etc.).
+        unsafe {
+            use std::arch::aarch64::__crc32cd;
+            __crc32cd(__crc32cd(0, key as u64), (key >> 64) as u64) as u64
+        }
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let mut h = (key as u64).wrapping_mul(0xff51afd7ed558ccd)
+            ^ ((key >> 64) as u64).wrapping_mul(0xc4ceb9fe1a85ec53);
+        h ^= h >> 33;
+        h = h.wrapping_mul(0xff51afd7ed558ccd);
+        h ^ (h >> 33)
+    }
+}
+
+/// Like [`classify_into_spans`] but ALSO fills `hashes` with each span's cache hash, derived in the
+/// same pass (pack the span's bytes → CRC). This is the classify→cache fusion: the model's cache
+/// probe then reuses this hash instead of re-hashing the pre-token bytes cold at lookup time.
+pub(crate) fn classify_into_spans_keyed(
+    bytes: &[u8],
+    fsm: impl FnOnce(&[u8], &[u8], &mut [Span]) -> usize,
+    out: &mut Vec<Split>,
+    keys: &mut Vec<u128>,
+) {
+    let base = out.len();
+    classify_into_spans(bytes, fsm, out);
+    keys.reserve(out.len() - base);
+    for s in &out[base..] {
+        let (start, len) = (s.start as usize, (s.end - s.start) as usize);
+        keys.push(pack_key(bytes, start, len));
+    }
+}
+
 pub trait Normalizer {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>>;
 }
@@ -95,6 +157,19 @@ pub trait Normalizer {
 pub trait PreTokenizer {
     /// Split `text` into pre-tokens, appending to `out`. Ranges are into `text`.
     fn pre_tokenize(&self, text: &str, out: &mut Vec<Split>) -> Result<()>;
+
+    /// Split, and where possible ALSO append each pre-token's cache hash to `hashes` (fused key
+    /// derivation — see [`classify_into_spans_keyed`]). Default: no hashes (the model then hashes
+    /// pre-token bytes itself). Only the byte-level GPT split path overrides this. A run either
+    /// fills `hashes` 1:1 with the spans it appended, or appends none — never partially.
+    fn pre_tokenize_keyed(
+        &self,
+        text: &str,
+        out: &mut Vec<Split>,
+        _keys: &mut Vec<u128>,
+    ) -> Result<()> {
+        self.pre_tokenize(text, out)
+    }
 }
 
 /// The pre-tokenizers a [`PipelineTokenizer`] can run.
@@ -134,6 +209,19 @@ impl PreTokenizer for PipelinePreTokenizer {
             Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, out),
             Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
             Self::WhitespaceSplit(pretok) => pretok.pre_tokenize(text, out),
+        }
+    }
+
+    fn pre_tokenize_keyed(
+        &self,
+        text: &str,
+        out: &mut Vec<Split>,
+        keys: &mut Vec<u128>,
+    ) -> Result<()> {
+        // Only the GPT byte-level Split path fuses keys; the rest use the default (no keys).
+        match self {
+            Self::Split(pretok) => pretok.pre_tokenize_keyed(text, out, keys),
+            other => other.pre_tokenize(text, out),
         }
     }
 }
@@ -454,6 +542,8 @@ impl PipelineTokenizer {
         output: &mut Vec<PipelineToken>,
         pre_tokens: &mut Vec<Split>,
     ) -> Result<()> {
+        // Per-pre-token packed keys, derived by the split (fused). Reused across segments.
+        let mut pre_keys: Vec<u128> = Vec::new();
         // First, we extract all special tokens from the non-normalized input
         for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
             match segment {
@@ -480,16 +570,23 @@ impl PipelineTokenizer {
                             }
                             Segment::Text(normalized_chunk) => {
                                 if STAGE >= Self::STAGE_SPLIT {
-                                    // Pre-tokenize the chunk of normalized text
+                                    // Pre-tokenize the chunk; the split also derives per-pre-token
+                                    // cache hashes here (fused) so the model probe skips re-hashing.
                                     pre_tokens.clear();
-                                    self.pre_tokenizer
-                                        .pre_tokenize(normalized_chunk, pre_tokens)?;
+                                    pre_keys.clear();
+                                    self.pre_tokenizer.pre_tokenize_keyed(
+                                        normalized_chunk,
+                                        pre_tokens,
+                                        &mut pre_keys,
+                                    )?;
                                     if STAGE >= Self::STAGE_MODEL {
-                                        // Tokenize each chunk
-                                        for pre_token in pre_tokens.iter() {
+                                        // keys carried 1:1 with spans, or none → model hashes bytes
+                                        let keyed = pre_keys.len() == pre_tokens.len();
+                                        for (i, pre_token) in pre_tokens.iter().enumerate() {
                                             self.model.tokenize_pipeline(
                                                 &normalized_chunk[pre_token.range()],
                                                 output,
+                                                keyed.then(|| pre_keys[i]),
                                             )?;
                                         }
                                     }
@@ -718,7 +815,14 @@ pub fn split_matches(
 }
 
 pub trait Model {
-    fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()>;
+    /// Tokenize one pre-token into `output`. `carried_hash` is the pre-token's cache hash when the
+    /// split derived it (fused); models that cache may use it instead of re-hashing, others ignore.
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        output: &mut Vec<PipelineToken>,
+        carried_key: Option<u128>,
+    ) -> Result<()>;
 }
 
 #[allow(
@@ -733,12 +837,17 @@ pub enum PipelineModel {
 }
 
 impl Model for PipelineModel {
-    fn tokenize_pipeline(&self, sequence: &str, output: &mut Vec<PipelineToken>) -> Result<()> {
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        output: &mut Vec<PipelineToken>,
+        carried_key: Option<u128>,
+    ) -> Result<()> {
         match self {
-            Self::BPE(model) => model.tokenize_pipeline(sequence, output),
-            Self::Unigram(model) => model.tokenize_pipeline(sequence, output),
-            Self::WordLevel(model) => model.tokenize_pipeline(sequence, output),
-            Self::WordPiece(model) => model.tokenize_pipeline(sequence, output),
+            Self::BPE(model) => model.tokenize_pipeline(sequence, output, carried_key),
+            Self::Unigram(model) => model.tokenize_pipeline(sequence, output, carried_key),
+            Self::WordLevel(model) => model.tokenize_pipeline(sequence, output, carried_key),
+            Self::WordPiece(model) => model.tokenize_pipeline(sequence, output, carried_key),
         }
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -32,8 +32,11 @@ use crate::{
 
 use super::{Result, SplitDelimiterBehavior};
 
-/// A pre-token split, a range into the input text.
+/// A pre-token split, a range into the input text. `repr(C)` and layout-identical to
+/// `atomsplit::fsm::Span` (`(u32, u32)`), so the FSM can write final `Split`s straight into a
+/// caller buffer with no scratch->out copy (see [`classify_into_spans`]).
 #[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Split {
     pub start: u32,
     pub end: u32,
@@ -58,20 +61,28 @@ pub(crate) fn classify_into_spans(
     out: &mut Vec<Split>,
 ) {
     thread_local! {
-        static SCRATCH: RefCell<(Vec<u8>, Vec<Span>)> = const { RefCell::new((Vec::new(), Vec::new())) };
+        static SCRATCH: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
     }
     let n = bytes.len();
     SCRATCH.with(|cell| {
-        let (tags, spans) = &mut *cell.borrow_mut();
+        let tags = &mut *cell.borrow_mut();
         if tags.len() < n {
             tags.resize(n, 0); // grow-only: after the largest segment, no realloc / no re-zeroing
         }
-        if spans.len() < n + 1 {
-            spans.resize(n + 1, (0, 0));
-        }
         classify::<Atoms>(bytes, &mut tags[..n]);
-        let k = fsm(bytes, &tags[..n], &mut spans[..n + 1]);
-        out.extend(spans[..k].iter().map(|&(s, e)| Split { start: s, end: e }));
+        // The FSM writes its `Span`s (== `Split`, repr(C) 2×u32) directly into `out`'s spare
+        // capacity — no `spans` scratch, no scratch->out copy (that copy was ~55% of split on
+        // Latin: ~250k tuple->struct moves per MB). One write, then `set_len`.
+        let base = out.len();
+        out.reserve(n + 1);
+        // SAFETY: reserved n+1 slots; `Split` and `Span` share layout, so the spare capacity is a
+        // valid `&mut [Span]`; the FSM fills `[0, k)` and we only expose those via `set_len`.
+        let spare = unsafe {
+            std::slice::from_raw_parts_mut(out.as_mut_ptr().add(base) as *mut Span, n + 1)
+        };
+        let k = fsm(bytes, &tags[..n], spare);
+        // SAFETY: FSM returned `k <= n+1` initialized spans, all in-bounds valid `Split`s.
+        unsafe { out.set_len(base + k) };
     });
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -86,28 +86,6 @@ pub(crate) fn classify_into_spans(
     });
 }
 
-/// Pack a pre-token's first ≤15 bytes into a `u128` (length in the top byte), by ONE unaligned
-/// 16-byte load off `bytes[start..]` — the bytes the classify pass just read, so they're hot. A
-/// span in the buffer's last 15 bytes (rare, once per input) falls back to a zero-padded copy.
-#[inline(always)]
-fn pack_key(bytes: &[u8], start: usize, len: usize) -> u128 {
-    // 0 = "not packable" (empty, or >15 bytes): the cache must byte-verify these, because a packed
-    // key only holds the first 15 bytes — two long pre-tokens sharing a 15-byte prefix would alias.
-    if len == 0 || len > 15 {
-        return 0;
-    }
-    let v: u128 = if start + 16 <= bytes.len() {
-        // SAFETY: `start + 16 <= len` — 16 readable bytes; unaligned load is always valid.
-        unsafe { (bytes.as_ptr().add(start) as *const u128).read_unaligned() }
-    } else {
-        let mut b = [0u8; 16];
-        b[..len].copy_from_slice(&bytes[start..start + len]);
-        u128::from_le_bytes(b)
-    };
-    let mask: u128 = (1u128 << (8 * len)) - 1;
-    (v & mask) | ((len as u128) << 120)
-}
-
 /// Hash the packed key with the hardware CRC32 instruction (~3 cycles) — the cheap hash gigatoken
 /// derives during its classify pass. On non-aarch64, a multiplicative finalizer.
 #[inline(always)]
@@ -130,22 +108,40 @@ pub(crate) fn crc_key_hash(key: u128) -> u64 {
     }
 }
 
-/// Like [`classify_into_spans`] but ALSO fills `hashes` with each span's cache hash, derived in the
-/// same pass (pack the span's bytes → CRC). This is the classify→cache fusion: the model's cache
-/// probe then reuses this hash instead of re-hashing the pre-token bytes cold at lookup time.
+/// Like [`classify_into_spans`] but the FSM ALSO writes each span's packed cache key into `keys`
+/// (same index as `out`) — the classify→cache fusion, derived at each bound as the FSM emits it
+/// (bytes still hot), no second walk. The model's probe then reuses the key for a register compare.
 pub(crate) fn classify_into_spans_keyed(
     bytes: &[u8],
-    fsm: impl FnOnce(&[u8], &[u8], &mut [Span]) -> usize,
+    fsm: impl FnOnce(&[u8], &[u8], &mut [Span], &mut [u128]) -> usize,
     out: &mut Vec<Split>,
     keys: &mut Vec<u128>,
 ) {
-    let base = out.len();
-    classify_into_spans(bytes, fsm, out);
-    keys.reserve(out.len() - base);
-    for s in &out[base..] {
-        let (start, len) = (s.start as usize, (s.end - s.start) as usize);
-        keys.push(pack_key(bytes, start, len));
+    thread_local! {
+        static TAGS: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
     }
+    let n = bytes.len();
+    TAGS.with(|cell| {
+        let tags = &mut *cell.borrow_mut();
+        if tags.len() < n {
+            tags.resize(n, 0);
+        }
+        classify::<Atoms>(bytes, &mut tags[..n]);
+        let (sbase, kbase) = (out.len(), keys.len());
+        out.reserve(n + 1);
+        keys.reserve(n + 1);
+        // SAFETY: both reserved n+1; Split==Span layout; FSM fills [0,k) of each, exposed via set_len.
+        let spans = unsafe {
+            std::slice::from_raw_parts_mut(out.as_mut_ptr().add(sbase) as *mut Span, n + 1)
+        };
+        let ks = unsafe { std::slice::from_raw_parts_mut(keys.as_mut_ptr().add(kbase), n + 1) };
+        let k = fsm(bytes, &tags[..n], spans, ks);
+        // SAFETY: FSM initialized [0,k) of both spare regions.
+        unsafe {
+            out.set_len(sbase + k);
+            keys.set_len(kbase + k);
+        }
+    });
 }
 
 pub trait Normalizer {


### PR DESCRIPTION
> **Draft, minimal.** Just the BPE cache/emit change on the `tk-encode` SIMD pipeline: **9 files, +299/−45**.

Based on the pre-cache pipeline commit (`perf/tk-encode-pretok-base`), so the diff is *only* this change. It is **not** based on #2223 (`feat/bpe-cache`): the two branches' pipelines diverged exactly here — this one is a 3-arg `FlatCache` path, #2223 is a 5-arg ScratchPool/word-cache path — so the change can't be a small diff on top of #2223 (it would be a reimplementation). Head-to-head perf of the full pipelines is in #2234's history / the comparison I posted.

## The change
- **Fused split cache** — the pre-token cache key (u128) is packed in the encode dispatch loop from the hot parent buffer; the probe is a CRC bucket + a register 128-bit compare (no ahash, no `memcmp`), split pays nothing.
- **De-virtualized per-chunk BPE** — the model call ran once per *pre-token* (enum match + thread-local cache borrow + `retarget`); now once per *chunk*, inner loop inlines pack→probe→emit. Emit is a `repr(transparent)` `&[u32]`→`&[Token]` memcpy.
- Split FSM writes spans directly into the output buffer (no scratch→copy).

Byte-exact: `idsEq OK` on 11 languages × 5 tokenizer families (gpt2, llama3/cl100k, deepseek, gpt-oss/o200k, glm).

## Perf (this change vs the same branch's pre-cache baseline, warm best-of, ns/byte)
The de-virtualization is the win, largest where per-pre-token overhead dominated:
- **llama3 / cl100k: −10…−17%** (English 5.22→4.45, Hindi 3.79→3.13, Chinese 2.48→2.16).
- **gpt2 / byte-level: −2…−6%.**

Two measured dead-ends documented in the code so they aren't retried: inlining ids into the cache slot (regresses in our L2-resident regime) and fusing emit into the probe (un-inlinable → +24%).

Tests: 297 pass; 2 pre-existing `precompiled`-normalizer failures unrelated to this change.
