### PR TITLE
Perf/hoist span dispatch

### DIFF
--- a/tokenizers/tk-encode/examples/profile_encode.rs
+++ b/tokenizers/tk-encode/examples/profile_encode.rs
@@ -1,0 +1,219 @@
+//! Single-thread E2E encode profiler for one model on one fixture.
+//!
+//! `fixture_bench.rs` answers *how fast*; this answers *where the time goes*. The whole
+//! measured region sits under one `#[inline(never)]` frame (`hot_loop`), so a sampled
+//! profile can be collapsed to just the encode path — model load, JSON parsing and
+//! fixture I/O stay outside it and can be filtered out wholesale.
+//!
+//! Chunking matches `fixture_bench` phase 1 (10 kB inputs, ≤100 of them, warm cache,
+//! `add_special_tokens = true`) so the profile describes the same regime the headline
+//! MB/s numbers come from. Unlike `fixture_bench` no synthetic added tokens are
+//! injected — the model is profiled exactly as shipped.
+//!
+//! ```text
+//! cargo build --release --example profile_encode
+//! samply record --main-thread-only -r 4000 -o prof.json.gz \
+//!     -- ./target/release/examples/profile_encode data/gpt2.json data/fixtures/lang/eng_Latn.txt
+//! ```
+//!
+//! `--stages` instead prints the `encode_generic` ablation ladder (ns/byte per stage)
+//! for the same model/fixture pair, as the quantitative companion to the flamegraph.
+//! Keep it out of profiled runs: partial-stage passes would land in the same samples.
+
+use std::convert::TryFrom;
+use std::hint::black_box;
+use std::time::Instant;
+
+use tk_encode::pipeline::{Model, PipelineTokenizer};
+use tk_encode::{ModelWrapper, Tokenizer};
+
+const CHUNK_BYTES: usize = 10 * 1024;
+const MAX_CHUNKS: usize = 100;
+const DEFAULT_SECONDS: f64 = 6.0;
+const REPS: usize = 5;
+
+fn make_chunks(text: &str) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut cur = String::new();
+    for line in text.lines().filter(|l| !l.trim().is_empty()) {
+        if !cur.is_empty() {
+            cur.push('\n');
+        }
+        cur.push_str(line);
+        if cur.len() >= CHUNK_BYTES {
+            chunks.push(std::mem::take(&mut cur));
+            if chunks.len() == MAX_CHUNKS {
+                return chunks;
+            }
+        }
+    }
+    if !cur.is_empty() {
+        chunks.push(cur);
+    }
+    chunks
+}
+
+/// Encode every chunk in a loop until `seconds` have elapsed; returns (passes, tokens).
+///
+/// `inline(never)` is the whole point: this frame is the filter the flamegraph post-pass
+/// keys on, so setup can be discarded without guessing which symbols belong to encode.
+#[inline(never)]
+fn hot_loop(pipeline: &PipelineTokenizer, chunks: &[String], seconds: f64) -> (usize, usize) {
+    let start = Instant::now();
+    let mut passes = 0usize;
+    let mut tokens = 0usize;
+    while start.elapsed().as_secs_f64() < seconds {
+        for chunk in chunks {
+            tokens += pipeline.encode(chunk, true).unwrap().len();
+        }
+        passes += 1;
+    }
+    black_box(tokens);
+    (passes, tokens)
+}
+
+fn median(mut v: Vec<f64>) -> f64 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    v[v.len() / 2]
+}
+
+/// Median seconds for one pass over `chunks` through `encode_generic::<STAGE>`, on a
+/// caller-owned scratch reused across chunks. Mirrors `fixture_bench::stage_secs`.
+fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) -> f64 {
+    let mut out = Vec::new();
+    let mut pre_tokens = Vec::new();
+    let mut scratch = pipeline.get_model().init_scratch();
+    let mut run = || {
+        for chunk in chunks {
+            out.clear();
+            let _ = pipeline.encode_generic::<STAGE>(
+                chunk,
+                true,
+                &mut pre_tokens,
+                &mut scratch,
+                &mut out,
+            );
+            black_box(&out);
+            black_box(&pre_tokens);
+        }
+    };
+    run();
+    let mut samples = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let t = Instant::now();
+        run();
+        samples.push(t.elapsed().as_secs_f64());
+    }
+    median(samples)
+}
+
+/// Order-sensitive hash of every id one pass emits, for diffing two builds of the encoder.
+fn checksum(pipeline: &PipelineTokenizer, chunks: &[String]) -> (u64, usize) {
+    let mut h: u64 = 0xcbf29ce484222325;
+    let mut n = 0;
+    for chunk in chunks {
+        for token in pipeline.encode(chunk, true).unwrap() {
+            h = (h ^ token.id as u64).wrapping_mul(0x100000001b3);
+            n += 1;
+        }
+    }
+    (h, n)
+}
+
+/// Pre-token count for one pass, so per-span costs can be quoted per word rather than as a
+/// share. `STAGE_SPLIT` stops after the pre-tokenizer, leaving its spans in `pre_tokens`.
+fn count_spans(pipeline: &PipelineTokenizer, chunks: &[String]) -> usize {
+    let mut out = Vec::new();
+    let mut pre_tokens = Vec::new();
+    let mut scratch = pipeline.get_model().init_scratch();
+    let mut spans = 0;
+    for chunk in chunks {
+        out.clear();
+        pre_tokens.clear();
+        let _ = pipeline.encode_generic::<{ PipelineTokenizer::STAGE_SPLIT }>(
+            chunk,
+            true,
+            &mut pre_tokens,
+            &mut scratch,
+            &mut out,
+        );
+        spans += pre_tokens.len();
+    }
+    spans
+}
+
+fn print_stages(pipeline: &PipelineTokenizer, chunks: &[String], bytes: usize) {
+    let t_frame = stage_secs::<{ PipelineTokenizer::STAGE_FRAME }>(pipeline, chunks);
+    let t_norm = stage_secs::<{ PipelineTokenizer::STAGE_NORMALIZE }>(pipeline, chunks);
+    let t_split = stage_secs::<{ PipelineTokenizer::STAGE_SPLIT }>(pipeline, chunks);
+    let t_model = stage_secs::<{ PipelineTokenizer::STAGE_MODEL }>(pipeline, chunks);
+    let t_post = stage_secs::<{ PipelineTokenizer::STAGE_POSTPROCESS }>(pipeline, chunks);
+    let nspb = |s: f64| s * 1e9 / bytes as f64;
+    println!("{{");
+    println!("  \"added_split\": {:.4},", nspb(t_frame));
+    println!("  \"pre_tokenize\": {:.4},", nspb(t_split - t_frame));
+    println!("  \"normalize\": {:.4},", nspb(t_norm - t_split));
+    println!("  \"model\": {:.4},", nspb(t_model - t_norm));
+    println!("  \"post_process\": {:.4},", nspb(t_post - t_model));
+    println!("  \"total\": {:.4}", nspb(t_post));
+    println!("}}");
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: profile_encode <model.json> <fixture.txt> [seconds|--stages]");
+        std::process::exit(2);
+    }
+    let stages = args.iter().any(|a| a == "--stages");
+    let seconds = args
+        .get(3)
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or(DEFAULT_SECONDS);
+
+    let mut tok = Tokenizer::from_file(&args[1]).expect("load tokenizer");
+    // `PipelineBPE::from_bpe` filters out a zero capacity, so this is the off switch for the
+    // BPE word cache -- the A/B that shows what the cache probe is worth on a given model.
+    if args.iter().any(|a| a == "--no-cache")
+        && let ModelWrapper::BPE(bpe) = tok.get_model_mut()
+    {
+        bpe.resize_cache(0);
+    }
+    let pipeline = PipelineTokenizer::try_from(&tok).expect("build pipeline");
+    let text = std::fs::read_to_string(&args[2]).expect("read fixture");
+    let chunks = make_chunks(&text);
+    let bytes: usize = chunks.iter().map(String::len).sum();
+
+    // Warm-up: fills the BPE word cache from this corpus, so the measured region is the
+    // warm steady state a plain `.encode()` loop reaches rather than cache cold-start.
+    for chunk in &chunks {
+        black_box(pipeline.encode(chunk, true).unwrap().len());
+    }
+
+    if args.iter().any(|a| a == "--checksum") {
+        let (h, n) = checksum(&pipeline, &chunks);
+        println!("{{\"ids\": {n}, \"checksum\": \"{h:016x}\"}}");
+        return;
+    }
+    if args.iter().any(|a| a == "--spans") {
+        let spans = count_spans(&pipeline, &chunks);
+        println!(
+            "{{\"bytes\": {bytes}, \"spans\": {spans}, \"bytes_per_span\": {:.3}}}",
+            bytes as f64 / spans as f64
+        );
+        return;
+    }
+    if stages {
+        print_stages(&pipeline, &chunks, bytes);
+        return;
+    }
+
+    let t = Instant::now();
+    let (passes, tokens) = hot_loop(&pipeline, &chunks, seconds);
+    let elapsed = t.elapsed().as_secs_f64();
+    let mbps = (bytes * passes) as f64 / elapsed / 1e6;
+    eprintln!(
+        "{} on {}: {bytes} B x {passes} passes in {elapsed:.2}s = {mbps:.1} MB/s ({tokens} tokens)",
+        args[1], args[2]
+    );
+}

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -768,7 +768,7 @@ impl PipelineBPE {
 
     fn merge_word(
         &self,
-        sequence: &str,
+        split: pipeline::Split<'_>,
         merge_queue: &mut QuaternaryHeap<Merge>,
         skip: &mut Vec<Merge>,
         word: &mut Word,
@@ -776,7 +776,7 @@ impl PipelineBPE {
         word.clear();
         match &self.atoms {
             Atoms::Bytes { byte_to_id } => {
-                for &b in sequence.as_bytes() {
+                for &b in split.as_bytes() {
                     word.add(byte_to_id[b as usize], 1);
                 }
             }
@@ -785,6 +785,7 @@ impl PipelineBPE {
                 unk_token,
                 fuse_unk,
             } => {
+                let sequence = split.as_str();
                 for char_str in sequence
                     .char_indices()
                     .map(|(i, c)| &sequence[i..i + c.len_utf8()])
@@ -826,10 +827,11 @@ impl pipeline::Model for PipelineBPE {
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
-        let sequence = split.as_str();
-        if sequence.is_empty() {
+        let bytes = split.as_bytes();
+        if bytes.is_empty() {
             return Ok(());
         }
+        let head = split.head();
 
         let BpeScratch {
             merge_queue,
@@ -839,22 +841,22 @@ impl pipeline::Model for PipelineBPE {
         } = scratch;
 
         if let Some(cache) = word_cache
-            && let Some(hit) = cache.get(split.as_bytes(), split.head())
+            && let Some(hit) = cache.get(bytes, head)
         {
             output.extend(hit.iter().map(|&id| PipelineToken { id }));
             return Ok(());
         }
         if self.ignore_merges
-            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
+            && let Some(id) = self.vocab.get_bytes(bytes)
         {
             output.push(PipelineToken { id });
             return Ok(());
         }
 
-        self.merge_word(sequence, merge_queue, skip, word);
+        self.merge_word(split, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
         if let Some(cache) = word_cache {
-            cache.insert(split.as_bytes(), split.head(), word.get_chars_iter());
+            cache.insert(bytes, head, word.get_chars_iter());
         }
 
         Ok(())

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -700,14 +700,12 @@ impl PipelineTokenizer {
                                     self.pre_tokenizer
                                         .pre_tokenize(normalized_chunk, pre_tokens)?;
                                     if STAGE >= Self::STAGE_MODEL {
-                                        // Tokenize each chunk
-                                        for pre_token in pre_tokens.iter() {
-                                            self.model.tokenize_pipeline(
-                                                Split::new(normalized_chunk, pre_token.range()),
-                                                scratch,
-                                                output,
-                                            )?;
-                                        }
+                                        self.model.tokenize_spans(
+                                            normalized_chunk,
+                                            pre_tokens,
+                                            scratch,
+                                            output,
+                                        )?;
                                     }
                                 }
                             }
@@ -992,25 +990,35 @@ pub trait ModelScratch: Default {
 /// number known only at run time is a call into `memcpy`.
 #[derive(Clone, Copy)]
 pub struct Split<'a> {
-    word: &'a str,
+    word: &'a [u8],
+    /// Slicing a `str` checks both ends for a UTF-8 boundary — two loads a byte-level model
+    /// never needs. Keeping the chunk and offset lets [`as_str`](Split::as_str) make that cut
+    /// only for the models that ask for text.
+    chunk: &'a str,
+    start: usize,
     head: Option<&'a [u8; 16]>,
 }
 
 impl<'a> Split<'a> {
     /// `range` is a byte range of `chunk`, the way a pre-tokenizer reports it.
     pub fn new(chunk: &'a str, range: Range<usize>) -> Self {
+        let bytes = chunk.as_bytes();
         Self {
-            word: &chunk[range.clone()],
-            head: chunk.as_bytes()[range.start..].first_chunk(),
+            word: &bytes[range.clone()],
+            chunk,
+            start: range.start,
+            head: bytes[range.start..].first_chunk(),
         }
     }
 
+    /// Prefer [`as_bytes`](Split::as_bytes) where bytes will do: this pays for two UTF-8
+    /// boundary checks.
     pub fn as_str(&self) -> &'a str {
-        self.word
+        &self.chunk[self.start..self.start + self.word.len()]
     }
 
     pub fn as_bytes(&self) -> &'a [u8] {
-        self.word.as_bytes()
+        self.word
     }
 
     /// The 16 bytes of the chunk that start where the word does. Anything past the
@@ -1041,6 +1049,23 @@ pub trait Model {
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()>;
+
+    /// Tokenize every span the pre-tokenizer found in `chunk`.
+    ///
+    /// Override this to lift per-call setup out of the loop. Words are short — 4 to 5 bytes on
+    /// prose — so a model pays anything it does per span around 200k times per megabyte.
+    fn tokenize_spans(
+        &self,
+        chunk: &str,
+        spans: &[Span],
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        for span in spans {
+            self.tokenize_pipeline(Split::new(chunk, span.range()), scratch, output)?;
+        }
+        Ok(())
+    }
 
     fn init_scratch(&self) -> Self::Scratch;
 }
@@ -1077,6 +1102,32 @@ impl Model for PipelineModel {
             }
             (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
                 model.tokenize_pipeline(split, scratch, output)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Pairing the model with its scratch is a 4x4 match that LLVM will not lift out of the
+    /// caller's span loop, so it runs here once per chunk instead of once per word.
+    fn tokenize_spans(
+        &self,
+        chunk: &str,
+        spans: &[Span],
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        match (self, scratch) {
+            (Self::BPE(model), PipelineModelScratch::BPE(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
+            }
+            (Self::Unigram(model), PipelineModelScratch::Unigram(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
+            }
+            (Self::WordLevel(model), PipelineModelScratch::WordLevel(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
+            }
+            (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
             }
             _ => unreachable!(),
         }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -983,38 +983,37 @@ pub trait ModelScratch: Default {
 /// One pre-token on its way to a model: the word to tokenize, plus the chunk of
 /// text it was split out of.
 ///
-/// A model that only wants the word calls [`Split::as_str`] and is none the wiser.
-/// The chunk is carried for [`Split::head`], which hands out a fixed-size window
-/// of bytes starting at the word — the BPE word cache builds its key out of one,
-/// because copying a fixed number of bytes compiles to a load, where copying a
-/// number known only at run time is a call into `memcpy`.
+/// The word is kept as bytes, which is what a byte-level model and the cache key both
+/// want; [`Split::as_str`] cuts a `&str` out of the chunk for the models that need text.
+/// The chunk is also where [`Split::head`] reads from: a fixed-size window of bytes
+/// starting at the word — the BPE word cache builds its key out of one, because copying a
+/// fixed number of bytes compiles to a load, where copying a number known only at run time
+/// is a call into `memcpy`.
 #[derive(Clone, Copy)]
 pub struct Split<'a> {
     word: &'a [u8],
-    /// Slicing a `str` checks both ends for a UTF-8 boundary — two loads a byte-level model
-    /// never needs. Keeping the chunk and offset lets [`as_str`](Split::as_str) make that cut
-    /// only for the models that ask for text.
     chunk: &'a str,
-    start: usize,
+    word_start: usize,
     head: Option<&'a [u8; 16]>,
 }
 
 impl<'a> Split<'a> {
     /// `range` is a byte range of `chunk`, the way a pre-tokenizer reports it.
     pub fn new(chunk: &'a str, range: Range<usize>) -> Self {
+        let Range { start, end } = range;
         let bytes = chunk.as_bytes();
         Self {
-            word: &bytes[range.clone()],
+            word: &bytes[start..end],
             chunk,
-            start: range.start,
-            head: bytes[range.start..].first_chunk(),
+            word_start: start,
+            head: bytes[start..].first_chunk(),
         }
     }
 
-    /// Prefer [`as_bytes`](Split::as_bytes) where bytes will do: this pays for two UTF-8
-    /// boundary checks.
+    /// Costs two UTF-8 boundary checks, so prefer [`as_bytes`](Split::as_bytes) where bytes
+    /// will do.
     pub fn as_str(&self) -> &'a str {
-        &self.chunk[self.start..self.start + self.word.len()]
+        &self.chunk[self.word_start..self.word_start + self.word.len()]
     }
 
     pub fn as_bytes(&self) -> &'a [u8] {
@@ -1052,8 +1051,9 @@ pub trait Model {
 
     /// Tokenize every span the pre-tokenizer found in `chunk`.
     ///
-    /// Override this to lift per-call setup out of the loop. Words are short — 4 to 5 bytes on
-    /// prose — so a model pays anything it does per span around 200k times per megabyte.
+    /// Override this when a model can do part of the work once for the whole batch instead of
+    /// once per word. Words are short — 4 to 5 bytes on prose — so anything done per span runs
+    /// some 200k times per megabyte.
     fn tokenize_spans(
         &self,
         chunk: &str,
@@ -1107,8 +1107,10 @@ impl Model for PipelineModel {
         }
     }
 
-    /// Pairing the model with its scratch is a 4x4 match that LLVM will not lift out of the
-    /// caller's span loop, so it runs here once per chunk instead of once per word.
+    /// The pipeline calls this rather than looping over [`Model::tokenize_pipeline`] itself.
+    /// The match below pairs a model with its scratch, and the compiler does not move that
+    /// match out of a per-word loop on its own — so doing it here, once per chunk, saves it
+    /// on every word.
     fn tokenize_spans(
         &self,
         chunk: &str,


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`20a3283d2 · 2026-07-28 22:07 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-overview.png" width="860">

**vs base branch** (`709ef7af5`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.87 vs v0.23.1 · ×0.98 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 11) · Pipeline 8+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.8 | 27.3 | ×3.50 | ×0.99 | 3% (1.2) | 75% (27.0) | 14% (5.0) | 7% (2.7) | 1% (0.3) | match |
| arb_Arab | lang | 4.2 | 24.7 | ×5.94 | ×0.99 | 3% (1.2) | 68% (27.4) | 9% (3.8) | 18% (7.3) | 1% (0.4) | match |
| ben_Beng | lang | 6.0 | 34.5 | ×5.76 | ×0.99 | 5% (1.5) | 66% (18.9) | 11% (3.3) | 17% (4.8) | 1% (0.2) | match |
| cmn_Hani | lang | 3.9 | 18.6 | ×4.82 | ×0.99 | 2% (1.2) | 71% (37.3) | 14% (7.2) | 13% (6.9) | 0% (0.1) | match |
| ell_Grek | lang | 3.8 | 23.6 | ×6.20 | ×0.99 | 3% (1.2) | 68% (28.6) | 9% (3.9) | 19% (8.2) | 1% (0.4) | match |
| eng_Latn | lang | 4.4 | 17.7 | ×4.00 | ×0.96 | 5% (2.6) | 71% (38.5) | 12% (6.7) | 11% (6.1) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 19.7 | ×4.68 | ×0.99 | 2% (1.2) | 75% (37.5) | 8% (4.2) | 14% (6.8) | 1% (0.5) | match |
| hin_Deva | lang | 6.4 | 27.2 | ×4.23 | ×0.99 | 3% (1.2) | 74% (27.0) | 10% (3.7) | 12% (4.3) | 1% (0.2) | match |
| jpn_Jpan | lang | 4.3 | 27.3 | ×6.41 | ×0.99 | 3% (1.2) | 64% (23.2) | 14% (5.0) | 18% (6.6) | 1% (0.3) | match |
| kat_Geor | lang | 6.1 | 28.2 | ×4.63 | ×1.01 | 3% (1.2) | 74% (26.5) | 9% (3.3) | 12% (4.3) | 1% (0.4) | match |
| kor_Hang | lang | 2.4 | 17.6 | ×7.27 | ×0.99 | 2% (1.2) | 62% (35.0) | 13% (7.6) | 22% (12.4) | 0% (0.2) | match |
| rus_Cyrl | lang | 3.7 | 23.6 | ×6.44 | ×0.99 | 3% (1.2) | 65% (27.4) | 9% (3.7) | 23% (9.6) | 1% (0.5) | match |
| tam_Taml | lang | 6.9 | 38.0 | ×5.48 | ×0.99 | 4% (1.2) | 71% (18.5) | 11% (2.8) | 13% (3.3) | 1% (0.2) | match |
| tha_Thai | lang | 8.2 | 32.8 | ×3.99 | ×1.01 | 4% (1.2) | 83% (25.1) | 7% (2.2) | 5% (1.4) | 1% (0.3) | match |
| added_normalized_dense | modalities | 6.7 | 18.7 | ×2.81 | ×0.95 | 3% (1.3) | 81% (40.4) | 19% (9.3) | 0% (0.0) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 17.7 | ×3.34 | ×0.96 | 4% (2.0) | 74% (39.5) | 18% (9.6) | 5% (2.5) | 0% (0.0) | match |
| added_special_dense | modalities | 5.3 | 37.3 | ×6.98 | ×0.96 | 20% (5.1) | 37% (9.2) | 38% (9.4) | 6% (1.4) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 20.9 | ×5.26 | ×0.98 | 8% (3.6) | 61% (27.9) | 22% (9.9) | 10% (4.4) | 0% (0.1) | match |
| agentic-traces | modalities | 3.8 | 17.6 | ×4.62 | ×0.97 | 5% (2.5) | 70% (38.3) | 13% (7.2) | 12% (6.4) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 18.9 | ×4.65 | ×0.97 | 4% (2.0) | 76% (38.4) | 12% (5.9) | 8% (4.3) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 18.4 | ×4.72 | ×0.97 | 4% (2.3) | 74% (38.4) | 12% (6.4) | 9% (4.9) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 17.6 | ×4.45 | ×0.97 | 5% (2.6) | 71% (38.4) | 13% (7.1) | 12% (6.3) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×26.13 vs v0.23.1 · ×6.24 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 67) · Pipeline 82+0 (peak 82)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 93.2 | ×21.96 | ×2.72 | 7% (0.7) | 0% (0.0) | 52% (4.8) | 41% (3.7) | 0% (0.0) | match |
| arb_Arab | lang | 4.1 | 119.0 | ×28.94 | ×7.16 | 8% (0.6) | 0% (0.0) | 47% (3.4) | 44% (3.2) | 1% (0.1) | match |
| ben_Beng | lang | 6.2 | 144.5 | ×23.19 | ×8.10 | 10% (0.6) | 0% (0.0) | 53% (3.1) | 37% (2.2) | 0% (0.0) | match |
| cmn_Hani | lang | 3.6 | 118.9 | ×33.05 | ×7.19 | 12% (0.8) | 1% (0.0) | 46% (3.1) | 41% (2.8) | 1% (0.1) | match |
| ell_Grek | lang | 4.6 | 122.1 | ×26.69 | ×6.83 | 9% (0.6) | 0% (0.0) | 49% (3.4) | 42% (2.9) | 1% (0.0) | match |
| eng_Latn | lang | 3.1 | 85.1 | ×27.38 | ×6.54 | 20% (2.1) | 0% (0.0) | 50% (5.3) | 31% (3.3) | 0% (0.0) | match |
| heb_Hebr | lang | 3.9 | 112.4 | ×29.02 | ×8.66 | 7% (0.6) | 0% (0.0) | 45% (3.6) | 47% (3.8) | 0% (0.0) | match |
| hin_Deva | lang | 5.8 | 133.3 | ×22.95 | ×6.26 | 9% (0.6) | 0% (0.0) | 50% (3.3) | 41% (2.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.2 | 138.9 | ×33.22 | ×7.74 | 12% (0.7) | 0% (0.0) | 51% (3.0) | 37% (2.2) | 1% (0.0) | match |
| kat_Geor | lang | 5.9 | 146.8 | ×24.84 | ×8.45 | 10% (0.6) | 0% (0.0) | 49% (2.9) | 41% (2.4) | 0% (0.0) | match |
| kor_Hang | lang | 3.6 | 94.4 | ×26.11 | ×4.77 | 7% (0.6) | 0% (0.0) | 40% (3.8) | 53% (5.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.3 | 127.4 | ×29.74 | ×9.00 | 9% (0.6) | 0% (0.0) | 49% (3.3) | 41% (2.8) | 0% (0.0) | match |
| tam_Taml | lang | 6.1 | 157.5 | ×25.71 | ×9.02 | 11% (0.6) | 0% (0.0) | 51% (2.7) | 37% (2.0) | 1% (0.0) | match |
| tha_Thai | lang | 6.9 | 214.2 | ×30.89 | ×14.97 | 16% (0.6) | 0% (0.0) | 57% (2.2) | 28% (1.0) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 159.7 | ×26.37 | ×6.80 | 14% (0.8) | 0% (0.0) | 49% (2.8) | 37% (2.1) | 1% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 124.3 | ×22.93 | ×6.34 | 17% (1.3) | 0% (0.0) | 51% (3.8) | 32% (2.4) | 0% (0.0) | match |
| added_special_dense | modalities | 3.6 | 57.8 | ×15.86 | ×1.54 | 41% (6.6) | 3% (0.4) | 41% (6.6) | 17% (2.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 66.3 | ×16.45 | ×3.19 | 28% (3.9) | 1% (0.1) | 51% (7.0) | 21% (2.9) | 0% (0.0) | match |
| agentic-traces | modalities | 2.9 | 81.8 | ×28.01 | ×5.73 | 17% (1.9) | 0% (0.0) | 48% (5.5) | 35% (4.0) | 0% (0.0) | match |
| agentic_swe | modalities | 3.0 | 104.6 | ×34.82 | ×7.02 | 16% (1.4) | 0% (0.0) | 44% (3.9) | 39% (3.4) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 94.2 | ×27.17 | ×6.06 | 17% (1.7) | 0% (0.0) | 48% (4.7) | 35% (3.4) | 0% (0.0) | match |
| math_latex | modalities | 2.8 | 82.5 | ×29.87 | ×5.88 | 18% (2.0) | 0% (0.0) | 49% (5.6) | 33% (3.8) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.39 | 4.80 | 5.41 | 43.5 | 20.7 | 9.4 | — | 9.1× / 8.0× | 4.3× / 3.8× | 2.0× / 1.7× | — |
| arb_Arab | 1.15 | 2.98 | 3.43 | 5.26 | 50.7 | 23.4 | 10.3 | — | 14.8× / 9.6× | 6.8× / 4.4× | 3.0× / 2.0× | — |
| ben_Beng | 1.61 | 2.94 | 3.14 | 4.47 | 36.9 | 16.1 | 7.6 | — | 11.7× / 8.2× | 5.1× / 3.6× | 2.4× / 1.7× | — |
| cmn_Hani | 1.11 | 2.24 | 3.14 | 4.26 | 62.7 | 34.3 | 14.6 | — | 20.0× / 14.7× | 10.9× / 8.0× | 4.6× / 3.4× | — |
| ell_Grek | 0.58 | 3.00 | 3.41 | 5.83 | 48.9 | 21.2 | 9.6 | — | 14.3× / 8.4× | 6.2× / 3.6× | 2.8× / 1.6× | — |
| eng_Latn | 0.11 | 1.45 | 5.29 | 6.63 | 68.6 | 40.9 | 17.1 | — | 13.0× / 10.3× | 7.7× / 6.2× | 3.2× / 2.6× | — |
| heb_Hebr | 1.14 | 3.06 | 3.58 | 5.50 | 52.5 | 24.5 | 10.9 | — | 14.7× / 9.6× | 6.8× / 4.4× | 3.0× / 2.0× | — |
| hin_Deva | 1.52 | 3.12 | 3.34 | 4.95 | 39.3 | 19.6 | 8.6 | — | 11.8× / 8.0× | 5.9× / 4.0× | 2.6× / 1.7× | — |
| jpn_Jpan | 1.70 | 3.34 | 2.99 | 4.63 | 54.7 | 27.2 | 12.0 | — | 18.3× / 11.8× | 9.1× / 5.9× | 4.0× / 2.6× | — |
| kat_Geor | 1.53 | 2.53 | 2.93 | 3.92 | 33.3 | 15.5 | 7.4 | — | 11.4× / 8.5× | 5.3× / 4.0× | 2.5× / 1.9× | — |
| kor_Hang | 1.23 | 2.75 | 3.75 | 5.28 | 52.0 | 27.4 | 12.1 | — | 13.9× / 9.8× | 7.3× / 5.2× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.17 | 2.87 | 3.29 | 4.99 | 48.8 | 21.5 | 9.6 | — | 14.8× / 9.8× | 6.5× / 4.3× | 2.9× / 1.9× | — |
| tam_Taml | 0.93 | 2.98 | 2.71 | 4.76 | 32.8 | 13.6 | 6.6 | — | 12.1× / 6.9× | 5.0× / 2.9× | 2.4× / 1.4× | — |
| tha_Thai | 1.51 | 2.57 | 2.16 | 3.21 | 27.9 | 10.1 | 5.3 | — | 12.9× / 8.7× | 4.7× / 3.2× | 2.4× / 1.6× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.77 | 4.19 | 44.3 | 20.1 | 9.2 | — | 16.0× / 10.6× | 7.2× / 4.8× | 3.3× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.80 | 5.22 | 51.0 | 26.5 | 11.3 | — | 13.4× / 9.8× | 7.0× / 5.1× | 3.0× / 2.2× | — |
| added_special_dense | 0.06 | 1.47 | 6.60 | 8.02 | 181.4 | 100.6 | 38.7 | — | 27.5× / 22.6× | 15.2× / 12.5× | 5.9× / 4.8× | — |
| added_special_sparse | 0.06 | 1.47 | 7.00 | 8.42 | 106.2 | 59.9 | 24.0 | — | 15.2× / 12.6× | 8.6× / 7.1× | 3.4× / 2.9× | — |
| agentic-traces | 0.81 | 1.48 | 5.53 | 6.20 | 84.0 | 54.6 | 20.5 | — | 15.2× / 13.5× | 9.9× / 8.8× | 3.7× / 3.3× | — |
| agentic_swe | 0.67 | 1.47 | 3.87 | 4.68 | 99.4 | 67.3 | 23.8 | — | 25.7× / 21.3× | 17.4× / 14.4× | 6.1× / 5.1× | — |
| code_mixed | 0.07 | 1.44 | 4.71 | 6.09 | 77.1 | 54.9 | 18.9 | — | 16.4× / 12.7× | 11.7× / 9.0× | 4.0× / 3.1× | — |
| math_latex | 0.72 | 1.48 | 5.56 | 6.32 | 82.0 | 49.9 | 19.9 | — | 14.8× / 13.0× | 9.0× / 7.9× | 3.6× / 3.1× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×2.17 vs v0.23.1 · ×1.05 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 371) · Pipeline 275+0 (peak 371)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 9.7 | 27.0 | ×2.79 | ×0.98 | 2% (0.7) | 6% (2.2) | 0% (0.0) | 92% (33.1) | 0% (0.1) | match |
| arb_Arab | lang | 6.3 | 11.5 | ×1.84 | ×0.87 | 1% (0.6) | 3% (2.7) | 0% (0.0) | 93% (79.6) | 3% (2.6) | match |
| ben_Beng | lang | 9.0 | 17.7 | ×1.97 | ×0.95 | 1% (0.6) | 3% (1.8) | 0% (0.0) | 99% (52.8) | 0% (0.0) | match |
| cmn_Hani | lang | 11.7 | 34.1 | ×2.92 | ×1.01 | 2% (0.6) | 1% (0.3) | 0% (0.0) | 98% (27.2) | 0% (0.0) | match |
| ell_Grek | lang | 7.0 | 14.6 | ×2.09 | ×0.98 | 1% (0.6) | 4% (2.7) | 0% (0.0) | 99% (67.0) | 0% (0.0) | match |
| eng_Latn | lang | 3.4 | 5.0 | ×1.47 | ×0.92 | 1% (2.2) | 3% (5.1) | 0% (0.0) | 98% (188.0) | 0% (0.0) | match |
| heb_Hebr | lang | 7.4 | 16.6 | ×2.25 | ×0.99 | 1% (0.6) | 5% (2.8) | 0% (0.0) | 94% (55.5) | 1% (0.5) | match |
| hin_Deva | lang | 8.0 | 17.5 | ×2.18 | ×0.98 | 1% (0.6) | 4% (2.4) | 0% (0.0) | 91% (51.3) | 4% (2.2) | match |
| jpn_Jpan | lang | 10.7 | 28.5 | ×2.66 | ×0.98 | 2% (0.6) | 1% (0.3) | 0% (0.0) | 97% (32.4) | 0% (0.2) | match |
| kat_Geor | lang | 11.5 | 24.4 | ×2.12 | ×1.00 | 1% (0.6) | 4% (1.5) | 0% (0.0) | 94% (37.9) | 0% (0.2) | match |
| kor_Hang | lang | 9.0 | 25.5 | ×2.83 | ×1.01 | 2% (0.6) | 7% (2.7) | 0% (0.0) | 95% (35.8) | 0% (0.0) | match |
| rus_Cyrl | lang | 6.2 | 10.3 | ×1.65 | ×0.92 | 1% (0.6) | 2% (2.4) | 0% (0.0) | 95% (93.8) | 2% (1.9) | match |
| tam_Taml | lang | 10.2 | 19.3 | ×1.89 | ×0.99 | 1% (0.6) | 3% (1.4) | 0% (0.0) | 97% (49.4) | 0% (0.0) | match |
| tha_Thai | lang | 12.1 | 23.5 | ×1.94 | ×0.99 | 1% (0.6) | 2% (0.7) | 0% (0.0) | 97% (40.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.5 | 6.8 | ×1.51 | ×0.91 | 1% (0.8) | 2% (3.1) | 0% (0.0) | 97% (139.6) | 1% (1.2) | match |
| added_normalized_sparse | modalities | 4.2 | 5.9 | ×1.41 | ×0.90 | 1% (1.5) | 3% (4.5) | 0% (0.0) | 97% (154.3) | 0% (0.0) | match |
| added_special_dense | modalities | 4.6 | 33.7 | ×7.30 | ×1.67 | 34% (9.5) | 31% (8.7) | 27% (7.6) | 8% (2.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 6.8 | 42.5 | ×6.23 | ×4.35 | 26% (5.3) | 44% (8.9) | 24% (4.9) | 7% (1.4) | 0% (0.0) | match |
| agentic-traces | modalities | 3.9 | 5.8 | ×1.51 | ×0.91 | 1% (1.9) | 3% (4.8) | 0% (0.0) | 95% (160.5) | 1% (2.5) | match |
| agentic_swe | modalities | 3.7 | 6.3 | ×1.67 | ×0.91 | 1% (1.4) | 5% (7.8) | 0% (0.0) | 93% (148.8) | 2% (3.1) | match |
| code_mixed | modalities | 3.8 | 5.9 | ×1.57 | ×0.90 | 1% (1.7) | 4% (6.6) | 0% (0.0) | 95% (157.3) | 0% (0.3) | match |
| math_latex | modalities | 3.7 | 5.6 | ×1.48 | ×0.93 | 1% (2.0) | 3% (4.9) | 0% (0.0) | 96% (171.3) | 1% (0.9) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×33.72 vs v0.23.1 · ×3.72 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 28+0 (peak 28)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.1 | 90.0 | ×28.56 | ×1.85 | 8% (0.7) | 0% (0.0) | 43% (3.7) | 54% (4.7) | 0% (0.0) | match |
| arb_Arab | lang | 2.9 | 104.6 | ×36.56 | ×4.07 | 8% (0.6) | 0% (0.0) | 32% (2.3) | 68% (5.0) | 0% (0.0) | match |
| ben_Beng | lang | 2.0 | 93.9 | ×46.49 | ×2.12 | 6% (0.6) | 0% (0.0) | 33% (3.1) | 60% (5.5) | 0% (0.0) | match |
| cmn_Hani | lang | 3.3 | 114.8 | ×35.15 | ×3.98 | 9% (0.6) | 0% (0.0) | 33% (2.3) | 57% (4.0) | 2% (0.1) | match |
| ell_Grek | lang | 3.8 | 122.0 | ×32.20 | ×4.30 | 8% (0.6) | 0% (0.0) | 30% (2.2) | 64% (4.5) | 0% (0.0) | match |
| eng_Latn | lang | 3.0 | 101.1 | ×33.65 | ×7.20 | 24% (2.1) | 0% (0.0) | 36% (3.1) | 41% (3.5) | 0% (0.0) | match |
| heb_Hebr | lang | 3.4 | 112.5 | ×32.84 | ×3.90 | 8% (0.6) | 0% (0.0) | 30% (2.3) | 59% (4.6) | 3% (0.3) | match |
| hin_Deva | lang | 2.6 | 113.4 | ×43.75 | ×2.80 | 7% (0.6) | 0% (0.0) | 37% (3.1) | 56% (4.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.1 | 144.3 | ×35.24 | ×6.56 | 11% (0.6) | 0% (0.0) | 38% (2.1) | 54% (3.1) | 0% (0.0) | match |
| kat_Geor | lang | 4.2 | 145.9 | ×34.87 | ×2.24 | 12% (0.6) | 0% (0.0) | 40% (2.1) | 58% (3.0) | 0% (0.0) | match |
| kor_Hang | lang | 2.8 | 92.8 | ×32.69 | ×2.12 | 7% (0.6) | 0% (0.0) | 26% (2.4) | 61% (5.6) | 6% (0.6) | match |
| rus_Cyrl | lang | 3.6 | 122.2 | ×34.13 | ×4.42 | 9% (0.6) | 0% (0.0) | 32% (2.1) | 59% (3.9) | 0% (0.0) | match |
| tam_Taml | lang | 2.3 | 112.6 | ×48.26 | ×1.56 | 7% (0.6) | 0% (0.0) | 33% (2.7) | 61% (5.0) | 0% (0.0) | match |
| tha_Thai | lang | 3.1 | 110.0 | ×35.93 | ×3.10 | 8% (0.6) | 0% (0.0) | 33% (2.5) | 55% (4.2) | 3% (0.3) | match |
| added_normalized_dense | modalities | 4.9 | 188.2 | ×38.73 | ×7.40 | 18% (0.7) | 0% (0.0) | 27% (1.1) | 63% (2.6) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.5 | 145.1 | ×32.01 | ×6.73 | 23% (1.4) | 0% (0.0) | 34% (2.1) | 40% (2.5) | 6% (0.4) | match |
| added_special_dense | modalities | 3.8 | 78.4 | ×20.49 | ×1.64 | 43% (5.3) | 1% (0.1) | 36% (4.4) | 19% (2.3) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.1 | 79.9 | ×19.70 | ×3.34 | 31% (3.4) | 0% (0.0) | 42% (4.7) | 28% (3.2) | 0% (0.0) | match |
| agentic-traces | modalities | 2.9 | 93.4 | ×32.72 | ×5.77 | 20% (1.9) | 0% (0.0) | 35% (3.4) | 46% (4.4) | 0% (0.0) | match |
| agentic_swe | modalities | 3.2 | 114.8 | ×35.42 | ×4.78 | 17% (1.4) | 0% (0.0) | 30% (2.4) | 50% (4.0) | 2% (0.2) | match |
| code_mixed | modalities | 3.3 | 104.1 | ×31.75 | ×5.08 | 19% (1.7) | 0% (0.0) | 33% (2.9) | 46% (4.1) | 2% (0.2) | match |
| math_latex | modalities | 2.7 | 97.0 | ×35.38 | ×6.36 | 21% (2.0) | 1% (0.1) | 35% (3.3) | 42% (4.0) | 1% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.42 | 3.66 | 4.30 | 29.0 | 21.7 | 6.1 | 4.8 | 7.9× / 6.8× | 5.9× / 5.1× | 1.7× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.96 | 2.30 | 4.11 | 34.1 | 26.7 | 6.9 | 5.1 | 14.8× / 8.3× | 11.6× / 6.5× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.61 | 2.90 | 3.07 | 4.36 | 70.5 | 58.4 | 14.6 | 4.1 | 22.9× / 16.2× | 19.0× / 13.4× | 4.7× / 3.3× | 1.3× / 0.9× |
| cmn_Hani | 1.13 | 2.23 | 2.33 | 3.43 | 27.8 | 21.8 | 6.3 | 2.4 | 11.9× / 8.1× | 9.4× / 6.4× | 2.7× / 1.8× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.98 | 2.16 | 4.55 | 30.2 | 22.9 | 6.2 | 4.7 | 14.0× / 6.6× | 10.6× / 5.0× | 2.9× / 1.4× | 2.2× / 1.0× |
| eng_Latn | 0.09 | 1.47 | 3.07 | 4.44 | 48.1 | 44.2 | 12.2 | 3.8 | 15.7× / 10.8× | 14.4× / 10.0× | 4.0× / 2.7× | 1.2× / 0.9× |
| heb_Hebr | 1.14 | 3.04 | 2.28 | 4.17 | 33.6 | 26.7 | 7.1 | 3.1 | 14.8× / 8.1× | 11.7× / 6.4× | 3.1× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.52 | 3.18 | 3.11 | 4.77 | 66.8 | 57.2 | 14.2 | 4.4 | 21.5× / 14.0× | 18.4× / 12.0× | 4.6× / 3.0× | 1.4× / 0.9× |
| jpn_Jpan | 1.71 | 3.34 | 2.12 | 3.76 | 24.7 | 17.9 | 5.3 | 3.8 | 11.6× / 6.6× | 8.4× / 4.8× | 2.5× / 1.4× | 1.8× / 1.0× |
| kat_Geor | 1.54 | 2.54 | 2.06 | 3.06 | 18.3 | 14.5 | 4.4 | 2.0 | 8.9× / 6.0× | 7.0× / 4.7× | 2.1× / 1.4× | 1.0× / 0.7× |
| kor_Hang | 1.23 | 2.70 | 2.44 | 3.91 | 34.0 | 29.4 | 8.0 | 3.7 | 13.9× / 8.7× | 12.0× / 7.5× | 3.3× / 2.0× | 1.5× / 1.0× |
| rus_Cyrl | 1.16 | 2.89 | 2.10 | 3.83 | 28.7 | 22.1 | 5.9 | 2.4 | 13.7× / 7.5× | 10.5× / 5.8× | 2.8× / 1.6× | 1.1× / 0.6× |
| tam_Taml | 0.94 | 2.94 | 2.72 | 4.71 | 73.8 | 61.2 | 14.9 | 3.9 | 27.1× / 15.6× | 22.5× / 13.0× | 5.5× / 3.2× | 1.4× / 0.8× |
| tha_Thai | 1.52 | 2.59 | 2.51 | 3.58 | 42.3 | 32.7 | 9.3 | 3.2 | 16.8× / 11.8× | 13.0× / 9.1× | 3.7× / 2.6× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.11 | 2.52 | 25.0 | 23.5 | 6.4 | 2.0 | 22.6× / 9.9× | 21.2× / 9.3× | 5.7× / 2.5× | 1.8× / 0.8× |
| added_normalized_sparse | 0.06 | 1.48 | 2.08 | 3.50 | 33.2 | 31.1 | 8.4 | 2.7 | 16.0× / 9.5× | 14.9× / 8.9× | 4.0× / 2.4× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.48 | 4.42 | 5.84 | 100.8 | 98.8 | 20.5 | 2.9 | 22.8× / 17.3× | 22.4× / 16.9× | 4.6× / 3.5× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 4.71 | 6.13 | 64.9 | 62.1 | 14.4 | 3.3 | 13.8× / 10.6× | 13.2× / 10.1× | 3.1× / 2.4× | 0.7× / 0.5× |
| agentic-traces | 0.72 | 1.48 | 3.41 | 4.17 | 63.1 | 62.5 | 15.9 | 4.7 | 18.5× / 15.1× | 18.3× / 15.0× | 4.7× / 3.8× | 1.4× / 1.1× |
| agentic_swe | 0.67 | 1.47 | 2.38 | 3.18 | 64.6 | 71.3 | 15.0 | 3.5 | 27.1× / 20.3× | 29.9× / 22.4× | 6.3× / 4.7× | 1.5× / 1.1× |
| code_mixed | 0.07 | 1.55 | 2.95 | 4.42 | 62.9 | 67.6 | 15.9 | 4.0 | 21.3× / 14.2× | 22.9× / 15.3× | 5.4× / 3.6× | 1.4× / 0.9× |
| math_latex | 0.93 | 1.49 | 3.30 | 3.86 | 56.0 | 52.7 | 14.5 | 4.2 | 17.0× / 14.5× | 16.0× / 13.6× | 4.4× / 3.7× | 1.3× / 1.1× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×20.83 vs v0.23.1 · ×3.97 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.5 | 86.8 | ×24.74 | ×3.73 | 7% (0.6) | 0% (0.0) | 50% (4.8) | 54% (5.1) | 0% (0.0) | match |
| arb_Arab | lang | 4.0 | 95.4 | ×23.58 | ×5.51 | 6% (0.6) | 0% (0.0) | 36% (3.3) | 53% (4.9) | 5% (0.4) | match |
| ben_Beng | lang | 6.4 | 119.8 | ×18.84 | ×6.83 | 8% (0.6) | 0% (0.0) | 51% (3.7) | 48% (3.5) | 0% (0.0) | match |
| cmn_Hani | lang | 4.0 | 107.0 | ×26.46 | ×8.80 | 8% (0.6) | 0% (0.0) | 42% (3.3) | 48% (3.8) | 2% (0.1) | match |
| ell_Grek | lang | 4.8 | 105.2 | ×22.05 | ×6.61 | 8% (0.6) | 0% (0.0) | 39% (3.3) | 57% (4.8) | 0% (0.0) | match |
| eng_Latn | lang | 3.6 | 58.6 | ×16.41 | ×1.38 | 14% (2.1) | 1% (0.1) | 30% (4.6) | 54% (8.2) | 2% (0.3) | match |
| heb_Hebr | lang | 4.1 | 96.2 | ×23.55 | ×5.79 | 7% (0.6) | 0% (0.0) | 37% (3.4) | 56% (5.1) | 1% (0.1) | match |
| hin_Deva | lang | 6.4 | 110.4 | ×17.20 | ×4.23 | 7% (0.6) | 0% (0.0) | 47% (3.8) | 46% (3.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.2 | 129.9 | ×25.03 | ×10.16 | 10% (0.6) | 0% (0.0) | 49% (3.1) | 42% (2.6) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 133.2 | ×21.43 | ×9.46 | 9% (0.6) | 0% (0.0) | 44% (2.9) | 52% (3.4) | 0% (0.0) | match |
| kor_Hang | lang | 3.4 | 76.6 | ×22.86 | ×5.00 | 5% (0.6) | 0% (0.0) | 32% (3.7) | 62% (7.3) | 1% (0.1) | match |
| rus_Cyrl | lang | 4.8 | 100.4 | ×20.94 | ×6.42 | 7% (0.6) | 0% (0.0) | 36% (3.1) | 67% (5.8) | 0% (0.0) | match |
| tam_Taml | lang | 6.4 | 137.6 | ×21.41 | ×10.39 | 9% (0.6) | 0% (0.0) | 50% (3.2) | 43% (2.7) | 0% (0.0) | match |
| tha_Thai | lang | 7.4 | 158.8 | ×21.35 | ×13.76 | 11% (0.6) | 0% (0.0) | 59% (3.2) | 27% (1.4) | 2% (0.1) | match |
| added_normalized_dense | modalities | 5.1 | 156.0 | ×30.42 | ×6.15 | 13% (0.7) | 0% (0.0) | 40% (2.2) | 47% (2.6) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 114.8 | ×21.66 | ×2.74 | 17% (1.4) | 0% (0.0) | 41% (3.3) | 43% (3.4) | 1% (0.0) | match |
| added_special_dense | modalities | 4.2 | 65.9 | ×15.59 | ×0.87 | 37% (5.3) | 0% (0.0) | 38% (5.5) | 26% (3.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 67.8 | ×15.33 | ×0.88 | 24% (3.4) | 0% (0.0) | 45% (6.2) | 31% (4.3) | 0% (0.0) | match |
| agentic-traces | modalities | 3.4 | 59.5 | ×17.71 | ×1.55 | 12% (1.9) | 0% (0.0) | 32% (5.0) | 55% (8.5) | 1% (0.1) | match |
| agentic_swe | modalities | 3.5 | 76.3 | ×21.51 | ×2.75 | 12% (1.4) | 0% (0.0) | 32% (3.7) | 56% (6.5) | 0% (0.0) | match |
| code_mixed | modalities | 3.7 | 71.8 | ×19.25 | ×1.42 | 13% (1.7) | 0% (0.0) | 34% (4.5) | 51% (6.8) | 2% (0.3) | match |
| math_latex | modalities | 3.3 | 59.5 | ×17.78 | ×1.54 | 14% (2.0) | 0% (0.0) | 33% (4.9) | 55% (8.1) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.42 | 4.83 | 5.47 | 29.8 | 14.5 | 7.1 | 4.8 | 6.2× / 5.5× | 3.0× / 2.7× | 1.5× / 1.3× | 1.0× / 0.9× |
| arb_Arab | 1.16 | 2.98 | 3.29 | 5.11 | 34.2 | 16.3 | 7.8 | 5.0 | 10.4× / 6.7× | 5.0× / 3.2× | 2.4× / 1.5× | 1.5× / 1.0× |
| ben_Beng | 1.61 | 2.97 | 3.71 | 5.06 | 23.9 | 10.9 | 5.6 | 2.8 | 6.4× / 4.7× | 2.9× / 2.2× | 1.5× / 1.1× | 0.8× / 0.6× |
| cmn_Hani | 1.12 | 2.22 | 3.32 | 4.42 | 21.8 | 11.2 | 5.6 | 2.5 | 6.6× / 4.9× | 3.4× / 2.5× | 1.7× / 1.3× | 0.7× / 0.6× |
| ell_Grek | 0.58 | 2.95 | 3.27 | 5.64 | 30.2 | 15.4 | 7.1 | 5.1 | 9.3× / 5.4× | 4.7× / 2.7× | 2.2× / 1.3× | 1.6× / 0.9× |
| eng_Latn | 0.09 | 1.46 | 4.55 | 5.92 | 44.6 | 30.2 | 14.4 | 4.2 | 9.8× / 7.5× | 6.6× / 5.1× | 3.2× / 2.4× | 0.9× / 0.7× |
| heb_Hebr | 1.15 | 3.00 | 3.37 | 5.22 | 33.6 | 17.4 | 8.2 | 2.8 | 10.0× / 6.4× | 5.2× / 3.3× | 2.4× / 1.6× | 0.8× / 0.5× |
| hin_Deva | 1.52 | 3.10 | 3.79 | 5.37 | 26.0 | 13.3 | 6.4 | 3.1 | 6.9× / 4.8× | 3.5× / 2.5× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.70 | 3.35 | 3.07 | 4.72 | 20.4 | 9.4 | 4.9 | 3.8 | 6.6× / 4.3× | 3.1× / 2.0× | 1.6× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.54 | 2.58 | 2.90 | 3.94 | 18.9 | 10.2 | 4.7 | 2.0 | 6.5× / 4.8× | 3.5× / 2.6× | 1.6× / 1.2× | 0.7× / 0.5× |
| kor_Hang | 1.23 | 2.68 | 3.72 | 5.17 | 33.5 | 19.5 | 9.2 | 3.6 | 9.0× / 6.5× | 5.2× / 3.8× | 2.5× / 1.8× | 1.0× / 0.7× |
| rus_Cyrl | 1.17 | 2.91 | 3.14 | 4.88 | 29.0 | 15.0 | 6.8 | 4.9 | 9.3× / 6.0× | 4.8× / 3.1× | 2.2× / 1.4× | 1.6× / 1.0× |
| tam_Taml | 0.93 | 2.90 | 3.20 | 5.17 | 19.3 | 9.0 | 4.4 | 2.9 | 6.0× / 3.7× | 2.8× / 1.7× | 1.4× / 0.9× | 0.9× / 0.6× |
| tha_Thai | 1.53 | 2.61 | 3.21 | 4.29 | 13.3 | 5.6 | 2.8 | 2.2 | 4.1× / 3.1× | 1.8× / 1.3× | 0.9× / 0.7× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.48 | 2.22 | 3.63 | 34.1 | 17.5 | 11.5 | 2.2 | 15.4× / 9.4× | 7.9× / 4.8× | 5.2× / 3.2× | 1.0× / 0.6× |
| added_normalized_sparse | 0.06 | 1.48 | 3.26 | 4.68 | 36.4 | 20.7 | 11.7 | 3.0 | 11.2× / 7.8× | 6.4× / 4.4× | 3.6× / 2.5× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.47 | 5.48 | 6.90 | 87.0 | 68.3 | 24.4 | 3.3 | 15.9× / 12.6× | 12.5× / 9.9× | 4.4× / 3.5× | 0.6× / 0.5× |
| added_special_sparse | 0.08 | 1.47 | 6.17 | 7.56 | 57.8 | 41.2 | 17.0 | 3.7 | 9.4× / 7.6× | 6.7× / 5.5× | 2.8× / 2.2× | 0.6× / 0.5× |
| agentic-traces | 0.72 | 1.48 | 5.04 | 5.80 | 53.8 | 44.0 | 17.8 | 4.9 | 10.7× / 9.3× | 8.7× / 7.6× | 3.5× / 3.1× | 1.0× / 0.8× |
| agentic_swe | 0.66 | 1.44 | 3.75 | 4.53 | 54.8 | 50.1 | 17.9 | 3.6 | 14.6× / 12.1× | 13.4× / 11.1× | 4.8× / 4.0× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.51 | 4.46 | 5.90 | 54.0 | 48.5 | 17.9 | 4.3 | 12.1× / 9.2× | 10.9× / 8.2× | 4.0× / 3.0× | 1.0× / 0.7× |
| math_latex | 0.71 | 1.53 | 4.88 | 5.70 | 51.0 | 36.0 | 16.4 | 4.6 | 10.4× / 8.9× | 7.4× / 6.3× | 3.4× / 2.9× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×21.96 vs v0.23.1 · ×3.28 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 90.0 | ×23.12 | ×1.87 | 13% (1.2) | 0% (0.0) | 40% (3.7) | 54% (5.0) | 0% (0.0) | match |
| arb_Arab | lang | 4.1 | 105.1 | ×25.90 | ×5.88 | 14% (1.2) | 0% (0.0) | 28% (2.3) | 60% (4.9) | 0% (0.0) | match |
| ben_Beng | lang | 4.2 | 113.6 | ×27.29 | ×4.27 | 14% (1.2) | 0% (0.0) | 38% (3.1) | 50% (4.1) | 0% (0.0) | match |
| cmn_Hani | lang | 4.8 | 118.1 | ×24.70 | ×8.09 | 17% (1.3) | 1% (0.1) | 32% (2.3) | 47% (3.5) | 2% (0.2) | match |
| ell_Grek | lang | 4.8 | 107.6 | ×22.46 | ×5.53 | 15% (1.2) | 0% (0.0) | 28% (2.2) | 58% (4.6) | 0% (0.0) | match |
| eng_Latn | lang | 3.7 | 64.3 | ×17.59 | ×1.44 | 20% (2.7) | 1% (0.1) | 23% (3.0) | 60% (8.0) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 101.7 | ×24.65 | ×3.97 | 14% (1.2) | 0% (0.0) | 27% (2.3) | 60% (5.2) | 0% (0.0) | match |
| hin_Deva | lang | 3.8 | 98.7 | ×25.74 | ×3.30 | 12% (1.2) | 0% (0.0) | 34% (3.2) | 54% (5.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.5 | 138.3 | ×25.16 | ×8.89 | 19% (1.2) | 0% (0.0) | 34% (2.2) | 55% (3.5) | 0% (0.0) | match |
| kat_Geor | lang | 6.3 | 137.5 | ×21.74 | ×6.21 | 20% (1.2) | 0% (0.0) | 35% (2.1) | 43% (2.6) | 2% (0.1) | match |
| kor_Hang | lang | 3.6 | 86.7 | ×24.15 | ×4.67 | 12% (1.2) | 0% (0.0) | 25% (2.5) | 63% (6.4) | 1% (0.1) | match |
| rus_Cyrl | lang | 4.7 | 104.9 | ×22.36 | ×5.59 | 14% (1.2) | 0% (0.0) | 27% (2.2) | 71% (5.7) | 0% (0.0) | match |
| tam_Taml | lang | 3.8 | 111.8 | ×29.66 | ×3.16 | 14% (1.2) | 0% (0.0) | 32% (2.7) | 53% (4.5) | 0% (0.0) | match |
| tha_Thai | lang | 4.8 | 112.9 | ×23.47 | ×5.37 | 15% (1.2) | 0% (0.0) | 33% (2.6) | 51% (4.0) | 2% (0.1) | match |
| added_normalized_dense | modalities | 6.0 | 169.6 | ×28.23 | ×6.27 | 26% (1.3) | 0% (0.0) | 22% (1.1) | 51% (2.5) | 1% (0.0) | match |
| added_normalized_sparse | modalities | 4.9 | 124.7 | ×25.31 | ×2.97 | 26% (1.9) | 0% (0.0) | 27% (1.9) | 45% (3.3) | 4% (0.3) | match |
| added_special_dense | modalities | 4.1 | 44.2 | ×10.86 | ×0.93 | 59% (12.5) | 0% (0.0) | 26% (5.6) | 16% (3.4) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.2 | 56.5 | ×13.61 | ×0.98 | 43% (6.9) | 0% (0.0) | 34% (5.4) | 24% (3.9) | 0% (0.0) | match |
| agentic-traces | modalities | 3.3 | 63.3 | ×19.43 | ×1.78 | 17% (2.6) | 0% (0.0) | 26% (3.8) | 52% (7.8) | 4% (0.6) | match |
| agentic_swe | modalities | 3.5 | 79.0 | ×22.52 | ×2.83 | 17% (2.0) | 0% (0.0) | 25% (3.0) | 59% (7.0) | 0% (0.0) | match |
| code_mixed | modalities | 3.8 | 74.8 | ×19.55 | ×1.64 | 18% (2.3) | 0% (0.0) | 26% (3.3) | 54% (6.9) | 1% (0.2) | match |
| math_latex | modalities | 3.6 | 62.6 | ×17.44 | ×1.61 | 19% (2.6) | 0% (0.0) | 25% (3.6) | 61% (8.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.89 | 3.43 | 3.70 | 4.25 | 26.6 | 16.3 | 6.2 | 4.8 | 7.2× / 6.3× | 4.4× / 3.8× | 1.7× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.98 | 2.31 | 4.15 | 30.1 | 20.0 | 7.1 | 5.2 | 13.0× / 7.3× | 8.7× / 4.8× | 3.1× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.62 | 2.93 | 3.14 | 4.45 | 44.0 | 27.9 | 10.7 | 3.7 | 14.0× / 9.9× | 8.9× / 6.3× | 3.4× / 2.4× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.27 | 2.32 | 3.47 | 19.0 | 11.9 | 4.9 | 2.4 | 8.2× / 5.5× | 5.1× / 3.4× | 2.1× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.96 | 2.20 | 4.57 | 27.5 | 17.5 | 6.4 | 4.8 | 12.5× / 6.0× | 8.0× / 3.8× | 2.9× / 1.4× | 2.2× / 1.0× |
| eng_Latn | 0.12 | 1.48 | 3.04 | 4.40 | 42.6 | 33.7 | 12.9 | 3.7 | 14.0× / 9.7× | 11.1× / 7.7× | 4.3× / 2.9× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.05 | 2.30 | 4.20 | 30.0 | 20.0 | 7.2 | 3.0 | 13.1× / 7.1× | 8.7× / 4.8× | 3.1× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 3.17 | 3.23 | 4.89 | 46.2 | 30.6 | 11.6 | 4.0 | 14.3× / 9.4× | 9.5× / 6.3× | 3.6× / 2.4× | 1.2× / 0.8× |
| jpn_Jpan | 1.71 | 3.41 | 2.16 | 3.86 | 17.8 | 9.7 | 4.2 | 3.7 | 8.2× / 4.6× | 4.5× / 2.5× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.53 | 2.59 | 2.10 | 3.15 | 16.6 | 11.2 | 4.5 | 2.0 | 7.9× / 5.3× | 5.4× / 3.6× | 2.1× / 1.4× | 1.0× / 0.6× |
| kor_Hang | 1.23 | 2.70 | 2.51 | 3.98 | 29.9 | 21.7 | 7.9 | 3.6 | 11.9× / 7.5× | 8.7× / 5.5× | 3.1× / 2.0× | 1.4× / 0.9× |
| rus_Cyrl | 1.16 | 2.96 | 2.17 | 3.96 | 26.2 | 16.7 | 6.2 | 2.5 | 12.1× / 6.6× | 7.7× / 4.2× | 2.9× / 1.6× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.91 | 2.71 | 4.70 | 43.1 | 26.8 | 10.4 | 3.4 | 15.9× / 9.2× | 9.9× / 5.7× | 3.8× / 2.2× | 1.2× / 0.7× |
| tha_Thai | 1.52 | 2.53 | 2.60 | 3.61 | 27.5 | 16.3 | 6.9 | 3.0 | 10.6× / 7.6× | 6.3× / 4.5× | 2.7× / 1.9× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.07 | 2.49 | 22.7 | 16.9 | 6.7 | 1.8 | 21.1× / 9.1× | 15.7× / 6.8× | 6.2× / 2.7× | 1.7× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.95 | 3.37 | 30.0 | 23.0 | 9.0 | 2.5 | 15.4× / 8.9× | 11.8× / 6.8× | 4.6× / 2.7× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 5.56 | 6.97 | 91.4 | 73.8 | 21.6 | 3.1 | 16.4× / 13.1× | 13.3× / 10.6× | 3.9× / 3.1× | 0.6× / 0.4× |
| added_special_sparse | 0.06 | 1.47 | 5.44 | 6.85 | 58.2 | 45.7 | 15.6 | 3.4 | 10.7× / 8.5× | 8.4× / 6.7× | 2.9× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.72 | 1.49 | 3.84 | 4.61 | 51.2 | 48.1 | 15.8 | 4.6 | 13.3× / 11.1× | 12.5× / 10.4× | 4.1× / 3.4× | 1.2× / 1.0× |
| agentic_swe | 0.67 | 1.45 | 2.97 | 3.75 | 54.0 | 55.0 | 16.2 | 3.4 | 18.2× / 14.4× | 18.5× / 14.7× | 5.5× / 4.3× | 1.1× / 0.9× |
| code_mixed | 0.07 | 1.45 | 3.33 | 4.71 | 51.3 | 53.2 | 15.8 | 4.0 | 15.4× / 10.9× | 15.9× / 11.3× | 4.7× / 3.4× | 1.2× / 0.8× |
| math_latex | 0.99 | 1.54 | 3.57 | 4.12 | 51.3 | 39.5 | 14.7 | 4.1 | 14.4× / 12.4× | 11.0× / 9.6× | 4.1× / 3.6× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×4.52 vs v0.23.1 · ×1.10 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 43.1 | ×10.67 | ×1.07 | 0% (0.0) | 12% (2.8) | 0% (0.0) | 86% (19.7) | 1% (0.3) | match |
| arb_Arab | lang | 9.2 | 50.2 | ×5.43 | ×1.03 | 0% (0.0) | 16% (3.2) | 0% (0.0) | 84% (16.5) | 0% (0.0) | match |
| ben_Beng | lang | 10.1 | 80.8 | ×7.96 | ×1.07 | 0% (0.0) | 18% (2.2) | 0% (0.0) | 82% (9.9) | 0% (0.0) | match |
| cmn_Hani | lang | 8.1 | 64.0 | ×7.94 | ×1.03 | 0% (0.1) | 3% (0.5) | 0% (0.0) | 96% (14.3) | 1% (0.1) | match |
| ell_Grek | lang | 9.4 | 57.4 | ×6.13 | ×1.04 | 0% (0.0) | 19% (3.2) | 0% (0.0) | 81% (13.8) | 0% (0.0) | match |
| eng_Latn | lang | 3.6 | 5.9 | ×1.62 | ×0.92 | 0% (0.1) | 4% (7.0) | 0% (0.0) | 96% (160.0) | 0% (0.5) | match |
| heb_Hebr | lang | 9.3 | 60.1 | ×6.44 | ×1.03 | 0% (0.0) | 20% (3.3) | 0% (0.0) | 79% (12.9) | 0% (0.0) | match |
| hin_Deva | lang | 10.9 | 78.7 | ×7.23 | ×1.07 | 0% (0.0) | 23% (2.9) | 0% (0.0) | 76% (9.5) | 1% (0.1) | match |
| jpn_Jpan | lang | 11.2 | 83.7 | ×7.49 | ×1.05 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 97% (10.9) | 0% (0.0) | match |
| kat_Geor | lang | 12.4 | 89.0 | ×7.18 | ×1.05 | 0% (0.0) | 18% (1.9) | 0% (0.0) | 82% (8.8) | 0% (0.0) | match |
| kor_Hang | lang | 6.5 | 50.9 | ×7.88 | ×1.03 | 0% (0.1) | 17% (3.3) | 0% (0.0) | 83% (16.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 6.9 | 15.8 | ×2.30 | ×0.99 | 0% (0.0) | 5% (2.9) | 0% (0.0) | 97% (60.0) | 0% (0.0) | match |
| tam_Taml | lang | 10.7 | 87.9 | ×8.21 | ×1.06 | 0% (0.0) | 16% (1.8) | 0% (0.0) | 84% (9.2) | 0% (0.0) | match |
| tha_Thai | lang | 13.0 | 83.9 | ×6.46 | ×1.02 | 0% (0.0) | 9% (1.0) | 0% (0.0) | 92% (10.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.4 | 8.4 | ×1.91 | ×0.95 | 0% (0.0) | 3% (3.8) | 0% (0.0) | 98% (116.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.1 | 6.8 | ×1.64 | ×0.91 | 0% (0.0) | 4% (6.2) | 0% (0.0) | 95% (138.9) | 1% (1.4) | match |
| added_special_dense | modalities | 3.5 | 38.4 | ×11.13 | ×1.91 | 21% (5.2) | 63% (15.9) | 6% (1.4) | 8% (2.0) | 2% (0.5) | match |
| added_special_sparse | modalities | 4.8 | 45.2 | ×9.41 | ×4.42 | 12% (2.3) | 77% (14.5) | 2% (0.4) | 9% (1.6) | 0% (0.1) | match |
| agentic-traces | modalities | 3.9 | 6.5 | ×1.69 | ×0.92 | 0% (0.1) | 4% (6.3) | 0% (0.0) | 96% (145.8) | 0% (0.2) | match |
| agentic_swe | modalities | 3.5 | 6.4 | ×1.84 | ×0.91 | 0% (0.0) | 6% (9.7) | 0% (0.0) | 93% (145.8) | 1% (1.2) | match |
| code_mixed | modalities | 3.6 | 6.4 | ×1.78 | ×0.92 | 0% (0.0) | 5% (8.0) | 0% (0.0) | 95% (146.3) | 0% (0.5) | match |
| math_latex | modalities | 3.8 | 6.2 | ×1.63 | ×0.92 | 0% (0.1) | 4% (6.6) | 0% (0.0) | 96% (152.0) | 0% (0.0) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×23.46 vs v0.23.1 · ×3.15 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 94)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 93.0 | ×22.92 | ×1.92 | 8% (0.7) | 0% (0.0) | 42% (3.7) | 48% (4.2) | 2% (0.2) | match |
| arb_Arab | lang | 4.0 | 108.3 | ×26.96 | ×6.05 | 8% (0.6) | 0% (0.0) | 30% (2.3) | 63% (4.9) | 0% (0.0) | match |
| ben_Beng | lang | 3.8 | 113.8 | ×29.92 | ×3.63 | 8% (0.6) | 0% (0.0) | 39% (3.1) | 54% (4.3) | 0% (0.0) | match |
| cmn_Hani | lang | 4.6 | 123.6 | ×26.73 | ×7.39 | 10% (0.6) | 0% (0.0) | 36% (2.4) | 54% (3.6) | 1% (0.1) | match |
| ell_Grek | lang | 4.9 | 116.7 | ×23.78 | ×6.05 | 8% (0.6) | 0% (0.0) | 30% (2.2) | 63% (4.6) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 65.7 | ×16.67 | ×1.42 | 16% (2.1) | 0% (0.0) | 24% (3.1) | 57% (7.5) | 4% (0.5) | match |
| heb_Hebr | lang | 3.9 | 108.1 | ×27.41 | ×4.16 | 7% (0.6) | 0% (0.0) | 28% (2.3) | 64% (5.2) | 1% (0.1) | match |
| hin_Deva | lang | 4.2 | 105.9 | ×25.03 | ×1.38 | 7% (0.6) | 0% (0.0) | 37% (3.2) | 59% (5.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.5 | 148.0 | ×27.09 | ×9.12 | 11% (0.6) | 0% (0.0) | 39% (2.2) | 53% (3.0) | 0% (0.0) | match |
| kat_Geor | lang | 5.5 | 143.0 | ×25.80 | ×3.85 | 10% (0.6) | 0% (0.0) | 36% (2.1) | 51% (3.0) | 3% (0.2) | match |
| kor_Hang | lang | 3.3 | 85.3 | ×26.13 | ×4.46 | 6% (0.6) | 0% (0.0) | 24% (2.5) | 66% (7.0) | 5% (0.5) | match |
| rus_Cyrl | lang | 4.5 | 115.6 | ×25.85 | ×7.07 | 8% (0.6) | 0% (0.0) | 29% (2.1) | 61% (4.5) | 2% (0.2) | match |
| tam_Taml | lang | 3.9 | 117.4 | ×29.98 | ×3.31 | 8% (0.6) | 0% (0.0) | 35% (2.7) | 58% (4.5) | 0% (0.0) | match |
| tha_Thai | lang | 4.9 | 112.9 | ×23.15 | ×5.56 | 8% (0.6) | 0% (0.0) | 34% (2.6) | 59% (4.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 189.3 | ×31.21 | ×6.97 | 18% (0.8) | 0% (0.0) | 25% (1.1) | 55% (2.4) | 2% (0.1) | match |
| added_normalized_sparse | modalities | 5.5 | 133.8 | ×24.33 | ×3.14 | 21% (1.4) | 0% (0.0) | 29% (1.9) | 49% (3.2) | 2% (0.1) | match |
| added_special_dense | modalities | 4.0 | 68.6 | ×17.16 | ×0.91 | 24% (4.9) | 0% (0.1) | 26% (5.3) | 17% (3.5) | 32% (6.6) | match |
| added_special_sparse | modalities | 4.2 | 72.1 | ×17.23 | ×0.99 | 26% (3.3) | 0% (0.0) | 40% (5.1) | 33% (4.1) | 1% (0.1) | match |
| agentic-traces | modalities | 3.5 | 68.2 | ×19.49 | ×1.82 | 14% (1.9) | 0% (0.0) | 29% (3.8) | 59% (7.9) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 81.8 | ×20.57 | ×2.88 | 12% (1.4) | 0% (0.0) | 25% (3.0) | 62% (7.4) | 2% (0.2) | match |
| code_mixed | modalities | 4.1 | 79.3 | ×19.42 | ×1.69 | 14% (1.7) | 0% (0.0) | 29% (3.4) | 57% (6.7) | 0% (0.0) | match |
| math_latex | modalities | 3.6 | 66.3 | ×18.21 | ×1.62 | 16% (2.1) | 0% (0.0) | 26% (3.5) | 58% (7.8) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.42 | 3.66 | 4.29 | 26.6 | 16.4 | 6.3 | 4.8 | 7.3× / 6.2× | 4.5× / 3.8× | 1.7× / 1.5× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.94 | 2.30 | 4.10 | 30.5 | 19.6 | 7.2 | 5.1 | 13.2× / 7.4× | 8.5× / 4.8× | 3.1× / 1.8× | 2.2× / 1.2× |
| ben_Beng | 1.62 | 3.00 | 3.13 | 4.51 | 44.5 | 28.2 | 11.0 | 3.7 | 14.2× / 9.9× | 9.0× / 6.3× | 3.5× / 2.4× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.23 | 2.36 | 3.46 | 19.2 | 11.9 | 4.8 | 2.4 | 8.1× / 5.5× | 5.0× / 3.4× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.99 | 2.17 | 4.59 | 27.9 | 17.4 | 6.4 | 4.8 | 12.8× / 6.1× | 8.0× / 3.8× | 3.0× / 1.4× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.46 | 3.12 | 4.48 | 43.0 | 34.0 | 13.0 | 3.7 | 13.8× / 9.6× | 10.9× / 7.6× | 4.2× / 2.9× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 3.03 | 2.29 | 4.18 | 30.4 | 20.5 | 7.2 | 3.0 | 13.3× / 7.3× | 8.9× / 4.9× | 3.2× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.52 | 3.12 | 3.23 | 4.83 | 46.9 | 30.8 | 12.0 | 4.0 | 14.5× / 9.7× | 9.5× / 6.4× | 3.7× / 2.5× | 1.2× / 0.8× |
| jpn_Jpan | 1.71 | 3.35 | 2.18 | 3.82 | 18.2 | 10.2 | 4.2 | 3.8 | 8.3× / 4.8× | 4.7× / 2.7× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.54 | 2.59 | 2.09 | 3.14 | 16.8 | 11.6 | 4.4 | 2.0 | 8.0× / 5.3× | 5.5× / 3.7× | 2.1× / 1.4× | 1.0× / 0.6× |
| kor_Hang | 1.23 | 2.68 | 2.49 | 3.94 | 30.4 | 21.9 | 8.0 | 3.6 | 12.2× / 7.7× | 8.8× / 5.6× | 3.2× / 2.0× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.93 | 2.13 | 3.90 | 26.5 | 17.0 | 6.3 | 2.5 | 12.4× / 6.8× | 7.9× / 4.3× | 3.0× / 1.6× | 1.2× / 0.6× |
| tam_Taml | 0.93 | 2.98 | 2.71 | 4.75 | 43.2 | 27.6 | 10.6 | 3.4 | 16.0× / 9.1× | 10.2× / 5.8× | 3.9× / 2.2× | 1.3× / 0.7× |
| tha_Thai | 1.68 | 2.55 | 2.58 | 3.45 | 27.7 | 16.4 | 7.1 | 3.0 | 10.7× / 8.0× | 6.4× / 4.8× | 2.8× / 2.1× | 1.2× / 0.9× |
| added_normalized_dense | 0.09 | 1.47 | 1.10 | 2.49 | 22.9 | 16.8 | 6.6 | 1.8 | 20.7× / 9.2× | 15.2× / 6.7× | 6.0× / 2.6× | 1.6× / 0.7× |
| added_normalized_sparse | 0.09 | 1.47 | 1.92 | 3.30 | 30.2 | 23.1 | 9.0 | 2.5 | 15.7× / 9.1× | 12.1× / 7.0× | 4.7× / 2.7× | 1.3× / 0.8× |
| added_special_dense | 0.10 | 1.47 | 5.34 | 6.72 | 91.9 | 73.8 | 21.6 | 3.2 | 17.2× / 13.7× | 13.8× / 11.0× | 4.0× / 3.2× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.08 | 6.50 | 58.9 | 46.0 | 15.6 | 3.4 | 11.6× / 9.1× | 9.0× / 7.1× | 3.1× / 2.4× | 0.7× / 0.5× |
| agentic-traces | 0.72 | 1.48 | 3.84 | 4.60 | 51.9 | 47.6 | 18.8 | 4.6 | 13.5× / 11.3× | 12.4× / 10.4× | 4.9× / 4.1× | 1.2× / 1.0× |
| agentic_swe | 0.66 | 1.45 | 2.97 | 3.75 | 54.8 | 58.2 | 16.5 | 3.4 | 18.5× / 14.6× | 19.6× / 15.5× | 5.6× / 4.4× | 1.1× / 0.9× |
| code_mixed | 0.07 | 1.46 | 3.38 | 4.78 | 52.0 | 52.0 | 16.0 | 4.0 | 15.4× / 10.9× | 15.4× / 10.9× | 4.7× / 3.3× | 1.2× / 0.8× |
| math_latex | 0.97 | 1.48 | 3.49 | 4.00 | 49.8 | 39.9 | 14.9 | 4.1 | 14.3× / 12.4× | 11.4× / 10.0× | 4.3× / 3.7× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×7.97 vs v0.23.1 · ×2.18 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 194) · Pipeline 108+0 (peak 194)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 43.8 | ×12.05 | ×1.45 | 6% (1.2) | 0% (0.0) | 69% (14.4) | 25% (5.2) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 39.2 | ×9.25 | ×2.28 | 5% (1.2) | 0% (0.0) | 69% (16.4) | 26% (6.2) | 0% (0.1) | match |
| ben_Beng | lang | 6.6 | 61.8 | ×9.41 | ×3.60 | 7% (1.2) | 0% (0.0) | 70% (10.9) | 22% (3.5) | 1% (0.1) | match |
| cmn_Hani | lang | 4.8 | 54.6 | ×11.42 | ×3.52 | 7% (1.2) | 0% (0.0) | 66% (11.5) | 27% (4.7) | 1% (0.2) | match |
| ell_Grek | lang | 5.0 | 43.9 | ×8.86 | ×2.87 | 5% (1.2) | 0% (0.0) | 71% (15.9) | 23% (5.1) | 1% (0.3) | match |
| eng_Latn | lang | 3.7 | 22.6 | ×6.12 | ×1.18 | 6% (2.7) | 0% (0.0) | 71% (30.2) | 24% (10.0) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 39.8 | ×9.63 | ×2.85 | 5% (1.2) | 0% (0.0) | 72% (17.4) | 22% (5.4) | 1% (0.2) | match |
| hin_Deva | lang | 6.3 | 53.5 | ×8.45 | ×2.49 | 6% (1.2) | 0% (0.0) | 72% (12.9) | 21% (3.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.3 | 65.9 | ×12.47 | ×4.33 | 8% (1.2) | 0% (0.0) | 67% (9.6) | 25% (3.6) | 0% (0.0) | match |
| kat_Geor | lang | 6.3 | 64.7 | ×10.31 | ×4.55 | 8% (1.2) | 0% (0.0) | 69% (10.1) | 20% (3.0) | 2% (0.4) | match |
| kor_Hang | lang | 3.7 | 34.0 | ×9.13 | ×2.24 | 4% (1.2) | 0% (0.0) | 68% (19.2) | 27% (7.6) | 1% (0.3) | match |
| rus_Cyrl | lang | 4.3 | 43.0 | ×9.99 | ×3.02 | 5% (1.2) | 0% (0.0) | 71% (15.1) | 26% (5.6) | 0% (0.0) | match |
| tam_Taml | lang | 6.3 | 72.4 | ×11.50 | ×4.96 | 9% (1.2) | 0% (0.0) | 69% (8.7) | 24% (3.1) | 0% (0.0) | match |
| tha_Thai | lang | 7.7 | 102.8 | ×13.39 | ×6.79 | 13% (1.2) | 0% (0.0) | 65% (5.8) | 22% (1.9) | 1% (0.1) | match |
| added_normalized_dense | modalities | 5.6 | 44.1 | ×7.83 | ×2.14 | 6% (1.3) | 0% (0.0) | 81% (17.4) | 12% (2.5) | 1% (0.3) | match |
| added_normalized_sparse | modalities | 5.3 | 36.7 | ×6.96 | ×1.48 | 7% (1.9) | 0% (0.0) | 78% (20.6) | 14% (3.6) | 1% (0.2) | match |
| added_special_dense | modalities | 4.2 | 16.0 | ×3.80 | ×0.96 | 8% (5.1) | 0% (0.1) | 85% (51.4) | 8% (4.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 21.6 | ×4.92 | ×0.98 | 8% (3.7) | 0% (0.0) | 80% (35.8) | 12% (5.3) | 0% (0.0) | match |
| agentic-traces | modalities | 3.2 | 17.9 | ×5.56 | ×1.21 | 4% (2.5) | 0% (0.0) | 77% (42.9) | 18% (10.3) | 0% (0.1) | match |
| agentic_swe | modalities | 3.3 | 15.5 | ×4.72 | ×1.38 | 3% (2.0) | 0% (0.0) | 83% (53.6) | 14% (9.0) | 0% (0.2) | match |
| code_mixed | modalities | 3.5 | 16.7 | ×4.70 | ×1.12 | 4% (2.3) | 0% (0.0) | 82% (48.6) | 14% (8.1) | 0% (0.1) | match |
| math_latex | modalities | 3.5 | 19.6 | ×5.68 | ×1.14 | 5% (2.6) | 0% (0.0) | 75% (36.9) | 19% (9.4) | 1% (0.4) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.79 | 3.49 | 14.39 | 15.09 | 27.6 | 14.6 | 7.3 | — | 1.9× / 1.8× | 1.0× / 1.0× | 0.5× / 0.5× | — |
| arb_Arab | 1.14 | 2.96 | 16.44 | 18.25 | 32.0 | 16.8 | 7.6 | — | 1.9× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| ben_Beng | 1.62 | 2.96 | 10.93 | 12.27 | 22.6 | 11.1 | 5.6 | — | 2.1× / 1.8× | 1.0× / 0.9× | 0.5× / 0.5× | — |
| cmn_Hani | 1.12 | 2.25 | 11.55 | 12.68 | 21.0 | 11.7 | 5.8 | — | 1.8× / 1.7× | 1.0× / 0.9× | 0.5× / 0.5× | — |
| ell_Grek | 0.59 | 2.98 | 15.86 | 18.26 | 27.9 | 15.9 | 6.8 | — | 1.8× / 1.5× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| eng_Latn | 0.09 | 1.45 | 30.15 | 31.51 | 40.9 | 31.4 | 13.9 | — | 1.4× / 1.3× | 1.0× / 1.0× | 0.5× / 0.4× | — |
| heb_Hebr | 1.15 | 3.01 | 17.43 | 19.29 | 30.8 | 18.4 | 8.0 | — | 1.8× / 1.6× | 1.1× / 1.0× | 0.5× / 0.4× | — |
| hin_Deva | 1.52 | 3.15 | 12.86 | 14.49 | 23.9 | 13.2 | 6.4 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| jpn_Jpan | 1.69 | 3.33 | 9.61 | 11.25 | 20.0 | 9.6 | 4.9 | — | 2.1× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| kat_Geor | 1.54 | 2.52 | 10.13 | 11.11 | 17.8 | 10.7 | 4.7 | — | 1.8× / 1.6× | 1.1× / 1.0× | 0.5× / 0.4× | — |
| kor_Hang | 1.23 | 2.71 | 19.24 | 20.73 | 31.4 | 20.0 | 9.1 | — | 1.6× / 1.5× | 1.0× / 1.0× | 0.5× / 0.4× | — |
| rus_Cyrl | 1.16 | 2.93 | 15.06 | 16.83 | 27.2 | 15.6 | 6.6 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| tam_Taml | 0.93 | 2.93 | 8.72 | 10.72 | 17.9 | 8.9 | 4.3 | — | 2.1× / 1.7× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| tha_Thai | 1.52 | 2.59 | 5.81 | 6.87 | 12.9 | 5.9 | 2.8 | — | 2.2× / 1.9× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| added_normalized_dense | 0.24 | 1.77 | 17.40 | 18.92 | 31.3 | 17.4 | 11.3 | — | 1.8× / 1.7× | 1.0× / 0.9× | 0.6× / 0.6× | — |
| added_normalized_sparse | 0.25 | 1.47 | 20.58 | 21.81 | 32.5 | 20.8 | 11.3 | — | 1.6× / 1.5× | 1.0× / 1.0× | 0.5× / 0.5× | — |
| added_special_dense | 0.24 | 1.47 | 51.42 | 52.65 | 81.6 | 66.8 | 23.8 | — | 1.6× / 1.6× | 1.3× / 1.3× | 0.5× / 0.5× | — |
| added_special_sparse | 0.24 | 1.47 | 35.79 | 37.02 | 52.0 | 41.0 | 16.3 | — | 1.5× / 1.4× | 1.1× / 1.1× | 0.5× / 0.4× | — |
| agentic-traces | 0.71 | 1.47 | 42.94 | 43.70 | 52.3 | 44.1 | 17.6 | — | 1.2× / 1.2× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| agentic_swe | 0.67 | 1.45 | 53.61 | 54.39 | 56.1 | 56.5 | 19.0 | — | 1.0× / 1.0× | 1.1× / 1.0× | 0.4× / 0.3× | — |
| code_mixed | 0.07 | 1.44 | 48.55 | 49.93 | 51.5 | 50.2 | 17.7 | — | 1.1× / 1.0× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| math_latex | 0.79 | 1.48 | 36.85 | 37.54 | 47.9 | 38.1 | 16.2 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30402484682-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
