### PR TITLE
WordCache: FlatCache tricks

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -822,10 +822,11 @@ impl pipeline::Model for PipelineBPE {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
+        let sequence = split.as_str();
         if sequence.is_empty() {
             return Ok(());
         }
@@ -838,7 +839,7 @@ impl pipeline::Model for PipelineBPE {
         } = scratch;
 
         if let Some(cache) = word_cache
-            && let Some(hit) = cache.get(sequence.as_bytes())
+            && let Some(hit) = cache.get(split.as_bytes(), split.head())
         {
             output.extend(hit.iter().map(|&id| PipelineToken { id }));
             return Ok(());
@@ -853,7 +854,7 @@ impl pipeline::Model for PipelineBPE {
         self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         if let Some(cache) = word_cache {
-            cache.insert(sequence.as_bytes(), word.get_chars_iter());
+            cache.insert(split.as_bytes(), split.head(), word.get_chars_iter());
         }
 
         Ok(())
@@ -1427,7 +1428,8 @@ mod tests {
         fn pipeline_ids(model: &PipelineBPE, sequence: &str) -> Vec<u32> {
             let mut out = Vec::new();
             let mut scratch = model.init_scratch();
-            pipeline::Model::tokenize_pipeline(model, sequence, &mut scratch, &mut out).unwrap();
+            pipeline::Model::tokenize_pipeline(model, sequence.into(), &mut scratch, &mut out)
+                .unwrap();
             out.iter().map(|t| t.id).collect()
         }
 
@@ -1479,7 +1481,8 @@ mod tests {
             let mut scratch = model.init_scratch();
             for input in ["hello", "hell", "helo", "oleh", "hello", "", "hxe"] {
                 let mut out = Vec::new();
-                pipeline::Model::tokenize_pipeline(&model, input, &mut scratch, &mut out).unwrap();
+                pipeline::Model::tokenize_pipeline(&model, input.into(), &mut scratch, &mut out)
+                    .unwrap();
                 let got: Vec<u32> = out.iter().map(|t| t.id).collect();
                 assert_eq!(got, reference_ids(&reference, input), "{input:?}");
             }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -830,13 +830,6 @@ impl pipeline::Model for PipelineBPE {
             return Ok(());
         }
 
-        if self.ignore_merges
-            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
-        {
-            output.push(PipelineToken { id });
-            return Ok(());
-        }
-
         let BpeScratch {
             merge_queue,
             skip,
@@ -848,6 +841,12 @@ impl pipeline::Model for PipelineBPE {
             && let Some(hit) = cache.get(sequence.as_bytes())
         {
             output.extend(hit.iter().map(|&id| PipelineToken { id }));
+            return Ok(());
+        }
+        if self.ignore_merges
+            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
+        {
+            output.push(PipelineToken { id });
             return Ok(());
         }
 

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,69 +1,195 @@
-use std::ops::Range;
-
 use ahash::RandomState;
 
 use crate::utils::cache::MAX_LENGTH;
 
-const WAYS: usize = 4;
+/// Slots searched from a key's home position. Linear probing normally settles in
+/// one or two, but the walk has to stop somewhere: nothing is ever removed, so a
+/// saturated table would otherwise scan forever looking for an empty slot.
+const WINDOW: usize = 16;
+/// Ids carried in the slot itself. Most pre-tokens encode to one or two tokens,
+/// so this keeps the arena for the tail rather than the common case.
+const INLINE_IDS: usize = 3;
+/// `count` marker for an entry whose key bytes and/or ids live in the arenas.
+const SPILLED: u8 = u8::MAX;
+/// Set in `key` when it holds a hash of a > 15-byte word rather than the word
+/// itself. Packed keys carry their length (1..=15) in the top byte, so the two
+/// can never be confused, and neither can be 0 — the empty-slot sentinel.
+const LONG_TAG: u128 = 1 << 127;
 
+/// A key of at most 15 bytes packed into a u128: bytes in the low lanes, length
+/// in the top byte. Different lengths therefore never collide, and the whole
+/// comparison is one register-width equality instead of a `memcmp`.
+fn pack_key(key: &[u8]) -> Option<u128> {
+    if key.is_empty() || key.len() > 15 {
+        return None;
+    }
+    let mut lanes = [0u8; 16];
+    lanes[..key.len()].copy_from_slice(key);
+    Some(u128::from_le_bytes(lanes) | ((key.len() as u128) << 120))
+}
+
+/// 32 bytes, two to a cache line. `w` holds the ids inline while
+/// `count <= INLINE_IDS`, and otherwise the arena coordinates
+/// `[key_off, ids_off, key_len << 16 | ids_len]` — where `key_len == 0` means the
+/// key is packed into `key` and no bytes were stored for it.
 #[derive(Clone, Copy, Default)]
+#[repr(C)]
 struct CacheSlot {
-    tag: u32,
-    key_off: u32,
-    ids_off: u32,
-    key_len: u16,
-    ids_len: u16,
+    key: u128,
+    w: [u32; INLINE_IDS],
+    count: u8,
+    freq: u8,
+    _pad: u16,
 }
 
-#[derive(Clone, Copy, Default)]
-#[repr(align(64))]
-struct Bucket([CacheSlot; WAYS]);
+const _: () = assert!(std::mem::size_of::<CacheSlot>() == 32);
 
-impl CacheSlot {
-    fn id_range(&self) -> Range<usize> {
-        self.ids_off as usize..(self.ids_off as usize + self.ids_len as usize)
+/// An arena that reuses the space of evicted entries instead of compacting.
+///
+/// Runs are freed to a list per exact length, which costs nothing here because
+/// `MAX_LENGTH` bounds every run: a freed run always has a list to go to, the
+/// next word of that shape takes it, and no length is ever rounded up. Without
+/// this the arena could only grow, and reclaiming it would mean relocating every
+/// live entry into a second buffer.
+struct Slab<T> {
+    data: Vec<T>,
+    free: Box<[Vec<u32>]>,
+    budget: usize,
+}
+
+impl<T: Copy + Default> Slab<T> {
+    fn new(budget: usize) -> Self {
+        Self {
+            data: Vec::new(),
+            free: (0..=MAX_LENGTH).map(|_| Vec::new()).collect(),
+            budget,
+        }
     }
 
-    fn key_range(&self) -> Range<usize> {
-        self.key_off as usize..(self.key_off as usize + self.key_len as usize)
+    fn alloc(&mut self, len: usize) -> Option<u32> {
+        if let Some(off) = self.free[len].pop() {
+            return Some(off);
+        }
+        if self.data.len() + len > self.budget {
+            return None;
+        }
+        let off = self.data.len() as u32;
+        self.data.resize(self.data.len() + len, T::default());
+        Some(off)
+    }
+
+    fn release(&mut self, off: u32, len: usize) {
+        self.free[len].push(off);
+    }
+
+    fn get(&self, off: u32, len: usize) -> &[T] {
+        &self.data[off as usize..off as usize + len]
+    }
+
+    fn fill(&mut self, off: u32, len: usize, values: impl Iterator<Item = T>) {
+        for (dst, value) in self.data[off as usize..off as usize + len]
+            .iter_mut()
+            .zip(values)
+        {
+            *dst = value;
+        }
     }
 }
 
+/// Pre-token bytes to their token ids, one instance per scratch and therefore
+/// per thread — no sharing, no locking.
+///
+/// Open addressing rather than fixed buckets, because a word that collides can
+/// take the next free slot instead of being locked out. Making room does not
+/// need a second copy of the table: a slot is overwritten in place, which is
+/// safe because slots go empty to occupied and never back, so no probe walk is
+/// ever cut short by a hole. What that costs is a bounded [`WINDOW`], and what
+/// it buys is that the table and its arenas only ever hold entries that are
+/// live.
+///
+/// Eviction picks the coldest slot of the window and halves the frequencies it
+/// passed, so a word has to keep being used to keep its place, and a burst of
+/// once-hot words cannot hold a window forever.
 pub struct WordCache {
     hasher: RandomState,
-    buckets: Box<[Bucket]>,
-    key_bytes: Vec<u8>,
-    ids: Vec<u32>,
-    bucket_mask: u64,
+    slots: Box<[CacheSlot]>,
+    key_bytes: Slab<u8>,
+    ids: Slab<u32>,
+    mask: usize,
+    /// Written by `get` so inline ids can be handed back as a slice.
+    unpacked: [u32; INLINE_IDS],
 }
 
 impl WordCache {
     pub fn new(capacity: usize) -> Self {
-        let n_buckets = (capacity.next_power_of_two() / WAYS).max(1);
+        let n_slots = capacity.next_power_of_two().max(WINDOW);
         Self {
             hasher: RandomState::new(),
-            buckets: vec![Bucket::default(); n_buckets].into_boxed_slice(),
-            ids: Vec::with_capacity(256),
-            key_bytes: Vec::with_capacity(1024),
-            bucket_mask: (n_buckets as u64) - 1,
+            slots: vec![CacheSlot::default(); n_slots].into_boxed_slice(),
+            // Ceilings, not reservations — the arenas below allocate only what is
+            // live. They are set high enough that the slot table runs out first:
+            // an arena that refuses inserts while slots sit empty is just a
+            // smaller cache.
+            key_bytes: Slab::new(n_slots * 48),
+            ids: Slab::new(n_slots * 16),
+            mask: n_slots - 1,
+            unpacked: [0; INLINE_IDS],
         }
     }
 
-    // The low hash bits pick the bucket index, the high bits form the occupancy tag
-    // 0x0 tag is reserved for empty spots (hence the `| 1`)
-    fn locate(&self, key: &[u8]) -> (usize, u32) {
+    /// The stored key, and the hash that places it. Short words key on their own
+    /// bytes and need no confirmation; longer ones key on a tagged hash and are
+    /// confirmed against `key_bytes`.
+    fn locate(&self, key: &[u8]) -> (u128, u64) {
         let hash = self.hasher.hash_one(key);
-        ((hash & self.bucket_mask) as usize, (hash >> 32) as u32 | 1)
+        match pack_key(key) {
+            Some(packed) => (packed, hash),
+            None => ((hash as u128) | LONG_TAG, hash),
+        }
     }
 
-    pub fn get(&self, key: &[u8]) -> Option<&[u32]> {
+    fn confirmed(&self, slot: &CacheSlot, key: &[u8]) -> bool {
+        if slot.key & LONG_TAG == 0 {
+            return true; // the packed key is the word
+        }
+        let key_len = (slot.w[2] >> 16) as usize;
+        key_len == key.len() && self.key_bytes.get(slot.w[0], key_len) == key
+    }
+
+    /// Return an overwritten entry's arena runs so the next entry can use them.
+    fn reclaim(&mut self, index: usize) {
+        let slot = self.slots[index];
+        if slot.count != SPILLED {
+            return;
+        }
+        let (key_len, ids_len) = ((slot.w[2] >> 16) as usize, (slot.w[2] & 0xFFFF) as usize);
+        if key_len > 0 {
+            self.key_bytes.release(slot.w[0], key_len);
+        }
+        if ids_len > 0 {
+            self.ids.release(slot.w[1], ids_len);
+        }
+    }
+
+    pub fn get(&mut self, key: &[u8]) -> Option<&[u32]> {
         if key.len() > MAX_LENGTH {
             return None;
         }
-        let (bucket_idx, tag) = self.locate(key);
-        for slot in &self.buckets[bucket_idx].0 {
-            if slot.tag == tag && key == &self.key_bytes[slot.key_range()] {
-                return Some(&self.ids[slot.id_range()]);
+        let (stored, hash) = self.locate(key);
+        let home = hash as usize;
+        for step in 0..WINDOW {
+            let index = (home + step) & self.mask;
+            let slot = self.slots[index];
+            if slot.key == 0 {
+                return None;
+            }
+            if slot.key == stored && self.confirmed(&slot, key) {
+                self.slots[index].freq = slot.freq.saturating_add(1);
+                if slot.count == SPILLED {
+                    return Some(self.ids.get(slot.w[1], (slot.w[2] & 0xFFFF) as usize));
+                }
+                self.unpacked = slot.w;
+                return Some(&self.unpacked[..slot.count as usize]);
             }
         }
         None
@@ -73,24 +199,79 @@ impl WordCache {
         if key.len() > MAX_LENGTH {
             return;
         }
-        let (bucket_idx, tag) = self.locate(key);
-        let Some(slot) = self.buckets[bucket_idx]
-            .0
-            .iter()
-            .position(|slot| slot.tag == 0)
-        else {
-            // bucket full: skip insert
-            return;
+        let (stored, hash) = self.locate(key);
+        let long = stored & LONG_TAG != 0;
+        let ids_len = ids.len();
+
+        // Reserve arena space before touching the table, so a full arena costs
+        // nothing but the attempt.
+        let (w, count) = if long || ids_len > INLINE_IDS {
+            let Some(key_off) = (if long {
+                self.key_bytes.alloc(key.len())
+            } else {
+                Some(0)
+            }) else {
+                return;
+            };
+            let Some(ids_off) = (if ids_len > 0 {
+                self.ids.alloc(ids_len)
+            } else {
+                Some(0)
+            }) else {
+                if long {
+                    self.key_bytes.release(key_off, key.len());
+                }
+                return;
+            };
+            if long {
+                self.key_bytes.fill(key_off, key.len(), key.iter().copied());
+            }
+            self.ids.fill(ids_off, ids_len, ids);
+            let key_len = if long { key.len() } else { 0 };
+            (
+                [key_off, ids_off, ((key_len as u32) << 16) | ids_len as u32],
+                SPILLED,
+            )
+        } else {
+            let mut w = [0u32; INLINE_IDS];
+            for (dst, id) in w.iter_mut().zip(ids) {
+                *dst = id;
+            }
+            (w, ids_len as u8)
         };
-        self.buckets[bucket_idx].0[slot] = CacheSlot {
-            tag,
-            key_off: self.key_bytes.len() as u32,
-            key_len: key.len() as u16,
-            ids_off: self.ids.len() as u32,
-            ids_len: ids.len() as u16,
+
+        let home = hash as usize;
+        let mut coldest = (u8::MAX, home & self.mask);
+        let mut empty = None;
+        for step in 0..WINDOW {
+            let index = (home + step) & self.mask;
+            if self.slots[index].key == 0 {
+                empty = Some(index);
+                break;
+            }
+            if self.slots[index].freq < coldest.0 {
+                coldest = (self.slots[index].freq, index);
+            }
+        }
+        let index = match empty {
+            Some(index) => index,
+            None => {
+                // Age the window on the way past: every entry it holds has to be
+                // used again before the next conflict or it becomes the victim.
+                for step in 0..WINDOW {
+                    self.slots[(home + step) & self.mask].freq >>= 1;
+                }
+                self.reclaim(coldest.1);
+                coldest.1
+            }
         };
-        self.key_bytes.extend_from_slice(key);
-        self.ids.extend(ids);
+        self.slots[index] = CacheSlot {
+            key: stored,
+            w,
+            count,
+            freq: 0, // on probation until it is used again
+            _pad: 0,
+        };
     }
 }
 
@@ -110,25 +291,104 @@ mod tests {
     }
 
     #[test]
-    fn single_bucket_holds_ways_entries_then_freezes() {
-        // capacity <= WAYS collapses to one bucket, making conflicts deterministic
-        let mut cache = WordCache::new(1);
-        let keys: Vec<Vec<u8>> = (0..WAYS as u8 + 2).map(|i| vec![i; 3]).collect();
-        for (i, key) in keys.iter().enumerate() {
-            cache.insert(key, [i as u32].into_iter());
-        }
-        let cached = keys.iter().filter(|k| cache.get(k).is_some()).count();
-        assert_eq!(cached, WAYS);
-        for (i, key) in keys.iter().enumerate().take(WAYS) {
-            assert_eq!(cache.get(key), Some(&[i as u32][..]));
-        }
-    }
-
-    #[test]
     fn oversized_keys_are_ignored() {
         let mut cache = WordCache::new(1 << 8);
         let big = vec![7u8; MAX_LENGTH + 1];
         cache.insert(&big, [1u32].into_iter());
         assert_eq!(cache.get(&big), None);
+    }
+
+    /// Both sides of the 15-byte packing boundary and both sides of the inline/
+    /// arena boundary have to survive a round trip, including the long key whose
+    /// stored `key` is only a hash and needs the byte comparison to confirm it.
+    #[test]
+    fn every_slot_shape_round_trips() {
+        let mut cache = WordCache::new(1 << 8);
+        let long = vec![b'x'; 200];
+        let cases: [(&[u8], Vec<u32>); 4] = [
+            (b"short", vec![1]),
+            (b"short-wide", (0..40).collect()),
+            (&long, vec![9]),
+            (&long[..64], (0..64).collect()),
+        ];
+        for (key, ids) in &cases {
+            cache.insert(key, ids.clone().into_iter());
+        }
+        for (key, ids) in &cases {
+            assert_eq!(cache.get(key), Some(&ids[..]), "{key:?}");
+        }
+    }
+
+    /// A word that hashes into a full window takes the coldest slot rather than
+    /// being turned away, and the words that were actually used keep their place.
+    #[test]
+    fn a_full_window_evicts_its_coldest_entry() {
+        let mut cache = WordCache::new(WINDOW);
+        let keys: Vec<Vec<u8>> = (0..WINDOW as u8).map(|i| vec![i; 4]).collect();
+        for (i, key) in keys.iter().enumerate() {
+            cache.insert(key, [i as u32].into_iter());
+        }
+        // Every key but the first earns a hit, leaving one clear coldest slot.
+        for key in &keys[1..] {
+            assert!(cache.get(key).is_some());
+        }
+        cache.insert(b"newcomer", [999u32].into_iter());
+        assert_eq!(cache.get(b"newcomer"), Some(&[999u32][..]));
+        assert_eq!(
+            cache.get(&keys[0]),
+            None,
+            "the unused entry should have gone"
+        );
+        for (i, key) in keys.iter().enumerate().skip(1) {
+            assert_eq!(
+                cache.get(key),
+                Some(&[i as u32][..]),
+                "used entry {i} was dropped"
+            );
+        }
+    }
+
+    /// Reusing an evicted entry's arena run is where this design can go wrong:
+    /// hand one run to two live entries and a hit starts returning another word's
+    /// ids. Churn a table far too small for the input and demand the invariant
+    /// that matters — an entry may be evicted, but a hit is never wrong.
+    #[test]
+    fn a_hit_never_returns_another_words_ids() {
+        let mut cache = WordCache::new(64);
+        let mut expected: Vec<(Vec<u8>, Vec<u32>)> = Vec::new();
+        for i in 0..2000usize {
+            let key = match i % 4 {
+                0 => format!("w{i}"),
+                1 => format!("a-long-word-past-fifteen-bytes-{i}"),
+                2 => format!("k{i}xxxxxxxxxxxx"),
+                _ => format!("{}-{i}", "z".repeat(i % 40)),
+            }
+            .into_bytes();
+            let ids: Vec<u32> = (0..=(i % 9) as u32).map(|k| i as u32 * 16 + k).collect();
+            cache.insert(&key, ids.clone().into_iter());
+            expected.push((key, ids));
+        }
+        let mut live = 0;
+        for (key, ids) in &expected {
+            if let Some(hit) = cache.get(key) {
+                assert_eq!(hit, &ids[..], "{key:?}");
+                live += 1;
+            }
+        }
+        assert!(live > 0, "everything was evicted — the test proves nothing");
+    }
+
+    /// Freed runs have to come back. Without reuse the arenas would grow with
+    /// every insert and the cache would be leaking rather than evicting.
+    #[test]
+    fn arenas_hold_the_live_set_not_every_insert() {
+        let mut cache = WordCache::new(64);
+        for i in 0..5000usize {
+            let key = format!("a-long-word-past-fifteen-bytes-{i}");
+            cache.insert(key.as_bytes(), [i as u32; 8].into_iter());
+        }
+        // 64 slots can hold at most 64 keys of ~34 bytes and 64 runs of 8 ids.
+        assert!(cache.key_bytes.data.len() < 8 * 1024);
+        assert!(cache.ids.data.len() < 8 * 1024);
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -288,13 +288,31 @@ const NEWBORN: u8 = 1;
 /// in the top byte. Including the length keeps `"a"` and `"a\0"` apart, and the
 /// whole key comparison becomes one register-wide equality instead of a
 /// `memcmp` against bytes somewhere else in memory.
-fn pack_word(word: &[u8]) -> Option<u128> {
-    if word.is_empty() || word.len() > 15 {
+///
+/// `head` is 16 bytes starting where the word does, which callers that know what
+/// surrounds the word can hand over — see `Split::head`. Taking the whole window
+/// and masking the surplus off costs one load, where copying just the word's own
+/// bytes costs a call into `memcpy`: its length is only known at run time, and
+/// LLVM can fold a copy into a load only when the length is a constant. That one
+/// call was about a third of what building a key cost.
+fn pack_word(word: &[u8], head: Option<&[u8; 16]>) -> Option<u128> {
+    let len = word.len();
+    if len == 0 || len > 15 {
         return None;
     }
-    let mut lanes = [0u8; 16];
-    lanes[..word.len()].copy_from_slice(word);
-    Some(u128::from_le_bytes(lanes) | ((word.len() as u128) << 120))
+    debug_assert!(
+        head.is_none_or(|head| head[..len] == *word),
+        "head has to start where the word does"
+    );
+    let lanes = match head {
+        Some(head) => u128::from_le_bytes(*head),
+        None => {
+            let mut lanes = [0u8; 16];
+            lanes[..len].copy_from_slice(word);
+            u128::from_le_bytes(lanes)
+        }
+    };
+    Some((lanes & (u128::MAX >> (8 * (16 - len)))) | ((len as u128) << 120))
 }
 
 /// One entry, in the three shapes the module docs draw out. In short:
@@ -438,12 +456,14 @@ impl WordCache {
 
     /// The ids `word` encoded to last time, if the entry is still there.
     ///
-    /// Takes `&mut self` because a hit is also a vote for keeping the entry.
-    pub fn get(&mut self, word: &[u8]) -> Option<&[u32]> {
+    /// `head` is the window `pack_word` builds the key from, and passing `None`
+    /// only costs speed. Takes `&mut self` because a hit is also a vote for keeping
+    /// the entry.
+    pub fn get(&mut self, word: &[u8], head: Option<&[u8; 16]>) -> Option<&[u32]> {
         if word.len() > MAX_LENGTH {
             return None;
         }
-        let (key, hash) = self.slot_key(word);
+        let (key, hash) = self.slot_key(word, head);
         let index = self.find(key, hash, word)?;
         self.freqs[index] = self.freqs[index].saturating_add(1);
         let slot = self.slots[index];
@@ -456,11 +476,16 @@ impl WordCache {
     /// Remember what `word` encoded to. Silently does nothing for a word over
     /// [`MAX_LENGTH`] or when an arena is full: a cache is free to forget, and
     /// the caller has the ids either way.
-    pub fn insert(&mut self, word: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
+    pub fn insert(
+        &mut self,
+        word: &[u8],
+        head: Option<&[u8; 16]>,
+        ids: impl ExactSizeIterator<Item = u32>,
+    ) {
         if word.len() > MAX_LENGTH {
             return;
         }
-        let (key, hash) = self.slot_key(word);
+        let (key, hash) = self.slot_key(word, head);
         // Callers insert after a miss, so there is no existing entry to update.
         let Some(entry) = self.build_entry(key, word, ids) else {
             return;
@@ -481,8 +506,8 @@ impl WordCache {
     /// from. Hashing a slice makes aHash mix the length in and then branch on it to
     /// choose a read width; a `u128` is one fixed-width fold with nothing to decide.
     /// The key already carries the length, so nothing is lost.
-    fn slot_key(&self, word: &[u8]) -> (u128, u64) {
-        match pack_word(word) {
+    fn slot_key(&self, word: &[u8], head: Option<&[u8; 16]>) -> (u128, u64) {
+        match pack_word(word, head) {
             Some(packed) => (packed, self.hasher.hash_one(packed)),
             None => {
                 let hash = self.hasher.hash_one(word);
@@ -635,12 +660,12 @@ mod tests {
     #[test]
     fn roundtrip() {
         let mut cache = WordCache::new(1 << 8);
-        assert_eq!(cache.get(b"hello"), None);
-        cache.insert(b"hello", [1u32, 2, 3].into_iter());
-        cache.insert(b"world", [4u32].into_iter());
-        assert_eq!(cache.get(b"hello"), Some(&[1u32, 2, 3][..]));
-        assert_eq!(cache.get(b"world"), Some(&[4u32][..]));
-        assert_eq!(cache.get(b"hell"), None);
+        assert_eq!(cache.get(b"hello", None), None);
+        cache.insert(b"hello", None, [1u32, 2, 3].into_iter());
+        cache.insert(b"world", None, [4u32].into_iter());
+        assert_eq!(cache.get(b"hello", None), Some(&[1u32, 2, 3][..]));
+        assert_eq!(cache.get(b"world", None), Some(&[4u32][..]));
+        assert_eq!(cache.get(b"hell", None), None);
     }
 
     /// The three properties the whole key encoding rests on: a packed key is
@@ -648,11 +673,33 @@ mod tests {
     /// like a hashed key.
     #[test]
     fn packed_keys_are_unique_and_tagged() {
-        assert_ne!(pack_word(b"a"), pack_word(b"a\0"));
-        assert_ne!(pack_word(&[0u8; 15]), Some(0));
-        assert_eq!(pack_word(&[0u8; 15]).unwrap() & LONG_TAG, 0);
-        assert_eq!(pack_word(b""), None);
-        assert_eq!(pack_word(&[b'x'; 16]), None);
+        assert_ne!(pack_word(b"a", None), pack_word(b"a\0", None));
+        assert_ne!(pack_word(&[0u8; 15], None), Some(0));
+        assert_eq!(pack_word(&[0u8; 15], None).unwrap() & LONG_TAG, 0);
+        assert_eq!(pack_word(b"", None), None);
+        assert_eq!(pack_word(&[b'x'; 16], None), None);
+    }
+
+    /// The window is a shortcut for reading the word, not part of what is stored:
+    /// the bytes it carries past the word belong to the neighbours and have to be
+    /// masked away. If any of them survived into the key, a word looked up with a
+    /// window would miss the entry stored without one — and every hit in a real
+    /// encode would depend on where in its chunk the word happened to sit.
+    #[test]
+    fn the_window_past_the_word_is_masked_off() {
+        let chunk = b"the quick brown fox jumps over the lazy dog";
+        let mut cache = WordCache::new(1 << 8);
+        for (start, len) in [(0usize, 3usize), (4, 5), (10, 5), (16, 3), (26, 4)] {
+            let word = &chunk[start..start + len];
+            let head: &[u8; 16] = chunk[start..start + 16].try_into().unwrap();
+            assert_eq!(
+                cache.slot_key(word, None),
+                cache.slot_key(word, Some(head)),
+                "{word:?}"
+            );
+            cache.insert(word, None, [start as u32].into_iter());
+            assert_eq!(cache.get(word, Some(head)), Some(&[start as u32][..]));
+        }
     }
 
     /// A short word's placement now comes out of its packed key rather than its
@@ -664,7 +711,7 @@ mod tests {
         let cache = WordCache::new(1 << 12);
         let homes: std::collections::HashSet<usize> = (0..1000)
             .map(|i| {
-                let (_, hash) = cache.slot_key(format!("tok{i}").as_bytes());
+                let (_, hash) = cache.slot_key(format!("tok{i}").as_bytes(), None);
                 hash as usize & cache.mask
             })
             .collect();
@@ -677,8 +724,8 @@ mod tests {
     fn oversized_words_are_ignored() {
         let mut cache = WordCache::new(1 << 8);
         let big = vec![7u8; MAX_LENGTH + 1];
-        cache.insert(&big, [1u32].into_iter());
-        assert_eq!(cache.get(&big), None);
+        cache.insert(&big, None, [1u32].into_iter());
+        assert_eq!(cache.get(&big, None), None);
     }
 
     /// Both sides of the 15-byte packing boundary and both sides of the inline/
@@ -697,10 +744,10 @@ mod tests {
             (&long[..64], (0..64).collect()),
         ];
         for (word, ids) in &cases {
-            cache.insert(word, ids.clone().into_iter());
+            cache.insert(word, None, ids.clone().into_iter());
         }
         for (word, ids) in &cases {
-            assert_eq!(cache.get(word), Some(&ids[..]), "{word:?}");
+            assert_eq!(cache.get(word, None), Some(&ids[..]), "{word:?}");
         }
     }
 
@@ -714,17 +761,17 @@ mod tests {
         let mine = vec![b'a'; 40];
         let theirs = vec![b'b'; 40];
 
-        cache.insert(&theirs, [7u32].into_iter());
-        let (their_key, their_hash) = cache.slot_key(&theirs);
+        cache.insert(&theirs, None, [7u32].into_iter());
+        let (their_key, their_hash) = cache.slot_key(&theirs, None);
         let their_slot = cache.slots[cache.find(their_key, their_hash, &theirs).unwrap()];
-        let (my_key, my_hash) = cache.slot_key(&mine);
+        let (my_key, my_hash) = cache.slot_key(&mine, None);
         cache.slots[my_hash as usize & cache.mask] = Slot {
             key: my_key,
             ..their_slot
         };
 
-        cache.insert(&mine, [1u32, 2].into_iter());
-        assert_eq!(cache.get(&mine), Some(&[1u32, 2][..]));
+        cache.insert(&mine, None, [1u32, 2].into_iter());
+        assert_eq!(cache.get(&mine, None), Some(&[1u32, 2][..]));
     }
 
     /// A word that hashes into a full window takes the coldest slot rather than
@@ -734,22 +781,22 @@ mod tests {
         let mut cache = WordCache::new(WINDOW);
         let words: Vec<Vec<u8>> = (0..WINDOW as u8).map(|i| vec![i; 4]).collect();
         for (i, word) in words.iter().enumerate() {
-            cache.insert(word, [i as u32].into_iter());
+            cache.insert(word, None, [i as u32].into_iter());
         }
         // Every word but the first earns a hit, leaving one clear coldest slot.
         for word in &words[1..] {
-            assert!(cache.get(word).is_some());
+            assert!(cache.get(word, None).is_some());
         }
-        cache.insert(b"newcomer", [999u32].into_iter());
-        assert_eq!(cache.get(b"newcomer"), Some(&[999u32][..]));
+        cache.insert(b"newcomer", None, [999u32].into_iter());
+        assert_eq!(cache.get(b"newcomer", None), Some(&[999u32][..]));
         assert_eq!(
-            cache.get(&words[0]),
+            cache.get(&words[0], None),
             None,
             "the unused entry should have gone"
         );
         for (i, word) in words.iter().enumerate().skip(1) {
             assert_eq!(
-                cache.get(word),
+                cache.get(word, None),
                 Some(&[i as u32][..]),
                 "used entry {i} was dropped"
             );
@@ -773,12 +820,12 @@ mod tests {
             }
             .into_bytes();
             let ids: Vec<u32> = (0..=(i % 9) as u32).map(|k| i as u32 * 16 + k).collect();
-            cache.insert(&word, ids.clone().into_iter());
+            cache.insert(&word, None, ids.clone().into_iter());
             expected.push((word, ids));
         }
         let mut live = 0;
         for (word, ids) in &expected {
-            if let Some(hit) = cache.get(word) {
+            if let Some(hit) = cache.get(word, None) {
                 assert_eq!(hit, &ids[..], "{word:?}");
                 live += 1;
             }
@@ -795,8 +842,8 @@ mod tests {
         let mut cache = WordCache::new(64);
         for i in 0..2000usize {
             let word = format!("word-{i}-{}", "x".repeat(i % 20));
-            cache.insert(word.as_bytes(), [i as u32, 7].into_iter());
-            cache.get(word.as_bytes());
+            cache.insert(word.as_bytes(), None, [i as u32, 7].into_iter());
+            cache.get(word.as_bytes(), None);
         }
         assert!(
             cache.freqs.iter().any(|&freq| freq != FREE),
@@ -822,10 +869,10 @@ mod tests {
         // in flight before the entry it replaces gives its own run back.
         let word = |i: usize| format!("a-long-word-past-fifteen-bytes-{i:04}");
         for i in 0..5000usize {
-            cache.insert(word(i).as_bytes(), [i as u32; 8].into_iter());
+            cache.insert(word(i).as_bytes(), None, [i as u32; 8].into_iter());
         }
         assert_eq!(
-            cache.get(word(4999).as_bytes()),
+            cache.get(word(4999).as_bytes(), None),
             Some(&[4999u32; 8][..]),
             "inserts stopped landing — the arenas ran out"
         );

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -7,12 +7,14 @@
 //! a hit has to be far cheaper than merging, and a miss has to cost close to
 //! nothing, because every word pays for one the first time it is seen.
 //!
-//! There are three pieces. The table is `N` fixed-size slots, `N` being the
-//! requested capacity rounded up to a power of two, and next to it two arenas
-//! hold what a slot is too small for:
+//! There are four pieces. The table is `N` fixed-size slots, `N` being the
+//! requested capacity rounded up to a power of two; beside it one byte per slot
+//! records how much that slot is being used; and two arenas hold what a slot is
+//! too small for:
 //!
 //! ```text
 //!   slots     [Slot; N]      32 bytes each, one word per slot
+//!   freqs     [u8; N]        how used each slot is — and 0 means "never written"
 //!   key_bytes Slab<u8>       the bytes of words longer than 15
 //!   ids       Slab<u32>      id runs longer than 3
 //! ```
@@ -44,11 +46,11 @@
 //!
 //! # What a slot holds
 //!
-//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and two bytes
-//! of bookkeeping. It takes one of three shapes, depending on how long the word
-//! is and how many ids it encoded to. The first is the common case — most words
-//! are short and encode to one or two tokens — and it touches nothing but the
-//! slot itself:
+//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and four bytes
+//! of bookkeeping, one of them spare. It takes one of three shapes, depending on
+//! how long the word is and how many ids it encoded to. The first is the common
+//! case for English or code — a short word encoding to one or two tokens — and it
+//! touches nothing but the slot itself:
 //!
 //! ```text
 //!  (1) at most 15 bytes, at most 3 ids — the slot holds everything
@@ -85,33 +87,36 @@
 //!
 //! An entry is born on a miss, keeps its slot for as long as it is being used,
 //! and is eventually overwritten by another word that hashes into the same
-//! window. The record of "being used" is one byte per slot, `freq`. Here are four
-//! slots of one window over time, each entry shown with its `freq` (`·` = still
-//! empty):
+//! window. All of that is decided by `freqs` — here are four of one window's
+//! sixteen bytes over time:
 //!
 //! ```text
-//!    1. A, B, C are inserted; a new entry          A:0   B:0   C:0    ·
-//!       starts at 0, on probation
+//!                                                    A    B    C    D
+//!    1. A, B, C inserted, each starting at            1    1    1    0
+//!       NEWBORN — on probation, but not free
 //!
-//!    2. B and C are looked up again,               A:0   B:3   C:1    ·
-//!       scoring one hit each
+//!    2. B is looked up three times, C once            1    4    2    0
 //!
-//!    3. D takes the last free slot, and            A:0   B:3   C:1   D:1
-//!       is used once too
+//!    3. D takes the last free slot, then a hit        1    4    2    2
 //!
-//!    4. E arrives, and the window is full, so one entry has to go:
+//!    4. E arrives and the window is full:
 //!
-//!         the coldest is A, stored but never used  A:0   B:3   C:1   D:1
-//!         every freq in the window is halved       A:0   B:1   C:0   D:0
-//!         A is overwritten where it lies           E:0   B:1   C:0   D:0
-//!                                                  └ and A's arena runs, if it
-//!                                                    had any, are handed back
+//!         A is the coldest — stored, never used       1    4    2    2
+//!         every frequency halves, floored at 1        1    2    1    1
+//!         A's slot goes to E, back at NEWBORN         1    2    1    1
+//!                                                     ▲ E's now; A's arena runs,
+//!                                                       if it had any, come back
 //! ```
 //!
 //! Halving is what keeps this from being "whoever got there first wins": B was
 //! hot once, but unless it keeps earning hits it will be down with the rest by
 //! the time the next word needs a slot. C and D are one unlucky moment from
 //! eviction and one hit from safety.
+//!
+//! The floor at [`NEWBORN`] is what lets the same byte also mean *free*: no live
+//! entry can ever fall to 0, so a 0 says nothing was ever stored in that slot, and
+//! one scan of sixteen bytes answers both "is there a free slot here?" and "which
+//! entry is coldest?".
 //!
 //! Overwriting the victim where it lies is what keeps the whole structure small.
 //! Removing an entry from an open-addressed table normally needs a tombstone or a
@@ -121,6 +126,36 @@
 //! changes owner. That is what lets a lookup stop at the first empty slot, and it
 //! is why the window has to be bounded — in a saturated table, that bound is all
 //! that stops a walk from running over the whole table.
+//!
+//! ## Why the frequencies are not in the slot
+//!
+//! There is room for them — the slot has a spare byte where one used to sit. But
+//! then a window's sixteen frequencies would be sixteen bytes scattered across
+//! eight cache lines of slot table, read one slot at a time. In their own array
+//! they are sixteen *consecutive* bytes, and picking a slot compiles to a 16-byte
+//! load, a vector minimum, and — when the window is full — a vector shift and a
+//! vector maximum to age the whole window at once.
+//!
+//! That is a trade, not a free win: a hit now also writes a byte to a line it
+//! would otherwise never touch, which buys nothing while the table still has room.
+//! Measured over 24 model × corpus × capacity combinations, against the same cache
+//! with `freq` back in the slot (`examples/cache_freq_bench.rs` — it runs both in
+//! one binary, because cross-binary timings here swing ±30% on code layout alone):
+//!
+//! ```text
+//!   evictions per 1000 lookups        time per word
+//!            0 -   2                      ×1.02      ← paying, getting nothing
+//!            5 - 100                      ×1.01
+//!          136 - 160                      ×0.96
+//!          230 - 240                      ×0.91
+//!          376 - 442                      ×0.92
+//! ```
+//!
+//! So the crossover is around 50 evictions per 1000 lookups. A cache comfortably
+//! larger than the corpus in front of it stays below that and pays the 2% — at the
+//! default capacity most of our fixtures never evict at all. A cache that is
+//! actually working sits above it: a table smaller than the vocabulary it sees, or
+//! a long-lived process whose traffic keeps changing shape.
 //!
 //! # Where an evicted entry's space goes
 //!
@@ -203,7 +238,7 @@
 //!   `while local.len() < capacity`, so the words from the first pages of text
 //!   keep their places forever, however useless they turn out to be. Choosing
 //!   *which* entry to drop needs evidence about how much each one is used, and
-//!   somewhere to keep it — the `freq` byte in the slot.
+//!   somewhere to keep it — the frequency byte beside every slot.
 //! - **Entries cost more than twice the memory.** 24 bytes for the `String` and
 //!   24 for the value's vector inside the table, before the two heap blocks they
 //!   point at, against 32 bytes here for the common word.
@@ -229,8 +264,10 @@ const MAX_LENGTH: usize = 1024;
 /// so a saturated table would otherwise scan forever looking for an empty slot.
 const WINDOW: usize = 16;
 /// Ids carried in the slot itself — three `u32`s is what fits beside the key.
-/// Most words encode to one or two tokens, so this keeps the id arena for the
-/// tail rather than the common case.
+/// Enough for 80-96% of lookups on English or code, but only about a quarter of
+/// them on Chinese or Korean, where a vocabulary holding none of those scripts
+/// spends ten ids or more on one word. `examples/cache_freq_bench.rs --lengths`
+/// prints the distribution per model and corpus.
 const INLINE_IDS: usize = 3;
 /// `len` marker for an entry whose ids, and possibly whose bytes, are in the
 /// arenas.
@@ -240,6 +277,12 @@ const SPILLED: u8 = u8::MAX;
 /// key can never be mistaken for a packed one, and neither can be 0 — the
 /// empty-slot marker.
 const LONG_TAG: u128 = 1 << 127;
+/// A `freqs` entry for a slot nothing has been stored in yet. Live entries are at
+/// least [`NEWBORN`], so the one array answers both "is this slot free?" and "how
+/// much is this entry being used?" — see [`WordCache::pick_slot`].
+const FREE: u8 = 0;
+/// Where a new entry's frequency starts: on probation, but not free.
+const NEWBORN: u8 = 1;
 
 /// A word of 1..=15 bytes packed into a `u128`: bytes in the low lanes, length
 /// in the top byte. Including the length keeps `"a"` and `"a\0"` apart, and the
@@ -264,18 +307,18 @@ fn pack_word(word: &[u8]) -> Option<u128> {
 /// - `key_len` is 0 unless the word's bytes went to `key_bytes`, so it doubles as
 ///   "does a matching `key` need confirming?".
 ///
-/// The size assertion is the point of the layout: 32 bytes means a hit reads the
-/// key, the ids and the bookkeeping in one go.
+/// How much an entry is used is *not* here — it lives in `WordCache::freqs`, for
+/// the reasons the module docs give. The byte it left behind cannot be spent on
+/// anything: `key`'s 16-byte alignment fixes the slot at 32 bytes, and a fourth
+/// inline id would need four. That the size is 32 is the point of the layout —
+/// a hit reads the key, the ids and the bookkeeping in one go.
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
 struct Slot {
     key: u128,
     payload: [u32; INLINE_IDS],
     len: u8,
-    /// How much the entry is being used, halved whenever its window has to make
-    /// room (see the module docs). A new entry starts at 0, on probation until
-    /// it earns a hit.
-    freq: u8,
+    _pad: u8,
     key_len: u16,
 }
 
@@ -364,6 +407,10 @@ pub struct WordCache {
     slots: Box<[Slot]>,
     key_bytes: Slab<u8>,
     ids: Slab<u32>,
+    /// How much each slot is being used, one byte per slot, [`FREE`] while the
+    /// slot has never been written. Outside the slots so that a whole window's
+    /// worth is 16 consecutive bytes — see [`WordCache::pick_slot`].
+    freqs: Box<[u8]>,
     /// `slots.len() - 1`. The table is a power of two, so this folds a hash into
     /// a slot index.
     mask: usize,
@@ -384,6 +431,7 @@ impl WordCache {
             // no CJK in it, which spends ~17 ids on a single Chinese word.
             key_bytes: Slab::new(n_slots * 48),
             ids: Slab::new(n_slots * 16),
+            freqs: vec![FREE; n_slots].into_boxed_slice(),
             mask: n_slots - 1,
         }
     }
@@ -397,8 +445,8 @@ impl WordCache {
         }
         let (key, hash) = self.slot_key(word);
         let index = self.find(key, hash, word)?;
+        self.freqs[index] = self.freqs[index].saturating_add(1);
         let slot = self.slots[index];
-        self.slots[index].freq = slot.freq.saturating_add(1);
         if slot.spilled() {
             return Some(self.ids.get(slot.ids_off(), slot.ids_len()));
         }
@@ -420,6 +468,9 @@ impl WordCache {
         let index = self.pick_slot(hash);
         self.reclaim(index);
         self.slots[index] = entry;
+        // Both writes or neither: a slot is occupied exactly when its frequency is
+        // above [`FREE`], and `pick_slot` reads emptiness out of `freqs` alone.
+        self.freqs[index] = NEWBORN;
     }
 
     /// The value a slot stores in its `key`, and the hash that places it. A short
@@ -476,7 +527,7 @@ impl WordCache {
                 key,
                 payload,
                 len: ids_len as u8,
-                freq: 0,
+                _pad: 0,
                 key_len: 0,
             });
         }
@@ -493,39 +544,72 @@ impl WordCache {
             key,
             payload: [key_off, ids_off, ids_len as u32],
             len: SPILLED,
-            freq: 0,
+            _pad: 0,
             key_len: key_len as u16,
         })
     }
 
-    /// The slot the next entry goes in: the first empty one in the window, or the
+    /// The slot the next entry goes in: the first free one in the window, or the
     /// coldest one if they are all taken.
+    ///
+    /// `#[inline]` because this and [`WordCache::reclaim`] exist to give the steps
+    /// of `insert` names, not to be called: left out of line they cost `insert` two
+    /// calls and the pointers it had already loaded.
+    ///
+    /// This reads nothing but `freqs`, which is why the frequencies live outside
+    /// the slots. A window's worth of them is 16 consecutive bytes, so the whole
+    /// decision is a 16-byte load, a vector minimum, and — when the window is full
+    /// — a vector shift to age it. Reading a `freq` out of each slot instead would
+    /// mean 16 strided reads over 8 cache lines. Both jobs come out of the one
+    /// array because [`FREE`] is a frequency no live entry can have.
+    #[inline]
     fn pick_slot(&mut self, hash: u64) -> usize {
         let home = hash as usize & self.mask;
-        // Starting at `home` rather than 0 matters when every slot in the window
-        // has reached the maximum `freq`: the victim still has to be in the
-        // window.
+        let Some(&window) = self.freqs[home..].first_chunk::<WINDOW>() else {
+            return self.pick_slot_wrapping(home);
+        };
+        let coldest = window.iter().copied().min().unwrap_or(FREE);
+        let offset = window.iter().position(|&freq| freq == coldest).unwrap_or(0);
+        if coldest == FREE {
+            return home + offset;
+        }
+        // Age the window on the way past: every entry in it now has to be used
+        // again before the next word arrives here, or become the next victim. The
+        // floor keeps them all distinguishable from a free slot.
+        for freq in &mut self.freqs[home..home + WINDOW] {
+            *freq = (*freq >> 1).max(NEWBORN);
+        }
+        home + offset
+    }
+
+    /// [`WordCache::pick_slot`] for the one home in `mask + 1` whose window runs
+    /// off the end of the table: same policy, read one slot at a time, because the
+    /// frequencies are not contiguous there.
+    #[inline]
+    fn pick_slot_wrapping(&mut self, home: usize) -> usize {
+        // Seeded at `home` rather than 0 so that a window whose entries have all
+        // reached the maximum frequency still evicts one of its own.
         let mut coldest = (u8::MAX, home);
         for step in 0..WINDOW {
             let index = (home + step) & self.mask;
-            let slot = &self.slots[index];
-            if slot.is_empty() {
+            let freq = self.freqs[index];
+            if freq == FREE {
                 return index;
             }
-            if slot.freq < coldest.0 {
-                coldest = (slot.freq, index);
+            if freq < coldest.0 {
+                coldest = (freq, index);
             }
         }
-        // Age the window on the way past: every entry in it now has to be used
-        // again before the next word arrives here, or become the next victim.
         for step in 0..WINDOW {
-            self.slots[(home + step) & self.mask].freq >>= 1;
+            let freq = &mut self.freqs[(home + step) & self.mask];
+            *freq = (*freq >> 1).max(NEWBORN);
         }
         coldest.1
     }
 
     /// Hand an overwritten entry's arena runs back, so the next entry can use
     /// them.
+    #[inline]
     fn reclaim(&mut self, index: usize) {
         let slot = self.slots[index];
         if !slot.spilled() {
@@ -675,6 +759,31 @@ mod tests {
             }
         }
         assert!(live > 0, "everything was evicted — the test proves nothing");
+    }
+
+    /// `find` reads emptiness off the slot's key and `pick_slot` reads it off the
+    /// frequency, so the two have to agree about every slot, always. They only can
+    /// if `insert` writes both and the aging never lets a live entry reach
+    /// [`FREE`].
+    #[test]
+    fn occupancy_agrees_between_slots_and_frequencies() {
+        let mut cache = WordCache::new(64);
+        for i in 0..2000usize {
+            let word = format!("word-{i}-{}", "x".repeat(i % 20));
+            cache.insert(word.as_bytes(), [i as u32, 7].into_iter());
+            cache.get(word.as_bytes());
+        }
+        assert!(
+            cache.freqs.iter().any(|&freq| freq != FREE),
+            "nothing was stored — the test proves nothing"
+        );
+        for (index, slot) in cache.slots.iter().enumerate() {
+            assert_eq!(
+                slot.is_empty(),
+                cache.freqs[index] == FREE,
+                "slot {index} and its frequency disagree"
+            );
+        }
     }
 
     /// Freed runs have to come back. Without reuse the arenas grow with every

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,6 +1,6 @@
 use ahash::RandomState;
 
-use crate::utils::cache::MAX_LENGTH;
+const MAX_LENGTH: usize = 1024;
 
 /// Slots searched from a key's home position. Linear probing normally settles in
 /// one or two, but the walk has to stop somewhere: nothing is ever removed, so a

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,59 +1,320 @@
+//! Remembers the token ids a word encodes to, so BPE only has to merge it once.
+//!
+//! Text repeats itself: a few thousand distinct words usually cover nearly every
+//! word of a document, and merging is the most expensive thing the BPE model
+//! does. So the second time a word shows up, the answer should come from a table
+//! instead of from the merge loop. Both sides of that table are on the hot path:
+//! a hit has to be far cheaper than merging, and a miss has to cost close to
+//! nothing, because every word pays for one the first time it is seen.
+//!
+//! There are three pieces. The table is `N` fixed-size slots, `N` being the
+//! requested capacity rounded up to a power of two, and next to it two arenas
+//! hold what a slot is too small for:
+//!
+//! ```text
+//!   slots     [Slot; N]      32 bytes each, one word per slot
+//!   key_bytes Slab<u8>       the bytes of words longer than 15
+//!   ids       Slab<u32>      id runs longer than 3
+//! ```
+//!
+//! One `WordCache` lives in one scratch buffer, so it is owned by a single
+//! thread: no sharing, no locking, no atomics.
+//!
+//! # Looking a word up
+//!
+//! A word's hash picks its *home* slot. If another word is already sitting
+//! there, the search steps forward one slot at a time — this is open addressing
+//! with linear probing — for at most [`WINDOW`] slots:
+//!
+//! ```text
+//!   get(b"tion")      home = hash(b"tion") & (N - 1) = 4
+//!
+//!     slot 3  │ "port"  │
+//!     slot 4  │ "ation" │ ← home, but another word got here first: step forward
+//!     slot 5  │ "tion"  │ ← the key matches: hit, hand back its ids
+//!     slot 6  │  empty  │
+//!     slot 7  │ "the"   │
+//!
+//!   get(b"xyz")       home = 4 → not "ation", not "tion", slot 6 is empty → miss
+//! ```
+//!
+//! A walk may stop at that empty slot instead of going the full [`WINDOW`],
+//! because no slot ever goes back to being empty once it has been used: an empty
+//! slot means nothing was ever stored beyond it.
+//!
+//! # What a slot holds
+//!
+//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and two bytes
+//! of bookkeeping. It takes one of three shapes, depending on how long the word
+//! is and how many ids it encoded to. The first is the common case — most words
+//! are short and encode to one or two tokens — and it touches nothing but the
+//! slot itself:
+//!
+//! ```text
+//!  (1) at most 15 bytes, at most 3 ids — the slot holds everything
+//!
+//!     b"tion" → [5378, 262]
+//!    key     │ t  i  o  n  00 … 00 │ 4 │   the word, length in the top byte
+//!    payload │ 5378 │ 262 │  ·  │          the ids, right here
+//!    len     2                             2 of the 3 payload words are ids
+//!    key_len 0                             none of it is in key_bytes
+//!
+//!  (2) at most 15 bytes, more than 3 ids — the ids move to the arena
+//!
+//!     b"电脑" (6 bytes) → 8 ids
+//!    key     │ e7 94 b5 e8 84 91 … │ 6 │   still the word itself
+//!    payload │  ·  │  40  │  8  │          8 ids, in the ids arena at 40
+//!    len     SPILLED                       payload is coordinates, not ids
+//!    key_len 0
+//!
+//!  (3) over 15 bytes — the bytes move too, and the key becomes a hash
+//!
+//!     b"unbelievabilities" (17 bytes) → 6 ids
+//!    key     │ hash(word) │ LONG_TAG │   no room for 17 bytes
+//!    payload │  12  │  40  │  6  │       bytes at 12, ids at 40
+//!    len     SPILLED
+//!    key_len 17                          so a hit has to check those bytes
+//! ```
+//!
+//! Shape (3) is the only one where a matching `key` is not proof: two different
+//! long words can hash alike, so a hit there also compares the bytes in
+//! `key_bytes`. Shapes (1) and (2) carry the word itself in the key, so an equal
+//! key *is* an equal word — one register-wide comparison, no memory to chase.
+//!
+//! # The life of an entry
+//!
+//! An entry is born on a miss, keeps its slot for as long as it is being used,
+//! and is eventually overwritten by another word that hashes into the same
+//! window. The record of "being used" is one byte per slot, `freq`. Here are four
+//! slots of one window over time, each entry shown with its `freq` (`·` = still
+//! empty):
+//!
+//! ```text
+//!    1. A, B, C are inserted; a new entry          A:0   B:0   C:0    ·
+//!       starts at 0, on probation
+//!
+//!    2. B and C are looked up again,               A:0   B:3   C:1    ·
+//!       scoring one hit each
+//!
+//!    3. D takes the last free slot, and            A:0   B:3   C:1   D:1
+//!       is used once too
+//!
+//!    4. E arrives, and the window is full, so one entry has to go:
+//!
+//!         the coldest is A, stored but never used  A:0   B:3   C:1   D:1
+//!         every freq in the window is halved       A:0   B:1   C:0   D:0
+//!         A is overwritten where it lies           E:0   B:1   C:0   D:0
+//!                                                  └ and A's arena runs, if it
+//!                                                    had any, are handed back
+//! ```
+//!
+//! Halving is what keeps this from being "whoever got there first wins": B was
+//! hot once, but unless it keeps earning hits it will be down with the rest by
+//! the time the next word needs a slot. C and D are one unlucky moment from
+//! eviction and one hit from safety.
+//!
+//! Overwriting the victim where it lies is what keeps the whole structure small.
+//! Removing an entry from an open-addressed table normally needs a tombstone or a
+//! backward shift, because a probe walk stops at the first empty slot and a hole
+//! in the middle of a chain would cut the walk short. Here nothing is ever
+//! removed: a slot goes from empty to occupied once and after that only ever
+//! changes owner. That is what lets a lookup stop at the first empty slot, and it
+//! is why the window has to be bounded — in a saturated table, that bound is all
+//! that stops a walk from running over the whole table.
+//!
+//! # Where an evicted entry's space goes
+//!
+//! Whatever A had in the arenas is handed back when A is overwritten, and the
+//! next word of the same shape takes it. Runs are never moved and never
+//! rounded up, because there is a free list for every length a run can have
+//! (see [`Slab`], and [`MAX_LENGTH`] for why that is finite):
+//!
+//! ```text
+//!   the ids arena, just after A — which had 6 ids at offset 12 — was evicted
+//!
+//!     data  ┌─────┬────────────────────────────┬─────┐
+//!           │  …  │ A's 6 ids, at offset 12    │  …  │   nothing is moved
+//!           └─────┴────────────────────────────┴─────┘
+//!
+//!     free  len 6 → [ 12 ]   the next word with 6 ids is handed offset 12
+//!           len 8 → [ ]      one list per length, 0 … MAX_LENGTH
+//! ```
+//!
+//! So the arenas hold the live set rather than every word ever seen. Without
+//! reuse they could only grow, and reclaiming them would mean copying every live
+//! entry into a second buffer — twice the memory for the same number of entries.
+//!
+//! # Why open addressing, and not fixed buckets
+//!
+//! The previous version of this cache was 4-way set-associative: the table was
+//! cut into buckets of four slots and a word could only live in the one bucket
+//! its hash picked. That is a single load per lookup and easy to reason about,
+//! but a word whose four slots are taken can never be cached at all, however
+//! empty the rest of the table is:
+//!
+//! ```text
+//!   4-way buckets — a word belongs to exactly one bucket of four
+//!
+//!     bucket 0        bucket 1        bucket 2
+//!     │●│●│●│●│       │●│·│·│·│       │·│·│·│·│
+//!      ▲
+//!      └ full, so this word goes uncached — the free slots one
+//!        bucket over may as well not exist
+//!
+//!   open addressing — the word walks on to the next free slot
+//!
+//!     │●│●│●│●│·│·│·│·│·│·│·│·│·│·│·│·│
+//!      ▲       ▲
+//!      home    └ stored here instead; only WINDOW slots taken in a
+//!                row can turn a word away
+//! ```
+//!
+//! With buckets that small, being locked out starts happening long before the
+//! table is genuinely full. On our multilingual fixtures it cost between 0.1% and
+//! 4% of all lookups, worst on Korean and Chinese, where a document holds far
+//! more distinct words.
+//!
+//! Probing a window closed that gap: on the same fixtures the misses went to ~0,
+//! and in the encoder (`examples/fixture_bench.rs`) the many-distinct-word
+//! scripts spent 10-40% less time in the model stage. English and code came out
+//! inside the noise —
+//! and the noise there is wide: running one binary against *itself* swings the
+//! model stage by ±30%, so measure that floor before believing anything smaller.
+//!
+//! # Why not a `HashMap`
+//!
+//! The legacy BPE model in `model.rs` caches in a thread-local
+//! `AHashMap<String, Word>` (`BPE_LOCAL_CACHE`), so the comparison is concrete.
+//! On a warm benchmark, where every word is already in the map, a hash map is
+//! not far off this table — it has no bucket conflicts either. What it cannot do
+//! is the rest of the job:
+//!
+//! - **Every word it accepts goes to the allocator.** The map owns its keys, so
+//!   an accepted word is copied into a fresh `String`, and each value keeps a
+//!   heap buffer of its own alive. That cost lands on misses, which is where a
+//!   cache can least afford it: a word misses the first time it is ever seen.
+//!   Here an insert writes into space that already exists.
+//! - **A hit is two more random loads.** The key bytes and the value both live
+//!   in their own heap blocks, elsewhere in memory from the table that pointed
+//!   at them. A slot here answers the common word out of the 32 bytes the probe
+//!   has already read.
+//! - **It cannot make room.** A `HashMap` grows until something stops it, and
+//!   the only thing it can do when stopped is refuse: the legacy cache inserts
+//!   `while local.len() < capacity`, so the words from the first pages of text
+//!   keep their places forever, however useless they turn out to be. Choosing
+//!   *which* entry to drop needs evidence about how much each one is used, and
+//!   somewhere to keep it — the `freq` byte in the slot.
+//! - **Entries cost more than twice the memory.** 24 bytes for the `String` and
+//!   24 for the value's vector inside the table, before the two heap blocks they
+//!   point at, against 32 bytes here for the common word.
+//!
+//! A *shared* map costs more again: [`crate::utils::cache::Cache`], which the
+//! Unigram model still uses, wraps one in an `RwLock` and then has to
+//! `try_read`/`try_write` and silently drop the read or the write whenever
+//! another thread holds it.
+
 use ahash::RandomState;
 
+/// Longest word the cache will store, in bytes.
+///
+/// Long words are rare and rarely repeat, so storing them buys little, and the
+/// lookup for one is a hash over every byte to learn nothing. The cap is also
+/// what makes the arenas' free lists possible (one list per length) and what
+/// bounds a run's size at all: a tokenizer with no pre-tokenizer hands this
+/// model whole documents as single "words", and uncapped the cache would
+/// cheerfully memoize documents.
 const MAX_LENGTH: usize = 1024;
-
-/// Slots searched from a key's home position. Linear probing normally settles in
-/// one or two, but the walk has to stop somewhere: nothing is ever removed, so a
-/// saturated table would otherwise scan forever looking for an empty slot.
+/// Slots searched from a word's home position. Linear probing normally settles
+/// in one or two, but the walk has to stop somewhere: nothing is ever removed,
+/// so a saturated table would otherwise scan forever looking for an empty slot.
 const WINDOW: usize = 16;
-/// Ids carried in the slot itself. Most pre-tokens encode to one or two tokens,
-/// so this keeps the arena for the tail rather than the common case.
+/// Ids carried in the slot itself — three `u32`s is what fits beside the key.
+/// Most words encode to one or two tokens, so this keeps the id arena for the
+/// tail rather than the common case.
 const INLINE_IDS: usize = 3;
-/// `count` marker for an entry whose key bytes and/or ids live in the arenas.
+/// `len` marker for an entry whose ids, and possibly whose bytes, are in the
+/// arenas.
 const SPILLED: u8 = u8::MAX;
-/// Set in `key` when it holds a hash of a > 15-byte word rather than the word
-/// itself. Packed keys carry their length (1..=15) in the top byte, so the two
-/// can never be confused, and neither can be 0 — the empty-slot sentinel.
+/// Set in `key` when it holds the hash of a long word instead of the word
+/// itself. Packed keys carry their length (1..=15) in the top byte, so a hashed
+/// key can never be mistaken for a packed one, and neither can be 0 — the
+/// empty-slot marker.
 const LONG_TAG: u128 = 1 << 127;
 
-/// A key of at most 15 bytes packed into a u128: bytes in the low lanes, length
-/// in the top byte. Different lengths therefore never collide, and the whole
-/// comparison is one register-width equality instead of a `memcmp`.
-fn pack_key(key: &[u8]) -> Option<u128> {
-    if key.is_empty() || key.len() > 15 {
+/// A word of 1..=15 bytes packed into a `u128`: bytes in the low lanes, length
+/// in the top byte. Including the length keeps `"a"` and `"a\0"` apart, and the
+/// whole key comparison becomes one register-wide equality instead of a
+/// `memcmp` against bytes somewhere else in memory.
+fn pack_word(word: &[u8]) -> Option<u128> {
+    if word.is_empty() || word.len() > 15 {
         return None;
     }
     let mut lanes = [0u8; 16];
-    lanes[..key.len()].copy_from_slice(key);
-    Some(u128::from_le_bytes(lanes) | ((key.len() as u128) << 120))
+    lanes[..word.len()].copy_from_slice(word);
+    Some(u128::from_le_bytes(lanes) | ((word.len() as u128) << 120))
 }
 
-/// 32 bytes, two to a cache line. `w` holds the ids inline while
-/// `count <= INLINE_IDS`, and otherwise the arena coordinates
-/// `[key_off, ids_off, key_len << 16 | ids_len]` — where `key_len == 0` means the
-/// key is packed into `key` and no bytes were stored for it.
+/// One entry, in the three shapes the module docs draw out. In short:
+///
+/// - `key` is the word itself when it fits in 15 bytes, otherwise its hash with
+///   [`LONG_TAG`] set.
+/// - `payload` is the token ids while `len` counts them, and becomes
+///   `[key_off, ids_off, ids_len]` once `len` is [`SPILLED`] — which is what the
+///   `key_off`/`ids_off`/`ids_len` readers below are for.
+/// - `key_len` is 0 unless the word's bytes went to `key_bytes`, so it doubles as
+///   "does a matching `key` need confirming?".
+///
+/// The size assertion is the point of the layout: 32 bytes means a hit reads the
+/// key, the ids and the bookkeeping in one go.
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
-struct CacheSlot {
+struct Slot {
     key: u128,
-    w: [u32; INLINE_IDS],
-    count: u8,
+    payload: [u32; INLINE_IDS],
+    len: u8,
+    /// How much the entry is being used, halved whenever its window has to make
+    /// room (see the module docs). A new entry starts at 0, on probation until
+    /// it earns a hit.
     freq: u8,
-    _pad: u16,
+    key_len: u16,
 }
 
-const _: () = assert!(std::mem::size_of::<CacheSlot>() == 32);
+const _: () = assert!(std::mem::size_of::<Slot>() == 32);
 
-/// An arena that reuses the space of evicted entries instead of compacting.
+impl Slot {
+    fn is_empty(&self) -> bool {
+        self.key == 0
+    }
+
+    fn spilled(&self) -> bool {
+        self.len == SPILLED
+    }
+
+    fn key_off(&self) -> u32 {
+        self.payload[0]
+    }
+
+    fn ids_off(&self) -> u32 {
+        self.payload[1]
+    }
+
+    fn ids_len(&self) -> usize {
+        self.payload[2] as usize
+    }
+}
+
+/// A grow-only arena that reuses the space of evicted entries instead of
+/// compacting.
 ///
-/// Runs are freed to a list per exact length, which costs nothing here because
-/// `MAX_LENGTH` bounds every run: a freed run always has a list to go to, the
-/// next word of that shape takes it, and no length is ever rounded up. Without
-/// this the arena could only grow, and reclaiming it would mean relocating every
-/// live entry into a second buffer.
+/// Freed runs go on a free list per exact length. That is only practical because
+/// `MAX_LENGTH` bounds every run: there is a list for every length a run can
+/// have, so a freed run is always reusable by the next word of the same shape
+/// and no length is ever rounded up to a bigger class. The price is
+/// `MAX_LENGTH + 1` empty `Vec`s per arena.
 struct Slab<T> {
     data: Vec<T>,
     free: Box<[Vec<u32>]>,
+    /// Ceiling on `data`, not a reservation.
     budget: usize,
 }
 
@@ -66,6 +327,7 @@ impl<T: Copy + Default> Slab<T> {
         }
     }
 
+    /// A run of `len` items, or `None` once the budget is spent.
     fn alloc(&mut self, len: usize) -> Option<u32> {
         if let Some(off) = self.free[len].pop() {
             return Some(off);
@@ -96,28 +358,15 @@ impl<T: Copy + Default> Slab<T> {
     }
 }
 
-/// Pre-token bytes to their token ids, one instance per scratch and therefore
-/// per thread — no sharing, no locking.
-///
-/// Open addressing rather than fixed buckets, because a word that collides can
-/// take the next free slot instead of being locked out. Making room does not
-/// need a second copy of the table: a slot is overwritten in place, which is
-/// safe because slots go empty to occupied and never back, so no probe walk is
-/// ever cut short by a hole. What that costs is a bounded [`WINDOW`], and what
-/// it buys is that the table and its arenas only ever hold entries that are
-/// live.
-///
-/// Eviction picks the coldest slot of the window and halves the frequencies it
-/// passed, so a word has to keep being used to keep its place, and a burst of
-/// once-hot words cannot hold a window forever.
+/// Word bytes to token ids. See the module docs for the design.
 pub struct WordCache {
     hasher: RandomState,
-    slots: Box<[CacheSlot]>,
+    slots: Box<[Slot]>,
     key_bytes: Slab<u8>,
     ids: Slab<u32>,
+    /// `slots.len() - 1`. The table is a power of two, so this folds a hash into
+    /// a slot index.
     mask: usize,
-    /// Written by `get` so inline ids can be handed back as a slice.
-    unpacked: [u32; INLINE_IDS],
 }
 
 impl WordCache {
@@ -125,153 +374,166 @@ impl WordCache {
         let n_slots = capacity.next_power_of_two().max(WINDOW);
         Self {
             hasher: RandomState::new(),
-            slots: vec![CacheSlot::default(); n_slots].into_boxed_slice(),
-            // Ceilings, not reservations — the arenas below allocate only what is
-            // live. They are set high enough that the slot table runs out first:
-            // an arena that refuses inserts while slots sit empty is just a
-            // smaller cache.
+            slots: vec![Slot::default(); n_slots].into_boxed_slice(),
+            // Ceilings, not reservations: the arenas grow only as far as the live
+            // set takes them. Deliberately generous, so that the slot table is
+            // what runs out first — an arena that turns inserts away while slots
+            // sit empty is a capacity limit in disguise, and tighter numbers here
+            // measured exactly that (tens of thousands of words refused at 35%
+            // occupancy). The worst case they have to cover is a vocabulary with
+            // no CJK in it, which spends ~17 ids on a single Chinese word.
             key_bytes: Slab::new(n_slots * 48),
             ids: Slab::new(n_slots * 16),
             mask: n_slots - 1,
-            unpacked: [0; INLINE_IDS],
         }
     }
 
-    /// The stored key, and the hash that places it. Short words key on their own
-    /// bytes and need no confirmation; longer ones key on a tagged hash and are
-    /// confirmed against `key_bytes`.
-    fn locate(&self, key: &[u8]) -> (u128, u64) {
-        let hash = self.hasher.hash_one(key);
-        match pack_key(key) {
+    /// The ids `word` encoded to last time, if the entry is still there.
+    ///
+    /// Takes `&mut self` because a hit is also a vote for keeping the entry.
+    pub fn get(&mut self, word: &[u8]) -> Option<&[u32]> {
+        if word.len() > MAX_LENGTH {
+            return None;
+        }
+        let (key, hash) = self.slot_key(word);
+        let index = self.find(key, hash, word)?;
+        let slot = self.slots[index];
+        self.slots[index].freq = slot.freq.saturating_add(1);
+        if slot.spilled() {
+            return Some(self.ids.get(slot.ids_off(), slot.ids_len()));
+        }
+        Some(&self.slots[index].payload[..slot.len as usize])
+    }
+
+    /// Remember what `word` encoded to. Silently does nothing for a word over
+    /// [`MAX_LENGTH`] or when an arena is full: a cache is free to forget, and
+    /// the caller has the ids either way.
+    pub fn insert(&mut self, word: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
+        if word.len() > MAX_LENGTH {
+            return;
+        }
+        let (key, hash) = self.slot_key(word);
+        // Callers insert after a miss, so there is no existing entry to update.
+        let Some(entry) = self.build_entry(key, word, ids) else {
+            return;
+        };
+        let index = self.pick_slot(hash);
+        self.reclaim(index);
+        self.slots[index] = entry;
+    }
+
+    /// The value a slot stores in its `key`, and the hash that places it. A short
+    /// word is its own key; a longer one keys on a tagged hash and has to be
+    /// confirmed against `key_bytes`, since two long words can hash alike.
+    fn slot_key(&self, word: &[u8]) -> (u128, u64) {
+        let hash = self.hasher.hash_one(word);
+        match pack_word(word) {
             Some(packed) => (packed, hash),
             None => ((hash as u128) | LONG_TAG, hash),
         }
     }
 
-    fn confirmed(&self, slot: &CacheSlot, key: &[u8]) -> bool {
-        if slot.key & LONG_TAG == 0 {
-            return true; // the packed key is the word
-        }
-        let key_len = (slot.w[2] >> 16) as usize;
-        key_len == key.len() && self.key_bytes.get(slot.w[0], key_len) == key
-    }
-
-    /// Return an overwritten entry's arena runs so the next entry can use them.
-    fn reclaim(&mut self, index: usize) {
-        let slot = self.slots[index];
-        if slot.count != SPILLED {
-            return;
-        }
-        let (key_len, ids_len) = ((slot.w[2] >> 16) as usize, (slot.w[2] & 0xFFFF) as usize);
-        if key_len > 0 {
-            self.key_bytes.release(slot.w[0], key_len);
-        }
-        if ids_len > 0 {
-            self.ids.release(slot.w[1], ids_len);
-        }
-    }
-
-    pub fn get(&mut self, key: &[u8]) -> Option<&[u32]> {
-        if key.len() > MAX_LENGTH {
-            return None;
-        }
-        let (stored, hash) = self.locate(key);
-        let home = hash as usize;
+    /// The slot holding `word`, searched from its home position. Stopping at the
+    /// first empty slot is safe because slots never go back to being empty: an
+    /// empty one means the word was never stored.
+    fn find(&self, key: u128, hash: u64, word: &[u8]) -> Option<usize> {
         for step in 0..WINDOW {
-            let index = (home + step) & self.mask;
-            let slot = self.slots[index];
-            if slot.key == 0 {
+            let index = (hash as usize + step) & self.mask;
+            let slot = &self.slots[index];
+            if slot.is_empty() {
                 return None;
             }
-            if slot.key == stored && self.confirmed(&slot, key) {
-                self.slots[index].freq = slot.freq.saturating_add(1);
-                if slot.count == SPILLED {
-                    return Some(self.ids.get(slot.w[1], (slot.w[2] & 0xFFFF) as usize));
-                }
-                self.unpacked = slot.w;
-                return Some(&self.unpacked[..slot.count as usize]);
+            if slot.key == key && self.holds_word(slot, word) {
+                return Some(index);
             }
         }
         None
     }
 
-    pub fn insert(&mut self, key: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
-        if key.len() > MAX_LENGTH {
-            return;
-        }
-        let (stored, hash) = self.locate(key);
-        let long = stored & LONG_TAG != 0;
-        let ids_len = ids.len();
+    /// Whether the entry really is `word`'s. A packed key is the word itself and
+    /// needs nothing further; a hashed one is only as good as its bytes.
+    fn holds_word(&self, slot: &Slot, word: &[u8]) -> bool {
+        slot.key_len == 0 || self.key_bytes.get(slot.key_off(), slot.key_len as usize) == word
+    }
 
-        // Reserve arena space before touching the table, so a full arena costs
-        // nothing but the attempt.
-        let (w, count) = if long || ids_len > INLINE_IDS {
-            let Some(key_off) = (if long {
-                self.key_bytes.alloc(key.len())
-            } else {
-                Some(0)
-            }) else {
-                return;
-            };
-            let Some(ids_off) = (if ids_len > 0 {
-                self.ids.alloc(ids_len)
-            } else {
-                Some(0)
-            }) else {
-                if long {
-                    self.key_bytes.release(key_off, key.len());
-                }
-                return;
-            };
-            if long {
-                self.key_bytes.fill(key_off, key.len(), key.iter().copied());
-            }
-            self.ids.fill(ids_off, ids_len, ids);
-            let key_len = if long { key.len() } else { 0 };
-            (
-                [key_off, ids_off, ((key_len as u32) << 16) | ids_len as u32],
-                SPILLED,
-            )
-        } else {
-            let mut w = [0u32; INLINE_IDS];
-            for (dst, id) in w.iter_mut().zip(ids) {
+    /// The entry to store, with whatever does not fit in a slot copied into the
+    /// arenas. `None` when an arena is full, so a rejected insert leaves the
+    /// table and the arenas exactly as they were.
+    fn build_entry(
+        &mut self,
+        key: u128,
+        word: &[u8],
+        ids: impl ExactSizeIterator<Item = u32>,
+    ) -> Option<Slot> {
+        let long = key & LONG_TAG != 0;
+        let ids_len = ids.len();
+        if !long && ids_len <= INLINE_IDS {
+            let mut payload = [0u32; INLINE_IDS];
+            for (dst, id) in payload.iter_mut().zip(ids) {
                 *dst = id;
             }
-            (w, ids_len as u8)
+            return Some(Slot {
+                key,
+                payload,
+                len: ids_len as u8,
+                freq: 0,
+                key_len: 0,
+            });
+        }
+        // A short word stays in the key, which is a zero-length run here.
+        let key_len = if long { word.len() } else { 0 };
+        let key_off = self.key_bytes.alloc(key_len)?;
+        let Some(ids_off) = self.ids.alloc(ids_len) else {
+            self.key_bytes.release(key_off, key_len);
+            return None;
         };
+        self.key_bytes.fill(key_off, key_len, word.iter().copied());
+        self.ids.fill(ids_off, ids_len, ids);
+        Some(Slot {
+            key,
+            payload: [key_off, ids_off, ids_len as u32],
+            len: SPILLED,
+            freq: 0,
+            key_len: key_len as u16,
+        })
+    }
 
-        let home = hash as usize;
-        let mut coldest = (u8::MAX, home & self.mask);
-        let mut empty = None;
+    /// The slot the next entry goes in: the first empty one in the window, or the
+    /// coldest one if they are all taken.
+    fn pick_slot(&mut self, hash: u64) -> usize {
+        let home = hash as usize & self.mask;
+        // Starting at `home` rather than 0 matters when every slot in the window
+        // has reached the maximum `freq`: the victim still has to be in the
+        // window.
+        let mut coldest = (u8::MAX, home);
         for step in 0..WINDOW {
             let index = (home + step) & self.mask;
-            if self.slots[index].key == 0 {
-                empty = Some(index);
-                break;
+            let slot = &self.slots[index];
+            if slot.is_empty() {
+                return index;
             }
-            if self.slots[index].freq < coldest.0 {
-                coldest = (self.slots[index].freq, index);
+            if slot.freq < coldest.0 {
+                coldest = (slot.freq, index);
             }
         }
-        let index = match empty {
-            Some(index) => index,
-            None => {
-                // Age the window on the way past: every entry it holds has to be
-                // used again before the next conflict or it becomes the victim.
-                for step in 0..WINDOW {
-                    self.slots[(home + step) & self.mask].freq >>= 1;
-                }
-                self.reclaim(coldest.1);
-                coldest.1
-            }
-        };
-        self.slots[index] = CacheSlot {
-            key: stored,
-            w,
-            count,
-            freq: 0, // on probation until it is used again
-            _pad: 0,
-        };
+        // Age the window on the way past: every entry in it now has to be used
+        // again before the next word arrives here, or become the next victim.
+        for step in 0..WINDOW {
+            self.slots[(home + step) & self.mask].freq >>= 1;
+        }
+        coldest.1
+    }
+
+    /// Hand an overwritten entry's arena runs back, so the next entry can use
+    /// them.
+    fn reclaim(&mut self, index: usize) {
+        let slot = self.slots[index];
+        if !slot.spilled() {
+            return;
+        }
+        self.key_bytes
+            .release(slot.key_off(), slot.key_len as usize);
+        self.ids.release(slot.ids_off(), slot.ids_len());
     }
 }
 
@@ -290,8 +552,20 @@ mod tests {
         assert_eq!(cache.get(b"hell"), None);
     }
 
+    /// The three properties the whole key encoding rests on: a packed key is
+    /// unique per word, is never `0` (the empty-slot marker), and never looks
+    /// like a hashed key.
     #[test]
-    fn oversized_keys_are_ignored() {
+    fn packed_keys_are_unique_and_tagged() {
+        assert_ne!(pack_word(b"a"), pack_word(b"a\0"));
+        assert_ne!(pack_word(&[0u8; 15]), Some(0));
+        assert_eq!(pack_word(&[0u8; 15]).unwrap() & LONG_TAG, 0);
+        assert_eq!(pack_word(b""), None);
+        assert_eq!(pack_word(&[b'x'; 16]), None);
+    }
+
+    #[test]
+    fn oversized_words_are_ignored() {
         let mut cache = WordCache::new(1 << 8);
         let big = vec![7u8; MAX_LENGTH + 1];
         cache.insert(&big, [1u32].into_iter());
@@ -299,24 +573,49 @@ mod tests {
     }
 
     /// Both sides of the 15-byte packing boundary and both sides of the inline/
-    /// arena boundary have to survive a round trip, including the long key whose
+    /// arena boundary have to survive a round trip, including the long word whose
     /// stored `key` is only a hash and needs the byte comparison to confirm it.
     #[test]
     fn every_slot_shape_round_trips() {
         let mut cache = WordCache::new(1 << 8);
         let long = vec![b'x'; 200];
-        let cases: [(&[u8], Vec<u32>); 4] = [
+        let cases: [(&[u8], Vec<u32>); 6] = [
             (b"short", vec![1]),
             (b"short-wide", (0..40).collect()),
+            (b"fifteen-bytes.", vec![2]),
+            (b"sixteen-bytes.aa", vec![3]),
             (&long, vec![9]),
             (&long[..64], (0..64).collect()),
         ];
-        for (key, ids) in &cases {
-            cache.insert(key, ids.clone().into_iter());
+        for (word, ids) in &cases {
+            cache.insert(word, ids.clone().into_iter());
         }
-        for (key, ids) in &cases {
-            assert_eq!(cache.get(key), Some(&ids[..]), "{key:?}");
+        for (word, ids) in &cases {
+            assert_eq!(cache.get(word), Some(&ids[..]), "{word:?}");
         }
+    }
+
+    /// Two long words can hash to the same key, and then only their bytes tell
+    /// them apart. Real hash collisions are too rare to write a test around, so
+    /// forge one: park another word's entry on this word's home slot and stamp
+    /// this word's key on it. The lookup has to walk past it.
+    #[test]
+    fn a_hashed_key_is_confirmed_against_the_word_bytes() {
+        let mut cache = WordCache::new(1 << 8);
+        let mine = vec![b'a'; 40];
+        let theirs = vec![b'b'; 40];
+
+        cache.insert(&theirs, [7u32].into_iter());
+        let (their_key, their_hash) = cache.slot_key(&theirs);
+        let their_slot = cache.slots[cache.find(their_key, their_hash, &theirs).unwrap()];
+        let (my_key, my_hash) = cache.slot_key(&mine);
+        cache.slots[my_hash as usize & cache.mask] = Slot {
+            key: my_key,
+            ..their_slot
+        };
+
+        cache.insert(&mine, [1u32, 2].into_iter());
+        assert_eq!(cache.get(&mine), Some(&[1u32, 2][..]));
     }
 
     /// A word that hashes into a full window takes the coldest slot rather than
@@ -324,24 +623,24 @@ mod tests {
     #[test]
     fn a_full_window_evicts_its_coldest_entry() {
         let mut cache = WordCache::new(WINDOW);
-        let keys: Vec<Vec<u8>> = (0..WINDOW as u8).map(|i| vec![i; 4]).collect();
-        for (i, key) in keys.iter().enumerate() {
-            cache.insert(key, [i as u32].into_iter());
+        let words: Vec<Vec<u8>> = (0..WINDOW as u8).map(|i| vec![i; 4]).collect();
+        for (i, word) in words.iter().enumerate() {
+            cache.insert(word, [i as u32].into_iter());
         }
-        // Every key but the first earns a hit, leaving one clear coldest slot.
-        for key in &keys[1..] {
-            assert!(cache.get(key).is_some());
+        // Every word but the first earns a hit, leaving one clear coldest slot.
+        for word in &words[1..] {
+            assert!(cache.get(word).is_some());
         }
         cache.insert(b"newcomer", [999u32].into_iter());
         assert_eq!(cache.get(b"newcomer"), Some(&[999u32][..]));
         assert_eq!(
-            cache.get(&keys[0]),
+            cache.get(&words[0]),
             None,
             "the unused entry should have gone"
         );
-        for (i, key) in keys.iter().enumerate().skip(1) {
+        for (i, word) in words.iter().enumerate().skip(1) {
             assert_eq!(
-                cache.get(key),
+                cache.get(word),
                 Some(&[i as u32][..]),
                 "used entry {i} was dropped"
             );
@@ -357,7 +656,7 @@ mod tests {
         let mut cache = WordCache::new(64);
         let mut expected: Vec<(Vec<u8>, Vec<u32>)> = Vec::new();
         for i in 0..2000usize {
-            let key = match i % 4 {
+            let word = match i % 4 {
                 0 => format!("w{i}"),
                 1 => format!("a-long-word-past-fifteen-bytes-{i}"),
                 2 => format!("k{i}xxxxxxxxxxxx"),
@@ -365,30 +664,38 @@ mod tests {
             }
             .into_bytes();
             let ids: Vec<u32> = (0..=(i % 9) as u32).map(|k| i as u32 * 16 + k).collect();
-            cache.insert(&key, ids.clone().into_iter());
-            expected.push((key, ids));
+            cache.insert(&word, ids.clone().into_iter());
+            expected.push((word, ids));
         }
         let mut live = 0;
-        for (key, ids) in &expected {
-            if let Some(hit) = cache.get(key) {
-                assert_eq!(hit, &ids[..], "{key:?}");
+        for (word, ids) in &expected {
+            if let Some(hit) = cache.get(word) {
+                assert_eq!(hit, &ids[..], "{word:?}");
                 live += 1;
             }
         }
         assert!(live > 0, "everything was evicted — the test proves nothing");
     }
 
-    /// Freed runs have to come back. Without reuse the arenas would grow with
-    /// every insert and the cache would be leaking rather than evicting.
+    /// Freed runs have to come back. Without reuse the arenas grow with every
+    /// insert until their budget is spent, and from then on the cache silently
+    /// stops accepting words even though the table has room for them.
     #[test]
     fn arenas_hold_the_live_set_not_every_insert() {
         let mut cache = WordCache::new(64);
+        // Same length every time, so one free list serves every word and the
+        // bounds below are exact: 64 slots, plus the run reserved for the insert
+        // in flight before the entry it replaces gives its own run back.
+        let word = |i: usize| format!("a-long-word-past-fifteen-bytes-{i:04}");
         for i in 0..5000usize {
-            let key = format!("a-long-word-past-fifteen-bytes-{i}");
-            cache.insert(key.as_bytes(), [i as u32; 8].into_iter());
+            cache.insert(word(i).as_bytes(), [i as u32; 8].into_iter());
         }
-        // 64 slots can hold at most 64 keys of ~34 bytes and 64 runs of 8 ids.
-        assert!(cache.key_bytes.data.len() < 8 * 1024);
-        assert!(cache.ids.data.len() < 8 * 1024);
+        assert_eq!(
+            cache.get(word(4999).as_bytes()),
+            Some(&[4999u32; 8][..]),
+            "inserts stopped landing — the arenas ran out"
+        );
+        assert!(cache.key_bytes.data.len() <= 65 * 35);
+        assert!(cache.ids.data.len() <= 65 * 8);
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -476,11 +476,18 @@ impl WordCache {
     /// The value a slot stores in its `key`, and the hash that places it. A short
     /// word is its own key; a longer one keys on a tagged hash and has to be
     /// confirmed against `key_bytes`, since two long words can hash alike.
+    ///
+    /// A packed key is hashed as one `u128`, not as the word's bytes it was built
+    /// from. Hashing a slice makes aHash mix the length in and then branch on it to
+    /// choose a read width; a `u128` is one fixed-width fold with nothing to decide.
+    /// The key already carries the length, so nothing is lost.
     fn slot_key(&self, word: &[u8]) -> (u128, u64) {
-        let hash = self.hasher.hash_one(word);
         match pack_word(word) {
-            Some(packed) => (packed, hash),
-            None => ((hash as u128) | LONG_TAG, hash),
+            Some(packed) => (packed, self.hasher.hash_one(packed)),
+            None => {
+                let hash = self.hasher.hash_one(word);
+                ((hash as u128) | LONG_TAG, hash)
+            }
         }
     }
 
@@ -646,6 +653,24 @@ mod tests {
         assert_eq!(pack_word(&[0u8; 15]).unwrap() & LONG_TAG, 0);
         assert_eq!(pack_word(b""), None);
         assert_eq!(pack_word(&[b'x'; 16]), None);
+    }
+
+    /// A short word's placement now comes out of its packed key rather than its
+    /// bytes, which leaves the hash doing all of the mixing. Words that differ in
+    /// one byte pack to keys that differ in one byte, so an index taken from those
+    /// bits as they are — `packed as u64` — drops most of these on one slot.
+    #[test]
+    fn short_words_spread_across_the_table() {
+        let cache = WordCache::new(1 << 12);
+        let homes: std::collections::HashSet<usize> = (0..1000)
+            .map(|i| {
+                let (_, hash) = cache.slot_key(format!("tok{i}").as_bytes());
+                hash as usize & cache.mask
+            })
+            .collect();
+        // 1000 words over 4096 slots share homes by chance alone; ~887 distinct is
+        // as good as a perfect hash gets, so the floor is well under it.
+        assert!(homes.len() > 820, "only {} distinct homes", homes.len());
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -522,11 +522,11 @@ impl pipeline::Model for Unigram {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         _scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
-        let str_tokens = self.encode(sequence)?;
+        let str_tokens = self.encode(split.as_str())?;
 
         for string in str_tokens {
             match self.token_to_ids.token_to_id(&string) {

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -220,11 +220,11 @@ impl pipeline::Model for WordLevel {
     fn init_scratch(&self) -> Self::Scratch {}
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         _scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
-        if let Some(&id) = self.vocab.get(sequence) {
+        if let Some(&id) = self.vocab.get(split.as_str()) {
             output.push(PipelineToken { id })
         } else if let Some(&unk_id) = self.vocab.get(&self.unk_token) {
             output.push(PipelineToken { id: unk_id });

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -370,10 +370,11 @@ impl pipeline::Model for PipelineWordPiece {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
+        let sequence = split.as_str();
         let checkpoint = output.len();
         let candidate = &mut scratch.candidate_str;
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1041,6 +1041,11 @@ impl Model for PipelineModel {
     }
 }
 
+// The BPE variant carries the word cache inline, making it much larger than the
+// others. Boxing it would put a pointer chase on the per-pre-token hot path to
+// save space in a struct that exists once per thread and is never moved after
+// the pool builds it.
+#[allow(clippy::large_enum_variant)]
 #[derive(Default)]
 pub enum PipelineModelScratch {
     BPE(BpeScratch),

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
 use std::mem;
+use std::ops::Range;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::{borrow::Cow, convert::TryFrom};
 
@@ -702,7 +703,7 @@ impl PipelineTokenizer {
                                         // Tokenize each chunk
                                         for pre_token in pre_tokens.iter() {
                                             self.model.tokenize_pipeline(
-                                                &normalized_chunk[pre_token.range()],
+                                                Split::new(normalized_chunk, pre_token.range()),
                                                 scratch,
                                                 output,
                                             )?;
@@ -981,12 +982,62 @@ pub trait ModelScratch: Default {
     fn clear(&mut self);
 }
 
+/// One pre-token on its way to a model: the word to tokenize, plus the chunk of
+/// text it was split out of.
+///
+/// A model that only wants the word calls [`Split::as_str`] and is none the wiser.
+/// The chunk is carried for [`Split::head`], which hands out a fixed-size window
+/// of bytes starting at the word — the BPE word cache builds its key out of one,
+/// because copying a fixed number of bytes compiles to a load, where copying a
+/// number known only at run time is a call into `memcpy`.
+#[derive(Clone, Copy)]
+pub struct Split<'a> {
+    word: &'a str,
+    head: Option<&'a [u8; 16]>,
+}
+
+impl<'a> Split<'a> {
+    /// `range` is a byte range of `chunk`, the way a pre-tokenizer reports it.
+    pub fn new(chunk: &'a str, range: Range<usize>) -> Self {
+        Self {
+            word: &chunk[range.clone()],
+            head: chunk.as_bytes()[range.start..].first_chunk(),
+        }
+    }
+
+    pub fn as_str(&self) -> &'a str {
+        self.word
+    }
+
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.word.as_bytes()
+    }
+
+    /// The 16 bytes of the chunk that start where the word does. Anything past the
+    /// word's own length belongs to whatever follows it, so a caller has to know
+    /// how much of the window means something.
+    ///
+    /// `None` when the word starts within 16 bytes of the chunk's end and there is
+    /// nothing to read — at most one word per chunk.
+    pub fn head(&self) -> Option<&'a [u8; 16]> {
+        self.head
+    }
+}
+
+/// A bare word, with no chunk around it: there is a window only when the word is
+/// long enough to fill one on its own.
+impl<'a> From<&'a str> for Split<'a> {
+    fn from(word: &'a str) -> Self {
+        Self::new(word, 0..word.len())
+    }
+}
+
 pub trait Model {
     type Scratch: ModelScratch;
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()>;
@@ -1010,22 +1061,22 @@ impl Model for PipelineModel {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
         match (self, scratch) {
             (Self::BPE(model), PipelineModelScratch::BPE(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             (Self::Unigram(model), PipelineModelScratch::Unigram(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             (Self::WordLevel(model), PipelineModelScratch::WordLevel(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             _ => unreachable!(),
         }
@@ -1075,6 +1126,29 @@ mod tests {
     use crate::models::wordpiece::WordPiece;
     use crate::pre_tokenizers::byte_level::ByteLevel;
     use crate::pre_tokenizers::sequence::Sequence;
+
+    /// Everything the window is good for rests on it starting at the word's first
+    /// byte and staying inside the chunk. A window taken from the wrong offset
+    /// would silently key one word's cache entry on another word's bytes.
+    #[test]
+    fn a_splits_window_starts_at_the_word_and_stops_at_the_chunk() {
+        let chunk = "the quick brown fox jumps";
+        let word = Split::new(chunk, 4..9);
+        assert_eq!(word.as_str(), "quick");
+        assert_eq!(word.head(), Some(b"quick brown fox "));
+
+        // A word near the end has no window: 25 - 20 is under 16 bytes.
+        let last = Split::new(chunk, 20..25);
+        assert_eq!(last.as_str(), "jumps");
+        assert_eq!(last.head(), None);
+
+        // A bare word is its own chunk, so it only has a window if it fills one.
+        assert_eq!(Split::from("quick").head(), None);
+        assert_eq!(
+            Split::from("sixteen bytes ok").head(),
+            Some(b"sixteen bytes ok")
+        );
+    }
 
     struct FixedMatcher(Vec<((usize, usize), u32)>);
     impl PipelinePatternMatcher for FixedMatcher {

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -54,6 +54,7 @@ pub struct BucketVocabStore {
     /// MPHF's non-minimal slot range (with phantom padding slots), so its length is not the
     /// token count.
     n: usize,
+    longest_token_len: usize,
 }
 
 impl fmt::Debug for BucketVocabStore {
@@ -139,6 +140,7 @@ impl BucketVocabStore {
             n_slots
         ];
         let mut id_to_slot = vec![u32::MAX; max_id as usize + 1];
+        let mut longest_token_len = 0;
         for (s, id) in &tokens {
             assert!(
                 s.len() <= u16::MAX as usize,
@@ -152,6 +154,7 @@ impl BucketVocabStore {
             };
             id_to_slot[*id as usize] = slot as u32;
             bytes.extend_from_slice(s);
+            longest_token_len = longest_token_len.max(s.len())
         }
 
         Self {
@@ -161,6 +164,7 @@ impl BucketVocabStore {
             entries: entries.into_boxed_slice(),
             id_to_slot: id_to_slot.into_boxed_slice(),
             n,
+            longest_token_len,
         }
     }
 
@@ -174,6 +178,7 @@ impl BucketVocabStore {
             entries: Box::new([]),
             id_to_slot: Box::new([]),
             n: 0,
+            longest_token_len: 0,
         }
     }
 
@@ -185,6 +190,9 @@ impl BucketVocabStore {
     pub fn get_bytes(&self, q: &[u8]) -> Option<u32> {
         if self.entries.is_empty() {
             return None;
+        }
+        if q.len() > self.longest_token_len {
+            return None
         }
         let slot = self.mphf.index(&self.hasher.hash_one(q));
 


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`2f16acfce · 2026-07-28 22:06 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 8 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-overview.png" width="860">

**vs base branch** (`709ef7af5`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.89 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 12) · Pipeline 8+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.8 | 27.8 | ×3.57 | ×1.01 | 3% (1.2) | 76% (27.4) | 13% (4.9) | 7% (2.6) | 0% (0.1) | match |
| arb_Arab | lang | 4.2 | 24.4 | ×5.82 | ×0.98 | 3% (1.2) | 68% (27.5) | 8% (3.3) | 21% (8.6) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 33.9 | ×5.63 | ×0.97 | 4% (1.2) | 65% (19.1) | 10% (2.9) | 21% (6.0) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 18.9 | ×4.88 | ×1.00 | 2% (1.2) | 71% (37.7) | 11% (5.7) | 16% (8.4) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 23.3 | ×6.17 | ×0.98 | 3% (1.2) | 67% (28.7) | 8% (3.4) | 22% (9.4) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 18.4 | ×4.15 | ×1.00 | 5% (2.5) | 71% (38.5) | 8% (4.4) | 16% (8.7) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 19.7 | ×4.68 | ×0.99 | 2% (1.2) | 74% (37.4) | 7% (3.8) | 17% (8.4) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 27.2 | ×4.19 | ×0.99 | 3% (1.2) | 73% (27.0) | 9% (3.2) | 15% (5.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 26.9 | ×6.29 | ×0.98 | 3% (1.2) | 63% (23.3) | 13% (4.6) | 21% (7.9) | 0% (0.0) | match |
| kat_Geor | lang | 6.1 | 27.8 | ×4.51 | ×0.99 | 3% (1.2) | 71% (26.5) | 9% (3.3) | 13% (4.9) | 5% (1.7) | match |
| kor_Hang | lang | 2.4 | 17.1 | ×7.03 | ×0.96 | 2% (1.2) | 60% (35.2) | 13% (7.3) | 25% (14.8) | 0% (0.1) | match |
| rus_Cyrl | lang | 3.7 | 23.3 | ×6.38 | ×0.98 | 3% (1.2) | 64% (27.4) | 7% (3.2) | 25% (10.8) | 0% (0.0) | match |
| tam_Taml | lang | 7.0 | 37.8 | ×5.38 | ×0.99 | 4% (1.2) | 71% (18.6) | 10% (2.6) | 15% (3.9) | 0% (0.0) | match |
| tha_Thai | lang | 8.3 | 33.2 | ×3.99 | ×1.02 | 4% (1.2) | 83% (25.0) | 8% (2.4) | 5% (1.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.8 | 19.6 | ×2.88 | ×0.99 | 3% (1.3) | 81% (40.6) | 14% (7.0) | 2% (1.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 18.3 | ×3.45 | ×0.99 | 3% (1.9) | 75% (40.0) | 13% (6.9) | 9% (4.9) | 0% (0.0) | match |
| added_special_dense | modalities | 5.3 | 38.4 | ×7.19 | ×0.99 | 21% (5.1) | 36% (9.1) | 36% (9.1) | 7% (1.7) | 0% (0.1) | match |
| added_special_sparse | modalities | 4.0 | 21.2 | ×5.29 | ×0.99 | 8% (3.6) | 60% (27.9) | 19% (8.9) | 13% (5.9) | 0% (0.0) | match |
| agentic-traces | modalities | 3.8 | 18.2 | ×4.75 | ×1.00 | 4% (2.3) | 70% (38.4) | 9% (4.9) | 17% (9.1) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 19.5 | ×4.76 | ×1.00 | 4% (1.9) | 76% (38.5) | 7% (3.6) | 14% (7.1) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 19.0 | ×4.83 | ×1.00 | 4% (2.1) | 73% (38.4) | 8% (4.3) | 14% (7.6) | 0% (0.2) | match |
| math_latex | modalities | 4.0 | 18.2 | ×4.56 | ×1.00 | 5% (2.5) | 71% (38.5) | 9% (4.9) | 16% (8.9) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×25.36 vs v0.23.1 · ×6.00 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 82+0 (peak 82)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 91.8 | ×21.18 | ×2.68 | 7% (0.7) | 0% (0.0) | 51% (4.7) | 43% (4.0) | 0% (0.0) | match |
| arb_Arab | lang | 4.1 | 111.7 | ×27.28 | ×6.72 | 8% (0.6) | 0% (0.0) | 45% (3.4) | 48% (3.6) | 0% (0.0) | match |
| ben_Beng | lang | 6.2 | 139.4 | ×22.49 | ×7.82 | 9% (0.6) | 0% (0.0) | 51% (3.2) | 41% (2.6) | 0% (0.0) | match |
| cmn_Hani | lang | 3.6 | 111.3 | ×31.06 | ×6.73 | 11% (0.8) | 0% (0.0) | 45% (3.2) | 45% (3.2) | 0% (0.0) | match |
| ell_Grek | lang | 4.6 | 117.1 | ×25.66 | ×6.55 | 8% (0.6) | 0% (0.0) | 47% (3.4) | 45% (3.3) | 0% (0.0) | match |
| eng_Latn | lang | 3.1 | 81.8 | ×26.72 | ×6.29 | 18% (2.0) | 0% (0.0) | 46% (5.1) | 36% (3.9) | 1% (0.1) | match |
| heb_Hebr | lang | 3.8 | 106.1 | ×27.60 | ×8.18 | 7% (0.6) | 0% (0.0) | 43% (3.5) | 51% (4.2) | 0% (0.0) | match |
| hin_Deva | lang | 5.9 | 129.5 | ×22.04 | ×6.08 | 9% (0.6) | 0% (0.0) | 51% (3.4) | 42% (2.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.1 | 131.5 | ×31.86 | ×7.32 | 10% (0.7) | 0% (0.0) | 47% (3.0) | 40% (2.5) | 2% (0.1) | match |
| kat_Geor | lang | 5.8 | 140.3 | ×24.01 | ×8.07 | 10% (0.6) | 0% (0.0) | 50% (2.9) | 41% (2.4) | 0% (0.0) | match |
| kor_Hang | lang | 3.4 | 88.1 | ×26.25 | ×4.46 | 6% (0.6) | 0% (0.0) | 38% (3.7) | 56% (5.4) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.1 | 120.1 | ×29.09 | ×8.48 | 9% (0.6) | 0% (0.0) | 47% (3.3) | 45% (3.1) | 0% (0.0) | match |
| tam_Taml | lang | 5.9 | 150.9 | ×25.54 | ×8.64 | 11% (0.6) | 0% (0.0) | 50% (2.7) | 39% (2.1) | 0% (0.0) | match |
| tha_Thai | lang | 6.7 | 206.9 | ×30.74 | ×14.45 | 15% (0.6) | 0% (0.0) | 55% (2.2) | 31% (1.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 154.4 | ×25.18 | ×6.58 | 12% (0.7) | 0% (0.0) | 46% (2.8) | 42% (2.5) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.5 | 119.9 | ×21.89 | ×6.12 | 16% (1.2) | 0% (0.0) | 49% (3.7) | 37% (2.9) | 0% (0.0) | match |
| added_special_dense | modalities | 3.7 | 58.5 | ×15.80 | ×1.56 | 39% (6.4) | 4% (0.6) | 36% (5.9) | 22% (3.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 65.3 | ×16.55 | ×3.14 | 27% (3.9) | 0% (0.0) | 46% (6.6) | 26% (3.8) | 1% (0.1) | match |
| agentic-traces | modalities | 2.8 | 78.5 | ×28.22 | ×5.50 | 15% (1.8) | 0% (0.0) | 46% (5.4) | 41% (4.9) | 0% (0.0) | match |
| agentic_swe | modalities | 3.0 | 99.4 | ×33.35 | ×6.67 | 14% (1.3) | 0% (0.0) | 42% (3.8) | 44% (4.0) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 91.3 | ×25.97 | ×5.87 | 15% (1.6) | 0% (0.0) | 45% (4.6) | 40% (4.1) | 0% (0.0) | match |
| math_latex | modalities | 2.8 | 80.0 | ×28.59 | ×5.71 | 16% (1.9) | 0% (0.0) | 46% (5.3) | 39% (4.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.85 | 3.42 | 4.75 | 5.31 | 42.5 | 20.8 | 9.2 | — | 9.0× / 8.0× | 4.4× / 3.9× | 1.9× / 1.7× | — |
| arb_Arab | 1.15 | 2.94 | 3.38 | 5.18 | 49.6 | 23.4 | 10.2 | — | 14.6× / 9.6× | 6.9× / 4.5× | 3.0× / 2.0× | — |
| ben_Beng | 1.61 | 2.94 | 3.16 | 4.49 | 36.4 | 16.5 | 7.5 | — | 11.5× / 8.1× | 5.2× / 3.7× | 2.4× / 1.7× | — |
| cmn_Hani | 1.13 | 2.22 | 3.19 | 4.28 | 61.3 | 34.3 | 14.3 | — | 19.2× / 14.3× | 10.8× / 8.0× | 4.5× / 3.3× | — |
| ell_Grek | 0.58 | 2.93 | 3.44 | 5.78 | 47.7 | 21.5 | 9.7 | — | 13.9× / 8.3× | 6.2× / 3.7× | 2.8× / 1.7× | — |
| eng_Latn | 0.09 | 1.53 | 5.10 | 6.53 | 66.0 | 40.7 | 16.2 | — | 13.0× / 10.1× | 8.0× / 6.2× | 3.2× / 2.5× | — |
| heb_Hebr | 1.15 | 3.00 | 3.53 | 5.38 | 51.5 | 24.8 | 10.8 | — | 14.6× / 9.6× | 7.0× / 4.6× | 3.1× / 2.0× | — |
| hin_Deva | 1.52 | 3.06 | 3.43 | 4.97 | 38.4 | 19.3 | 8.5 | — | 11.2× / 7.7× | 5.6× / 3.9× | 2.5× / 1.7× | — |
| jpn_Jpan | 1.70 | 3.37 | 3.00 | 4.67 | 53.8 | 27.4 | 11.8 | — | 17.9× / 11.5× | 9.1× / 5.9× | 3.9× / 2.5× | — |
| kat_Geor | 1.55 | 2.58 | 2.94 | 3.97 | 32.5 | 15.3 | 7.2 | — | 11.1× / 8.2× | 5.2× / 3.9× | 2.4× / 1.8× | — |
| kor_Hang | 1.22 | 2.73 | 3.68 | 5.18 | 50.8 | 27.9 | 11.9 | — | 13.8× / 9.8× | 7.6× / 5.4× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.16 | 2.92 | 3.25 | 5.01 | 47.9 | 21.6 | 9.5 | — | 14.7× / 9.6× | 6.6× / 4.3× | 2.9× / 1.9× | — |
| tam_Taml | 0.93 | 2.96 | 2.71 | 4.74 | 32.2 | 13.7 | 6.5 | — | 11.9× / 6.8× | 5.0× / 2.9× | 2.4× / 1.4× | — |
| tha_Thai | 1.52 | 2.57 | 2.16 | 3.21 | 26.7 | 10.1 | 5.2 | — | 12.4× / 8.3× | 4.7× / 3.2× | 2.4× / 1.6× | — |
| added_normalized_dense | 0.06 | 1.48 | 2.77 | 4.19 | 42.0 | 20.5 | 9.0 | — | 15.2× / 10.0× | 7.4× / 4.9× | 3.3× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.75 | 5.16 | 49.2 | 26.5 | 11.3 | — | 13.1× / 9.5× | 7.1× / 5.1× | 3.0× / 2.2× | — |
| added_special_dense | 0.06 | 1.47 | 5.86 | 7.28 | 175.5 | 99.2 | 38.1 | — | 29.9× / 24.1× | 16.9× / 13.6× | 6.5× / 5.2× | — |
| added_special_sparse | 0.06 | 1.47 | 6.58 | 7.99 | 103.6 | 58.5 | 23.6 | — | 15.7× / 13.0× | 8.9× / 7.3× | 3.6× / 3.0× | — |
| agentic-traces | 0.74 | 1.49 | 5.37 | 6.12 | 81.1 | 54.7 | 20.2 | — | 15.1× / 13.3× | 10.2× / 8.9× | 3.8× / 3.3× | — |
| agentic_swe | 0.65 | 1.49 | 3.83 | 4.67 | 96.7 | 66.9 | 23.8 | — | 25.2× / 20.7× | 17.5× / 14.3× | 6.2× / 5.1× | — |
| code_mixed | 0.09 | 1.47 | 4.60 | 5.98 | 74.5 | 55.1 | 18.7 | — | 16.2× / 12.4× | 12.0× / 9.2× | 4.1× / 3.1× | — |
| math_latex | 0.73 | 1.52 | 5.29 | 6.08 | 79.4 | 49.3 | 19.5 | — | 15.0× / 13.1× | 9.3× / 8.1× | 3.7× / 3.2× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×2.09 vs v0.23.1 · ×1.09 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 371) · Pipeline 275+0 (peak 371)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 10.4 | 27.3 | ×2.64 | ×0.99 | 2% (0.7) | 6% (2.1) | 0% (0.0) | 92% (31.9) | 0% (0.0) | match |
| arb_Arab | lang | 7.0 | 12.5 | ×1.78 | ×0.94 | 1% (0.6) | 3% (2.5) | 0% (0.0) | 95% (71.6) | 1% (0.6) | match |
| ben_Beng | lang | 9.7 | 18.3 | ×1.88 | ×0.98 | 1% (0.6) | 3% (1.7) | 0% (0.0) | 96% (50.6) | 0% (0.1) | match |
| cmn_Hani | lang | 11.7 | 33.6 | ×2.88 | ×1.00 | 2% (0.6) | 1% (0.3) | 0% (0.0) | 98% (26.6) | 0% (0.0) | match |
| ell_Grek | lang | 7.5 | 14.8 | ×1.96 | ×0.99 | 1% (0.6) | 4% (2.5) | 0% (0.0) | 95% (62.9) | 0% (0.0) | match |
| eng_Latn | lang | 3.7 | 5.4 | ×1.45 | ×0.99 | 1% (2.0) | 3% (4.8) | 0% (0.0) | 97% (176.4) | 0% (0.0) | match |
| heb_Hebr | lang | 7.8 | 16.6 | ×2.13 | ×0.99 | 1% (0.6) | 4% (2.6) | 0% (0.0) | 95% (55.5) | 0% (0.0) | match |
| hin_Deva | lang | 9.3 | 18.1 | ×1.93 | ×1.01 | 1% (0.6) | 4% (2.3) | 0% (0.0) | 95% (50.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 12.5 | 29.1 | ×2.33 | ×1.00 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 98% (31.7) | 0% (0.0) | match |
| kat_Geor | lang | 11.8 | 24.7 | ×2.09 | ×1.01 | 2% (0.6) | 4% (1.4) | 0% (0.0) | 95% (37.3) | 0% (0.0) | match |
| kor_Hang | lang | 9.3 | 25.7 | ×2.75 | ×1.02 | 2% (0.6) | 7% (2.6) | 0% (0.0) | 91% (33.7) | 0% (0.1) | match |
| rus_Cyrl | lang | 7.0 | 10.8 | ×1.53 | ×0.97 | 1% (0.6) | 2% (2.3) | 0% (0.0) | 96% (88.0) | 1% (0.5) | match |
| tam_Taml | lang | 10.9 | 19.7 | ×1.81 | ×1.01 | 1% (0.6) | 3% (1.3) | 0% (0.0) | 95% (47.4) | 1% (0.4) | match |
| tha_Thai | lang | 12.8 | 23.9 | ×1.87 | ×1.00 | 2% (0.6) | 2% (0.7) | 0% (0.0) | 97% (38.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.1 | 7.2 | ×1.42 | ×0.97 | 1% (0.7) | 2% (2.9) | 0% (0.1) | 96% (130.1) | 2% (2.2) | match |
| added_normalized_sparse | modalities | 4.6 | 6.4 | ×1.39 | ×0.97 | 1% (1.3) | 3% (4.4) | 0% (0.0) | 97% (145.8) | 0% (0.0) | match |
| added_special_dense | modalities | 4.7 | 33.8 | ×7.20 | ×1.67 | 35% (9.6) | 29% (8.2) | 28% (7.8) | 8% (2.3) | 0% (0.0) | match |
| added_special_sparse | modalities | 7.0 | 44.8 | ×6.39 | ×4.58 | 26% (5.2) | 41% (8.4) | 25% (5.0) | 7% (1.4) | 1% (0.2) | match |
| agentic-traces | modalities | 4.2 | 6.3 | ×1.51 | ×0.98 | 1% (1.8) | 3% (4.4) | 0% (0.0) | 96% (151.2) | 1% (0.8) | match |
| agentic_swe | modalities | 3.9 | 6.8 | ×1.73 | ×0.99 | 1% (1.3) | 5% (7.3) | 0% (0.0) | 94% (137.6) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 6.4 | ×1.58 | ×0.98 | 1% (1.6) | 4% (6.0) | 0% (0.0) | 96% (147.5) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 5.9 | ×1.46 | ×0.98 | 1% (1.9) | 3% (4.5) | 0% (0.0) | 96% (163.0) | 0% (0.5) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×30.08 vs v0.23.1 · ×3.66 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 27+0 (peak 27)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 90.9 | ×25.41 | ×1.87 | 8% (0.7) | 0% (0.0) | 45% (3.7) | 48% (3.9) | 0% (0.0) | match |
| arb_Arab | lang | 3.4 | 107.5 | ×31.50 | ×4.19 | 8% (0.6) | 0% (0.0) | 31% (2.3) | 62% (4.5) | 0% (0.0) | match |
| ben_Beng | lang | 2.7 | 90.7 | ×33.83 | ×2.05 | 6% (0.6) | 0% (0.0) | 31% (3.0) | 64% (6.3) | 0% (0.0) | match |
| cmn_Hani | lang | 3.5 | 113.0 | ×31.87 | ×3.92 | 9% (0.6) | 0% (0.0) | 36% (2.3) | 56% (3.6) | 0% (0.0) | match |
| ell_Grek | lang | 4.0 | 120.5 | ×29.89 | ×4.25 | 9% (0.6) | 0% (0.0) | 32% (2.2) | 61% (4.1) | 0% (0.0) | match |
| eng_Latn | lang | 3.3 | 98.5 | ×30.12 | ×7.01 | 22% (2.0) | 0% (0.0) | 34% (2.9) | 46% (4.0) | 0% (0.0) | match |
| heb_Hebr | lang | 3.7 | 112.3 | ×29.99 | ×3.90 | 8% (0.6) | 0% (0.0) | 30% (2.3) | 63% (4.8) | 0% (0.0) | match |
| hin_Deva | lang | 3.0 | 105.8 | ×35.65 | ×2.61 | 7% (0.6) | 0% (0.0) | 35% (3.1) | 60% (5.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 143.5 | ×33.02 | ×6.52 | 11% (0.6) | 0% (0.0) | 39% (2.1) | 50% (2.7) | 0% (0.0) | match |
| kat_Geor | lang | 4.6 | 149.7 | ×32.79 | ×2.30 | 11% (0.6) | 0% (0.0) | 39% (2.1) | 51% (2.7) | 0% (0.0) | match |
| kor_Hang | lang | 3.2 | 95.1 | ×29.53 | ×2.18 | 7% (0.6) | 0% (0.0) | 27% (2.4) | 66% (5.9) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.0 | 122.3 | ×30.85 | ×4.42 | 9% (0.6) | 0% (0.0) | 31% (2.1) | 61% (4.1) | 0% (0.0) | match |
| tam_Taml | lang | 2.6 | 105.6 | ×40.08 | ×1.46 | 7% (0.6) | 0% (0.0) | 30% (2.6) | 63% (5.7) | 0% (0.0) | match |
| tha_Thai | lang | 3.4 | 110.1 | ×32.68 | ×3.10 | 8% (0.6) | 0% (0.0) | 33% (2.5) | 61% (4.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 187.2 | ×31.82 | ×7.36 | 16% (0.7) | 0% (0.0) | 23% (1.1) | 64% (2.9) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.0 | 145.7 | ×28.97 | ×6.76 | 21% (1.3) | 0% (0.0) | 31% (2.0) | 51% (3.2) | 0% (0.0) | match |
| added_special_dense | modalities | 4.0 | 78.8 | ×19.47 | ×1.65 | 44% (5.2) | 0% (0.0) | 34% (4.0) | 23% (2.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.2 | 79.8 | ×19.18 | ×3.34 | 30% (3.2) | 0% (0.0) | 38% (4.2) | 35% (3.9) | 0% (0.0) | match |
| agentic-traces | modalities | 3.0 | 89.2 | ×29.91 | ×5.52 | 17% (1.8) | 0% (0.0) | 34% (3.5) | 49% (5.0) | 0% (0.0) | match |
| agentic_swe | modalities | 3.2 | 106.8 | ×33.06 | ×4.45 | 15% (1.3) | 0% (0.0) | 27% (2.4) | 57% (4.9) | 1% (0.1) | match |
| code_mixed | modalities | 3.4 | 100.1 | ×29.41 | ×4.88 | 17% (1.5) | 0% (0.0) | 31% (2.9) | 53% (4.9) | 0% (0.0) | match |
| math_latex | modalities | 3.0 | 94.1 | ×30.91 | ×6.18 | 20% (1.9) | 0% (0.0) | 34% (3.2) | 47% (4.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.44 | 3.66 | 4.31 | 28.2 | 21.8 | 5.8 | 4.8 | 7.7× / 6.5× | 6.0× / 5.0× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.95 | 2.26 | 4.06 | 33.0 | 27.2 | 6.8 | 5.1 | 14.6× / 8.1× | 12.0× / 6.7× | 3.0× / 1.7× | 2.3× / 1.3× |
| ben_Beng | 1.62 | 2.91 | 2.99 | 4.28 | 68.4 | 59.5 | 13.9 | 4.0 | 22.9× / 16.0× | 19.9× / 13.9× | 4.7× / 3.3× | 1.3× / 0.9× |
| cmn_Hani | 1.12 | 2.25 | 2.31 | 3.45 | 27.0 | 22.1 | 6.0 | 2.4 | 11.7× / 7.8× | 9.6× / 6.4× | 2.6× / 1.8× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.96 | 2.16 | 4.54 | 29.0 | 23.4 | 6.0 | 4.8 | 13.4× / 6.4× | 10.8× / 5.1× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.45 | 2.94 | 4.30 | 45.6 | 45.7 | 11.9 | 3.8 | 15.5× / 10.6× | 15.5× / 10.6× | 4.1× / 2.8× | 1.3× / 0.9× |
| heb_Hebr | 1.14 | 3.01 | 2.25 | 4.12 | 32.3 | 27.5 | 6.9 | 3.0 | 14.3× / 7.8× | 12.2× / 6.7× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.10 | 3.06 | 4.65 | 64.3 | 57.8 | 13.7 | 4.3 | 21.0× / 13.8× | 18.9× / 12.4× | 4.5× / 2.9× | 1.4× / 0.9× |
| jpn_Jpan | 1.69 | 3.36 | 2.12 | 3.78 | 24.1 | 18.5 | 5.1 | 3.8 | 11.4× / 6.4× | 8.7× / 4.9× | 2.4× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.54 | 2.52 | 2.07 | 3.05 | 17.9 | 14.9 | 4.2 | 2.0 | 8.6× / 5.9× | 7.2× / 4.9× | 2.0× / 1.4× | 1.0× / 0.6× |
| kor_Hang | 1.22 | 2.70 | 2.44 | 3.91 | 33.0 | 29.5 | 7.5 | 3.6 | 13.5× / 8.4× | 12.1× / 7.6× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.93 | 2.09 | 3.86 | 28.0 | 22.6 | 5.8 | 2.5 | 13.4× / 7.3× | 10.8× / 5.9× | 2.8× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 1.11 | 2.96 | 2.65 | 4.49 | 71.8 | 62.1 | 14.5 | 3.8 | 27.1× / 16.0× | 23.5× / 13.8× | 5.5× / 3.2× | 1.4× / 0.8× |
| tha_Thai | 1.83 | 2.53 | 2.50 | 3.20 | 41.4 | 33.7 | 8.8 | 3.2 | 16.6× / 13.0× | 13.5× / 10.5× | 3.5× / 2.8× | 1.3× / 1.0× |
| added_normalized_dense | 0.06 | 1.47 | 1.06 | 2.47 | 23.8 | 23.7 | 6.3 | 2.0 | 22.5× / 9.6× | 22.4× / 9.6× | 5.9× / 2.5× | 1.9× / 0.8× |
| added_normalized_sparse | 0.06 | 1.48 | 1.96 | 3.38 | 31.7 | 32.5 | 8.5 | 2.7 | 16.2× / 9.4× | 16.6× / 9.6× | 4.3× / 2.5× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 3.97 | 5.39 | 95.8 | 101.7 | 20.1 | 2.9 | 24.1× / 17.8× | 25.6× / 18.9× | 5.0× / 3.7× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 4.15 | 5.57 | 61.9 | 65.8 | 14.2 | 3.3 | 14.9× / 11.1× | 15.9× / 11.8× | 3.4× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.75 | 1.50 | 3.46 | 4.21 | 60.2 | 63.1 | 15.7 | 4.6 | 17.4× / 14.3× | 18.2× / 15.0× | 4.5× / 3.7× | 1.3× / 1.1× |
| agentic_swe | 0.66 | 1.49 | 2.37 | 3.21 | 61.2 | 71.6 | 14.8 | 3.5 | 25.8× / 19.1× | 30.2× / 22.3× | 6.2× / 4.6× | 1.5× / 1.1× |
| code_mixed | 0.07 | 1.45 | 2.89 | 4.27 | 60.1 | 69.4 | 15.2 | 4.1 | 20.8× / 14.1× | 24.0× / 16.3× | 5.2× / 3.6× | 1.4× / 1.0× |
| math_latex | 0.74 | 1.48 | 3.25 | 3.98 | 53.7 | 54.4 | 13.9 | 4.2 | 16.5× / 13.5× | 16.8× / 13.7× | 4.3× / 3.5× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×19.88 vs v0.23.1 · ×3.93 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 86.9 | ×22.94 | ×3.74 | 7% (0.7) | 0% (0.0) | 48% (4.7) | 47% (4.6) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 93.7 | ×21.36 | ×5.41 | 7% (0.6) | 0% (0.0) | 35% (3.2) | 59% (5.3) | 0% (0.0) | match |
| ben_Beng | lang | 6.5 | 117.6 | ×18.16 | ×6.71 | 8% (0.6) | 0% (0.0) | 49% (3.6) | 42% (3.1) | 1% (0.1) | match |
| cmn_Hani | lang | 4.4 | 107.7 | ×24.35 | ×8.86 | 8% (0.6) | 0% (0.0) | 44% (3.4) | 50% (3.8) | 0% (0.0) | match |
| ell_Grek | lang | 4.9 | 103.0 | ×20.85 | ×6.48 | 7% (0.6) | 0% (0.0) | 39% (3.2) | 52% (4.3) | 1% (0.1) | match |
| eng_Latn | lang | 3.9 | 60.3 | ×15.43 | ×1.42 | 14% (2.0) | 0% (0.0) | 32% (4.5) | 55% (7.7) | 0% (0.0) | match |
| heb_Hebr | lang | 4.3 | 94.4 | ×21.86 | ×5.69 | 6% (0.6) | 0% (0.0) | 36% (3.3) | 58% (5.3) | 0% (0.0) | match |
| hin_Deva | lang | 6.7 | 108.1 | ×16.04 | ×4.14 | 8% (0.6) | 0% (0.0) | 48% (3.7) | 45% (3.5) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.3 | 127.6 | ×24.09 | ×9.97 | 9% (0.6) | 0% (0.0) | 48% (3.1) | 41% (2.7) | 1% (0.1) | match |
| kat_Geor | lang | 6.5 | 134.0 | ×20.63 | ×9.52 | 10% (0.6) | 0% (0.0) | 47% (2.9) | 45% (2.8) | 0% (0.0) | match |
| kor_Hang | lang | 3.8 | 77.3 | ×20.35 | ×5.05 | 5% (0.6) | 0% (0.0) | 32% (3.7) | 63% (7.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.9 | 98.5 | ×20.06 | ×6.30 | 7% (0.6) | 0% (0.0) | 38% (3.1) | 57% (4.7) | 0% (0.0) | match |
| tam_Taml | lang | 6.7 | 134.8 | ×20.25 | ×10.18 | 10% (0.6) | 0% (0.0) | 51% (3.2) | 39% (2.4) | 0% (0.0) | match |
| tha_Thai | lang | 7.6 | 158.9 | ×20.89 | ×13.77 | 12% (0.6) | 0% (0.0) | 61% (3.2) | 28% (1.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.1 | 151.9 | ×30.01 | ×5.99 | 12% (0.7) | 0% (0.0) | 37% (2.2) | 49% (2.9) | 2% (0.1) | match |
| added_normalized_sparse | modalities | 5.0 | 112.8 | ×22.75 | ×2.69 | 16% (1.3) | 0% (0.0) | 39% (3.2) | 47% (3.8) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 66.5 | ×16.24 | ×0.88 | 36% (5.1) | 1% (0.1) | 34% (4.8) | 31% (4.4) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.2 | 66.5 | ×15.77 | ×0.86 | 22% (3.1) | 0% (0.0) | 42% (5.8) | 36% (5.0) | 0% (0.0) | match |
| agentic-traces | modalities | 3.6 | 60.2 | ×16.55 | ×1.57 | 12% (1.8) | 0% (0.0) | 33% (5.0) | 56% (8.3) | 0% (0.0) | match |
| agentic_swe | modalities | 3.8 | 74.8 | ×19.65 | ×2.69 | 11% (1.3) | 0% (0.0) | 31% (3.7) | 59% (7.1) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 70.4 | ×18.08 | ×1.39 | 12% (1.5) | 0% (0.0) | 35% (4.4) | 56% (7.0) | 0% (0.0) | match |
| math_latex | modalities | 3.5 | 59.0 | ×17.00 | ×1.53 | 13% (1.9) | 0% (0.0) | 32% (4.8) | 57% (8.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.41 | 4.68 | 5.31 | 30.0 | 14.4 | 7.0 | 4.7 | 6.4× / 5.6× | 3.1× / 2.7× | 1.5× / 1.3× | 1.0× / 0.9× |
| arb_Arab | 1.14 | 2.99 | 3.20 | 5.04 | 34.4 | 16.4 | 7.5 | 5.1 | 10.7× / 6.8× | 5.1× / 3.3× | 2.3× / 1.5× | 1.6× / 1.0× |
| ben_Beng | 1.62 | 3.00 | 3.64 | 5.02 | 24.0 | 11.4 | 5.4 | 2.7 | 6.6× / 4.8× | 3.1× / 2.3× | 1.5× / 1.1× | 0.7× / 0.5× |
| cmn_Hani | 1.12 | 2.29 | 3.37 | 4.53 | 21.9 | 11.0 | 5.4 | 2.5 | 6.5× / 4.8× | 3.3× / 2.4× | 1.6× / 1.2× | 0.7× / 0.5× |
| ell_Grek | 0.58 | 2.93 | 3.24 | 5.59 | 30.4 | 15.5 | 6.8 | 5.0 | 9.4× / 5.4× | 4.8× / 2.8× | 2.1× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.09 | 1.46 | 4.54 | 5.91 | 43.3 | 30.2 | 13.7 | 4.2 | 9.5× / 7.3× | 6.6× / 5.1× | 3.0× / 2.3× | 0.9× / 0.7× |
| heb_Hebr | 1.14 | 3.06 | 3.28 | 5.20 | 33.8 | 18.2 | 8.0 | 2.9 | 10.3× / 6.5× | 5.6× / 3.5× | 2.4× / 1.5× | 0.9× / 0.6× |
| hin_Deva | 1.51 | 3.06 | 3.71 | 5.26 | 26.2 | 13.0 | 6.4 | 3.1 | 7.0× / 5.0× | 3.5× / 2.5× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.70 | 3.34 | 3.13 | 4.76 | 20.5 | 9.4 | 4.7 | 3.9 | 6.5× / 4.3× | 3.0× / 2.0× | 1.5× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.55 | 2.53 | 2.92 | 3.90 | 19.2 | 10.3 | 4.6 | 2.1 | 6.6× / 4.9× | 3.5× / 2.6× | 1.6× / 1.2× | 0.7× / 0.5× |
| kor_Hang | 1.22 | 2.71 | 3.65 | 5.14 | 34.1 | 19.4 | 8.9 | 3.6 | 9.3× / 6.6× | 5.3× / 3.8× | 2.4× / 1.7× | 1.0× / 0.7× |
| rus_Cyrl | 1.16 | 2.93 | 3.13 | 4.89 | 29.2 | 15.3 | 6.7 | 4.9 | 9.3× / 6.0× | 4.9× / 3.1× | 2.2× / 1.4× | 1.6× / 1.0× |
| tam_Taml | 0.93 | 2.91 | 3.16 | 5.14 | 19.2 | 9.0 | 4.2 | 2.9 | 6.1× / 3.7× | 2.8× / 1.8× | 1.3× / 0.8× | 0.9× / 0.6× |
| tha_Thai | 1.52 | 2.57 | 3.17 | 4.22 | 13.2 | 5.8 | 2.7 | 2.2 | 4.2× / 3.1× | 1.8× / 1.4× | 0.9× / 0.6× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.47 | 2.16 | 3.57 | 32.4 | 18.0 | 11.2 | 2.2 | 15.0× / 9.1× | 8.3× / 5.0× | 5.2× / 3.1× | 1.0× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.17 | 4.58 | 35.0 | 21.7 | 11.4 | 3.0 | 11.1× / 7.6× | 6.8× / 4.7× | 3.6× / 2.5× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.47 | 4.84 | 6.25 | 84.3 | 70.9 | 24.8 | 3.4 | 17.4× / 13.5× | 14.7× / 11.3× | 5.1× / 4.0× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.82 | 7.23 | 56.2 | 43.1 | 16.9 | 3.7 | 9.7× / 7.8× | 7.4× / 6.0× | 2.9× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.72 | 1.47 | 4.96 | 5.71 | 52.3 | 43.7 | 17.4 | 4.9 | 10.6× / 9.2× | 8.8× / 7.6× | 3.5× / 3.1× | 1.0× / 0.9× |
| agentic_swe | 0.65 | 1.56 | 3.73 | 4.64 | 52.8 | 51.6 | 17.5 | 3.6 | 14.1× / 11.4× | 13.8× / 11.1× | 4.7× / 3.8× | 1.0× / 0.8× |
| code_mixed | 0.06 | 1.44 | 4.37 | 5.75 | 51.9 | 48.7 | 17.5 | 4.3 | 11.9× / 9.0× | 11.1× / 8.5× | 4.0× / 3.0× | 1.0× / 0.7× |
| math_latex | 0.75 | 1.50 | 4.82 | 5.57 | 49.9 | 37.0 | 15.9 | 4.5 | 10.3× / 8.9× | 7.7× / 6.6× | 3.3× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×20.77 vs v0.23.1 · ×3.20 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 89.2 | ×21.75 | ×1.85 | 13% (1.2) | 0% (0.0) | 41% (3.7) | 47% (4.3) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 100.5 | ×22.65 | ×5.62 | 14% (1.2) | 0% (0.0) | 28% (2.3) | 59% (5.0) | 0% (0.0) | match |
| ben_Beng | lang | 4.3 | 106.7 | ×25.08 | ×4.01 | 13% (1.2) | 0% (0.0) | 37% (3.2) | 50% (4.4) | 0% (0.0) | match |
| cmn_Hani | lang | 4.8 | 115.3 | ×24.03 | ×7.90 | 16% (1.2) | 0% (0.0) | 32% (2.4) | 48% (3.5) | 4% (0.3) | match |
| ell_Grek | lang | 5.0 | 108.3 | ×21.52 | ×5.56 | 15% (1.2) | 0% (0.0) | 28% (2.2) | 53% (4.3) | 5% (0.4) | match |
| eng_Latn | lang | 3.8 | 63.6 | ×16.65 | ×1.43 | 19% (2.5) | 0% (0.0) | 23% (3.0) | 58% (7.8) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 101.1 | ×24.02 | ×3.94 | 14% (1.2) | 0% (0.0) | 28% (2.4) | 59% (5.0) | 0% (0.0) | match |
| hin_Deva | lang | 3.9 | 93.2 | ×23.65 | ×3.12 | 12% (1.2) | 0% (0.0) | 33% (3.3) | 57% (5.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.6 | 136.1 | ×24.53 | ×8.75 | 20% (1.2) | 0% (0.0) | 37% (2.2) | 44% (2.6) | 0% (0.0) | match |
| kat_Geor | lang | 6.3 | 136.7 | ×21.58 | ×6.18 | 19% (1.2) | 0% (0.0) | 35% (2.1) | 45% (2.7) | 1% (0.0) | match |
| kor_Hang | lang | 3.8 | 84.3 | ×22.23 | ×4.54 | 11% (1.2) | 0% (0.0) | 24% (2.6) | 66% (6.9) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.9 | 102.2 | ×20.90 | ×5.45 | 15% (1.2) | 0% (0.0) | 27% (2.2) | 59% (4.7) | 0% (0.0) | match |
| tam_Taml | lang | 3.8 | 106.1 | ×27.65 | ×2.99 | 13% (1.2) | 0% (0.0) | 32% (2.7) | 57% (4.9) | 0% (0.0) | match |
| tha_Thai | lang | 4.8 | 108.6 | ×22.54 | ×5.17 | 15% (1.2) | 0% (0.0) | 34% (2.6) | 53% (4.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.0 | 167.8 | ×28.02 | ×6.20 | 25% (1.3) | 0% (0.0) | 21% (1.1) | 58% (2.9) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 121.2 | ×22.32 | ×2.89 | 24% (1.8) | 0% (0.0) | 27% (2.0) | 49% (3.7) | 2% (0.1) | match |
| added_special_dense | modalities | 4.2 | 44.4 | ×10.69 | ×0.94 | 59% (12.7) | 1% (0.3) | 24% (5.0) | 17% (3.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 56.9 | ×13.14 | ×0.99 | 43% (7.0) | 1% (0.1) | 30% (4.9) | 27% (4.4) | 0% (0.0) | match |
| agentic-traces | modalities | 3.5 | 63.2 | ×18.26 | ×1.78 | 17% (2.5) | 0% (0.0) | 26% (3.7) | 55% (7.9) | 2% (0.2) | match |
| agentic_swe | modalities | 3.7 | 75.1 | ×20.43 | ×2.69 | 17% (1.9) | 0% (0.0) | 25% (2.9) | 59% (6.9) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 72.7 | ×18.51 | ×1.59 | 18% (2.2) | 0% (0.0) | 27% (3.3) | 55% (6.7) | 0% (0.0) | match |
| math_latex | modalities | 3.7 | 62.6 | ×17.05 | ×1.61 | 17% (2.5) | 0% (0.0) | 24% (3.5) | 59% (8.4) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.41 | 3.71 | 4.34 | 27.6 | 16.5 | 5.9 | 4.8 | 7.4× / 6.4× | 4.5× / 3.8× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.98 | 2.34 | 4.17 | 31.7 | 20.3 | 6.9 | 5.1 | 13.5× / 7.6× | 8.7× / 4.9× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.61 | 2.94 | 3.19 | 4.52 | 45.6 | 28.8 | 10.3 | 3.7 | 14.3× / 10.1× | 9.0× / 6.4× | 3.2× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.26 | 2.40 | 3.54 | 20.1 | 11.9 | 4.7 | 2.5 | 8.4× / 5.7× | 5.0× / 3.4× | 1.9× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 3.00 | 2.24 | 4.65 | 28.6 | 17.6 | 6.1 | 4.7 | 12.8× / 6.2× | 7.9× / 3.8× | 2.7× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.11 | 1.46 | 3.04 | 4.40 | 44.3 | 34.1 | 12.6 | 3.7 | 14.6× / 10.1× | 11.2× / 7.8× | 4.1× / 2.9× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.02 | 2.36 | 4.24 | 31.1 | 20.5 | 6.9 | 3.0 | 13.2× / 7.3× | 8.7× / 4.8× | 2.9× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.52 | 3.12 | 3.29 | 4.89 | 48.4 | 31.1 | 11.3 | 4.0 | 14.7× / 9.9× | 9.5× / 6.4× | 3.4× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.70 | 3.35 | 2.21 | 3.86 | 18.6 | 10.1 | 4.0 | 3.7 | 8.4× / 4.8× | 4.6× / 2.6× | 1.8× / 1.0× | 1.7× / 1.0× |
| kat_Geor | 1.54 | 2.51 | 2.13 | 3.09 | 17.2 | 11.6 | 4.2 | 2.0 | 8.1× / 5.5× | 5.5× / 3.7× | 2.0× / 1.3× | 0.9× / 0.7× |
| kor_Hang | 1.22 | 2.70 | 2.56 | 4.04 | 31.5 | 21.7 | 7.3 | 3.6 | 12.3× / 7.8× | 8.5× / 5.4× | 2.9× / 1.8× | 1.4× / 0.9× |
| rus_Cyrl | 1.16 | 2.90 | 2.16 | 3.90 | 27.3 | 17.0 | 5.9 | 2.4 | 12.6× / 7.0× | 7.9× / 4.4× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.95 | 2.74 | 4.76 | 45.0 | 27.5 | 9.9 | 3.4 | 16.4× / 9.4× | 10.0× / 5.8× | 3.6× / 2.1× | 1.3× / 0.7× |
| tha_Thai | 1.51 | 2.53 | 2.64 | 3.66 | 28.5 | 16.7 | 6.8 | 3.0 | 10.8× / 7.8× | 6.3× / 4.6× | 2.6× / 1.8× | 1.1× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.06 | 2.48 | 23.5 | 17.3 | 6.5 | 1.8 | 22.2× / 9.5× | 16.4× / 7.0× | 6.2× / 2.6× | 1.7× / 0.7× |
| added_normalized_sparse | 0.06 | 1.48 | 2.03 | 3.44 | 31.2 | 23.4 | 8.8 | 2.5 | 15.4× / 9.1× | 11.6× / 6.8× | 4.3× / 2.5× | 1.2× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 5.04 | 6.46 | 95.0 | 76.5 | 21.2 | 3.1 | 18.8× / 14.7× | 15.2× / 11.8× | 4.2× / 3.3× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.86 | 6.27 | 60.9 | 46.9 | 15.0 | 3.4 | 12.5× / 9.7× | 9.6× / 7.5× | 3.1× / 2.4× | 0.7× / 0.5× |
| agentic-traces | 0.72 | 1.53 | 3.75 | 4.56 | 53.3 | 46.6 | 15.1 | 4.5 | 14.2× / 11.7× | 12.4× / 10.2× | 4.0× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.66 | 1.49 | 2.90 | 3.74 | 54.9 | 53.1 | 15.8 | 3.4 | 18.9× / 14.7× | 18.3× / 14.2× | 5.5× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.29 | 4.65 | 52.6 | 52.0 | 15.4 | 4.0 | 16.0× / 11.3× | 15.8× / 11.2× | 4.7× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.73 | 1.54 | 3.48 | 4.30 | 51.3 | 40.3 | 14.2 | 4.1 | 14.7× / 11.9× | 11.6× / 9.4× | 4.1× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×4.05 vs v0.23.1 · ×1.13 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 18+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.7 | 42.3 | ×8.98 | ×1.05 | 0% (0.0) | 11% (2.7) | 0% (0.1) | 88% (21.0) | 0% (0.0) | match |
| arb_Arab | lang | 10.3 | 49.2 | ×4.77 | ×1.01 | 0% (0.0) | 16% (3.2) | 1% (0.1) | 83% (16.7) | 0% (0.1) | match |
| ben_Beng | lang | 11.1 | 81.1 | ×7.34 | ×1.07 | 0% (0.0) | 18% (2.1) | 1% (0.1) | 81% (9.7) | 0% (0.1) | match |
| cmn_Hani | lang | 9.1 | 64.6 | ×7.08 | ×1.04 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 97% (14.4) | 0% (0.0) | match |
| ell_Grek | lang | 10.3 | 57.6 | ×5.56 | ×1.04 | 0% (0.0) | 18% (3.1) | 1% (0.1) | 81% (13.9) | 0% (0.1) | match |
| eng_Latn | lang | 4.1 | 6.3 | ×1.53 | ×0.99 | 0% (0.0) | 4% (7.0) | 0% (0.2) | 96% (151.5) | 0% (0.0) | match |
| heb_Hebr | lang | 10.3 | 60.2 | ×5.83 | ×1.03 | 0% (0.0) | 20% (3.3) | 1% (0.1) | 79% (13.0) | 0% (0.0) | match |
| hin_Deva | lang | 12.3 | 79.4 | ×6.47 | ×1.08 | 0% (0.0) | 23% (2.8) | 1% (0.1) | 76% (9.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 12.9 | 83.7 | ×6.50 | ×1.05 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 97% (10.9) | 0% (0.0) | match |
| kat_Geor | lang | 14.4 | 89.5 | ×6.22 | ×1.06 | 0% (0.1) | 18% (1.9) | 1% (0.1) | 81% (8.7) | 0% (0.0) | match |
| kor_Hang | lang | 7.3 | 50.9 | ×6.95 | ×1.02 | 0% (0.1) | 17% (3.3) | 1% (0.1) | 82% (15.8) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.9 | 16.0 | ×2.03 | ×1.00 | 0% (0.0) | 5% (2.8) | 0% (0.2) | 95% (59.2) | 0% (0.0) | match |
| tam_Taml | lang | 12.7 | 89.6 | ×7.05 | ×1.08 | 0% (0.0) | 16% (1.8) | 0% (0.1) | 83% (9.0) | 0% (0.0) | match |
| tha_Thai | lang | 15.6 | 84.5 | ×5.43 | ×1.03 | 0% (0.0) | 9% (1.0) | 0% (0.0) | 90% (10.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.5 | 8.7 | ×1.59 | ×0.99 | 0% (0.0) | 3% (3.8) | 0% (0.1) | 97% (112.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.7 | 7.4 | ×1.57 | ×1.00 | 0% (0.0) | 5% (6.2) | 0% (0.2) | 95% (127.6) | 0% (0.3) | match |
| added_special_dense | modalities | 3.8 | 39.0 | ×10.25 | ×1.94 | 21% (5.2) | 63% (15.3) | 5% (1.3) | 11% (2.6) | 0% (0.1) | match |
| added_special_sparse | modalities | 5.3 | 45.5 | ×8.55 | ×4.44 | 12% (2.1) | 77% (14.2) | 3% (0.5) | 9% (1.7) | 0% (0.0) | match |
| agentic-traces | modalities | 4.4 | 7.0 | ×1.59 | ×0.99 | 0% (0.1) | 4% (6.2) | 0% (0.2) | 95% (135.4) | 0% (0.2) | match |
| agentic_swe | modalities | 4.0 | 6.9 | ×1.72 | ×0.99 | 0% (0.0) | 7% (9.7) | 0% (0.2) | 93% (134.7) | 0% (0.5) | match |
| code_mixed | modalities | 4.2 | 6.9 | ×1.64 | ×0.98 | 0% (0.0) | 5% (8.0) | 0% (0.3) | 94% (136.5) | 0% (0.0) | match |
| math_latex | modalities | 4.3 | 6.6 | ×1.54 | ×0.98 | 0% (0.1) | 4% (6.5) | 0% (0.2) | 95% (143.2) | 0% (0.1) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×21.96 vs v0.23.1 · ×3.09 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 95)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 94.4 | ×21.72 | ×1.95 | 8% (0.7) | 0% (0.0) | 43% (3.7) | 50% (4.3) | 0% (0.0) | match |
| arb_Arab | lang | 4.5 | 105.3 | ×23.40 | ×5.88 | 7% (0.6) | 0% (0.0) | 29% (2.3) | 67% (5.4) | 0% (0.0) | match |
| ben_Beng | lang | 4.2 | 109.4 | ×26.29 | ×3.49 | 7% (0.6) | 0% (0.0) | 37% (3.1) | 56% (4.7) | 0% (0.0) | match |
| cmn_Hani | lang | 5.0 | 125.4 | ×24.92 | ×7.50 | 9% (0.6) | 0% (0.0) | 37% (2.4) | 52% (3.5) | 2% (0.1) | match |
| ell_Grek | lang | 5.2 | 117.2 | ×22.37 | ×6.07 | 8% (0.6) | 0% (0.0) | 31% (2.2) | 60% (4.3) | 1% (0.1) | match |
| eng_Latn | lang | 4.2 | 67.2 | ×15.92 | ×1.45 | 16% (2.0) | 0% (0.0) | 25% (3.0) | 60% (7.4) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 107.5 | ×25.74 | ×4.14 | 8% (0.6) | 0% (0.0) | 30% (2.3) | 63% (4.9) | 0% (0.0) | match |
| hin_Deva | lang | 4.3 | 99.7 | ×23.24 | ×1.30 | 6% (0.6) | 0% (0.0) | 36% (3.3) | 59% (5.5) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.6 | 147.5 | ×26.24 | ×9.09 | 11% (0.6) | 0% (0.0) | 41% (2.2) | 50% (2.7) | 0% (0.0) | match |
| kat_Geor | lang | 5.6 | 143.4 | ×25.41 | ×3.87 | 11% (0.6) | 0% (0.0) | 38% (2.1) | 52% (2.9) | 0% (0.0) | match |
| kor_Hang | lang | 3.9 | 85.8 | ×22.05 | ×4.49 | 6% (0.6) | 0% (0.0) | 25% (2.5) | 69% (6.9) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.8 | 113.6 | ×23.69 | ×6.94 | 8% (0.6) | 0% (0.0) | 30% (2.2) | 62% (4.5) | 0% (0.0) | match |
| tam_Taml | lang | 3.9 | 111.9 | ×28.40 | ×3.15 | 7% (0.6) | 0% (0.0) | 34% (2.7) | 60% (4.9) | 0% (0.0) | match |
| tha_Thai | lang | 5.0 | 110.1 | ×21.88 | ×5.42 | 8% (0.6) | 0% (0.0) | 34% (2.6) | 57% (4.3) | 1% (0.1) | match |
| added_normalized_dense | modalities | 6.1 | 182.7 | ×29.99 | ×6.73 | 16% (0.7) | 0% (0.0) | 25% (1.2) | 58% (2.7) | 1% (0.1) | match |
| added_normalized_sparse | modalities | 5.6 | 130.7 | ×23.44 | ×3.07 | 18% (1.3) | 0% (0.0) | 27% (1.9) | 53% (3.7) | 2% (0.1) | match |
| added_special_dense | modalities | 4.2 | 65.8 | ×15.74 | ×0.87 | 36% (5.0) | 0% (0.0) | 35% (4.7) | 29% (3.9) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 70.8 | ×16.26 | ×0.98 | 25% (3.1) | 0% (0.1) | 38% (4.8) | 38% (4.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.6 | 65.2 | ×18.31 | ×1.74 | 13% (1.8) | 0% (0.0) | 28% (3.7) | 58% (7.8) | 1% (0.1) | match |
| agentic_swe | modalities | 4.0 | 80.9 | ×20.01 | ×2.85 | 12% (1.3) | 0% (0.0) | 27% (2.9) | 65% (6.9) | 0% (0.0) | match |
| code_mixed | modalities | 4.1 | 77.4 | ×18.80 | ×1.64 | 14% (1.5) | 0% (0.0) | 29% (3.3) | 58% (6.6) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 65.0 | ×17.31 | ×1.59 | 14% (1.9) | 0% (0.0) | 26% (3.5) | 60% (7.9) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.39 | 3.71 | 4.31 | 27.2 | 16.7 | 5.9 | 4.8 | 7.3× / 6.3× | 4.5× / 3.9× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.17 | 2.98 | 2.33 | 4.14 | 31.2 | 19.8 | 6.9 | 5.1 | 13.4× / 7.5× | 8.5× / 4.8× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.63 | 3.01 | 3.15 | 4.52 | 45.5 | 28.8 | 10.5 | 3.7 | 14.5× / 10.1× | 9.1× / 6.4× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.13 | 2.24 | 2.41 | 3.52 | 20.0 | 11.8 | 4.7 | 2.4 | 8.3× / 5.7× | 4.9× / 3.4× | 1.9× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.60 | 2.95 | 2.19 | 4.54 | 28.7 | 17.5 | 6.3 | 4.8 | 13.1× / 6.3× | 8.0× / 3.8× | 2.9× / 1.4× | 2.2× / 1.0× |
| eng_Latn | 0.11 | 1.46 | 3.04 | 4.40 | 44.4 | 34.8 | 13.0 | 3.7 | 14.6× / 10.1× | 11.4× / 7.9× | 4.3× / 3.0× | 1.2× / 0.8× |
| heb_Hebr | 1.16 | 3.04 | 2.33 | 4.21 | 30.9 | 20.3 | 7.0 | 3.0 | 13.3× / 7.4× | 8.7× / 4.8× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.55 | 3.10 | 3.29 | 4.84 | 48.2 | 31.8 | 11.8 | 4.0 | 14.7× / 10.0× | 9.7× / 6.6× | 3.6× / 2.4× | 1.2× / 0.8× |
| jpn_Jpan | 1.70 | 3.36 | 2.20 | 3.86 | 18.5 | 10.0 | 4.1 | 3.8 | 8.4× / 4.8× | 4.5× / 2.6× | 1.8× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.57 | 2.56 | 2.11 | 3.10 | 17.2 | 11.4 | 4.1 | 2.0 | 8.1× / 5.5× | 5.4× / 3.7× | 2.0× / 1.3× | 1.0× / 0.7× |
| kor_Hang | 1.23 | 2.69 | 2.52 | 3.97 | 31.7 | 21.8 | 7.6 | 3.7 | 12.6× / 8.0× | 8.7× / 5.5× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.18 | 2.91 | 2.17 | 3.90 | 27.3 | 17.0 | 5.9 | 2.5 | 12.6× / 7.0× | 7.9× / 4.4× | 2.7× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.96 | 2.92 | 2.73 | 4.69 | 45.0 | 27.5 | 10.1 | 3.4 | 16.5× / 9.6× | 10.1× / 5.9× | 3.7× / 2.1× | 1.3× / 0.7× |
| tha_Thai | 1.55 | 2.57 | 2.62 | 3.65 | 28.1 | 16.4 | 6.7 | 3.0 | 10.7× / 7.7× | 6.3× / 4.5× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.48 | 1.15 | 2.57 | 23.0 | 17.5 | 6.6 | 1.8 | 20.0× / 8.9× | 15.2× / 6.8× | 5.7× / 2.6× | 1.5× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.90 | 3.31 | 31.2 | 23.2 | 8.5 | 2.5 | 16.4× / 9.4× | 12.2× / 7.0× | 4.5× / 2.6× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.70 | 6.12 | 94.7 | 74.8 | 21.1 | 3.1 | 20.1× / 15.5× | 15.9× / 12.2× | 4.5× / 3.4× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.81 | 6.22 | 61.1 | 46.4 | 15.1 | 3.4 | 12.7× / 9.8× | 9.7× / 7.5× | 3.1× / 2.4× | 0.7× / 0.5× |
| agentic-traces | 0.74 | 1.47 | 3.73 | 4.46 | 52.4 | 45.8 | 15.2 | 4.6 | 14.0× / 11.7× | 12.3× / 10.3× | 4.1× / 3.4× | 1.2× / 1.0× |
| agentic_swe | 0.68 | 1.44 | 2.87 | 3.63 | 55.0 | 54.0 | 15.7 | 3.4 | 19.1× / 15.2× | 18.8× / 14.9× | 5.5× / 4.3× | 1.2× / 0.9× |
| code_mixed | 0.10 | 1.44 | 3.31 | 4.66 | 52.8 | 51.2 | 15.4 | 4.0 | 15.9× / 11.3× | 15.5× / 11.0× | 4.7× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.79 | 1.48 | 3.49 | 4.18 | 51.2 | 40.1 | 14.2 | 4.1 | 14.7× / 12.3× | 11.5× / 9.6× | 4.1× / 3.4× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×7.71 vs v0.23.1 · ×2.15 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 194) · Pipeline 108+0 (peak 194)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 42.4 | ×11.88 | ×1.40 | 6% (1.2) | 0% (0.0) | 71% (14.8) | 23% (4.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 38.9 | ×8.77 | ×2.26 | 5% (1.2) | 0% (0.0) | 71% (16.9) | 24% (5.8) | 0% (0.0) | match |
| ben_Beng | lang | 6.5 | 60.0 | ×9.20 | ×3.49 | 7% (1.2) | 0% (0.0) | 71% (11.2) | 22% (3.5) | 0% (0.0) | match |
| cmn_Hani | lang | 4.7 | 53.0 | ×11.36 | ×3.41 | 7% (1.2) | 0% (0.0) | 68% (11.9) | 23% (4.0) | 2% (0.4) | match |
| ell_Grek | lang | 5.0 | 43.6 | ×8.66 | ×2.84 | 5% (1.2) | 0% (0.0) | 72% (15.8) | 22% (4.9) | 0% (0.1) | match |
| eng_Latn | lang | 3.8 | 22.7 | ×6.04 | ×1.19 | 6% (2.5) | 0% (0.0) | 73% (31.0) | 22% (9.5) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 39.0 | ×9.41 | ×2.79 | 5% (1.2) | 0% (0.0) | 73% (18.0) | 23% (5.7) | 0% (0.0) | match |
| hin_Deva | lang | 6.4 | 51.8 | ×8.13 | ×2.41 | 6% (1.2) | 0% (0.0) | 72% (13.2) | 22% (4.0) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.4 | 65.3 | ×12.19 | ×4.29 | 8% (1.2) | 0% (0.0) | 69% (9.9) | 23% (3.2) | 1% (0.1) | match |
| kat_Geor | lang | 6.3 | 63.4 | ×10.04 | ×4.45 | 8% (1.2) | 0% (0.0) | 71% (10.5) | 21% (3.1) | 0% (0.0) | match |
| kor_Hang | lang | 3.8 | 33.1 | ×8.81 | ×2.19 | 4% (1.2) | 0% (0.0) | 68% (19.8) | 27% (7.7) | 1% (0.3) | match |
| rus_Cyrl | lang | 4.6 | 43.3 | ×9.40 | ×3.04 | 5% (1.2) | 0% (0.0) | 71% (15.5) | 26% (5.7) | 0% (0.0) | match |
| tam_Taml | lang | 6.6 | 72.8 | ×11.11 | ×5.00 | 9% (1.2) | 0% (0.0) | 70% (9.1) | 21% (2.7) | 0% (0.0) | match |
| tha_Thai | lang | 7.9 | 103.6 | ×13.16 | ×6.85 | 13% (1.2) | 0% (0.0) | 68% (5.9) | 18% (1.6) | 1% (0.1) | match |
| added_normalized_dense | modalities | 5.8 | 43.8 | ×7.59 | ×2.13 | 6% (1.3) | 0% (0.0) | 81% (17.9) | 13% (2.8) | 1% (0.2) | match |
| added_normalized_sparse | modalities | 5.5 | 35.7 | ×6.49 | ×1.44 | 7% (1.9) | 0% (0.0) | 78% (21.2) | 15% (4.1) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 16.0 | ×3.74 | ×0.96 | 8% (5.2) | 0% (0.1) | 82% (51.1) | 9% (5.6) | 1% (0.5) | match |
| added_special_sparse | modalities | 4.6 | 21.3 | ×4.66 | ×0.97 | 8% (3.6) | 0% (0.0) | 79% (35.9) | 13% (5.8) | 1% (0.3) | match |
| agentic-traces | modalities | 3.3 | 17.3 | ×5.23 | ×1.16 | 4% (2.4) | 0% (0.0) | 77% (44.0) | 19% (10.8) | 0% (0.1) | match |
| agentic_swe | modalities | 3.4 | 15.1 | ×4.49 | ×1.35 | 3% (1.9) | 0% (0.0) | 82% (54.3) | 15% (9.7) | 1% (0.7) | match |
| code_mixed | modalities | 3.6 | 16.8 | ×4.61 | ×1.13 | 5% (3.2) | 0% (0.0) | 81% (48.8) | 16% (9.4) | 0% (0.0) | match |
| math_latex | modalities | 3.5 | 19.2 | ×5.44 | ×1.11 | 5% (2.5) | 0% (0.0) | 75% (38.5) | 20% (10.0) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.43 | 14.78 | 15.43 | 28.8 | 14.6 | 6.7 | — | 1.9× / 1.9× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| arb_Arab | 1.15 | 2.99 | 16.91 | 18.76 | 32.9 | 16.5 | 7.2 | — | 1.9× / 1.8× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| ben_Beng | 1.62 | 2.89 | 11.21 | 12.48 | 23.0 | 11.0 | 5.2 | — | 2.1× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| cmn_Hani | 1.11 | 2.25 | 11.87 | 13.01 | 21.8 | 11.6 | 5.5 | — | 1.8× / 1.7× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| ell_Grek | 0.58 | 3.01 | 15.75 | 18.18 | 28.9 | 15.5 | 6.6 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| eng_Latn | 0.09 | 1.45 | 31.00 | 32.36 | 41.7 | 31.0 | 13.4 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| heb_Hebr | 1.14 | 3.05 | 18.01 | 19.92 | 32.3 | 18.0 | 7.7 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| hin_Deva | 1.51 | 3.10 | 13.21 | 14.80 | 25.0 | 13.4 | 6.0 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| jpn_Jpan | 1.69 | 3.38 | 9.85 | 11.54 | 20.4 | 9.7 | 4.9 | — | 2.1× / 1.8× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| kat_Geor | 1.55 | 2.51 | 10.50 | 11.46 | 18.6 | 10.4 | 4.4 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| kor_Hang | 1.23 | 2.69 | 19.77 | 21.23 | 32.8 | 19.8 | 8.7 | — | 1.7× / 1.5× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| rus_Cyrl | 1.16 | 2.92 | 15.47 | 17.23 | 28.0 | 15.4 | 6.3 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| tam_Taml | 0.93 | 2.89 | 9.07 | 11.03 | 18.7 | 8.9 | 4.2 | — | 2.1× / 1.7× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| tha_Thai | 1.51 | 2.60 | 5.94 | 7.03 | 13.3 | 5.9 | 2.8 | — | 2.2× / 1.9× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| added_normalized_dense | 0.24 | 1.47 | 17.93 | 19.16 | 30.4 | 17.8 | 11.3 | — | 1.7× / 1.6× | 1.0× / 0.9× | 0.6× / 0.6× | — |
| added_normalized_sparse | 0.25 | 1.47 | 21.19 | 22.42 | 32.4 | 20.8 | 11.1 | — | 1.5× / 1.4× | 1.0× / 0.9× | 0.5× / 0.5× | — |
| added_special_dense | 0.24 | 1.47 | 51.13 | 52.36 | 82.9 | 69.1 | 23.5 | — | 1.6× / 1.6× | 1.4× / 1.3× | 0.5× / 0.4× | — |
| added_special_sparse | 0.24 | 1.47 | 35.93 | 37.16 | 53.8 | 42.4 | 16.4 | — | 1.5× / 1.4× | 1.2× / 1.1× | 0.5× / 0.4× | — |
| agentic-traces | 0.74 | 1.55 | 44.03 | 44.84 | 52.1 | 44.7 | 16.9 | — | 1.2× / 1.2× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| agentic_swe | 0.66 | 1.47 | 54.32 | 55.13 | 56.9 | 56.2 | 26.8 | — | 1.0× / 1.0× | 1.0× / 1.0× | 0.5× / 0.5× | — |
| code_mixed | 0.07 | 1.48 | 48.83 | 50.24 | 51.7 | 50.2 | 17.4 | — | 1.1× / 1.0× | 1.0× / 1.0× | 0.4× / 0.3× | — |
| math_latex | 0.71 | 1.48 | 38.51 | 39.27 | 49.5 | 38.2 | 15.7 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402519928-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->

