### PR TITLE
perf: handroll tekken regex

### DIFF
--- a/tokenizers/atomsplit/Cargo.toml
+++ b/tokenizers/atomsplit/Cargo.toml
@@ -36,7 +36,7 @@ fancy-regex = "0.13"    # second regex engine in the throughput benches
 logos = "0.15"          # third: a compile-time DFA lexer-generator (pure Rust)
 pcre2 = "0.2"           # fourth: PCRE2 with its JIT (C, pregenerated bindings — no libclang)
 [[bench]]
-name = "regex"        # gpt2 · cl100k · o200k · deepseek, one run per regex family
+name = "regex"        # gpt2 · cl100k · o200k · tekken · deepseek, one run per regex family
 harness = false
 
 [[bench]]

--- a/tokenizers/atomsplit/benches/regex.rs
+++ b/tokenizers/atomsplit/benches/regex.rs
@@ -1,5 +1,5 @@
 //! Pre-tokenization on BIG real text (Wikipedia / big.txt), per language, for every pre-tokenizer at
-//! once — the GPT regex FSMs (gpt2 · cl100k · o200k · deepseek) and the class family (WhitespaceSplit ·
+//! once — the GPT regex FSMs (gpt2 · cl100k · o200k · tekken · deepseek) and the class family (WhitespaceSplit ·
 //! Whitespace · Digits · Punctuation · Bert). Per (engine, corpus): classify (SIMD vs scalar) + fsm in
 //! ns/byte, and the full pipeline (SIMD classify + scalar fsm) vs FOUR reference engines — onig (C),
 //! fancy-regex (pure Rust), logos (compile-time DFA lexer), pcre2 (C + JIT). GPT regexes come from
@@ -12,7 +12,9 @@
 //!
 //! Run: cargo bench --bench regex
 use atomsplit::classify::{classify, classify_scalar, mask};
-use atomsplit::fsm::{Span, class_runs_into, fsm_byte_level, fsm_cl100k, fsm_deepseek, fsm_o200k};
+use atomsplit::fsm::{
+    Span, class_runs_into, fsm_byte_level, fsm_cl100k, fsm_deepseek, fsm_o200k, fsm_tekken,
+};
 use atomsplit::regexes;
 use fancy_regex::Regex as Fancy;
 use logos::Logos;
@@ -70,6 +72,27 @@ enum LO200k {
     Space,
 }
 
+// tekken = LO200k with no contraction suffix and one token per digit.
+#[derive(Logos)]
+enum LTekken {
+    #[regex(
+        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+",
+        priority = 6
+    )]
+    LettersA,
+    #[regex(
+        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*",
+        priority = 5
+    )]
+    LettersB,
+    #[regex(r"\p{N}")]
+    Num,
+    #[regex(r" ?[^\s\p{L}\p{N}]+[\r\n/]*", priority = 2)]
+    Other,
+    #[regex(r"\s+")]
+    Space,
+}
+
 // class-family logos grammars. The whitespace-dropping ones use `skip` so logos never emits ws tokens.
 #[derive(Logos)]
 #[logos(skip r"\s+")]
@@ -112,6 +135,7 @@ fn logos_ns(ename: &str, s: &str, len: usize, iters: u32) -> Option<f64> {
         "gpt2" => |s| lex_count::<LGpt2>(s),
         "cl100k" => |s| lex_count::<LCl100k>(s),
         "o200k" => |s| lex_count::<LO200k>(s),
+        "tekken" => |s| lex_count::<LTekken>(s),
         "ws_split" => |s| lex_count::<LWsSplit>(s),
         "whitespace" => |s| lex_count::<LWhitespace>(s),
         "digits" => |s| lex_count::<LDigits>(s),
@@ -159,6 +183,7 @@ const ENGINES: &[(&str, Fsm, &[&str], bool, bool)] = &[
     ("gpt2", fsm_byte_level as Fsm, &[regexes::GPT2], true, true),
     ("cl100k", fsm_cl100k as Fsm, &[regexes::CL100K], true, true),
     ("o200k", fsm_o200k as Fsm, &[regexes::O200K], true, true),
+    ("tekken", fsm_tekken as Fsm, &[regexes::TEKKEN], true, true),
     (
         "deepseek",
         fsm_deepseek as Fsm,
@@ -396,7 +421,7 @@ fn main() {
     }
     println!(
         "\n(ns/byte, lower better. pipeline = SIMD classify + scalar fsm; vs onig / fancy / logos / \
-         pcre2(JIT). GPT FSMs (gpt2/cl100k/o200k/deepseek): the regex IS the spec, ✓ = byte-exact, \
+         pcre2(JIT). GPT FSMs (gpt2/cl100k/o200k/tekken/deepseek): the regex IS the spec, ✓ = byte-exact, \
          ✗ = regression. Class family (ws_split/whitespace/digits/punct/bert): the mask can't be written \
          as a regex class, so the reference is approximate — ✓ where it happens to match, ≈ where it \
          diverges (speed still comparable). logos approximates the grammar (deepseek/punct/bert: n/a).)"

--- a/tokenizers/atomsplit/src/fsm.rs
+++ b/tokenizers/atomsplit/src/fsm.rs
@@ -5,8 +5,9 @@
 //! The class family (WhitespaceSplit / Punctuation / Digits / Whitespace / Bert) goes through
 //! [`class_runs_into`]: on aarch64/wasm the SIMD movemask boundary-extractor + homogeneous-chunk
 //! early-out (in `simd_fsm`), elsewhere the scalar run-end core ([`emit_class_spans`]). The
-//! regex-shaped ones ([`fsm_cl100k`] / [`fsm_o200k`] / [`fsm_deepseek`] / [`fsm_byte_level`]) are scalar
-//! jump-tables (only the class family's [`class_runs_into`] has a SIMD path).
+//! regex-shaped ones ([`fsm_cl100k`] / [`fsm_o200k`] / [`fsm_tekken`] / [`fsm_deepseek`] /
+//! [`fsm_byte_level`]) are scalar jump-tables (only the class family's [`class_runs_into`] has a SIMD
+//! path).
 
 pub(crate) use crate::classify::{Atom, char_len, classify, in_mask, mask};
 // Atom-tag aliases, shared with the per-tokenizer FSM submodules (`fsm/*.rs`) via `use super::*`.
@@ -240,7 +241,7 @@ mod o200k;
 pub use byte_level::fsm_byte_level;
 pub use cl100k::{fsm_cl100k, fsm_cl100k_cap};
 pub use deepseek::fsm_deepseek;
-pub use o200k::fsm_o200k;
+pub use o200k::{fsm_o200k, fsm_tekken};
 
 // ── Composition recipes ────────────────────────────────────────────────────────────────────────
 // Each pre-tokenizer = (classify → fsm shape + params). `tags` and `out` are caller-owned

--- a/tokenizers/atomsplit/src/fsm/o200k.rs
+++ b/tokenizers/atomsplit/src/fsm/o200k.rs
@@ -52,9 +52,10 @@ fn o200k_letter_match(tags: &[u8], p: usize, re: usize) -> usize {
 
 /// Emit the o200k case-split of the letter run `[ls, re)` into `out[*w..]`: the first sub-token starts at
 /// `pfx` (the optional `[^\r\n\p{L}\p{N}]?` prefix; `pfx == ls` when none), the last absorbs a trailing
-/// contraction. Returns the new cursor (past the contraction). `ls < re` (caller-guaranteed).
+/// contraction (`CONTRACTION` — off for tekken). Returns the new cursor (past the contraction).
+/// `ls < re` (caller-guaranteed).
 #[inline(always)]
-fn emit_o200k_letters(
+fn emit_o200k_letters<const CONTRACTION: bool>(
     text: &[u8],
     tags: &[u8],
     pfx: usize,
@@ -67,7 +68,11 @@ fn emit_o200k_letters(
     while p < re {
         let e = o200k_letter_match(tags, p, re);
         let start = if first { pfx } else { p };
-        let tok_end = if e == re { e + contraction(text, e) } else { e };
+        let tok_end = if CONTRACTION && e == re {
+            e + contraction(text, e)
+        } else {
+            e
+        };
         unsafe {
             *out.get_unchecked_mut(*w) = Span {
                 start: start as u32,
@@ -89,6 +94,21 @@ fn emit_o200k_letters(
 /// Unlike deepseek there are no gaps: rule 4's `[^\s\p{L}\p{N}]+` is a catch-all. Scalar; ┌ OWNER: shared ┐
 #[must_use]
 pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
+    o200k::<true, 3>(text, tags, out)
+}
+
+/// Mistral tekken ([`crate::regexes::TEKKEN`]) — the o200k FSM with the contraction suffix off and one
+/// token per digit. Every other rule is shared, so both are the same code monomorphized twice.
+#[must_use]
+pub fn fsm_tekken(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
+    o200k::<false, 1>(text, tags, out)
+}
+
+fn o200k<const CONTRACTION: bool, const DIGIT_CAP: usize>(
+    text: &[u8],
+    tags: &[u8],
+    out: &mut [Span],
+) -> usize {
     debug_assert!(out.len() >= text.len() && tags.len() >= text.len());
     let end = text.len();
     // Tie `tags.len() == end` so the optimizer drops the per-byte bounds check on every interior
@@ -147,6 +167,10 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
     };
     // rules 5-7 (`\s*[\r\n]+ | \s+(?!\S) | \s+`) → the shared `ws_tail` (identical to cl100k).
     let ws = |i: usize| -> usize { ws_tail(text, tags, i, end) };
+    // The letter rules: case-split the run starting at `ls`, first sub-token starting at the prefix `pfx`.
+    let letters = |pfx: usize, ls: usize, out: &mut [Span], w: &mut usize| -> usize {
+        emit_o200k_letters::<CONTRACTION>(text, tags, pfx, ls, letter_end(ls), out, w)
+    };
 
     let mut i = 0;
     let mut w = 0usize;
@@ -154,10 +178,10 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
         let start = i;
         let b = text[i];
         match tags[i] & 0x0F {
-            // rule 3: `\p{N}{1,3}` (no prefix)
+            // rule 3: `\p{N}{1,DIGIT_CAP}`, no prefix (3 = o200k, 1 = tekken)
             NW | NO => {
                 let (mut p, mut cnt) = (i, 0);
-                while p < end && cnt < 3 && in_mask(tags[p], mask::NUMBER) {
+                while p < end && cnt < DIGIT_CAP && in_mask(tags[p], mask::NUMBER) {
                     p += char_len(text[p]);
                     cnt += 1;
                 }
@@ -167,12 +191,12 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             // take the `[^\r\n\p{L}\p{N}]?` prefix / rule-4 path instead.
             LET | MRK => {
                 if tags[i] != ASM && tags[i] != ZWJ {
-                    i = emit_o200k_letters(text, tags, i, i, letter_end(i), out, &mut w);
+                    i = letters(i, i, out, &mut w);
                     continue;
                 }
                 let a = i + char_len(b);
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = letters(i, a, out, &mut w);
                     continue;
                 }
                 i = other(i); // ∈ NOT_WS_L_N ⇒ > i
@@ -181,7 +205,7 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             SPC => {
                 let a = i + 1; // Space is ASCII (0x20)
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = letters(i, a, out, &mut w);
                     continue;
                 }
                 let p = other(a);
@@ -191,7 +215,7 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             WSO => {
                 let a = i + char_len(b);
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = letters(i, a, out, &mut w);
                     continue;
                 }
                 i = ws(i);
@@ -201,7 +225,7 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             CON | PUN | APO | SYM | NMO | CTL => {
                 let a = i + char_len(b);
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = letters(i, a, out, &mut w);
                     continue;
                 }
                 i = other(i); // ∈ NOT_WS_L_N ⇒ > i

--- a/tokenizers/atomsplit/src/lib.rs
+++ b/tokenizers/atomsplit/src/lib.rs
@@ -3,8 +3,9 @@
 //! One SIMD pass ([`classify`]) maps every codepoint to a tiny "atom" alphabet; a family of no-push
 //! FSMs ([`fsm`]) turn that atom stream into token spans (byte ranges) — the pre-tokenizer stage that
 //! runs before a BPE/WordPiece model. Pre-tokenizers implemented: `WhitespaceSplit`, `Punctuation`,
-//! `Digits`, `Whitespace`, `Bert`, `Cl100k`, `DeepSeek`, `ByteLevel`, `CharDelimiterSplit` (o200k is
-//! exposed as the [`fsm::fsm_o200k`] function rather than a recipe struct).
+//! `Digits`, `Whitespace`, `Bert`, `Cl100k`, `DeepSeek`, `ByteLevel`, `CharDelimiterSplit` (o200k and
+//! Mistral's tekken are exposed as the [`fsm::fsm_o200k`] / [`fsm::fsm_tekken`] functions rather than
+//! recipe structs).
 //!
 //! Design: every fsm is *no-push* — it writes spans into a caller-preallocated `&mut [fsm::Span]`
 //! (length ≥ `text.len()`) and returns the token count; there is no `Vec`/allocation on the hot path.

--- a/tokenizers/atomsplit/src/regexes.rs
+++ b/tokenizers/atomsplit/src/regexes.rs
@@ -18,6 +18,11 @@ pub const CL100K: &str = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+
 /// [`crate::fsm::fsm_o200k`].
 pub const O200K: &str = r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+";
 
+/// Mistral tekken (mistral-small-4 / mistral-4). o200k's grammar with two changes: letter tokens take
+/// no contraction suffix, and the digit rule is a bare `\p{N}` — one token per digit. Reproduced by
+/// [`crate::fsm::fsm_tekken`].
+pub const TEKKEN: &str = r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+
 /// deepseek-v3 `Sequence`: `NUM` → `CJK` → `BIG`, each `Isolated`. Reproduced by
 /// [`crate::fsm::fsm_deepseek`] as one pass.
 pub const DEEPSEEK_NUM: &str = r"\p{N}{1,3}";

--- a/tokenizers/atomsplit/tests/fsm.rs
+++ b/tokenizers/atomsplit/tests/fsm.rs
@@ -2,7 +2,7 @@
 use atomsplit::classify::{classify, mask};
 use atomsplit::fsm::{
     CharDelimiterSplit, Span, class_runs_into, emit_class_spans, fsm_byte_level, fsm_cl100k,
-    fsm_deepseek,
+    fsm_deepseek, fsm_o200k, fsm_tekken,
 };
 
 /// Run a no-push fsm into a fresh buffer and return the emitted spans.
@@ -24,6 +24,18 @@ fn cl100k_rules() {
     assert_eq!(cl("a1234"), vec![(0, 1), (1, 4), (4, 5)]); // "a" | "123" | "4" ({1,3} cap)
     assert_eq!(cl("  hi"), vec![(0, 1), (1, 4)]); // " " | " hi"
     assert_eq!(cl("a, b"), vec![(0, 1), (1, 2), (2, 4)]); // "a" | "," | " b"
+}
+
+/// Mistral's tekken split is o200k's, minus the contraction suffix, with one token per digit.
+#[test]
+fn tekken_rules() {
+    let tk = |s| spans(fsm_tekken, s);
+    assert_eq!(tk("don't"), vec![(0, 3), (3, 5)]); // "don" | "'t" — prefix+letters, not a contraction
+    assert_eq!(spans(fsm_o200k, "don't"), vec![(0, 5)]); // o200k glues the contraction on
+    assert_eq!(tk("a1234"), vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]); // `\p{N}`, one digit each
+    assert_eq!(tk("XMLHttpRequest"), vec![(0, 7), (7, 14)]); // case split: "XMLHttp" | "Request"
+    assert_eq!(tk("a/\r\nb"), vec![(0, 1), (1, 4), (4, 5)]); // "/" run + its `[\r\n/]*` tail
+    assert_eq!(tk("hi   ok"), vec![(0, 2), (2, 4), (4, 7)]); // \s+(?!\S) leaves one space
 }
 
 #[test]

--- a/tokenizers/atomsplit/tests/parity.rs
+++ b/tokenizers/atomsplit/tests/parity.rs
@@ -1,25 +1,37 @@
 //! Reference-parity gates for the regex-shaped pre-tokenizers. Each of `fsm_cl100k` / `fsm_o200k` /
-//! `fsm_byte_level` / `fsm_deepseek` must be BYTE-EXACT with the real reference — the oniguruma regex, composed exactly
-//! as HF applies it (deepseek is a `Sequence` of three Isolated splits) — on a representative
-//! multilingual corpus (ASCII, contractions, digits, punctuation runs, whitespace variants, Latin
-//! accents/marks, Cyrillic/Greek/Arabic/Devanagari, Han/Kana/Hangul, ZWJ, astral emoji).
+//! `fsm_tekken` / `fsm_byte_level` / `fsm_deepseek` must be BYTE-EXACT with the real reference — the
+//! oniguruma regex, composed exactly as HF applies it (deepseek is a `Sequence` of three Isolated
+//! splits) — on two corpora: a multilingual one (ASCII, contractions, digits, punctuation runs,
+//! whitespace variants, Latin accents/marks, Cyrillic/Greek/Arabic/Devanagari, Han/Kana/Hangul, ZWJ,
+//! astral emoji) and an edge-case one (see [`EDGE`]).
 //!
-//! This is the byte-exactness gate the hand cases in `fsm.rs` don't provide; the same corpus + gate
+//! This is the byte-exactness gate the hand cases in `fsm.rs` don't provide; the same corpora + gate
 //! should run under x86 (Intel SDE) in CI to validate the SIMD paths.
 //!
 //! Gated off wasm32: the oniguruma reference is a C library that has no wasi libc to build against.
 #![cfg(not(target_arch = "wasm32"))]
 use atomsplit::classify::classify;
-use atomsplit::fsm::{Span, fsm_byte_level, fsm_cl100k, fsm_deepseek, fsm_o200k};
+use atomsplit::fsm::{Span, fsm_byte_level, fsm_cl100k, fsm_deepseek, fsm_o200k, fsm_tekken};
 use onig::Regex;
 // The oracle regexes are the canonical specs the FSMs implement — single source of truth in atomsplit.
 use atomsplit::regexes::{
     CL100K, DEEPSEEK_BIG as DS_BIG, DEEPSEEK_CJK as DS_CJK, DEEPSEEK_NUM as DS_NUM, GPT2, O200K,
+    TEKKEN,
 };
 
 const CORPUS: &str = "The quick brown fox. Don't 12345 numbers, \u{00BD}\u{00B2}\u{00BC} \u{2168}! \
      café × naïve — Привет, наука! Ελλάδα 中文分词。ひらがな カタカナ 한글 مرحبا العربية \
      नरेंद्र मोदी x_y a1b2c3 e-mail@host.com 😀👍 hello  world\ttabs\nnewlines   end ";
+
+/// Second corpus, aimed at the axes where the o200k-shaped FSMs differ from each other: apostrophes
+/// (contraction suffix vs plain prefix+letters), digit-run length (`{1,3}` vs one-per-token), and the
+/// `[\r\n/]*` tail after a symbol run.
+const EDGE: &str = "IT'S O'Brien can't 'quoted' l'été rock'n'roll\r\n\
+     0 42 999 1000 1234567 v1.2.3 3.14159 1,000,000 \
+     https://host/a/b?c=1&d=2 path/to//file /\r\n/ ///x \
+     CamelCase XMLHttpRequest ĲSSELMEER ǅAMBO ŀl a\u{0301}b \
+     日本語1234テスト ½3¼ \u{2168}42\u{2169} #tag @user $9.99 100% \
+     end\n\n\nlines\r\n\r\n  \t  trailing   ";
 
 fn spans(f: impl Fn(&[u8], &[u8], &mut [Span]) -> usize, s: &str) -> Vec<Span> {
     let mut tags = vec![0u8; s.len()];
@@ -73,25 +85,37 @@ fn deepseek_ref(text: &str) -> Vec<Span> {
         .collect()
 }
 
+/// Both corpora, one regex: the FSM must reproduce the oracle span-for-span.
+fn check(fsm: impl Fn(&[u8], &[u8], &mut [Span]) -> usize + Copy, pattern: &str) {
+    let re = Regex::new(pattern).unwrap();
+    for text in [CORPUS, EDGE] {
+        assert_eq!(spans(fsm, text), onig_spans(&re, text), "{text:?}");
+    }
+}
+
 #[test]
 fn cl100k_parity() {
-    let re = Regex::new(CL100K).unwrap();
-    assert_eq!(spans(fsm_cl100k, CORPUS), onig_spans(&re, CORPUS));
+    check(fsm_cl100k, CL100K);
 }
 
 #[test]
 fn o200k_parity() {
-    let re = Regex::new(O200K).unwrap();
-    assert_eq!(spans(fsm_o200k, CORPUS), onig_spans(&re, CORPUS));
+    check(fsm_o200k, O200K);
+}
+
+#[test]
+fn tekken_parity() {
+    check(fsm_tekken, TEKKEN);
 }
 
 #[test]
 fn byte_level_parity() {
-    let re = Regex::new(GPT2).unwrap();
-    assert_eq!(spans(fsm_byte_level, CORPUS), onig_spans(&re, CORPUS));
+    check(fsm_byte_level, GPT2);
 }
 
 #[test]
 fn deepseek_parity() {
-    assert_eq!(spans(fsm_deepseek, CORPUS), deepseek_ref(CORPUS));
+    for text in [CORPUS, EDGE] {
+        assert_eq!(spans(fsm_deepseek, text), deepseek_ref(text), "{text:?}");
+    }
 }

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -172,6 +172,7 @@ impl pipeline::PreTokenizer for Split {
                     }
                     GptFsm::Gpt2 => atomsplit::fsm::fsm_byte_level(bytes, tags, spans),
                     GptFsm::O200k => atomsplit::fsm::fsm_o200k(bytes, tags, spans),
+                    GptFsm::Tekken => atomsplit::fsm::fsm_tekken(bytes, tags, spans),
                 },
                 out,
             );
@@ -462,6 +463,34 @@ mod tests {
 
         assert_eq!(
             pipeline_split(SplitPattern::Regex(o200k.into()), Isolated, false, corpus),
+            legacy,
+        );
+    }
+
+    #[test]
+    fn pipeline_tekken_uses_fsm_and_matches_legacy() {
+        // Mistral's tekken regex (mistral-small-4) → recognized → routes to fsm_tekken. Same corpus
+        // shape as o200k, whose grammar it shares: the differences it must get right are apostrophes
+        // (no contraction suffix, so `'s` starts a new token) and one token per digit.
+        let tekken = atomsplit::regexes::TEKKEN;
+        let corpus = "McDonald's iPhone SQLite HELLOWorld camelCase don't I'll We've 3.14159 café Straße 世界 안녕\n\n  path/to/file Mixed CASE end.";
+        let pretok = Split::new(SplitPattern::Regex(tekken.into()), Isolated, false).unwrap();
+        assert_eq!(
+            pretok.fsm,
+            Some(crate::utils::GptFsm::Tekken),
+            "tekken / mistral pattern should route to the native FSM"
+        );
+
+        let mut pre = PreTokenizedString::from(corpus);
+        pretok.pre_tokenize(&mut pre).unwrap();
+        let legacy: Vec<(&str, (u32, u32))> = pre
+            .get_splits(OffsetReferential::Original, OffsetType::Byte)
+            .into_iter()
+            .map(|(s, o, _)| (s, (o.0 as u32, o.1 as u32)))
+            .collect();
+
+        assert_eq!(
+            pipeline_split(SplitPattern::Regex(tekken.into()), Isolated, false, corpus),
             legacy,
         );
     }

--- a/tokenizers/tk-encode/src/utils/unrolled_regex.rs
+++ b/tokenizers/tk-encode/src/utils/unrolled_regex.rs
@@ -5,7 +5,7 @@
 // Canonical GPT pre-tokenization regexes (the look-ahead originals), used as recognition keys — the
 // single source of truth lives in `atomsplit::regexes`. `gpt_fsm` maps each to the `atomsplit` FSM that
 // reproduces its `Isolated` split byte-for-byte.
-use atomsplit::regexes::{GPT2, O200K};
+use atomsplit::regexes::{GPT2, O200K, TEKKEN};
 // cl100k is recognized structurally (see `cl100k_digit_cap`), so the exact pattern is only a test key.
 #[cfg(test)]
 use atomsplit::regexes::CL100K;
@@ -20,6 +20,9 @@ pub enum GptFsm {
     Cl100k { digit_cap: usize },
     /// o200k / GPT-4o regex → `atomsplit::fsm::fsm_o200k`.
     O200k,
+    /// Mistral tekken regex → `atomsplit::fsm::fsm_tekken` (o200k's grammar with no contraction
+    /// suffix and one token per digit).
+    Tekken,
 }
 
 /// The cl100k-family template is fixed except rule 3's digit rule. If `pattern` is that template, return
@@ -39,14 +42,16 @@ fn cl100k_digit_cap(pattern: &str) -> Option<usize> {
 }
 
 /// If `pattern` is a recognized GPT pre-tokenization regex, name the native FSM that reproduces its
-/// `Isolated` split byte-for-byte. GPT-2 and o200k are matched exactly; the cl100k family is matched
-/// structurally ([`cl100k_digit_cap`]) so digit-cap variants (Qwen2 …) unroll too. An unrecognized
-/// pattern → `None` (the SysRegex / fancy-regex path handles it).
+/// `Isolated` split byte-for-byte. GPT-2, o200k and tekken are matched exactly; the cl100k family is
+/// matched structurally ([`cl100k_digit_cap`]) so digit-cap variants (Qwen2 …) unroll too. An
+/// unrecognized pattern → `None` (the SysRegex / fancy-regex path handles it).
 pub fn gpt_fsm(pattern: &str) -> Option<GptFsm> {
     if pattern == GPT2 {
         Some(GptFsm::Gpt2)
     } else if pattern == O200K {
         Some(GptFsm::O200k)
+    } else if pattern == TEKKEN {
+        Some(GptFsm::Tekken)
     } else {
         cl100k_digit_cap(pattern).map(|digit_cap| GptFsm::Cl100k { digit_cap })
     }
@@ -77,6 +82,7 @@ impl crate::tokenizer::pattern::Pattern for GptFsmPattern {
                 atomsplit::fsm::fsm_cl100k_cap(bytes, &tags, &mut spans, digit_cap)
             }
             GptFsm::O200k => atomsplit::fsm::fsm_o200k(bytes, &tags, &mut spans),
+            GptFsm::Tekken => atomsplit::fsm::fsm_tekken(bytes, &tags, &mut spans),
         };
         Ok(spans[..n]
             .iter()
@@ -115,6 +121,7 @@ mod tests {
         // Exact matches for gpt2 / o200k, structural (any digit cap) for the cl100k family.
         assert_eq!(gpt_fsm(GPT2), Some(GptFsm::Gpt2));
         assert_eq!(gpt_fsm(O200K), Some(GptFsm::O200k));
+        assert_eq!(gpt_fsm(TEKKEN), Some(GptFsm::Tekken));
         assert_eq!(gpt_fsm(CL100K), Some(GptFsm::Cl100k { digit_cap: 3 }));
         // Qwen2: cl100k with rule 3 = `\p{N}` → cap 1.
         let qwen2 = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+";

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -107,9 +107,10 @@ fn check_model(tok_file: &str) {
     );
 }
 
-// Same model set as the decode oracle (one per decoder archetype); whichever files
-// a given checkout has get run (bert-wiki + llama-3 ship with `make test`; the rest
-// with `make bench-models`). Unsupported models skip, not fail.
+// The decode oracle's model set (one per decoder archetype) plus mistral-small-4, whose
+// tekken pre-tokenizer is its own encode archetype; whichever files a given checkout has
+// get run (bert-wiki + llama-3 ship with `make test`; the rest with `make bench-models`).
+// Unsupported models skip, not fail.
 #[test]
 fn bert_wiki() {
     check_model("bert-wiki.json");
@@ -143,4 +144,9 @@ fn t5_base() {
 #[test]
 fn albert() {
     check_model("albert-base-v1-tokenizer.json");
+}
+
+#[test]
+fn mistral_small_4() {
+    check_model("mistral-small-4.json");
 }


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`0c4f0edb6 · 2026-07-28 22:09 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-overview.png" width="860">

**vs base branch** (`709ef7af5`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.95 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 12) · Pipeline 8+0 (peak 16)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.8 | 27.8 | ×3.54 | ×1.01 | 3% (1.2) | 76% (27.5) | 13% (4.7) | 8% (2.9) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 24.3 | ×5.84 | ×0.97 | 3% (1.2) | 67% (27.5) | 11% (4.7) | 19% (7.7) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 33.8 | ×5.63 | ×0.97 | 4% (1.2) | 65% (19.2) | 13% (3.8) | 18% (5.4) | 0% (0.0) | match |
| cmn_Hani | lang | 3.8 | 18.5 | ×4.87 | ×0.99 | 2% (1.2) | 70% (37.8) | 11% (6.0) | 17% (9.0) | 0% (0.1) | match |
| ell_Grek | lang | 3.7 | 23.3 | ×6.23 | ×0.98 | 3% (1.2) | 67% (28.6) | 8% (3.4) | 22% (9.6) | 0% (0.0) | match |
| eng_Latn | lang | 4.3 | 18.3 | ×4.26 | ×1.00 | 5% (2.5) | 69% (38.6) | 8% (4.4) | 19% (10.5) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 19.3 | ×4.71 | ×0.97 | 2% (1.2) | 73% (37.4) | 10% (5.0) | 14% (7.3) | 0% (0.1) | match |
| hin_Deva | lang | 6.4 | 27.0 | ×4.19 | ×0.98 | 3% (1.2) | 73% (27.1) | 11% (3.9) | 13% (4.8) | 0% (0.1) | match |
| jpn_Jpan | lang | 4.2 | 26.8 | ×6.37 | ×0.98 | 3% (1.2) | 63% (23.4) | 12% (4.7) | 21% (7.9) | 1% (0.3) | match |
| kat_Geor | lang | 6.1 | 27.8 | ×4.57 | ×1.00 | 3% (1.2) | 76% (27.0) | 8% (2.7) | 17% (6.0) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 17.1 | ×7.09 | ×0.96 | 2% (1.2) | 61% (35.6) | 11% (6.6) | 26% (15.3) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.6 | 23.3 | ×6.44 | ×0.98 | 3% (1.2) | 62% (27.5) | 7% (3.3) | 28% (12.4) | 0% (0.0) | match |
| tam_Taml | lang | 6.9 | 37.6 | ×5.43 | ×0.98 | 4% (1.2) | 71% (18.6) | 13% (3.3) | 12% (3.2) | 0% (0.0) | match |
| tha_Thai | lang | 8.2 | 33.0 | ×4.01 | ×1.01 | 4% (1.2) | 84% (24.9) | 10% (2.9) | 4% (1.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.7 | 19.6 | ×2.92 | ×0.99 | 3% (1.3) | 79% (40.6) | 14% (7.0) | 5% (2.6) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.0 | 18.1 | ×3.63 | ×0.98 | 4% (1.9) | 72% (39.9) | 13% (7.0) | 12% (6.5) | 0% (0.1) | match |
| added_special_dense | modalities | 5.3 | 39.0 | ×7.38 | ×1.00 | 20% (5.1) | 37% (9.2) | 35% (8.6) | 8% (2.0) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 21.1 | ×5.39 | ×0.99 | 8% (3.6) | 60% (27.9) | 18% (8.6) | 14% (6.3) | 1% (0.3) | match |
| agentic-traces | modalities | 3.8 | 18.2 | ×4.82 | ×1.00 | 4% (2.4) | 68% (38.5) | 9% (5.0) | 19% (10.7) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 19.4 | ×4.86 | ×1.00 | 4% (1.9) | 73% (38.6) | 7% (3.6) | 16% (8.7) | 0% (0.1) | match |
| code_mixed | modalities | 3.8 | 18.9 | ×4.94 | ×1.00 | 4% (2.2) | 71% (38.5) | 8% (4.2) | 17% (9.4) | 0% (0.0) | match |
| math_latex | modalities | 3.9 | 18.2 | ×4.64 | ×1.00 | 4% (2.5) | 68% (38.5) | 8% (4.7) | 19% (10.9) | 0% (0.1) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×23.10 vs v0.23.1 · ×5.36 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 82+0 (peak 81)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 90.3 | ×21.26 | ×2.63 | 7% (0.7) | 0% (0.0) | 49% (4.7) | 45% (4.3) | 0% (0.0) | match |
| arb_Arab | lang | 3.9 | 98.0 | ×24.82 | ×5.89 | 7% (0.6) | 0% (0.0) | 39% (3.5) | 55% (5.0) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 140.7 | ×23.32 | ×7.89 | 10% (0.6) | 0% (0.0) | 51% (3.1) | 40% (2.5) | 0% (0.0) | match |
| cmn_Hani | lang | 3.4 | 78.8 | ×22.92 | ×4.76 | 6% (0.8) | 0% (0.0) | 27% (3.2) | 59% (7.0) | 8% (0.9) | match |
| ell_Grek | lang | 4.3 | 110.2 | ×25.36 | ×6.17 | 8% (0.6) | 0% (0.0) | 43% (3.4) | 47% (3.7) | 2% (0.2) | match |
| eng_Latn | lang | 2.9 | 71.6 | ×24.54 | ×5.50 | 15% (2.0) | 0% (0.0) | 40% (5.1) | 45% (5.8) | 0% (0.0) | match |
| heb_Hebr | lang | 3.6 | 93.2 | ×25.90 | ×7.18 | 6% (0.6) | 0% (0.0) | 38% (3.6) | 58% (5.5) | 0% (0.0) | match |
| hin_Deva | lang | 5.6 | 132.4 | ×23.81 | ×6.22 | 9% (0.6) | 0% (0.0) | 49% (3.3) | 41% (2.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.1 | 111.3 | ×26.84 | ×6.20 | 9% (0.7) | 0% (0.0) | 40% (3.0) | 46% (3.5) | 5% (0.4) | match |
| kat_Geor | lang | 5.9 | 138.8 | ×23.72 | ×7.99 | 9% (0.6) | 0% (0.0) | 46% (2.9) | 44% (2.8) | 1% (0.0) | match |
| kor_Hang | lang | 3.3 | 69.3 | ×20.77 | ×3.51 | 5% (0.6) | 0% (0.0) | 29% (3.7) | 66% (8.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.2 | 102.9 | ×24.60 | ×7.26 | 7% (0.6) | 0% (0.0) | 38% (3.3) | 54% (4.6) | 1% (0.1) | match |
| tam_Taml | lang | 6.2 | 149.3 | ×24.28 | ×8.55 | 9% (0.6) | 0% (0.0) | 43% (2.7) | 42% (2.6) | 7% (0.4) | match |
| tha_Thai | lang | 6.8 | 90.1 | ×13.25 | ×6.29 | 6% (0.6) | 0% (0.0) | 21% (2.1) | 75% (7.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 160.1 | ×26.97 | ×6.82 | 13% (0.7) | 0% (0.0) | 50% (2.8) | 37% (2.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 117.1 | ×21.85 | ×5.98 | 17% (1.3) | 0% (0.0) | 47% (3.7) | 38% (3.0) | 0% (0.0) | match |
| added_special_dense | modalities | 3.7 | 60.7 | ×16.58 | ×1.62 | 42% (6.6) | 3% (0.5) | 39% (6.1) | 11% (1.7) | 6% (0.9) | match |
| added_special_sparse | modalities | 4.0 | 67.0 | ×16.96 | ×3.23 | 29% (3.9) | 1% (0.2) | 50% (6.8) | 19% (2.5) | 1% (0.2) | match |
| agentic-traces | modalities | 2.8 | 69.2 | ×24.94 | ×4.85 | 14% (1.9) | 0% (0.0) | 40% (5.4) | 46% (6.3) | 1% (0.1) | match |
| agentic_swe | modalities | 2.9 | 96.2 | ×32.70 | ×6.45 | 14% (1.3) | 0% (0.0) | 40% (3.8) | 47% (4.5) | 0% (0.0) | match |
| code_mixed | modalities | 3.4 | 85.5 | ×25.14 | ×5.50 | 14% (1.6) | 0% (0.0) | 42% (4.6) | 42% (4.7) | 2% (0.2) | match |
| math_latex | modalities | 2.7 | 70.2 | ×25.90 | ×5.00 | 14% (1.9) | 0% (0.0) | 41% (5.4) | 44% (5.8) | 1% (0.2) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.89 | 3.10 | 4.72 | 4.93 | 41.3 | 20.4 | 9.2 | — | 8.7× / 8.4× | 4.3× / 4.1× | 2.0× / 1.9× | — |
| arb_Arab | 1.00 | 2.77 | 3.47 | 5.23 | 48.6 | 23.2 | 10.3 | — | 14.0× / 9.3× | 6.7× / 4.4× | 3.0× / 2.0× | — |
| ben_Beng | 1.46 | 2.66 | 3.13 | 4.34 | 35.6 | 16.7 | 7.6 | — | 11.4× / 8.2× | 5.3× / 3.8× | 2.4× / 1.8× | — |
| cmn_Hani | 1.13 | 2.00 | 3.15 | 4.03 | 58.9 | 34.9 | 14.4 | — | 18.7× / 14.6× | 11.1× / 8.7× | 4.6× / 3.6× | — |
| ell_Grek | 0.58 | 2.76 | 3.41 | 5.59 | 47.1 | 21.1 | 9.6 | — | 13.8× / 8.4× | 6.2× / 3.8× | 2.8× / 1.7× | — |
| eng_Latn | 0.11 | 1.45 | 5.11 | 6.45 | 64.2 | 40.1 | 16.5 | — | 12.6× / 9.9× | 7.8× / 6.2× | 3.2× / 2.6× | — |
| heb_Hebr | 1.01 | 2.81 | 3.57 | 5.37 | 50.5 | 25.0 | 10.9 | — | 14.1× / 9.4× | 7.0× / 4.7× | 3.1× / 2.0× | — |
| hin_Deva | 1.36 | 2.82 | 3.35 | 4.80 | 37.6 | 19.3 | 8.6 | — | 11.2× / 7.8× | 5.8× / 4.0× | 2.6× / 1.8× | — |
| jpn_Jpan | 1.56 | 3.13 | 2.97 | 4.54 | 52.8 | 27.9 | 12.0 | — | 17.8× / 11.6× | 9.4× / 6.1× | 4.1× / 2.6× | — |
| kat_Geor | 1.39 | 2.17 | 2.93 | 3.72 | 32.3 | 15.8 | 7.2 | — | 11.0× / 8.7× | 5.4× / 4.2× | 2.5× / 1.9× | — |
| kor_Hang | 1.13 | 2.49 | 3.72 | 5.08 | 49.6 | 27.5 | 11.9 | — | 13.3× / 9.8× | 7.4× / 5.4× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.02 | 2.74 | 3.32 | 5.04 | 47.1 | 21.5 | 9.7 | — | 14.2× / 9.3× | 6.5× / 4.3× | 2.9× / 1.9× | — |
| tam_Taml | 0.93 | 2.65 | 2.70 | 4.43 | 31.7 | 13.9 | 6.6 | — | 11.7× / 7.2× | 5.2× / 3.1× | 2.4× / 1.5× | — |
| tha_Thai | 1.36 | 2.26 | 2.14 | 3.03 | 27.4 | 10.1 | 5.2 | — | 12.8× / 9.0× | 4.7× / 3.3× | 2.4× / 1.7× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.78 | 4.20 | 42.1 | 20.4 | 9.0 | — | 15.1× / 10.0× | 7.3× / 4.9× | 3.2× / 2.1× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.74 | 5.16 | 48.2 | 26.1 | 11.2 | — | 12.9× / 9.3× | 7.0× / 5.1× | 3.0× / 2.2× | — |
| added_special_dense | 0.06 | 1.47 | 6.10 | 7.52 | 164.4 | 99.7 | 38.9 | — | 26.9× / 21.9× | 16.3× / 13.3× | 6.4× / 5.2× | — |
| added_special_sparse | 0.06 | 1.47 | 6.79 | 8.20 | 98.2 | 57.1 | 24.0 | — | 14.5× / 12.0× | 8.4× / 7.0× | 3.5× / 2.9× | — |
| agentic-traces | 0.58 | 1.46 | 5.40 | 6.29 | 78.3 | 55.0 | 20.2 | — | 14.5× / 12.4× | 10.2× / 8.7× | 3.7× / 3.2× | — |
| agentic_swe | 0.51 | 1.46 | 3.82 | 4.77 | 92.3 | 66.6 | 23.8 | — | 24.2× / 19.3× | 17.4× / 14.0× | 6.2× / 5.0× | — |
| code_mixed | 0.07 | 1.44 | 4.62 | 6.00 | 72.0 | 54.0 | 18.9 | — | 15.6× / 12.0× | 11.7× / 9.0× | 4.1× / 3.1× | — |
| math_latex | 0.56 | 1.48 | 5.40 | 6.32 | 76.8 | 50.4 | 20.9 | — | 14.2× / 12.2× | 9.3× / 8.0× | 3.9× / 3.3× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×2.25 vs v0.23.1 · ×1.03 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 371) · Pipeline 275+0 (peak 371)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 9.4 | 26.4 | ×2.80 | ×0.96 | 2% (0.7) | 6% (2.1) | 0% (0.0) | 94% (35.1) | 0% (0.0) | match |
| arb_Arab | lang | 6.3 | 11.3 | ×1.80 | ×0.85 | 1% (0.6) | 3% (2.6) | 0% (0.0) | 97% (86.3) | 0% (0.0) | match |
| ben_Beng | lang | 8.3 | 17.3 | ×2.09 | ×0.93 | 1% (0.6) | 3% (1.7) | 0% (0.0) | 94% (54.3) | 2% (0.9) | match |
| cmn_Hani | lang | 9.6 | 31.4 | ×3.29 | ×0.93 | 2% (0.6) | 1% (0.3) | 0% (0.0) | 99% (29.6) | 0% (0.0) | match |
| ell_Grek | lang | 6.7 | 13.9 | ×2.08 | ×0.94 | 1% (0.6) | 3% (2.5) | 0% (0.0) | 95% (67.5) | 1% (0.6) | match |
| eng_Latn | lang | 3.2 | 5.1 | ×1.60 | ×0.93 | 1% (2.0) | 2% (4.8) | 0% (0.1) | 96% (194.3) | 1% (1.6) | match |
| heb_Hebr | lang | 7.1 | 16.2 | ×2.29 | ×0.97 | 1% (0.6) | 4% (2.6) | 0% (0.0) | 94% (57.5) | 1% (0.6) | match |
| hin_Deva | lang | 7.9 | 16.6 | ×2.11 | ×0.93 | 1% (0.6) | 4% (2.2) | 0% (0.0) | 97% (56.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 10.2 | 27.2 | ×2.68 | ×0.94 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 95% (34.9) | 3% (1.1) | match |
| kat_Geor | lang | 10.9 | 24.3 | ×2.23 | ×0.99 | 1% (0.6) | 3% (1.4) | 0% (0.0) | 94% (38.6) | 1% (0.6) | match |
| kor_Hang | lang | 7.9 | 24.8 | ×3.12 | ×0.98 | 2% (0.6) | 6% (2.6) | 0% (0.0) | 93% (38.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 6.0 | 10.1 | ×1.67 | ×0.91 | 1% (0.6) | 2% (2.2) | 0% (0.0) | 96% (96.7) | 2% (1.5) | match |
| tam_Taml | lang | 9.4 | 18.8 | ×2.00 | ×0.96 | 1% (0.6) | 2% (1.2) | 0% (0.0) | 93% (50.4) | 3% (1.8) | match |
| tha_Thai | lang | 10.9 | 22.9 | ×2.10 | ×0.96 | 1% (0.6) | 1% (0.6) | 0% (0.0) | 95% (42.5) | 2% (1.1) | match |
| added_normalized_dense | modalities | 4.7 | 6.5 | ×1.37 | ×0.87 | 1% (0.7) | 2% (2.9) | 0% (0.0) | 100% (139.6) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.2 | 6.5 | ×1.54 | ×0.98 | 1% (1.4) | 3% (4.3) | 0% (0.0) | 102% (157.5) | 0% (0.0) | match |
| added_special_dense | modalities | 4.6 | 35.0 | ×7.66 | ×1.73 | 36% (9.4) | 31% (8.1) | 27% (7.0) | 7% (1.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 6.8 | 43.0 | ×6.31 | ×4.39 | 34% (6.9) | 34% (6.8) | 23% (4.6) | 10% (2.1) | 0% (0.0) | match |
| agentic-traces | modalities | 3.6 | 5.9 | ×1.64 | ×0.92 | 1% (1.8) | 3% (4.5) | 0% (0.0) | 96% (164.2) | 0% (0.3) | match |
| agentic_swe | modalities | 3.6 | 6.5 | ×1.80 | ×0.94 | 1% (1.4) | 5% (7.4) | 0% (0.0) | 94% (145.3) | 0% (0.6) | match |
| code_mixed | modalities | 3.7 | 6.3 | ×1.69 | ×0.96 | 1% (1.6) | 4% (6.0) | 0% (0.0) | 96% (154.1) | 0% (0.0) | match |
| math_latex | modalities | 3.5 | 5.4 | ×1.56 | ×0.90 | 1% (1.9) | 3% (4.6) | 0% (0.0) | 96% (173.7) | 1% (1.6) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×30.34 vs v0.23.1 · ×3.58 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 27+0 (peak 27)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.7 | 94.5 | ×25.53 | ×1.94 | 8% (0.7) | 0% (0.0) | 43% (3.6) | 47% (4.0) | 2% (0.2) | match |
| arb_Arab | lang | 3.4 | 102.4 | ×29.75 | ×3.98 | 8% (0.6) | 0% (0.0) | 29% (2.3) | 64% (5.0) | 0% (0.0) | match |
| ben_Beng | lang | 2.4 | 97.2 | ×40.35 | ×2.20 | 7% (0.6) | 0% (0.0) | 33% (3.0) | 61% (5.5) | 0% (0.0) | match |
| cmn_Hani | lang | 3.2 | 95.4 | ×30.14 | ×3.31 | 8% (0.6) | 0% (0.0) | 29% (2.3) | 64% (5.1) | 0% (0.0) | match |
| ell_Grek | lang | 3.7 | 118.8 | ×31.95 | ×4.19 | 9% (0.6) | 0% (0.0) | 31% (2.2) | 61% (4.2) | 0% (0.0) | match |
| eng_Latn | lang | 3.0 | 84.0 | ×28.40 | ×5.98 | 19% (2.0) | 0% (0.0) | 28% (3.0) | 53% (5.6) | 0% (0.0) | match |
| heb_Hebr | lang | 3.5 | 108.2 | ×30.65 | ×3.76 | 7% (0.6) | 0% (0.0) | 28% (2.3) | 64% (5.2) | 1% (0.1) | match |
| hin_Deva | lang | 2.9 | 106.5 | ×36.52 | ×2.63 | 7% (0.6) | 0% (0.0) | 34% (3.0) | 59% (5.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.4 | 132.6 | ×29.88 | ×6.03 | 9% (0.6) | 0% (0.0) | 32% (2.1) | 60% (3.9) | 0% (0.0) | match |
| kat_Geor | lang | 4.5 | 158.5 | ×34.99 | ×2.44 | 11% (0.6) | 0% (0.0) | 39% (2.1) | 52% (2.8) | 0% (0.0) | match |
| kor_Hang | lang | 3.2 | 89.7 | ×27.92 | ×2.05 | 6% (0.6) | 0% (0.0) | 24% (2.4) | 70% (7.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.8 | 117.1 | ×30.81 | ×4.23 | 8% (0.6) | 0% (0.0) | 28% (2.1) | 63% (4.7) | 1% (0.0) | match |
| tam_Taml | lang | 2.6 | 116.5 | ×44.02 | ×1.61 | 7% (0.6) | 0% (0.0) | 33% (2.7) | 60% (4.9) | 0% (0.0) | match |
| tha_Thai | lang | 3.4 | 114.0 | ×33.73 | ×3.21 | 8% (0.6) | 0% (0.0) | 34% (2.5) | 58% (4.3) | 1% (0.0) | match |
| added_normalized_dense | modalities | 5.4 | 197.0 | ×36.47 | ×7.75 | 17% (0.7) | 0% (0.0) | 26% (1.1) | 55% (2.3) | 2% (0.1) | match |
| added_normalized_sparse | modalities | 4.8 | 143.4 | ×29.72 | ×6.66 | 21% (1.3) | 0% (0.0) | 32% (2.0) | 49% (3.1) | 0% (0.0) | match |
| added_special_dense | modalities | 4.0 | 81.4 | ×20.14 | ×1.70 | 43% (4.9) | 1% (0.1) | 38% (4.4) | 18% (2.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 86.4 | ×21.74 | ×3.62 | 30% (3.2) | 1% (0.1) | 42% (4.4) | 28% (2.9) | 0% (0.0) | match |
| agentic-traces | modalities | 3.1 | 79.0 | ×25.83 | ×4.88 | 15% (1.8) | 0% (0.0) | 29% (3.5) | 56% (6.7) | 0% (0.0) | match |
| agentic_swe | modalities | 3.3 | 104.6 | ×31.56 | ×4.36 | 15% (1.3) | 0% (0.0) | 27% (2.4) | 59% (5.2) | 0% (0.0) | match |
| code_mixed | modalities | 3.3 | 95.3 | ×28.77 | ×4.65 | 16% (1.5) | 0% (0.0) | 29% (2.9) | 54% (5.3) | 0% (0.0) | match |
| math_latex | modalities | 2.8 | 80.9 | ×28.89 | ×5.31 | 18% (2.0) | 0% (0.0) | 28% (3.2) | 54% (6.1) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.66 | 3.17 | 3.63 | 4.14 | 27.6 | 22.2 | 5.8 | 4.8 | 7.6× / 6.7× | 6.1× / 5.4× | 1.6× / 1.4× | 1.3× / 1.2× |
| arb_Arab | 1.00 | 2.82 | 2.27 | 4.09 | 32.3 | 28.3 | 7.1 | 5.3 | 14.3× / 7.9× | 12.5× / 6.9× | 3.1× / 1.7× | 2.3× / 1.3× |
| ben_Beng | 1.47 | 2.71 | 2.99 | 4.24 | 67.0 | 61.3 | 14.3 | 4.0 | 22.4× / 15.8× | 20.5× / 14.4× | 4.8× / 3.4× | 1.3× / 1.0× |
| cmn_Hani | 1.12 | 2.00 | 2.33 | 3.21 | 26.4 | 22.6 | 6.0 | 2.5 | 11.3× / 8.2× | 9.7× / 7.0× | 2.6× / 1.9× | 1.1× / 0.8× |
| ell_Grek | 0.58 | 2.79 | 2.16 | 4.37 | 28.5 | 23.8 | 6.0 | 4.7 | 13.2× / 6.5× | 11.0× / 5.4× | 2.8× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.10 | 1.45 | 2.99 | 4.34 | 44.5 | 46.8 | 12.2 | 3.9 | 14.9× / 10.2× | 15.7× / 10.8× | 4.1× / 2.8× | 1.3× / 0.9× |
| heb_Hebr | 1.01 | 2.82 | 2.28 | 4.10 | 32.0 | 28.6 | 6.8 | 3.1 | 14.1× / 7.8× | 12.6× / 7.0× | 3.0× / 1.7× | 1.4× / 0.8× |
| hin_Deva | 1.36 | 2.80 | 3.04 | 4.48 | 63.1 | 59.2 | 13.9 | 4.2 | 20.7× / 14.1× | 19.5× / 13.2× | 4.6× / 3.1× | 1.4× / 0.9× |
| jpn_Jpan | 1.56 | 3.16 | 2.12 | 3.72 | 23.7 | 18.6 | 5.1 | 3.9 | 11.2× / 6.4× | 8.8× / 5.0× | 2.4× / 1.4× | 1.9× / 1.1× |
| kat_Geor | 1.39 | 2.18 | 2.06 | 2.85 | 17.7 | 15.6 | 4.3 | 2.0 | 8.6× / 6.2× | 7.6× / 5.5× | 2.1× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.07 | 2.48 | 2.45 | 3.85 | 32.3 | 30.1 | 7.7 | 3.7 | 13.2× / 8.4× | 12.3× / 7.8× | 3.1× / 2.0× | 1.5× / 1.0× |
| rus_Cyrl | 1.02 | 2.73 | 2.10 | 3.82 | 27.6 | 23.0 | 5.8 | 2.5 | 13.1× / 7.2× | 11.0× / 6.0× | 2.8× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.93 | 2.67 | 2.66 | 4.41 | 70.2 | 63.0 | 14.3 | 3.8 | 26.3× / 15.9× | 23.6× / 14.3× | 5.3× / 3.2× | 1.4× / 0.9× |
| tha_Thai | 1.36 | 2.27 | 2.49 | 3.41 | 40.3 | 34.5 | 8.9 | 3.2 | 16.2× / 11.8× | 13.9× / 10.1× | 3.6× / 2.6× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.11 | 2.52 | 23.6 | 24.9 | 6.3 | 1.9 | 21.3× / 9.3× | 22.4× / 9.9× | 5.7× / 2.5× | 1.8× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.97 | 3.38 | 31.4 | 32.8 | 8.3 | 2.7 | 16.0× / 9.3× | 16.7× / 9.7× | 4.2× / 2.5× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.65 | 4.41 | 6.00 | 95.0 | 103.5 | 19.6 | 3.0 | 21.5× / 15.8× | 23.5× / 17.2× | 4.4× / 3.3× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.40 | 5.81 | 62.2 | 64.7 | 14.4 | 3.4 | 14.1× / 10.7× | 14.7× / 11.1× | 3.3× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.58 | 1.48 | 3.49 | 4.38 | 59.4 | 64.3 | 15.8 | 4.7 | 17.0× / 13.5× | 18.4× / 14.7× | 4.5× / 3.6× | 1.4× / 1.1× |
| agentic_swe | 0.53 | 1.53 | 2.35 | 3.35 | 60.6 | 73.2 | 14.8 | 3.6 | 25.7× / 18.1× | 31.1× / 21.9× | 6.3× / 4.4× | 1.5× / 1.1× |
| code_mixed | 0.08 | 1.74 | 2.89 | 4.55 | 59.3 | 70.3 | 15.5 | 4.1 | 20.5× / 13.0× | 24.3× / 15.5× | 5.4× / 3.4× | 1.4× / 0.9× |
| math_latex | 0.58 | 1.47 | 3.20 | 4.10 | 53.0 | 56.2 | 14.2 | 4.2 | 16.5× / 12.9× | 17.5× / 13.7× | 4.4× / 3.5× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×18.93 vs v0.23.1 · ×3.41 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.2 | 68.9 | ×21.50 | ×2.96 | 5% (0.7) | 0% (0.0) | 37% (4.7) | 56% (7.2) | 2% (0.2) | match |
| arb_Arab | lang | 3.5 | 75.0 | ×21.70 | ×4.33 | 5% (0.6) | 0% (0.0) | 28% (3.3) | 68% (8.0) | 0% (0.0) | match |
| ben_Beng | lang | 5.9 | 106.6 | ×18.05 | ×6.08 | 7% (0.6) | 0% (0.0) | 42% (3.7) | 49% (4.3) | 1% (0.1) | match |
| cmn_Hani | lang | 3.9 | 63.0 | ×16.03 | ×5.18 | 4% (0.6) | 0% (0.0) | 24% (3.5) | 71% (10.4) | 1% (0.1) | match |
| ell_Grek | lang | 4.3 | 89.5 | ×21.00 | ×5.63 | 6% (0.6) | 0% (0.0) | 32% (3.2) | 61% (6.2) | 1% (0.1) | match |
| eng_Latn | lang | 3.5 | 62.4 | ×18.06 | ×1.47 | 13% (2.0) | 0% (0.1) | 31% (4.6) | 54% (8.2) | 2% (0.3) | match |
| heb_Hebr | lang | 3.6 | 73.5 | ×20.25 | ×4.43 | 5% (0.6) | 0% (0.0) | 28% (3.4) | 66% (8.0) | 1% (0.1) | match |
| hin_Deva | lang | 6.2 | 105.5 | ×16.93 | ×4.04 | 7% (0.6) | 0% (0.0) | 44% (3.8) | 48% (4.1) | 1% (0.1) | match |
| jpn_Jpan | lang | 4.7 | 88.7 | ×18.69 | ×6.93 | 6% (0.6) | 0% (0.0) | 33% (3.3) | 62% (6.2) | 0% (0.0) | match |
| kat_Geor | lang | 5.9 | 112.7 | ×19.02 | ×8.00 | 8% (0.6) | 0% (0.0) | 37% (2.9) | 59% (4.6) | 0% (0.0) | match |
| kor_Hang | lang | 3.1 | 51.2 | ×16.71 | ×3.35 | 3% (0.6) | 0% (0.0) | 20% (3.7) | 78% (14.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.3 | 80.4 | ×18.53 | ×5.14 | 5% (0.6) | 0% (0.0) | 28% (3.1) | 62% (6.9) | 5% (0.6) | match |
| tam_Taml | lang | 6.2 | 111.8 | ×18.05 | ×8.44 | 7% (0.6) | 0% (0.0) | 39% (3.2) | 52% (4.3) | 2% (0.1) | match |
| tha_Thai | lang | 7.1 | 62.1 | ×8.77 | ×5.38 | 4% (0.6) | 0% (0.0) | 21% (3.2) | 75% (11.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.1 | 153.3 | ×29.99 | ×6.04 | 13% (0.7) | 0% (0.0) | 38% (2.2) | 50% (2.9) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 119.2 | ×22.32 | ×2.84 | 17% (1.3) | 0% (0.0) | 40% (3.1) | 43% (3.4) | 1% (0.0) | match |
| added_special_dense | modalities | 4.3 | 76.5 | ×17.68 | ×1.01 | 40% (5.0) | 1% (0.1) | 40% (5.1) | 23% (2.9) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 76.8 | ×17.60 | ×0.99 | 26% (3.1) | 0% (0.0) | 48% (5.8) | 24% (2.9) | 2% (0.3) | match |
| agentic-traces | modalities | 3.2 | 61.6 | ×19.41 | ×1.60 | 12% (1.8) | 0% (0.0) | 33% (5.0) | 55% (8.3) | 1% (0.2) | match |
| agentic_swe | modalities | 3.4 | 81.9 | ×24.27 | ×2.95 | 11% (1.3) | 0% (0.0) | 32% (3.7) | 55% (6.4) | 2% (0.3) | match |
| code_mixed | modalities | 3.6 | 77.8 | ×21.62 | ×1.54 | 12% (1.5) | 0% (0.0) | 35% (4.3) | 52% (6.3) | 1% (0.1) | match |
| math_latex | modalities | 3.2 | 62.0 | ×19.38 | ×1.61 | 13% (1.9) | 0% (0.0) | 32% (4.9) | 54% (8.3) | 1% (0.2) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.60 | 3.13 | 4.71 | 5.24 | 29.4 | 15.3 | 7.2 | 4.7 | 6.2× / 5.6× | 3.3× / 2.9× | 1.5× / 1.4× | 1.0× / 0.9× |
| arb_Arab | 1.01 | 2.80 | 3.31 | 5.10 | 33.7 | 17.7 | 7.6 | 5.1 | 10.2× / 6.6× | 5.3× / 3.5× | 2.3× / 1.5× | 1.5× / 1.0× |
| ben_Beng | 1.46 | 2.69 | 3.66 | 4.89 | 23.9 | 11.8 | 5.5 | 2.8 | 6.5× / 4.9× | 3.2× / 2.4× | 1.5× / 1.1× | 0.8× / 0.6× |
| cmn_Hani | 1.12 | 2.02 | 3.55 | 4.44 | 21.4 | 11.5 | 5.5 | 2.4 | 6.0× / 4.8× | 3.2× / 2.6× | 1.6× / 1.2× | 0.7× / 0.5× |
| ell_Grek | 0.58 | 2.79 | 3.22 | 5.43 | 29.8 | 16.3 | 7.0 | 5.1 | 9.3× / 5.5× | 5.1× / 3.0× | 2.2× / 1.3× | 1.6× / 0.9× |
| eng_Latn | 0.11 | 1.47 | 4.62 | 5.97 | 42.3 | 31.6 | 14.1 | 4.1 | 9.2× / 7.1× | 6.8× / 5.3× | 3.0× / 2.4× | 0.9× / 0.7× |
| heb_Hebr | 1.01 | 2.76 | 3.39 | 5.14 | 32.9 | 18.3 | 8.2 | 2.9 | 9.7× / 6.4× | 5.4× / 3.6× | 2.4× / 1.6× | 0.8× / 0.6× |
| hin_Deva | 1.37 | 2.82 | 3.78 | 5.23 | 25.6 | 13.7 | 6.6 | 3.2 | 6.8× / 4.9× | 3.6× / 2.6× | 1.7× / 1.3× | 0.8× / 0.6× |
| jpn_Jpan | 1.55 | 3.11 | 3.30 | 4.86 | 20.3 | 9.8 | 4.8 | 3.8 | 6.1× / 4.2× | 3.0× / 2.0× | 1.4× / 1.0× | 1.1× / 0.8× |
| kat_Geor | 1.39 | 2.17 | 2.87 | 3.64 | 18.4 | 10.8 | 4.6 | 2.1 | 6.4× / 5.0× | 3.8× / 3.0× | 1.6× / 1.3× | 0.7× / 0.6× |
| kor_Hang | 1.07 | 2.51 | 3.71 | 5.15 | 32.6 | 20.0 | 9.0 | 3.6 | 8.8× / 6.3× | 5.4× / 3.9× | 2.4× / 1.7× | 1.0× / 0.7× |
| rus_Cyrl | 1.02 | 2.75 | 3.13 | 4.87 | 28.7 | 15.8 | 6.7 | 4.8 | 9.2× / 5.9× | 5.0× / 3.2× | 2.1× / 1.4× | 1.5× / 1.0× |
| tam_Taml | 0.93 | 2.67 | 3.19 | 4.92 | 18.8 | 9.3 | 4.3 | 3.0 | 5.9× / 3.8× | 2.9× / 1.9× | 1.3× / 0.9× | 0.9× / 0.6× |
| tha_Thai | 1.36 | 2.27 | 3.22 | 4.14 | 13.1 | 6.0 | 2.8 | 2.2 | 4.1× / 3.2× | 1.9× / 1.4× | 0.9× / 0.7× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.47 | 2.19 | 3.61 | 33.0 | 17.9 | 11.4 | 2.1 | 15.1× / 9.2× | 8.1× / 5.0× | 5.2× / 3.1× | 1.0× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.08 | 4.49 | 35.0 | 22.1 | 11.8 | 2.9 | 11.4× / 7.8× | 7.2× / 4.9× | 3.8× / 2.6× | 1.0× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 5.14 | 6.55 | 83.4 | 71.1 | 24.1 | 3.3 | 16.2× / 12.7× | 13.8× / 10.8× | 4.7× / 3.7× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.82 | 7.23 | 55.1 | 43.6 | 16.8 | 3.7 | 9.5× / 7.6× | 7.5× / 6.0× | 2.9× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.57 | 1.48 | 4.96 | 5.87 | 51.5 | 44.5 | 17.8 | 4.9 | 10.4× / 8.8× | 9.0× / 7.6× | 3.6× / 3.0× | 1.0× / 0.8× |
| agentic_swe | 0.52 | 1.44 | 3.68 | 4.61 | 52.1 | 51.4 | 17.5 | 3.6 | 14.1× / 11.3× | 14.0× / 11.1× | 4.8× / 3.8× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.46 | 4.34 | 5.73 | 51.4 | 49.2 | 17.5 | 4.2 | 11.8× / 9.0× | 11.3× / 8.6× | 4.0× / 3.0× | 1.0× / 0.7× |
| math_latex | 0.56 | 1.49 | 4.87 | 5.80 | 48.7 | 37.4 | 16.3 | 4.5 | 10.0× / 8.4× | 7.7× / 6.5× | 3.3× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×20.14 vs v0.23.1 · ×2.96 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 76.1 | ×20.99 | ×1.58 | 11% (1.2) | 0% (0.0) | 33% (3.7) | 61% (6.8) | 0% (0.0) | match |
| arb_Arab | lang | 3.8 | 80.0 | ×20.96 | ×4.48 | 10% (1.2) | 0% (0.0) | 20% (2.3) | 66% (7.6) | 4% (0.5) | match |
| ben_Beng | lang | 4.0 | 94.7 | ×23.79 | ×3.56 | 12% (1.2) | 0% (0.0) | 32% (3.2) | 56% (5.6) | 1% (0.1) | match |
| cmn_Hani | lang | 4.6 | 73.3 | ×16.03 | ×5.02 | 9% (1.2) | 0% (0.0) | 19% (2.4) | 69% (9.0) | 3% (0.4) | match |
| ell_Grek | lang | 4.8 | 100.1 | ×20.81 | ×5.14 | 13% (1.2) | 0% (0.0) | 24% (2.2) | 67% (6.2) | 0% (0.0) | match |
| eng_Latn | lang | 3.8 | 72.6 | ×19.06 | ×1.63 | 19% (2.6) | 0% (0.0) | 23% (3.1) | 55% (7.4) | 3% (0.4) | match |
| heb_Hebr | lang | 4.2 | 85.5 | ×20.30 | ×3.34 | 10% (1.2) | 0% (0.0) | 23% (2.8) | 67% (7.9) | 0% (0.0) | match |
| hin_Deva | lang | 3.9 | 87.1 | ×22.44 | ×2.91 | 11% (1.2) | 0% (0.0) | 30% (3.3) | 59% (6.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.5 | 103.4 | ×18.64 | ×6.65 | 13% (1.2) | 0% (0.0) | 24% (2.2) | 60% (5.6) | 4% (0.4) | match |
| kat_Geor | lang | 6.4 | 122.0 | ×18.94 | ×5.51 | 15% (1.2) | 0% (0.0) | 30% (2.3) | 57% (4.4) | 0% (0.0) | match |
| kor_Hang | lang | 3.9 | 60.9 | ×15.61 | ×3.28 | 7% (1.2) | 0% (0.0) | 16% (2.5) | 80% (13.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.9 | 92.9 | ×19.09 | ×4.95 | 11% (1.2) | 0% (0.0) | 22% (2.2) | 68% (6.9) | 0% (0.0) | match |
| tam_Taml | lang | 3.7 | 97.5 | ×26.39 | ×2.75 | 12% (1.2) | 0% (0.0) | 27% (2.7) | 61% (6.1) | 0% (0.0) | match |
| tha_Thai | lang | 4.4 | 82.7 | ×18.67 | ×3.93 | 11% (1.2) | 0% (0.0) | 24% (2.6) | 66% (7.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.8 | 167.2 | ×29.01 | ×6.18 | 26% (1.3) | 0% (0.0) | 21% (1.1) | 54% (2.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.9 | 128.3 | ×26.10 | ×3.06 | 27% (1.9) | 0% (0.0) | 27% (1.9) | 44% (3.1) | 2% (0.2) | match |
| added_special_dense | modalities | 3.7 | 47.9 | ×12.90 | ×1.01 | 67% (13.4) | 0% (0.0) | 23% (4.6) | 11% (2.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 62.8 | ×16.10 | ×1.09 | 50% (7.4) | 0% (0.0) | 33% (4.8) | 18% (2.7) | 1% (0.1) | match |
| agentic-traces | modalities | 3.3 | 66.6 | ×20.07 | ×1.87 | 17% (2.5) | 0% (0.0) | 26% (3.8) | 57% (8.2) | 0% (0.0) | match |
| agentic_swe | modalities | 3.4 | 85.2 | ×24.74 | ×3.05 | 17% (2.0) | 0% (0.0) | 26% (2.9) | 57% (6.5) | 0% (0.0) | match |
| code_mixed | modalities | 3.8 | 81.3 | ×21.15 | ×1.78 | 19% (2.2) | 0% (0.0) | 28% (3.3) | 53% (6.2) | 0% (0.0) | match |
| math_latex | modalities | 3.6 | 67.1 | ×18.86 | ×1.72 | 18% (2.6) | 0% (0.0) | 24% (3.4) | 59% (8.3) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.61 | 3.16 | 3.71 | 4.26 | 26.8 | 16.5 | 5.9 | 4.8 | 7.2× / 6.3× | 4.4× / 3.9× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 2.77 | 2.34 | 4.11 | 30.5 | 20.5 | 7.1 | 5.2 | 13.0× / 7.4× | 8.8× / 5.0× | 3.0× / 1.7× | 2.2× / 1.3× |
| ben_Beng | 1.47 | 2.61 | 3.16 | 4.30 | 44.0 | 27.7 | 10.4 | 3.7 | 13.9× / 10.2× | 8.8× / 6.4× | 3.3× / 2.4× | 1.2× / 0.9× |
| cmn_Hani | 1.12 | 2.04 | 2.40 | 3.31 | 19.4 | 11.9 | 4.7 | 2.5 | 8.1× / 5.9× | 5.0× / 3.6× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.84 | 2.24 | 4.50 | 27.8 | 17.8 | 6.3 | 4.8 | 12.4× / 6.2× | 7.9× / 3.9× | 2.8× / 1.4× | 2.1× / 1.1× |
| eng_Latn | 0.09 | 1.46 | 3.10 | 4.46 | 43.0 | 33.4 | 12.5 | 3.7 | 13.9× / 9.6× | 10.8× / 7.5× | 4.0× / 2.8× | 1.2× / 0.8× |
| heb_Hebr | 1.00 | 2.87 | 2.79 | 4.65 | 30.6 | 20.2 | 7.1 | 3.1 | 11.0× / 6.6× | 7.2× / 4.3× | 2.5× / 1.5× | 1.1× / 0.7× |
| hin_Deva | 1.37 | 2.83 | 3.27 | 4.73 | 46.5 | 31.6 | 11.4 | 4.1 | 14.2× / 9.8× | 9.7× / 6.7× | 3.5× / 2.4× | 1.2× / 0.9× |
| jpn_Jpan | 1.56 | 3.13 | 2.20 | 3.77 | 18.5 | 10.0 | 4.1 | 3.8 | 8.4× / 4.9× | 4.6× / 2.7× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.39 | 2.16 | 2.26 | 3.03 | 16.7 | 11.7 | 4.2 | 2.1 | 7.4× / 5.5× | 5.2× / 3.9× | 1.9× / 1.4× | 0.9× / 0.7× |
| kor_Hang | 1.08 | 2.48 | 2.53 | 3.94 | 30.1 | 22.7 | 7.8 | 3.7 | 11.9× / 7.6× | 9.0× / 5.8× | 3.1× / 2.0× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.75 | 2.18 | 3.92 | 26.6 | 17.1 | 6.1 | 2.5 | 12.2× / 6.8× | 7.8× / 4.4× | 2.8× / 1.6× | 1.2× / 0.6× |
| tam_Taml | 0.92 | 2.68 | 2.74 | 4.50 | 43.2 | 26.8 | 10.1 | 3.4 | 15.8× / 9.6× | 9.8× / 6.0× | 3.7× / 2.3× | 1.3× / 0.8× |
| tha_Thai | 1.37 | 2.26 | 2.59 | 3.48 | 27.8 | 16.9 | 6.9 | 3.1 | 10.8× / 8.0× | 6.5× / 4.9× | 2.7× / 2.0× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.06 | 2.47 | 22.6 | 16.9 | 6.5 | 1.9 | 21.4× / 9.1× | 16.0× / 6.8× | 6.1× / 2.6× | 1.8× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.94 | 3.35 | 30.7 | 24.8 | 9.4 | 2.6 | 15.8× / 9.1× | 12.8× / 7.4× | 4.8× / 2.8× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.59 | 6.01 | 91.5 | 74.8 | 21.3 | 3.2 | 19.9× / 15.2× | 16.3× / 12.4× | 4.6× / 3.5× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.80 | 6.22 | 58.3 | 46.6 | 15.2 | 3.4 | 12.1× / 9.4× | 9.7× / 7.5× | 3.2× / 2.4× | 0.7× / 0.5× |
| agentic-traces | 0.57 | 1.48 | 3.76 | 4.67 | 51.1 | 47.9 | 15.1 | 4.6 | 13.6× / 11.0× | 12.7× / 10.3× | 4.0× / 3.2× | 1.2× / 1.0× |
| agentic_swe | 0.53 | 1.57 | 2.91 | 3.96 | 53.7 | 57.8 | 15.7 | 3.4 | 18.4× / 13.6× | 19.8× / 14.6× | 5.4× / 4.0× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.45 | 3.33 | 4.71 | 51.7 | 54.2 | 15.4 | 3.9 | 15.5× / 11.0× | 16.3× / 11.5× | 4.6× / 3.3× | 1.2× / 0.8× |
| math_latex | 0.57 | 1.47 | 3.41 | 4.32 | 49.2 | 39.8 | 14.5 | 4.1 | 14.4× / 11.4× | 11.7× / 9.2× | 4.2× / 3.4× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×4.35 vs v0.23.1 · ×1.13 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 42.7 | ×9.88 | ×1.06 | 0% (0.0) | 12% (2.8) | 0% (0.1) | 88% (20.4) | 0% (0.0) | match |
| arb_Arab | lang | 9.8 | 49.8 | ×5.08 | ×1.02 | 0% (0.0) | 16% (3.2) | 0% (0.0) | 84% (17.1) | 0% (0.0) | match |
| ben_Beng | lang | 10.4 | 82.8 | ×7.96 | ×1.09 | 0% (0.0) | 18% (2.2) | 0% (0.0) | 83% (10.1) | 0% (0.0) | match |
| cmn_Hani | lang | 8.6 | 64.4 | ×7.45 | ×1.04 | 0% (0.1) | 3% (0.5) | 0% (0.0) | 96% (14.7) | 0% (0.0) | match |
| ell_Grek | lang | 9.6 | 57.5 | ×6.00 | ×1.04 | 0% (0.0) | 18% (3.2) | 0% (0.0) | 82% (14.5) | 0% (0.0) | match |
| eng_Latn | lang | 3.8 | 6.4 | ×1.66 | ×1.00 | 0% (0.0) | 4% (6.9) | 0% (0.0) | 95% (151.8) | 0% (0.2) | match |
| heb_Hebr | lang | 9.9 | 61.0 | ×6.17 | ×1.04 | 0% (0.0) | 20% (3.3) | 0% (0.0) | 80% (13.4) | 0% (0.0) | match |
| hin_Deva | lang | 11.8 | 77.3 | ×6.57 | ×1.05 | 0% (0.0) | 22% (2.9) | 0% (0.0) | 79% (10.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 12.6 | 85.2 | ×6.77 | ×1.07 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 96% (11.1) | 0% (0.0) | match |
| kat_Geor | lang | 13.5 | 89.3 | ×6.61 | ×1.05 | 0% (0.0) | 17% (1.9) | 0% (0.0) | 82% (9.1) | 1% (0.1) | match |
| kor_Hang | lang | 6.9 | 51.6 | ×7.50 | ×1.04 | 0% (0.1) | 17% (3.3) | 0% (0.0) | 83% (16.1) | 1% (0.1) | match |
| rus_Cyrl | lang | 7.5 | 15.9 | ×2.13 | ×0.99 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 97% (59.5) | 0% (0.0) | match |
| tam_Taml | lang | 11.6 | 90.5 | ×7.82 | ×1.09 | 0% (0.0) | 16% (1.8) | 0% (0.0) | 83% (9.2) | 1% (0.2) | match |
| tha_Thai | lang | 14.4 | 83.3 | ×5.77 | ×1.01 | 0% (0.0) | 9% (1.0) | 0% (0.0) | 91% (10.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.6 | 8.9 | ×1.91 | ×1.00 | 0% (0.0) | 3% (3.8) | 0% (0.0) | 97% (111.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.3 | 7.6 | ×1.75 | ×1.02 | 0% (0.0) | 5% (6.0) | 0% (0.0) | 96% (124.1) | 0% (0.0) | match |
| added_special_dense | modalities | 3.6 | 39.8 | ×11.19 | ×1.97 | 21% (5.0) | 64% (14.8) | 4% (1.0) | 11% (2.5) | 0% (0.0) | match |
| added_special_sparse | modalities | 5.1 | 44.7 | ×8.84 | ×4.37 | 12% (2.1) | 76% (14.0) | 3% (0.5) | 11% (2.1) | 0% (0.0) | match |
| agentic-traces | modalities | 4.2 | 7.1 | ×1.71 | ×1.01 | 0% (0.1) | 5% (6.3) | 0% (0.3) | 94% (131.1) | 1% (1.3) | match |
| agentic_swe | modalities | 3.9 | 7.1 | ×1.80 | ×1.01 | 0% (0.0) | 7% (9.6) | 0% (0.0) | 93% (132.7) | 1% (0.8) | match |
| code_mixed | modalities | 4.1 | 7.0 | ×1.71 | ×0.99 | 0% (0.0) | 6% (7.9) | 0% (0.0) | 95% (134.9) | 0% (0.0) | match |
| math_latex | modalities | 4.1 | 6.7 | ×1.66 | ×1.00 | 0% (0.1) | 4% (6.4) | 0% (0.0) | 95% (138.9) | 1% (1.7) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×21.92 vs v0.23.1 · ×2.83 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 95)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.7 | 77.9 | ×21.16 | ×1.61 | 6% (0.7) | 0% (0.0) | 33% (3.7) | 61% (6.7) | 0% (0.0) | match |
| arb_Arab | lang | 3.9 | 85.9 | ×22.23 | ×4.80 | 6% (0.6) | 0% (0.0) | 21% (2.3) | 73% (8.0) | 1% (0.1) | match |
| ben_Beng | lang | 3.8 | 94.7 | ×25.16 | ×3.02 | 6% (0.6) | 0% (0.0) | 31% (3.1) | 63% (6.5) | 0% (0.0) | match |
| cmn_Hani | lang | 4.6 | 75.1 | ×16.40 | ×4.49 | 5% (0.6) | 0% (0.0) | 19% (2.4) | 65% (8.1) | 11% (1.3) | match |
| ell_Grek | lang | 4.5 | 103.4 | ×22.85 | ×5.36 | 7% (0.6) | 0% (0.0) | 25% (2.2) | 64% (5.7) | 5% (0.4) | match |
| eng_Latn | lang | 3.9 | 73.7 | ×18.88 | ×1.59 | 17% (2.1) | 0% (0.0) | 25% (3.1) | 56% (6.9) | 3% (0.3) | match |
| heb_Hebr | lang | 3.9 | 83.4 | ×21.28 | ×3.21 | 6% (0.6) | 0% (0.0) | 26% (2.8) | 74% (7.8) | 0% (0.0) | match |
| hin_Deva | lang | 4.1 | 112.8 | ×27.38 | ×1.47 | 7% (0.6) | 0% (0.0) | 40% (3.3) | 52% (4.4) | 1% (0.1) | match |
| jpn_Jpan | lang | 5.2 | 105.7 | ×20.14 | ×6.51 | 7% (0.6) | 0% (0.0) | 27% (2.2) | 63% (5.1) | 3% (0.2) | match |
| kat_Geor | lang | 5.5 | 125.3 | ×22.91 | ×3.38 | 9% (0.6) | 0% (0.0) | 32% (2.1) | 60% (4.0) | 0% (0.0) | match |
| kor_Hang | lang | 3.2 | 58.6 | ×18.30 | ×3.06 | 4% (0.6) | 0% (0.0) | 16% (2.5) | 79% (12.4) | 1% (0.2) | match |
| rus_Cyrl | lang | 4.2 | 90.6 | ×21.59 | ×5.54 | 6% (0.6) | 0% (0.0) | 22% (2.2) | 64% (6.3) | 7% (0.7) | match |
| tam_Taml | lang | 3.7 | 102.7 | ×27.61 | ×2.89 | 7% (0.6) | 0% (0.0) | 30% (2.7) | 64% (5.8) | 0% (0.0) | match |
| tha_Thai | lang | 4.6 | 92.8 | ×20.17 | ×4.57 | 6% (0.6) | 0% (0.0) | 27% (2.6) | 68% (6.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 175.7 | ×29.94 | ×6.47 | 15% (0.7) | 0% (0.0) | 22% (1.1) | 58% (2.9) | 5% (0.2) | match |
| added_normalized_sparse | modalities | 5.2 | 132.8 | ×25.35 | ×3.11 | 19% (1.3) | 0% (0.0) | 29% (2.0) | 50% (3.4) | 2% (0.2) | match |
| added_special_dense | modalities | 4.0 | 76.8 | ×18.99 | ×1.02 | 39% (4.9) | 1% (0.1) | 39% (4.9) | 19% (2.4) | 2% (0.2) | match |
| added_special_sparse | modalities | 4.2 | 82.1 | ×19.75 | ×1.13 | 30% (3.2) | 0% (0.0) | 43% (4.7) | 26% (2.8) | 2% (0.2) | match |
| agentic-traces | modalities | 3.2 | 69.2 | ×21.72 | ×1.85 | 13% (1.7) | 0% (0.0) | 28% (3.8) | 60% (7.9) | 0% (0.0) | match |
| agentic_swe | modalities | 3.9 | 90.2 | ×23.38 | ×3.17 | 12% (1.3) | 0% (0.0) | 28% (2.9) | 59% (6.2) | 1% (0.1) | match |
| code_mixed | modalities | 4.0 | 85.5 | ×21.61 | ×1.82 | 15% (1.7) | 1% (0.1) | 29% (3.2) | 54% (6.0) | 1% (0.1) | match |
| math_latex | modalities | 3.4 | 69.1 | ×20.34 | ×1.69 | 15% (1.9) | 0% (0.0) | 27% (3.5) | 61% (7.9) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.60 | 3.13 | 3.69 | 4.22 | 26.9 | 17.1 | 6.0 | 4.7 | 7.3× / 6.4× | 4.6× / 4.1× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 2.77 | 2.34 | 4.11 | 30.5 | 19.8 | 7.0 | 5.2 | 13.0× / 7.4× | 8.5× / 4.8× | 3.0× / 1.7× | 2.2× / 1.3× |
| ben_Beng | 1.47 | 2.63 | 3.15 | 4.31 | 44.6 | 28.6 | 10.8 | 3.7 | 14.2× / 10.4× | 9.1× / 6.6× | 3.4× / 2.5× | 1.2× / 0.9× |
| cmn_Hani | 1.13 | 2.00 | 2.38 | 3.26 | 19.3 | 11.9 | 4.8 | 2.4 | 8.1× / 5.9× | 5.0× / 3.7× | 2.0× / 1.5× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.79 | 2.23 | 4.44 | 28.0 | 17.7 | 6.4 | 4.8 | 12.5× / 6.3× | 7.9× / 4.0× | 2.9× / 1.4× | 2.1× / 1.1× |
| eng_Latn | 0.09 | 1.47 | 3.06 | 4.44 | 42.7 | 33.8 | 12.8 | 3.8 | 14.0× / 9.6× | 11.0× / 7.6× | 4.2× / 2.9× | 1.2× / 0.8× |
| heb_Hebr | 1.00 | 2.76 | 2.78 | 4.53 | 30.5 | 20.5 | 7.1 | 3.0 | 11.0× / 6.7× | 7.4× / 4.5× | 2.6× / 1.6× | 1.1× / 0.7× |
| hin_Deva | 1.36 | 2.77 | 3.31 | 4.71 | 47.2 | 31.0 | 11.6 | 4.1 | 14.3× / 10.0× | 9.4× / 6.6× | 3.5× / 2.5× | 1.2× / 0.9× |
| jpn_Jpan | 1.56 | 3.11 | 2.20 | 3.75 | 18.3 | 10.1 | 4.2 | 3.7 | 8.3× / 4.9× | 4.6× / 2.7× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.39 | 2.17 | 2.11 | 2.89 | 16.8 | 11.5 | 4.2 | 2.1 | 7.9× / 5.8× | 5.4× / 4.0× | 2.0× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.09 | 2.56 | 2.54 | 4.02 | 30.6 | 21.9 | 7.8 | 3.7 | 12.0× / 7.6× | 8.6× / 5.5× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.74 | 2.18 | 3.91 | 26.5 | 17.5 | 6.2 | 2.6 | 12.1× / 6.8× | 8.0× / 4.5× | 2.8× / 1.6× | 1.2× / 0.7× |
| tam_Taml | 0.92 | 2.63 | 2.72 | 4.43 | 43.6 | 26.9 | 10.2 | 3.4 | 16.1× / 9.9× | 9.9× / 6.1× | 3.8× / 2.3× | 1.3× / 0.8× |
| tha_Thai | 1.36 | 2.26 | 2.57 | 3.47 | 27.8 | 16.6 | 6.8 | 3.0 | 10.8× / 8.0× | 6.5× / 4.8× | 2.7× / 2.0× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.07 | 2.49 | 22.7 | 16.9 | 6.5 | 1.9 | 21.1× / 9.1× | 15.7× / 6.8× | 6.0× / 2.6× | 1.7× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.99 | 3.41 | 30.0 | 23.3 | 8.8 | 2.6 | 15.0× / 8.8× | 11.7× / 6.8× | 4.4× / 2.6× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.89 | 6.30 | 91.2 | 75.2 | 21.5 | 3.2 | 18.7× / 14.5× | 15.4× / 11.9× | 4.4× / 3.4× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.75 | 6.16 | 58.5 | 46.0 | 15.0 | 3.6 | 12.3× / 9.5× | 9.7× / 7.5× | 3.2× / 2.4× | 0.8× / 0.6× |
| agentic-traces | 0.57 | 1.46 | 3.75 | 4.64 | 51.4 | 47.0 | 15.5 | 4.5 | 13.7× / 11.1× | 12.5× / 10.1× | 4.1× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.52 | 1.44 | 2.91 | 3.83 | 54.0 | 55.5 | 16.0 | 3.4 | 18.6× / 14.1× | 19.1× / 14.5× | 5.5× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.06 | 1.46 | 3.22 | 4.62 | 51.8 | 52.4 | 15.7 | 3.9 | 16.1× / 11.2× | 16.3× / 11.3× | 4.9× / 3.4× | 1.2× / 0.9× |
| math_latex | 0.58 | 1.47 | 3.50 | 4.39 | 49.4 | 40.4 | 14.6 | 4.1 | 14.1× / 11.3× | 11.6× / 9.2× | 4.2× / 3.3× | 1.2× / 0.9× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×18.35 vs v0.23.1 · ×4.91 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 194) · Pipeline 109+0 (peak 195)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.2 | 69.3 | ×21.37 | ×2.29 | 10% (1.2) | 0% (0.0) | 36% (4.6) | 55% (6.9) | 0% (0.0) | match |
| arb_Arab | lang | 4.1 | 78.9 | ×19.43 | ×4.59 | 10% (1.2) | 0% (0.0) | 27% (3.2) | 57% (6.8) | 7% (0.8) | match |
| ben_Beng | lang | 6.4 | 105.1 | ×16.43 | ×6.12 | 13% (1.2) | 0% (0.0) | 40% (3.6) | 44% (4.0) | 3% (0.3) | match |
| cmn_Hani | lang | 4.6 | 71.6 | ×15.44 | ×4.61 | 9% (1.2) | 0% (0.0) | 27% (3.5) | 66% (8.4) | 0% (0.0) | match |
| ell_Grek | lang | 5.0 | 90.2 | ×17.98 | ×5.88 | 11% (1.2) | 0% (0.0) | 31% (3.1) | 55% (5.7) | 3% (0.3) | match |
| eng_Latn | lang | 3.5 | 63.0 | ×17.83 | ×3.29 | 20% (2.5) | 0% (0.0) | 34% (4.4) | 49% (6.4) | 0% (0.0) | match |
| heb_Hebr | lang | 4.0 | 77.5 | ×19.31 | ×5.55 | 10% (1.2) | 0% (0.0) | 32% (3.7) | 55% (6.4) | 3% (0.3) | match |
| hin_Deva | lang | 5.9 | 103.0 | ×17.57 | ×4.80 | 14% (1.2) | 0% (0.0) | 44% (3.7) | 43% (3.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.1 | 93.6 | ×18.27 | ×6.14 | 13% (1.2) | 0% (0.0) | 33% (3.2) | 47% (4.5) | 7% (0.7) | match |
| kat_Geor | lang | 6.1 | 109.3 | ×17.99 | ×7.68 | 14% (1.2) | 0% (0.0) | 35% (2.9) | 51% (4.2) | 0% (0.0) | match |
| kor_Hang | lang | 3.6 | 57.8 | ×16.10 | ×3.82 | 8% (1.2) | 0% (0.0) | 25% (3.6) | 73% (10.6) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.3 | 86.4 | ×20.21 | ×6.08 | 11% (1.2) | 0% (0.0) | 29% (3.1) | 60% (6.3) | 0% (0.0) | match |
| tam_Taml | lang | 6.5 | 113.9 | ×17.40 | ×7.81 | 14% (1.2) | 0% (0.0) | 38% (3.2) | 39% (3.2) | 9% (0.7) | match |
| tha_Thai | lang | 7.8 | 74.6 | ×9.57 | ×4.93 | 9% (1.2) | 0% (0.0) | 25% (3.2) | 65% (8.4) | 1% (0.1) | match |
| added_normalized_dense | modalities | 5.5 | 144.3 | ×26.10 | ×7.01 | 25% (1.6) | 0% (0.0) | 29% (1.9) | 46% (3.0) | 1% (0.1) | match |
| added_normalized_sparse | modalities | 5.1 | 109.4 | ×21.30 | ×4.40 | 24% (2.1) | 0% (0.0) | 37% (3.2) | 39% (3.3) | 1% (0.1) | match |
| added_special_dense | modalities | 4.2 | 74.1 | ×17.44 | ×4.46 | 40% (5.0) | 0% (0.1) | 41% (5.2) | 18% (2.3) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.4 | 74.4 | ×16.74 | ×3.40 | 30% (3.8) | 0% (0.0) | 43% (5.4) | 27% (3.4) | 1% (0.2) | match |
| agentic-traces | modalities | 3.1 | 61.0 | ×19.86 | ×4.11 | 16% (2.5) | 0% (0.0) | 32% (4.9) | 52% (8.0) | 0% (0.1) | match |
| agentic_swe | modalities | 3.2 | 77.8 | ×24.05 | ×6.96 | 16% (2.0) | 0% (0.0) | 30% (3.7) | 56% (7.0) | 0% (0.0) | match |
| code_mixed | modalities | 3.6 | 74.8 | ×20.97 | ×5.03 | 17% (2.1) | 0% (0.0) | 34% (4.3) | 49% (6.2) | 0% (0.0) | match |
| math_latex | modalities | 3.4 | 64.0 | ×18.96 | ×3.71 | 17% (2.6) | 0% (0.0) | 31% (4.7) | 51% (7.7) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.66 | 3.13 | 4.63 | 5.10 | 28.8 | 14.6 | 6.9 | — | 6.2× / 5.6× | 3.2× / 2.9× | 1.5× / 1.3× | — |
| arb_Arab | 1.03 | 2.78 | 3.20 | 4.95 | 33.2 | 16.6 | 7.4 | — | 10.4× / 6.7× | 5.2× / 3.4× | 2.3× / 1.5× | — |
| ben_Beng | 1.47 | 2.70 | 3.63 | 4.87 | 23.1 | 11.3 | 5.2 | — | 6.4× / 4.7× | 3.1× / 2.3× | 1.4× / 1.1× | — |
| cmn_Hani | 1.13 | 2.01 | 3.46 | 4.34 | 21.7 | 11.8 | 5.6 | — | 6.3× / 5.0× | 3.4× / 2.7× | 1.6× / 1.3× | — |
| ell_Grek | 0.58 | 2.84 | 3.15 | 5.40 | 29.2 | 15.4 | 6.7 | — | 9.3× / 5.4× | 4.9× / 2.9× | 2.1× / 1.2× | — |
| eng_Latn | 0.10 | 1.46 | 4.36 | 5.72 | 43.1 | 30.5 | 13.5 | — | 9.9× / 7.5× | 7.0× / 5.3× | 3.1× / 2.4× | — |
| heb_Hebr | 1.01 | 2.80 | 3.69 | 5.47 | 32.5 | 17.7 | 7.9 | — | 8.8× / 5.9× | 4.8× / 3.2× | 2.1× / 1.4× | — |
| hin_Deva | 1.36 | 2.79 | 3.70 | 5.14 | 24.8 | 13.1 | 6.0 | — | 6.7× / 4.8× | 3.5× / 2.6× | 1.6× / 1.2× | — |
| jpn_Jpan | 1.55 | 3.12 | 3.17 | 4.74 | 20.3 | 9.9 | 4.8 | — | 6.4× / 4.3× | 3.1× / 2.1× | 1.5× / 1.0× | — |
| kat_Geor | 1.39 | 2.16 | 2.87 | 3.64 | 18.2 | 10.5 | 4.5 | — | 6.3× / 5.0× | 3.7× / 2.9× | 1.6× / 1.2× | — |
| kor_Hang | 1.07 | 2.55 | 3.59 | 5.07 | 32.6 | 20.0 | 9.0 | — | 9.1× / 6.4× | 5.6× / 3.9× | 2.5× / 1.8× | — |
| rus_Cyrl | 1.03 | 2.73 | 3.07 | 4.78 | 28.2 | 15.5 | 6.4 | — | 9.2× / 5.9× | 5.0× / 3.2× | 2.1× / 1.3× | — |
| tam_Taml | 0.93 | 2.68 | 3.16 | 4.91 | 18.6 | 9.0 | 4.2 | — | 5.9× / 3.8× | 2.9× / 1.8× | 1.3× / 0.8× | — |
| tha_Thai | 1.37 | 2.26 | 3.23 | 4.13 | 13.2 | 6.0 | 2.8 | — | 4.1× / 3.2× | 1.9× / 1.4× | 0.9× / 0.7× | — |
| added_normalized_dense | 0.09 | 1.47 | 1.91 | 3.29 | 32.3 | 17.4 | 11.5 | — | 16.9× / 9.8× | 9.1× / 5.3× | 6.0× / 3.5× | — |
| added_normalized_sparse | 0.08 | 1.47 | 3.19 | 4.58 | 34.0 | 20.6 | 11.3 | — | 10.6× / 7.4× | 6.4× / 4.5× | 3.5× / 2.5× | — |
| added_special_dense | 0.08 | 1.47 | 5.23 | 6.62 | 85.4 | 68.0 | 23.8 | — | 16.3× / 12.9× | 13.0× / 10.3× | 4.5× / 3.6× | — |
| added_special_sparse | 0.08 | 1.47 | 5.44 | 6.83 | 55.2 | 41.2 | 16.0 | — | 10.2× / 8.1× | 7.6× / 6.0× | 2.9× / 2.3× | — |
| agentic-traces | 0.57 | 1.46 | 4.93 | 5.82 | 54.8 | 45.7 | 17.9 | — | 11.1× / 9.4× | 9.3× / 7.9× | 3.6× / 3.1× | — |
| agentic_swe | 0.51 | 1.44 | 3.71 | 4.64 | 59.4 | 56.5 | 19.1 | — | 16.0× / 12.8× | 15.2× / 12.2× | 5.1× / 4.1× | — |
| code_mixed | 0.07 | 1.44 | 4.29 | 5.66 | 53.9 | 48.7 | 18.0 | — | 12.6× / 9.5× | 11.4× / 8.6× | 4.2× / 3.2× | — |
| math_latex | 0.56 | 1.47 | 4.69 | 5.59 | 51.1 | 38.6 | 16.5 | — | 10.9× / 9.1× | 8.2× / 6.9× | 3.5× / 2.9× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402679688-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->


