### PR TITLE
Fix panic in Strip decoder on short all-content tokens

### DIFF
--- a/tokenizers/src/decoders/strip.rs
+++ b/tokenizers/src/decoders/strip.rs
@@ -42,7 +42,11 @@ impl Decoder for Strip {
                 }
 
                 let mut stop_cut = chars.len();
-                for i in 0..self.stop {
+                // Bound the trailing strip by the token length: `self.stop` is a raw
+                // config value, so without `.min(chars.len())` a token made entirely
+                // of `content` and shorter than `stop` keeps decrementing `index` past
+                // 0, underflowing `usize` (debug panic / out-of-bounds index in release).
+                for i in 0..self.stop.min(chars.len()) {
                     let index = chars.len() - i - 1;
                     if chars[index] == self.content {
                         stop_cut = index;
@@ -52,6 +56,11 @@ impl Decoder for Strip {
                     }
                 }
 
+                // The leading and trailing windows can overlap when a short token is
+                // stripped from both ends (start_cut > stop_cut), which would make the
+                // slice range reversed and panic. Clamp so an over-stripped token
+                // collapses to an empty string instead.
+                let stop_cut = stop_cut.max(start_cut);
                 let new_token: String = chars[start_cut..stop_cut].iter().collect();
                 new_token
             })
@@ -76,5 +85,31 @@ mod tests {
             .decode_chain(vec!["Hey".into(), " friend!".into()])
             .unwrap();
         assert_eq!(res, vec!["He", " friend!"]);
+    }
+
+    #[test]
+    fn short_all_content_token_does_not_panic() {
+        // A token made entirely of `content` and shorter than `stop` used to
+        // underflow `chars.len() - i - 1` (debug: subtract overflow; release:
+        // out-of-bounds index). It should strip what is there and stop.
+        let decoder = Strip::new('_', 0, 2);
+        let res = decoder.decode_chain(vec!["_".into()]).unwrap();
+        assert_eq!(res, vec![""]);
+
+        let decoder = Strip::new('a', 0, 5);
+        let res = decoder
+            .decode_chain(vec!["aa".into(), "aab".into()])
+            .unwrap();
+        assert_eq!(res, vec!["", "aab"]);
+    }
+
+    #[test]
+    fn overlapping_start_stop_windows_collapse_to_empty() {
+        // When the leading and trailing windows overlap on a short token,
+        // start_cut can exceed stop_cut; the slice used to panic on a reversed
+        // range and now collapses to an empty string.
+        let decoder = Strip::new('H', 2, 1);
+        let res = decoder.decode_chain(vec!["HH".into()]).unwrap();
+        assert_eq!(res, vec![""]);
     }
 }


### PR DESCRIPTION
### Problem

`Strip::decode_chain`'s trailing-strip loop panics on short tokens made up of the `content` char:

```rust
let mut stop_cut = chars.len();
for i in 0..self.stop {                 // not bounded by chars.len()
    let index = chars.len() - i - 1;    // underflows once i >= chars.len()
    if chars[index] == self.content {
        stop_cut = index;
        continue;
    } else { break; }
}
let new_token: String = chars[start_cut..stop_cut].iter().collect();
```

`self.stop` is a raw config value. A token that is entirely `content` and shorter than `stop` keeps decrementing `index` past 0:

- **debug:** `panicked at strip.rs: attempt to subtract with overflow`
- **release:** `index out of bounds: the len is 1 but the index is 18446744073709551615`

Separately, when the leading and trailing windows overlap on a short token, `start_cut` can exceed `stop_cut`, so the final `chars[start_cut..stop_cut]` panics on a reversed slice range (`slice index starts at 2 but ends at 1`).

Both are reachable through `Tokenizer::decode` for any tokenizer whose decoder is a `Strip` with `stop >= 1`. Decoders aren't wrapped in `catch_unwind`, so one such token crashes the whole `decode`/`decode_batch`.

### Fix

Bound the trailing loop with `self.stop.min(chars.len())` and clamp the range with `stop_cut.max(start_cut)` so an over-stripped token collapses to an empty string. Existing valid inputs are unaffected (the current tests still pass).

### Tests

Added regression tests for the short all-content token (`Strip::new('_', 0, 2)` on `["_"]`, and a mixed batch) and the overlapping start/stop windows (`Strip::new('H', 2, 1)` on `["HH"]`). Both panic on the pre-fix code and pass with the fix.

cc @ArthurZucker @Narsil
