### PR TITLE
Fix usize underflow in BPE / Strip decoders on empty / short input

### DIFF
--- a/tokenizers/src/decoders/bpe.rs
+++ b/tokenizers/src/decoders/bpe.rs
@@ -25,7 +25,7 @@ impl Default for BPEDecoder {
 
 impl Decoder for BPEDecoder {
     fn decode_chain(&self, tokens: Vec<String>) -> Result<Vec<String>> {
-        let n = tokens.len() - 1;
+        let n = tokens.len().saturating_sub(1);
         Ok(tokens
             .into_iter()
             .enumerate()

--- a/tokenizers/src/decoders/strip.rs
+++ b/tokenizers/src/decoders/strip.rs
@@ -42,7 +42,7 @@ impl Decoder for Strip {
                 }
 
                 let mut stop_cut = chars.len();
-                for i in 0..self.stop {
+                for i in 0..self.stop.min(chars.len() - start_cut) {
                     let index = chars.len() - i - 1;
                     if chars[index] == self.content {
                         stop_cut = index;


### PR DESCRIPTION
## Describe the Bug

`decode_chain()` of BPE / Strip decoders compute an index with an unchecked `usize` subtraction that may underflow.

- `bpe.rs`: `tokens.len() - 1` underflows when the token list is empty.
- `strip.rs`: `chars.len() - i - 1` underflows when `stop` exceeds the token length


## Reproduce
```python
from tokenizers.decoders import BPEDecoder, Strip

BPEDecoder().decode([])
Strip(content="H", right=3).decode(["HH"])
```

Run the code above, and `PanicException` will be throw on debug build.

```
thread '<unnamed>' (3152788) panicked at /root/tokenizers/tokenizers/src/decoders/bpe.rs:28:17:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "<string>", line 1, in <module>
pyo3_runtime.PanicException: attempt to subtract with overflow
```
## Fix
The fix is quite straightforward, please take a look at the patch, it just contains 2 lines.

## Notes
This issue was first reported by [@devdan](https://github.com/devdanzin) via [fusil](https://github.com/devdanzin/fusil), the original report can be found here: https://github.com/devdanzin/fusil-extensions-findings/blob/main/tokenizers/reports/TOKENIZERS-0001-bpe-decoder-empty-underflow/report.md
