### PR TITLE
experiment(bpe cache): just a hashmap with evict

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,134 +1,38 @@
-use std::ops::Range;
+use ahash::AHashMap;
 
-use ahash::RandomState;
-
-use crate::utils::cache::MAX_LENGTH;
-
-const WAYS: usize = 4;
-
-#[derive(Clone, Copy, Default)]
-struct CacheSlot {
-    tag: u32,
-    key_off: u32,
-    ids_off: u32,
-    key_len: u16,
-    ids_len: u16,
-}
-
-#[derive(Clone, Copy, Default)]
-#[repr(align(64))]
-struct Bucket([CacheSlot; WAYS]);
-
-impl CacheSlot {
-    fn id_range(&self) -> Range<usize> {
-        self.ids_off as usize..(self.ids_off as usize + self.ids_len as usize)
-    }
-
-    fn key_range(&self) -> Range<usize> {
-        self.key_off as usize..(self.key_off as usize + self.key_len as usize)
-    }
-}
+const MAX_LENGTH: usize = 1024;
 
 pub struct WordCache {
-    hasher: RandomState,
-    buckets: Box<[Bucket]>,
-    key_bytes: Vec<u8>,
-    ids: Vec<u32>,
-    bucket_mask: u64,
+    lookup: AHashMap<Box<[u8]>, Box<[u32]>>,
+    capacity: usize,
 }
 
 impl WordCache {
     pub fn new(capacity: usize) -> Self {
-        let n_buckets = (capacity.next_power_of_two() / WAYS).max(1);
         Self {
-            hasher: RandomState::new(),
-            buckets: vec![Bucket::default(); n_buckets].into_boxed_slice(),
-            ids: Vec::with_capacity(256),
-            key_bytes: Vec::with_capacity(1024),
-            bucket_mask: (n_buckets as u64) - 1,
+            capacity,
+            lookup: AHashMap::with_capacity(capacity),
         }
-    }
-
-    // The low hash bits pick the bucket index, the high bits form the occupancy tag
-    // 0x0 tag is reserved for empty spots (hence the `| 1`)
-    fn locate(&self, key: &[u8]) -> (usize, u32) {
-        let hash = self.hasher.hash_one(key);
-        ((hash & self.bucket_mask) as usize, (hash >> 32) as u32 | 1)
     }
 
     pub fn get(&self, key: &[u8]) -> Option<&[u32]> {
         if key.len() > MAX_LENGTH {
             return None;
         }
-        let (bucket_idx, tag) = self.locate(key);
-        for slot in &self.buckets[bucket_idx].0 {
-            if slot.tag == tag && key == &self.key_bytes[slot.key_range()] {
-                return Some(&self.ids[slot.id_range()]);
-            }
-        }
-        None
+        self.lookup.get(key).map(|boxed| &boxed[..])
     }
 
     pub fn insert(&mut self, key: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
         if key.len() > MAX_LENGTH {
             return;
         }
-        let (bucket_idx, tag) = self.locate(key);
-        let Some(slot) = self.buckets[bucket_idx]
-            .0
-            .iter()
-            .position(|slot| slot.tag == 0)
-        else {
-            // bucket full: skip insert
-            return;
-        };
-        self.buckets[bucket_idx].0[slot] = CacheSlot {
-            tag,
-            key_off: self.key_bytes.len() as u32,
-            key_len: key.len() as u16,
-            ids_off: self.ids.len() as u32,
-            ids_len: ids.len() as u16,
-        };
-        self.key_bytes.extend_from_slice(key);
-        self.ids.extend(ids);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn roundtrip() {
-        let mut cache = WordCache::new(1 << 8);
-        assert_eq!(cache.get(b"hello"), None);
-        cache.insert(b"hello", [1u32, 2, 3].into_iter());
-        cache.insert(b"world", [4u32].into_iter());
-        assert_eq!(cache.get(b"hello"), Some(&[1u32, 2, 3][..]));
-        assert_eq!(cache.get(b"world"), Some(&[4u32][..]));
-        assert_eq!(cache.get(b"hell"), None);
-    }
-
-    #[test]
-    fn single_bucket_holds_ways_entries_then_freezes() {
-        // capacity <= WAYS collapses to one bucket, making conflicts deterministic
-        let mut cache = WordCache::new(1);
-        let keys: Vec<Vec<u8>> = (0..WAYS as u8 + 2).map(|i| vec![i; 3]).collect();
-        for (i, key) in keys.iter().enumerate() {
-            cache.insert(key, [i as u32].into_iter());
+        if self.lookup.len() >= self.capacity {
+            self.evict();
         }
-        let cached = keys.iter().filter(|k| cache.get(k).is_some()).count();
-        assert_eq!(cached, WAYS);
-        for (i, key) in keys.iter().enumerate().take(WAYS) {
-            assert_eq!(cache.get(key), Some(&[i as u32][..]));
-        }
+        self.lookup.insert(Box::from(key), ids.collect());
     }
 
-    #[test]
-    fn oversized_keys_are_ignored() {
-        let mut cache = WordCache::new(1 << 8);
-        let big = vec![7u8; MAX_LENGTH + 1];
-        cache.insert(&big, [1u32].into_iter());
-        assert_eq!(cache.get(&big), None);
+    fn evict(&mut self) {
+        self.lookup.extract_if(|_, _| true).next();
     }
 }


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`07d1f9c31 · 2026-07-28 09:56 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 32 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-overview.png" width="860">

**vs base branch** (`709ef7af5`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.97 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 11+0 (peak 12) · Pipeline 8+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.8 | 27.6 | ×3.52 | ×1.01 | 3% (1.2) | 76% (27.3) | 13% (4.8) | 8% (2.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.1 | 25.0 | ×6.04 | ×1.00 | 3% (1.2) | 69% (27.5) | 8% (3.3) | 21% (8.2) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 34.9 | ×5.80 | ×1.00 | 4% (1.2) | 67% (19.0) | 10% (2.9) | 19% (5.3) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 18.9 | ×4.90 | ×1.01 | 2% (1.2) | 71% (37.7) | 11% (5.6) | 17% (8.9) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 23.8 | ×6.31 | ×1.00 | 3% (1.2) | 68% (28.5) | 8% (3.4) | 21% (8.6) | 0% (0.0) | match |
| eng_Latn | lang | 4.3 | 18.4 | ×4.22 | ×1.00 | 5% (2.7) | 71% (38.4) | 8% (4.4) | 16% (8.6) | 0% (0.1) | match |
| heb_Hebr | lang | 4.2 | 20.0 | ×4.77 | ×1.00 | 2% (1.2) | 76% (37.5) | 7% (3.7) | 15% (7.5) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 27.7 | ×4.27 | ×1.01 | 3% (1.2) | 74% (26.7) | 10% (3.5) | 14% (4.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.2 | 27.3 | ×6.46 | ×1.00 | 3% (1.2) | 64% (23.3) | 13% (4.6) | 20% (7.3) | 0% (0.1) | match |
| kat_Geor | lang | 6.1 | 28.5 | ×4.65 | ×1.02 | 3% (1.2) | 75% (26.5) | 9% (3.1) | 13% (4.4) | 0% (0.1) | match |
| kor_Hang | lang | 2.4 | 17.7 | ×7.40 | ×1.00 | 2% (1.2) | 62% (35.1) | 14% (7.7) | 22% (12.4) | 0% (0.1) | match |
| rus_Cyrl | lang | 3.6 | 23.8 | ×6.53 | ×1.00 | 3% (1.2) | 66% (27.3) | 8% (3.1) | 24% (10.0) | 0% (0.0) | match |
| tam_Taml | lang | 7.0 | 38.3 | ×5.48 | ×1.00 | 5% (1.2) | 72% (18.5) | 9% (2.4) | 14% (3.6) | 0% (0.0) | match |
| tha_Thai | lang | 8.3 | 33.6 | ×4.04 | ×1.03 | 4% (1.2) | 83% (24.9) | 7% (2.2) | 5% (1.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.7 | 19.7 | ×2.92 | ×1.00 | 3% (1.3) | 81% (40.3) | 14% (7.1) | 2% (1.2) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 18.3 | ×3.45 | ×1.00 | 4% (1.9) | 74% (39.7) | 13% (7.0) | 9% (4.8) | 0% (0.0) | match |
| added_special_dense | modalities | 5.4 | 38.8 | ×7.20 | ×1.00 | 20% (5.0) | 37% (9.2) | 36% (8.8) | 7% (1.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 21.5 | ×5.34 | ×1.00 | 8% (3.6) | 61% (28.0) | 19% (8.6) | 12% (5.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.8 | 18.2 | ×4.76 | ×1.00 | 4% (2.4) | 70% (38.4) | 9% (4.7) | 17% (9.1) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 19.6 | ×4.81 | ×1.00 | 4% (2.0) | 76% (38.4) | 7% (3.5) | 13% (6.9) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 19.1 | ×4.86 | ×1.00 | 4% (2.2) | 73% (38.3) | 8% (4.1) | 14% (7.4) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 18.3 | ×4.55 | ×1.00 | 4% (2.4) | 70% (38.3) | 9% (4.7) | 16% (8.9) | 0% (0.3) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×21.00 vs v0.23.1 · ×5.19 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 82+0 (peak 82)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.7 | 81.1 | ×17.27 | ×2.36 | 5% (0.7) | 0% (0.0) | 39% (4.8) | 55% (6.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.5 | 92.4 | ×20.70 | ×5.56 | 6% (0.6) | 0% (0.0) | 33% (3.5) | 60% (6.2) | 1% (0.1) | match |
| ben_Beng | lang | 6.4 | 123.5 | ×19.19 | ×6.93 | 8% (0.6) | 0% (0.0) | 43% (3.1) | 49% (3.6) | 0% (0.0) | match |
| cmn_Hani | lang | 3.7 | 96.9 | ×26.20 | ×5.86 | 7% (0.8) | 0% (0.0) | 27% (3.2) | 65% (7.6) | 1% (0.1) | match |
| ell_Grek | lang | 4.9 | 97.7 | ×20.07 | ×5.47 | 6% (0.6) | 0% (0.0) | 34% (3.4) | 64% (6.3) | 0% (0.0) | match |
| eng_Latn | lang | 3.4 | 64.7 | ×19.13 | ×4.97 | 13% (2.0) | 0% (0.0) | 34% (5.2) | 54% (8.3) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 86.4 | ×20.84 | ×6.66 | 6% (0.6) | 0% (0.0) | 32% (3.6) | 61% (6.7) | 1% (0.2) | match |
| hin_Deva | lang | 5.7 | 112.4 | ×19.60 | ×5.28 | 8% (0.6) | 0% (0.0) | 43% (3.3) | 54% (4.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.4 | 109.1 | ×24.81 | ×6.08 | 7% (0.7) | 0% (0.0) | 31% (3.0) | 63% (6.0) | 0% (0.0) | match |
| kat_Geor | lang | 6.1 | 122.5 | ×20.14 | ×7.05 | 8% (0.6) | 0% (0.0) | 38% (2.9) | 54% (4.2) | 1% (0.0) | match |
| kor_Hang | lang | 4.0 | 77.6 | ×19.62 | ×3.92 | 5% (0.6) | 0% (0.0) | 29% (3.7) | 67% (8.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.4 | 94.8 | ×21.40 | ×6.70 | 6% (0.6) | 0% (0.0) | 32% (3.3) | 57% (5.8) | 5% (0.5) | match |
| tam_Taml | lang | 6.4 | 125.2 | ×19.46 | ×7.17 | 8% (0.6) | 0% (0.0) | 38% (2.7) | 58% (4.1) | 0% (0.0) | match |
| tha_Thai | lang | 7.0 | 183.9 | ×26.19 | ×12.85 | 12% (0.6) | 0% (0.0) | 41% (2.2) | 37% (1.9) | 10% (0.5) | match |
| added_normalized_dense | modalities | 5.6 | 151.7 | ×27.05 | ×6.46 | 12% (0.7) | 0% (0.0) | 47% (2.8) | 40% (2.4) | 1% (0.1) | match |
| added_normalized_sparse | modalities | 5.0 | 113.8 | ×22.66 | ×5.81 | 16% (1.3) | 0% (0.0) | 46% (3.8) | 38% (3.1) | 0% (0.0) | match |
| added_special_dense | modalities | 3.3 | 58.9 | ×17.99 | ×1.57 | 42% (6.4) | 3% (0.4) | 39% (6.0) | 18% (2.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.7 | 65.8 | ×17.77 | ×3.17 | 27% (3.8) | 2% (0.3) | 48% (6.7) | 24% (3.3) | 0% (0.0) | match |
| agentic-traces | modalities | 3.1 | 64.5 | ×20.61 | ×4.52 | 12% (1.8) | 0% (0.0) | 36% (5.5) | 52% (8.0) | 0% (0.1) | match |
| agentic_swe | modalities | 3.3 | 83.4 | ×24.91 | ×5.59 | 11% (1.3) | 0% (0.0) | 33% (3.8) | 57% (6.5) | 0% (0.0) | match |
| code_mixed | modalities | 3.8 | 75.4 | ×19.86 | ×4.85 | 12% (1.5) | 0% (0.0) | 37% (4.6) | 53% (6.5) | 0% (0.0) | match |
| math_latex | modalities | 3.1 | 63.7 | ×20.38 | ×4.54 | 13% (1.9) | 0% (0.0) | 35% (5.4) | 53% (8.2) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.45 | 4.76 | 5.42 | 43.8 | 20.6 | 9.2 | — | 9.2× / 8.1× | 4.3× / 3.8× | 1.9× / 1.7× | — |
| arb_Arab | 1.15 | 2.98 | 3.46 | 5.29 | 51.7 | 23.5 | 10.4 | — | 15.0× / 9.8× | 6.8× / 4.4× | 3.0× / 2.0× | — |
| ben_Beng | 1.61 | 2.99 | 3.14 | 4.53 | 37.3 | 16.4 | 7.6 | — | 11.9× / 8.2× | 5.2× / 3.6× | 2.4× / 1.7× | — |
| cmn_Hani | 1.12 | 2.27 | 3.16 | 4.31 | 64.3 | 35.0 | 14.5 | — | 20.4× / 14.9× | 11.1× / 8.1× | 4.6× / 3.4× | — |
| ell_Grek | 0.58 | 2.94 | 3.40 | 5.76 | 50.0 | 21.4 | 9.6 | — | 14.7× / 8.7× | 6.3× / 3.7× | 2.8× / 1.7× | — |
| eng_Latn | 0.09 | 1.46 | 5.16 | 6.53 | 69.7 | 40.6 | 16.3 | — | 13.5× / 10.7× | 7.9× / 6.2× | 3.2× / 2.5× | — |
| heb_Hebr | 1.15 | 3.00 | 3.55 | 5.40 | 53.7 | 24.8 | 10.7 | — | 15.1× / 9.9× | 7.0× / 4.6× | 3.0× / 2.0× | — |
| hin_Deva | 1.52 | 3.08 | 3.33 | 4.89 | 40.9 | 19.1 | 8.7 | — | 12.3× / 8.4× | 5.7× / 3.9× | 2.6× / 1.8× | — |
| jpn_Jpan | 1.70 | 3.34 | 2.98 | 4.62 | 56.0 | 27.7 | 11.8 | — | 18.8× / 12.1× | 9.3× / 6.0× | 4.0× / 2.6× | — |
| kat_Geor | 1.54 | 2.53 | 2.94 | 3.93 | 34.1 | 15.3 | 7.3 | — | 11.6× / 8.7× | 5.2× / 3.9× | 2.5× / 1.9× | — |
| kor_Hang | 1.23 | 2.67 | 3.70 | 5.14 | 52.9 | 27.5 | 11.8 | — | 14.3× / 10.3× | 7.4× / 5.4× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.17 | 2.92 | 3.28 | 5.04 | 49.9 | 21.6 | 9.6 | — | 15.2× / 9.9× | 6.6× / 4.3× | 2.9× / 1.9× | — |
| tam_Taml | 0.93 | 2.91 | 2.71 | 4.70 | 33.0 | 13.5 | 6.5 | — | 12.2× / 7.0× | 5.0× / 2.9× | 2.4× / 1.4× | — |
| tha_Thai | 1.53 | 2.61 | 2.16 | 3.23 | 28.5 | 10.4 | 5.2 | — | 13.2× / 8.8× | 4.8× / 3.2× | 2.4× / 1.6× | — |
| added_normalized_dense | 0.06 | 1.48 | 2.78 | 4.20 | 45.2 | 20.5 | 9.1 | — | 16.3× / 10.8× | 7.4× / 4.9× | 3.3× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.78 | 5.20 | 51.9 | 26.8 | 11.3 | — | 13.7× / 10.0× | 7.1× / 5.2× | 3.0× / 2.2× | — |
| added_special_dense | 0.06 | 1.48 | 5.98 | 7.40 | 189.9 | 99.9 | 38.0 | — | 31.7× / 25.7× | 16.7× / 13.5× | 6.3× / 5.1× | — |
| added_special_sparse | 0.06 | 1.47 | 6.66 | 8.08 | 109.9 | 59.0 | 23.9 | — | 16.5× / 13.6× | 8.9× / 7.3× | 3.6× / 3.0× | — |
| agentic-traces | 0.72 | 1.48 | 5.46 | 6.22 | 85.6 | 54.7 | 20.3 | — | 15.7× / 13.8× | 10.0× / 8.8× | 3.7× / 3.3× | — |
| agentic_swe | 0.68 | 1.45 | 3.79 | 4.56 | 102.2 | 67.8 | 23.9 | — | 26.9× / 22.4× | 17.9× / 14.9× | 6.3× / 5.2× | — |
| code_mixed | 0.08 | 1.45 | 4.60 | 5.96 | 79.4 | 55.8 | 18.6 | — | 17.3× / 13.3× | 12.1× / 9.4× | 4.0× / 3.1× | — |
| math_latex | 0.73 | 1.49 | 5.40 | 6.16 | 83.9 | 48.7 | 19.4 | — | 15.5× / 13.6× | 9.0× / 7.9× | 3.6× / 3.1× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×2.11 vs v0.23.1 · ×1.11 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 303+0 (peak 371) · Pipeline 275+0 (peak 371)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 10.8 | 28.4 | ×2.64 | ×1.03 | 2% (0.7) | 6% (2.1) | 0% (0.1) | 92% (31.9) | 0% (0.0) | match |
| arb_Arab | lang | 7.3 | 13.4 | ×1.85 | ×1.01 | 1% (0.6) | 3% (2.5) | 0% (0.0) | 98% (72.0) | 0% (0.0) | match |
| ben_Beng | lang | 10.2 | 18.8 | ×1.84 | ×1.01 | 1% (0.6) | 3% (1.6) | 0% (0.0) | 96% (50.0) | 0% (0.1) | match |
| cmn_Hani | lang | 12.9 | 35.3 | ×2.74 | ×1.05 | 2% (0.6) | 1% (0.3) | 0% (0.0) | 97% (26.9) | 0% (0.0) | match |
| ell_Grek | lang | 7.7 | 15.3 | ×1.98 | ×1.02 | 1% (0.6) | 4% (2.5) | 0% (0.0) | 96% (62.1) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 5.5 | ×1.42 | ×1.01 | 1% (2.1) | 3% (4.7) | 0% (0.0) | 97% (173.2) | 0% (0.0) | match |
| heb_Hebr | lang | 7.6 | 17.1 | ×2.25 | ×1.02 | 1% (0.6) | 4% (2.6) | 0% (0.0) | 95% (54.9) | 0% (0.0) | match |
| hin_Deva | lang | 9.1 | 18.2 | ×2.00 | ×1.02 | 1% (0.6) | 4% (2.2) | 0% (0.0) | 95% (50.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 12.4 | 30.0 | ×2.42 | ×1.03 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 98% (31.3) | 0% (0.0) | match |
| kat_Geor | lang | 12.0 | 25.4 | ×2.12 | ×1.04 | 2% (0.6) | 4% (1.4) | 0% (0.0) | 94% (37.0) | 1% (0.3) | match |
| kor_Hang | lang | 9.9 | 26.6 | ×2.70 | ×1.06 | 2% (0.6) | 7% (2.5) | 0% (0.0) | 92% (32.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.1 | 11.1 | ×1.55 | ×1.00 | 1% (0.6) | 3% (2.2) | 0% (0.0) | 98% (85.4) | 0% (0.0) | match |
| tam_Taml | lang | 11.2 | 20.2 | ×1.80 | ×1.04 | 1% (0.6) | 3% (1.2) | 0% (0.0) | 96% (46.7) | 0% (0.0) | match |
| tha_Thai | lang | 13.3 | 24.7 | ×1.86 | ×1.04 | 2% (0.6) | 2% (0.6) | 0% (0.0) | 97% (38.1) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.9 | 7.4 | ×1.50 | ×0.99 | 1% (0.8) | 2% (2.9) | 0% (0.0) | 96% (129.3) | 1% (1.4) | match |
| added_normalized_sparse | modalities | 4.6 | 6.6 | ×1.42 | ×0.99 | 1% (1.5) | 3% (4.2) | 0% (0.0) | 96% (142.8) | 0% (0.3) | match |
| added_special_dense | modalities | 4.7 | 35.0 | ×7.38 | ×1.73 | 33% (9.3) | 29% (8.0) | 27% (7.6) | 10% (2.9) | 1% (0.2) | match |
| added_special_sparse | modalities | 7.1 | 45.7 | ×6.39 | ×4.67 | 23% (5.1) | 37% (8.3) | 22% (5.0) | 20% (4.5) | 0% (0.0) | match |
| agentic-traces | modalities | 4.3 | 6.4 | ×1.50 | ×1.00 | 1% (1.8) | 3% (4.3) | 0% (0.1) | 95% (147.6) | 1% (0.9) | match |
| agentic_swe | modalities | 4.0 | 6.8 | ×1.70 | ×0.99 | 1% (1.3) | 5% (7.2) | 0% (0.0) | 94% (134.4) | 0% (0.1) | match |
| code_mixed | modalities | 4.0 | 6.3 | ×1.60 | ×0.96 | 1% (1.5) | 4% (5.9) | 0% (0.1) | 96% (143.8) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 5.9 | ×1.49 | ×0.98 | 1% (1.9) | 3% (4.5) | 0% (0.0) | 96% (158.2) | 0% (0.0) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×22.78 vs v0.23.1 · ×3.15 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 27+0 (peak 27)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 82.7 | ×19.67 | ×1.70 | 6% (0.7) | 0% (0.0) | 32% (3.7) | 63% (7.3) | 0% (0.0) | match |
| arb_Arab | lang | 4.1 | 88.5 | ×21.33 | ×3.44 | 6% (0.6) | 0% (0.0) | 21% (2.3) | 71% (7.5) | 2% (0.2) | match |
| ben_Beng | lang | 3.0 | 85.3 | ×28.88 | ×1.93 | 6% (0.6) | 0% (0.0) | 29% (3.1) | 64% (6.8) | 1% (0.2) | match |
| cmn_Hani | lang | 4.2 | 90.9 | ×21.87 | ×3.15 | 5% (0.6) | 0% (0.0) | 20% (2.3) | 73% (8.4) | 2% (0.2) | match |
| ell_Grek | lang | 4.6 | 95.5 | ×20.56 | ×3.37 | 6% (0.6) | 0% (0.0) | 22% (2.2) | 81% (7.8) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 75.9 | ×19.40 | ×5.40 | 16% (2.0) | 0% (0.0) | 23% (2.9) | 65% (8.2) | 0% (0.0) | match |
| heb_Hebr | lang | 4.4 | 91.9 | ×21.08 | ×3.19 | 5% (0.6) | 0% (0.0) | 21% (2.3) | 60% (6.5) | 14% (1.6) | match |
| hin_Deva | lang | 3.2 | 93.1 | ×29.23 | ×2.30 | 6% (0.6) | 0% (0.0) | 30% (3.1) | 60% (6.1) | 4% (0.4) | match |
| jpn_Jpan | lang | 4.9 | 117.9 | ×24.03 | ×5.36 | 7% (0.6) | 0% (0.0) | 24% (2.1) | 63% (5.5) | 7% (0.6) | match |
| kat_Geor | lang | 5.6 | 130.5 | ×23.50 | ×2.01 | 10% (0.6) | 0% (0.0) | 35% (2.1) | 63% (3.7) | 0% (0.0) | match |
| kor_Hang | lang | 4.0 | 82.8 | ×20.76 | ×1.89 | 5% (0.6) | 0% (0.0) | 21% (2.5) | 74% (8.8) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.6 | 101.7 | ×21.94 | ×3.68 | 6% (0.6) | 0% (0.0) | 22% (2.1) | 63% (6.2) | 9% (0.9) | match |
| tam_Taml | lang | 2.7 | 101.4 | ×37.14 | ×1.40 | 7% (0.6) | 0% (0.0) | 30% (2.7) | 63% (5.7) | 0% (0.0) | match |
| tha_Thai | lang | 4.4 | 89.1 | ×20.47 | ×2.51 | 6% (0.6) | 0% (0.0) | 26% (2.5) | 79% (7.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.6 | 189.4 | ×33.82 | ×7.45 | 16% (0.7) | 0% (0.0) | 27% (1.2) | 54% (2.5) | 3% (0.1) | match |
| added_normalized_sparse | modalities | 5.1 | 138.7 | ×27.01 | ×6.44 | 20% (1.3) | 0% (0.0) | 27% (1.8) | 53% (3.5) | 0% (0.0) | match |
| added_special_dense | modalities | 3.9 | 84.1 | ×21.60 | ×1.76 | 44% (4.9) | 1% (0.1) | 35% (3.9) | 21% (2.4) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 82.9 | ×21.18 | ×3.47 | 30% (3.2) | 0% (0.0) | 39% (4.3) | 31% (3.4) | 0% (0.0) | match |
| agentic-traces | modalities | 3.7 | 67.5 | ×18.16 | ×4.18 | 13% (1.8) | 0% (0.0) | 26% (3.5) | 63% (8.3) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 84.5 | ×21.07 | ×3.52 | 13% (1.3) | 0% (0.0) | 24% (2.4) | 65% (6.5) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 79.4 | ×19.87 | ×3.87 | 13% (1.5) | 0% (0.0) | 26% (2.9) | 57% (6.5) | 4% (0.5) | match |
| math_latex | modalities | 3.8 | 68.7 | ×18.15 | ×4.51 | 15% (1.9) | 0% (0.0) | 26% (3.3) | 63% (7.9) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.43 | 3.66 | 4.30 | 29.0 | 22.5 | 5.8 | 4.8 | 7.9× / 6.7× | 6.2× / 5.2× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.16 | 2.97 | 2.27 | 4.07 | 33.5 | 27.3 | 6.8 | 5.1 | 14.8× / 8.2× | 12.1× / 6.7× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.64 | 2.94 | 3.05 | 4.36 | 69.3 | 59.4 | 14.7 | 4.0 | 22.7× / 15.9× | 19.4× / 13.6× | 4.8× / 3.4× | 1.3× / 0.9× |
| cmn_Hani | 1.12 | 2.23 | 2.33 | 3.44 | 24.0 | 22.3 | 6.0 | 2.4 | 10.3× / 7.0× | 9.5× / 6.5× | 2.6× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.99 | 2.16 | 4.56 | 25.7 | 23.2 | 5.9 | 4.8 | 11.9× / 5.6× | 10.8× / 5.1× | 2.7× / 1.3× | 2.2× / 1.1× |
| eng_Latn | 0.09 | 1.45 | 2.94 | 4.30 | 48.5 | 44.8 | 12.1 | 3.8 | 16.5× / 11.3× | 15.2× / 10.4× | 4.1× / 2.8× | 1.3× / 0.9× |
| heb_Hebr | 1.15 | 3.04 | 2.29 | 4.17 | 33.6 | 27.8 | 7.0 | 3.0 | 14.7× / 8.1× | 12.1× / 6.7× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.52 | 3.09 | 3.12 | 4.68 | 67.2 | 58.5 | 14.1 | 4.2 | 21.5× / 14.3× | 18.8× / 12.5× | 4.5× / 3.0× | 1.3× / 0.9× |
| jpn_Jpan | 1.70 | 3.38 | 2.11 | 3.80 | 21.8 | 18.5 | 5.0 | 3.9 | 10.3× / 5.7× | 8.8× / 4.9× | 2.4× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.54 | 2.55 | 2.06 | 3.07 | 15.9 | 14.9 | 4.2 | 1.9 | 7.7× / 5.2× | 7.2× / 4.9× | 2.0× / 1.4× | 0.9× / 0.6× |
| kor_Hang | 1.23 | 2.74 | 2.46 | 3.98 | 28.7 | 30.0 | 7.5 | 3.7 | 11.7× / 7.2× | 12.2× / 7.6× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.17 | 2.92 | 2.11 | 3.86 | 24.8 | 22.3 | 5.8 | 2.4 | 11.8× / 6.4× | 10.6× / 5.8× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.95 | 2.70 | 4.72 | 63.5 | 64.3 | 14.7 | 3.7 | 23.5× / 13.4× | 23.8× / 13.6× | 5.4× / 3.1× | 1.4× / 0.8× |
| tha_Thai | 1.54 | 2.57 | 2.52 | 3.55 | 36.8 | 33.8 | 8.8 | 3.2 | 14.6× / 10.4× | 13.4× / 9.5× | 3.5× / 2.5× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.22 | 2.64 | 21.2 | 24.5 | 6.4 | 1.9 | 17.4× / 8.0× | 20.1× / 9.3× | 5.2× / 2.4× | 1.6× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.80 | 3.22 | 28.8 | 32.8 | 8.4 | 2.7 | 16.0× / 9.0× | 18.2× / 10.2× | 4.6× / 2.6× | 1.5× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 3.92 | 5.33 | 84.6 | 102.2 | 20.0 | 2.6 | 21.6× / 15.9× | 26.1× / 19.2× | 5.1× / 3.7× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 4.28 | 5.99 | 55.1 | 65.6 | 14.4 | 3.4 | 12.9× / 9.2× | 15.3× / 10.9× | 3.4× / 2.4× | 0.8× / 0.6× |
| agentic-traces | 0.76 | 1.47 | 3.46 | 4.17 | 53.8 | 64.8 | 15.5 | 4.6 | 15.6× / 12.9× | 18.7× / 15.5× | 4.5× / 3.7× | 1.3× / 1.1× |
| agentic_swe | 0.66 | 1.44 | 2.38 | 3.17 | 54.4 | 73.2 | 14.9 | 3.4 | 22.8× / 17.2× | 30.7× / 23.1× | 6.3× / 4.7× | 1.4× / 1.1× |
| code_mixed | 0.07 | 1.44 | 2.91 | 4.27 | 53.5 | 71.9 | 15.4 | 4.0 | 18.4× / 12.5× | 24.7× / 16.8× | 5.3× / 3.6× | 1.4× / 0.9× |
| math_latex | 0.71 | 1.47 | 3.28 | 4.05 | 48.0 | 54.8 | 14.2 | 4.2 | 14.6× / 11.9× | 16.7× / 13.5× | 4.3× / 3.5× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×18.96 vs v0.23.1 · ×3.51 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.2 | 63.8 | ×19.97 | ×2.74 | 4% (0.7) | 0% (0.0) | 30% (4.8) | 63% (10.1) | 3% (0.4) | match |
| arb_Arab | lang | 3.4 | 72.3 | ×21.00 | ×4.17 | 4% (0.6) | 0% (0.0) | 23% (3.3) | 80% (11.3) | 0% (0.0) | match |
| ben_Beng | lang | 5.5 | 93.6 | ×17.14 | ×5.34 | 6% (0.6) | 0% (0.0) | 35% (3.7) | 56% (5.8) | 3% (0.3) | match |
| cmn_Hani | lang | 4.1 | 85.0 | ×20.67 | ×6.99 | 5% (0.6) | 0% (0.0) | 27% (3.3) | 64% (7.9) | 4% (0.5) | match |
| ell_Grek | lang | 4.3 | 87.7 | ×20.54 | ×5.51 | 5% (0.6) | 0% (0.0) | 28% (3.3) | 67% (7.8) | 0% (0.0) | match |
| eng_Latn | lang | 3.2 | 55.1 | ×16.99 | ×1.30 | 13% (2.0) | 0% (0.0) | 30% (4.6) | 55% (8.4) | 2% (0.3) | match |
| heb_Hebr | lang | 4.1 | 77.4 | ×18.78 | ×4.66 | 5% (0.6) | 0% (0.0) | 27% (3.4) | 66% (8.4) | 3% (0.4) | match |
| hin_Deva | lang | 5.6 | 98.7 | ×17.57 | ×3.78 | 6% (0.6) | 0% (0.0) | 38% (3.8) | 57% (5.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.2 | 101.8 | ×19.42 | ×7.96 | 7% (0.6) | 0% (0.0) | 34% (3.1) | 81% (7.4) | 0% (0.0) | match |
| kat_Geor | lang | 6.0 | 107.2 | ×17.82 | ×7.61 | 6% (0.6) | 0% (0.0) | 30% (2.9) | 58% (5.6) | 6% (0.6) | match |
| kor_Hang | lang | 3.0 | 59.3 | ×19.67 | ×3.88 | 3% (0.6) | 0% (0.0) | 20% (3.7) | 65% (11.9) | 12% (2.1) | match |
| rus_Cyrl | lang | 4.7 | 81.8 | ×17.34 | ×5.23 | 4% (0.6) | 0% (0.0) | 23% (3.2) | 74% (10.0) | 0% (0.0) | match |
| tam_Taml | lang | 6.8 | 107.9 | ×15.75 | ×8.14 | 6% (0.6) | 0% (0.0) | 30% (3.2) | 65% (6.9) | 0% (0.0) | match |
| tha_Thai | lang | 7.5 | 128.1 | ×17.16 | ×11.10 | 8% (0.6) | 0% (0.0) | 41% (3.2) | 54% (4.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.6 | 151.3 | ×26.99 | ×5.96 | 13% (0.8) | 0% (0.0) | 37% (2.2) | 52% (3.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.6 | 117.0 | ×20.73 | ×2.79 | 17% (1.3) | 0% (0.0) | 41% (3.3) | 43% (3.4) | 0% (0.0) | match |
| added_special_dense | modalities | 4.5 | 76.1 | ×16.84 | ×1.01 | 40% (4.9) | 1% (0.2) | 40% (4.9) | 23% (2.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.7 | 74.7 | ×15.97 | ×0.97 | 27% (3.3) | 0% (0.0) | 46% (5.6) | 27% (3.3) | 0% (0.0) | match |
| agentic-traces | modalities | 3.3 | 62.4 | ×18.74 | ×1.62 | 12% (1.8) | 0% (0.1) | 32% (4.9) | 57% (8.7) | 0% (0.0) | match |
| agentic_swe | modalities | 3.5 | 77.8 | ×21.92 | ×2.80 | 10% (1.3) | 0% (0.0) | 30% (3.7) | 58% (7.2) | 3% (0.3) | match |
| code_mixed | modalities | 3.6 | 74.8 | ×20.82 | ×1.48 | 12% (1.6) | 0% (0.0) | 33% (4.4) | 55% (7.4) | 0% (0.0) | match |
| math_latex | modalities | 3.2 | 59.3 | ×18.53 | ×1.54 | 11% (1.9) | 0% (0.0) | 29% (4.9) | 61% (10.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.81 | 3.48 | 4.81 | 5.49 | 28.8 | 14.5 | 7.2 | 4.7 | 6.0× / 5.3× | 3.0× / 2.6× | 1.5× / 1.3× | 1.0× / 0.9× |
| arb_Arab | 1.17 | 2.94 | 3.31 | 5.08 | 33.2 | 16.5 | 7.7 | 5.1 | 10.0× / 6.5× | 5.0× / 3.2× | 2.3× / 1.5× | 1.5× / 1.0× |
| ben_Beng | 1.62 | 2.97 | 3.68 | 5.03 | 24.0 | 11.2 | 5.5 | 2.7 | 6.5× / 4.8× | 3.1× / 2.2× | 1.5× / 1.1× | 0.7× / 0.5× |
| cmn_Hani | 1.11 | 2.26 | 3.31 | 4.46 | 21.8 | 11.1 | 5.5 | 2.6 | 6.6× / 4.9× | 3.3× / 2.5× | 1.7× / 1.2× | 0.8× / 0.6× |
| ell_Grek | 0.58 | 2.97 | 3.26 | 5.65 | 30.5 | 15.5 | 7.0 | 5.1 | 9.4× / 5.4× | 4.8× / 2.7× | 2.2× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.11 | 1.45 | 4.58 | 5.93 | 42.1 | 30.1 | 14.2 | 4.2 | 9.2× / 7.1× | 6.6× / 5.1× | 3.1× / 2.4× | 0.9× / 0.7× |
| heb_Hebr | 1.14 | 3.00 | 3.38 | 5.24 | 33.9 | 17.6 | 8.3 | 2.7 | 10.0× / 6.5× | 5.2× / 3.4× | 2.5× / 1.6× | 0.8× / 0.5× |
| hin_Deva | 1.51 | 3.14 | 3.80 | 5.43 | 26.2 | 13.2 | 6.6 | 3.1 | 6.9× / 4.8× | 3.5× / 2.4× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.70 | 3.37 | 3.08 | 4.76 | 19.8 | 9.4 | 4.8 | 3.8 | 6.4× / 4.2× | 3.0× / 2.0× | 1.5× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.74 | 2.55 | 2.92 | 3.73 | 18.9 | 10.3 | 4.6 | 2.1 | 6.5× / 5.1× | 3.5× / 2.8× | 1.6× / 1.2× | 0.7× / 0.6× |
| kor_Hang | 1.23 | 2.72 | 3.71 | 5.21 | 33.8 | 19.8 | 9.4 | 3.6 | 9.1× / 6.5× | 5.3× / 3.8× | 2.5× / 1.8× | 1.0× / 0.7× |
| rus_Cyrl | 1.17 | 2.90 | 3.15 | 4.88 | 29.4 | 15.2 | 7.0 | 4.9 | 9.3× / 6.0× | 4.8× / 3.1× | 2.2× / 1.4× | 1.5× / 1.0× |
| tam_Taml | 0.93 | 2.95 | 3.22 | 5.25 | 18.6 | 8.9 | 4.3 | 2.9 | 5.8× / 3.6× | 2.8× / 1.7× | 1.3× / 0.8× | 0.9× / 0.5× |
| tha_Thai | 1.52 | 2.60 | 3.20 | 4.28 | 12.9 | 5.8 | 2.8 | 2.2 | 4.0× / 3.0× | 1.8× / 1.4× | 0.9× / 0.7× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.48 | 2.21 | 3.63 | 32.8 | 17.9 | 11.4 | 2.2 | 14.8× / 9.0× | 8.1× / 4.9× | 5.1× / 3.1× | 1.0× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.29 | 4.71 | 36.3 | 21.1 | 11.7 | 3.0 | 11.0× / 7.7× | 6.4× / 4.5× | 3.5× / 2.5× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.71 | 4.86 | 6.52 | 87.5 | 69.4 | 24.5 | 3.2 | 18.0× / 13.4× | 14.3× / 10.6× | 5.0× / 3.8× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 5.61 | 7.32 | 54.9 | 42.2 | 16.9 | 3.7 | 9.8× / 7.5× | 7.5× / 5.8× | 3.0× / 2.3× | 0.7× / 0.5× |
| agentic-traces | 0.76 | 1.48 | 4.91 | 5.63 | 54.0 | 45.4 | 18.0 | 4.8 | 11.0× / 9.6× | 9.2× / 8.1× | 3.7× / 3.2× | 1.0× / 0.9× |
| agentic_swe | 0.69 | 1.45 | 3.70 | 4.45 | 54.6 | 50.9 | 18.0 | 3.6 | 14.8× / 12.3× | 13.8× / 11.4× | 4.9× / 4.0× | 1.0× / 0.8× |
| code_mixed | 0.08 | 1.48 | 4.35 | 5.75 | 51.5 | 49.7 | 17.7 | 4.2 | 11.8× / 8.9× | 11.4× / 8.6× | 4.1× / 3.1× | 1.0× / 0.7× |
| math_latex | 0.98 | 1.48 | 4.92 | 5.42 | 48.6 | 37.7 | 16.5 | 4.5 | 9.9× / 9.0× | 7.7× / 7.0× | 3.4× / 3.0× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×17.91 vs v0.23.1 · ×3.04 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.7 | 74.5 | ×15.73 | ×1.55 | 11% (1.2) | 0% (0.0) | 34% (3.7) | 54% (5.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.7 | 83.9 | ×17.69 | ×4.69 | 12% (1.2) | 0% (0.0) | 24% (2.3) | 64% (6.2) | 0% (0.0) | match |
| ben_Beng | lang | 4.4 | 88.8 | ×20.24 | ×3.34 | 11% (1.2) | 0% (0.0) | 29% (3.1) | 59% (6.3) | 1% (0.1) | match |
| cmn_Hani | lang | 5.2 | 97.5 | ×18.62 | ×6.68 | 16% (1.2) | 0% (0.0) | 32% (2.4) | 52% (3.9) | 0% (0.0) | match |
| ell_Grek | lang | 5.5 | 99.3 | ×18.09 | ×5.10 | 10% (1.2) | 0% (0.0) | 19% (2.2) | 44% (5.0) | 27% (3.1) | match |
| eng_Latn | lang | 4.5 | 72.0 | ×16.16 | ×1.61 | 23% (2.5) | 0% (0.0) | 27% (3.0) | 50% (5.7) | 0% (0.0) | match |
| heb_Hebr | lang | 4.7 | 80.0 | ×17.20 | ×3.12 | 11% (1.2) | 0% (0.0) | 23% (2.3) | 67% (6.8) | 0% (0.0) | match |
| hin_Deva | lang | 4.3 | 82.5 | ×19.22 | ×2.76 | 10% (1.2) | 0% (0.0) | 29% (3.3) | 60% (6.7) | 1% (0.1) | match |
| jpn_Jpan | lang | 6.3 | 116.7 | ×18.60 | ×7.50 | 18% (1.2) | 0% (0.0) | 33% (2.2) | 49% (3.3) | 1% (0.0) | match |
| kat_Geor | lang | 7.1 | 119.4 | ×16.80 | ×5.39 | 17% (1.2) | 0% (0.0) | 31% (2.1) | 52% (3.5) | 1% (0.0) | match |
| kor_Hang | lang | 4.4 | 72.3 | ×16.27 | ×3.89 | 11% (1.2) | 0% (0.0) | 23% (2.5) | 65% (7.0) | 1% (0.1) | match |
| rus_Cyrl | lang | 5.7 | 107.0 | ×18.65 | ×5.71 | 15% (1.2) | 0% (0.0) | 27% (2.1) | 58% (4.7) | 0% (0.0) | match |
| tam_Taml | lang | 4.2 | 88.7 | ×21.36 | ×2.50 | 11% (1.2) | 0% (0.0) | 27% (2.7) | 62% (6.4) | 0% (0.0) | match |
| tha_Thai | lang | 5.4 | 84.8 | ×15.65 | ×4.03 | 13% (1.2) | 0% (0.0) | 28% (2.6) | 59% (5.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.2 | 172.3 | ×27.75 | ×6.37 | 25% (1.3) | 0% (0.0) | 21% (1.1) | 54% (2.9) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.5 | 133.5 | ×24.39 | ×3.18 | 28% (1.9) | 0% (0.0) | 28% (1.9) | 45% (3.1) | 0% (0.0) | match |
| added_special_dense | modalities | 4.2 | 48.8 | ×11.60 | ×1.03 | 64% (12.5) | 0% (0.0) | 26% (5.2) | 12% (2.3) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 64.4 | ×14.77 | ×1.12 | 45% (6.8) | 0% (0.0) | 33% (5.0) | 22% (3.3) | 0% (0.0) | match |
| agentic-traces | modalities | 3.9 | 66.7 | ×17.11 | ×1.87 | 20% (2.5) | 0% (0.0) | 29% (3.7) | 51% (6.5) | 1% (0.1) | match |
| agentic_swe | modalities | 4.4 | 82.5 | ×18.94 | ×2.95 | 19% (2.0) | 0% (0.0) | 27% (2.9) | 53% (5.6) | 1% (0.1) | match |
| code_mixed | modalities | 4.2 | 82.7 | ×19.58 | ×1.81 | 21% (2.3) | 0% (0.0) | 30% (3.2) | 48% (5.1) | 0% (0.1) | match |
| math_latex | modalities | 4.3 | 67.3 | ×15.69 | ×1.73 | 20% (2.5) | 1% (0.2) | 28% (3.4) | 50% (6.2) | 1% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.77 | 3.44 | 3.69 | 4.36 | 25.8 | 16.8 | 5.9 | 4.8 | 7.0× / 5.9× | 4.6× / 3.9× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.92 | 2.32 | 4.10 | 29.5 | 20.3 | 6.9 | 5.2 | 12.7× / 7.2× | 8.8× / 5.0× | 3.0× / 1.7× | 2.2× / 1.3× |
| ben_Beng | 1.62 | 2.95 | 3.12 | 4.46 | 41.7 | 29.1 | 10.1 | 3.6 | 13.3× / 9.3× | 9.3× / 6.5× | 3.2× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.11 | 2.26 | 2.38 | 3.52 | 18.5 | 12.0 | 4.7 | 2.4 | 7.8× / 5.2× | 5.0× / 3.4× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.98 | 2.20 | 4.60 | 27.1 | 17.8 | 6.2 | 4.7 | 12.3× / 5.9× | 8.1× / 3.9× | 2.8× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.11 | 1.46 | 3.00 | 4.35 | 41.1 | 34.7 | 12.2 | 3.7 | 13.7× / 9.4× | 11.6× / 8.0× | 4.1× / 2.8× | 1.2× / 0.8× |
| heb_Hebr | 1.15 | 3.03 | 2.32 | 4.21 | 29.5 | 20.6 | 6.9 | 2.9 | 12.7× / 7.0× | 8.9× / 4.9× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.11 | 3.26 | 4.86 | 43.4 | 31.3 | 11.0 | 3.9 | 13.3× / 8.9× | 9.6× / 6.4× | 3.4× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.70 | 3.38 | 2.19 | 3.87 | 17.5 | 10.1 | 4.1 | 3.7 | 8.0× / 4.5× | 4.6× / 2.6× | 1.9× / 1.1× | 1.7× / 0.9× |
| kat_Geor | 1.54 | 2.52 | 2.10 | 3.07 | 16.3 | 11.5 | 4.2 | 2.0 | 7.8× / 5.3× | 5.5× / 3.7× | 2.0× / 1.4× | 0.9× / 0.6× |
| kor_Hang | 1.23 | 2.70 | 2.51 | 3.98 | 29.1 | 22.3 | 7.3 | 3.7 | 11.6× / 7.3× | 8.9× / 5.6× | 2.9× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.17 | 2.92 | 2.15 | 3.89 | 25.7 | 17.1 | 6.1 | 2.4 | 12.0× / 6.6× | 7.9× / 4.4× | 2.8× / 1.6× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.96 | 2.74 | 4.78 | 41.2 | 27.8 | 9.9 | 3.4 | 15.0× / 8.6× | 10.1× / 5.8× | 3.6× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.52 | 2.58 | 2.59 | 3.65 | 26.7 | 17.1 | 6.7 | 3.0 | 10.3× / 7.3× | 6.6× / 4.7× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.11 | 2.52 | 22.3 | 17.5 | 6.5 | 1.8 | 20.1× / 8.8× | 15.8× / 6.9× | 5.9× / 2.6× | 1.7× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.92 | 3.33 | 29.4 | 23.7 | 9.0 | 2.5 | 15.3× / 8.8× | 12.3× / 7.1× | 4.7× / 2.7× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 5.15 | 6.57 | 89.4 | 76.0 | 21.5 | 3.0 | 17.4× / 13.6× | 14.8× / 11.6× | 4.2× / 3.3× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 4.95 | 6.37 | 57.5 | 48.9 | 15.3 | 3.4 | 11.6× / 9.0× | 9.9× / 7.7× | 3.1× / 2.4× | 0.7× / 0.5× |
| agentic-traces | 0.72 | 1.48 | 3.71 | 4.47 | 49.7 | 46.6 | 14.9 | 4.6 | 13.4× / 11.1× | 12.6× / 10.4× | 4.0× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.65 | 1.45 | 2.87 | 3.66 | 52.0 | 54.2 | 15.6 | 3.4 | 18.1× / 14.2× | 18.9× / 14.8× | 5.4× / 4.3× | 1.2× / 0.9× |
| code_mixed | 0.09 | 1.44 | 3.24 | 4.59 | 49.7 | 52.6 | 15.0 | 4.0 | 15.3× / 10.8× | 16.2× / 11.5× | 4.6× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.74 | 1.48 | 3.40 | 4.14 | 47.6 | 40.8 | 14.0 | 4.1 | 14.0× / 11.5× | 12.0× / 9.9× | 4.1× / 3.4× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×4.08 vs v0.23.1 · ×1.16 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 23) · Pipeline 24+0 (peak 24)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.7 | 43.3 | ×9.21 | ×1.08 | 0% (0.0) | 12% (2.8) | 0% (0.0) | 86% (19.8) | 2% (0.5) | match |
| arb_Arab | lang | 10.3 | 50.9 | ×4.96 | ×1.04 | 0% (0.0) | 16% (3.2) | 0% (0.0) | 84% (16.8) | 0% (0.0) | match |
| ben_Beng | lang | 10.9 | 84.7 | ×7.77 | ×1.12 | 0% (0.0) | 18% (2.2) | 0% (0.0) | 82% (9.7) | 0% (0.0) | match |
| cmn_Hani | lang | 9.3 | 68.2 | ×7.33 | ×1.10 | 0% (0.1) | 3% (0.5) | 0% (0.0) | 97% (14.5) | 0% (0.0) | match |
| ell_Grek | lang | 10.4 | 59.6 | ×5.74 | ×1.08 | 0% (0.0) | 18% (3.1) | 0% (0.0) | 83% (14.2) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 6.6 | ×1.51 | ×1.02 | 0% (0.0) | 4% (6.8) | 0% (0.0) | 95% (144.4) | 0% (0.4) | match |
| heb_Hebr | lang | 10.2 | 61.0 | ×6.00 | ×1.05 | 0% (0.0) | 20% (3.3) | 0% (0.0) | 80% (13.4) | 0% (0.0) | match |
| hin_Deva | lang | 12.4 | 82.0 | ×6.64 | ×1.11 | 0% (0.0) | 23% (2.8) | 0% (0.0) | 77% (9.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.2 | 89.2 | ×6.77 | ×1.12 | 0% (0.0) | 3% (0.4) | 0% (0.0) | 97% (10.8) | 0% (0.0) | match |
| kat_Geor | lang | 14.5 | 92.8 | ×6.41 | ×1.10 | 0% (0.0) | 18% (2.0) | 0% (0.0) | 82% (9.1) | 0% (0.0) | match |
| kor_Hang | lang | 7.4 | 52.5 | ×7.05 | ×1.06 | 0% (0.1) | 17% (3.2) | 0% (0.0) | 83% (16.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 8.3 | 16.5 | ×1.97 | ×1.03 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (57.5) | 0% (0.0) | match |
| tam_Taml | lang | 12.8 | 91.3 | ×7.11 | ×1.10 | 0% (0.0) | 16% (1.8) | 0% (0.0) | 84% (9.3) | 0% (0.0) | match |
| tha_Thai | lang | 15.9 | 89.7 | ×5.65 | ×1.09 | 0% (0.0) | 9% (1.0) | 0% (0.0) | 91% (10.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.6 | 8.9 | ×1.59 | ×1.01 | 0% (0.1) | 3% (3.8) | 0% (0.0) | 97% (112.5) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.0 | 7.8 | ×1.56 | ×1.05 | 0% (0.0) | 5% (6.0) | 0% (0.0) | 96% (124.6) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 39.2 | ×9.48 | ×1.94 | 22% (5.5) | 63% (15.7) | 4% (1.1) | 10% (2.5) | 0% (0.0) | match |
| added_special_sparse | modalities | 6.2 | 45.1 | ×7.33 | ×4.41 | 11% (2.2) | 75% (15.3) | 3% (0.6) | 10% (2.1) | 0% (0.1) | match |
| agentic-traces | modalities | 4.6 | 7.3 | ×1.60 | ×1.04 | 0% (0.1) | 4% (6.1) | 0% (0.0) | 95% (129.9) | 1% (1.3) | match |
| agentic_swe | modalities | 4.1 | 7.2 | ×1.76 | ×1.02 | 0% (0.0) | 7% (9.6) | 0% (0.0) | 93% (130.5) | 0% (0.2) | match |
| code_mixed | modalities | 4.3 | 7.1 | ×1.65 | ×1.02 | 0% (0.0) | 6% (8.0) | 0% (0.0) | 94% (132.3) | 0% (0.6) | match |
| math_latex | modalities | 4.5 | 6.9 | ×1.53 | ×1.03 | 0% (0.1) | 4% (6.4) | 0% (0.0) | 96% (137.8) | 0% (0.0) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×19.38 vs v0.23.1 · ×3.00 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 94)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.1 | 79.1 | ×15.59 | ×1.63 | 7% (0.7) | 0% (0.0) | 37% (3.7) | 61% (6.0) | 0% (0.0) | match |
| arb_Arab | lang | 5.1 | 88.4 | ×17.49 | ×4.94 | 7% (0.6) | 0% (0.0) | 26% (2.3) | 65% (5.6) | 2% (0.2) | match |
| ben_Beng | lang | 4.3 | 86.5 | ×20.20 | ×2.76 | 6% (0.6) | 0% (0.0) | 30% (3.1) | 65% (6.8) | 0% (0.0) | match |
| cmn_Hani | lang | 5.5 | 106.2 | ×19.23 | ×6.35 | 9% (0.6) | 0% (0.0) | 35% (2.4) | 56% (3.8) | 1% (0.0) | match |
| ell_Grek | lang | 5.8 | 102.7 | ×17.85 | ×5.32 | 8% (0.6) | 0% (0.0) | 29% (2.2) | 64% (4.8) | 0% (0.0) | match |
| eng_Latn | lang | 4.6 | 76.7 | ×16.49 | ×1.66 | 19% (1.9) | 0% (0.0) | 28% (3.0) | 52% (5.4) | 1% (0.1) | match |
| heb_Hebr | lang | 4.8 | 83.3 | ×17.29 | ×3.21 | 6% (0.6) | 0% (0.0) | 24% (2.3) | 70% (6.6) | 0% (0.0) | match |
| hin_Deva | lang | 4.6 | 108.8 | ×23.70 | ×1.42 | 7% (0.6) | 0% (0.0) | 40% (3.2) | 52% (4.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.3 | 130.5 | ×20.63 | ×8.05 | 9% (0.6) | 0% (0.0) | 34% (2.2) | 47% (3.0) | 10% (0.6) | match |
| kat_Geor | lang | 6.6 | 127.1 | ×19.27 | ×3.43 | 10% (0.6) | 0% (0.0) | 33% (2.1) | 58% (3.7) | 0% (0.0) | match |
| kor_Hang | lang | 4.8 | 77.5 | ×16.30 | ×4.05 | 6% (0.6) | 0% (0.0) | 25% (2.5) | 72% (7.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.6 | 102.6 | ×18.46 | ×6.27 | 8% (0.6) | 0% (0.0) | 29% (2.1) | 64% (4.8) | 0% (0.0) | match |
| tam_Taml | lang | 4.2 | 95.3 | ×22.81 | ×2.69 | 6% (0.6) | 0% (0.0) | 27% (2.7) | 67% (6.6) | 0% (0.0) | match |
| tha_Thai | lang | 5.7 | 105.5 | ×18.43 | ×5.20 | 8% (0.6) | 0% (0.0) | 34% (2.6) | 58% (4.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.3 | 183.1 | ×29.11 | ×6.74 | 15% (0.7) | 0% (0.0) | 22% (1.1) | 63% (3.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 139.5 | ×25.77 | ×3.27 | 19% (1.3) | 0% (0.0) | 28% (1.9) | 50% (3.4) | 3% (0.2) | match |
| added_special_dense | modalities | 4.2 | 79.4 | ×19.06 | ×1.05 | 41% (5.0) | 1% (0.1) | 41% (4.9) | 19% (2.3) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 84.1 | ×19.42 | ×1.16 | 29% (3.2) | 0% (0.0) | 43% (4.7) | 30% (3.3) | 0% (0.0) | match |
| agentic-traces | modalities | 4.0 | 71.3 | ×17.83 | ×1.90 | 15% (1.7) | 0% (0.0) | 31% (3.7) | 52% (6.1) | 1% (0.1) | match |
| agentic_swe | modalities | 4.5 | 88.9 | ×19.75 | ×3.13 | 14% (1.3) | 0% (0.0) | 30% (2.9) | 55% (5.3) | 1% (0.1) | match |
| code_mixed | modalities | 4.4 | 86.9 | ×19.54 | ×1.85 | 16% (1.6) | 0% (0.0) | 32% (3.2) | 51% (5.0) | 0% (0.0) | match |
| math_latex | modalities | 4.4 | 75.0 | ×17.15 | ×1.83 | 17% (1.9) | 0% (0.0) | 30% (3.4) | 53% (6.0) | 1% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.45 | 3.66 | 4.32 | 25.9 | 16.3 | 6.0 | 4.7 | 7.1× / 6.0× | 4.5× / 3.8× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.94 | 2.28 | 4.07 | 29.8 | 19.7 | 6.8 | 5.2 | 13.0× / 7.3× | 8.6× / 4.8× | 3.0× / 1.7× | 2.3× / 1.3× |
| ben_Beng | 1.61 | 2.94 | 3.11 | 4.44 | 42.9 | 28.0 | 10.2 | 3.6 | 13.8× / 9.7× | 9.0× / 6.3× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.25 | 2.36 | 3.49 | 18.9 | 11.9 | 4.7 | 2.3 | 8.0× / 5.4× | 5.1× / 3.4× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.98 | 2.17 | 4.57 | 27.2 | 17.5 | 6.2 | 4.7 | 12.5× / 6.0× | 8.1× / 3.8× | 2.9× / 1.4× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.46 | 2.97 | 4.34 | 41.4 | 33.9 | 12.2 | 3.7 | 13.9× / 9.5× | 11.4× / 7.8× | 4.1× / 2.8× | 1.2× / 0.9× |
| heb_Hebr | 1.14 | 3.03 | 2.31 | 4.19 | 29.7 | 20.0 | 7.0 | 3.0 | 12.9× / 7.1× | 8.6× / 4.8× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.52 | 3.05 | 3.21 | 4.74 | 45.4 | 30.8 | 11.1 | 3.9 | 14.1× / 9.6× | 9.6× / 6.5× | 3.5× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.70 | 3.40 | 2.16 | 3.87 | 17.9 | 10.1 | 4.0 | 3.8 | 8.3× / 4.6× | 4.7× / 2.6× | 1.9× / 1.0× | 1.8× / 1.0× |
| kat_Geor | 1.55 | 2.62 | 2.10 | 3.16 | 16.4 | 11.3 | 4.2 | 2.0 | 7.8× / 5.2× | 5.4× / 3.6× | 2.0× / 1.3× | 0.9× / 0.6× |
| kor_Hang | 1.22 | 2.70 | 2.49 | 3.96 | 29.4 | 21.9 | 7.4 | 3.6 | 11.8× / 7.4× | 8.8× / 5.5× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.91 | 2.15 | 3.90 | 25.8 | 16.7 | 6.0 | 2.5 | 12.0× / 6.6× | 7.8× / 4.3× | 2.8× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.93 | 2.91 | 2.71 | 4.70 | 42.0 | 27.1 | 9.8 | 3.3 | 15.5× / 9.0× | 10.0× / 5.8× | 3.6× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.52 | 2.54 | 2.57 | 3.60 | 27.3 | 16.4 | 6.8 | 3.0 | 10.6× / 7.6× | 6.4× / 4.6× | 2.6× / 1.9× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.77 | 1.11 | 2.82 | 22.3 | 17.2 | 6.7 | 1.8 | 20.1× / 7.9× | 15.4× / 6.1× | 6.0× / 2.4× | 1.6× / 0.6× |
| added_normalized_sparse | 0.06 | 1.48 | 1.88 | 3.29 | 29.4 | 23.2 | 8.7 | 2.5 | 15.6× / 8.9× | 12.4× / 7.0× | 4.6× / 2.6× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.94 | 6.36 | 89.9 | 76.5 | 21.9 | 3.0 | 18.2× / 14.1× | 15.5× / 12.0× | 4.4× / 3.4× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 4.73 | 6.15 | 57.4 | 46.9 | 15.5 | 3.4 | 12.1× / 9.3× | 9.9× / 7.6× | 3.3× / 2.5× | 0.7× / 0.6× |
| agentic-traces | 0.72 | 1.47 | 3.66 | 4.41 | 50.1 | 44.9 | 14.8 | 4.5 | 13.7× / 11.3× | 12.3× / 10.2× | 4.0× / 3.4× | 1.2× / 1.0× |
| agentic_swe | 0.65 | 1.46 | 2.87 | 3.68 | 52.6 | 52.5 | 15.5 | 3.4 | 18.3× / 14.3× | 18.3× / 14.3× | 5.4× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.08 | 1.46 | 3.21 | 4.59 | 50.3 | 51.1 | 15.2 | 4.0 | 15.7× / 11.0× | 15.9× / 11.1× | 4.7× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.71 | 1.48 | 3.42 | 4.18 | 48.2 | 40.6 | 14.0 | 4.1 | 14.1× / 11.5× | 11.9× / 9.7× | 4.1× / 3.4× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×6.79 vs v0.23.1 · ×2.09 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 193) · Pipeline 109+0 (peak 195)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 39.3 | ×9.92 | ×1.30 | 4% (1.2) | 0% (0.0) | 50% (15.1) | 47% (14.1) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 37.8 | ×8.57 | ×2.20 | 5% (1.2) | 0% (0.0) | 73% (17.2) | 24% (5.6) | 0% (0.0) | match |
| ben_Beng | lang | 7.0 | 57.0 | ×8.19 | ×3.32 | 7% (1.2) | 0% (0.0) | 69% (11.3) | 23% (3.7) | 1% (0.1) | match |
| cmn_Hani | lang | 5.3 | 50.1 | ×9.49 | ×3.23 | 5% (1.2) | 0% (0.0) | 53% (12.0) | 42% (9.4) | 0% (0.0) | match |
| ell_Grek | lang | 5.5 | 41.4 | ×7.50 | ×2.70 | 5% (1.2) | 0% (0.0) | 72% (16.1) | 23% (5.1) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 23.5 | ×5.33 | ×1.23 | 6% (2.5) | 0% (0.0) | 79% (31.6) | 17% (6.9) | 0% (0.0) | match |
| heb_Hebr | lang | 4.9 | 36.8 | ×7.54 | ×2.64 | 4% (1.2) | 0% (0.0) | 68% (18.0) | 25% (6.4) | 3% (0.7) | match |
| hin_Deva | lang | 7.0 | 49.2 | ×7.04 | ×2.29 | 6% (1.2) | 0% (0.0) | 72% (13.4) | 21% (4.0) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.2 | 58.6 | ×9.50 | ×3.85 | 6% (1.2) | 0% (0.0) | 54% (9.9) | 39% (7.2) | 0% (0.0) | match |
| kat_Geor | lang | 7.1 | 59.1 | ×8.27 | ×4.15 | 8% (1.2) | 0% (0.0) | 69% (10.6) | 23% (3.5) | 0% (0.0) | match |
| kor_Hang | lang | 4.4 | 31.9 | ×7.21 | ×2.11 | 4% (1.2) | 0% (0.0) | 70% (20.1) | 24% (7.0) | 2% (0.5) | match |
| rus_Cyrl | lang | 5.2 | 41.7 | ×7.96 | ×2.93 | 5% (1.2) | 0% (0.0) | 72% (15.6) | 23% (5.0) | 0% (0.0) | match |
| tam_Taml | lang | 7.3 | 68.5 | ×9.44 | ×4.70 | 9% (1.2) | 0% (0.0) | 68% (9.2) | 23% (3.1) | 0% (0.0) | match |
| tha_Thai | lang | 8.4 | 86.1 | ×10.22 | ×5.69 | 13% (1.2) | 0% (0.0) | 67% (6.1) | 21% (1.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 43.8 | ×7.64 | ×2.13 | 6% (1.3) | 0% (0.0) | 80% (17.9) | 14% (3.1) | 1% (0.1) | match |
| added_normalized_sparse | modalities | 5.3 | 35.9 | ×6.75 | ×1.44 | 7% (1.9) | 0% (0.0) | 80% (21.6) | 13% (3.5) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 16.3 | ×3.78 | ×0.98 | 8% (5.1) | 0% (0.0) | 85% (51.9) | 7% (4.5) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.6 | 22.4 | ×4.86 | ×1.02 | 8% (3.6) | 0% (0.0) | 82% (36.3) | 9% (4.1) | 0% (0.0) | match |
| agentic-traces | modalities | 3.9 | 17.9 | ×4.59 | ×1.21 | 4% (2.4) | 0% (0.0) | 83% (44.5) | 13% (7.2) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 15.2 | ×3.80 | ×1.36 | 3% (1.9) | 0% (0.0) | 88% (55.6) | 10% (6.2) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 16.8 | ×4.19 | ×1.13 | 4% (2.1) | 0% (0.0) | 87% (49.8) | 9% (5.3) | 0% (0.0) | match |
| math_latex | modalities | 4.2 | 20.0 | ×4.75 | ×1.16 | 5% (2.5) | 0% (0.0) | 81% (38.5) | 14% (6.6) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.45 | 15.05 | 15.73 | 28.3 | 14.9 | 6.9 | — | 1.9× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| arb_Arab | 1.15 | 2.92 | 17.18 | 18.95 | 32.7 | 17.0 | 7.4 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| ben_Beng | 1.62 | 2.92 | 11.34 | 12.63 | 22.9 | 11.1 | 5.3 | — | 2.0× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| cmn_Hani | 1.12 | 2.25 | 12.00 | 13.13 | 21.5 | 12.0 | 5.5 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| ell_Grek | 0.58 | 2.94 | 16.09 | 18.45 | 28.9 | 15.7 | 6.8 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| eng_Latn | 0.10 | 1.48 | 31.59 | 32.97 | 42.1 | 31.0 | 13.3 | — | 1.3× / 1.3× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| heb_Hebr | 1.14 | 3.04 | 18.00 | 19.89 | 31.9 | 17.7 | 8.0 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| hin_Deva | 1.53 | 3.06 | 13.37 | 14.90 | 24.6 | 13.0 | 6.1 | — | 1.8× / 1.7× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| jpn_Jpan | 1.69 | 3.37 | 9.93 | 11.60 | 20.3 | 9.8 | 4.8 | — | 2.0× / 1.7× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| kat_Geor | 1.54 | 2.52 | 10.57 | 11.55 | 18.0 | 10.3 | 4.5 | — | 1.7× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| kor_Hang | 1.23 | 2.68 | 20.07 | 21.51 | 32.0 | 19.8 | 8.8 | — | 1.6× / 1.5× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| rus_Cyrl | 1.17 | 2.93 | 15.58 | 17.34 | 28.0 | 15.6 | 6.5 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| tam_Taml | 0.92 | 2.98 | 9.19 | 11.24 | 18.4 | 8.9 | 4.2 | — | 2.0× / 1.6× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| tha_Thai | 1.53 | 2.58 | 6.07 | 7.12 | 13.1 | 5.9 | 2.8 | — | 2.2× / 1.8× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| added_normalized_dense | 0.24 | 1.47 | 17.94 | 19.17 | 32.4 | 18.0 | 11.5 | — | 1.8× / 1.7× | 1.0× / 0.9× | 0.6× / 0.6× | — |
| added_normalized_sparse | 0.25 | 1.47 | 21.59 | 22.82 | 33.7 | 20.8 | 11.3 | — | 1.6× / 1.5× | 1.0× / 0.9× | 0.5× / 0.5× | — |
| added_special_dense | 0.24 | 1.77 | 51.87 | 53.40 | 85.5 | 71.0 | 24.1 | — | 1.6× / 1.6× | 1.4× / 1.3× | 0.5× / 0.5× | — |
| added_special_sparse | 0.24 | 1.48 | 36.33 | 37.56 | 55.0 | 41.7 | 16.1 | — | 1.5× / 1.5× | 1.1× / 1.1× | 0.4× / 0.4× | — |
| agentic-traces | 0.74 | 1.49 | 44.52 | 45.27 | 54.3 | 44.6 | 17.1 | — | 1.2× / 1.2× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| agentic_swe | 0.66 | 1.53 | 55.58 | 56.46 | 57.9 | 55.1 | 18.0 | — | 1.0× / 1.0× | 1.0× / 1.0× | 0.3× / 0.3× | — |
| code_mixed | 0.07 | 1.47 | 49.82 | 51.22 | 53.1 | 49.8 | 17.4 | — | 1.1× / 1.0× | 1.0× / 1.0× | 0.4× / 0.3× | — |
| math_latex | 0.72 | 1.50 | 38.54 | 39.31 | 49.7 | 38.0 | 15.4 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30347879292-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
