### PR TITLE
fix(bench): use full tokenizer configs, add gemma-4 and mistral-small-4

### DIFF
--- a/tokenizers/tk-encode/examples/bench_models.json
+++ b/tokenizers/tk-encode/examples/bench_models.json
@@ -1,10 +1,12 @@
 [
   { "name": "bert-base-uncased", "file": "bert-base-uncased.json", "desc": "normalizer-heavy WordPiece" },
   { "name": "deepseek-v4",       "file": "deepseek-v4.json",       "desc": "deepseek 3-regex split-heavy byte-level BPE" },
+  { "name": "gemma-4",           "file": "gemma-4.json",           "desc": "byte-fallback BPE, Metaspace-style split (gemma-4)" },
   { "name": "gpt2",              "file": "gpt2.json",              "desc": "gpt2 ByteLevel regex" },
-  { "name": "gpt-oss",           "file": "gpt-oss-slim.json",      "desc": "o200k-regex byte-level BPE (gpt-oss)" },
-  { "name": "glm-5.2",           "file": "glm-5.2-slim.json",      "desc": "cl100k-variant regex byte-level BPE (glm-5.2)" },
+  { "name": "gpt-oss",           "file": "gpt-oss.json",           "desc": "o200k-regex byte-level BPE (gpt-oss)" },
+  { "name": "glm-5.2",           "file": "glm-5.2.json",           "desc": "cl100k-variant regex byte-level BPE (glm-5.2)" },
   { "name": "llama-2",           "file": "llama-2.json",           "desc": "model-bounded BPE, no pre-tokenizer" },
   { "name": "llama-3",           "file": "llama-3-tokenizer.json", "desc": "cl100k-regex byte-level BPE (llama-3), single regex" },
+  { "name": "mistral-small-4",   "file": "mistral-small-4.json",   "desc": "tekken byte-level BPE, 1k added specials (mistral-small-4)" },
   { "name": "t5-base",           "file": "t5-base.json",           "desc": "Unigram + Metaspace" }
 ]


### PR DESCRIPTION
The manifest loaded gpt-oss-slim.json (3,060 of 199,998 vocab entries) and glm-5.2-slim.json (2,951 of 154,820), so their bench numbers ran on ~1.5% of the real vocab — unrealistically small merge tables and cache footprints. Point both at the full configs and add two archetypes: gemma-4 (262,144-vocab byte-fallback BPE, slim-only until now) and mistral-small-4 (tekken byte-level BPE with 1,000 added specials).

The full configs land in hf-internal-testing/tokenizers-test-data via a pending PR (which also refreshes llama-2.json and llama-3-tokenizer.json to byte-exact copies of the source models), so `make bench-models` needs that merge to fetch them.

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`deeb4bf6f · 2026-07-27 10:33 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-overview.png" width="860">

**vs base branch** (`8abd11215`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.95 vs v0.23.1 · ×1.04 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 11) · Pipeline 8+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 27.9 | ×3.53 | ×1.03 | 3% (1.2) | 76% (27.4) | 13% (4.8) | 7% (2.7) | 0% (0.1) | match |
| arb_Arab | lang | 4.2 | 24.9 | ×5.90 | ×1.03 | 3% (1.2) | 69% (27.5) | 8% (3.3) | 20% (8.0) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 34.9 | ×5.79 | ×1.03 | 4% (1.2) | 67% (19.1) | 10% (2.9) | 19% (5.4) | 0% (0.0) | match |
| cmn_Hani | lang | 3.8 | 18.8 | ×4.88 | ×1.04 | 2% (1.2) | 69% (37.6) | 10% (5.6) | 18% (9.8) | 0% (0.2) | match |
| ell_Grek | lang | 3.8 | 23.7 | ×6.24 | ×1.03 | 3% (1.2) | 68% (28.6) | 8% (3.5) | 21% (8.9) | 0% (0.0) | match |
| eng_Latn | lang | 4.5 | 18.4 | ×4.11 | ×1.08 | 5% (2.5) | 69% (38.7) | 8% (4.4) | 18% (10.3) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 20.1 | ×4.76 | ×1.04 | 2% (1.2) | 74% (37.1) | 8% (4.0) | 16% (7.9) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 27.4 | ×4.25 | ×1.03 | 3% (1.2) | 74% (27.0) | 9% (3.2) | 14% (5.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 27.4 | ×6.43 | ×1.02 | 3% (1.2) | 64% (23.2) | 13% (4.6) | 20% (7.5) | 0% (0.0) | match |
| kat_Geor | lang | 6.1 | 28.1 | ×4.58 | ×1.03 | 3% (1.2) | 75% (26.5) | 9% (3.1) | 13% (4.6) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 17.7 | ×7.30 | ×1.02 | 2% (1.2) | 63% (35.4) | 12% (7.0) | 23% (12.7) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.7 | 23.8 | ×6.47 | ×1.03 | 3% (1.2) | 65% (27.4) | 8% (3.2) | 24% (10.3) | 0% (0.1) | match |
| tam_Taml | lang | 7.0 | 38.5 | ×5.53 | ×1.04 | 4% (1.2) | 72% (18.6) | 10% (2.5) | 14% (3.7) | 0% (0.0) | match |
| tha_Thai | lang | 8.3 | 33.3 | ×4.01 | ×1.03 | 4% (1.2) | 83% (24.9) | 8% (2.3) | 6% (1.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.6 | 19.7 | ×2.99 | ×1.08 | 3% (1.3) | 78% (40.7) | 13% (7.0) | 5% (2.8) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.2 | 18.4 | ×3.53 | ×1.07 | 3% (1.9) | 72% (40.0) | 12% (6.8) | 11% (6.3) | 0% (0.2) | match |
| added_special_dense | modalities | 5.3 | 39.0 | ×7.31 | ×1.02 | 21% (5.3) | 37% (9.1) | 34% (8.4) | 7% (1.8) | 1% (0.2) | match |
| added_special_sparse | modalities | 4.0 | 21.5 | ×5.39 | ×1.04 | 8% (3.6) | 60% (28.0) | 18% (8.4) | 13% (6.1) | 2% (0.7) | match |
| agentic-traces | modalities | 3.9 | 18.2 | ×4.72 | ×1.07 | 4% (2.3) | 68% (38.5) | 9% (4.9) | 19% (10.6) | 0% (0.1) | match |
| agentic_swe | modalities | 4.1 | 19.5 | ×4.78 | ×1.08 | 4% (1.9) | 73% (38.6) | 7% (3.6) | 16% (8.6) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 19.0 | ×4.86 | ×1.08 | 4% (2.1) | 71% (38.5) | 8% (4.2) | 17% (9.2) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 18.2 | ×4.51 | ×1.08 | 4% (2.5) | 69% (38.6) | 8% (4.8) | 19% (10.4) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×4.04 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 82+0 (peak 81)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 32.8 | ×7.45 | ×0.97 | 2% (0.6) | 0% (0.0) | 16% (4.7) | 82% (23.2) | 0% (0.0) | match |
| arb_Arab | lang | 4.3 | 16.4 | ×3.82 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (54.7) | 0% (0.3) | match |
| ben_Beng | lang | 6.4 | 17.3 | ×2.71 | ×0.97 | 1% (0.6) | 0% (0.0) | 6% (3.1) | 94% (51.9) | 0% (0.0) | match |
| cmn_Hani | lang | 3.7 | 16.2 | ×4.35 | ×0.98 | 1% (0.8) | 0% (0.0) | 5% (3.1) | 92% (53.3) | 1% (0.8) | match |
| ell_Grek | lang | 4.7 | 17.5 | ×3.68 | ×0.97 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (51.7) | 0% (0.0) | match |
| eng_Latn | lang | 3.2 | 12.8 | ×3.98 | ×0.99 | 3% (2.0) | 0% (0.0) | 7% (5.0) | 89% (66.9) | 1% (1.0) | match |
| heb_Hebr | lang | 4.1 | 12.9 | ×3.15 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (3.6) | 95% (71.4) | 0% (0.0) | match |
| hin_Deva | lang | 5.9 | 21.1 | ×3.55 | ×1.00 | 1% (0.6) | 0% (0.0) | 7% (3.3) | 91% (41.8) | 0% (0.1) | match |
| jpn_Jpan | lang | 4.3 | 17.7 | ×4.13 | ×1.01 | 1% (0.7) | 0% (0.0) | 6% (3.0) | 94% (50.4) | 0% (0.0) | match |
| kat_Geor | lang | 6.0 | 17.5 | ×2.89 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (2.9) | 94% (52.0) | 0% (0.0) | match |
| kor_Hang | lang | 3.8 | 19.7 | ×5.24 | ×1.00 | 1% (0.6) | 0% (0.0) | 8% (3.7) | 91% (44.0) | 1% (0.3) | match |
| rus_Cyrl | lang | 4.4 | 14.4 | ×3.28 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (3.2) | 94% (63.8) | 0% (0.0) | match |
| tam_Taml | lang | 6.3 | 17.3 | ×2.74 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (2.7) | 94% (53.0) | 0% (0.0) | match |
| tha_Thai | lang | 7.0 | 14.3 | ×2.03 | ×1.00 | 1% (0.6) | 0% (0.0) | 3% (2.2) | 96% (65.1) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 23.4 | ×3.81 | ×1.00 | 2% (0.7) | 0% (0.0) | 7% (2.8) | 92% (37.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 19.6 | ×3.60 | ×1.00 | 3% (1.3) | 0% (0.0) | 8% (3.9) | 90% (44.7) | 0% (0.0) | match |
| added_special_dense | modalities | 3.6 | 37.2 | ×10.37 | ×1.01 | 25% (6.5) | 2% (0.5) | 23% (5.8) | 49% (12.6) | 1% (0.2) | match |
| added_special_sparse | modalities | 4.0 | 20.9 | ×5.17 | ×1.01 | 8% (3.9) | 1% (0.2) | 14% (6.7) | 76% (35.6) | 1% (0.3) | match |
| agentic-traces | modalities | 3.0 | 14.3 | ×4.71 | ×1.00 | 3% (1.8) | 0% (0.0) | 8% (5.4) | 90% (60.7) | 0% (0.0) | match |
| agentic_swe | modalities | 3.1 | 15.0 | ×4.85 | ×1.00 | 2% (1.3) | 0% (0.0) | 6% (3.8) | 92% (58.9) | 1% (0.4) | match |
| code_mixed | modalities | 3.5 | 15.4 | ×4.38 | ×0.99 | 3% (1.6) | 0% (0.0) | 7% (4.6) | 90% (55.8) | 0% (0.0) | match |
| math_latex | modalities | 2.9 | 13.9 | ×4.84 | ×1.00 | 3% (1.9) | 0% (0.0) | 8% (5.3) | 89% (61.2) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.76 | 3.44 | 4.68 | 5.36 | 41.6 | 20.4 | 9.2 | — | 8.9× / 7.8× | 4.4× / 3.8× | 2.0× / 1.7× | — |
| arb_Arab | 1.15 | 2.99 | 3.38 | 5.22 | 48.3 | 23.3 | 10.2 | — | 14.3× / 9.3× | 6.9× / 4.5× | 3.0× / 1.9× | — |
| ben_Beng | 1.60 | 2.97 | 3.10 | 4.47 | 35.3 | 16.2 | 7.5 | — | 11.4× / 7.9× | 5.2× / 3.6× | 2.4× / 1.7× | — |
| cmn_Hani | 1.12 | 2.28 | 3.14 | 4.30 | 59.6 | 34.5 | 14.4 | — | 19.0× / 13.9× | 11.0× / 8.0× | 4.6× / 3.4× | — |
| ell_Grek | 0.58 | 2.96 | 3.37 | 5.75 | 46.2 | 21.6 | 9.5 | — | 13.7× / 8.0× | 6.4× / 3.8× | 2.8× / 1.6× | — |
| eng_Latn | 0.10 | 1.46 | 5.00 | 6.36 | 64.1 | 40.3 | 16.4 | — | 12.8× / 10.1× | 8.1× / 6.3× | 3.3× / 2.6× | — |
| heb_Hebr | 1.14 | 3.03 | 3.56 | 5.45 | 50.1 | 24.0 | 10.5 | — | 14.1× / 9.2× | 6.7× / 4.4× | 3.0× / 1.9× | — |
| hin_Deva | 1.50 | 3.08 | 3.30 | 4.89 | 37.4 | 19.2 | 8.5 | — | 11.3× / 7.7× | 5.8× / 3.9× | 2.6× / 1.7× | — |
| jpn_Jpan | 1.70 | 3.41 | 2.98 | 4.69 | 52.5 | 27.5 | 11.8 | — | 17.6× / 11.2× | 9.2× / 5.9× | 4.0× / 2.5× | — |
| kat_Geor | 1.53 | 2.59 | 2.92 | 3.99 | 32.5 | 15.6 | 7.2 | — | 11.2× / 8.2× | 5.4× / 3.9× | 2.5× / 1.8× | — |
| kor_Hang | 1.23 | 2.74 | 3.71 | 5.22 | 49.3 | 27.2 | 12.0 | — | 13.3× / 9.5× | 7.3× / 5.2× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.18 | 2.89 | 3.25 | 4.96 | 46.5 | 21.2 | 9.4 | — | 14.3× / 9.4× | 6.5× / 4.3× | 2.9× / 1.9× | — |
| tam_Taml | 0.92 | 2.97 | 2.66 | 4.71 | 31.5 | 13.7 | 6.6 | — | 11.9× / 6.7× | 5.2× / 2.9× | 2.5× / 1.4× | — |
| tha_Thai | 1.50 | 2.59 | 2.17 | 3.26 | 26.3 | 10.2 | 5.2 | — | 12.1× / 8.1× | 4.7× / 3.1× | 2.4× / 1.6× | — |
| added_normalized_dense | 0.06 | 1.77 | 2.78 | 4.49 | 42.8 | 21.3 | 9.2 | — | 15.4× / 9.5× | 7.7× / 4.7× | 3.3× / 2.0× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.86 | 5.27 | 47.3 | 26.8 | 11.3 | — | 12.3× / 9.0× | 6.9× / 5.1× | 2.9× / 2.1× | — |
| added_special_dense | 0.06 | 1.48 | 5.85 | 7.27 | 167.8 | 100.7 | 38.4 | — | 28.7× / 23.1× | 17.2× / 13.9× | 6.6× / 5.3× | — |
| added_special_sparse | 0.06 | 1.48 | 6.65 | 8.07 | 100.3 | 58.5 | 23.6 | — | 15.1× / 12.4× | 8.8× / 7.2× | 3.5× / 2.9× | — |
| agentic-traces | 0.74 | 1.48 | 5.38 | 6.12 | 78.5 | 53.4 | 19.7 | — | 14.6× / 12.8× | 9.9× / 8.7× | 3.7× / 3.2× | — |
| agentic_swe | 0.68 | 1.45 | 3.81 | 4.58 | 92.7 | 67.5 | 23.3 | — | 24.3× / 20.2× | 17.7× / 14.7× | 6.1× / 5.1× | — |
| code_mixed | 0.07 | 1.45 | 4.63 | 6.01 | 71.6 | 54.7 | 18.2 | — | 15.5× / 11.9× | 11.8× / 9.1× | 3.9× / 3.0× | — |
| math_latex | 0.71 | 1.48 | 5.34 | 6.11 | 76.4 | 48.5 | 18.9 | — | 14.3× / 12.5× | 9.1× / 7.9× | 3.5× / 3.1× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×1.88 vs v0.23.1 · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 370) · Pipeline 275+0 (peak 371)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 10.2 | 26.9 | ×2.64 | — | 2% (0.7) | 6% (2.1) | 0% (0.0) | 92% (31.5) | 0% (0.1) | match |
| arb_Arab | lang | 7.2 | 13.3 | ×1.86 | — | 1% (0.6) | 4% (2.5) | 0% (0.0) | 97% (68.4) | 0% (0.0) | match |
| ben_Beng | lang | 10.0 | 18.2 | ×1.81 | — | 1% (0.6) | 3% (1.7) | 0% (0.0) | 96% (49.0) | 0% (0.0) | match |
| cmn_Hani | lang | 12.9 | 34.0 | ×2.63 | — | 2% (0.6) | 1% (0.3) | 0% (0.0) | 97% (24.5) | 0% (0.0) | match |
| ell_Grek | lang | 7.7 | 14.9 | ×1.92 | — | 1% (0.6) | 4% (2.5) | 0% (0.0) | 96% (60.9) | 0% (0.0) | match |
| eng_Latn | lang | 3.8 | 5.5 | ×1.46 | — | 1% (2.0) | 3% (4.8) | 0% (0.0) | 94% (163.7) | 3% (4.5) | match |
| heb_Hebr | lang | 7.7 | 16.7 | ×2.16 | — | 1% (0.6) | 5% (2.6) | 0% (0.1) | 94% (53.5) | 0% (0.3) | match |
| hin_Deva | lang | 9.3 | 17.7 | ×1.90 | — | 1% (0.6) | 4% (2.2) | 0% (0.0) | 94% (49.3) | 1% (0.4) | match |
| jpn_Jpan | lang | 12.8 | 28.9 | ×2.26 | — | 2% (0.6) | 1% (0.2) | 0% (0.0) | 98% (31.4) | 0% (0.0) | match |
| kat_Geor | lang | 11.7 | 24.5 | ×2.09 | — | 2% (0.6) | 4% (1.4) | 0% (0.0) | 94% (36.4) | 1% (0.4) | match |
| kor_Hang | lang | 9.3 | 25.5 | ×2.73 | — | 2% (0.6) | 7% (2.6) | 0% (0.0) | 92% (32.9) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.1 | 10.9 | ×1.53 | — | 1% (0.6) | 3% (2.3) | 0% (0.0) | 98% (84.7) | 0% (0.0) | match |
| tam_Taml | lang | 11.2 | 19.7 | ×1.75 | — | 1% (0.6) | 3% (1.3) | 0% (0.0) | 96% (46.8) | 0% (0.1) | match |
| tha_Thai | lang | 13.3 | 23.8 | ×1.79 | — | 2% (0.6) | 2% (0.6) | 0% (0.0) | 98% (38.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.0 | 7.4 | ×1.48 | — | 1% (0.7) | 2% (2.9) | 0% (0.0) | 97% (127.3) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.5 | 6.6 | ×1.45 | — | 1% (1.3) | 3% (4.4) | 0% (0.0) | 96% (140.7) | 0% (0.6) | match |
| added_special_dense | modalities | 4.6 | 20.0 | ×4.37 | — | 20% (9.3) | 18% (8.7) | 15% (7.1) | 47% (22.4) | 0% (0.1) | match |
| added_special_sparse | modalities | 7.2 | 9.8 | ×1.36 | — | 5% (5.1) | 9% (8.7) | 5% (4.5) | 81% (81.3) | 0% (0.2) | match |
| agentic-traces | modalities | 4.4 | 6.3 | ×1.44 | — | 1% (1.8) | 3% (4.5) | 0% (0.0) | 96% (145.2) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 7.0 | ×1.68 | — | 1% (1.3) | 5% (7.3) | 0% (0.0) | 95% (131.5) | 0% (0.0) | match |
| code_mixed | modalities | 4.3 | 6.6 | ×1.55 | — | 1% (1.5) | 4% (6.0) | 0% (0.0) | 94% (137.8) | 1% (1.2) | match |
| math_latex | modalities | 4.2 | 6.0 | ×1.41 | — | 1% (1.9) | 3% (4.5) | 0% (0.0) | 96% (154.3) | 0% (0.8) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×8.05 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 27+0 (peak 27)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 44.4 | ×11.44 | ×0.87 | 3% (0.7) | 0% (0.0) | 18% (3.6) | 80% (16.4) | 0% (0.0) | match |
| arb_Arab | lang | 3.8 | 25.4 | ×6.72 | ×0.98 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 92% (34.8) | 0% (0.1) | match |
| ben_Beng | lang | 2.9 | 45.5 | ×15.95 | ×0.98 | 3% (0.6) | 0% (0.0) | 14% (3.0) | 83% (17.1) | 0% (0.0) | match |
| cmn_Hani | lang | 3.7 | 29.2 | ×7.92 | ×0.99 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (29.5) | 0% (0.0) | match |
| ell_Grek | lang | 4.2 | 28.0 | ×6.62 | ×0.99 | 2% (0.6) | 0% (0.0) | 6% (2.2) | 92% (31.4) | 0% (0.0) | match |
| eng_Latn | lang | 3.4 | 14.0 | ×4.08 | ×0.99 | 3% (2.0) | 0% (0.0) | 4% (2.9) | 93% (64.8) | 0% (0.0) | match |
| heb_Hebr | lang | 3.9 | 29.3 | ×7.57 | ×1.03 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (29.4) | 0% (0.0) | match |
| hin_Deva | lang | 3.0 | 41.1 | ×13.64 | ×1.01 | 3% (0.6) | 0% (0.0) | 13% (3.0) | 84% (19.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.4 | 21.5 | ×4.86 | ×0.97 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (42.1) | 0% (0.0) | match |
| kat_Geor | lang | 4.7 | 73.0 | ×15.65 | ×1.07 | 5% (0.6) | 0% (0.0) | 16% (2.0) | 80% (10.5) | 0% (0.0) | match |
| kor_Hang | lang | 3.3 | 45.3 | ×13.66 | ×1.04 | 3% (0.6) | 0% (0.0) | 12% (2.4) | 85% (18.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.1 | 26.8 | ×6.52 | ×0.93 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 93% (33.9) | 0% (0.0) | match |
| tam_Taml | lang | 2.6 | 77.7 | ×29.49 | ×1.14 | 5% (0.6) | 0% (0.0) | 22% (2.6) | 74% (9.0) | 0% (0.0) | match |
| tha_Thai | lang | 3.6 | 38.6 | ×10.82 | ×1.04 | 2% (0.6) | 0% (0.0) | 10% (2.5) | 88% (21.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 25.9 | ×4.37 | ×1.02 | 2% (0.7) | 0% (0.0) | 3% (1.1) | 95% (35.4) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.1 | 21.9 | ×4.30 | ×1.02 | 3% (1.2) | 0% (0.0) | 4% (2.0) | 93% (41.3) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 48.0 | ×11.70 | ×1.00 | 25% (4.9) | 1% (0.2) | 20% (4.0) | 53% (10.5) | 1% (0.2) | match |
| added_special_sparse | modalities | 4.2 | 24.1 | ×5.67 | ×1.00 | 8% (3.2) | 0% (0.0) | 11% (4.5) | 81% (32.4) | 0% (0.0) | match |
| agentic-traces | modalities | 3.1 | 16.4 | ×5.30 | ×1.01 | 3% (1.8) | 0% (0.0) | 6% (3.5) | 91% (54.6) | 0% (0.0) | match |
| agentic_swe | modalities | 3.3 | 24.9 | ×7.46 | ×1.00 | 3% (1.3) | 0% (0.0) | 6% (2.4) | 90% (35.0) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 20.8 | ×5.90 | ×1.00 | 3% (1.5) | 0% (0.0) | 6% (2.9) | 91% (42.4) | 0% (0.0) | match |
| math_latex | modalities | 3.1 | 15.3 | ×5.01 | ×1.00 | 3% (1.9) | 0% (0.0) | 5% (3.3) | 92% (58.5) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.40 | 3.61 | 4.26 | 27.3 | 21.5 | 5.7 | 4.8 | 7.5× / 6.4× | 5.9× / 5.0× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.92 | 2.26 | 4.03 | 32.0 | 26.5 | 6.8 | 5.1 | 14.2× / 7.9× | 11.7× / 6.6× | 3.0× / 1.7× | 2.3× / 1.3× |
| ben_Beng | 1.59 | 2.93 | 2.97 | 4.30 | 66.2 | 57.4 | 13.6 | 4.0 | 22.3× / 15.4× | 19.3× / 13.3× | 4.6× / 3.2× | 1.4× / 0.9× |
| cmn_Hani | 1.11 | 2.25 | 2.33 | 3.47 | 26.3 | 21.7 | 5.8 | 2.4 | 11.3× / 7.6× | 9.3× / 6.2× | 2.5× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.97 | 2.17 | 4.56 | 28.0 | 22.5 | 5.9 | 4.8 | 12.9× / 6.1× | 10.4× / 4.9× | 2.7× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.48 | 2.90 | 4.28 | 43.4 | 43.4 | 11.6 | 3.8 | 15.0× / 10.1× | 15.0× / 10.1× | 4.0× / 2.7× | 1.3× / 0.9× |
| heb_Hebr | 1.14 | 3.01 | 2.27 | 4.14 | 31.1 | 27.3 | 6.8 | 3.1 | 13.7× / 7.5× | 12.0× / 6.6× | 3.0× / 1.6× | 1.4× / 0.7× |
| hin_Deva | 1.49 | 3.15 | 3.04 | 4.69 | 62.6 | 57.7 | 13.7 | 4.3 | 20.6× / 13.4× | 19.0× / 12.3× | 4.5× / 2.9× | 1.4× / 0.9× |
| jpn_Jpan | 1.69 | 3.35 | 2.12 | 3.78 | 23.7 | 18.1 | 5.0 | 3.9 | 11.2× / 6.3× | 8.5× / 4.8× | 2.3× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.53 | 2.62 | 2.04 | 3.14 | 17.4 | 14.6 | 4.2 | 1.9 | 8.5× / 5.6× | 7.2× / 4.7× | 2.0× / 1.3× | 0.9× / 0.6× |
| kor_Hang | 1.23 | 2.71 | 2.43 | 3.91 | 31.7 | 28.8 | 7.5 | 3.7 | 13.0× / 8.1× | 11.8× / 7.4× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.91 | 2.09 | 3.84 | 27.1 | 21.7 | 5.8 | 2.5 | 13.0× / 7.1× | 10.4× / 5.7× | 2.8× / 1.5× | 1.2× / 0.7× |
| tam_Taml | 0.91 | 2.94 | 2.63 | 4.66 | 70.7 | 60.5 | 14.3 | 3.8 | 26.9× / 15.2× | 23.0× / 13.0× | 5.4× / 3.1× | 1.4× / 0.8× |
| tha_Thai | 1.51 | 2.60 | 2.48 | 3.56 | 39.9 | 33.0 | 8.7 | 3.2 | 16.1× / 11.2× | 13.3× / 9.3× | 3.5× / 2.4× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.48 | 1.05 | 2.47 | 23.1 | 23.6 | 6.2 | 2.0 | 21.9× / 9.3× | 22.4× / 9.5× | 5.9× / 2.5× | 1.9× / 0.8× |
| added_normalized_sparse | 0.06 | 1.77 | 1.96 | 3.67 | 30.8 | 32.0 | 8.3 | 2.8 | 15.7× / 8.4× | 16.3× / 8.7× | 4.3× / 2.3× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 3.98 | 5.40 | 92.1 | 99.4 | 19.5 | 2.9 | 23.2× / 17.1× | 25.0× / 18.4× | 4.9× / 3.6× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.54 | 5.96 | 60.8 | 62.9 | 14.9 | 3.3 | 13.4× / 10.2× | 13.8× / 10.5× | 3.3× / 2.5× | 0.7× / 0.6× |
| agentic-traces | 0.73 | 1.49 | 3.46 | 4.22 | 58.9 | 63.3 | 15.1 | 4.7 | 17.0× / 14.0× | 18.3× / 15.0× | 4.4× / 3.6× | 1.4× / 1.1× |
| agentic_swe | 0.65 | 1.45 | 2.40 | 3.20 | 59.9 | 71.1 | 14.6 | 3.5 | 25.0× / 18.7× | 29.6× / 22.3× | 6.1× / 4.6× | 1.4× / 1.1× |
| code_mixed | 0.08 | 1.45 | 2.90 | 4.28 | 57.2 | 68.6 | 14.9 | 4.1 | 19.7× / 13.4× | 23.6× / 16.0× | 5.1× / 3.5× | 1.4× / 0.9× |
| math_latex | 0.72 | 1.49 | 3.26 | 4.02 | 51.8 | 53.2 | 13.6 | 4.2 | 15.9× / 12.9× | 16.3× / 13.2× | 4.2× / 3.4× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×4.79 vs v0.23.1 · ×0.78 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 24.0 | ×5.89 | ×0.41 | 2% (0.7) | 0% (0.0) | 13% (4.9) | 86% (33.7) | 0% (0.0) | match |
| arb_Arab | lang | 4.6 | 17.9 | ×3.87 | ×0.71 | 1% (0.6) | 0% (0.0) | 7% (3.8) | 90% (48.5) | 2% (0.8) | match |
| ben_Beng | lang | 6.8 | 17.8 | ×2.62 | ×0.65 | 1% (0.6) | 0% (0.0) | 7% (3.9) | 91% (48.9) | 1% (0.3) | match |
| cmn_Hani | lang | 4.6 | 12.2 | ×2.62 | ×0.32 | 1% (0.6) | 0% (0.0) | 4% (3.3) | 96% (76.8) | 0% (0.0) | match |
| ell_Grek | lang | 5.1 | 15.9 | ×3.12 | ×0.51 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 94% (57.7) | 0% (0.0) | match |
| eng_Latn | lang | 4.0 | 41.6 | ×10.52 | ×1.93 | 10% (2.0) | 0% (0.0) | 22% (4.5) | 70% (14.3) | 0% (0.0) | match |
| heb_Hebr | lang | 4.6 | 16.6 | ×3.59 | ×0.59 | 1% (0.6) | 0% (0.0) | 6% (3.7) | 92% (53.7) | 1% (0.5) | match |
| hin_Deva | lang | 7.1 | 27.3 | ×3.85 | ×1.17 | 2% (0.6) | 0% (0.0) | 12% (4.0) | 89% (30.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.5 | 12.6 | ×2.32 | ×0.34 | 1% (0.6) | 0% (0.0) | 4% (3.1) | 96% (73.0) | 0% (0.0) | match |
| kat_Geor | lang | 6.8 | 14.2 | ×2.10 | ×0.57 | 1% (0.6) | 0% (0.0) | 4% (2.9) | 96% (65.4) | 0% (0.0) | match |
| kor_Hang | lang | 4.1 | 15.0 | ×3.67 | ×0.32 | 1% (0.6) | 0% (0.0) | 6% (3.9) | 92% (55.8) | 1% (0.5) | match |
| rus_Cyrl | lang | 5.1 | 15.6 | ×3.05 | ×0.69 | 1% (0.6) | 0% (0.0) | 5% (3.2) | 90% (56.9) | 4% (2.3) | match |
| tam_Taml | lang | 6.9 | 13.1 | ×1.91 | ×0.45 | 1% (0.6) | 0% (0.0) | 5% (3.4) | 94% (69.3) | 0% (0.3) | match |
| tha_Thai | lang | 7.9 | 11.4 | ×1.44 | ×0.42 | 1% (0.6) | 0% (0.0) | 4% (3.4) | 96% (81.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.8 | 25.5 | ×4.39 | ×0.56 | 2% (0.7) | 0% (0.0) | 6% (2.3) | 92% (36.0) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.7 | 42.0 | ×7.40 | ×1.14 | 5% (1.2) | 0% (0.0) | 14% (3.2) | 81% (18.9) | 0% (0.0) | match |
| added_special_dense | modalities | 4.5 | 73.4 | ×16.37 | ×1.35 | 41% (5.1) | 0% (0.0) | 40% (5.0) | 18% (2.2) | 2% (0.2) | match |
| added_special_sparse | modalities | 4.7 | 77.4 | ×16.60 | ×2.24 | 26% (3.2) | 0% (0.0) | 47% (5.7) | 25% (3.0) | 1% (0.1) | match |
| agentic-traces | modalities | 3.8 | 38.1 | ×10.14 | ×1.66 | 7% (1.8) | 0% (0.0) | 21% (5.0) | 72% (16.8) | 0% (0.0) | match |
| agentic_swe | modalities | 3.8 | 27.4 | ×7.19 | ×1.25 | 4% (1.3) | 0% (0.0) | 11% (3.8) | 85% (29.8) | 0% (0.1) | match |
| code_mixed | modalities | 3.9 | 50.0 | ×12.77 | ×1.68 | 9% (1.6) | 0% (0.0) | 25% (4.4) | 66% (11.4) | 0% (0.1) | match |
| math_latex | modalities | 3.5 | 38.1 | ×10.84 | ×1.68 | 8% (1.9) | 0% (0.0) | 21% (4.8) | 71% (16.1) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.42 | 4.90 | 5.57 | 29.6 | 14.2 | 7.0 | 4.9 | 6.0× / 5.3× | 2.9× / 2.5× | 1.4× / 1.3× | 1.0× / 0.9× |
| arb_Arab | 1.14 | 2.92 | 3.77 | 5.54 | 34.0 | 16.2 | 7.5 | 5.1 | 9.0× / 6.1× | 4.3× / 2.9× | 2.0× / 1.4× | 1.3× / 0.9× |
| ben_Beng | 1.60 | 2.93 | 3.91 | 5.24 | 23.9 | 10.8 | 5.5 | 2.7 | 6.1× / 4.6× | 2.8× / 2.1× | 1.4× / 1.0× | 0.7× / 0.5× |
| cmn_Hani | 1.12 | 2.26 | 3.31 | 4.45 | 21.8 | 11.1 | 5.5 | 2.5 | 6.6× / 4.9× | 3.3× / 2.5× | 1.7× / 1.2× | 0.7× / 0.6× |
| ell_Grek | 0.58 | 2.99 | 3.29 | 5.70 | 29.9 | 15.1 | 7.0 | 5.0 | 9.1× / 5.2× | 4.6× / 2.6× | 2.1× / 1.2× | 1.5× / 0.9× |
| eng_Latn | 0.10 | 1.46 | 4.50 | 5.87 | 42.8 | 29.6 | 13.8 | 4.2 | 9.5× / 7.3× | 6.6× / 5.1× | 3.1× / 2.4× | 0.9× / 0.7× |
| heb_Hebr | 1.14 | 3.05 | 3.68 | 5.58 | 33.7 | 17.1 | 8.1 | 2.7 | 9.2× / 6.0× | 4.7× / 3.1× | 2.2× / 1.5× | 0.7× / 0.5× |
| hin_Deva | 1.50 | 3.10 | 4.02 | 5.62 | 25.9 | 12.9 | 6.4 | 3.1 | 6.4× / 4.6× | 3.2× / 2.3× | 1.6× / 1.1× | 0.8× / 0.6× |
| jpn_Jpan | 1.69 | 3.34 | 3.07 | 4.72 | 20.4 | 9.2 | 4.8 | 3.8 | 6.6× / 4.3× | 3.0× / 2.0× | 1.6× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.84 | 2.58 | 2.90 | 3.64 | 19.1 | 10.0 | 4.7 | 2.1 | 6.6× / 5.3× | 3.4× / 2.7× | 1.6× / 1.3× | 0.7× / 0.6× |
| kor_Hang | 1.22 | 2.72 | 3.87 | 5.37 | 33.3 | 19.1 | 9.0 | 3.6 | 8.6× / 6.2× | 4.9× / 3.6× | 2.3× / 1.7× | 0.9× / 0.7× |
| rus_Cyrl | 1.16 | 2.92 | 3.18 | 4.94 | 28.7 | 15.3 | 6.7 | 4.9 | 9.0× / 5.8× | 4.8× / 3.1× | 2.1× / 1.4× | 1.5× / 1.0× |
| tam_Taml | 0.91 | 2.91 | 3.43 | 5.42 | 19.3 | 8.8 | 4.3 | 2.9 | 5.6× / 3.6× | 2.6× / 1.6× | 1.2× / 0.8× | 0.8× / 0.5× |
| tha_Thai | 1.50 | 2.61 | 3.42 | 4.53 | 13.4 | 5.7 | 2.8 | 2.2 | 3.9× / 3.0× | 1.7× / 1.3× | 0.8× / 0.6× | 0.6× / 0.5× |
| added_normalized_dense | 0.06 | 1.47 | 2.35 | 3.76 | 32.0 | 17.4 | 11.3 | 2.2 | 13.7× / 8.5× | 7.4× / 4.6× | 4.8× / 3.0× | 0.9× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.17 | 4.59 | 34.5 | 21.4 | 11.4 | 3.0 | 10.9× / 7.5× | 6.7× / 4.7× | 3.6× / 2.5× | 0.9× / 0.7× |
| added_special_dense | 0.06 | 1.77 | 5.03 | 6.73 | 82.7 | 69.2 | 24.0 | 3.3 | 16.5× / 12.3× | 13.8× / 10.3× | 4.8× / 3.6× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.73 | 7.15 | 55.3 | 40.8 | 17.3 | 3.7 | 9.7× / 7.7× | 7.1× / 5.7× | 3.0× / 2.4× | 0.7× / 0.5× |
| agentic-traces | 0.72 | 1.48 | 4.96 | 5.72 | 51.3 | 43.7 | 17.4 | 4.9 | 10.3× / 9.0× | 8.8× / 7.6× | 3.5× / 3.0× | 1.0× / 0.9× |
| agentic_swe | 0.66 | 1.45 | 3.75 | 4.54 | 51.3 | 48.7 | 17.2 | 3.6 | 13.7× / 11.3× | 13.0× / 10.7× | 4.6× / 3.8× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.43 | 4.36 | 5.72 | 51.3 | 46.7 | 17.1 | 4.3 | 11.8× / 9.0× | 10.7× / 8.2× | 3.9× / 3.0× | 1.0× / 0.7× |
| math_latex | 0.73 | 1.50 | 4.83 | 5.60 | 49.3 | 35.4 | 15.8 | 4.5 | 10.2× / 8.8× | 7.3× / 6.3× | 3.3× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×6.37 vs v0.23.1 · ×0.61 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 50.4 | ×11.44 | ×0.82 | 6% (1.2) | 0% (0.0) | 20% (3.7) | 74% (13.8) | 0% (0.1) | match |
| arb_Arab | lang | 4.8 | 18.1 | ×3.73 | ×0.32 | 2% (1.2) | 0% (0.0) | 4% (2.3) | 93% (50.3) | 0% (0.1) | match |
| ben_Beng | lang | 4.3 | 28.3 | ×6.57 | ×0.40 | 3% (1.2) | 0% (0.0) | 9% (3.1) | 88% (30.0) | 0% (0.0) | match |
| cmn_Hani | lang | 5.2 | 15.6 | ×2.98 | ×0.23 | 2% (1.2) | 0% (0.0) | 4% (2.4) | 95% (56.9) | 0% (0.0) | match |
| ell_Grek | lang | 5.3 | 19.5 | ×3.64 | ×0.27 | 2% (1.2) | 0% (0.0) | 5% (2.2) | 93% (45.6) | 0% (0.0) | match |
| eng_Latn | lang | 4.2 | 50.6 | ×12.02 | ×2.20 | 13% (2.5) | 0% (0.0) | 16% (3.0) | 70% (13.4) | 0% (0.0) | match |
| heb_Hebr | lang | 4.6 | 26.3 | ×5.71 | ×0.35 | 3% (1.2) | 0% (0.0) | 6% (2.3) | 90% (33.1) | 0% (0.1) | match |
| hin_Deva | lang | 4.1 | 30.8 | ×7.57 | ×0.45 | 4% (1.2) | 0% (0.0) | 10% (3.2) | 86% (26.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.1 | 15.9 | ×2.62 | ×0.23 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 95% (56.1) | 0% (0.0) | match |
| kat_Geor | lang | 7.0 | 23.2 | ×3.33 | ×0.27 | 3% (1.2) | 0% (0.0) | 5% (2.1) | 92% (37.8) | 0% (0.1) | match |
| kor_Hang | lang | 4.2 | 19.5 | ×4.59 | ×0.29 | 2% (1.2) | 0% (0.0) | 5% (2.5) | 92% (45.5) | 1% (0.4) | match |
| rus_Cyrl | lang | 5.6 | 19.8 | ×3.52 | ×0.50 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 93% (46.6) | 0% (0.0) | match |
| tam_Taml | lang | 4.0 | 36.7 | ×9.14 | ×0.51 | 4% (1.2) | 0% (0.0) | 10% (2.7) | 85% (22.6) | 0% (0.0) | match |
| tha_Thai | lang | 5.2 | 23.0 | ×4.38 | ×0.32 | 3% (1.2) | 0% (0.0) | 6% (2.6) | 91% (37.7) | 0% (0.2) | match |
| added_normalized_dense | modalities | 6.1 | 27.0 | ×4.39 | ×0.58 | 4% (1.3) | 0% (0.0) | 3% (1.2) | 93% (33.2) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.3 | 42.2 | ×7.94 | ×1.04 | 8% (1.9) | 0% (0.0) | 9% (2.0) | 83% (18.8) | 0% (0.1) | match |
| added_special_dense | modalities | 4.2 | 47.7 | ×11.44 | ×1.17 | 62% (12.8) | 0% (0.0) | 26% (5.3) | 12% (2.6) | 1% (0.2) | match |
| added_special_sparse | modalities | 4.4 | 57.1 | ×13.01 | ×1.67 | 40% (6.8) | 0% (0.0) | 30% (5.0) | 29% (4.8) | 1% (0.2) | match |
| agentic-traces | modalities | 3.6 | 37.3 | ×10.47 | ×1.56 | 10% (2.5) | 0% (0.0) | 15% (3.7) | 75% (18.5) | 0% (0.0) | match |
| agentic_swe | modalities | 3.9 | 28.5 | ×7.27 | ×1.28 | 6% (1.9) | 0% (0.0) | 8% (2.9) | 86% (30.1) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 49.1 | ×12.15 | ×1.57 | 11% (2.2) | 0% (0.0) | 17% (3.3) | 72% (14.0) | 0% (0.0) | match |
| math_latex | modalities | 3.7 | 42.1 | ×11.37 | ×1.73 | 11% (2.5) | 0% (0.0) | 16% (3.4) | 73% (16.1) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.43 | 3.66 | 4.34 | 27.8 | 16.5 | 5.9 | 4.8 | 7.6× / 6.4× | 4.5× / 3.8× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.97 | 2.32 | 4.14 | 31.5 | 19.7 | 6.8 | 5.2 | 13.6× / 7.6× | 8.5× / 4.8× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.60 | 2.92 | 3.12 | 4.43 | 45.7 | 28.6 | 10.2 | 3.7 | 14.6× / 10.3× | 9.2× / 6.5× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.23 | 2.38 | 3.49 | 19.9 | 12.1 | 4.7 | 2.3 | 8.4× / 5.7× | 5.1× / 3.5× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.98 | 2.21 | 4.60 | 28.4 | 17.7 | 6.1 | 4.7 | 12.8× / 6.2× | 8.0× / 3.8× | 2.7× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.10 | 1.45 | 3.03 | 4.38 | 44.6 | 33.5 | 12.2 | 3.7 | 14.7× / 10.2× | 11.1× / 7.7× | 4.0× / 2.8× | 1.2× / 0.9× |
| heb_Hebr | 1.15 | 2.98 | 2.31 | 4.13 | 30.7 | 19.9 | 6.9 | 3.0 | 13.3× / 7.4× | 8.6× / 4.8× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.49 | 3.17 | 3.22 | 4.89 | 47.9 | 31.9 | 11.1 | 4.0 | 14.9× / 9.8× | 9.9× / 6.5× | 3.4× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.69 | 3.36 | 2.19 | 3.86 | 18.5 | 10.1 | 4.1 | 3.6 | 8.5× / 4.8× | 4.6× / 2.6× | 1.9× / 1.1× | 1.7× / 0.9× |
| kat_Geor | 1.53 | 2.54 | 2.11 | 3.12 | 17.0 | 11.6 | 4.2 | 2.0 | 8.1× / 5.4× | 5.5× / 3.7× | 2.0× / 1.4× | 1.0× / 0.6× |
| kor_Hang | 1.23 | 2.71 | 2.51 | 3.99 | 31.2 | 21.5 | 7.4 | 3.7 | 12.4× / 7.8× | 8.6× / 5.4× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.17 | 2.92 | 2.16 | 3.91 | 27.1 | 16.7 | 5.9 | 2.4 | 12.6× / 6.9× | 7.8× / 4.3× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.91 | 2.95 | 2.71 | 4.76 | 44.5 | 26.8 | 9.8 | 3.4 | 16.4× / 9.4× | 9.9× / 5.6× | 3.6× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.70 | 2.54 | 2.59 | 3.43 | 28.3 | 17.0 | 6.8 | 3.0 | 10.9× / 8.3× | 6.6× / 5.0× | 2.6× / 2.0× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.16 | 2.57 | 23.2 | 17.0 | 6.4 | 1.8 | 20.1× / 9.0× | 14.7× / 6.6× | 5.6× / 2.5× | 1.5× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.95 | 3.37 | 31.7 | 23.1 | 8.7 | 2.5 | 16.2× / 9.4× | 11.9× / 6.9× | 4.4× / 2.6× | 1.3× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 5.26 | 6.67 | 96.0 | 74.1 | 21.1 | 3.2 | 18.3× / 14.4× | 14.1× / 11.1× | 4.0× / 3.2× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 4.99 | 6.69 | 61.7 | 46.8 | 15.1 | 3.6 | 12.4× / 9.2× | 9.4× / 7.0× | 3.0× / 2.3× | 0.7× / 0.5× |
| agentic-traces | 0.78 | 1.48 | 3.72 | 4.43 | 52.5 | 45.2 | 14.8 | 4.6 | 14.1× / 11.8× | 12.2× / 10.2× | 4.0× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.67 | 1.44 | 2.88 | 3.65 | 55.1 | 52.8 | 15.3 | 3.4 | 19.1× / 15.1× | 18.3× / 14.5× | 5.3× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.28 | 4.65 | 51.6 | 51.3 | 14.9 | 4.0 | 15.8× / 11.1× | 15.7× / 11.0× | 4.5× / 3.2× | 1.2× / 0.9× |
| math_latex | 0.72 | 1.47 | 3.43 | 4.19 | 49.9 | 39.6 | 13.8 | 4.1 | 14.5× / 11.9× | 11.5× / 9.5× | 4.0× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.53 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.8 | 41.4 | ×8.55 | ×0.99 | 0% (0.0) | 12% (2.7) | 0% (0.0) | 88% (19.9) | 0% (0.0) | match |
| arb_Arab | lang | 10.5 | 47.9 | ×4.55 | ×0.99 | 0% (0.0) | 16% (3.2) | 0% (0.0) | 83% (16.5) | 0% (0.0) | match |
| ben_Beng | lang | 11.4 | 80.5 | ×7.07 | ×1.01 | 0% (0.0) | 19% (2.2) | 0% (0.0) | 81% (9.4) | 0% (0.0) | match |
| cmn_Hani | lang | 9.5 | 63.9 | ×6.69 | ×1.01 | 0% (0.1) | 3% (0.5) | 0% (0.0) | 96% (13.7) | 0% (0.0) | match |
| ell_Grek | lang | 10.7 | 57.0 | ×5.34 | ×1.01 | 0% (0.0) | 19% (3.1) | 0% (0.0) | 81% (13.4) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 6.4 | ×1.46 | ×1.00 | 0% (0.1) | 5% (6.9) | 0% (0.1) | 96% (144.8) | 0% (0.0) | match |
| heb_Hebr | lang | 10.4 | 59.8 | ×5.73 | ×1.01 | 0% (0.0) | 21% (3.3) | 0% (0.0) | 79% (12.6) | 0% (0.0) | match |
| hin_Deva | lang | 12.3 | 74.8 | ×6.08 | ×1.00 | 0% (0.0) | 23% (2.8) | 0% (0.0) | 76% (9.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.3 | 80.5 | ×6.07 | ×0.99 | 1% (0.1) | 3% (0.4) | 0% (0.0) | 96% (10.7) | 0% (0.0) | match |
| kat_Geor | lang | 15.0 | 87.1 | ×5.82 | ×0.99 | 0% (0.0) | 18% (1.9) | 0% (0.0) | 82% (8.6) | 0% (0.0) | match |
| kor_Hang | lang | 7.6 | 50.5 | ×6.66 | ×1.01 | 0% (0.1) | 17% (3.2) | 0% (0.0) | 82% (15.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 8.6 | 16.1 | ×1.88 | ×1.01 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (58.0) | 0% (0.0) | match |
| tam_Taml | lang | 13.0 | 85.0 | ×6.56 | ×1.00 | 0% (0.0) | 16% (1.7) | 0% (0.0) | 84% (9.1) | 0% (0.0) | match |
| tha_Thai | lang | 16.1 | 82.6 | ×5.13 | ×0.99 | 0% (0.0) | 9% (1.0) | 0% (0.0) | 91% (10.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.5 | 8.7 | ×1.58 | ×1.00 | 0% (0.1) | 3% (3.8) | 0% (0.0) | 96% (108.4) | 0% (0.5) | match |
| added_normalized_sparse | modalities | 4.8 | 7.3 | ×1.53 | ×0.99 | 0% (0.0) | 5% (6.1) | 0% (0.0) | 96% (124.1) | 0% (0.0) | match |
| added_special_dense | modalities | 3.7 | 20.1 | ×5.36 | ×1.00 | 10% (4.9) | 33% (16.0) | 2% (1.1) | 54% (25.8) | 0% (0.2) | match |
| added_special_sparse | modalities | 5.4 | 10.2 | ×1.89 | ×1.00 | 2% (2.1) | 15% (14.7) | 0% (0.3) | 82% (78.7) | 0% (0.1) | match |
| agentic-traces | modalities | 4.7 | 7.1 | ×1.52 | ×1.01 | 0% (0.1) | 5% (6.2) | 0% (0.0) | 95% (130.8) | 0% (0.2) | match |
| agentic_swe | modalities | 4.1 | 7.0 | ×1.70 | ×0.94 | 0% (0.0) | 7% (9.7) | 0% (0.1) | 93% (129.2) | 0% (0.0) | match |
| code_mixed | modalities | 4.3 | 7.0 | ×1.63 | ×0.98 | 0% (0.0) | 6% (8.0) | 0% (0.1) | 94% (130.9) | 0% (0.0) | match |
| math_latex | modalities | 4.5 | 6.8 | ×1.50 | ×0.99 | 0% (0.1) | 4% (6.4) | 0% (0.1) | 94% (137.9) | 1% (1.5) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×6.90 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 95)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.5 | 50.6 | ×11.36 | ×0.96 | 4% (0.7) | 0% (0.0) | 21% (3.6) | 75% (12.7) | 0% (0.0) | match |
| arb_Arab | lang | 4.9 | 18.0 | ×3.68 | ×0.97 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 94% (49.8) | 0% (0.2) | match |
| ben_Beng | lang | 4.2 | 31.2 | ×7.47 | ×0.98 | 2% (0.6) | 0% (0.0) | 10% (3.1) | 88% (26.8) | 0% (0.1) | match |
| cmn_Hani | lang | 5.3 | 16.8 | ×3.17 | ×0.97 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 95% (51.8) | 0% (0.0) | match |
| ell_Grek | lang | 5.5 | 19.5 | ×3.56 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (2.2) | 94% (45.2) | 0% (0.2) | match |
| eng_Latn | lang | 4.2 | 46.2 | ×10.87 | ×0.91 | 11% (2.0) | 0% (0.0) | 17% (3.0) | 72% (13.1) | 0% (0.0) | match |
| heb_Hebr | lang | 4.4 | 26.2 | ×5.97 | ×1.02 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 92% (32.9) | 0% (0.0) | match |
| hin_Deva | lang | 4.5 | 77.0 | ×17.07 | ×1.00 | 5% (0.6) | 0% (0.0) | 27% (3.2) | 67% (7.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.0 | 16.5 | ×2.74 | ×1.01 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (53.8) | 0% (0.0) | match |
| kat_Geor | lang | 5.9 | 37.9 | ×6.47 | ×1.08 | 2% (0.6) | 0% (0.0) | 8% (2.1) | 89% (21.6) | 0% (0.0) | match |
| kor_Hang | lang | 4.3 | 19.6 | ×4.53 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 93% (44.5) | 0% (0.1) | match |
| rus_Cyrl | lang | 5.3 | 16.6 | ×3.12 | ×0.98 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (53.1) | 0% (0.1) | match |
| tam_Taml | lang | 4.1 | 36.1 | ×8.86 | ×1.03 | 2% (0.6) | 0% (0.0) | 10% (2.7) | 87% (23.2) | 0% (0.1) | match |
| tha_Thai | lang | 5.5 | 20.5 | ×3.71 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (2.6) | 93% (42.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.2 | 27.3 | ×4.40 | ×1.00 | 2% (0.7) | 0% (0.0) | 3% (1.2) | 94% (33.4) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.5 | 43.1 | ×7.87 | ×1.00 | 6% (1.3) | 0% (0.0) | 9% (1.9) | 86% (19.0) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 76.3 | ×18.45 | ×1.02 | 40% (5.0) | 0% (0.0) | 38% (4.8) | 21% (2.7) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.4 | 72.4 | ×16.38 | ×0.99 | 24% (3.2) | 0% (0.1) | 37% (4.8) | 37% (4.8) | 2% (0.2) | match |
| agentic-traces | modalities | 3.7 | 37.8 | ×10.18 | ×1.00 | 7% (1.8) | 0% (0.0) | 16% (3.7) | 77% (18.0) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 28.9 | ×6.95 | ×1.00 | 4% (1.3) | 0% (0.0) | 9% (2.9) | 87% (28.0) | 0% (0.0) | match |
| code_mixed | modalities | 4.2 | 47.8 | ×11.25 | ×1.01 | 8% (1.5) | 0% (0.0) | 18% (3.3) | 74% (13.7) | 0% (0.0) | match |
| math_latex | modalities | 3.9 | 41.3 | ×10.72 | ×0.99 | 9% (1.9) | 0% (0.0) | 16% (3.4) | 75% (15.8) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.45 | 3.64 | 4.34 | 28.0 | 16.9 | 6.0 | 4.8 | 7.7× / 6.5× | 4.6× / 3.9× | 1.7× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.16 | 2.96 | 2.31 | 4.11 | 32.6 | 19.7 | 6.7 | 5.2 | 14.1× / 7.9× | 8.5× / 4.8× | 2.9× / 1.6× | 2.2× / 1.3× |
| ben_Beng | 1.59 | 2.93 | 3.10 | 4.44 | 46.7 | 31.1 | 10.6 | 3.7 | 15.0× / 10.5× | 10.0× / 7.0× | 3.4× / 2.4× | 1.2× / 0.8× |
| cmn_Hani | 1.11 | 2.25 | 2.38 | 3.51 | 20.3 | 11.9 | 4.7 | 2.3 | 8.5× / 5.8× | 5.0× / 3.4× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.00 | 2.19 | 4.60 | 29.0 | 17.8 | 6.0 | 4.8 | 13.2× / 6.3× | 8.2× / 3.9× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.51 | 3.03 | 4.44 | 45.4 | 33.8 | 12.2 | 3.7 | 15.0× / 10.2× | 11.2× / 7.6× | 4.0× / 2.7× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.00 | 2.31 | 4.17 | 31.5 | 20.4 | 6.8 | 3.0 | 13.6× / 7.6× | 8.8× / 4.9× | 2.9× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.50 | 3.11 | 3.19 | 4.79 | 49.3 | 30.8 | 11.5 | 4.0 | 15.5× / 10.3× | 9.7× / 6.4× | 3.6× / 2.4× | 1.3× / 0.8× |
| jpn_Jpan | 1.69 | 3.37 | 2.17 | 3.85 | 18.8 | 10.4 | 4.1 | 3.7 | 8.7× / 4.9× | 4.8× / 2.7× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.53 | 2.55 | 2.06 | 3.08 | 17.6 | 11.6 | 4.2 | 2.0 | 8.5× / 5.7× | 5.6× / 3.8× | 2.1× / 1.4× | 1.0× / 0.7× |
| kor_Hang | 1.23 | 2.70 | 2.50 | 3.97 | 32.1 | 22.6 | 7.5 | 3.7 | 12.9× / 8.1× | 9.0× / 5.7× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.91 | 2.15 | 3.90 | 27.7 | 16.7 | 5.9 | 2.6 | 12.9× / 7.1× | 7.8× / 4.3× | 2.7× / 1.5× | 1.2× / 0.7× |
| tam_Taml | 0.91 | 2.92 | 2.71 | 4.72 | 45.7 | 29.1 | 9.9 | 3.4 | 16.9× / 9.7× | 10.7× / 6.2× | 3.6× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.50 | 2.61 | 2.58 | 3.69 | 28.9 | 17.0 | 6.7 | 3.0 | 11.2× / 7.8× | 6.6× / 4.6× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.16 | 2.58 | 24.1 | 17.6 | 6.5 | 1.8 | 20.7× / 9.3× | 15.2× / 6.8× | 5.6× / 2.5× | 1.5× / 0.7× |
| added_normalized_sparse | 0.06 | 1.77 | 1.90 | 3.61 | 32.1 | 23.8 | 8.7 | 2.5 | 16.9× / 8.9× | 12.5× / 6.6× | 4.6× / 2.4× | 1.3× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 4.76 | 6.18 | 97.9 | 77.2 | 21.1 | 3.1 | 20.6× / 15.8× | 16.2× / 12.5× | 4.4× / 3.4× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.81 | 6.23 | 62.5 | 47.1 | 14.9 | 3.6 | 13.0× / 10.0× | 9.8× / 7.6× | 3.1× / 2.4× | 0.8× / 0.6× |
| agentic-traces | 0.72 | 1.48 | 3.71 | 4.47 | 54.1 | 44.8 | 14.9 | 4.5 | 14.6× / 12.1× | 12.1× / 10.0× | 4.0× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.67 | 1.46 | 2.85 | 3.65 | 56.2 | 52.9 | 15.6 | 3.4 | 19.7× / 15.4× | 18.5× / 14.5× | 5.5× / 4.3× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.26 | 4.62 | 54.4 | 51.8 | 15.2 | 4.0 | 16.7× / 11.8× | 15.9× / 11.2× | 4.6× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.72 | 1.48 | 3.43 | 4.19 | 52.2 | 40.5 | 13.9 | 4.1 | 15.2× / 12.5× | 11.8× / 9.7× | 4.1× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×3.41 vs v0.23.1 · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 193) · Pipeline 109+0 (peak 195)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 30.8 | ×7.98 | — | 4% (1.2) | 0% (0.0) | 49% (14.4) | 47% (13.7) | 0% (0.0) | match |
| arb_Arab | lang | 4.9 | 17.4 | ×3.55 | — | 2% (1.2) | 0% (0.0) | 30% (16.3) | 68% (36.6) | 0% (0.0) | match |
| ben_Beng | lang | 6.9 | 16.6 | ×2.41 | — | 2% (1.2) | 0% (0.0) | 19% (10.9) | 79% (44.9) | 0% (0.2) | match |
| cmn_Hani | lang | 5.1 | 15.9 | ×3.12 | — | 2% (1.2) | 0% (0.0) | 20% (11.7) | 78% (47.0) | 0% (0.0) | match |
| ell_Grek | lang | 5.3 | 15.5 | ×2.93 | — | 2% (1.2) | 0% (0.0) | 25% (15.4) | 73% (44.9) | 0% (0.1) | match |
| eng_Latn | lang | 3.8 | 19.7 | ×5.13 | — | 5% (2.5) | 0% (0.0) | 63% (30.1) | 32% (15.2) | 0% (0.0) | match |
| heb_Hebr | lang | 4.7 | 13.8 | ×2.93 | — | 2% (1.2) | 0% (0.0) | 25% (17.4) | 74% (50.9) | 0% (0.0) | match |
| hin_Deva | lang | 6.9 | 21.4 | ×3.11 | — | 3% (1.2) | 0% (0.0) | 29% (12.9) | 68% (30.3) | 0% (0.1) | match |
| jpn_Jpan | lang | 5.7 | 15.3 | ×2.66 | — | 2% (1.2) | 0% (0.0) | 16% (9.8) | 82% (50.4) | 0% (0.1) | match |
| kat_Geor | lang | 6.8 | 14.5 | ×2.14 | — | 2% (1.2) | 0% (0.0) | 15% (10.3) | 83% (55.6) | 0% (0.1) | match |
| kor_Hang | lang | 4.3 | 15.4 | ×3.56 | — | 2% (1.2) | 0% (0.0) | 31% (19.3) | 67% (40.9) | 0% (0.2) | match |
| rus_Cyrl | lang | 5.2 | 14.5 | ×2.80 | — | 2% (1.2) | 0% (0.0) | 22% (15.0) | 75% (50.5) | 1% (0.3) | match |
| tam_Taml | lang | 7.0 | 14.8 | ×2.11 | — | 2% (1.2) | 0% (0.0) | 14% (8.9) | 85% (55.7) | 0% (0.0) | match |
| tha_Thai | lang | 8.3 | 15.2 | ×1.82 | — | 2% (1.2) | 0% (0.0) | 9% (5.9) | 89% (56.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 20.6 | ×3.63 | — | 3% (1.3) | 0% (0.0) | 36% (17.0) | 62% (29.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.5 | 24.8 | ×4.54 | — | 5% (1.8) | 0% (0.0) | 51% (20.2) | 44% (17.2) | 1% (0.3) | match |
| added_special_dense | modalities | 4.3 | 16.6 | ×3.88 | — | 9% (5.1) | 0% (0.0) | 85% (49.9) | 6% (3.5) | 0% (0.1) | match |
| added_special_sparse | modalities | 4.4 | 22.0 | ×5.02 | — | 8% (3.6) | 0% (0.0) | 79% (34.9) | 13% (5.7) | 0% (0.2) | match |
| agentic-traces | modalities | 3.5 | 15.0 | ×4.33 | — | 4% (2.4) | 0% (0.0) | 67% (43.1) | 30% (19.1) | 0% (0.1) | match |
| agentic_swe | modalities | 3.5 | 11.3 | ×3.19 | — | 2% (1.9) | 0% (0.0) | 62% (54.0) | 36% (31.8) | 0% (0.1) | match |
| code_mixed | modalities | 3.8 | 15.1 | ×3.98 | — | 3% (2.1) | 0% (0.0) | 73% (48.5) | 24% (15.5) | 0% (0.0) | match |
| math_latex | modalities | 3.6 | 17.4 | ×4.80 | — | 4% (2.5) | 0% (0.0) | 68% (37.0) | 28% (15.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.76 | 3.42 | 14.36 | 15.02 | 28.3 | 14.3 | 6.7 | — | 2.0× / 1.9× | 1.0× / 1.0× | 0.5× / 0.4× | — |
| arb_Arab | 1.15 | 2.90 | 16.26 | 18.02 | 32.7 | 16.3 | 7.3 | — | 2.0× / 1.8× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| ben_Beng | 1.60 | 3.02 | 10.94 | 12.36 | 22.9 | 10.9 | 5.3 | — | 2.1× / 1.9× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| cmn_Hani | 1.12 | 2.26 | 11.72 | 12.86 | 21.6 | 11.5 | 5.5 | — | 1.8× / 1.7× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| ell_Grek | 0.58 | 2.99 | 15.38 | 17.78 | 28.5 | 15.6 | 6.6 | — | 1.9× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| eng_Latn | 0.09 | 1.46 | 30.12 | 31.48 | 41.0 | 30.3 | 13.5 | — | 1.4× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| heb_Hebr | 1.14 | 3.04 | 17.35 | 19.25 | 32.0 | 17.8 | 7.7 | — | 1.8× / 1.7× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| hin_Deva | 1.50 | 3.05 | 12.92 | 14.47 | 24.7 | 12.9 | 6.1 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| jpn_Jpan | 1.69 | 3.34 | 9.79 | 11.44 | 20.3 | 9.8 | 4.8 | — | 2.1× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| kat_Geor | 1.52 | 2.50 | 10.29 | 11.27 | 18.5 | 10.3 | 4.5 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| kor_Hang | 1.23 | 2.68 | 19.28 | 20.73 | 32.1 | 19.5 | 8.6 | — | 1.7× / 1.5× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| rus_Cyrl | 1.16 | 2.91 | 14.99 | 16.74 | 27.7 | 15.2 | 6.6 | — | 1.8× / 1.7× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| tam_Taml | 0.91 | 2.95 | 8.92 | 10.96 | 18.5 | 9.2 | 4.2 | — | 2.1× / 1.7× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| tha_Thai | 1.50 | 2.56 | 5.92 | 6.98 | 13.3 | 5.9 | 2.8 | — | 2.2× / 1.9× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| added_normalized_dense | 0.24 | 1.47 | 17.04 | 18.27 | 30.1 | 17.6 | 11.5 | — | 1.8× / 1.6× | 1.0× / 1.0× | 0.7× / 0.6× | — |
| added_normalized_sparse | 0.25 | 1.77 | 20.23 | 21.75 | 32.0 | 21.2 | 11.3 | — | 1.6× / 1.5× | 1.0× / 1.0× | 0.6× / 0.5× | — |
| added_special_dense | 0.24 | 1.48 | 49.94 | 51.17 | 81.7 | 71.2 | 23.4 | — | 1.6× / 1.6× | 1.4× / 1.4× | 0.5× / 0.5× | — |
| added_special_sparse | 0.24 | 1.48 | 34.89 | 36.12 | 52.8 | 41.9 | 16.5 | — | 1.5× / 1.5× | 1.2× / 1.2× | 0.5× / 0.5× | — |
| agentic-traces | 0.71 | 1.48 | 43.11 | 43.88 | 51.1 | 43.6 | 16.7 | — | 1.2× / 1.2× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| agentic_swe | 0.65 | 1.44 | 54.01 | 54.79 | 55.4 | 56.2 | 17.9 | — | 1.0× / 1.0× | 1.0× / 1.0× | 0.3× / 0.3× | — |
| code_mixed | 0.07 | 1.46 | 48.45 | 49.85 | 51.1 | 49.6 | 17.4 | — | 1.1× / 1.0× | 1.0× / 1.0× | 0.4× / 0.3× | — |
| math_latex | 0.96 | 1.51 | 37.04 | 37.58 | 48.1 | 37.6 | 15.6 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30257757176-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
