### PR TITLE
experiment: fat key for bucket vocab store

### DIFF
--- a/tokenizers/tk-encode/examples/vocab_entry_bench.rs
+++ b/tokenizers/tk-encode/examples/vocab_entry_bench.rs
@@ -1,0 +1,511 @@
+//! Does `WordCache`'s packed key pay off in `BucketVocabStore`? All variants in
+//! **one binary**, because cross-binary timings in this workspace swing ±30% on
+//! code layout alone.
+//!
+//! `get_bytes` is three dependent memory accesses: the MPHF's pivots, then
+//! `entries[slot]`, then the token's bytes in the slab, followed by a `memcmp`. The
+//! question is whether the two tricks that made `WordCache`'s key cheap help here:
+//!
+//! 1. **Hash the packed key** instead of the token's bytes — `WordCache::slot_key`.
+//!    Pure ALU saving, so it only shows if the lookup is not memory-bound.
+//! 2. **Put the token in the entry** — `WordCache`'s slot carries the word itself
+//!    for anything up to 15 bytes, so confirming a hit is one register compare.
+//!    That removes the slab access and the `memcmp` outright, at 32 bytes per slot
+//!    instead of 12.
+//!
+//! The word stream is the real one: the model's own normalizer and pre-tokenizer
+//! over a real corpus, so hit rate, token-length mix and query skew are whatever
+//! the model and the language actually produce — a uniform sweep over the vocab
+//! would flatter (2) by making every lookup miss cache. Words land in one
+//! contiguous buffer, so each has the 16-byte window `Split::head` provides.
+//!
+//! The shipped `BucketVocabStore` is measured alongside as a fidelity control on
+//! the copies. Every variant must return identical ids: the checksum is asserted,
+//! not printed, because an earlier draft of this comparison silently benched a
+//! hit-heavy variant against an all-miss one.
+//!
+//! ```text
+//! cargo run --release --example vocab_entry_bench
+//! cargo run --release --example vocab_entry_bench -- gpt2 eng_Latn
+//! ```
+
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use ahash::RandomState;
+use ptr_hash::{FastPtrHash, PtrHashParams, hash::NoHash};
+use serde_json::Value;
+use tk_encode::vocab::bucket_vocab_store::BucketVocabStore;
+use tk_encode::{
+    NormalizedString, Normalizer, OffsetReferential, OffsetType, PreTokenizedString, PreTokenizer,
+    Tokenizer,
+};
+
+const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
+const MODELS: [&str; 2] = ["gpt2", "llama-3-tokenizer"];
+const CORPORA: [&str; 3] = ["eng_Latn", "cmn_Hani", "code_mixed"];
+/// Real encode sees ~10 kB inputs; pre-tokenization is per input.
+const CHUNK_BYTES: usize = 10 * 1024;
+const MAX_WORDS: usize = 300_000;
+/// Reported number is the **minimum** over all reps: interference from the rest of
+/// the machine can only add time, so the fastest pass is closest to the cost of the
+/// code itself.
+const REPS: usize = 7;
+const SEEDS: (u64, u64, u64, u64) = (0x5eed_0001, 0x5eed_0002, 0x5eed_0003, 0x5eed_0004);
+
+// ---------------------------------------------------------------------------
+// The entry layouts under test
+// ---------------------------------------------------------------------------
+
+type Mphf = FastPtrHash<NoHash, u64>;
+
+/// What ships: coordinates into the byte slab.
+#[derive(Clone, Copy, Default)]
+#[repr(C)]
+struct Thin {
+    start: u32,
+    len: u16,
+    id: u32,
+}
+
+/// `WordCache`'s slot: the token itself when it fits in 15 bytes, otherwise its
+/// hash with [`LONG_TAG`] set and the slab coordinates beside it.
+#[derive(Clone, Copy, Default)]
+#[repr(C)]
+struct Fat {
+    key: u128,
+    id: u32,
+    start: u32,
+    len: u16,
+    _pad: u16,
+}
+
+/// [`Fat`] with the key as bytes, which drops `u128`'s 16-byte alignment and with
+/// it four bytes of tail padding per slot.
+#[derive(Clone, Copy, Default)]
+#[repr(C)]
+struct Slim {
+    key: [u8; 16],
+    id: u32,
+    start: u32,
+    len: u16,
+    _pad: u16,
+}
+
+const LONG_TAG: u128 = 1 << 127;
+
+/// One lookup shape: the query, and the 16-byte window when the caller has one.
+type Lookup = fn(&Store, &[u8], Option<&[u8; 16]>) -> Option<u32>;
+
+/// Packing from a bare slice: the copy length is only known at run time, so this is
+/// a call into `memcpy`. Used at build time and wherever a query has no window.
+fn pack_owned(token: &[u8]) -> Option<u128> {
+    let len = token.len();
+    if len == 0 || len > 15 {
+        return None;
+    }
+    let mut lanes = [0u8; 16];
+    lanes[..len].copy_from_slice(token);
+    Some(u128::from_le_bytes(lanes) | ((len as u128) << 120))
+}
+
+/// Packing from a window the caller already holds — one load and a mask.
+#[inline(always)]
+fn pack_window(len: usize, head: Option<&[u8; 16]>) -> Option<u128> {
+    if len == 0 || len > 15 {
+        return None;
+    }
+    let lanes = u128::from_le_bytes(*head?);
+    Some((lanes & (u128::MAX >> (8 * (16 - len)))) | ((len as u128) << 120))
+}
+
+#[inline(always)]
+fn key_of(h: &RandomState, token: &[u8]) -> u64 {
+    match pack_owned(token) {
+        Some(packed) => h.hash_one(packed),
+        None => h.hash_one(token),
+    }
+}
+
+struct Store {
+    h: RandomState,
+    /// Keyed on the tokens' bytes, as the shipped store is.
+    mphf_bytes: Mphf,
+    /// Keyed on the packed tokens — trick 1.
+    mphf_packed: Mphf,
+    slab: Vec<u8>,
+    thin_bytes: Vec<Thin>,
+    thin_packed: Vec<Thin>,
+    fat: Vec<Fat>,
+    slim: Vec<Slim>,
+}
+
+impl Store {
+    fn build(tokens: &[(Vec<u8>, u32)]) -> Self {
+        let h = RandomState::with_seeds(SEEDS.0, SEEDS.1, SEEDS.2, SEEDS.3);
+        let params = PtrHashParams::default_fast();
+        let mphf_bytes = Mphf::new(
+            &tokens
+                .iter()
+                .map(|(t, _)| h.hash_one(t.as_slice()))
+                .collect::<Vec<_>>(),
+            params,
+        );
+        let mphf_packed = Mphf::new(
+            &tokens
+                .iter()
+                .map(|(t, _)| key_of(&h, t))
+                .collect::<Vec<_>>(),
+            params,
+        );
+
+        let mut slab = Vec::new();
+        let mut thin_bytes = vec![Thin::default(); mphf_bytes.max_index()];
+        let mut thin_packed = vec![Thin::default(); mphf_packed.max_index()];
+        let mut fat = vec![Fat::default(); mphf_packed.max_index()];
+        let mut slim = vec![Slim::default(); mphf_packed.max_index()];
+        for (token, id) in tokens {
+            let start = slab.len() as u32;
+            slab.extend_from_slice(token);
+            let thin = Thin {
+                start,
+                len: token.len() as u16,
+                id: *id,
+            };
+            thin_bytes[mphf_bytes.index(&h.hash_one(token.as_slice()))] = thin;
+            let slot = mphf_packed.index(&key_of(&h, token));
+            thin_packed[slot] = thin;
+            let key =
+                pack_owned(token).unwrap_or((h.hash_one(token.as_slice()) as u128) | LONG_TAG);
+            fat[slot] = Fat {
+                key,
+                id: *id,
+                start,
+                len: token.len() as u16,
+                _pad: 0,
+            };
+            slim[slot] = Slim {
+                key: key.to_le_bytes(),
+                id: *id,
+                start,
+                len: token.len() as u16,
+                _pad: 0,
+            };
+        }
+        Self {
+            h,
+            mphf_bytes,
+            mphf_packed,
+            slab,
+            thin_bytes,
+            thin_packed,
+            fat,
+            slim,
+        }
+    }
+
+    fn entries_bytes(&self) -> (usize, usize, usize) {
+        (
+            size_of::<Thin>() * self.thin_bytes.len(),
+            size_of::<Fat>() * self.fat.len(),
+            size_of::<Slim>() * self.slim.len(),
+        )
+    }
+}
+
+/// Today: hash the bytes, confirm against the slab.
+#[inline(never)]
+fn v_today(s: &Store, q: &[u8], _head: Option<&[u8; 16]>) -> Option<u32> {
+    let e = s.thin_bytes[s.mphf_bytes.index(&s.h.hash_one(q))];
+    let (start, len) = (e.start as usize, e.len as usize);
+    (len == q.len() && s.slab[start..start + len] == *q).then_some(e.id)
+}
+
+/// Trick 1 only: hash the packed key, still confirm against the slab.
+#[inline(never)]
+fn v_packed_hash(s: &Store, q: &[u8], head: Option<&[u8; 16]>) -> Option<u32> {
+    let hash = match pack_window(q.len(), head) {
+        Some(packed) => s.h.hash_one(packed),
+        None => key_of(&s.h, q),
+    };
+    let e = s.thin_packed[s.mphf_packed.index(&hash)];
+    let (start, len) = (e.start as usize, e.len as usize);
+    (len == q.len() && s.slab[start..start + len] == *q).then_some(e.id)
+}
+
+/// Tricks 1 and 2: the token lives in the entry, so a short token never touches
+/// the slab and the comparison is one register-wide equality.
+#[inline(never)]
+fn v_fat(s: &Store, q: &[u8], head: Option<&[u8; 16]>) -> Option<u32> {
+    if let Some(packed) = pack_window(q.len(), head) {
+        let e = s.fat[s.mphf_packed.index(&s.h.hash_one(packed))];
+        return (e.key == packed).then_some(e.id);
+    }
+    let hash = key_of(&s.h, q);
+    let e = s.fat[s.mphf_packed.index(&hash)];
+    if let Some(packed) = pack_owned(q) {
+        return (e.key == packed).then_some(e.id);
+    }
+    let (start, len) = (e.start as usize, e.len as usize);
+    (e.key == (hash as u128) | LONG_TAG && len == q.len() && s.slab[start..start + len] == *q)
+        .then_some(e.id)
+}
+
+/// [`v_fat`] with no window from the caller, so the query is packed with the
+/// run-time-length copy. This is what a `get_bytes(&[u8])` that keeps its current
+/// signature would cost.
+#[inline(never)]
+fn v_fat_owned(s: &Store, q: &[u8], _head: Option<&[u8; 16]>) -> Option<u32> {
+    // Pack once and hash what was packed, so this pays for exactly one copy.
+    if let Some(packed) = pack_owned(q) {
+        let e = s.fat[s.mphf_packed.index(&s.h.hash_one(packed))];
+        return (e.key == packed).then_some(e.id);
+    }
+    let hash = s.h.hash_one(q);
+    let e = s.fat[s.mphf_packed.index(&hash)];
+    let (start, len) = (e.start as usize, e.len as usize);
+    (e.key == (hash as u128) | LONG_TAG && len == q.len() && s.slab[start..start + len] == *q)
+        .then_some(e.id)
+}
+
+/// As [`v_fat`], on the 28-byte entry.
+#[inline(never)]
+fn v_slim(s: &Store, q: &[u8], head: Option<&[u8; 16]>) -> Option<u32> {
+    if let Some(packed) = pack_window(q.len(), head) {
+        let e = s.slim[s.mphf_packed.index(&s.h.hash_one(packed))];
+        return (u128::from_le_bytes(e.key) == packed).then_some(e.id);
+    }
+    let hash = key_of(&s.h, q);
+    let e = s.slim[s.mphf_packed.index(&hash)];
+    let key = u128::from_le_bytes(e.key);
+    if let Some(packed) = pack_owned(q) {
+        return (key == packed).then_some(e.id);
+    }
+    let (start, len) = (e.start as usize, e.len as usize);
+    (key == (hash as u128) | LONG_TAG && len == q.len() && s.slab[start..start + len] == *q)
+        .then_some(e.id)
+}
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+fn vocab_of(model_json: &Path) -> Vec<(Vec<u8>, u32)> {
+    let raw: Value = serde_json::from_str(&std::fs::read_to_string(model_json).unwrap()).unwrap();
+    let map = raw["model"]["vocab"].as_object().expect("model.vocab");
+    // The tokens as the store holds them before byte-level un-mapping, which is the
+    // same alphabet the byte-level pre-tokenizer emits below — so the two pair up.
+    map.iter()
+        .map(|(token, id)| (token.as_bytes().to_vec(), id.as_u64().unwrap() as u32))
+        .collect()
+}
+
+/// The model's own normalizer and pre-tokenizer over `corpus`, flattened into one
+/// buffer so every word has a 16-byte window after it.
+fn word_stream(tok: &Tokenizer, corpus: &str) -> (Vec<u8>, Vec<(usize, usize)>) {
+    let mut buf = Vec::new();
+    let mut spans = Vec::new();
+    for chunk in chunks(corpus, CHUNK_BYTES) {
+        if spans.len() >= MAX_WORDS {
+            break;
+        }
+        let mut normalized = NormalizedString::from(chunk);
+        if let Some(n) = tok.get_normalizer() {
+            n.normalize(&mut normalized).unwrap();
+        }
+        let mut pretokenized = PreTokenizedString::from(normalized);
+        if let Some(pt) = tok.get_pre_tokenizer() {
+            pt.pre_tokenize(&mut pretokenized).unwrap();
+        }
+        for (word, _, _) in pretokenized.get_splits(OffsetReferential::Normalized, OffsetType::Byte)
+        {
+            if word.is_empty() {
+                continue;
+            }
+            spans.push((buf.len(), word.len()));
+            buf.extend_from_slice(word.as_bytes());
+        }
+    }
+    // Slack so the final word still has a window, as a chunk's interior words do.
+    buf.extend_from_slice(&[0u8; 16]);
+    (buf, spans)
+}
+
+fn chunks(text: &str, size: usize) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        let mut end = (start + size).min(text.len());
+        while end < text.len() && !text.is_char_boundary(end) {
+            end += 1;
+        }
+        out.push(&text[start..end]);
+        start = end;
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let models: Vec<&str> = if args.is_empty() {
+        MODELS.to_vec()
+    } else {
+        MODELS
+            .into_iter()
+            .filter(|m| args.iter().any(|a| m.contains(a.as_str())))
+            .collect()
+    };
+    let corpora: Vec<&str> = if args.len() < 2 {
+        CORPORA.to_vec()
+    } else {
+        CORPORA
+            .into_iter()
+            .filter(|c| args.iter().any(|a| c.contains(a.as_str())))
+            .collect()
+    };
+
+    for model in &models {
+        let json = PathBuf::from(DATA_DIR).join(format!("{model}.json"));
+        if !json.exists() {
+            println!("-- {model}: {} missing, skipped", json.display());
+            continue;
+        }
+        let tok = match Tokenizer::from_file(&json) {
+            Ok(tok) => tok,
+            Err(e) => {
+                println!("-- {model}: could not load ({e}), skipped");
+                continue;
+            }
+        };
+        let tokens = vocab_of(&json);
+        let store = Store::build(&tokens);
+        let short = tokens.iter().filter(|(t, _)| t.len() <= 15).count();
+        let (thin_b, fat_b, slim_b) = store.entries_bytes();
+        println!("\n=== {model} ===");
+        println!(
+            "{} tokens, {:.1}% fit in 15 bytes | slab {:.2} MB | entries: thin {:.2} MB, fat {:.2} MB (+{:.2}), slim {:.2} MB (+{:.2})",
+            tokens.len(),
+            100.0 * short as f64 / tokens.len() as f64,
+            store.slab.len() as f64 / 1e6,
+            thin_b as f64 / 1e6,
+            fat_b as f64 / 1e6,
+            (fat_b - thin_b) as f64 / 1e6,
+            slim_b as f64 / 1e6,
+            (slim_b - thin_b) as f64 / 1e6,
+        );
+
+        for corpus in &corpora {
+            let path = PathBuf::from(DATA_DIR)
+                .join("fixtures/lang")
+                .join(format!("{corpus}.txt"));
+            let path = if path.exists() {
+                path
+            } else {
+                PathBuf::from(DATA_DIR)
+                    .join("fixtures/modalities")
+                    .join(format!("{corpus}.txt"))
+            };
+            let Ok(text) = std::fs::read_to_string(&path) else {
+                println!("  {corpus}: missing, skipped");
+                continue;
+            };
+            let (buf, spans) = word_stream(&tok, &text);
+            if spans.is_empty() {
+                println!("  {corpus}: no words, skipped");
+                continue;
+            }
+
+            let variants: [(&str, Lookup); 5] = [
+                ("today   hash bytes  + slab memcmp    ", v_today),
+                ("trick 1 hash packed + slab memcmp    ", v_packed_hash),
+                ("1 + 2   fat, window from caller      ", v_fat),
+                ("1 + 2   fat, no window (memcpy pack) ", v_fat_owned),
+                ("1 + 2   slim, window from caller     ", v_slim),
+            ];
+            let mut best = [f64::MAX; 5];
+            let mut sums = [0u64; 5];
+            let mut hits = 0usize;
+            for _ in 0..REPS {
+                for (i, (_, f)) in variants.iter().enumerate() {
+                    let mut sum = 0u64;
+                    let mut found = 0usize;
+                    for &(off, len) in &spans {
+                        let q = &buf[off..off + len];
+                        let head: Option<&[u8; 16]> = buf[off..].first_chunk();
+                        if let Some(id) = black_box(f(&store, black_box(q), head)) {
+                            sum += id as u64 + 1;
+                            found += 1;
+                        }
+                    }
+                    let t = Instant::now();
+                    for &(off, len) in &spans {
+                        let q = &buf[off..off + len];
+                        let head: Option<&[u8; 16]> = buf[off..].first_chunk();
+                        sum += black_box(f(&store, black_box(q), head)).map_or(0, |id| id as u64);
+                    }
+                    let ns = t.elapsed().as_secs_f64() * 1e9 / spans.len() as f64;
+                    if ns < best[i] {
+                        best[i] = ns;
+                    }
+                    sums[i] = sum;
+                    hits = found;
+                }
+            }
+
+            // The shipped store, as a fidelity control on the copies above.
+            let shipped = BucketVocabStore::build(tokens.clone());
+            let mut shipped_best = f64::MAX;
+            let mut shipped_sum = 0u64;
+            for _ in 0..REPS {
+                let mut sum = 0u64;
+                for &(off, len) in &spans {
+                    sum += black_box(
+                        shipped
+                            .get_bytes(black_box(&buf[off..off + len]), buf[off..].first_chunk()),
+                    )
+                    .map_or(0, |id| id as u64 + 1);
+                }
+                let t = Instant::now();
+                for &(off, len) in &spans {
+                    sum += black_box(
+                        shipped
+                            .get_bytes(black_box(&buf[off..off + len]), buf[off..].first_chunk()),
+                    )
+                    .map_or(0, |id| id as u64);
+                }
+                let ns = t.elapsed().as_secs_f64() * 1e9 / spans.len() as f64;
+                if ns < shipped_best {
+                    shipped_best = ns;
+                }
+                shipped_sum = sum;
+            }
+
+            println!(
+                "  {corpus}: {} words, {:.1}% in vocab",
+                spans.len(),
+                100.0 * hits as f64 / spans.len() as f64
+            );
+            for (i, (name, _)) in variants.iter().enumerate() {
+                println!(
+                    "      {name}  {:6.2} ns  {:+6.1}%",
+                    best[i],
+                    100.0 * (best[i] - best[0]) / best[0]
+                );
+            }
+            println!(
+                "      shipped BucketVocabStore (control)  {shipped_best:6.2} ns  {:+6.1}%",
+                100.0 * (shipped_best - best[0]) / best[0]
+            );
+            for i in 1..5 {
+                assert_eq!(sums[i], sums[0], "{} returned different ids", variants[i].0);
+            }
+            assert_eq!(
+                shipped_sum, sums[0],
+                "the copies disagree with the shipped store"
+            );
+        }
+    }
+}

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -822,10 +822,11 @@ impl pipeline::Model for PipelineBPE {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
+        let sequence = split.as_str();
         if sequence.is_empty() {
             return Ok(());
         }
@@ -838,7 +839,7 @@ impl pipeline::Model for PipelineBPE {
         } = scratch;
 
         if let Some(cache) = word_cache
-            && let Some(hit) = cache.get(sequence.as_bytes())
+            && let Some(hit) = cache.get(split.as_bytes(), split.head())
         {
             output.extend(hit.iter().map(|&id| PipelineToken { id }));
             return Ok(());
@@ -853,7 +854,7 @@ impl pipeline::Model for PipelineBPE {
         self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         if let Some(cache) = word_cache {
-            cache.insert(sequence.as_bytes(), word.get_chars_iter());
+            cache.insert(split.as_bytes(), split.head(), word.get_chars_iter());
         }
 
         Ok(())
@@ -1427,7 +1428,8 @@ mod tests {
         fn pipeline_ids(model: &PipelineBPE, sequence: &str) -> Vec<u32> {
             let mut out = Vec::new();
             let mut scratch = model.init_scratch();
-            pipeline::Model::tokenize_pipeline(model, sequence, &mut scratch, &mut out).unwrap();
+            pipeline::Model::tokenize_pipeline(model, sequence.into(), &mut scratch, &mut out)
+                .unwrap();
             out.iter().map(|t| t.id).collect()
         }
 
@@ -1479,7 +1481,8 @@ mod tests {
             let mut scratch = model.init_scratch();
             for input in ["hello", "hell", "helo", "oleh", "hello", "", "hxe"] {
                 let mut out = Vec::new();
-                pipeline::Model::tokenize_pipeline(&model, input, &mut scratch, &mut out).unwrap();
+                pipeline::Model::tokenize_pipeline(&model, input.into(), &mut scratch, &mut out)
+                    .unwrap();
                 let got: Vec<u32> = out.iter().map(|t| t.id).collect();
                 assert_eq!(got, reference_ids(&reference, input), "{input:?}");
             }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -722,7 +722,7 @@ impl PipelineBPE {
             let mut byte_to_id = [0u32; 256];
             for b in 0u8..=255 {
                 byte_to_id[b as usize] = vocab
-                    .get_bytes(&[b])
+                    .get_bytes(&[b], None)
                     .ok_or(Error::ByteAtomOutOfVocabulary(b))?;
             }
             (vocab, Atoms::Bytes { byte_to_id })
@@ -845,7 +845,7 @@ impl pipeline::Model for PipelineBPE {
             return Ok(());
         }
         if self.ignore_merges
-            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
+            && let Some(id) = self.vocab.get_bytes(split.as_bytes(), split.head())
         {
             output.push(PipelineToken { id });
             return Ok(());

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -830,6 +830,12 @@ impl pipeline::Model for PipelineBPE {
         if sequence.is_empty() {
             return Ok(());
         }
+        if self.ignore_merges
+            && let Some(id) = self.vocab.get_bytes(split.as_bytes(), split.head())
+        {
+            output.push(PipelineToken { id });
+            return Ok(());
+        }
 
         let BpeScratch {
             merge_queue,
@@ -842,12 +848,6 @@ impl pipeline::Model for PipelineBPE {
             && let Some(hit) = cache.get(split.as_bytes(), split.head())
         {
             output.extend(hit.iter().map(|&id| PipelineToken { id }));
-            return Ok(());
-        }
-        if self.ignore_merges
-            && let Some(id) = self.vocab.get_bytes(split.as_bytes(), split.head())
-        {
-            output.push(PipelineToken { id });
             return Ok(());
         }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -830,13 +830,6 @@ impl pipeline::Model for PipelineBPE {
             return Ok(());
         }
 
-        if self.ignore_merges
-            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
-        {
-            output.push(PipelineToken { id });
-            return Ok(());
-        }
-
         let BpeScratch {
             merge_queue,
             skip,
@@ -848,6 +841,12 @@ impl pipeline::Model for PipelineBPE {
             && let Some(hit) = cache.get(sequence.as_bytes())
         {
             output.extend(hit.iter().map(|&id| PipelineToken { id }));
+            return Ok(());
+        }
+        if self.ignore_merges
+            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
+        {
+            output.push(PipelineToken { id });
             return Ok(());
         }
 

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,69 +1,195 @@
-use std::ops::Range;
-
 use ahash::RandomState;
 
 use crate::utils::cache::MAX_LENGTH;
 
-const WAYS: usize = 4;
+/// Slots searched from a key's home position. Linear probing normally settles in
+/// one or two, but the walk has to stop somewhere: nothing is ever removed, so a
+/// saturated table would otherwise scan forever looking for an empty slot.
+const WINDOW: usize = 16;
+/// Ids carried in the slot itself. Most pre-tokens encode to one or two tokens,
+/// so this keeps the arena for the tail rather than the common case.
+const INLINE_IDS: usize = 3;
+/// `count` marker for an entry whose key bytes and/or ids live in the arenas.
+const SPILLED: u8 = u8::MAX;
+/// Set in `key` when it holds a hash of a > 15-byte word rather than the word
+/// itself. Packed keys carry their length (1..=15) in the top byte, so the two
+/// can never be confused, and neither can be 0 — the empty-slot sentinel.
+const LONG_TAG: u128 = 1 << 127;
 
+/// A key of at most 15 bytes packed into a u128: bytes in the low lanes, length
+/// in the top byte. Different lengths therefore never collide, and the whole
+/// comparison is one register-width equality instead of a `memcmp`.
+fn pack_key(key: &[u8]) -> Option<u128> {
+    if key.is_empty() || key.len() > 15 {
+        return None;
+    }
+    let mut lanes = [0u8; 16];
+    lanes[..key.len()].copy_from_slice(key);
+    Some(u128::from_le_bytes(lanes) | ((key.len() as u128) << 120))
+}
+
+/// 32 bytes, two to a cache line. `w` holds the ids inline while
+/// `count <= INLINE_IDS`, and otherwise the arena coordinates
+/// `[key_off, ids_off, key_len << 16 | ids_len]` — where `key_len == 0` means the
+/// key is packed into `key` and no bytes were stored for it.
 #[derive(Clone, Copy, Default)]
+#[repr(C)]
 struct CacheSlot {
-    tag: u32,
-    key_off: u32,
-    ids_off: u32,
-    key_len: u16,
-    ids_len: u16,
+    key: u128,
+    w: [u32; INLINE_IDS],
+    count: u8,
+    freq: u8,
+    _pad: u16,
 }
 
-#[derive(Clone, Copy, Default)]
-#[repr(align(64))]
-struct Bucket([CacheSlot; WAYS]);
+const _: () = assert!(std::mem::size_of::<CacheSlot>() == 32);
 
-impl CacheSlot {
-    fn id_range(&self) -> Range<usize> {
-        self.ids_off as usize..(self.ids_off as usize + self.ids_len as usize)
+/// An arena that reuses the space of evicted entries instead of compacting.
+///
+/// Runs are freed to a list per exact length, which costs nothing here because
+/// `MAX_LENGTH` bounds every run: a freed run always has a list to go to, the
+/// next word of that shape takes it, and no length is ever rounded up. Without
+/// this the arena could only grow, and reclaiming it would mean relocating every
+/// live entry into a second buffer.
+struct Slab<T> {
+    data: Vec<T>,
+    free: Box<[Vec<u32>]>,
+    budget: usize,
+}
+
+impl<T: Copy + Default> Slab<T> {
+    fn new(budget: usize) -> Self {
+        Self {
+            data: Vec::new(),
+            free: (0..=MAX_LENGTH).map(|_| Vec::new()).collect(),
+            budget,
+        }
     }
 
-    fn key_range(&self) -> Range<usize> {
-        self.key_off as usize..(self.key_off as usize + self.key_len as usize)
+    fn alloc(&mut self, len: usize) -> Option<u32> {
+        if let Some(off) = self.free[len].pop() {
+            return Some(off);
+        }
+        if self.data.len() + len > self.budget {
+            return None;
+        }
+        let off = self.data.len() as u32;
+        self.data.resize(self.data.len() + len, T::default());
+        Some(off)
+    }
+
+    fn release(&mut self, off: u32, len: usize) {
+        self.free[len].push(off);
+    }
+
+    fn get(&self, off: u32, len: usize) -> &[T] {
+        &self.data[off as usize..off as usize + len]
+    }
+
+    fn fill(&mut self, off: u32, len: usize, values: impl Iterator<Item = T>) {
+        for (dst, value) in self.data[off as usize..off as usize + len]
+            .iter_mut()
+            .zip(values)
+        {
+            *dst = value;
+        }
     }
 }
 
+/// Pre-token bytes to their token ids, one instance per scratch and therefore
+/// per thread — no sharing, no locking.
+///
+/// Open addressing rather than fixed buckets, because a word that collides can
+/// take the next free slot instead of being locked out. Making room does not
+/// need a second copy of the table: a slot is overwritten in place, which is
+/// safe because slots go empty to occupied and never back, so no probe walk is
+/// ever cut short by a hole. What that costs is a bounded [`WINDOW`], and what
+/// it buys is that the table and its arenas only ever hold entries that are
+/// live.
+///
+/// Eviction picks the coldest slot of the window and halves the frequencies it
+/// passed, so a word has to keep being used to keep its place, and a burst of
+/// once-hot words cannot hold a window forever.
 pub struct WordCache {
     hasher: RandomState,
-    buckets: Box<[Bucket]>,
-    key_bytes: Vec<u8>,
-    ids: Vec<u32>,
-    bucket_mask: u64,
+    slots: Box<[CacheSlot]>,
+    key_bytes: Slab<u8>,
+    ids: Slab<u32>,
+    mask: usize,
+    /// Written by `get` so inline ids can be handed back as a slice.
+    unpacked: [u32; INLINE_IDS],
 }
 
 impl WordCache {
     pub fn new(capacity: usize) -> Self {
-        let n_buckets = (capacity.next_power_of_two() / WAYS).max(1);
+        let n_slots = capacity.next_power_of_two().max(WINDOW);
         Self {
             hasher: RandomState::new(),
-            buckets: vec![Bucket::default(); n_buckets].into_boxed_slice(),
-            ids: Vec::with_capacity(256),
-            key_bytes: Vec::with_capacity(1024),
-            bucket_mask: (n_buckets as u64) - 1,
+            slots: vec![CacheSlot::default(); n_slots].into_boxed_slice(),
+            // Ceilings, not reservations — the arenas below allocate only what is
+            // live. They are set high enough that the slot table runs out first:
+            // an arena that refuses inserts while slots sit empty is just a
+            // smaller cache.
+            key_bytes: Slab::new(n_slots * 48),
+            ids: Slab::new(n_slots * 16),
+            mask: n_slots - 1,
+            unpacked: [0; INLINE_IDS],
         }
     }
 
-    // The low hash bits pick the bucket index, the high bits form the occupancy tag
-    // 0x0 tag is reserved for empty spots (hence the `| 1`)
-    fn locate(&self, key: &[u8]) -> (usize, u32) {
+    /// The stored key, and the hash that places it. Short words key on their own
+    /// bytes and need no confirmation; longer ones key on a tagged hash and are
+    /// confirmed against `key_bytes`.
+    fn locate(&self, key: &[u8]) -> (u128, u64) {
         let hash = self.hasher.hash_one(key);
-        ((hash & self.bucket_mask) as usize, (hash >> 32) as u32 | 1)
+        match pack_key(key) {
+            Some(packed) => (packed, hash),
+            None => ((hash as u128) | LONG_TAG, hash),
+        }
     }
 
-    pub fn get(&self, key: &[u8]) -> Option<&[u32]> {
+    fn confirmed(&self, slot: &CacheSlot, key: &[u8]) -> bool {
+        if slot.key & LONG_TAG == 0 {
+            return true; // the packed key is the word
+        }
+        let key_len = (slot.w[2] >> 16) as usize;
+        key_len == key.len() && self.key_bytes.get(slot.w[0], key_len) == key
+    }
+
+    /// Return an overwritten entry's arena runs so the next entry can use them.
+    fn reclaim(&mut self, index: usize) {
+        let slot = self.slots[index];
+        if slot.count != SPILLED {
+            return;
+        }
+        let (key_len, ids_len) = ((slot.w[2] >> 16) as usize, (slot.w[2] & 0xFFFF) as usize);
+        if key_len > 0 {
+            self.key_bytes.release(slot.w[0], key_len);
+        }
+        if ids_len > 0 {
+            self.ids.release(slot.w[1], ids_len);
+        }
+    }
+
+    pub fn get(&mut self, key: &[u8]) -> Option<&[u32]> {
         if key.len() > MAX_LENGTH {
             return None;
         }
-        let (bucket_idx, tag) = self.locate(key);
-        for slot in &self.buckets[bucket_idx].0 {
-            if slot.tag == tag && key == &self.key_bytes[slot.key_range()] {
-                return Some(&self.ids[slot.id_range()]);
+        let (stored, hash) = self.locate(key);
+        let home = hash as usize;
+        for step in 0..WINDOW {
+            let index = (home + step) & self.mask;
+            let slot = self.slots[index];
+            if slot.key == 0 {
+                return None;
+            }
+            if slot.key == stored && self.confirmed(&slot, key) {
+                self.slots[index].freq = slot.freq.saturating_add(1);
+                if slot.count == SPILLED {
+                    return Some(self.ids.get(slot.w[1], (slot.w[2] & 0xFFFF) as usize));
+                }
+                self.unpacked = slot.w;
+                return Some(&self.unpacked[..slot.count as usize]);
             }
         }
         None
@@ -73,24 +199,79 @@ impl WordCache {
         if key.len() > MAX_LENGTH {
             return;
         }
-        let (bucket_idx, tag) = self.locate(key);
-        let Some(slot) = self.buckets[bucket_idx]
-            .0
-            .iter()
-            .position(|slot| slot.tag == 0)
-        else {
-            // bucket full: skip insert
-            return;
+        let (stored, hash) = self.locate(key);
+        let long = stored & LONG_TAG != 0;
+        let ids_len = ids.len();
+
+        // Reserve arena space before touching the table, so a full arena costs
+        // nothing but the attempt.
+        let (w, count) = if long || ids_len > INLINE_IDS {
+            let Some(key_off) = (if long {
+                self.key_bytes.alloc(key.len())
+            } else {
+                Some(0)
+            }) else {
+                return;
+            };
+            let Some(ids_off) = (if ids_len > 0 {
+                self.ids.alloc(ids_len)
+            } else {
+                Some(0)
+            }) else {
+                if long {
+                    self.key_bytes.release(key_off, key.len());
+                }
+                return;
+            };
+            if long {
+                self.key_bytes.fill(key_off, key.len(), key.iter().copied());
+            }
+            self.ids.fill(ids_off, ids_len, ids);
+            let key_len = if long { key.len() } else { 0 };
+            (
+                [key_off, ids_off, ((key_len as u32) << 16) | ids_len as u32],
+                SPILLED,
+            )
+        } else {
+            let mut w = [0u32; INLINE_IDS];
+            for (dst, id) in w.iter_mut().zip(ids) {
+                *dst = id;
+            }
+            (w, ids_len as u8)
         };
-        self.buckets[bucket_idx].0[slot] = CacheSlot {
-            tag,
-            key_off: self.key_bytes.len() as u32,
-            key_len: key.len() as u16,
-            ids_off: self.ids.len() as u32,
-            ids_len: ids.len() as u16,
+
+        let home = hash as usize;
+        let mut coldest = (u8::MAX, home & self.mask);
+        let mut empty = None;
+        for step in 0..WINDOW {
+            let index = (home + step) & self.mask;
+            if self.slots[index].key == 0 {
+                empty = Some(index);
+                break;
+            }
+            if self.slots[index].freq < coldest.0 {
+                coldest = (self.slots[index].freq, index);
+            }
+        }
+        let index = match empty {
+            Some(index) => index,
+            None => {
+                // Age the window on the way past: every entry it holds has to be
+                // used again before the next conflict or it becomes the victim.
+                for step in 0..WINDOW {
+                    self.slots[(home + step) & self.mask].freq >>= 1;
+                }
+                self.reclaim(coldest.1);
+                coldest.1
+            }
         };
-        self.key_bytes.extend_from_slice(key);
-        self.ids.extend(ids);
+        self.slots[index] = CacheSlot {
+            key: stored,
+            w,
+            count,
+            freq: 0, // on probation until it is used again
+            _pad: 0,
+        };
     }
 }
 
@@ -110,25 +291,104 @@ mod tests {
     }
 
     #[test]
-    fn single_bucket_holds_ways_entries_then_freezes() {
-        // capacity <= WAYS collapses to one bucket, making conflicts deterministic
-        let mut cache = WordCache::new(1);
-        let keys: Vec<Vec<u8>> = (0..WAYS as u8 + 2).map(|i| vec![i; 3]).collect();
-        for (i, key) in keys.iter().enumerate() {
-            cache.insert(key, [i as u32].into_iter());
-        }
-        let cached = keys.iter().filter(|k| cache.get(k).is_some()).count();
-        assert_eq!(cached, WAYS);
-        for (i, key) in keys.iter().enumerate().take(WAYS) {
-            assert_eq!(cache.get(key), Some(&[i as u32][..]));
-        }
-    }
-
-    #[test]
     fn oversized_keys_are_ignored() {
         let mut cache = WordCache::new(1 << 8);
         let big = vec![7u8; MAX_LENGTH + 1];
         cache.insert(&big, [1u32].into_iter());
         assert_eq!(cache.get(&big), None);
+    }
+
+    /// Both sides of the 15-byte packing boundary and both sides of the inline/
+    /// arena boundary have to survive a round trip, including the long key whose
+    /// stored `key` is only a hash and needs the byte comparison to confirm it.
+    #[test]
+    fn every_slot_shape_round_trips() {
+        let mut cache = WordCache::new(1 << 8);
+        let long = vec![b'x'; 200];
+        let cases: [(&[u8], Vec<u32>); 4] = [
+            (b"short", vec![1]),
+            (b"short-wide", (0..40).collect()),
+            (&long, vec![9]),
+            (&long[..64], (0..64).collect()),
+        ];
+        for (key, ids) in &cases {
+            cache.insert(key, ids.clone().into_iter());
+        }
+        for (key, ids) in &cases {
+            assert_eq!(cache.get(key), Some(&ids[..]), "{key:?}");
+        }
+    }
+
+    /// A word that hashes into a full window takes the coldest slot rather than
+    /// being turned away, and the words that were actually used keep their place.
+    #[test]
+    fn a_full_window_evicts_its_coldest_entry() {
+        let mut cache = WordCache::new(WINDOW);
+        let keys: Vec<Vec<u8>> = (0..WINDOW as u8).map(|i| vec![i; 4]).collect();
+        for (i, key) in keys.iter().enumerate() {
+            cache.insert(key, [i as u32].into_iter());
+        }
+        // Every key but the first earns a hit, leaving one clear coldest slot.
+        for key in &keys[1..] {
+            assert!(cache.get(key).is_some());
+        }
+        cache.insert(b"newcomer", [999u32].into_iter());
+        assert_eq!(cache.get(b"newcomer"), Some(&[999u32][..]));
+        assert_eq!(
+            cache.get(&keys[0]),
+            None,
+            "the unused entry should have gone"
+        );
+        for (i, key) in keys.iter().enumerate().skip(1) {
+            assert_eq!(
+                cache.get(key),
+                Some(&[i as u32][..]),
+                "used entry {i} was dropped"
+            );
+        }
+    }
+
+    /// Reusing an evicted entry's arena run is where this design can go wrong:
+    /// hand one run to two live entries and a hit starts returning another word's
+    /// ids. Churn a table far too small for the input and demand the invariant
+    /// that matters — an entry may be evicted, but a hit is never wrong.
+    #[test]
+    fn a_hit_never_returns_another_words_ids() {
+        let mut cache = WordCache::new(64);
+        let mut expected: Vec<(Vec<u8>, Vec<u32>)> = Vec::new();
+        for i in 0..2000usize {
+            let key = match i % 4 {
+                0 => format!("w{i}"),
+                1 => format!("a-long-word-past-fifteen-bytes-{i}"),
+                2 => format!("k{i}xxxxxxxxxxxx"),
+                _ => format!("{}-{i}", "z".repeat(i % 40)),
+            }
+            .into_bytes();
+            let ids: Vec<u32> = (0..=(i % 9) as u32).map(|k| i as u32 * 16 + k).collect();
+            cache.insert(&key, ids.clone().into_iter());
+            expected.push((key, ids));
+        }
+        let mut live = 0;
+        for (key, ids) in &expected {
+            if let Some(hit) = cache.get(key) {
+                assert_eq!(hit, &ids[..], "{key:?}");
+                live += 1;
+            }
+        }
+        assert!(live > 0, "everything was evicted — the test proves nothing");
+    }
+
+    /// Freed runs have to come back. Without reuse the arenas would grow with
+    /// every insert and the cache would be leaking rather than evicting.
+    #[test]
+    fn arenas_hold_the_live_set_not_every_insert() {
+        let mut cache = WordCache::new(64);
+        for i in 0..5000usize {
+            let key = format!("a-long-word-past-fifteen-bytes-{i}");
+            cache.insert(key.as_bytes(), [i as u32; 8].into_iter());
+        }
+        // 64 slots can hold at most 64 keys of ~34 bytes and 64 runs of 8 ids.
+        assert!(cache.key_bytes.data.len() < 8 * 1024);
+        assert!(cache.ids.data.len() < 8 * 1024);
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -288,13 +288,31 @@ const NEWBORN: u8 = 1;
 /// in the top byte. Including the length keeps `"a"` and `"a\0"` apart, and the
 /// whole key comparison becomes one register-wide equality instead of a
 /// `memcmp` against bytes somewhere else in memory.
-fn pack_word(word: &[u8]) -> Option<u128> {
-    if word.is_empty() || word.len() > 15 {
+///
+/// `head` is 16 bytes starting where the word does, which callers that know what
+/// surrounds the word can hand over — see `Split::head`. Taking the whole window
+/// and masking the surplus off costs one load, where copying just the word's own
+/// bytes costs a call into `memcpy`: its length is only known at run time, and
+/// LLVM can fold a copy into a load only when the length is a constant. That one
+/// call was about a third of what building a key cost.
+fn pack_word(word: &[u8], head: Option<&[u8; 16]>) -> Option<u128> {
+    let len = word.len();
+    if len == 0 || len > 15 {
         return None;
     }
-    let mut lanes = [0u8; 16];
-    lanes[..word.len()].copy_from_slice(word);
-    Some(u128::from_le_bytes(lanes) | ((word.len() as u128) << 120))
+    debug_assert!(
+        head.is_none_or(|head| head[..len] == *word),
+        "head has to start where the word does"
+    );
+    let lanes = match head {
+        Some(head) => u128::from_le_bytes(*head),
+        None => {
+            let mut lanes = [0u8; 16];
+            lanes[..len].copy_from_slice(word);
+            u128::from_le_bytes(lanes)
+        }
+    };
+    Some((lanes & (u128::MAX >> (8 * (16 - len)))) | ((len as u128) << 120))
 }
 
 /// One entry, in the three shapes the module docs draw out. In short:
@@ -438,12 +456,14 @@ impl WordCache {
 
     /// The ids `word` encoded to last time, if the entry is still there.
     ///
-    /// Takes `&mut self` because a hit is also a vote for keeping the entry.
-    pub fn get(&mut self, word: &[u8]) -> Option<&[u32]> {
+    /// `head` is the window `pack_word` builds the key from, and passing `None`
+    /// only costs speed. Takes `&mut self` because a hit is also a vote for keeping
+    /// the entry.
+    pub fn get(&mut self, word: &[u8], head: Option<&[u8; 16]>) -> Option<&[u32]> {
         if word.len() > MAX_LENGTH {
             return None;
         }
-        let (key, hash) = self.slot_key(word);
+        let (key, hash) = self.slot_key(word, head);
         let index = self.find(key, hash, word)?;
         self.freqs[index] = self.freqs[index].saturating_add(1);
         let slot = self.slots[index];
@@ -456,11 +476,16 @@ impl WordCache {
     /// Remember what `word` encoded to. Silently does nothing for a word over
     /// [`MAX_LENGTH`] or when an arena is full: a cache is free to forget, and
     /// the caller has the ids either way.
-    pub fn insert(&mut self, word: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
+    pub fn insert(
+        &mut self,
+        word: &[u8],
+        head: Option<&[u8; 16]>,
+        ids: impl ExactSizeIterator<Item = u32>,
+    ) {
         if word.len() > MAX_LENGTH {
             return;
         }
-        let (key, hash) = self.slot_key(word);
+        let (key, hash) = self.slot_key(word, head);
         // Callers insert after a miss, so there is no existing entry to update.
         let Some(entry) = self.build_entry(key, word, ids) else {
             return;
@@ -481,8 +506,8 @@ impl WordCache {
     /// from. Hashing a slice makes aHash mix the length in and then branch on it to
     /// choose a read width; a `u128` is one fixed-width fold with nothing to decide.
     /// The key already carries the length, so nothing is lost.
-    fn slot_key(&self, word: &[u8]) -> (u128, u64) {
-        match pack_word(word) {
+    fn slot_key(&self, word: &[u8], head: Option<&[u8; 16]>) -> (u128, u64) {
+        match pack_word(word, head) {
             Some(packed) => (packed, self.hasher.hash_one(packed)),
             None => {
                 let hash = self.hasher.hash_one(word);
@@ -635,12 +660,12 @@ mod tests {
     #[test]
     fn roundtrip() {
         let mut cache = WordCache::new(1 << 8);
-        assert_eq!(cache.get(b"hello"), None);
-        cache.insert(b"hello", [1u32, 2, 3].into_iter());
-        cache.insert(b"world", [4u32].into_iter());
-        assert_eq!(cache.get(b"hello"), Some(&[1u32, 2, 3][..]));
-        assert_eq!(cache.get(b"world"), Some(&[4u32][..]));
-        assert_eq!(cache.get(b"hell"), None);
+        assert_eq!(cache.get(b"hello", None), None);
+        cache.insert(b"hello", None, [1u32, 2, 3].into_iter());
+        cache.insert(b"world", None, [4u32].into_iter());
+        assert_eq!(cache.get(b"hello", None), Some(&[1u32, 2, 3][..]));
+        assert_eq!(cache.get(b"world", None), Some(&[4u32][..]));
+        assert_eq!(cache.get(b"hell", None), None);
     }
 
     /// The three properties the whole key encoding rests on: a packed key is
@@ -648,11 +673,33 @@ mod tests {
     /// like a hashed key.
     #[test]
     fn packed_keys_are_unique_and_tagged() {
-        assert_ne!(pack_word(b"a"), pack_word(b"a\0"));
-        assert_ne!(pack_word(&[0u8; 15]), Some(0));
-        assert_eq!(pack_word(&[0u8; 15]).unwrap() & LONG_TAG, 0);
-        assert_eq!(pack_word(b""), None);
-        assert_eq!(pack_word(&[b'x'; 16]), None);
+        assert_ne!(pack_word(b"a", None), pack_word(b"a\0", None));
+        assert_ne!(pack_word(&[0u8; 15], None), Some(0));
+        assert_eq!(pack_word(&[0u8; 15], None).unwrap() & LONG_TAG, 0);
+        assert_eq!(pack_word(b"", None), None);
+        assert_eq!(pack_word(&[b'x'; 16], None), None);
+    }
+
+    /// The window is a shortcut for reading the word, not part of what is stored:
+    /// the bytes it carries past the word belong to the neighbours and have to be
+    /// masked away. If any of them survived into the key, a word looked up with a
+    /// window would miss the entry stored without one — and every hit in a real
+    /// encode would depend on where in its chunk the word happened to sit.
+    #[test]
+    fn the_window_past_the_word_is_masked_off() {
+        let chunk = b"the quick brown fox jumps over the lazy dog";
+        let mut cache = WordCache::new(1 << 8);
+        for (start, len) in [(0usize, 3usize), (4, 5), (10, 5), (16, 3), (26, 4)] {
+            let word = &chunk[start..start + len];
+            let head: &[u8; 16] = chunk[start..start + 16].try_into().unwrap();
+            assert_eq!(
+                cache.slot_key(word, None),
+                cache.slot_key(word, Some(head)),
+                "{word:?}"
+            );
+            cache.insert(word, None, [start as u32].into_iter());
+            assert_eq!(cache.get(word, Some(head)), Some(&[start as u32][..]));
+        }
     }
 
     /// A short word's placement now comes out of its packed key rather than its
@@ -664,7 +711,7 @@ mod tests {
         let cache = WordCache::new(1 << 12);
         let homes: std::collections::HashSet<usize> = (0..1000)
             .map(|i| {
-                let (_, hash) = cache.slot_key(format!("tok{i}").as_bytes());
+                let (_, hash) = cache.slot_key(format!("tok{i}").as_bytes(), None);
                 hash as usize & cache.mask
             })
             .collect();
@@ -677,8 +724,8 @@ mod tests {
     fn oversized_words_are_ignored() {
         let mut cache = WordCache::new(1 << 8);
         let big = vec![7u8; MAX_LENGTH + 1];
-        cache.insert(&big, [1u32].into_iter());
-        assert_eq!(cache.get(&big), None);
+        cache.insert(&big, None, [1u32].into_iter());
+        assert_eq!(cache.get(&big, None), None);
     }
 
     /// Both sides of the 15-byte packing boundary and both sides of the inline/
@@ -697,10 +744,10 @@ mod tests {
             (&long[..64], (0..64).collect()),
         ];
         for (word, ids) in &cases {
-            cache.insert(word, ids.clone().into_iter());
+            cache.insert(word, None, ids.clone().into_iter());
         }
         for (word, ids) in &cases {
-            assert_eq!(cache.get(word), Some(&ids[..]), "{word:?}");
+            assert_eq!(cache.get(word, None), Some(&ids[..]), "{word:?}");
         }
     }
 
@@ -714,17 +761,17 @@ mod tests {
         let mine = vec![b'a'; 40];
         let theirs = vec![b'b'; 40];
 
-        cache.insert(&theirs, [7u32].into_iter());
-        let (their_key, their_hash) = cache.slot_key(&theirs);
+        cache.insert(&theirs, None, [7u32].into_iter());
+        let (their_key, their_hash) = cache.slot_key(&theirs, None);
         let their_slot = cache.slots[cache.find(their_key, their_hash, &theirs).unwrap()];
-        let (my_key, my_hash) = cache.slot_key(&mine);
+        let (my_key, my_hash) = cache.slot_key(&mine, None);
         cache.slots[my_hash as usize & cache.mask] = Slot {
             key: my_key,
             ..their_slot
         };
 
-        cache.insert(&mine, [1u32, 2].into_iter());
-        assert_eq!(cache.get(&mine), Some(&[1u32, 2][..]));
+        cache.insert(&mine, None, [1u32, 2].into_iter());
+        assert_eq!(cache.get(&mine, None), Some(&[1u32, 2][..]));
     }
 
     /// A word that hashes into a full window takes the coldest slot rather than
@@ -734,22 +781,22 @@ mod tests {
         let mut cache = WordCache::new(WINDOW);
         let words: Vec<Vec<u8>> = (0..WINDOW as u8).map(|i| vec![i; 4]).collect();
         for (i, word) in words.iter().enumerate() {
-            cache.insert(word, [i as u32].into_iter());
+            cache.insert(word, None, [i as u32].into_iter());
         }
         // Every word but the first earns a hit, leaving one clear coldest slot.
         for word in &words[1..] {
-            assert!(cache.get(word).is_some());
+            assert!(cache.get(word, None).is_some());
         }
-        cache.insert(b"newcomer", [999u32].into_iter());
-        assert_eq!(cache.get(b"newcomer"), Some(&[999u32][..]));
+        cache.insert(b"newcomer", None, [999u32].into_iter());
+        assert_eq!(cache.get(b"newcomer", None), Some(&[999u32][..]));
         assert_eq!(
-            cache.get(&words[0]),
+            cache.get(&words[0], None),
             None,
             "the unused entry should have gone"
         );
         for (i, word) in words.iter().enumerate().skip(1) {
             assert_eq!(
-                cache.get(word),
+                cache.get(word, None),
                 Some(&[i as u32][..]),
                 "used entry {i} was dropped"
             );
@@ -773,12 +820,12 @@ mod tests {
             }
             .into_bytes();
             let ids: Vec<u32> = (0..=(i % 9) as u32).map(|k| i as u32 * 16 + k).collect();
-            cache.insert(&word, ids.clone().into_iter());
+            cache.insert(&word, None, ids.clone().into_iter());
             expected.push((word, ids));
         }
         let mut live = 0;
         for (word, ids) in &expected {
-            if let Some(hit) = cache.get(word) {
+            if let Some(hit) = cache.get(word, None) {
                 assert_eq!(hit, &ids[..], "{word:?}");
                 live += 1;
             }
@@ -795,8 +842,8 @@ mod tests {
         let mut cache = WordCache::new(64);
         for i in 0..2000usize {
             let word = format!("word-{i}-{}", "x".repeat(i % 20));
-            cache.insert(word.as_bytes(), [i as u32, 7].into_iter());
-            cache.get(word.as_bytes());
+            cache.insert(word.as_bytes(), None, [i as u32, 7].into_iter());
+            cache.get(word.as_bytes(), None);
         }
         assert!(
             cache.freqs.iter().any(|&freq| freq != FREE),
@@ -822,10 +869,10 @@ mod tests {
         // in flight before the entry it replaces gives its own run back.
         let word = |i: usize| format!("a-long-word-past-fifteen-bytes-{i:04}");
         for i in 0..5000usize {
-            cache.insert(word(i).as_bytes(), [i as u32; 8].into_iter());
+            cache.insert(word(i).as_bytes(), None, [i as u32; 8].into_iter());
         }
         assert_eq!(
-            cache.get(word(4999).as_bytes()),
+            cache.get(word(4999).as_bytes(), None),
             Some(&[4999u32; 8][..]),
             "inserts stopped landing — the arenas ran out"
         );

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -7,12 +7,14 @@
 //! a hit has to be far cheaper than merging, and a miss has to cost close to
 //! nothing, because every word pays for one the first time it is seen.
 //!
-//! There are three pieces. The table is `N` fixed-size slots, `N` being the
-//! requested capacity rounded up to a power of two, and next to it two arenas
-//! hold what a slot is too small for:
+//! There are four pieces. The table is `N` fixed-size slots, `N` being the
+//! requested capacity rounded up to a power of two; beside it one byte per slot
+//! records how much that slot is being used; and two arenas hold what a slot is
+//! too small for:
 //!
 //! ```text
 //!   slots     [Slot; N]      32 bytes each, one word per slot
+//!   freqs     [u8; N]        how used each slot is — and 0 means "never written"
 //!   key_bytes Slab<u8>       the bytes of words longer than 15
 //!   ids       Slab<u32>      id runs longer than 3
 //! ```
@@ -44,11 +46,11 @@
 //!
 //! # What a slot holds
 //!
-//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and two bytes
-//! of bookkeeping. It takes one of three shapes, depending on how long the word
-//! is and how many ids it encoded to. The first is the common case — most words
-//! are short and encode to one or two tokens — and it touches nothing but the
-//! slot itself:
+//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and four bytes
+//! of bookkeeping, one of them spare. It takes one of three shapes, depending on
+//! how long the word is and how many ids it encoded to. The first is the common
+//! case for English or code — a short word encoding to one or two tokens — and it
+//! touches nothing but the slot itself:
 //!
 //! ```text
 //!  (1) at most 15 bytes, at most 3 ids — the slot holds everything
@@ -85,33 +87,36 @@
 //!
 //! An entry is born on a miss, keeps its slot for as long as it is being used,
 //! and is eventually overwritten by another word that hashes into the same
-//! window. The record of "being used" is one byte per slot, `freq`. Here are four
-//! slots of one window over time, each entry shown with its `freq` (`·` = still
-//! empty):
+//! window. All of that is decided by `freqs` — here are four of one window's
+//! sixteen bytes over time:
 //!
 //! ```text
-//!    1. A, B, C are inserted; a new entry          A:0   B:0   C:0    ·
-//!       starts at 0, on probation
+//!                                                    A    B    C    D
+//!    1. A, B, C inserted, each starting at            1    1    1    0
+//!       NEWBORN — on probation, but not free
 //!
-//!    2. B and C are looked up again,               A:0   B:3   C:1    ·
-//!       scoring one hit each
+//!    2. B is looked up three times, C once            1    4    2    0
 //!
-//!    3. D takes the last free slot, and            A:0   B:3   C:1   D:1
-//!       is used once too
+//!    3. D takes the last free slot, then a hit        1    4    2    2
 //!
-//!    4. E arrives, and the window is full, so one entry has to go:
+//!    4. E arrives and the window is full:
 //!
-//!         the coldest is A, stored but never used  A:0   B:3   C:1   D:1
-//!         every freq in the window is halved       A:0   B:1   C:0   D:0
-//!         A is overwritten where it lies           E:0   B:1   C:0   D:0
-//!                                                  └ and A's arena runs, if it
-//!                                                    had any, are handed back
+//!         A is the coldest — stored, never used       1    4    2    2
+//!         every frequency halves, floored at 1        1    2    1    1
+//!         A's slot goes to E, back at NEWBORN         1    2    1    1
+//!                                                     ▲ E's now; A's arena runs,
+//!                                                       if it had any, come back
 //! ```
 //!
 //! Halving is what keeps this from being "whoever got there first wins": B was
 //! hot once, but unless it keeps earning hits it will be down with the rest by
 //! the time the next word needs a slot. C and D are one unlucky moment from
 //! eviction and one hit from safety.
+//!
+//! The floor at [`NEWBORN`] is what lets the same byte also mean *free*: no live
+//! entry can ever fall to 0, so a 0 says nothing was ever stored in that slot, and
+//! one scan of sixteen bytes answers both "is there a free slot here?" and "which
+//! entry is coldest?".
 //!
 //! Overwriting the victim where it lies is what keeps the whole structure small.
 //! Removing an entry from an open-addressed table normally needs a tombstone or a
@@ -121,6 +126,36 @@
 //! changes owner. That is what lets a lookup stop at the first empty slot, and it
 //! is why the window has to be bounded — in a saturated table, that bound is all
 //! that stops a walk from running over the whole table.
+//!
+//! ## Why the frequencies are not in the slot
+//!
+//! There is room for them — the slot has a spare byte where one used to sit. But
+//! then a window's sixteen frequencies would be sixteen bytes scattered across
+//! eight cache lines of slot table, read one slot at a time. In their own array
+//! they are sixteen *consecutive* bytes, and picking a slot compiles to a 16-byte
+//! load, a vector minimum, and — when the window is full — a vector shift and a
+//! vector maximum to age the whole window at once.
+//!
+//! That is a trade, not a free win: a hit now also writes a byte to a line it
+//! would otherwise never touch, which buys nothing while the table still has room.
+//! Measured over 24 model × corpus × capacity combinations, against the same cache
+//! with `freq` back in the slot (`examples/cache_freq_bench.rs` — it runs both in
+//! one binary, because cross-binary timings here swing ±30% on code layout alone):
+//!
+//! ```text
+//!   evictions per 1000 lookups        time per word
+//!            0 -   2                      ×1.02      ← paying, getting nothing
+//!            5 - 100                      ×1.01
+//!          136 - 160                      ×0.96
+//!          230 - 240                      ×0.91
+//!          376 - 442                      ×0.92
+//! ```
+//!
+//! So the crossover is around 50 evictions per 1000 lookups. A cache comfortably
+//! larger than the corpus in front of it stays below that and pays the 2% — at the
+//! default capacity most of our fixtures never evict at all. A cache that is
+//! actually working sits above it: a table smaller than the vocabulary it sees, or
+//! a long-lived process whose traffic keeps changing shape.
 //!
 //! # Where an evicted entry's space goes
 //!
@@ -203,7 +238,7 @@
 //!   `while local.len() < capacity`, so the words from the first pages of text
 //!   keep their places forever, however useless they turn out to be. Choosing
 //!   *which* entry to drop needs evidence about how much each one is used, and
-//!   somewhere to keep it — the `freq` byte in the slot.
+//!   somewhere to keep it — the frequency byte beside every slot.
 //! - **Entries cost more than twice the memory.** 24 bytes for the `String` and
 //!   24 for the value's vector inside the table, before the two heap blocks they
 //!   point at, against 32 bytes here for the common word.
@@ -229,8 +264,10 @@ const MAX_LENGTH: usize = 1024;
 /// so a saturated table would otherwise scan forever looking for an empty slot.
 const WINDOW: usize = 16;
 /// Ids carried in the slot itself — three `u32`s is what fits beside the key.
-/// Most words encode to one or two tokens, so this keeps the id arena for the
-/// tail rather than the common case.
+/// Enough for 80-96% of lookups on English or code, but only about a quarter of
+/// them on Chinese or Korean, where a vocabulary holding none of those scripts
+/// spends ten ids or more on one word. `examples/cache_freq_bench.rs --lengths`
+/// prints the distribution per model and corpus.
 const INLINE_IDS: usize = 3;
 /// `len` marker for an entry whose ids, and possibly whose bytes, are in the
 /// arenas.
@@ -240,6 +277,12 @@ const SPILLED: u8 = u8::MAX;
 /// key can never be mistaken for a packed one, and neither can be 0 — the
 /// empty-slot marker.
 const LONG_TAG: u128 = 1 << 127;
+/// A `freqs` entry for a slot nothing has been stored in yet. Live entries are at
+/// least [`NEWBORN`], so the one array answers both "is this slot free?" and "how
+/// much is this entry being used?" — see [`WordCache::pick_slot`].
+const FREE: u8 = 0;
+/// Where a new entry's frequency starts: on probation, but not free.
+const NEWBORN: u8 = 1;
 
 /// A word of 1..=15 bytes packed into a `u128`: bytes in the low lanes, length
 /// in the top byte. Including the length keeps `"a"` and `"a\0"` apart, and the
@@ -264,18 +307,18 @@ fn pack_word(word: &[u8]) -> Option<u128> {
 /// - `key_len` is 0 unless the word's bytes went to `key_bytes`, so it doubles as
 ///   "does a matching `key` need confirming?".
 ///
-/// The size assertion is the point of the layout: 32 bytes means a hit reads the
-/// key, the ids and the bookkeeping in one go.
+/// How much an entry is used is *not* here — it lives in `WordCache::freqs`, for
+/// the reasons the module docs give. The byte it left behind cannot be spent on
+/// anything: `key`'s 16-byte alignment fixes the slot at 32 bytes, and a fourth
+/// inline id would need four. That the size is 32 is the point of the layout —
+/// a hit reads the key, the ids and the bookkeeping in one go.
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
 struct Slot {
     key: u128,
     payload: [u32; INLINE_IDS],
     len: u8,
-    /// How much the entry is being used, halved whenever its window has to make
-    /// room (see the module docs). A new entry starts at 0, on probation until
-    /// it earns a hit.
-    freq: u8,
+    _pad: u8,
     key_len: u16,
 }
 
@@ -364,6 +407,10 @@ pub struct WordCache {
     slots: Box<[Slot]>,
     key_bytes: Slab<u8>,
     ids: Slab<u32>,
+    /// How much each slot is being used, one byte per slot, [`FREE`] while the
+    /// slot has never been written. Outside the slots so that a whole window's
+    /// worth is 16 consecutive bytes — see [`WordCache::pick_slot`].
+    freqs: Box<[u8]>,
     /// `slots.len() - 1`. The table is a power of two, so this folds a hash into
     /// a slot index.
     mask: usize,
@@ -384,6 +431,7 @@ impl WordCache {
             // no CJK in it, which spends ~17 ids on a single Chinese word.
             key_bytes: Slab::new(n_slots * 48),
             ids: Slab::new(n_slots * 16),
+            freqs: vec![FREE; n_slots].into_boxed_slice(),
             mask: n_slots - 1,
         }
     }
@@ -397,8 +445,8 @@ impl WordCache {
         }
         let (key, hash) = self.slot_key(word);
         let index = self.find(key, hash, word)?;
+        self.freqs[index] = self.freqs[index].saturating_add(1);
         let slot = self.slots[index];
-        self.slots[index].freq = slot.freq.saturating_add(1);
         if slot.spilled() {
             return Some(self.ids.get(slot.ids_off(), slot.ids_len()));
         }
@@ -420,6 +468,9 @@ impl WordCache {
         let index = self.pick_slot(hash);
         self.reclaim(index);
         self.slots[index] = entry;
+        // Both writes or neither: a slot is occupied exactly when its frequency is
+        // above [`FREE`], and `pick_slot` reads emptiness out of `freqs` alone.
+        self.freqs[index] = NEWBORN;
     }
 
     /// The value a slot stores in its `key`, and the hash that places it. A short
@@ -476,7 +527,7 @@ impl WordCache {
                 key,
                 payload,
                 len: ids_len as u8,
-                freq: 0,
+                _pad: 0,
                 key_len: 0,
             });
         }
@@ -493,39 +544,72 @@ impl WordCache {
             key,
             payload: [key_off, ids_off, ids_len as u32],
             len: SPILLED,
-            freq: 0,
+            _pad: 0,
             key_len: key_len as u16,
         })
     }
 
-    /// The slot the next entry goes in: the first empty one in the window, or the
+    /// The slot the next entry goes in: the first free one in the window, or the
     /// coldest one if they are all taken.
+    ///
+    /// `#[inline]` because this and [`WordCache::reclaim`] exist to give the steps
+    /// of `insert` names, not to be called: left out of line they cost `insert` two
+    /// calls and the pointers it had already loaded.
+    ///
+    /// This reads nothing but `freqs`, which is why the frequencies live outside
+    /// the slots. A window's worth of them is 16 consecutive bytes, so the whole
+    /// decision is a 16-byte load, a vector minimum, and — when the window is full
+    /// — a vector shift to age it. Reading a `freq` out of each slot instead would
+    /// mean 16 strided reads over 8 cache lines. Both jobs come out of the one
+    /// array because [`FREE`] is a frequency no live entry can have.
+    #[inline]
     fn pick_slot(&mut self, hash: u64) -> usize {
         let home = hash as usize & self.mask;
-        // Starting at `home` rather than 0 matters when every slot in the window
-        // has reached the maximum `freq`: the victim still has to be in the
-        // window.
+        let Some(&window) = self.freqs[home..].first_chunk::<WINDOW>() else {
+            return self.pick_slot_wrapping(home);
+        };
+        let coldest = window.iter().copied().min().unwrap_or(FREE);
+        let offset = window.iter().position(|&freq| freq == coldest).unwrap_or(0);
+        if coldest == FREE {
+            return home + offset;
+        }
+        // Age the window on the way past: every entry in it now has to be used
+        // again before the next word arrives here, or become the next victim. The
+        // floor keeps them all distinguishable from a free slot.
+        for freq in &mut self.freqs[home..home + WINDOW] {
+            *freq = (*freq >> 1).max(NEWBORN);
+        }
+        home + offset
+    }
+
+    /// [`WordCache::pick_slot`] for the one home in `mask + 1` whose window runs
+    /// off the end of the table: same policy, read one slot at a time, because the
+    /// frequencies are not contiguous there.
+    #[inline]
+    fn pick_slot_wrapping(&mut self, home: usize) -> usize {
+        // Seeded at `home` rather than 0 so that a window whose entries have all
+        // reached the maximum frequency still evicts one of its own.
         let mut coldest = (u8::MAX, home);
         for step in 0..WINDOW {
             let index = (home + step) & self.mask;
-            let slot = &self.slots[index];
-            if slot.is_empty() {
+            let freq = self.freqs[index];
+            if freq == FREE {
                 return index;
             }
-            if slot.freq < coldest.0 {
-                coldest = (slot.freq, index);
+            if freq < coldest.0 {
+                coldest = (freq, index);
             }
         }
-        // Age the window on the way past: every entry in it now has to be used
-        // again before the next word arrives here, or become the next victim.
         for step in 0..WINDOW {
-            self.slots[(home + step) & self.mask].freq >>= 1;
+            let freq = &mut self.freqs[(home + step) & self.mask];
+            *freq = (*freq >> 1).max(NEWBORN);
         }
         coldest.1
     }
 
     /// Hand an overwritten entry's arena runs back, so the next entry can use
     /// them.
+    #[inline]
     fn reclaim(&mut self, index: usize) {
         let slot = self.slots[index];
         if !slot.spilled() {
@@ -675,6 +759,31 @@ mod tests {
             }
         }
         assert!(live > 0, "everything was evicted — the test proves nothing");
+    }
+
+    /// `find` reads emptiness off the slot's key and `pick_slot` reads it off the
+    /// frequency, so the two have to agree about every slot, always. They only can
+    /// if `insert` writes both and the aging never lets a live entry reach
+    /// [`FREE`].
+    #[test]
+    fn occupancy_agrees_between_slots_and_frequencies() {
+        let mut cache = WordCache::new(64);
+        for i in 0..2000usize {
+            let word = format!("word-{i}-{}", "x".repeat(i % 20));
+            cache.insert(word.as_bytes(), [i as u32, 7].into_iter());
+            cache.get(word.as_bytes());
+        }
+        assert!(
+            cache.freqs.iter().any(|&freq| freq != FREE),
+            "nothing was stored — the test proves nothing"
+        );
+        for (index, slot) in cache.slots.iter().enumerate() {
+            assert_eq!(
+                slot.is_empty(),
+                cache.freqs[index] == FREE,
+                "slot {index} and its frequency disagree"
+            );
+        }
     }
 
     /// Freed runs have to come back. Without reuse the arenas grow with every

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,6 +1,6 @@
 use ahash::RandomState;
 
-use crate::utils::cache::MAX_LENGTH;
+const MAX_LENGTH: usize = 1024;
 
 /// Slots searched from a key's home position. Linear probing normally settles in
 /// one or two, but the walk has to stop somewhere: nothing is ever removed, so a

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -1,59 +1,320 @@
+//! Remembers the token ids a word encodes to, so BPE only has to merge it once.
+//!
+//! Text repeats itself: a few thousand distinct words usually cover nearly every
+//! word of a document, and merging is the most expensive thing the BPE model
+//! does. So the second time a word shows up, the answer should come from a table
+//! instead of from the merge loop. Both sides of that table are on the hot path:
+//! a hit has to be far cheaper than merging, and a miss has to cost close to
+//! nothing, because every word pays for one the first time it is seen.
+//!
+//! There are three pieces. The table is `N` fixed-size slots, `N` being the
+//! requested capacity rounded up to a power of two, and next to it two arenas
+//! hold what a slot is too small for:
+//!
+//! ```text
+//!   slots     [Slot; N]      32 bytes each, one word per slot
+//!   key_bytes Slab<u8>       the bytes of words longer than 15
+//!   ids       Slab<u32>      id runs longer than 3
+//! ```
+//!
+//! One `WordCache` lives in one scratch buffer, so it is owned by a single
+//! thread: no sharing, no locking, no atomics.
+//!
+//! # Looking a word up
+//!
+//! A word's hash picks its *home* slot. If another word is already sitting
+//! there, the search steps forward one slot at a time — this is open addressing
+//! with linear probing — for at most [`WINDOW`] slots:
+//!
+//! ```text
+//!   get(b"tion")      home = hash(b"tion") & (N - 1) = 4
+//!
+//!     slot 3  │ "port"  │
+//!     slot 4  │ "ation" │ ← home, but another word got here first: step forward
+//!     slot 5  │ "tion"  │ ← the key matches: hit, hand back its ids
+//!     slot 6  │  empty  │
+//!     slot 7  │ "the"   │
+//!
+//!   get(b"xyz")       home = 4 → not "ation", not "tion", slot 6 is empty → miss
+//! ```
+//!
+//! A walk may stop at that empty slot instead of going the full [`WINDOW`],
+//! because no slot ever goes back to being empty once it has been used: an empty
+//! slot means nothing was ever stored beyond it.
+//!
+//! # What a slot holds
+//!
+//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and two bytes
+//! of bookkeeping. It takes one of three shapes, depending on how long the word
+//! is and how many ids it encoded to. The first is the common case — most words
+//! are short and encode to one or two tokens — and it touches nothing but the
+//! slot itself:
+//!
+//! ```text
+//!  (1) at most 15 bytes, at most 3 ids — the slot holds everything
+//!
+//!     b"tion" → [5378, 262]
+//!    key     │ t  i  o  n  00 … 00 │ 4 │   the word, length in the top byte
+//!    payload │ 5378 │ 262 │  ·  │          the ids, right here
+//!    len     2                             2 of the 3 payload words are ids
+//!    key_len 0                             none of it is in key_bytes
+//!
+//!  (2) at most 15 bytes, more than 3 ids — the ids move to the arena
+//!
+//!     b"电脑" (6 bytes) → 8 ids
+//!    key     │ e7 94 b5 e8 84 91 … │ 6 │   still the word itself
+//!    payload │  ·  │  40  │  8  │          8 ids, in the ids arena at 40
+//!    len     SPILLED                       payload is coordinates, not ids
+//!    key_len 0
+//!
+//!  (3) over 15 bytes — the bytes move too, and the key becomes a hash
+//!
+//!     b"unbelievabilities" (17 bytes) → 6 ids
+//!    key     │ hash(word) │ LONG_TAG │   no room for 17 bytes
+//!    payload │  12  │  40  │  6  │       bytes at 12, ids at 40
+//!    len     SPILLED
+//!    key_len 17                          so a hit has to check those bytes
+//! ```
+//!
+//! Shape (3) is the only one where a matching `key` is not proof: two different
+//! long words can hash alike, so a hit there also compares the bytes in
+//! `key_bytes`. Shapes (1) and (2) carry the word itself in the key, so an equal
+//! key *is* an equal word — one register-wide comparison, no memory to chase.
+//!
+//! # The life of an entry
+//!
+//! An entry is born on a miss, keeps its slot for as long as it is being used,
+//! and is eventually overwritten by another word that hashes into the same
+//! window. The record of "being used" is one byte per slot, `freq`. Here are four
+//! slots of one window over time, each entry shown with its `freq` (`·` = still
+//! empty):
+//!
+//! ```text
+//!    1. A, B, C are inserted; a new entry          A:0   B:0   C:0    ·
+//!       starts at 0, on probation
+//!
+//!    2. B and C are looked up again,               A:0   B:3   C:1    ·
+//!       scoring one hit each
+//!
+//!    3. D takes the last free slot, and            A:0   B:3   C:1   D:1
+//!       is used once too
+//!
+//!    4. E arrives, and the window is full, so one entry has to go:
+//!
+//!         the coldest is A, stored but never used  A:0   B:3   C:1   D:1
+//!         every freq in the window is halved       A:0   B:1   C:0   D:0
+//!         A is overwritten where it lies           E:0   B:1   C:0   D:0
+//!                                                  └ and A's arena runs, if it
+//!                                                    had any, are handed back
+//! ```
+//!
+//! Halving is what keeps this from being "whoever got there first wins": B was
+//! hot once, but unless it keeps earning hits it will be down with the rest by
+//! the time the next word needs a slot. C and D are one unlucky moment from
+//! eviction and one hit from safety.
+//!
+//! Overwriting the victim where it lies is what keeps the whole structure small.
+//! Removing an entry from an open-addressed table normally needs a tombstone or a
+//! backward shift, because a probe walk stops at the first empty slot and a hole
+//! in the middle of a chain would cut the walk short. Here nothing is ever
+//! removed: a slot goes from empty to occupied once and after that only ever
+//! changes owner. That is what lets a lookup stop at the first empty slot, and it
+//! is why the window has to be bounded — in a saturated table, that bound is all
+//! that stops a walk from running over the whole table.
+//!
+//! # Where an evicted entry's space goes
+//!
+//! Whatever A had in the arenas is handed back when A is overwritten, and the
+//! next word of the same shape takes it. Runs are never moved and never
+//! rounded up, because there is a free list for every length a run can have
+//! (see [`Slab`], and [`MAX_LENGTH`] for why that is finite):
+//!
+//! ```text
+//!   the ids arena, just after A — which had 6 ids at offset 12 — was evicted
+//!
+//!     data  ┌─────┬────────────────────────────┬─────┐
+//!           │  …  │ A's 6 ids, at offset 12    │  …  │   nothing is moved
+//!           └─────┴────────────────────────────┴─────┘
+//!
+//!     free  len 6 → [ 12 ]   the next word with 6 ids is handed offset 12
+//!           len 8 → [ ]      one list per length, 0 … MAX_LENGTH
+//! ```
+//!
+//! So the arenas hold the live set rather than every word ever seen. Without
+//! reuse they could only grow, and reclaiming them would mean copying every live
+//! entry into a second buffer — twice the memory for the same number of entries.
+//!
+//! # Why open addressing, and not fixed buckets
+//!
+//! The previous version of this cache was 4-way set-associative: the table was
+//! cut into buckets of four slots and a word could only live in the one bucket
+//! its hash picked. That is a single load per lookup and easy to reason about,
+//! but a word whose four slots are taken can never be cached at all, however
+//! empty the rest of the table is:
+//!
+//! ```text
+//!   4-way buckets — a word belongs to exactly one bucket of four
+//!
+//!     bucket 0        bucket 1        bucket 2
+//!     │●│●│●│●│       │●│·│·│·│       │·│·│·│·│
+//!      ▲
+//!      └ full, so this word goes uncached — the free slots one
+//!        bucket over may as well not exist
+//!
+//!   open addressing — the word walks on to the next free slot
+//!
+//!     │●│●│●│●│·│·│·│·│·│·│·│·│·│·│·│·│
+//!      ▲       ▲
+//!      home    └ stored here instead; only WINDOW slots taken in a
+//!                row can turn a word away
+//! ```
+//!
+//! With buckets that small, being locked out starts happening long before the
+//! table is genuinely full. On our multilingual fixtures it cost between 0.1% and
+//! 4% of all lookups, worst on Korean and Chinese, where a document holds far
+//! more distinct words.
+//!
+//! Probing a window closed that gap: on the same fixtures the misses went to ~0,
+//! and in the encoder (`examples/fixture_bench.rs`) the many-distinct-word
+//! scripts spent 10-40% less time in the model stage. English and code came out
+//! inside the noise —
+//! and the noise there is wide: running one binary against *itself* swings the
+//! model stage by ±30%, so measure that floor before believing anything smaller.
+//!
+//! # Why not a `HashMap`
+//!
+//! The legacy BPE model in `model.rs` caches in a thread-local
+//! `AHashMap<String, Word>` (`BPE_LOCAL_CACHE`), so the comparison is concrete.
+//! On a warm benchmark, where every word is already in the map, a hash map is
+//! not far off this table — it has no bucket conflicts either. What it cannot do
+//! is the rest of the job:
+//!
+//! - **Every word it accepts goes to the allocator.** The map owns its keys, so
+//!   an accepted word is copied into a fresh `String`, and each value keeps a
+//!   heap buffer of its own alive. That cost lands on misses, which is where a
+//!   cache can least afford it: a word misses the first time it is ever seen.
+//!   Here an insert writes into space that already exists.
+//! - **A hit is two more random loads.** The key bytes and the value both live
+//!   in their own heap blocks, elsewhere in memory from the table that pointed
+//!   at them. A slot here answers the common word out of the 32 bytes the probe
+//!   has already read.
+//! - **It cannot make room.** A `HashMap` grows until something stops it, and
+//!   the only thing it can do when stopped is refuse: the legacy cache inserts
+//!   `while local.len() < capacity`, so the words from the first pages of text
+//!   keep their places forever, however useless they turn out to be. Choosing
+//!   *which* entry to drop needs evidence about how much each one is used, and
+//!   somewhere to keep it — the `freq` byte in the slot.
+//! - **Entries cost more than twice the memory.** 24 bytes for the `String` and
+//!   24 for the value's vector inside the table, before the two heap blocks they
+//!   point at, against 32 bytes here for the common word.
+//!
+//! A *shared* map costs more again: [`crate::utils::cache::Cache`], which the
+//! Unigram model still uses, wraps one in an `RwLock` and then has to
+//! `try_read`/`try_write` and silently drop the read or the write whenever
+//! another thread holds it.
+
 use ahash::RandomState;
 
+/// Longest word the cache will store, in bytes.
+///
+/// Long words are rare and rarely repeat, so storing them buys little, and the
+/// lookup for one is a hash over every byte to learn nothing. The cap is also
+/// what makes the arenas' free lists possible (one list per length) and what
+/// bounds a run's size at all: a tokenizer with no pre-tokenizer hands this
+/// model whole documents as single "words", and uncapped the cache would
+/// cheerfully memoize documents.
 const MAX_LENGTH: usize = 1024;
-
-/// Slots searched from a key's home position. Linear probing normally settles in
-/// one or two, but the walk has to stop somewhere: nothing is ever removed, so a
-/// saturated table would otherwise scan forever looking for an empty slot.
+/// Slots searched from a word's home position. Linear probing normally settles
+/// in one or two, but the walk has to stop somewhere: nothing is ever removed,
+/// so a saturated table would otherwise scan forever looking for an empty slot.
 const WINDOW: usize = 16;
-/// Ids carried in the slot itself. Most pre-tokens encode to one or two tokens,
-/// so this keeps the arena for the tail rather than the common case.
+/// Ids carried in the slot itself — three `u32`s is what fits beside the key.
+/// Most words encode to one or two tokens, so this keeps the id arena for the
+/// tail rather than the common case.
 const INLINE_IDS: usize = 3;
-/// `count` marker for an entry whose key bytes and/or ids live in the arenas.
+/// `len` marker for an entry whose ids, and possibly whose bytes, are in the
+/// arenas.
 const SPILLED: u8 = u8::MAX;
-/// Set in `key` when it holds a hash of a > 15-byte word rather than the word
-/// itself. Packed keys carry their length (1..=15) in the top byte, so the two
-/// can never be confused, and neither can be 0 — the empty-slot sentinel.
+/// Set in `key` when it holds the hash of a long word instead of the word
+/// itself. Packed keys carry their length (1..=15) in the top byte, so a hashed
+/// key can never be mistaken for a packed one, and neither can be 0 — the
+/// empty-slot marker.
 const LONG_TAG: u128 = 1 << 127;
 
-/// A key of at most 15 bytes packed into a u128: bytes in the low lanes, length
-/// in the top byte. Different lengths therefore never collide, and the whole
-/// comparison is one register-width equality instead of a `memcmp`.
-fn pack_key(key: &[u8]) -> Option<u128> {
-    if key.is_empty() || key.len() > 15 {
+/// A word of 1..=15 bytes packed into a `u128`: bytes in the low lanes, length
+/// in the top byte. Including the length keeps `"a"` and `"a\0"` apart, and the
+/// whole key comparison becomes one register-wide equality instead of a
+/// `memcmp` against bytes somewhere else in memory.
+fn pack_word(word: &[u8]) -> Option<u128> {
+    if word.is_empty() || word.len() > 15 {
         return None;
     }
     let mut lanes = [0u8; 16];
-    lanes[..key.len()].copy_from_slice(key);
-    Some(u128::from_le_bytes(lanes) | ((key.len() as u128) << 120))
+    lanes[..word.len()].copy_from_slice(word);
+    Some(u128::from_le_bytes(lanes) | ((word.len() as u128) << 120))
 }
 
-/// 32 bytes, two to a cache line. `w` holds the ids inline while
-/// `count <= INLINE_IDS`, and otherwise the arena coordinates
-/// `[key_off, ids_off, key_len << 16 | ids_len]` — where `key_len == 0` means the
-/// key is packed into `key` and no bytes were stored for it.
+/// One entry, in the three shapes the module docs draw out. In short:
+///
+/// - `key` is the word itself when it fits in 15 bytes, otherwise its hash with
+///   [`LONG_TAG`] set.
+/// - `payload` is the token ids while `len` counts them, and becomes
+///   `[key_off, ids_off, ids_len]` once `len` is [`SPILLED`] — which is what the
+///   `key_off`/`ids_off`/`ids_len` readers below are for.
+/// - `key_len` is 0 unless the word's bytes went to `key_bytes`, so it doubles as
+///   "does a matching `key` need confirming?".
+///
+/// The size assertion is the point of the layout: 32 bytes means a hit reads the
+/// key, the ids and the bookkeeping in one go.
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
-struct CacheSlot {
+struct Slot {
     key: u128,
-    w: [u32; INLINE_IDS],
-    count: u8,
+    payload: [u32; INLINE_IDS],
+    len: u8,
+    /// How much the entry is being used, halved whenever its window has to make
+    /// room (see the module docs). A new entry starts at 0, on probation until
+    /// it earns a hit.
     freq: u8,
-    _pad: u16,
+    key_len: u16,
 }
 
-const _: () = assert!(std::mem::size_of::<CacheSlot>() == 32);
+const _: () = assert!(std::mem::size_of::<Slot>() == 32);
 
-/// An arena that reuses the space of evicted entries instead of compacting.
+impl Slot {
+    fn is_empty(&self) -> bool {
+        self.key == 0
+    }
+
+    fn spilled(&self) -> bool {
+        self.len == SPILLED
+    }
+
+    fn key_off(&self) -> u32 {
+        self.payload[0]
+    }
+
+    fn ids_off(&self) -> u32 {
+        self.payload[1]
+    }
+
+    fn ids_len(&self) -> usize {
+        self.payload[2] as usize
+    }
+}
+
+/// A grow-only arena that reuses the space of evicted entries instead of
+/// compacting.
 ///
-/// Runs are freed to a list per exact length, which costs nothing here because
-/// `MAX_LENGTH` bounds every run: a freed run always has a list to go to, the
-/// next word of that shape takes it, and no length is ever rounded up. Without
-/// this the arena could only grow, and reclaiming it would mean relocating every
-/// live entry into a second buffer.
+/// Freed runs go on a free list per exact length. That is only practical because
+/// `MAX_LENGTH` bounds every run: there is a list for every length a run can
+/// have, so a freed run is always reusable by the next word of the same shape
+/// and no length is ever rounded up to a bigger class. The price is
+/// `MAX_LENGTH + 1` empty `Vec`s per arena.
 struct Slab<T> {
     data: Vec<T>,
     free: Box<[Vec<u32>]>,
+    /// Ceiling on `data`, not a reservation.
     budget: usize,
 }
 
@@ -66,6 +327,7 @@ impl<T: Copy + Default> Slab<T> {
         }
     }
 
+    /// A run of `len` items, or `None` once the budget is spent.
     fn alloc(&mut self, len: usize) -> Option<u32> {
         if let Some(off) = self.free[len].pop() {
             return Some(off);
@@ -96,28 +358,15 @@ impl<T: Copy + Default> Slab<T> {
     }
 }
 
-/// Pre-token bytes to their token ids, one instance per scratch and therefore
-/// per thread — no sharing, no locking.
-///
-/// Open addressing rather than fixed buckets, because a word that collides can
-/// take the next free slot instead of being locked out. Making room does not
-/// need a second copy of the table: a slot is overwritten in place, which is
-/// safe because slots go empty to occupied and never back, so no probe walk is
-/// ever cut short by a hole. What that costs is a bounded [`WINDOW`], and what
-/// it buys is that the table and its arenas only ever hold entries that are
-/// live.
-///
-/// Eviction picks the coldest slot of the window and halves the frequencies it
-/// passed, so a word has to keep being used to keep its place, and a burst of
-/// once-hot words cannot hold a window forever.
+/// Word bytes to token ids. See the module docs for the design.
 pub struct WordCache {
     hasher: RandomState,
-    slots: Box<[CacheSlot]>,
+    slots: Box<[Slot]>,
     key_bytes: Slab<u8>,
     ids: Slab<u32>,
+    /// `slots.len() - 1`. The table is a power of two, so this folds a hash into
+    /// a slot index.
     mask: usize,
-    /// Written by `get` so inline ids can be handed back as a slice.
-    unpacked: [u32; INLINE_IDS],
 }
 
 impl WordCache {
@@ -125,153 +374,166 @@ impl WordCache {
         let n_slots = capacity.next_power_of_two().max(WINDOW);
         Self {
             hasher: RandomState::new(),
-            slots: vec![CacheSlot::default(); n_slots].into_boxed_slice(),
-            // Ceilings, not reservations — the arenas below allocate only what is
-            // live. They are set high enough that the slot table runs out first:
-            // an arena that refuses inserts while slots sit empty is just a
-            // smaller cache.
+            slots: vec![Slot::default(); n_slots].into_boxed_slice(),
+            // Ceilings, not reservations: the arenas grow only as far as the live
+            // set takes them. Deliberately generous, so that the slot table is
+            // what runs out first — an arena that turns inserts away while slots
+            // sit empty is a capacity limit in disguise, and tighter numbers here
+            // measured exactly that (tens of thousands of words refused at 35%
+            // occupancy). The worst case they have to cover is a vocabulary with
+            // no CJK in it, which spends ~17 ids on a single Chinese word.
             key_bytes: Slab::new(n_slots * 48),
             ids: Slab::new(n_slots * 16),
             mask: n_slots - 1,
-            unpacked: [0; INLINE_IDS],
         }
     }
 
-    /// The stored key, and the hash that places it. Short words key on their own
-    /// bytes and need no confirmation; longer ones key on a tagged hash and are
-    /// confirmed against `key_bytes`.
-    fn locate(&self, key: &[u8]) -> (u128, u64) {
-        let hash = self.hasher.hash_one(key);
-        match pack_key(key) {
+    /// The ids `word` encoded to last time, if the entry is still there.
+    ///
+    /// Takes `&mut self` because a hit is also a vote for keeping the entry.
+    pub fn get(&mut self, word: &[u8]) -> Option<&[u32]> {
+        if word.len() > MAX_LENGTH {
+            return None;
+        }
+        let (key, hash) = self.slot_key(word);
+        let index = self.find(key, hash, word)?;
+        let slot = self.slots[index];
+        self.slots[index].freq = slot.freq.saturating_add(1);
+        if slot.spilled() {
+            return Some(self.ids.get(slot.ids_off(), slot.ids_len()));
+        }
+        Some(&self.slots[index].payload[..slot.len as usize])
+    }
+
+    /// Remember what `word` encoded to. Silently does nothing for a word over
+    /// [`MAX_LENGTH`] or when an arena is full: a cache is free to forget, and
+    /// the caller has the ids either way.
+    pub fn insert(&mut self, word: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
+        if word.len() > MAX_LENGTH {
+            return;
+        }
+        let (key, hash) = self.slot_key(word);
+        // Callers insert after a miss, so there is no existing entry to update.
+        let Some(entry) = self.build_entry(key, word, ids) else {
+            return;
+        };
+        let index = self.pick_slot(hash);
+        self.reclaim(index);
+        self.slots[index] = entry;
+    }
+
+    /// The value a slot stores in its `key`, and the hash that places it. A short
+    /// word is its own key; a longer one keys on a tagged hash and has to be
+    /// confirmed against `key_bytes`, since two long words can hash alike.
+    fn slot_key(&self, word: &[u8]) -> (u128, u64) {
+        let hash = self.hasher.hash_one(word);
+        match pack_word(word) {
             Some(packed) => (packed, hash),
             None => ((hash as u128) | LONG_TAG, hash),
         }
     }
 
-    fn confirmed(&self, slot: &CacheSlot, key: &[u8]) -> bool {
-        if slot.key & LONG_TAG == 0 {
-            return true; // the packed key is the word
-        }
-        let key_len = (slot.w[2] >> 16) as usize;
-        key_len == key.len() && self.key_bytes.get(slot.w[0], key_len) == key
-    }
-
-    /// Return an overwritten entry's arena runs so the next entry can use them.
-    fn reclaim(&mut self, index: usize) {
-        let slot = self.slots[index];
-        if slot.count != SPILLED {
-            return;
-        }
-        let (key_len, ids_len) = ((slot.w[2] >> 16) as usize, (slot.w[2] & 0xFFFF) as usize);
-        if key_len > 0 {
-            self.key_bytes.release(slot.w[0], key_len);
-        }
-        if ids_len > 0 {
-            self.ids.release(slot.w[1], ids_len);
-        }
-    }
-
-    pub fn get(&mut self, key: &[u8]) -> Option<&[u32]> {
-        if key.len() > MAX_LENGTH {
-            return None;
-        }
-        let (stored, hash) = self.locate(key);
-        let home = hash as usize;
+    /// The slot holding `word`, searched from its home position. Stopping at the
+    /// first empty slot is safe because slots never go back to being empty: an
+    /// empty one means the word was never stored.
+    fn find(&self, key: u128, hash: u64, word: &[u8]) -> Option<usize> {
         for step in 0..WINDOW {
-            let index = (home + step) & self.mask;
-            let slot = self.slots[index];
-            if slot.key == 0 {
+            let index = (hash as usize + step) & self.mask;
+            let slot = &self.slots[index];
+            if slot.is_empty() {
                 return None;
             }
-            if slot.key == stored && self.confirmed(&slot, key) {
-                self.slots[index].freq = slot.freq.saturating_add(1);
-                if slot.count == SPILLED {
-                    return Some(self.ids.get(slot.w[1], (slot.w[2] & 0xFFFF) as usize));
-                }
-                self.unpacked = slot.w;
-                return Some(&self.unpacked[..slot.count as usize]);
+            if slot.key == key && self.holds_word(slot, word) {
+                return Some(index);
             }
         }
         None
     }
 
-    pub fn insert(&mut self, key: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
-        if key.len() > MAX_LENGTH {
-            return;
-        }
-        let (stored, hash) = self.locate(key);
-        let long = stored & LONG_TAG != 0;
-        let ids_len = ids.len();
+    /// Whether the entry really is `word`'s. A packed key is the word itself and
+    /// needs nothing further; a hashed one is only as good as its bytes.
+    fn holds_word(&self, slot: &Slot, word: &[u8]) -> bool {
+        slot.key_len == 0 || self.key_bytes.get(slot.key_off(), slot.key_len as usize) == word
+    }
 
-        // Reserve arena space before touching the table, so a full arena costs
-        // nothing but the attempt.
-        let (w, count) = if long || ids_len > INLINE_IDS {
-            let Some(key_off) = (if long {
-                self.key_bytes.alloc(key.len())
-            } else {
-                Some(0)
-            }) else {
-                return;
-            };
-            let Some(ids_off) = (if ids_len > 0 {
-                self.ids.alloc(ids_len)
-            } else {
-                Some(0)
-            }) else {
-                if long {
-                    self.key_bytes.release(key_off, key.len());
-                }
-                return;
-            };
-            if long {
-                self.key_bytes.fill(key_off, key.len(), key.iter().copied());
-            }
-            self.ids.fill(ids_off, ids_len, ids);
-            let key_len = if long { key.len() } else { 0 };
-            (
-                [key_off, ids_off, ((key_len as u32) << 16) | ids_len as u32],
-                SPILLED,
-            )
-        } else {
-            let mut w = [0u32; INLINE_IDS];
-            for (dst, id) in w.iter_mut().zip(ids) {
+    /// The entry to store, with whatever does not fit in a slot copied into the
+    /// arenas. `None` when an arena is full, so a rejected insert leaves the
+    /// table and the arenas exactly as they were.
+    fn build_entry(
+        &mut self,
+        key: u128,
+        word: &[u8],
+        ids: impl ExactSizeIterator<Item = u32>,
+    ) -> Option<Slot> {
+        let long = key & LONG_TAG != 0;
+        let ids_len = ids.len();
+        if !long && ids_len <= INLINE_IDS {
+            let mut payload = [0u32; INLINE_IDS];
+            for (dst, id) in payload.iter_mut().zip(ids) {
                 *dst = id;
             }
-            (w, ids_len as u8)
+            return Some(Slot {
+                key,
+                payload,
+                len: ids_len as u8,
+                freq: 0,
+                key_len: 0,
+            });
+        }
+        // A short word stays in the key, which is a zero-length run here.
+        let key_len = if long { word.len() } else { 0 };
+        let key_off = self.key_bytes.alloc(key_len)?;
+        let Some(ids_off) = self.ids.alloc(ids_len) else {
+            self.key_bytes.release(key_off, key_len);
+            return None;
         };
+        self.key_bytes.fill(key_off, key_len, word.iter().copied());
+        self.ids.fill(ids_off, ids_len, ids);
+        Some(Slot {
+            key,
+            payload: [key_off, ids_off, ids_len as u32],
+            len: SPILLED,
+            freq: 0,
+            key_len: key_len as u16,
+        })
+    }
 
-        let home = hash as usize;
-        let mut coldest = (u8::MAX, home & self.mask);
-        let mut empty = None;
+    /// The slot the next entry goes in: the first empty one in the window, or the
+    /// coldest one if they are all taken.
+    fn pick_slot(&mut self, hash: u64) -> usize {
+        let home = hash as usize & self.mask;
+        // Starting at `home` rather than 0 matters when every slot in the window
+        // has reached the maximum `freq`: the victim still has to be in the
+        // window.
+        let mut coldest = (u8::MAX, home);
         for step in 0..WINDOW {
             let index = (home + step) & self.mask;
-            if self.slots[index].key == 0 {
-                empty = Some(index);
-                break;
+            let slot = &self.slots[index];
+            if slot.is_empty() {
+                return index;
             }
-            if self.slots[index].freq < coldest.0 {
-                coldest = (self.slots[index].freq, index);
+            if slot.freq < coldest.0 {
+                coldest = (slot.freq, index);
             }
         }
-        let index = match empty {
-            Some(index) => index,
-            None => {
-                // Age the window on the way past: every entry it holds has to be
-                // used again before the next conflict or it becomes the victim.
-                for step in 0..WINDOW {
-                    self.slots[(home + step) & self.mask].freq >>= 1;
-                }
-                self.reclaim(coldest.1);
-                coldest.1
-            }
-        };
-        self.slots[index] = CacheSlot {
-            key: stored,
-            w,
-            count,
-            freq: 0, // on probation until it is used again
-            _pad: 0,
-        };
+        // Age the window on the way past: every entry in it now has to be used
+        // again before the next word arrives here, or become the next victim.
+        for step in 0..WINDOW {
+            self.slots[(home + step) & self.mask].freq >>= 1;
+        }
+        coldest.1
+    }
+
+    /// Hand an overwritten entry's arena runs back, so the next entry can use
+    /// them.
+    fn reclaim(&mut self, index: usize) {
+        let slot = self.slots[index];
+        if !slot.spilled() {
+            return;
+        }
+        self.key_bytes
+            .release(slot.key_off(), slot.key_len as usize);
+        self.ids.release(slot.ids_off(), slot.ids_len());
     }
 }
 
@@ -290,8 +552,20 @@ mod tests {
         assert_eq!(cache.get(b"hell"), None);
     }
 
+    /// The three properties the whole key encoding rests on: a packed key is
+    /// unique per word, is never `0` (the empty-slot marker), and never looks
+    /// like a hashed key.
     #[test]
-    fn oversized_keys_are_ignored() {
+    fn packed_keys_are_unique_and_tagged() {
+        assert_ne!(pack_word(b"a"), pack_word(b"a\0"));
+        assert_ne!(pack_word(&[0u8; 15]), Some(0));
+        assert_eq!(pack_word(&[0u8; 15]).unwrap() & LONG_TAG, 0);
+        assert_eq!(pack_word(b""), None);
+        assert_eq!(pack_word(&[b'x'; 16]), None);
+    }
+
+    #[test]
+    fn oversized_words_are_ignored() {
         let mut cache = WordCache::new(1 << 8);
         let big = vec![7u8; MAX_LENGTH + 1];
         cache.insert(&big, [1u32].into_iter());
@@ -299,24 +573,49 @@ mod tests {
     }
 
     /// Both sides of the 15-byte packing boundary and both sides of the inline/
-    /// arena boundary have to survive a round trip, including the long key whose
+    /// arena boundary have to survive a round trip, including the long word whose
     /// stored `key` is only a hash and needs the byte comparison to confirm it.
     #[test]
     fn every_slot_shape_round_trips() {
         let mut cache = WordCache::new(1 << 8);
         let long = vec![b'x'; 200];
-        let cases: [(&[u8], Vec<u32>); 4] = [
+        let cases: [(&[u8], Vec<u32>); 6] = [
             (b"short", vec![1]),
             (b"short-wide", (0..40).collect()),
+            (b"fifteen-bytes.", vec![2]),
+            (b"sixteen-bytes.aa", vec![3]),
             (&long, vec![9]),
             (&long[..64], (0..64).collect()),
         ];
-        for (key, ids) in &cases {
-            cache.insert(key, ids.clone().into_iter());
+        for (word, ids) in &cases {
+            cache.insert(word, ids.clone().into_iter());
         }
-        for (key, ids) in &cases {
-            assert_eq!(cache.get(key), Some(&ids[..]), "{key:?}");
+        for (word, ids) in &cases {
+            assert_eq!(cache.get(word), Some(&ids[..]), "{word:?}");
         }
+    }
+
+    /// Two long words can hash to the same key, and then only their bytes tell
+    /// them apart. Real hash collisions are too rare to write a test around, so
+    /// forge one: park another word's entry on this word's home slot and stamp
+    /// this word's key on it. The lookup has to walk past it.
+    #[test]
+    fn a_hashed_key_is_confirmed_against_the_word_bytes() {
+        let mut cache = WordCache::new(1 << 8);
+        let mine = vec![b'a'; 40];
+        let theirs = vec![b'b'; 40];
+
+        cache.insert(&theirs, [7u32].into_iter());
+        let (their_key, their_hash) = cache.slot_key(&theirs);
+        let their_slot = cache.slots[cache.find(their_key, their_hash, &theirs).unwrap()];
+        let (my_key, my_hash) = cache.slot_key(&mine);
+        cache.slots[my_hash as usize & cache.mask] = Slot {
+            key: my_key,
+            ..their_slot
+        };
+
+        cache.insert(&mine, [1u32, 2].into_iter());
+        assert_eq!(cache.get(&mine), Some(&[1u32, 2][..]));
     }
 
     /// A word that hashes into a full window takes the coldest slot rather than
@@ -324,24 +623,24 @@ mod tests {
     #[test]
     fn a_full_window_evicts_its_coldest_entry() {
         let mut cache = WordCache::new(WINDOW);
-        let keys: Vec<Vec<u8>> = (0..WINDOW as u8).map(|i| vec![i; 4]).collect();
-        for (i, key) in keys.iter().enumerate() {
-            cache.insert(key, [i as u32].into_iter());
+        let words: Vec<Vec<u8>> = (0..WINDOW as u8).map(|i| vec![i; 4]).collect();
+        for (i, word) in words.iter().enumerate() {
+            cache.insert(word, [i as u32].into_iter());
         }
-        // Every key but the first earns a hit, leaving one clear coldest slot.
-        for key in &keys[1..] {
-            assert!(cache.get(key).is_some());
+        // Every word but the first earns a hit, leaving one clear coldest slot.
+        for word in &words[1..] {
+            assert!(cache.get(word).is_some());
         }
         cache.insert(b"newcomer", [999u32].into_iter());
         assert_eq!(cache.get(b"newcomer"), Some(&[999u32][..]));
         assert_eq!(
-            cache.get(&keys[0]),
+            cache.get(&words[0]),
             None,
             "the unused entry should have gone"
         );
-        for (i, key) in keys.iter().enumerate().skip(1) {
+        for (i, word) in words.iter().enumerate().skip(1) {
             assert_eq!(
-                cache.get(key),
+                cache.get(word),
                 Some(&[i as u32][..]),
                 "used entry {i} was dropped"
             );
@@ -357,7 +656,7 @@ mod tests {
         let mut cache = WordCache::new(64);
         let mut expected: Vec<(Vec<u8>, Vec<u32>)> = Vec::new();
         for i in 0..2000usize {
-            let key = match i % 4 {
+            let word = match i % 4 {
                 0 => format!("w{i}"),
                 1 => format!("a-long-word-past-fifteen-bytes-{i}"),
                 2 => format!("k{i}xxxxxxxxxxxx"),
@@ -365,30 +664,38 @@ mod tests {
             }
             .into_bytes();
             let ids: Vec<u32> = (0..=(i % 9) as u32).map(|k| i as u32 * 16 + k).collect();
-            cache.insert(&key, ids.clone().into_iter());
-            expected.push((key, ids));
+            cache.insert(&word, ids.clone().into_iter());
+            expected.push((word, ids));
         }
         let mut live = 0;
-        for (key, ids) in &expected {
-            if let Some(hit) = cache.get(key) {
-                assert_eq!(hit, &ids[..], "{key:?}");
+        for (word, ids) in &expected {
+            if let Some(hit) = cache.get(word) {
+                assert_eq!(hit, &ids[..], "{word:?}");
                 live += 1;
             }
         }
         assert!(live > 0, "everything was evicted — the test proves nothing");
     }
 
-    /// Freed runs have to come back. Without reuse the arenas would grow with
-    /// every insert and the cache would be leaking rather than evicting.
+    /// Freed runs have to come back. Without reuse the arenas grow with every
+    /// insert until their budget is spent, and from then on the cache silently
+    /// stops accepting words even though the table has room for them.
     #[test]
     fn arenas_hold_the_live_set_not_every_insert() {
         let mut cache = WordCache::new(64);
+        // Same length every time, so one free list serves every word and the
+        // bounds below are exact: 64 slots, plus the run reserved for the insert
+        // in flight before the entry it replaces gives its own run back.
+        let word = |i: usize| format!("a-long-word-past-fifteen-bytes-{i:04}");
         for i in 0..5000usize {
-            let key = format!("a-long-word-past-fifteen-bytes-{i}");
-            cache.insert(key.as_bytes(), [i as u32; 8].into_iter());
+            cache.insert(word(i).as_bytes(), [i as u32; 8].into_iter());
         }
-        // 64 slots can hold at most 64 keys of ~34 bytes and 64 runs of 8 ids.
-        assert!(cache.key_bytes.data.len() < 8 * 1024);
-        assert!(cache.ids.data.len() < 8 * 1024);
+        assert_eq!(
+            cache.get(word(4999).as_bytes()),
+            Some(&[4999u32; 8][..]),
+            "inserts stopped landing — the arenas ran out"
+        );
+        assert!(cache.key_bytes.data.len() <= 65 * 35);
+        assert!(cache.ids.data.len() <= 65 * 8);
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -476,11 +476,18 @@ impl WordCache {
     /// The value a slot stores in its `key`, and the hash that places it. A short
     /// word is its own key; a longer one keys on a tagged hash and has to be
     /// confirmed against `key_bytes`, since two long words can hash alike.
+    ///
+    /// A packed key is hashed as one `u128`, not as the word's bytes it was built
+    /// from. Hashing a slice makes aHash mix the length in and then branch on it to
+    /// choose a read width; a `u128` is one fixed-width fold with nothing to decide.
+    /// The key already carries the length, so nothing is lost.
     fn slot_key(&self, word: &[u8]) -> (u128, u64) {
-        let hash = self.hasher.hash_one(word);
         match pack_word(word) {
-            Some(packed) => (packed, hash),
-            None => ((hash as u128) | LONG_TAG, hash),
+            Some(packed) => (packed, self.hasher.hash_one(packed)),
+            None => {
+                let hash = self.hasher.hash_one(word);
+                ((hash as u128) | LONG_TAG, hash)
+            }
         }
     }
 
@@ -646,6 +653,24 @@ mod tests {
         assert_eq!(pack_word(&[0u8; 15]).unwrap() & LONG_TAG, 0);
         assert_eq!(pack_word(b""), None);
         assert_eq!(pack_word(&[b'x'; 16]), None);
+    }
+
+    /// A short word's placement now comes out of its packed key rather than its
+    /// bytes, which leaves the hash doing all of the mixing. Words that differ in
+    /// one byte pack to keys that differ in one byte, so an index taken from those
+    /// bits as they are — `packed as u64` — drops most of these on one slot.
+    #[test]
+    fn short_words_spread_across_the_table() {
+        let cache = WordCache::new(1 << 12);
+        let homes: std::collections::HashSet<usize> = (0..1000)
+            .map(|i| {
+                let (_, hash) = cache.slot_key(format!("tok{i}").as_bytes());
+                hash as usize & cache.mask
+            })
+            .collect();
+        // 1000 words over 4096 slots share homes by chance alone; ~887 distinct is
+        // as good as a perfect hash gets, so the floor is well under it.
+        assert!(homes.len() > 820, "only {} distinct homes", homes.len());
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/models/bpe/word_cache.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word_cache.rs
@@ -250,6 +250,8 @@
 
 use ahash::RandomState;
 
+use crate::utils::packed_key::{LONG_TAG, pack};
+
 /// Longest word the cache will store, in bytes.
 ///
 /// Long words are rare and rarely repeat, so storing them buys little, and the
@@ -272,48 +274,12 @@ const INLINE_IDS: usize = 3;
 /// `len` marker for an entry whose ids, and possibly whose bytes, are in the
 /// arenas.
 const SPILLED: u8 = u8::MAX;
-/// Set in `key` when it holds the hash of a long word instead of the word
-/// itself. Packed keys carry their length (1..=15) in the top byte, so a hashed
-/// key can never be mistaken for a packed one, and neither can be 0 — the
-/// empty-slot marker.
-const LONG_TAG: u128 = 1 << 127;
 /// A `freqs` entry for a slot nothing has been stored in yet. Live entries are at
 /// least [`NEWBORN`], so the one array answers both "is this slot free?" and "how
 /// much is this entry being used?" — see [`WordCache::pick_slot`].
 const FREE: u8 = 0;
 /// Where a new entry's frequency starts: on probation, but not free.
 const NEWBORN: u8 = 1;
-
-/// A word of 1..=15 bytes packed into a `u128`: bytes in the low lanes, length
-/// in the top byte. Including the length keeps `"a"` and `"a\0"` apart, and the
-/// whole key comparison becomes one register-wide equality instead of a
-/// `memcmp` against bytes somewhere else in memory.
-///
-/// `head` is 16 bytes starting where the word does, which callers that know what
-/// surrounds the word can hand over — see `Split::head`. Taking the whole window
-/// and masking the surplus off costs one load, where copying just the word's own
-/// bytes costs a call into `memcpy`: its length is only known at run time, and
-/// LLVM can fold a copy into a load only when the length is a constant. That one
-/// call was about a third of what building a key cost.
-fn pack_word(word: &[u8], head: Option<&[u8; 16]>) -> Option<u128> {
-    let len = word.len();
-    if len == 0 || len > 15 {
-        return None;
-    }
-    debug_assert!(
-        head.is_none_or(|head| head[..len] == *word),
-        "head has to start where the word does"
-    );
-    let lanes = match head {
-        Some(head) => u128::from_le_bytes(*head),
-        None => {
-            let mut lanes = [0u8; 16];
-            lanes[..len].copy_from_slice(word);
-            u128::from_le_bytes(lanes)
-        }
-    };
-    Some((lanes & (u128::MAX >> (8 * (16 - len)))) | ((len as u128) << 120))
-}
 
 /// One entry, in the three shapes the module docs draw out. In short:
 ///
@@ -507,7 +473,7 @@ impl WordCache {
     /// choose a read width; a `u128` is one fixed-width fold with nothing to decide.
     /// The key already carries the length, so nothing is lost.
     fn slot_key(&self, word: &[u8], head: Option<&[u8; 16]>) -> (u128, u64) {
-        match pack_word(word, head) {
+        match pack(word, head) {
             Some(packed) => (packed, self.hasher.hash_one(packed)),
             None => {
                 let hash = self.hasher.hash_one(word);
@@ -668,37 +634,23 @@ mod tests {
         assert_eq!(cache.get(b"hell", None), None);
     }
 
-    /// The three properties the whole key encoding rests on: a packed key is
-    /// unique per word, is never `0` (the empty-slot marker), and never looks
-    /// like a hashed key.
+    /// A word stored without a window has to be found with one, and vice versa —
+    /// otherwise a hit in a real encode would depend on where in its chunk the word
+    /// happened to sit. The key encoding is tested in [`crate::utils::packed_key`];
+    /// this is the same property seen through the table.
     #[test]
-    fn packed_keys_are_unique_and_tagged() {
-        assert_ne!(pack_word(b"a", None), pack_word(b"a\0", None));
-        assert_ne!(pack_word(&[0u8; 15], None), Some(0));
-        assert_eq!(pack_word(&[0u8; 15], None).unwrap() & LONG_TAG, 0);
-        assert_eq!(pack_word(b"", None), None);
-        assert_eq!(pack_word(&[b'x'; 16], None), None);
-    }
-
-    /// The window is a shortcut for reading the word, not part of what is stored:
-    /// the bytes it carries past the word belong to the neighbours and have to be
-    /// masked away. If any of them survived into the key, a word looked up with a
-    /// window would miss the entry stored without one — and every hit in a real
-    /// encode would depend on where in its chunk the word happened to sit.
-    #[test]
-    fn the_window_past_the_word_is_masked_off() {
+    fn a_window_does_not_change_what_the_cache_finds() {
         let chunk = b"the quick brown fox jumps over the lazy dog";
         let mut cache = WordCache::new(1 << 8);
         for (start, len) in [(0usize, 3usize), (4, 5), (10, 5), (16, 3), (26, 4)] {
             let word = &chunk[start..start + len];
             let head: &[u8; 16] = chunk[start..start + 16].try_into().unwrap();
+            cache.insert(word, None, [start as u32].into_iter());
             assert_eq!(
-                cache.slot_key(word, None),
-                cache.slot_key(word, Some(head)),
+                cache.get(word, Some(head)),
+                Some(&[start as u32][..]),
                 "{word:?}"
             );
-            cache.insert(word, None, [start as u32].into_iter());
-            assert_eq!(cache.get(word, Some(head)), Some(&[start as u32][..]));
         }
     }
 

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -522,11 +522,11 @@ impl pipeline::Model for Unigram {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         _scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
-        let str_tokens = self.encode(sequence)?;
+        let str_tokens = self.encode(split.as_str())?;
 
         for string in str_tokens {
             match self.token_to_ids.token_to_id(&string) {

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -220,11 +220,11 @@ impl pipeline::Model for WordLevel {
     fn init_scratch(&self) -> Self::Scratch {}
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         _scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
-        if let Some(&id) = self.vocab.get(sequence) {
+        if let Some(&id) = self.vocab.get(split.as_str()) {
             output.push(PipelineToken { id })
         } else if let Some(&unk_id) = self.vocab.get(&self.unk_token) {
             output.push(PipelineToken { id: unk_id });

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -370,10 +370,11 @@ impl pipeline::Model for PipelineWordPiece {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
+        let sequence = split.as_str();
         let checkpoint = output.len();
         let candidate = &mut scratch.candidate_str;
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1041,6 +1041,11 @@ impl Model for PipelineModel {
     }
 }
 
+// The BPE variant carries the word cache inline, making it much larger than the
+// others. Boxing it would put a pointer chase on the per-pre-token hot path to
+// save space in a struct that exists once per thread and is never moved after
+// the pool builds it.
+#[allow(clippy::large_enum_variant)]
 #[derive(Default)]
 pub enum PipelineModelScratch {
     BPE(BpeScratch),

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
 use std::mem;
+use std::ops::Range;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::{borrow::Cow, convert::TryFrom};
 
@@ -702,7 +703,7 @@ impl PipelineTokenizer {
                                         // Tokenize each chunk
                                         for pre_token in pre_tokens.iter() {
                                             self.model.tokenize_pipeline(
-                                                &normalized_chunk[pre_token.range()],
+                                                Split::new(normalized_chunk, pre_token.range()),
                                                 scratch,
                                                 output,
                                             )?;
@@ -981,12 +982,62 @@ pub trait ModelScratch: Default {
     fn clear(&mut self);
 }
 
+/// One pre-token on its way to a model: the word to tokenize, plus the chunk of
+/// text it was split out of.
+///
+/// A model that only wants the word calls [`Split::as_str`] and is none the wiser.
+/// The chunk is carried for [`Split::head`], which hands out a fixed-size window
+/// of bytes starting at the word — the BPE word cache builds its key out of one,
+/// because copying a fixed number of bytes compiles to a load, where copying a
+/// number known only at run time is a call into `memcpy`.
+#[derive(Clone, Copy)]
+pub struct Split<'a> {
+    word: &'a str,
+    head: Option<&'a [u8; 16]>,
+}
+
+impl<'a> Split<'a> {
+    /// `range` is a byte range of `chunk`, the way a pre-tokenizer reports it.
+    pub fn new(chunk: &'a str, range: Range<usize>) -> Self {
+        Self {
+            word: &chunk[range.clone()],
+            head: chunk.as_bytes()[range.start..].first_chunk(),
+        }
+    }
+
+    pub fn as_str(&self) -> &'a str {
+        self.word
+    }
+
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.word.as_bytes()
+    }
+
+    /// The 16 bytes of the chunk that start where the word does. Anything past the
+    /// word's own length belongs to whatever follows it, so a caller has to know
+    /// how much of the window means something.
+    ///
+    /// `None` when the word starts within 16 bytes of the chunk's end and there is
+    /// nothing to read — at most one word per chunk.
+    pub fn head(&self) -> Option<&'a [u8; 16]> {
+        self.head
+    }
+}
+
+/// A bare word, with no chunk around it: there is a window only when the word is
+/// long enough to fill one on its own.
+impl<'a> From<&'a str> for Split<'a> {
+    fn from(word: &'a str) -> Self {
+        Self::new(word, 0..word.len())
+    }
+}
+
 pub trait Model {
     type Scratch: ModelScratch;
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()>;
@@ -1010,22 +1061,22 @@ impl Model for PipelineModel {
 
     fn tokenize_pipeline(
         &self,
-        sequence: &str,
+        split: Split<'_>,
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
         match (self, scratch) {
             (Self::BPE(model), PipelineModelScratch::BPE(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             (Self::Unigram(model), PipelineModelScratch::Unigram(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             (Self::WordLevel(model), PipelineModelScratch::WordLevel(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
-                model.tokenize_pipeline(sequence, scratch, output)
+                model.tokenize_pipeline(split, scratch, output)
             }
             _ => unreachable!(),
         }
@@ -1075,6 +1126,29 @@ mod tests {
     use crate::models::wordpiece::WordPiece;
     use crate::pre_tokenizers::byte_level::ByteLevel;
     use crate::pre_tokenizers::sequence::Sequence;
+
+    /// Everything the window is good for rests on it starting at the word's first
+    /// byte and staying inside the chunk. A window taken from the wrong offset
+    /// would silently key one word's cache entry on another word's bytes.
+    #[test]
+    fn a_splits_window_starts_at_the_word_and_stops_at_the_chunk() {
+        let chunk = "the quick brown fox jumps";
+        let word = Split::new(chunk, 4..9);
+        assert_eq!(word.as_str(), "quick");
+        assert_eq!(word.head(), Some(b"quick brown fox "));
+
+        // A word near the end has no window: 25 - 20 is under 16 bytes.
+        let last = Split::new(chunk, 20..25);
+        assert_eq!(last.as_str(), "jumps");
+        assert_eq!(last.head(), None);
+
+        // A bare word is its own chunk, so it only has a window if it fills one.
+        assert_eq!(Split::from("quick").head(), None);
+        assert_eq!(
+            Split::from("sixteen bytes ok").head(),
+            Some(b"sixteen bytes ok")
+        );
+    }
 
     struct FixedMatcher(Vec<((usize, usize), u32)>);
     impl PipelinePatternMatcher for FixedMatcher {

--- a/tokenizers/tk-encode/src/utils/mod.rs
+++ b/tokenizers/tk-encode/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod cache;
 #[cfg(feature = "http")]
 pub(crate) mod from_pretrained;
+pub(crate) mod packed_key;
 
 // Optional system-regex backend for arbitrary (non-atomsplit) patterns. With `fancy-regex` off a
 // stub compiles and arbitrary-regex features error at load — the atomsplit-native pre-tokenizers

--- a/tokenizers/tk-encode/src/utils/packed_key.rs
+++ b/tokenizers/tk-encode/src/utils/packed_key.rs
@@ -1,0 +1,88 @@
+//! A short byte string as a `u128`, so that comparing two of them is one
+//! register-wide equality instead of a `memcmp` against bytes somewhere else in
+//! memory.
+//!
+//! Used by anything that keys on token or word bytes — the BPE word cache and the
+//! vocabulary store both do. They share this rather than each holding a copy,
+//! because the two would have to agree byte for byte and nothing would catch them
+//! drifting apart: a key built one way and compared the other is not a crash, it is
+//! a silently wrong token id.
+//!
+//! ```text
+//!   b"tion"                 │ t  i  o  n  00 … 00 │ 4 │   bytes, then the length
+//!   b"unbelievabilities"    │        hash         │▲│     too long: only a hash
+//!                                                  └ LONG_TAG
+//! ```
+//!
+//! The length in the top byte does two jobs: it keeps `"a"` and `"a\0"` apart, and
+//! it means a packed key can never be `0` or collide with a [`LONG_TAG`] one.
+
+/// Longest byte string that fits in a key. One byte of the sixteen holds the
+/// length.
+pub(crate) const MAX_PACKED: usize = 15;
+
+/// Set when the key holds a hash instead of the bytes themselves. A holder of such
+/// a key has to confirm a match against the real bytes, since two long strings can
+/// hash alike.
+pub(crate) const LONG_TAG: u128 = 1 << 127;
+
+/// `word` as a key, or `None` when it is empty or longer than [`MAX_PACKED`] and
+/// the caller has to fall back to a hash.
+///
+/// `head` is 16 readable bytes starting where `word` does, which a caller that
+/// knows what surrounds it can hand over — a pre-tokenized word has the rest of its
+/// chunk after it, so `Split::head` supplies one. Reading the whole window and
+/// masking the surplus off costs one load, where copying just `word`'s own bytes
+/// costs a call into `memcpy`: the length is only known at run time, and LLVM folds
+/// a copy into a load only when the length is a constant. Passing `None` is correct
+/// and produces the same key, it just pays for that call.
+#[inline]
+pub(crate) fn pack(word: &[u8], head: Option<&[u8; 16]>) -> Option<u128> {
+    let len = word.len();
+    if len == 0 || len > MAX_PACKED {
+        return None;
+    }
+    debug_assert!(
+        head.is_none_or(|head| head[..len] == *word),
+        "head has to start where the word does"
+    );
+    let lanes = match head {
+        Some(head) => u128::from_le_bytes(*head),
+        None => {
+            let mut lanes = [0u8; 16];
+            lanes[..len].copy_from_slice(word);
+            u128::from_le_bytes(lanes)
+        }
+    };
+    Some((lanes & (u128::MAX >> (8 * (16 - len)))) | ((len as u128) << 120))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The properties every holder of a key relies on: it is unique per byte
+    /// string, is never `0` (which callers use as "nothing here"), and never looks
+    /// like a hashed key.
+    #[test]
+    fn a_packed_key_is_unique_and_never_looks_long() {
+        assert_ne!(pack(b"a", None), pack(b"a\0", None));
+        assert_ne!(pack(&[0u8; 15], None), Some(0));
+        assert_eq!(pack(&[0u8; 15], None).unwrap() & LONG_TAG, 0);
+        assert_eq!(pack(b"", None), None);
+        assert_eq!(pack(&[b'x'; 16], None), None);
+    }
+
+    /// The window is a cheaper way to read the same bytes, not part of the key. If
+    /// any byte past the word survived, the same word would key differently
+    /// depending on what happened to follow it.
+    #[test]
+    fn the_window_past_the_word_is_masked_off() {
+        let chunk = b"the quick brown fox jumps over the lazy dog";
+        for (start, len) in [(0usize, 3usize), (4, 5), (10, 5), (16, 3), (26, 4)] {
+            let word = &chunk[start..start + len];
+            let head: &[u8; 16] = chunk[start..start + 16].try_into().unwrap();
+            assert_eq!(pack(word, None), pack(word, Some(head)), "{word:?}");
+        }
+    }
+}

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -4,6 +4,8 @@ use ahash::RandomState;
 use ptr_hash::{FastPtrHash, PtrHashParams, hash::NoHash};
 use std::fmt;
 
+use crate::utils::packed_key::{LONG_TAG, pack};
+
 type Mphf = FastPtrHash<NoHash, u64>;
 
 // Fixed seeds so a given vocab always hashes identically (the hasher is also stored on the struct,
@@ -15,12 +17,30 @@ const SEEDS: [u64; 4] = [
     0x082E_FA98_EC4E_6C89,
 ];
 
-#[derive(Clone, Copy, Debug)]
+/// One slot. `key` is the token itself when it fits in 15 bytes, otherwise its hash
+/// with `LONG_TAG` set — see [`crate::utils::packed_key`].
+///
+/// Carrying the token here rather than only its coordinates is what makes a lookup
+/// one memory access instead of two: confirming a hit is a register compare, so
+/// `start`/`len` and the `bytes` slab are only touched for a token too long to pack.
+/// That costs 32 bytes a slot against 12 (`key`'s alignment rounds 28 up), which on
+/// llama-3's 128k tokens is 4.1 MB of entries against 1.5 MB. Measured on real
+/// vocabularies and real pre-tokenized words it halves `get_bytes` on English and
+/// code — `examples/vocab_entry_bench.rs` runs both layouts in one binary.
+///
+/// `len == 0` still marks a slot the build never wrote, which is what the
+/// enumeration paths filter on.
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
 struct Entry {
+    key: u128,
+    id: u32,
     start: u32,
     len: u16,
-    id: u32,
+    _pad: u16,
 }
+
+const _: () = assert!(std::mem::size_of::<Entry>() == 32);
 
 /// The BucketVocabStore optimizes for space and speed. We don't use a HashMap to prevent duplicating the
 /// keys. Instead, we just use an `id_to_slot` and `entries` table. When you query bytes, you hash
@@ -87,16 +107,36 @@ impl Default for BucketVocabStore {
     }
 }
 
+/// What a slot stores in its `key`, and the hash that places it.
+///
+/// A free function rather than a method because [`BucketVocabStore::build`] needs it
+/// before there is a store, and both must derive the key the same way: the MPHF is
+/// built from these hashes, so two derivations means every lookup misses.
+#[inline]
+fn slot_key(hasher: &RandomState, token: &[u8], head: Option<&[u8; 16]>) -> (u128, u64) {
+    match pack(token, head) {
+        // The key is the token, so it is also the whole hash input — one fixed-width
+        // fold, where hashing the slice would mix the length in and then branch on it.
+        Some(packed) => (packed, hasher.hash_one(packed)),
+        None => {
+            let hash = hasher.hash_one(token);
+            ((hash as u128) | LONG_TAG, hash)
+        }
+    }
+}
+
 impl BucketVocabStore {
     pub fn build(tokens: Vec<(Vec<u8>, u32)>) -> Self {
         let n = tokens.len();
 
         let hasher = RandomState::with_seeds(SEEDS[0], SEEDS[1], SEEDS[2], SEEDS[3]);
 
-        // 1. Pre-hash token bytes -> u64 keys using near perfect hash func
+        // 1. Pre-hash tokens -> u64 keys using near perfect hash func. Goes through
+        //    `slot_key` because a query has to land on the same key, and the MPHF is
+        //    built from these: derive them two different ways and every lookup misses.
         let keys: Vec<u64> = tokens
             .iter()
-            .map(|(s, _)| hasher.hash_one(s.as_slice()))
+            .map(|(s, _)| slot_key(&hasher, s, None).1)
             .collect();
 
         // 2. A perfect hash needs distinct keys. Collisions are astronomically unlikely
@@ -131,14 +171,7 @@ impl BucketVocabStore {
         let total: usize = tokens.iter().map(|(s, _)| s.len()).sum();
         let max_id = tokens.iter().map(|(_, id)| *id).max().unwrap();
         let mut bytes = Vec::with_capacity(total);
-        let mut entries = vec![
-            Entry {
-                start: 0,
-                len: 0,
-                id: 0
-            };
-            n_slots
-        ];
+        let mut entries = vec![Entry::default(); n_slots];
         let mut id_to_slot = vec![u32::MAX; max_id as usize + 1];
         let mut longest_token_len = 0;
         for (s, id) in &tokens {
@@ -146,11 +179,14 @@ impl BucketVocabStore {
                 s.len() <= u16::MAX as usize,
                 "token longer than 65535 bytes"
             );
-            let slot = mphf.index(&hasher.hash_one(s.as_slice()));
+            let (key, hash) = slot_key(&hasher, s, None);
+            let slot = mphf.index(&hash);
             entries[slot] = Entry {
+                key,
+                id: *id,
                 start: bytes.len() as u32,
                 len: s.len() as u16,
-                id: *id,
+                _pad: 0,
             };
             id_to_slot[*id as usize] = slot as u32;
             bytes.extend_from_slice(s);
@@ -186,30 +222,36 @@ impl BucketVocabStore {
     /// corresponding to the key `q`. Since `mphf` always return a slot, we check
     /// whether the token indexed by that slot actually match the query. We don't
     /// care about collisions on query because of this!
+    ///
+    /// `head` is 16 readable bytes starting where `q` does, when the caller has them
+    /// — a pre-tokenized word has the rest of its chunk behind it, so `Split::head`
+    /// supplies one. `None` is always correct and returns the same id; it just packs
+    /// the query with a copy whose length is known only at run time, which on real
+    /// vocabularies is the difference between halving this function's cost and
+    /// shaving a tenth off it.
     #[inline]
-    pub fn get_bytes(&self, q: &[u8]) -> Option<u32> {
-        if self.entries.is_empty() {
+    pub fn get_bytes(&self, q: &[u8], head: Option<&[u8; 16]>) -> Option<u32> {
+        if self.entries.is_empty() || q.len() > self.longest_token_len {
             return None;
         }
-        if q.len() > self.longest_token_len {
-            return None
+        let (key, hash) = slot_key(&self.hasher, q, head);
+        let e = self.entries[self.mphf.index(&hash)];
+        if e.key != key {
+            return None;
         }
-        let slot = self.mphf.index(&self.hasher.hash_one(q));
-
-        let e = self.entries[slot];
+        // A packed key *is* the token, so an equal key is an equal token and there is
+        // nothing left to check. A tagged one is only a hash, and two long tokens can
+        // hash alike, so that case still confirms against the bytes.
+        if key & LONG_TAG == 0 {
+            return Some(e.id);
+        }
         let (start, len) = (e.start as usize, e.len as usize);
-        // Byte equality: confirms `q` really is the token at this slot (perfect hashing only
-        // guarantees a valid slot for in-vocab keys; this rejects collisions and Out Of Vocab queries).
-        if len == q.len() && self.bytes[start..start + len] == *q {
-            Some(e.id)
-        } else {
-            None
-        }
+        (len == q.len() && self.bytes[start..start + len] == *q).then_some(e.id)
     }
 
     #[inline]
     pub fn token_to_id(&self, s: &str) -> Option<u32> {
-        self.get_bytes(s.as_bytes())
+        self.get_bytes(s.as_bytes(), None)
     }
 
     /// `id -> token bytes`, borrowing from the slab (no allocation).
@@ -292,7 +334,7 @@ mod tests {
         let vocab = BucketVocabStore::build(toks.clone());
 
         for (s, id) in &toks {
-            assert_eq!(vocab.get_bytes(s), Some(*id), "fwd {s:?}");
+            assert_eq!(vocab.get_bytes(s, None), Some(*id), "fwd {s:?}");
             assert_eq!(vocab.id_to_token_bytes(*id), Some(s.as_slice()), "rev {id}");
         }
         for q in ["", "zzz", "th", "theX", "fo", "doggo"] {
@@ -300,6 +342,40 @@ mod tests {
         }
         assert_eq!(vocab.id_to_token(n as u32), None);
         assert_eq!(vocab.len(), n);
+    }
+
+    /// A token past 15 bytes keys on a hash instead of on its own bytes, so its slot
+    /// still needs the byte comparison that a packed key makes unnecessary. Nothing
+    /// else in this module reaches that branch.
+    #[test]
+    fn long_tokens_are_confirmed_against_their_bytes() {
+        let long = b"a-token-well-past-fifteen-bytes".to_vec();
+        let other = b"another-token-of-the-same-size!".to_vec();
+        assert_eq!(long.len(), other.len(), "the point is a same-length miss");
+        let vocab = BucketVocabStore::build(vec![(long.clone(), 7), (b"short".to_vec(), 1)]);
+
+        assert_eq!(vocab.get_bytes(&long, None), Some(7));
+        assert_eq!(vocab.id_to_token_bytes(7), Some(long.as_slice()));
+        // Not in the vocabulary: it lands on some slot regardless, and only the bytes
+        // say so. The length check cannot help here.
+        assert_eq!(vocab.get_bytes(&other, None), None);
+    }
+
+    /// The window is a cheaper way to read the query, not part of the key, so it must
+    /// not change the answer — for a packed key or a hashed one.
+    #[test]
+    fn a_window_does_not_change_the_id() {
+        let chunk = b"short a-token-well-past-fifteen-bytes tail-padding-so-a-window-exists";
+        let vocab = BucketVocabStore::build(vec![
+            (b"short".to_vec(), 1),
+            (b"a-token-well-past-fifteen-bytes".to_vec(), 7),
+        ]);
+        for (start, len, want) in [(0usize, 5usize, Some(1)), (6, 31, Some(7)), (38, 4, None)] {
+            let q = &chunk[start..start + len];
+            let head: &[u8; 16] = chunk[start..start + 16].try_into().unwrap();
+            assert_eq!(vocab.get_bytes(q, None), want, "{q:?}");
+            assert_eq!(vocab.get_bytes(q, Some(head)), want, "{q:?} with a window");
+        }
     }
 
     #[test]
@@ -325,7 +401,7 @@ mod tests {
         assert!(vocab.is_empty());
         assert_eq!(vocab.len(), 0);
         assert_eq!(vocab.token_to_id("anything"), None);
-        assert_eq!(vocab.get_bytes(b""), None);
+        assert_eq!(vocab.get_bytes(b"", None), None);
         assert_eq!(vocab.id_to_token(0), None);
         assert!(vocab.content().is_empty());
     }
@@ -358,7 +434,7 @@ mod tests {
     fn non_utf8_token_is_lossy_on_string_but_exact_on_bytes() {
         let raw = vec![0xffu8, 0xfe];
         let vocab = BucketVocabStore::build(vec![(raw.clone(), 0)]);
-        assert_eq!(vocab.get_bytes(&raw), Some(0));
+        assert_eq!(vocab.get_bytes(&raw, None), Some(0));
         assert_eq!(vocab.id_to_token_bytes(0), Some(raw.as_slice()));
         assert_eq!(vocab.id_to_token(0), Some("\u{fffd}\u{fffd}".to_string()));
     }

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -54,6 +54,7 @@ pub struct BucketVocabStore {
     /// MPHF's non-minimal slot range (with phantom padding slots), so its length is not the
     /// token count.
     n: usize,
+    longest_token_len: usize,
 }
 
 impl fmt::Debug for BucketVocabStore {
@@ -139,6 +140,7 @@ impl BucketVocabStore {
             n_slots
         ];
         let mut id_to_slot = vec![u32::MAX; max_id as usize + 1];
+        let mut longest_token_len = 0;
         for (s, id) in &tokens {
             assert!(
                 s.len() <= u16::MAX as usize,
@@ -152,6 +154,7 @@ impl BucketVocabStore {
             };
             id_to_slot[*id as usize] = slot as u32;
             bytes.extend_from_slice(s);
+            longest_token_len = longest_token_len.max(s.len())
         }
 
         Self {
@@ -161,6 +164,7 @@ impl BucketVocabStore {
             entries: entries.into_boxed_slice(),
             id_to_slot: id_to_slot.into_boxed_slice(),
             n,
+            longest_token_len,
         }
     }
 
@@ -174,6 +178,7 @@ impl BucketVocabStore {
             entries: Box::new([]),
             id_to_slot: Box::new([]),
             n: 0,
+            longest_token_len: 0,
         }
     }
 
@@ -185,6 +190,9 @@ impl BucketVocabStore {
     pub fn get_bytes(&self, q: &[u8]) -> Option<u32> {
         if self.entries.is_empty() {
             return None;
+        }
+        if q.len() > self.longest_token_len {
+            return None
         }
         let slot = self.mphf.index(&self.hasher.hash_one(q));
 

--- a/tokenizers/tk-encode/src/vocab/buckets.rs
+++ b/tokenizers/tk-encode/src/vocab/buckets.rs
@@ -316,7 +316,9 @@ impl Buckets {
         for &len in bucket.length_list[length_id as usize].iter() {
             let len = len as usize;
             if pos + len <= n
-                && let Some(id) = self.vocab.get_bytes(&bytes[pos..pos + len])
+                && let Some(id) = self
+                    .vocab
+                    .get_bytes(&bytes[pos..pos + len], bytes[pos..].first_chunk())
             {
                 return Some((id, len as u32));
             }

--- a/tokenizers/tk-encode/src/vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab_store.rs
@@ -32,14 +32,16 @@ impl VocabStore {
         Self::default()
     }
 
+    /// `head` is ignored — a map lookup has no key to pack. It is in the signature so
+    /// this stays a drop-in twin of `BucketVocabStore`, which uses it.
     #[inline]
-    pub fn get_bytes(&self, q: &[u8]) -> Option<u32> {
+    pub fn get_bytes(&self, q: &[u8], _head: Option<&[u8; 16]>) -> Option<u32> {
         self.by_bytes.get(q).copied()
     }
 
     #[inline]
     pub fn token_to_id(&self, s: &str) -> Option<u32> {
-        self.get_bytes(s.as_bytes())
+        self.get_bytes(s.as_bytes(), None)
     }
 
     #[inline]


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`e3b285c21 · 2026-07-28 15:08 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 64 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-overview.png" width="860">

**vs base branch** (`709ef7af5`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.89 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 12) · Pipeline 8+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 27.7 | ×3.50 | ×1.01 | 3% (1.2) | 75% (27.0) | 13% (4.7) | 8% (3.0) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 24.6 | ×5.79 | ×0.99 | 3% (1.2) | 68% (27.4) | 8% (3.3) | 21% (8.7) | 0% (0.0) | match |
| ben_Beng | lang | 6.1 | 34.1 | ×5.61 | ×0.98 | 4% (1.2) | 66% (19.3) | 9% (2.8) | 20% (6.0) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 18.8 | ×4.85 | ×1.00 | 2% (1.2) | 70% (37.4) | 10% (5.5) | 16% (8.6) | 1% (0.4) | match |
| ell_Grek | lang | 3.8 | 23.3 | ×6.16 | ×0.98 | 3% (1.2) | 67% (28.6) | 8% (3.4) | 22% (9.3) | 0% (0.0) | match |
| eng_Latn | lang | 4.6 | 18.5 | ×4.06 | ×1.01 | 4% (2.4) | 71% (38.3) | 8% (4.4) | 16% (8.6) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 19.8 | ×4.66 | ×0.99 | 2% (1.2) | 74% (37.0) | 7% (3.6) | 17% (8.3) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 27.3 | ×4.18 | ×1.00 | 3% (1.2) | 74% (26.9) | 8% (3.0) | 15% (5.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 27.0 | ×6.24 | ×0.98 | 3% (1.2) | 63% (23.2) | 13% (4.7) | 21% (7.7) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 27.8 | ×4.51 | ×1.00 | 3% (1.2) | 74% (26.1) | 9% (3.1) | 14% (5.0) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 17.1 | ×7.04 | ×0.97 | 2% (1.2) | 60% (35.0) | 12% (7.3) | 25% (14.8) | 0% (0.1) | match |
| rus_Cyrl | lang | 3.6 | 23.4 | ×6.42 | ×0.98 | 3% (1.2) | 64% (27.3) | 7% (3.2) | 25% (10.8) | 0% (0.0) | match |
| tam_Taml | lang | 7.0 | 38.0 | ×5.43 | ×0.99 | 4% (1.2) | 71% (18.7) | 9% (2.3) | 15% (4.0) | 0% (0.1) | match |
| tha_Thai | lang | 8.3 | 33.5 | ×4.04 | ×1.03 | 4% (1.2) | 83% (24.7) | 7% (2.1) | 6% (1.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.7 | 20.0 | ×2.96 | ×1.01 | 3% (1.3) | 81% (40.1) | 14% (7.0) | 2% (1.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 18.6 | ×3.51 | ×1.01 | 3% (1.8) | 74% (39.4) | 14% (7.2) | 9% (4.5) | 0% (0.0) | match |
| added_special_dense | modalities | 5.4 | 39.2 | ×7.28 | ×1.01 | 19% (4.7) | 38% (9.3) | 35% (8.5) | 8% (1.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 21.7 | ×5.42 | ×1.02 | 7% (3.3) | 61% (27.8) | 19% (8.6) | 15% (6.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.9 | 18.2 | ×4.72 | ×1.00 | 4% (2.2) | 70% (38.2) | 9% (4.9) | 17% (9.2) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 19.5 | ×4.72 | ×1.00 | 3% (1.8) | 75% (38.3) | 8% (3.8) | 14% (7.0) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 19.0 | ×4.81 | ×1.00 | 4% (2.0) | 74% (38.4) | 8% (4.1) | 15% (7.6) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 18.3 | ×4.53 | ×1.00 | 4% (2.3) | 71% (38.2) | 9% (4.8) | 16% (8.9) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×27.50 vs v0.23.1 · ×5.79 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 91+0 (peak 91)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.7 | 84.3 | ×22.69 | ×2.45 | 6% (0.6) | 0% (0.0) | 47% (4.8) | 47% (4.8) | 0% (0.0) | match |
| arb_Arab | lang | 3.4 | 106.1 | ×31.40 | ×6.38 | 7% (0.6) | 0% (0.0) | 42% (3.4) | 53% (4.4) | 0% (0.0) | match |
| ben_Beng | lang | 5.7 | 131.5 | ×22.90 | ×7.37 | 9% (0.6) | 0% (0.0) | 47% (3.1) | 45% (3.0) | 0% (0.0) | match |
| cmn_Hani | lang | 3.2 | 104.5 | ×32.78 | ×6.31 | 9% (0.7) | 0% (0.0) | 38% (3.2) | 52% (4.4) | 1% (0.0) | match |
| ell_Grek | lang | 3.6 | 100.6 | ×27.93 | ×5.63 | 8% (0.6) | 0% (0.0) | 43% (3.4) | 50% (4.0) | 0% (0.0) | match |
| eng_Latn | lang | 2.7 | 80.0 | ×29.90 | ×6.15 | 16% (1.8) | 0% (0.0) | 44% (5.1) | 38% (4.5) | 2% (0.2) | match |
| heb_Hebr | lang | 3.3 | 102.5 | ×31.42 | ×7.90 | 7% (0.6) | 0% (0.0) | 41% (3.6) | 53% (4.6) | 0% (0.0) | match |
| hin_Deva | lang | 5.5 | 125.9 | ×22.76 | ×5.91 | 8% (0.6) | 0% (0.0) | 47% (3.4) | 46% (3.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 3.8 | 125.5 | ×32.59 | ×6.99 | 9% (0.7) | 0% (0.0) | 42% (3.0) | 48% (3.4) | 1% (0.1) | match |
| kat_Geor | lang | 5.5 | 133.6 | ×24.43 | ×7.69 | 9% (0.6) | 0% (0.0) | 44% (3.0) | 47% (3.2) | 0% (0.0) | match |
| kor_Hang | lang | 2.8 | 82.5 | ×29.85 | ×4.17 | 6% (0.6) | 0% (0.0) | 35% (3.7) | 59% (6.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.6 | 114.2 | ×31.67 | ×8.06 | 8% (0.6) | 0% (0.0) | 44% (3.3) | 46% (3.5) | 2% (0.2) | match |
| tam_Taml | lang | 5.5 | 146.2 | ×26.42 | ×8.38 | 10% (0.6) | 0% (0.0) | 45% (2.7) | 45% (2.7) | 1% (0.0) | match |
| tha_Thai | lang | 6.4 | 201.1 | ×31.60 | ×14.05 | 14% (0.6) | 0% (0.0) | 49% (2.2) | 36% (1.6) | 1% (0.0) | match |
| added_normalized_dense | modalities | 5.6 | 150.8 | ×26.80 | ×6.42 | 12% (0.7) | 0% (0.0) | 46% (2.8) | 42% (2.5) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.9 | 120.2 | ×24.63 | ×6.13 | 15% (1.1) | 0% (0.0) | 50% (3.9) | 36% (2.8) | 0% (0.0) | match |
| added_special_dense | modalities | 3.4 | 61.7 | ×18.34 | ×1.65 | 38% (5.6) | 2% (0.2) | 39% (5.7) | 24% (3.5) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.8 | 65.7 | ×17.36 | ×3.16 | 25% (3.5) | 0% (0.1) | 47% (6.5) | 27% (3.7) | 1% (0.1) | match |
| agentic-traces | modalities | 2.5 | 78.0 | ×31.74 | ×5.46 | 14% (1.6) | 0% (0.0) | 45% (5.5) | 42% (5.1) | 0% (0.0) | match |
| agentic_swe | modalities | 2.7 | 98.8 | ×37.24 | ×6.62 | 13% (1.2) | 0% (0.0) | 42% (3.9) | 48% (4.5) | 0% (0.0) | match |
| code_mixed | modalities | 3.2 | 90.1 | ×28.60 | ×5.79 | 14% (1.4) | 0% (0.0) | 45% (4.7) | 43% (4.4) | 0% (0.0) | match |
| math_latex | modalities | 2.4 | 78.5 | ×32.36 | ×5.60 | 15% (1.7) | 0% (0.0) | 45% (5.4) | 40% (4.8) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.81 | 3.44 | 4.77 | 5.39 | 43.2 | 20.7 | 9.5 | — | 9.1× / 8.0× | 4.3× / 3.8× | 2.0× / 1.8× | — |
| arb_Arab | 1.15 | 2.95 | 3.42 | 5.22 | 50.0 | 23.6 | 10.5 | — | 14.6× / 9.6× | 6.9× / 4.5× | 3.1× / 2.0× | — |
| ben_Beng | 1.61 | 2.94 | 3.15 | 4.47 | 36.9 | 16.4 | 7.6 | — | 11.7× / 8.3× | 5.2× / 3.7× | 2.4× / 1.7× | — |
| cmn_Hani | 1.12 | 2.23 | 3.18 | 4.30 | 63.3 | 34.6 | 14.4 | — | 19.9× / 14.7× | 10.9× / 8.0× | 4.5× / 3.4× | — |
| ell_Grek | 0.59 | 2.99 | 3.42 | 5.82 | 48.1 | 21.7 | 9.8 | — | 14.1× / 8.3× | 6.3× / 3.7× | 2.9× / 1.7× | — |
| eng_Latn | 0.11 | 1.45 | 5.13 | 6.47 | 67.8 | 40.3 | 16.6 | — | 13.2× / 10.5× | 7.9× / 6.2× | 3.2× / 2.6× | — |
| heb_Hebr | 1.14 | 3.03 | 3.57 | 5.46 | 52.2 | 24.9 | 11.0 | — | 14.6× / 9.6× | 7.0× / 4.6× | 3.1× / 2.0× | — |
| hin_Deva | 1.52 | 3.13 | 3.35 | 4.97 | 39.3 | 19.2 | 8.6 | — | 11.7× / 7.9× | 5.7× / 3.9× | 2.6× / 1.7× | — |
| jpn_Jpan | 1.70 | 3.35 | 2.98 | 4.63 | 54.8 | 27.7 | 12.0 | — | 18.4× / 11.8× | 9.3× / 6.0× | 4.0× / 2.6× | — |
| kat_Geor | 1.57 | 2.51 | 2.96 | 3.89 | 33.7 | 15.5 | 7.2 | — | 11.4× / 8.7× | 5.2× / 4.0× | 2.4× / 1.9× | — |
| kor_Hang | 1.22 | 2.74 | 3.71 | 5.23 | 52.2 | 27.8 | 12.1 | — | 14.1× / 10.0× | 7.5× / 5.3× | 3.3× / 2.3× | — |
| rus_Cyrl | 1.41 | 2.94 | 3.34 | 4.87 | 47.6 | 21.6 | 9.6 | — | 14.2× / 9.8× | 6.5× / 4.4× | 2.9× / 2.0× | — |
| tam_Taml | 0.93 | 2.96 | 2.71 | 4.74 | 32.5 | 13.9 | 6.7 | — | 12.0× / 6.9× | 5.1× / 2.9× | 2.5× / 1.4× | — |
| tha_Thai | 1.73 | 2.60 | 2.17 | 3.04 | 27.9 | 10.2 | 5.2 | — | 12.9× / 9.2× | 4.7× / 3.3× | 2.4× / 1.7× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.77 | 4.19 | 43.2 | 20.7 | 9.2 | — | 15.6× / 10.3× | 7.5× / 4.9× | 3.3× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.90 | 5.31 | 50.0 | 26.5 | 11.5 | — | 12.8× / 9.4× | 6.8× / 5.0× | 3.0× / 2.2× | — |
| added_special_dense | 0.06 | 1.47 | 5.68 | 7.10 | 183.4 | 100.3 | 39.0 | — | 32.3× / 25.8× | 17.6× / 14.1× | 6.9× / 5.5× | — |
| added_special_sparse | 0.06 | 1.77 | 6.48 | 8.19 | 106.2 | 59.0 | 23.9 | — | 16.4× / 13.0× | 9.1× / 7.2× | 3.7× / 2.9× | — |
| agentic-traces | 0.72 | 1.48 | 5.48 | 6.23 | 83.7 | 55.8 | 20.6 | — | 15.3× / 13.4× | 10.2× / 9.0× | 3.8× / 3.3× | — |
| agentic_swe | 0.67 | 1.45 | 3.87 | 4.65 | 99.1 | 67.7 | 23.9 | — | 25.6× / 21.3× | 17.5× / 14.6× | 6.2× / 5.1× | — |
| code_mixed | 0.07 | 1.44 | 4.66 | 6.03 | 76.6 | 55.7 | 19.2 | — | 16.4× / 12.7× | 11.9× / 9.2× | 4.1× / 3.2× | — |
| math_latex | 0.76 | 1.55 | 5.37 | 6.15 | 81.2 | 49.2 | 20.0 | — | 15.1× / 13.2× | 9.2× / 8.0× | 3.7× / 3.2× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×1.94 vs v0.23.1 · ×1.06 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 371) · Pipeline 275+0 (peak 371)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 11.0 | 24.9 | ×2.27 | ×0.91 | 2% (0.6) | 6% (2.2) | 0% (0.0) | 93% (36.3) | 0% (0.0) | match |
| arb_Arab | lang | 7.4 | 12.4 | ×1.67 | ×0.93 | 1% (0.6) | 3% (2.6) | 0% (0.0) | 94% (76.8) | 2% (1.5) | match |
| ben_Beng | lang | 10.6 | 17.5 | ×1.65 | ×0.94 | 1% (0.6) | 3% (1.7) | 0% (0.0) | 97% (56.0) | 0% (0.0) | match |
| cmn_Hani | lang | 13.8 | 32.5 | ×2.36 | ×0.96 | 2% (0.6) | 1% (0.3) | 0% (0.0) | 99% (31.1) | 0% (0.0) | match |
| ell_Grek | lang | 7.8 | 13.6 | ×1.73 | ×0.91 | 1% (0.6) | 4% (2.6) | 0% (0.0) | 97% (70.7) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 5.4 | ×1.36 | ×0.98 | 1% (1.8) | 3% (4.8) | 0% (0.0) | 98% (177.6) | 0% (0.0) | match |
| heb_Hebr | lang | 8.3 | 15.6 | ×1.88 | ×0.93 | 1% (0.6) | 4% (2.7) | 0% (0.0) | 94% (59.3) | 0% (0.3) | match |
| hin_Deva | lang | 10.1 | 17.2 | ×1.71 | ×0.97 | 1% (0.6) | 4% (2.3) | 0% (0.0) | 95% (53.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.0 | 27.0 | ×2.07 | ×0.93 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 98% (34.0) | 0% (0.0) | match |
| kat_Geor | lang | 12.4 | 23.5 | ×1.89 | ×0.96 | 1% (0.6) | 3% (1.5) | 0% (0.0) | 96% (40.5) | 0% (0.0) | match |
| kor_Hang | lang | 9.6 | 23.8 | ×2.48 | ×0.95 | 2% (0.6) | 7% (2.7) | 0% (0.0) | 92% (36.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.1 | 11.4 | ×1.62 | ×1.03 | 1% (0.6) | 3% (2.3) | 0% (0.0) | 97% (81.7) | 0% (0.0) | match |
| tam_Taml | lang | 11.3 | 18.5 | ×1.63 | ×0.95 | 1% (0.6) | 3% (1.3) | 0% (0.0) | 96% (50.1) | 0% (0.2) | match |
| tha_Thai | lang | 13.6 | 22.7 | ×1.67 | ×0.95 | 1% (0.6) | 2% (0.7) | 0% (0.0) | 98% (41.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.2 | 6.9 | ×1.34 | ×0.93 | 1% (0.7) | 2% (3.0) | 0% (0.0) | 97% (138.6) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.7 | 6.2 | ×1.33 | ×0.94 | 1% (1.2) | 3% (4.4) | 0% (0.0) | 97% (152.7) | 0% (0.0) | match |
| added_special_dense | modalities | 4.8 | 36.4 | ×7.63 | ×1.80 | 32% (8.5) | 30% (7.9) | 29% (7.7) | 10% (2.6) | 0% (0.1) | match |
| added_special_sparse | modalities | 7.2 | 50.5 | ×6.98 | ×5.16 | 23% (4.4) | 44% (8.5) | 25% (4.8) | 9% (1.7) | 0% (0.0) | match |
| agentic-traces | modalities | 4.4 | 6.1 | ×1.40 | ×0.95 | 1% (1.6) | 3% (4.5) | 0% (0.0) | 97% (155.2) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 6.7 | ×1.62 | ×0.97 | 1% (1.2) | 5% (7.4) | 0% (0.0) | 94% (137.9) | 0% (0.3) | match |
| code_mixed | modalities | 4.2 | 6.3 | ×1.48 | ×0.95 | 1% (1.4) | 4% (6.1) | 0% (0.0) | 95% (147.4) | 0% (0.0) | match |
| math_latex | modalities | 4.1 | 5.7 | ×1.39 | ×0.94 | 1% (1.7) | 3% (4.6) | 0% (0.0) | 94% (165.6) | 2% (3.9) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×30.67 vs v0.23.1 · ×3.91 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 30+0 (peak 30)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 93.6 | ×23.89 | ×1.93 | 8% (0.6) | 0% (0.0) | 46% (3.7) | 47% (3.7) | 0% (0.0) | match |
| arb_Arab | lang | 3.8 | 112.1 | ×29.45 | ×4.36 | 8% (0.6) | 0% (0.0) | 31% (2.3) | 62% (4.5) | 0% (0.0) | match |
| ben_Beng | lang | 2.9 | 92.1 | ×31.95 | ×2.08 | 6% (0.6) | 0% (0.0) | 31% (3.0) | 64% (6.3) | 0% (0.0) | match |
| cmn_Hani | lang | 3.7 | 135.4 | ×36.14 | ×4.69 | 10% (0.6) | 0% (0.0) | 37% (2.3) | 55% (3.5) | 0% (0.0) | match |
| ell_Grek | lang | 4.3 | 137.0 | ×31.84 | ×4.83 | 9% (0.6) | 0% (0.0) | 32% (2.2) | 59% (3.9) | 0% (0.0) | match |
| eng_Latn | lang | 3.5 | 113.3 | ×32.07 | ×8.06 | 21% (1.8) | 0% (0.0) | 35% (2.9) | 44% (3.8) | 0% (0.0) | match |
| heb_Hebr | lang | 3.9 | 125.3 | ×31.93 | ×4.35 | 8% (0.6) | 0% (0.0) | 31% (2.3) | 62% (4.6) | 0% (0.0) | match |
| hin_Deva | lang | 3.0 | 106.1 | ×34.86 | ×2.62 | 7% (0.6) | 0% (0.0) | 35% (3.1) | 60% (5.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.4 | 145.4 | ×32.73 | ×6.61 | 11% (0.6) | 0% (0.0) | 40% (2.1) | 47% (2.5) | 2% (0.1) | match |
| kat_Geor | lang | 4.7 | 151.3 | ×32.21 | ×2.33 | 11% (0.6) | 0% (0.0) | 40% (2.1) | 51% (2.6) | 0% (0.0) | match |
| kor_Hang | lang | 3.3 | 102.6 | ×30.69 | ×2.35 | 7% (0.6) | 0% (0.0) | 28% (2.4) | 66% (5.8) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.2 | 145.1 | ×34.74 | ×5.25 | 9% (0.6) | 0% (0.0) | 32% (2.1) | 59% (3.8) | 0% (0.0) | match |
| tam_Taml | lang | 2.7 | 105.7 | ×39.47 | ×1.46 | 7% (0.6) | 0% (0.0) | 30% (2.7) | 63% (5.7) | 0% (0.0) | match |
| tha_Thai | lang | 3.6 | 127.4 | ×35.51 | ×3.59 | 8% (0.6) | 0% (0.0) | 35% (2.5) | 58% (4.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 194.5 | ×32.78 | ×7.65 | 16% (0.7) | 0% (0.0) | 22% (1.0) | 59% (2.7) | 3% (0.1) | match |
| added_normalized_sparse | modalities | 5.1 | 151.2 | ×29.75 | ×7.02 | 19% (1.2) | 0% (0.0) | 32% (2.0) | 49% (3.0) | 1% (0.0) | match |
| added_special_dense | modalities | 4.1 | 83.1 | ×20.37 | ×1.74 | 44% (5.0) | 0% (0.0) | 35% (4.0) | 25% (2.9) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.2 | 84.8 | ×20.13 | ×3.55 | 29% (3.1) | 0% (0.0) | 40% (4.3) | 35% (3.8) | 0% (0.0) | match |
| agentic-traces | modalities | 3.1 | 92.8 | ×29.55 | ×5.74 | 16% (1.6) | 0% (0.0) | 35% (3.4) | 50% (4.9) | 0% (0.0) | match |
| agentic_swe | modalities | 3.4 | 111.9 | ×32.89 | ×4.66 | 14% (1.2) | 0% (0.0) | 29% (2.4) | 57% (4.8) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 104.9 | ×29.86 | ×5.12 | 16% (1.4) | 0% (0.0) | 32% (2.9) | 53% (4.7) | 0% (0.0) | match |
| math_latex | modalities | 3.2 | 96.7 | ×30.26 | ×6.34 | 19% (1.7) | 0% (0.0) | 35% (3.3) | 47% (4.3) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.77 | 3.43 | 3.65 | 4.31 | 26.4 | 21.8 | 5.7 | 4.8 | 7.2× / 6.1× | 6.0× / 5.1× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.95 | 2.27 | 4.07 | 30.8 | 27.1 | 6.8 | 5.1 | 13.6× / 7.6× | 11.9× / 6.7× | 3.0× / 1.7× | 2.2× / 1.3× |
| ben_Beng | 1.62 | 2.92 | 3.04 | 4.35 | 63.5 | 58.4 | 13.8 | 4.0 | 20.9× / 14.6× | 19.2× / 13.4× | 4.5× / 3.2× | 1.3× / 0.9× |
| cmn_Hani | 1.12 | 2.23 | 2.33 | 3.44 | 25.5 | 22.4 | 5.9 | 2.4 | 11.0× / 7.4× | 9.6× / 6.5× | 2.5× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.94 | 2.15 | 4.51 | 27.2 | 22.9 | 5.9 | 4.8 | 12.6× / 6.0× | 10.6× / 5.1× | 2.8× / 1.3× | 2.2× / 1.1× |
| eng_Latn | 0.10 | 1.46 | 2.92 | 4.28 | 42.4 | 45.1 | 11.9 | 3.8 | 14.5× / 9.9× | 15.4× / 10.5× | 4.1× / 2.8× | 1.3× / 0.9× |
| heb_Hebr | 1.14 | 3.04 | 2.29 | 4.19 | 30.3 | 27.5 | 6.8 | 3.1 | 13.2× / 7.2× | 12.0× / 6.6× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.12 | 3.09 | 4.70 | 58.9 | 57.6 | 13.5 | 4.3 | 19.1× / 12.5× | 18.6× / 12.2× | 4.4× / 2.9× | 1.4× / 0.9× |
| jpn_Jpan | 1.70 | 3.40 | 2.11 | 3.81 | 23.1 | 18.7 | 5.0 | 3.8 | 10.9× / 6.0× | 8.8× / 4.9× | 2.4× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.54 | 2.59 | 2.06 | 3.10 | 16.7 | 15.1 | 4.2 | 2.0 | 8.1× / 5.4× | 7.3× / 4.9× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.22 | 2.68 | 2.44 | 3.90 | 30.5 | 29.2 | 7.5 | 3.6 | 12.5× / 7.8× | 12.0× / 7.5× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.97 | 2.11 | 3.93 | 26.1 | 22.2 | 5.8 | 2.4 | 12.4× / 6.7× | 10.5× / 5.7× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.94 | 2.71 | 4.73 | 66.6 | 60.3 | 15.0 | 3.8 | 24.6× / 14.1× | 22.2× / 12.8× | 5.5× / 3.2× | 1.4× / 0.8× |
| tha_Thai | 1.62 | 2.64 | 2.54 | 3.55 | 38.6 | 34.1 | 8.8 | 3.2 | 15.2× / 10.9× | 13.4× / 9.6× | 3.5× / 2.5× | 1.3× / 0.9× |
| added_normalized_dense | 0.09 | 1.47 | 1.04 | 2.42 | 22.6 | 24.0 | 6.5 | 2.0 | 21.8× / 9.3× | 23.1× / 9.9× | 6.2× / 2.7× | 1.9× / 0.8× |
| added_normalized_sparse | 0.09 | 1.47 | 1.96 | 3.34 | 30.0 | 32.7 | 8.5 | 2.7 | 15.3× / 9.0× | 16.7× / 9.8× | 4.3× / 2.5× | 1.4× / 0.8× |
| added_special_dense | 0.09 | 1.47 | 4.01 | 5.39 | 90.9 | 100.5 | 20.2 | 2.9 | 22.7× / 16.9× | 25.1× / 18.6× | 5.0× / 3.7× | 0.7× / 0.5× |
| added_special_sparse | 0.09 | 1.48 | 4.34 | 5.72 | 58.8 | 65.1 | 14.4 | 3.4 | 13.6× / 10.3× | 15.0× / 11.4× | 3.3× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.73 | 1.48 | 3.44 | 4.19 | 56.4 | 63.9 | 15.3 | 4.7 | 16.4× / 13.4× | 18.6× / 15.2× | 4.4× / 3.6× | 1.4× / 1.1× |
| agentic_swe | 0.68 | 1.45 | 2.38 | 3.15 | 57.6 | 72.0 | 14.4 | 3.5 | 24.2× / 18.3× | 30.3× / 22.9× | 6.1× / 4.6× | 1.5× / 1.1× |
| code_mixed | 0.07 | 1.46 | 2.87 | 4.27 | 55.8 | 69.7 | 15.1 | 4.1 | 19.4× / 13.1× | 24.3× / 16.3× | 5.2× / 3.5× | 1.4× / 0.9× |
| math_latex | 0.74 | 1.54 | 3.25 | 4.05 | 50.2 | 54.7 | 13.8 | 4.2 | 15.4× / 12.4× | 16.8× / 13.5× | 4.2× / 3.4× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×20.30 vs v0.23.1 · ×3.85 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.5 | 71.8 | ×20.40 | ×3.09 | 5% (0.6) | 0% (0.0) | 38% (4.9) | 56% (7.1) | 1% (0.1) | match |
| arb_Arab | lang | 3.8 | 83.2 | ×22.00 | ×4.80 | 6% (0.6) | 0% (0.0) | 34% (3.3) | 68% (6.6) | 0% (0.0) | match |
| ben_Beng | lang | 6.2 | 105.0 | ×16.84 | ×5.99 | 7% (0.6) | 0% (0.0) | 45% (3.7) | 49% (4.1) | 0% (0.0) | match |
| cmn_Hani | lang | 4.3 | 89.0 | ×20.92 | ×7.32 | 6% (0.6) | 0% (0.0) | 34% (3.3) | 60% (5.9) | 0% (0.0) | match |
| ell_Grek | lang | 4.8 | 92.8 | ×19.40 | ×5.84 | 6% (0.6) | 0% (0.0) | 34% (3.2) | 64% (6.2) | 0% (0.0) | match |
| eng_Latn | lang | 3.7 | 74.3 | ×20.12 | ×1.75 | 14% (1.8) | 0% (0.0) | 36% (4.6) | 49% (6.1) | 1% (0.1) | match |
| heb_Hebr | lang | 4.1 | 79.3 | ×19.47 | ×4.78 | 5% (0.6) | 0% (0.0) | 30% (3.4) | 66% (7.4) | 0% (0.0) | match |
| hin_Deva | lang | 6.4 | 106.6 | ×16.58 | ×4.08 | 7% (0.6) | 0% (0.0) | 45% (3.8) | 46% (3.9) | 1% (0.1) | match |
| jpn_Jpan | lang | 5.1 | 108.0 | ×21.30 | ×8.45 | 7% (0.6) | 0% (0.0) | 38% (3.1) | 55% (4.4) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 113.5 | ×18.34 | ×8.06 | 8% (0.6) | 0% (0.0) | 39% (3.0) | 53% (4.1) | 0% (0.0) | match |
| kor_Hang | lang | 3.5 | 64.1 | ×18.25 | ×4.19 | 5% (0.6) | 0% (0.0) | 28% (3.7) | 70% (9.3) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.6 | 91.4 | ×19.95 | ×5.85 | 7% (0.6) | 0% (0.0) | 35% (3.1) | 58% (5.2) | 0% (0.0) | match |
| tam_Taml | lang | 6.3 | 111.3 | ×17.53 | ×8.40 | 8% (0.6) | 0% (0.0) | 42% (3.2) | 51% (4.0) | 0% (0.0) | match |
| tha_Thai | lang | 7.3 | 144.9 | ×19.78 | ×12.56 | 10% (0.6) | 0% (0.0) | 52% (3.2) | 39% (2.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.2 | 142.8 | ×27.70 | ×5.63 | 11% (0.7) | 0% (0.0) | 35% (2.2) | 54% (3.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 120.0 | ×22.98 | ×2.86 | 15% (1.1) | 0% (0.0) | 44% (3.4) | 40% (3.1) | 1% (0.1) | match |
| added_special_dense | modalities | 4.2 | 74.4 | ×17.69 | ×0.99 | 39% (4.9) | 0% (0.0) | 42% (5.3) | 22% (2.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 75.6 | ×17.51 | ×0.98 | 24% (3.0) | 0% (0.0) | 48% (5.9) | 29% (3.6) | 0% (0.0) | match |
| agentic-traces | modalities | 3.4 | 75.2 | ×21.87 | ×1.95 | 13% (1.6) | 0% (0.0) | 39% (4.9) | 48% (6.1) | 1% (0.1) | match |
| agentic_swe | modalities | 3.6 | 92.4 | ×25.83 | ×3.33 | 12% (1.2) | 0% (0.0) | 37% (3.8) | 51% (5.2) | 0% (0.0) | match |
| code_mixed | modalities | 3.7 | 88.2 | ×23.90 | ×1.74 | 13% (1.4) | 0% (0.0) | 41% (4.4) | 45% (4.8) | 0% (0.0) | match |
| math_latex | modalities | 3.3 | 72.9 | ×22.33 | ×1.89 | 13% (1.7) | 0% (0.0) | 37% (4.8) | 50% (6.4) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.45 | 4.85 | 5.52 | 31.5 | 14.7 | 7.0 | 4.8 | 6.5× / 5.7× | 3.0× / 2.7× | 1.4× / 1.3× | 1.0× / 0.9× |
| arb_Arab | 1.15 | 2.97 | 3.29 | 5.11 | 36.1 | 16.9 | 7.8 | 5.1 | 11.0× / 7.1× | 5.1× / 3.3× | 2.4× / 1.5× | 1.6× / 1.0× |
| ben_Beng | 1.61 | 2.91 | 3.72 | 5.02 | 25.3 | 11.4 | 5.5 | 2.7 | 6.8× / 5.0× | 3.1× / 2.3× | 1.5× / 1.1× | 0.7× / 0.5× |
| cmn_Hani | 1.12 | 2.28 | 3.35 | 4.50 | 23.0 | 11.1 | 5.5 | 2.5 | 6.9× / 5.1× | 3.3× / 2.5× | 1.6× / 1.2× | 0.7× / 0.5× |
| ell_Grek | 0.59 | 3.01 | 3.24 | 5.66 | 31.8 | 16.0 | 7.1 | 5.1 | 9.8× / 5.6× | 4.9× / 2.8× | 2.2× / 1.3× | 1.6× / 0.9× |
| eng_Latn | 0.12 | 1.45 | 4.56 | 5.89 | 47.4 | 30.7 | 14.3 | 4.3 | 10.4× / 8.0× | 6.7× / 5.2× | 3.1× / 2.4× | 0.9× / 0.7× |
| heb_Hebr | 1.14 | 3.02 | 3.41 | 5.29 | 35.8 | 17.7 | 8.3 | 2.8 | 10.5× / 6.8× | 5.2× / 3.3× | 2.4× / 1.6× | 0.8× / 0.5× |
| hin_Deva | 1.52 | 3.13 | 3.82 | 5.43 | 27.8 | 13.9 | 6.5 | 3.2 | 7.3× / 5.1× | 3.6× / 2.6× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.69 | 3.42 | 3.08 | 4.81 | 21.4 | 9.4 | 4.7 | 3.9 | 6.9× / 4.4× | 3.0× / 1.9× | 1.5× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.54 | 2.59 | 2.96 | 4.01 | 20.0 | 10.5 | 4.6 | 2.1 | 6.8× / 5.0× | 3.5× / 2.6× | 1.5× / 1.1× | 0.7× / 0.5× |
| kor_Hang | 1.23 | 2.70 | 3.72 | 5.19 | 35.8 | 19.8 | 9.0 | 3.6 | 9.6× / 6.9× | 5.3× / 3.8× | 2.4× / 1.7× | 1.0× / 0.7× |
| rus_Cyrl | 1.17 | 2.92 | 3.13 | 4.88 | 30.5 | 15.4 | 6.7 | 4.9 | 9.7× / 6.2× | 4.9× / 3.2× | 2.1× / 1.4× | 1.6× / 1.0× |
| tam_Taml | 0.93 | 2.97 | 3.23 | 5.27 | 20.0 | 9.0 | 4.2 | 3.0 | 6.2× / 3.8× | 2.8× / 1.7× | 1.3× / 0.8× | 0.9× / 0.6× |
| tha_Thai | 1.52 | 2.58 | 3.19 | 4.26 | 13.7 | 5.7 | 2.8 | 2.2 | 4.3× / 3.2× | 1.8× / 1.3× | 0.9× / 0.6× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.48 | 2.20 | 3.62 | 35.2 | 18.4 | 11.5 | 2.2 | 16.0× / 9.7× | 8.4× / 5.1× | 5.2× / 3.2× | 1.0× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.36 | 4.78 | 38.1 | 21.7 | 11.5 | 3.0 | 11.3× / 8.0× | 6.4× / 4.5× | 3.4× / 2.4× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.48 | 5.28 | 6.70 | 92.1 | 71.0 | 24.1 | 3.3 | 17.4× / 13.7× | 13.4× / 10.6× | 4.6× / 3.6× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 5.88 | 7.30 | 61.3 | 42.6 | 17.0 | 3.7 | 10.4× / 8.4× | 7.2× / 5.8× | 2.9× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.72 | 1.48 | 4.95 | 5.71 | 56.7 | 44.5 | 17.3 | 5.0 | 11.4× / 9.9× | 9.0× / 7.8× | 3.5× / 3.0× | 1.0× / 0.9× |
| agentic_swe | 0.66 | 1.44 | 3.76 | 4.54 | 57.4 | 51.2 | 17.8 | 3.6 | 15.3× / 12.6× | 13.6× / 11.3× | 4.7× / 3.9× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.46 | 4.37 | 5.75 | 57.9 | 48.5 | 17.7 | 4.3 | 13.3× / 10.1× | 11.1× / 8.4× | 4.1× / 3.1× | 1.0× / 0.7× |
| math_latex | 0.76 | 1.48 | 4.82 | 5.54 | 54.3 | 37.2 | 16.2 | 4.5 | 11.3× / 9.8× | 7.7× / 6.7× | 3.4× / 2.9× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×20.12 vs v0.23.1 · ×3.18 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 230) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 78.9 | ×18.57 | ×1.64 | 12% (1.2) | 0% (0.0) | 37% (3.7) | 51% (5.0) | 0% (0.0) | match |
| arb_Arab | lang | 4.8 | 90.0 | ×18.68 | ×5.03 | 13% (1.2) | 0% (0.0) | 26% (2.3) | 60% (5.3) | 0% (0.0) | match |
| ben_Beng | lang | 4.3 | 92.5 | ×21.34 | ×3.48 | 12% (1.2) | 0% (0.0) | 32% (3.2) | 57% (5.7) | 0% (0.0) | match |
| cmn_Hani | lang | 5.0 | 100.8 | ×20.22 | ×6.91 | 16% (1.2) | 0% (0.0) | 32% (2.4) | 53% (4.0) | 0% (0.0) | match |
| ell_Grek | lang | 5.3 | 101.1 | ×19.19 | ×5.19 | 15% (1.2) | 0% (0.0) | 28% (2.2) | 57% (4.4) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 83.7 | ×21.36 | ×1.87 | 25% (2.4) | 0% (0.0) | 31% (3.0) | 47% (4.5) | 0% (0.0) | match |
| heb_Hebr | lang | 4.3 | 84.8 | ×19.63 | ×3.31 | 12% (1.2) | 0% (0.0) | 24% (2.3) | 61% (5.9) | 3% (0.3) | match |
| hin_Deva | lang | 4.0 | 84.6 | ×21.24 | ×2.83 | 11% (1.2) | 0% (0.0) | 30% (3.2) | 60% (6.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.8 | 118.8 | ×20.64 | ×7.64 | 19% (1.2) | 0% (0.0) | 36% (2.2) | 44% (2.6) | 1% (0.1) | match |
| kat_Geor | lang | 6.4 | 117.3 | ×18.21 | ×5.30 | 18% (1.2) | 0% (0.0) | 33% (2.1) | 50% (3.2) | 0% (0.0) | match |
| kor_Hang | lang | 4.1 | 71.9 | ×17.65 | ×3.87 | 11% (1.2) | 0% (0.0) | 23% (2.5) | 68% (7.4) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.0 | 102.3 | ×20.62 | ×5.46 | 16% (1.2) | 0% (0.0) | 30% (2.2) | 54% (3.9) | 0% (0.0) | match |
| tam_Taml | lang | 3.8 | 91.2 | ×23.73 | ×2.57 | 12% (1.2) | 0% (0.0) | 28% (2.7) | 61% (5.9) | 0% (0.0) | match |
| tha_Thai | lang | 5.0 | 93.1 | ×18.68 | ×4.43 | 14% (1.2) | 0% (0.0) | 32% (2.6) | 56% (4.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.0 | 159.5 | ×26.75 | ×5.90 | 23% (1.3) | 0% (0.0) | 19% (1.1) | 61% (3.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.5 | 134.1 | ×24.58 | ×3.19 | 25% (1.7) | 0% (0.0) | 30% (2.1) | 47% (3.2) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 48.0 | ×11.74 | ×1.01 | 62% (12.4) | 0% (0.0) | 24% (4.8) | 15% (3.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 63.8 | ×14.73 | ×1.11 | 45% (6.6) | 0% (0.0) | 33% (4.8) | 24% (3.4) | 0% (0.0) | match |
| agentic-traces | modalities | 3.5 | 78.3 | ×22.10 | ×2.20 | 21% (2.3) | 0% (0.0) | 34% (3.7) | 45% (5.0) | 0% (0.0) | match |
| agentic_swe | modalities | 3.8 | 93.9 | ×24.59 | ×3.36 | 20% (1.8) | 0% (0.0) | 31% (2.9) | 49% (4.5) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 93.5 | ×23.52 | ×2.05 | 22% (2.1) | 0% (0.0) | 34% (3.2) | 46% (4.3) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 79.4 | ×21.13 | ×2.04 | 21% (2.3) | 0% (0.0) | 32% (3.4) | 45% (4.8) | 2% (0.2) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.41 | 3.68 | 4.31 | 27.6 | 16.5 | 5.9 | 4.7 | 7.5× / 6.4× | 4.5× / 3.8× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.97 | 2.32 | 4.15 | 31.8 | 19.7 | 6.8 | 5.2 | 13.7× / 7.7× | 8.5× / 4.8× | 2.9× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.62 | 2.94 | 3.15 | 4.47 | 46.7 | 28.3 | 10.2 | 3.7 | 14.8× / 10.5× | 9.0× / 6.3× | 3.2× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.11 | 2.24 | 2.38 | 3.51 | 20.2 | 11.9 | 4.7 | 2.3 | 8.5× / 5.8× | 5.0× / 3.4× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.00 | 2.19 | 4.61 | 29.0 | 17.5 | 6.1 | 4.7 | 13.2× / 6.3× | 8.0× / 3.8× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.47 | 3.00 | 4.38 | 45.2 | 33.8 | 12.4 | 3.7 | 15.0× / 10.3× | 11.3× / 7.7× | 4.1× / 2.8× | 1.2× / 0.9× |
| heb_Hebr | 1.15 | 3.01 | 2.31 | 4.17 | 31.8 | 20.5 | 6.9 | 3.0 | 13.8× / 7.6× | 8.9× / 4.9× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.52 | 3.12 | 3.25 | 4.85 | 49.5 | 31.7 | 11.1 | 4.0 | 15.2× / 10.2× | 9.8× / 6.5× | 3.4× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.70 | 3.35 | 2.19 | 3.84 | 18.7 | 10.0 | 4.1 | 3.8 | 8.5× / 4.9× | 4.5× / 2.6× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.54 | 2.56 | 2.11 | 3.12 | 17.4 | 11.7 | 4.2 | 1.9 | 8.3× / 5.6× | 5.5× / 3.7× | 2.0× / 1.3× | 0.9× / 0.6× |
| kor_Hang | 1.22 | 2.71 | 2.50 | 3.98 | 31.9 | 21.6 | 7.5 | 3.6 | 12.8× / 8.0× | 8.7× / 5.4× | 3.0× / 1.9× | 1.4× / 0.9× |
| rus_Cyrl | 1.16 | 2.95 | 2.15 | 3.94 | 27.5 | 17.5 | 5.9 | 2.6 | 12.8× / 7.0× | 8.1× / 4.4× | 2.7× / 1.5× | 1.2× / 0.7× |
| tam_Taml | 0.93 | 2.94 | 2.74 | 4.75 | 45.6 | 27.6 | 9.8 | 3.4 | 16.6× / 9.6× | 10.1× / 5.8× | 3.6× / 2.1× | 1.3× / 0.7× |
| tha_Thai | 1.72 | 2.57 | 2.62 | 3.46 | 28.8 | 16.8 | 6.9 | 3.0 | 11.0× / 8.3× | 6.4× / 4.8× | 2.7× / 2.0× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.08 | 2.50 | 24.2 | 17.8 | 6.5 | 1.8 | 22.4× / 9.7× | 16.5× / 7.1× | 6.0× / 2.6× | 1.6× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 2.08 | 3.49 | 32.2 | 24.2 | 8.7 | 2.5 | 15.5× / 9.2× | 11.6× / 6.9× | 4.2× / 2.5× | 1.2× / 0.7× |
| added_special_dense | 0.06 | 1.48 | 4.78 | 6.20 | 97.7 | 75.4 | 20.9 | 3.1 | 20.4× / 15.8× | 15.8× / 12.2× | 4.4× / 3.4× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.78 | 6.20 | 62.6 | 47.6 | 15.3 | 3.4 | 13.1× / 10.1× | 10.0× / 7.7× | 3.2× / 2.5× | 0.7× / 0.6× |
| agentic-traces | 0.85 | 1.48 | 3.70 | 4.33 | 54.8 | 46.1 | 15.0 | 4.6 | 14.8× / 12.7× | 12.5× / 10.6× | 4.1× / 3.5× | 1.2× / 1.1× |
| agentic_swe | 0.65 | 1.48 | 2.88 | 3.71 | 56.9 | 53.5 | 15.6 | 3.4 | 19.7× / 15.4× | 18.6× / 14.4× | 5.4× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.22 | 4.60 | 54.7 | 51.6 | 15.3 | 4.0 | 17.0× / 11.9× | 16.0× / 11.2× | 4.7× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.70 | 1.54 | 3.43 | 4.27 | 52.5 | 40.0 | 13.9 | 4.1 | 15.3× / 12.3× | 11.7× / 9.4× | 4.1× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.46 vs v0.23.1 · ×0.97 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 23) · Pipeline 24+0 (peak 24)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.8 | 36.6 | ×7.64 | ×0.91 | 0% (0.0) | 10% (2.8) | 0% (0.0) | 90% (23.9) | 0% (0.0) | match |
| arb_Arab | lang | 10.3 | 39.1 | ×3.79 | ×0.80 | 0% (0.0) | 13% (3.3) | 0% (0.0) | 87% (22.1) | 0% (0.0) | match |
| ben_Beng | lang | 10.9 | 63.0 | ×5.77 | ×0.83 | 0% (0.0) | 14% (2.2) | 0% (0.0) | 86% (13.3) | 0% (0.0) | match |
| cmn_Hani | lang | 9.1 | 50.3 | ×5.55 | ×0.81 | 0% (0.1) | 3% (0.5) | 0% (0.0) | 97% (18.0) | 0% (0.0) | match |
| ell_Grek | lang | 10.3 | 44.0 | ×4.29 | ×0.80 | 0% (0.0) | 14% (3.2) | 0% (0.0) | 86% (19.1) | 0% (0.0) | match |
| eng_Latn | lang | 4.2 | 6.0 | ×1.42 | ×0.93 | 0% (0.1) | 4% (6.7) | 0% (0.0) | 96% (159.7) | 0% (0.4) | match |
| heb_Hebr | lang | 10.4 | 46.7 | ×4.49 | ×0.80 | 0% (0.0) | 16% (3.3) | 0% (0.0) | 85% (17.7) | 0% (0.0) | match |
| hin_Deva | lang | 12.3 | 60.3 | ×4.92 | ×0.82 | 0% (0.0) | 18% (2.9) | 0% (0.0) | 81% (13.4) | 1% (0.1) | match |
| jpn_Jpan | lang | 12.9 | 63.8 | ×4.95 | ×0.80 | 0% (0.0) | 3% (0.4) | 0% (0.0) | 98% (14.5) | 0% (0.0) | match |
| kat_Geor | lang | 14.5 | 66.6 | ×4.59 | ×0.79 | 0% (0.0) | 13% (2.0) | 0% (0.0) | 86% (12.6) | 0% (0.0) | match |
| kor_Hang | lang | 7.5 | 42.0 | ×5.63 | ×0.85 | 0% (0.1) | 14% (3.3) | 0% (0.0) | 86% (19.8) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.8 | 14.0 | ×1.80 | ×0.88 | 0% (0.0) | 4% (2.9) | 0% (0.0) | 96% (66.9) | 0% (0.0) | match |
| tam_Taml | lang | 12.8 | 67.8 | ×5.30 | ×0.82 | 0% (0.0) | 13% (1.8) | 0% (0.0) | 88% (12.7) | 0% (0.0) | match |
| tha_Thai | lang | 15.6 | 65.5 | ×4.19 | ×0.80 | 0% (0.0) | 7% (1.0) | 0% (0.0) | 93% (13.7) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.5 | 8.7 | ×1.60 | ×0.99 | 0% (0.0) | 3% (3.8) | 0% (0.0) | 97% (109.1) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 4.8 | 7.0 | ×1.45 | ×0.94 | 0% (0.0) | 4% (6.0) | 0% (0.0) | 96% (137.0) | 0% (0.0) | match |
| added_special_dense | modalities | 4.0 | 39.7 | ×9.87 | ×1.97 | 20% (4.8) | 63% (15.3) | 6% (1.4) | 11% (2.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 5.7 | 50.2 | ×8.73 | ×4.90 | 12% (2.1) | 76% (13.8) | 3% (0.5) | 8% (1.5) | 1% (0.2) | match |
| agentic-traces | modalities | 4.4 | 6.6 | ×1.49 | ×0.93 | 0% (0.1) | 4% (6.1) | 0% (0.0) | 96% (144.9) | 0% (0.2) | match |
| agentic_swe | modalities | 3.8 | 6.5 | ×1.68 | ×0.92 | 0% (0.0) | 6% (9.7) | 0% (0.0) | 94% (144.1) | 0% (0.0) | match |
| code_mixed | modalities | 4.1 | 6.4 | ×1.56 | ×0.92 | 0% (0.0) | 5% (8.0) | 0% (0.0) | 95% (146.9) | 0% (0.0) | match |
| math_latex | modalities | 4.4 | 6.3 | ×1.43 | ×0.93 | 0% (0.1) | 4% (6.3) | 0% (0.0) | 95% (151.5) | 1% (1.1) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×22.09 vs v0.23.1 · ×3.16 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 101+0 (peak 101)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 82.6 | ×19.22 | ×1.71 | 7% (0.6) | 0% (0.0) | 40% (3.6) | 56% (5.1) | 0% (0.0) | match |
| arb_Arab | lang | 4.6 | 95.5 | ×20.65 | ×5.33 | 8% (0.6) | 0% (0.0) | 29% (2.3) | 70% (5.4) | 0% (0.0) | match |
| ben_Beng | lang | 4.1 | 95.2 | ×23.38 | ×3.04 | 6% (0.6) | 0% (0.0) | 32% (3.1) | 62% (6.0) | 0% (0.0) | match |
| cmn_Hani | lang | 5.1 | 108.1 | ×21.28 | ×6.46 | 9% (0.6) | 0% (0.0) | 35% (2.4) | 57% (3.9) | 0% (0.0) | match |
| ell_Grek | lang | 5.3 | 108.3 | ×20.43 | ×5.61 | 9% (0.6) | 0% (0.0) | 31% (2.2) | 58% (4.1) | 2% (0.2) | match |
| eng_Latn | lang | 4.1 | 89.9 | ×21.67 | ×1.94 | 21% (1.8) | 0% (0.0) | 34% (3.0) | 45% (3.9) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 89.4 | ×21.15 | ×3.44 | 7% (0.6) | 0% (0.0) | 27% (2.3) | 67% (5.8) | 0% (0.0) | match |
| hin_Deva | lang | 4.4 | 123.4 | ×28.31 | ×1.61 | 8% (0.6) | 0% (0.0) | 46% (3.2) | 46% (3.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.9 | 129.0 | ×22.03 | ×7.95 | 11% (0.6) | 0% (0.0) | 39% (2.2) | 49% (2.7) | 1% (0.0) | match |
| kat_Geor | lang | 5.7 | 121.9 | ×21.24 | ×3.29 | 10% (0.6) | 0% (0.0) | 36% (2.1) | 56% (3.3) | 0% (0.0) | match |
| kor_Hang | lang | 4.1 | 77.6 | ×18.81 | ×4.06 | 6% (0.6) | 0% (0.0) | 24% (2.5) | 68% (7.0) | 2% (0.2) | match |
| rus_Cyrl | lang | 5.0 | 107.5 | ×21.34 | ×6.57 | 9% (0.6) | 0% (0.0) | 32% (2.1) | 58% (3.9) | 1% (0.1) | match |
| tam_Taml | lang | 4.1 | 99.5 | ×24.26 | ×2.81 | 6% (0.6) | 0% (0.0) | 30% (2.7) | 66% (6.1) | 0% (0.0) | match |
| tha_Thai | lang | 5.2 | 106.8 | ×20.53 | ×5.26 | 8% (0.6) | 0% (0.0) | 34% (2.6) | 59% (4.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.2 | 173.7 | ×28.23 | ×6.39 | 14% (0.7) | 0% (0.0) | 23% (1.2) | 59% (3.0) | 5% (0.2) | match |
| added_normalized_sparse | modalities | 5.5 | 143.3 | ×26.06 | ×3.36 | 19% (1.2) | 0% (0.0) | 30% (1.9) | 53% (3.3) | 0% (0.0) | match |
| added_special_dense | modalities | 4.2 | 76.9 | ×18.15 | ×1.02 | 40% (5.0) | 0% (0.0) | 38% (4.7) | 23% (2.9) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.5 | 81.5 | ×18.27 | ×1.12 | 26% (3.0) | 0% (0.0) | 42% (4.7) | 33% (3.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.6 | 85.0 | ×23.49 | ×2.27 | 16% (1.6) | 0% (0.0) | 36% (3.7) | 48% (4.8) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 102.0 | ×25.14 | ×3.59 | 14% (1.2) | 0% (0.0) | 35% (2.9) | 51% (4.2) | 0% (0.0) | match |
| code_mixed | modalities | 4.3 | 100.1 | ×23.52 | ×2.13 | 17% (1.4) | 0% (0.0) | 38% (3.2) | 46% (3.9) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 85.6 | ×22.44 | ×2.09 | 18% (1.7) | 0% (0.0) | 35% (3.4) | 52% (5.0) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.80 | 3.49 | 3.65 | 4.34 | 27.6 | 16.5 | 5.9 | 4.8 | 7.6× / 6.4× | 4.5× / 3.8× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.96 | 2.31 | 4.12 | 31.7 | 19.8 | 6.8 | 5.1 | 13.7× / 7.7× | 8.6× / 4.8× | 2.9× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.62 | 2.94 | 3.11 | 4.43 | 46.0 | 29.1 | 10.3 | 3.7 | 14.8× / 10.4× | 9.4× / 6.6× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.24 | 2.37 | 3.49 | 20.0 | 11.8 | 4.7 | 2.4 | 8.4× / 5.7× | 5.0× / 3.4× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.95 | 2.21 | 4.58 | 28.5 | 17.8 | 6.1 | 4.7 | 12.9× / 6.2× | 8.1× / 3.9× | 2.8× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.48 | 2.99 | 4.37 | 44.8 | 35.3 | 12.3 | 3.7 | 15.0× / 10.2× | 11.8× / 8.1× | 4.1× / 2.8× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.04 | 2.29 | 4.19 | 31.4 | 20.3 | 6.9 | 3.0 | 13.7× / 7.5× | 8.8× / 4.8× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.11 | 3.21 | 4.81 | 49.2 | 31.2 | 11.3 | 4.0 | 15.3× / 10.2× | 9.7× / 6.5× | 3.5× / 2.4× | 1.2× / 0.8× |
| jpn_Jpan | 1.70 | 3.37 | 2.17 | 3.84 | 18.5 | 10.1 | 4.1 | 3.7 | 8.5× / 4.8× | 4.6× / 2.6× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.54 | 2.52 | 2.09 | 3.07 | 17.2 | 11.3 | 4.1 | 2.0 | 8.2× / 5.6× | 5.4× / 3.7× | 2.0× / 1.3× | 1.0× / 0.7× |
| kor_Hang | 1.23 | 2.73 | 2.48 | 3.97 | 31.6 | 22.4 | 7.6 | 3.6 | 12.8× / 8.0× | 9.0× / 5.6× | 3.1× / 1.9× | 1.4× / 0.9× |
| rus_Cyrl | 1.16 | 2.89 | 2.14 | 3.87 | 27.3 | 17.1 | 5.9 | 2.4 | 12.8× / 7.1× | 8.0× / 4.4× | 2.8× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.94 | 2.92 | 2.73 | 4.71 | 45.1 | 27.6 | 10.1 | 3.4 | 16.5× / 9.6× | 10.1× / 5.9× | 3.7× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.52 | 2.58 | 2.59 | 3.65 | 28.4 | 16.8 | 6.7 | 3.0 | 11.0× / 7.8× | 6.5× / 4.6× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.48 | 1.17 | 2.58 | 23.8 | 17.8 | 6.5 | 1.8 | 20.4× / 9.2× | 15.2× / 6.9× | 5.6× / 2.5× | 1.5× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.88 | 3.29 | 31.7 | 24.0 | 8.6 | 2.5 | 16.9× / 9.6× | 12.8× / 7.3× | 4.6× / 2.6× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.48 | 4.75 | 6.17 | 96.2 | 77.2 | 21.4 | 3.2 | 20.3× / 15.6× | 16.3× / 12.5× | 4.5× / 3.5× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 4.73 | 6.15 | 61.7 | 48.2 | 15.2 | 3.5 | 13.0× / 10.0× | 10.2× / 7.8× | 3.2× / 2.5× | 0.7× / 0.6× |
| agentic-traces | 0.74 | 1.47 | 3.66 | 4.39 | 54.0 | 46.4 | 15.0 | 4.6 | 14.7× / 12.3× | 12.7× / 10.6× | 4.1× / 3.4× | 1.2× / 1.0× |
| agentic_swe | 0.65 | 1.47 | 2.86 | 3.67 | 56.3 | 53.7 | 15.6 | 3.4 | 19.7× / 15.3× | 18.8× / 14.6× | 5.4× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.09 | 1.44 | 3.24 | 4.58 | 53.7 | 51.8 | 15.4 | 4.0 | 16.6× / 11.7× | 16.0× / 11.3× | 4.8× / 3.4× | 1.2× / 0.9× |
| math_latex | 0.75 | 1.48 | 3.39 | 4.12 | 51.8 | 40.9 | 14.3 | 4.1 | 15.3× / 12.6× | 12.1× / 9.9× | 4.2× / 3.5× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×7.86 vs v0.23.1 · ×2.14 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 194) · Pipeline 109+0 (peak 195)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 39.7 | ×11.18 | ×1.31 | 5% (1.2) | 0% (0.0) | 66% (14.6) | 31% (6.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.3 | 38.7 | ×9.06 | ×2.25 | 5% (1.2) | 0% (0.0) | 71% (16.7) | 25% (6.0) | 0% (0.0) | match |
| ben_Beng | lang | 6.5 | 57.1 | ×8.80 | ×3.32 | 7% (1.1) | 0% (0.0) | 69% (11.1) | 24% (3.9) | 0% (0.0) | match |
| cmn_Hani | lang | 4.7 | 50.5 | ×10.68 | ×3.25 | 6% (1.2) | 0% (0.0) | 65% (11.9) | 30% (5.5) | 0% (0.0) | match |
| ell_Grek | lang | 5.0 | 41.5 | ×8.37 | ×2.71 | 5% (1.2) | 0% (0.0) | 70% (15.6) | 26% (5.8) | 0% (0.0) | match |
| eng_Latn | lang | 3.6 | 24.5 | ×6.83 | ×1.28 | 6% (2.4) | 0% (0.0) | 78% (30.9) | 16% (6.2) | 1% (0.3) | match |
| heb_Hebr | lang | 4.1 | 36.7 | ×8.88 | ×2.63 | 4% (1.2) | 0% (0.0) | 69% (17.8) | 27% (6.9) | 0% (0.0) | match |
| hin_Deva | lang | 5.8 | 51.6 | ×8.90 | ×2.40 | 6% (1.2) | 0% (0.1) | 72% (13.1) | 21% (3.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.4 | 62.1 | ×11.53 | ×4.08 | 8% (1.2) | 0% (0.0) | 66% (10.0) | 26% (3.9) | 0% (0.0) | match |
| kat_Geor | lang | 6.4 | 60.3 | ×9.45 | ×4.24 | 8% (1.2) | 0% (0.0) | 69% (10.5) | 21% (3.2) | 3% (0.5) | match |
| kor_Hang | lang | 3.9 | 32.1 | ×8.16 | ×2.12 | 4% (1.2) | 0% (0.0) | 69% (19.9) | 29% (8.4) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.6 | 43.0 | ×9.38 | ×3.02 | 5% (1.2) | 0% (0.0) | 71% (15.4) | 26% (5.7) | 0% (0.0) | match |
| tam_Taml | lang | 6.3 | 66.5 | ×10.55 | ×4.56 | 8% (1.2) | 0% (0.0) | 65% (9.1) | 24% (3.4) | 2% (0.3) | match |
| tha_Thai | lang | 7.7 | 101.4 | ×13.11 | ×6.70 | 13% (1.2) | 0% (0.0) | 68% (6.0) | 16% (1.4) | 3% (0.3) | match |
| added_normalized_dense | modalities | 5.6 | 43.2 | ×7.69 | ×2.10 | 6% (1.3) | 0% (0.0) | 80% (17.8) | 15% (3.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 36.4 | ×7.02 | ×1.46 | 6% (1.7) | 0% (0.0) | 79% (21.3) | 15% (3.9) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 16.6 | ×4.07 | ×1.00 | 8% (4.6) | 0% (0.0) | 85% (51.0) | 8% (4.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 22.4 | ×5.15 | ×1.02 | 7% (3.3) | 0% (0.0) | 82% (36.2) | 10% (4.6) | 0% (0.0) | match |
| agentic-traces | modalities | 3.2 | 18.8 | ×5.81 | ×1.26 | 4% (2.2) | 0% (0.0) | 82% (43.6) | 14% (7.2) | 0% (0.1) | match |
| agentic_swe | modalities | 3.2 | 16.0 | ×4.96 | ×1.43 | 3% (1.8) | 0% (0.0) | 86% (54.3) | 12% (7.3) | 0% (0.0) | match |
| code_mixed | modalities | 3.6 | 17.5 | ×4.90 | ×1.18 | 4% (2.0) | 0% (0.0) | 86% (48.6) | 11% (6.4) | 0% (0.0) | match |
| math_latex | modalities | 3.3 | 21.1 | ×6.35 | ×1.22 | 5% (2.3) | 0% (0.0) | 81% (37.9) | 13% (6.1) | 1% (0.3) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.43 | 14.62 | 15.27 | 27.8 | 14.8 | 6.7 | — | 1.9× / 1.8× | 1.0× / 1.0× | 0.5× / 0.4× | — |
| arb_Arab | 1.15 | 2.94 | 16.69 | 18.47 | 32.0 | 17.2 | 7.4 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| ben_Beng | 1.62 | 2.98 | 11.15 | 12.51 | 22.6 | 11.4 | 5.4 | — | 2.0× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| cmn_Hani | 1.11 | 2.28 | 11.90 | 13.07 | 21.6 | 11.9 | 5.6 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| ell_Grek | 0.58 | 3.00 | 15.60 | 18.01 | 28.1 | 16.1 | 6.7 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| eng_Latn | 0.12 | 1.45 | 30.90 | 32.23 | 41.0 | 31.3 | 13.5 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| heb_Hebr | 1.15 | 3.09 | 17.79 | 19.73 | 31.4 | 18.2 | 8.0 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| hin_Deva | 1.51 | 3.10 | 13.14 | 14.73 | 24.5 | 13.6 | 6.1 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| jpn_Jpan | 1.70 | 3.35 | 9.99 | 11.64 | 20.2 | 9.8 | 4.7 | — | 2.0× / 1.7× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| kat_Geor | 1.55 | 2.63 | 10.49 | 11.58 | 18.1 | 10.6 | 4.6 | — | 1.7× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| kor_Hang | 1.23 | 2.69 | 19.89 | 21.36 | 31.7 | 20.6 | 8.7 | — | 1.6× / 1.5× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| rus_Cyrl | 1.17 | 2.96 | 15.41 | 17.20 | 27.0 | 15.5 | 6.5 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| tam_Taml | 0.94 | 2.96 | 9.08 | 11.10 | 18.3 | 9.0 | 4.1 | — | 2.0× / 1.6× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| tha_Thai | 1.52 | 2.60 | 5.97 | 7.05 | 13.0 | 5.9 | 2.8 | — | 2.2× / 1.8× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| added_normalized_dense | 0.24 | 1.47 | 17.79 | 19.02 | 30.9 | 17.9 | 11.5 | — | 1.7× / 1.6× | 1.0× / 0.9× | 0.6× / 0.6× | — |
| added_normalized_sparse | 0.25 | 1.47 | 21.34 | 22.56 | 32.3 | 21.2 | 11.4 | — | 1.5× / 1.4× | 1.0× / 0.9× | 0.5× / 0.5× | — |
| added_special_dense | 0.24 | 1.47 | 50.99 | 52.22 | 80.8 | 71.2 | 23.4 | — | 1.6× / 1.5× | 1.4× / 1.4× | 0.5× / 0.4× | — |
| added_special_sparse | 0.24 | 1.48 | 36.24 | 37.47 | 52.3 | 42.6 | 16.2 | — | 1.4× / 1.4× | 1.2× / 1.1× | 0.4× / 0.4× | — |
| agentic-traces | 0.72 | 1.48 | 43.65 | 44.40 | 52.3 | 46.3 | 17.7 | — | 1.2× / 1.2× | 1.1× / 1.0× | 0.4× / 0.4× | — |
| agentic_swe | 0.66 | 1.46 | 54.32 | 55.12 | 57.0 | 56.7 | 19.0 | — | 1.0× / 1.0× | 1.0× / 1.0× | 0.4× / 0.3× | — |
| code_mixed | 0.07 | 1.44 | 48.65 | 50.02 | 51.4 | 49.9 | 17.6 | — | 1.1× / 1.0× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| math_latex | 0.71 | 1.54 | 37.90 | 38.73 | 49.0 | 39.1 | 16.0 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30370974135-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->

