### PR TITLE
perf: wire tekken-style (mistral 4) regex in atomsplit

### DIFF
--- a/tokenizers/atomsplit/Cargo.toml
+++ b/tokenizers/atomsplit/Cargo.toml
@@ -36,7 +36,7 @@ fancy-regex = "0.13"    # second regex engine in the throughput benches
 logos = "0.15"          # third: a compile-time DFA lexer-generator (pure Rust)
 pcre2 = "0.2"           # fourth: PCRE2 with its JIT (C, pregenerated bindings — no libclang)
 [[bench]]
-name = "regex"        # gpt2 · cl100k · o200k · deepseek, one run per regex family
+name = "regex"        # gpt2 · cl100k · o200k · tekken · deepseek, one run per regex family
 harness = false
 
 [[bench]]

--- a/tokenizers/atomsplit/benches/regex.rs
+++ b/tokenizers/atomsplit/benches/regex.rs
@@ -1,5 +1,5 @@
 //! Pre-tokenization on BIG real text (Wikipedia / big.txt), per language, for every pre-tokenizer at
-//! once — the GPT regex FSMs (gpt2 · cl100k · o200k · deepseek) and the class family (WhitespaceSplit ·
+//! once — the GPT regex FSMs (gpt2 · cl100k · o200k · tekken · deepseek) and the class family (WhitespaceSplit ·
 //! Whitespace · Digits · Punctuation · Bert). Per (engine, corpus): classify (SIMD vs scalar) + fsm in
 //! ns/byte, and the full pipeline (SIMD classify + scalar fsm) vs FOUR reference engines — onig (C),
 //! fancy-regex (pure Rust), logos (compile-time DFA lexer), pcre2 (C + JIT). GPT regexes come from
@@ -12,7 +12,9 @@
 //!
 //! Run: cargo bench --bench regex
 use atomsplit::classify::{classify, classify_scalar, mask};
-use atomsplit::fsm::{Span, class_runs_into, fsm_byte_level, fsm_cl100k, fsm_deepseek, fsm_o200k};
+use atomsplit::fsm::{
+    Span, class_runs_into, fsm_byte_level, fsm_cl100k, fsm_deepseek, fsm_o200k, fsm_tekken,
+};
 use atomsplit::regexes;
 use fancy_regex::Regex as Fancy;
 use logos::Logos;
@@ -70,6 +72,27 @@ enum LO200k {
     Space,
 }
 
+// tekken = LO200k with no contraction suffix and one token per digit.
+#[derive(Logos)]
+enum LTekken {
+    #[regex(
+        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+",
+        priority = 6
+    )]
+    LettersA,
+    #[regex(
+        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*",
+        priority = 5
+    )]
+    LettersB,
+    #[regex(r"\p{N}")]
+    Num,
+    #[regex(r" ?[^\s\p{L}\p{N}]+[\r\n/]*", priority = 2)]
+    Other,
+    #[regex(r"\s+")]
+    Space,
+}
+
 // class-family logos grammars. The whitespace-dropping ones use `skip` so logos never emits ws tokens.
 #[derive(Logos)]
 #[logos(skip r"\s+")]
@@ -112,6 +135,7 @@ fn logos_ns(ename: &str, s: &str, len: usize, iters: u32) -> Option<f64> {
         "gpt2" => |s| lex_count::<LGpt2>(s),
         "cl100k" => |s| lex_count::<LCl100k>(s),
         "o200k" => |s| lex_count::<LO200k>(s),
+        "tekken" => |s| lex_count::<LTekken>(s),
         "ws_split" => |s| lex_count::<LWsSplit>(s),
         "whitespace" => |s| lex_count::<LWhitespace>(s),
         "digits" => |s| lex_count::<LDigits>(s),
@@ -159,6 +183,7 @@ const ENGINES: &[(&str, Fsm, &[&str], bool, bool)] = &[
     ("gpt2", fsm_byte_level as Fsm, &[regexes::GPT2], true, true),
     ("cl100k", fsm_cl100k as Fsm, &[regexes::CL100K], true, true),
     ("o200k", fsm_o200k as Fsm, &[regexes::O200K], true, true),
+    ("tekken", fsm_tekken as Fsm, &[regexes::TEKKEN], true, true),
     (
         "deepseek",
         fsm_deepseek as Fsm,
@@ -396,7 +421,7 @@ fn main() {
     }
     println!(
         "\n(ns/byte, lower better. pipeline = SIMD classify + scalar fsm; vs onig / fancy / logos / \
-         pcre2(JIT). GPT FSMs (gpt2/cl100k/o200k/deepseek): the regex IS the spec, ✓ = byte-exact, \
+         pcre2(JIT). GPT FSMs (gpt2/cl100k/o200k/tekken/deepseek): the regex IS the spec, ✓ = byte-exact, \
          ✗ = regression. Class family (ws_split/whitespace/digits/punct/bert): the mask can't be written \
          as a regex class, so the reference is approximate — ✓ where it happens to match, ≈ where it \
          diverges (speed still comparable). logos approximates the grammar (deepseek/punct/bert: n/a).)"

--- a/tokenizers/atomsplit/src/fsm.rs
+++ b/tokenizers/atomsplit/src/fsm.rs
@@ -5,8 +5,9 @@
 //! The class family (WhitespaceSplit / Punctuation / Digits / Whitespace / Bert) goes through
 //! [`class_runs_into`]: on aarch64/wasm the SIMD movemask boundary-extractor + homogeneous-chunk
 //! early-out (in `simd_fsm`), elsewhere the scalar run-end core ([`emit_class_spans`]). The
-//! regex-shaped ones ([`fsm_cl100k`] / [`fsm_o200k`] / [`fsm_deepseek`] / [`fsm_byte_level`]) are scalar
-//! jump-tables (only the class family's [`class_runs_into`] has a SIMD path).
+//! regex-shaped ones ([`fsm_cl100k`] / [`fsm_o200k`] / [`fsm_tekken`] / [`fsm_deepseek`] /
+//! [`fsm_byte_level`]) are scalar jump-tables (only the class family's [`class_runs_into`] has a SIMD
+//! path).
 
 pub(crate) use crate::classify::{Atom, char_len, classify, in_mask, mask};
 // Atom-tag aliases, shared with the per-tokenizer FSM submodules (`fsm/*.rs`) via `use super::*`.
@@ -240,7 +241,7 @@ mod o200k;
 pub use byte_level::fsm_byte_level;
 pub use cl100k::{fsm_cl100k, fsm_cl100k_cap};
 pub use deepseek::fsm_deepseek;
-pub use o200k::fsm_o200k;
+pub use o200k::{fsm_o200k, fsm_tekken};
 
 // ── Composition recipes ────────────────────────────────────────────────────────────────────────
 // Each pre-tokenizer = (classify → fsm shape + params). `tags` and `out` are caller-owned

--- a/tokenizers/atomsplit/src/fsm/o200k.rs
+++ b/tokenizers/atomsplit/src/fsm/o200k.rs
@@ -52,9 +52,10 @@ fn o200k_letter_match(tags: &[u8], p: usize, re: usize) -> usize {
 
 /// Emit the o200k case-split of the letter run `[ls, re)` into `out[*w..]`: the first sub-token starts at
 /// `pfx` (the optional `[^\r\n\p{L}\p{N}]?` prefix; `pfx == ls` when none), the last absorbs a trailing
-/// contraction. Returns the new cursor (past the contraction). `ls < re` (caller-guaranteed).
+/// contraction (`CONTRACTION` — off for tekken). Returns the new cursor (past the contraction).
+/// `ls < re` (caller-guaranteed).
 #[inline(always)]
-fn emit_o200k_letters(
+fn emit_o200k_letters<const CONTRACTION: bool>(
     text: &[u8],
     tags: &[u8],
     pfx: usize,
@@ -67,7 +68,11 @@ fn emit_o200k_letters(
     while p < re {
         let e = o200k_letter_match(tags, p, re);
         let start = if first { pfx } else { p };
-        let tok_end = if e == re { e + contraction(text, e) } else { e };
+        let tok_end = if CONTRACTION && e == re {
+            e + contraction(text, e)
+        } else {
+            e
+        };
         unsafe {
             *out.get_unchecked_mut(*w) = Span {
                 start: start as u32,
@@ -89,6 +94,21 @@ fn emit_o200k_letters(
 /// Unlike deepseek there are no gaps: rule 4's `[^\s\p{L}\p{N}]+` is a catch-all. Scalar; ┌ OWNER: shared ┐
 #[must_use]
 pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
+    o200k::<true, 3>(text, tags, out)
+}
+
+/// Mistral tekken ([`crate::regexes::TEKKEN`]) — the o200k FSM with the contraction suffix off and one
+/// token per digit. Every other rule is shared, so both are the same code monomorphized twice.
+#[must_use]
+pub fn fsm_tekken(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
+    o200k::<false, 1>(text, tags, out)
+}
+
+fn o200k<const CONTRACTION: bool, const DIGIT_CAP: usize>(
+    text: &[u8],
+    tags: &[u8],
+    out: &mut [Span],
+) -> usize {
     debug_assert!(out.len() >= text.len() && tags.len() >= text.len());
     let end = text.len();
     // Tie `tags.len() == end` so the optimizer drops the per-byte bounds check on every interior
@@ -147,6 +167,10 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
     };
     // rules 5-7 (`\s*[\r\n]+ | \s+(?!\S) | \s+`) → the shared `ws_tail` (identical to cl100k).
     let ws = |i: usize| -> usize { ws_tail(text, tags, i, end) };
+    // The letter rules: case-split the run starting at `ls`, first sub-token starting at the prefix `pfx`.
+    let letters = |pfx: usize, ls: usize, out: &mut [Span], w: &mut usize| -> usize {
+        emit_o200k_letters::<CONTRACTION>(text, tags, pfx, ls, letter_end(ls), out, w)
+    };
 
     let mut i = 0;
     let mut w = 0usize;
@@ -154,10 +178,10 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
         let start = i;
         let b = text[i];
         match tags[i] & 0x0F {
-            // rule 3: `\p{N}{1,3}` (no prefix)
+            // rule 3: `\p{N}{1,DIGIT_CAP}`, no prefix (3 = o200k, 1 = tekken)
             NW | NO => {
                 let (mut p, mut cnt) = (i, 0);
-                while p < end && cnt < 3 && in_mask(tags[p], mask::NUMBER) {
+                while p < end && cnt < DIGIT_CAP && in_mask(tags[p], mask::NUMBER) {
                     p += char_len(text[p]);
                     cnt += 1;
                 }
@@ -167,12 +191,12 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             // take the `[^\r\n\p{L}\p{N}]?` prefix / rule-4 path instead.
             LET | MRK => {
                 if tags[i] != ASM && tags[i] != ZWJ {
-                    i = emit_o200k_letters(text, tags, i, i, letter_end(i), out, &mut w);
+                    i = letters(i, i, out, &mut w);
                     continue;
                 }
                 let a = i + char_len(b);
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = letters(i, a, out, &mut w);
                     continue;
                 }
                 i = other(i); // ∈ NOT_WS_L_N ⇒ > i
@@ -181,7 +205,7 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             SPC => {
                 let a = i + 1; // Space is ASCII (0x20)
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = letters(i, a, out, &mut w);
                     continue;
                 }
                 let p = other(a);
@@ -191,7 +215,7 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             WSO => {
                 let a = i + char_len(b);
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = letters(i, a, out, &mut w);
                     continue;
                 }
                 i = ws(i);
@@ -201,7 +225,7 @@ pub fn fsm_o200k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             CON | PUN | APO | SYM | NMO | CTL => {
                 let a = i + char_len(b);
                 if is_lm(a) {
-                    i = emit_o200k_letters(text, tags, i, a, letter_end(a), out, &mut w);
+                    i = letters(i, a, out, &mut w);
                     continue;
                 }
                 i = other(i); // ∈ NOT_WS_L_N ⇒ > i

--- a/tokenizers/atomsplit/src/lib.rs
+++ b/tokenizers/atomsplit/src/lib.rs
@@ -3,8 +3,9 @@
 //! One SIMD pass ([`classify`]) maps every codepoint to a tiny "atom" alphabet; a family of no-push
 //! FSMs ([`fsm`]) turn that atom stream into token spans (byte ranges) — the pre-tokenizer stage that
 //! runs before a BPE/WordPiece model. Pre-tokenizers implemented: `WhitespaceSplit`, `Punctuation`,
-//! `Digits`, `Whitespace`, `Bert`, `Cl100k`, `DeepSeek`, `ByteLevel`, `CharDelimiterSplit` (o200k is
-//! exposed as the [`fsm::fsm_o200k`] function rather than a recipe struct).
+//! `Digits`, `Whitespace`, `Bert`, `Cl100k`, `DeepSeek`, `ByteLevel`, `CharDelimiterSplit` (o200k and
+//! Mistral's tekken are exposed as the [`fsm::fsm_o200k`] / [`fsm::fsm_tekken`] functions rather than
+//! recipe structs).
 //!
 //! Design: every fsm is *no-push* — it writes spans into a caller-preallocated `&mut [fsm::Span]`
 //! (length ≥ `text.len()`) and returns the token count; there is no `Vec`/allocation on the hot path.

--- a/tokenizers/atomsplit/src/regexes.rs
+++ b/tokenizers/atomsplit/src/regexes.rs
@@ -18,6 +18,11 @@ pub const CL100K: &str = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+
 /// [`crate::fsm::fsm_o200k`].
 pub const O200K: &str = r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+";
 
+/// Mistral tekken (mistral-small-4 / mistral-4). o200k's grammar with two changes: letter tokens take
+/// no contraction suffix, and the digit rule is a bare `\p{N}` — one token per digit. Reproduced by
+/// [`crate::fsm::fsm_tekken`].
+pub const TEKKEN: &str = r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+
 /// deepseek-v3 `Sequence`: `NUM` → `CJK` → `BIG`, each `Isolated`. Reproduced by
 /// [`crate::fsm::fsm_deepseek`] as one pass.
 pub const DEEPSEEK_NUM: &str = r"\p{N}{1,3}";

--- a/tokenizers/atomsplit/tests/fsm.rs
+++ b/tokenizers/atomsplit/tests/fsm.rs
@@ -2,7 +2,7 @@
 use atomsplit::classify::{classify, mask};
 use atomsplit::fsm::{
     CharDelimiterSplit, Span, class_runs_into, emit_class_spans, fsm_byte_level, fsm_cl100k,
-    fsm_deepseek,
+    fsm_deepseek, fsm_o200k, fsm_tekken,
 };
 
 /// Run a no-push fsm into a fresh buffer and return the emitted spans.
@@ -24,6 +24,18 @@ fn cl100k_rules() {
     assert_eq!(cl("a1234"), vec![(0, 1), (1, 4), (4, 5)]); // "a" | "123" | "4" ({1,3} cap)
     assert_eq!(cl("  hi"), vec![(0, 1), (1, 4)]); // " " | " hi"
     assert_eq!(cl("a, b"), vec![(0, 1), (1, 2), (2, 4)]); // "a" | "," | " b"
+}
+
+/// Mistral's tekken split is o200k's, minus the contraction suffix, with one token per digit.
+#[test]
+fn tekken_rules() {
+    let tk = |s| spans(fsm_tekken, s);
+    assert_eq!(tk("don't"), vec![(0, 3), (3, 5)]); // "don" | "'t" — prefix+letters, not a contraction
+    assert_eq!(spans(fsm_o200k, "don't"), vec![(0, 5)]); // o200k glues the contraction on
+    assert_eq!(tk("a1234"), vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]); // `\p{N}`, one digit each
+    assert_eq!(tk("XMLHttpRequest"), vec![(0, 7), (7, 14)]); // case split: "XMLHttp" | "Request"
+    assert_eq!(tk("a/\r\nb"), vec![(0, 1), (1, 4), (4, 5)]); // "/" run + its `[\r\n/]*` tail
+    assert_eq!(tk("hi   ok"), vec![(0, 2), (2, 4), (4, 7)]); // \s+(?!\S) leaves one space
 }
 
 #[test]

--- a/tokenizers/atomsplit/tests/parity.rs
+++ b/tokenizers/atomsplit/tests/parity.rs
@@ -1,25 +1,37 @@
 //! Reference-parity gates for the regex-shaped pre-tokenizers. Each of `fsm_cl100k` / `fsm_o200k` /
-//! `fsm_byte_level` / `fsm_deepseek` must be BYTE-EXACT with the real reference — the oniguruma regex, composed exactly
-//! as HF applies it (deepseek is a `Sequence` of three Isolated splits) — on a representative
-//! multilingual corpus (ASCII, contractions, digits, punctuation runs, whitespace variants, Latin
-//! accents/marks, Cyrillic/Greek/Arabic/Devanagari, Han/Kana/Hangul, ZWJ, astral emoji).
+//! `fsm_tekken` / `fsm_byte_level` / `fsm_deepseek` must be BYTE-EXACT with the real reference — the
+//! oniguruma regex, composed exactly as HF applies it (deepseek is a `Sequence` of three Isolated
+//! splits) — on two corpora: a multilingual one (ASCII, contractions, digits, punctuation runs,
+//! whitespace variants, Latin accents/marks, Cyrillic/Greek/Arabic/Devanagari, Han/Kana/Hangul, ZWJ,
+//! astral emoji) and an edge-case one (see [`EDGE`]).
 //!
-//! This is the byte-exactness gate the hand cases in `fsm.rs` don't provide; the same corpus + gate
+//! This is the byte-exactness gate the hand cases in `fsm.rs` don't provide; the same corpora + gate
 //! should run under x86 (Intel SDE) in CI to validate the SIMD paths.
 //!
 //! Gated off wasm32: the oniguruma reference is a C library that has no wasi libc to build against.
 #![cfg(not(target_arch = "wasm32"))]
 use atomsplit::classify::classify;
-use atomsplit::fsm::{Span, fsm_byte_level, fsm_cl100k, fsm_deepseek, fsm_o200k};
+use atomsplit::fsm::{Span, fsm_byte_level, fsm_cl100k, fsm_deepseek, fsm_o200k, fsm_tekken};
 use onig::Regex;
 // The oracle regexes are the canonical specs the FSMs implement — single source of truth in atomsplit.
 use atomsplit::regexes::{
     CL100K, DEEPSEEK_BIG as DS_BIG, DEEPSEEK_CJK as DS_CJK, DEEPSEEK_NUM as DS_NUM, GPT2, O200K,
+    TEKKEN,
 };
 
 const CORPUS: &str = "The quick brown fox. Don't 12345 numbers, \u{00BD}\u{00B2}\u{00BC} \u{2168}! \
      café × naïve — Привет, наука! Ελλάδα 中文分词。ひらがな カタカナ 한글 مرحبا العربية \
      नरेंद्र मोदी x_y a1b2c3 e-mail@host.com 😀👍 hello  world\ttabs\nnewlines   end ";
+
+/// Second corpus, aimed at the axes where the o200k-shaped FSMs differ from each other: apostrophes
+/// (contraction suffix vs plain prefix+letters), digit-run length (`{1,3}` vs one-per-token), and the
+/// `[\r\n/]*` tail after a symbol run.
+const EDGE: &str = "IT'S O'Brien can't 'quoted' l'été rock'n'roll\r\n\
+     0 42 999 1000 1234567 v1.2.3 3.14159 1,000,000 \
+     https://host/a/b?c=1&d=2 path/to//file /\r\n/ ///x \
+     CamelCase XMLHttpRequest ĲSSELMEER ǅAMBO ŀl a\u{0301}b \
+     日本語1234テスト ½3¼ \u{2168}42\u{2169} #tag @user $9.99 100% \
+     end\n\n\nlines\r\n\r\n  \t  trailing   ";
 
 fn spans(f: impl Fn(&[u8], &[u8], &mut [Span]) -> usize, s: &str) -> Vec<Span> {
     let mut tags = vec![0u8; s.len()];
@@ -73,25 +85,37 @@ fn deepseek_ref(text: &str) -> Vec<Span> {
         .collect()
 }
 
+/// Both corpora, one regex: the FSM must reproduce the oracle span-for-span.
+fn check(fsm: impl Fn(&[u8], &[u8], &mut [Span]) -> usize + Copy, pattern: &str) {
+    let re = Regex::new(pattern).unwrap();
+    for text in [CORPUS, EDGE] {
+        assert_eq!(spans(fsm, text), onig_spans(&re, text), "{text:?}");
+    }
+}
+
 #[test]
 fn cl100k_parity() {
-    let re = Regex::new(CL100K).unwrap();
-    assert_eq!(spans(fsm_cl100k, CORPUS), onig_spans(&re, CORPUS));
+    check(fsm_cl100k, CL100K);
 }
 
 #[test]
 fn o200k_parity() {
-    let re = Regex::new(O200K).unwrap();
-    assert_eq!(spans(fsm_o200k, CORPUS), onig_spans(&re, CORPUS));
+    check(fsm_o200k, O200K);
+}
+
+#[test]
+fn tekken_parity() {
+    check(fsm_tekken, TEKKEN);
 }
 
 #[test]
 fn byte_level_parity() {
-    let re = Regex::new(GPT2).unwrap();
-    assert_eq!(spans(fsm_byte_level, CORPUS), onig_spans(&re, CORPUS));
+    check(fsm_byte_level, GPT2);
 }
 
 #[test]
 fn deepseek_parity() {
-    assert_eq!(spans(fsm_deepseek, CORPUS), deepseek_ref(CORPUS));
+    for text in [CORPUS, EDGE] {
+        assert_eq!(spans(fsm_deepseek, text), deepseek_ref(text), "{text:?}");
+    }
 }

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -172,6 +172,7 @@ impl pipeline::PreTokenizer for Split {
                     }
                     GptFsm::Gpt2 => atomsplit::fsm::fsm_byte_level(bytes, tags, spans),
                     GptFsm::O200k => atomsplit::fsm::fsm_o200k(bytes, tags, spans),
+                    GptFsm::Tekken => atomsplit::fsm::fsm_tekken(bytes, tags, spans),
                 },
                 out,
             );
@@ -462,6 +463,34 @@ mod tests {
 
         assert_eq!(
             pipeline_split(SplitPattern::Regex(o200k.into()), Isolated, false, corpus),
+            legacy,
+        );
+    }
+
+    #[test]
+    fn pipeline_tekken_uses_fsm_and_matches_legacy() {
+        // Mistral's tekken regex (mistral-small-4) → recognized → routes to fsm_tekken. Same corpus
+        // shape as o200k, whose grammar it shares: the differences it must get right are apostrophes
+        // (no contraction suffix, so `'s` starts a new token) and one token per digit.
+        let tekken = atomsplit::regexes::TEKKEN;
+        let corpus = "McDonald's iPhone SQLite HELLOWorld camelCase don't I'll We've 3.14159 café Straße 世界 안녕\n\n  path/to/file Mixed CASE end.";
+        let pretok = Split::new(SplitPattern::Regex(tekken.into()), Isolated, false).unwrap();
+        assert_eq!(
+            pretok.fsm,
+            Some(crate::utils::GptFsm::Tekken),
+            "tekken / mistral pattern should route to the native FSM"
+        );
+
+        let mut pre = PreTokenizedString::from(corpus);
+        pretok.pre_tokenize(&mut pre).unwrap();
+        let legacy: Vec<(&str, (u32, u32))> = pre
+            .get_splits(OffsetReferential::Original, OffsetType::Byte)
+            .into_iter()
+            .map(|(s, o, _)| (s, (o.0 as u32, o.1 as u32)))
+            .collect();
+
+        assert_eq!(
+            pipeline_split(SplitPattern::Regex(tekken.into()), Isolated, false, corpus),
             legacy,
         );
     }

--- a/tokenizers/tk-encode/src/utils/unrolled_regex.rs
+++ b/tokenizers/tk-encode/src/utils/unrolled_regex.rs
@@ -5,7 +5,7 @@
 // Canonical GPT pre-tokenization regexes (the look-ahead originals), used as recognition keys — the
 // single source of truth lives in `atomsplit::regexes`. `gpt_fsm` maps each to the `atomsplit` FSM that
 // reproduces its `Isolated` split byte-for-byte.
-use atomsplit::regexes::{GPT2, O200K};
+use atomsplit::regexes::{GPT2, O200K, TEKKEN};
 // cl100k is recognized structurally (see `cl100k_digit_cap`), so the exact pattern is only a test key.
 #[cfg(test)]
 use atomsplit::regexes::CL100K;
@@ -20,6 +20,9 @@ pub enum GptFsm {
     Cl100k { digit_cap: usize },
     /// o200k / GPT-4o regex → `atomsplit::fsm::fsm_o200k`.
     O200k,
+    /// Mistral tekken regex → `atomsplit::fsm::fsm_tekken` (o200k's grammar with no contraction
+    /// suffix and one token per digit).
+    Tekken,
 }
 
 /// The cl100k-family template is fixed except rule 3's digit rule. If `pattern` is that template, return
@@ -39,14 +42,16 @@ fn cl100k_digit_cap(pattern: &str) -> Option<usize> {
 }
 
 /// If `pattern` is a recognized GPT pre-tokenization regex, name the native FSM that reproduces its
-/// `Isolated` split byte-for-byte. GPT-2 and o200k are matched exactly; the cl100k family is matched
-/// structurally ([`cl100k_digit_cap`]) so digit-cap variants (Qwen2 …) unroll too. An unrecognized
-/// pattern → `None` (the SysRegex / fancy-regex path handles it).
+/// `Isolated` split byte-for-byte. GPT-2, o200k and tekken are matched exactly; the cl100k family is
+/// matched structurally ([`cl100k_digit_cap`]) so digit-cap variants (Qwen2 …) unroll too. An
+/// unrecognized pattern → `None` (the SysRegex / fancy-regex path handles it).
 pub fn gpt_fsm(pattern: &str) -> Option<GptFsm> {
     if pattern == GPT2 {
         Some(GptFsm::Gpt2)
     } else if pattern == O200K {
         Some(GptFsm::O200k)
+    } else if pattern == TEKKEN {
+        Some(GptFsm::Tekken)
     } else {
         cl100k_digit_cap(pattern).map(|digit_cap| GptFsm::Cl100k { digit_cap })
     }
@@ -77,6 +82,7 @@ impl crate::tokenizer::pattern::Pattern for GptFsmPattern {
                 atomsplit::fsm::fsm_cl100k_cap(bytes, &tags, &mut spans, digit_cap)
             }
             GptFsm::O200k => atomsplit::fsm::fsm_o200k(bytes, &tags, &mut spans),
+            GptFsm::Tekken => atomsplit::fsm::fsm_tekken(bytes, &tags, &mut spans),
         };
         Ok(spans[..n]
             .iter()
@@ -115,6 +121,7 @@ mod tests {
         // Exact matches for gpt2 / o200k, structural (any digit cap) for the cl100k family.
         assert_eq!(gpt_fsm(GPT2), Some(GptFsm::Gpt2));
         assert_eq!(gpt_fsm(O200K), Some(GptFsm::O200k));
+        assert_eq!(gpt_fsm(TEKKEN), Some(GptFsm::Tekken));
         assert_eq!(gpt_fsm(CL100K), Some(GptFsm::Cl100k { digit_cap: 3 }));
         // Qwen2: cl100k with rule 3 = `\p{N}` → cap 1.
         let qwen2 = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+";

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -107,9 +107,10 @@ fn check_model(tok_file: &str) {
     );
 }
 
-// Same model set as the decode oracle (one per decoder archetype); whichever files
-// a given checkout has get run (bert-wiki + llama-3 ship with `make test`; the rest
-// with `make bench-models`). Unsupported models skip, not fail.
+// The decode oracle's model set (one per decoder archetype) plus mistral-small-4, whose
+// tekken pre-tokenizer is its own encode archetype; whichever files a given checkout has
+// get run (bert-wiki + llama-3 ship with `make test`; the rest with `make bench-models`).
+// Unsupported models skip, not fail.
 #[test]
 fn bert_wiki() {
     check_model("bert-wiki.json");
@@ -143,4 +144,9 @@ fn t5_base() {
 #[test]
 fn albert() {
     check_model("albert-base-v1-tokenizer.json");
+}
+
+#[test]
+fn mistral_small_4() {
+    check_model("mistral-small-4.json");
 }


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`0c4f0edb6 · 2026-07-28 22:27 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-overview.png" width="860">

**vs base branch** (`709ef7af5`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.92 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 11+0 (peak 11) · Pipeline 8+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.7 | 27.5 | ×3.55 | ×1.00 | 3% (1.2) | 76% (27.5) | 13% (4.8) | 8% (2.9) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 24.9 | ×5.90 | ×1.00 | 3% (1.2) | 69% (27.5) | 8% (3.3) | 20% (7.9) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 34.7 | ×5.77 | ×0.99 | 4% (1.2) | 67% (19.2) | 10% (2.9) | 19% (5.3) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 18.7 | ×4.82 | ×1.00 | 2% (1.2) | 71% (37.6) | 11% (5.6) | 16% (8.6) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 23.8 | ×6.25 | ×1.00 | 3% (1.2) | 68% (28.7) | 8% (3.5) | 21% (8.6) | 0% (0.0) | match |
| eng_Latn | lang | 4.5 | 18.2 | ×4.05 | ×0.99 | 5% (2.7) | 71% (38.7) | 8% (4.5) | 16% (8.7) | 0% (0.1) | match |
| heb_Hebr | lang | 4.2 | 19.9 | ×4.73 | ×1.00 | 2% (1.2) | 75% (37.4) | 8% (3.8) | 15% (7.5) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 27.2 | ×4.20 | ×0.99 | 3% (1.2) | 74% (27.1) | 9% (3.2) | 14% (4.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.2 | 27.0 | ×6.47 | ×0.99 | 3% (1.2) | 64% (23.2) | 13% (4.7) | 20% (7.3) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 28.1 | ×4.57 | ×1.01 | 3% (1.2) | 74% (26.5) | 9% (3.1) | 13% (4.8) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 17.7 | ×7.30 | ×1.00 | 2% (1.2) | 60% (35.0) | 13% (7.5) | 22% (12.6) | 4% (2.1) | match |
| rus_Cyrl | lang | 3.7 | 23.6 | ×6.42 | ×0.99 | 3% (1.2) | 66% (27.4) | 8% (3.2) | 24% (10.0) | 0% (0.0) | match |
| tam_Taml | lang | 7.0 | 38.2 | ×5.45 | ×1.00 | 4% (1.2) | 72% (18.6) | 10% (2.5) | 14% (3.6) | 0% (0.0) | match |
| tha_Thai | lang | 8.3 | 33.5 | ×4.02 | ×1.03 | 4% (1.2) | 83% (25.0) | 7% (2.2) | 6% (1.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.7 | 19.7 | ×2.94 | ×1.00 | 3% (1.5) | 81% (40.6) | 14% (7.0) | 2% (1.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 18.4 | ×3.50 | ×1.00 | 4% (2.2) | 73% (39.7) | 13% (7.1) | 8% (4.5) | 1% (0.6) | match |
| added_special_dense | modalities | 5.3 | 37.9 | ×7.12 | ×0.97 | 21% (5.1) | 37% (9.1) | 35% (8.8) | 8% (2.0) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 21.3 | ×5.33 | ×1.00 | 8% (3.7) | 61% (28.0) | 19% (8.6) | 13% (5.9) | 0% (0.0) | match |
| agentic-traces | modalities | 3.8 | 18.1 | ×4.70 | ×0.99 | 5% (2.7) | 70% (38.6) | 9% (5.0) | 16% (9.0) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 19.4 | ×4.73 | ×1.00 | 4% (1.9) | 75% (38.7) | 7% (3.7) | 13% (6.9) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 18.8 | ×4.81 | ×0.99 | 4% (2.2) | 73% (38.7) | 8% (4.2) | 14% (7.5) | 0% (0.2) | match |
| math_latex | modalities | 4.0 | 18.1 | ×4.54 | ×0.99 | 5% (2.8) | 70% (38.7) | 9% (4.8) | 16% (8.8) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×4.04 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 67) · Pipeline 82+0 (peak 81)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 34.4 | ×7.86 | ×1.00 | 2% (0.7) | 0% (0.0) | 17% (4.7) | 81% (22.6) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 16.4 | ×3.74 | ×0.99 | 1% (0.6) | 0% (0.0) | 6% (3.3) | 94% (55.2) | 0% (0.0) | match |
| ben_Beng | lang | 6.4 | 17.6 | ×2.77 | ×0.99 | 1% (0.6) | 0% (0.0) | 6% (3.1) | 93% (51.2) | 0% (0.1) | match |
| cmn_Hani | lang | 3.8 | 16.5 | ×4.36 | ×1.00 | 1% (0.8) | 0% (0.0) | 6% (3.2) | 92% (53.2) | 1% (0.5) | match |
| ell_Grek | lang | 4.8 | 17.9 | ×3.76 | ×1.00 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 92% (50.4) | 0% (0.1) | match |
| eng_Latn | lang | 3.2 | 12.8 | ×3.98 | ×0.98 | 3% (2.1) | 0% (0.0) | 7% (5.1) | 91% (68.8) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 12.9 | ×3.16 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (3.5) | 94% (71.4) | 0% (0.1) | match |
| hin_Deva | lang | 5.9 | 21.1 | ×3.56 | ×0.99 | 1% (0.6) | 0% (0.0) | 7% (3.3) | 92% (42.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 17.8 | ×4.14 | ×0.99 | 1% (0.7) | 0% (0.0) | 6% (3.0) | 93% (50.3) | 0% (0.0) | match |
| kat_Geor | lang | 6.1 | 17.8 | ×2.93 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (2.9) | 94% (51.0) | 0% (0.0) | match |
| kor_Hang | lang | 3.7 | 19.8 | ×5.28 | ×1.00 | 1% (0.6) | 0% (0.0) | 7% (3.7) | 91% (44.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.5 | 14.4 | ×3.23 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 94% (63.7) | 0% (0.0) | match |
| tam_Taml | lang | 6.3 | 17.2 | ×2.72 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (2.7) | 94% (53.3) | 0% (0.2) | match |
| tha_Thai | lang | 7.0 | 14.3 | ×2.04 | ×1.00 | 1% (0.6) | 0% (0.0) | 3% (2.1) | 96% (65.0) | 0% (0.1) | match |
| added_normalized_dense | modalities | 6.2 | 23.1 | ×3.74 | ×0.98 | 2% (0.8) | 0% (0.0) | 7% (2.8) | 91% (37.9) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.5 | 19.2 | ×3.49 | ×0.98 | 3% (1.3) | 0% (0.0) | 8% (3.9) | 90% (44.3) | 0% (0.0) | match |
| added_special_dense | modalities | 3.7 | 36.2 | ×9.83 | ×0.97 | 25% (6.6) | 1% (0.3) | 22% (5.7) | 50% (13.0) | 1% (0.2) | match |
| added_special_sparse | modalities | 4.1 | 20.5 | ×5.04 | ×0.98 | 8% (3.9) | 0% (0.2) | 14% (6.4) | 77% (36.0) | 1% (0.4) | match |
| agentic-traces | modalities | 3.0 | 14.2 | ×4.76 | ×1.00 | 3% (1.9) | 0% (0.0) | 8% (5.4) | 89% (61.2) | 0% (0.0) | match |
| agentic_swe | modalities | 3.1 | 15.0 | ×4.90 | ×1.01 | 2% (1.4) | 0% (0.0) | 6% (3.8) | 92% (60.9) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 15.2 | ×4.30 | ×0.98 | 3% (1.6) | 0% (0.0) | 7% (4.6) | 90% (56.6) | 0% (0.0) | match |
| math_latex | modalities | 2.9 | 13.9 | ×4.83 | ×0.99 | 3% (2.0) | 0% (0.0) | 7% (5.3) | 90% (64.2) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.09 | 4.67 | 5.13 | 42.6 | 20.5 | 9.2 | — | 9.1× / 8.3× | 4.4× / 4.0× | 2.0× / 1.8× | — |
| arb_Arab | 1.00 | 2.75 | 3.35 | 5.09 | 49.5 | 23.0 | 10.1 | — | 14.8× / 9.7× | 6.9× / 4.5× | 3.0× / 2.0× | — |
| ben_Beng | 1.46 | 2.58 | 3.09 | 4.21 | 36.1 | 16.2 | 7.5 | — | 11.7× / 8.6× | 5.3× / 3.9× | 2.4× / 1.8× | — |
| cmn_Hani | 1.12 | 1.97 | 3.20 | 4.05 | 61.4 | 34.3 | 14.3 | — | 19.2× / 15.2× | 10.7× / 8.5× | 4.5× / 3.5× | — |
| ell_Grek | 0.58 | 2.76 | 3.36 | 5.53 | 47.5 | 21.2 | 9.6 | — | 14.2× / 8.6× | 6.3× / 3.8× | 2.9× / 1.7× | — |
| eng_Latn | 0.10 | 0.90 | 5.06 | 5.86 | 66.0 | 39.6 | 16.3 | — | 13.0× / 11.3× | 7.8× / 6.8× | 3.2× / 2.8× | — |
| heb_Hebr | 1.00 | 2.85 | 3.51 | 5.36 | 51.5 | 24.3 | 10.6 | — | 14.7× / 9.6× | 6.9× / 4.5× | 3.0× / 2.0× | — |
| hin_Deva | 1.36 | 2.73 | 3.27 | 4.63 | 38.3 | 18.6 | 8.5 | — | 11.7× / 8.3× | 5.7× / 4.0× | 2.6× / 1.8× | — |
| jpn_Jpan | 1.56 | 3.11 | 3.00 | 4.54 | 53.7 | 27.7 | 11.8 | — | 17.9× / 11.8× | 9.2× / 6.1× | 3.9× / 2.6× | — |
| kat_Geor | 1.38 | 2.22 | 2.91 | 3.75 | 32.5 | 15.2 | 7.0 | — | 11.2× / 8.7× | 5.2× / 4.0× | 2.4× / 1.9× | — |
| kor_Hang | 1.09 | 2.38 | 3.66 | 4.96 | 50.7 | 27.5 | 11.8 | — | 13.9× / 10.2× | 7.5× / 5.5× | 3.2× / 2.4× | — |
| rus_Cyrl | 1.02 | 2.72 | 3.27 | 4.98 | 47.5 | 20.8 | 9.4 | — | 14.5× / 9.6× | 6.4× / 4.2× | 2.9× / 1.9× | — |
| tam_Taml | 0.92 | 2.61 | 2.67 | 4.36 | 32.1 | 13.7 | 6.5 | — | 12.0× / 7.4× | 5.1× / 3.1× | 2.4× / 1.5× | — |
| tha_Thai | 1.36 | 2.23 | 2.14 | 3.01 | 26.7 | 10.1 | 5.2 | — | 12.5× / 8.9× | 4.7× / 3.4× | 2.4× / 1.7× | — |
| added_normalized_dense | 0.06 | 0.88 | 2.85 | 3.68 | 42.5 | 20.2 | 9.1 | — | 14.9× / 11.6× | 7.1× / 5.5× | 3.2× / 2.5× | — |
| added_normalized_sparse | 0.06 | 0.88 | 3.87 | 4.70 | 49.2 | 25.8 | 11.2 | — | 12.7× / 10.5× | 6.7× / 5.5× | 2.9× / 2.4× | — |
| added_special_dense | 0.06 | 0.88 | 5.74 | 6.57 | 176.9 | 99.8 | 38.3 | — | 30.8× / 26.9× | 17.4× / 15.2× | 6.7× / 5.8× | — |
| added_special_sparse | 0.07 | 0.88 | 6.39 | 7.20 | 104.0 | 58.5 | 23.6 | — | 16.3× / 14.5× | 9.2× / 8.1× | 3.7× / 3.3× | — |
| agentic-traces | 0.57 | 0.92 | 5.41 | 5.75 | 81.4 | 53.3 | 20.1 | — | 15.0× / 14.1× | 9.9× / 9.3× | 3.7× / 3.5× | — |
| agentic_swe | 0.51 | 0.87 | 3.83 | 4.20 | 96.7 | 66.7 | 23.7 | — | 25.3× / 23.0× | 17.4× / 15.9× | 6.2× / 5.6× | — |
| code_mixed | 0.07 | 0.86 | 4.60 | 5.39 | 74.3 | 55.1 | 18.4 | — | 16.2× / 13.8× | 12.0× / 10.2× | 4.0× / 3.4× | — |
| math_latex | 0.57 | 0.92 | 5.29 | 5.64 | 79.4 | 48.9 | 19.3 | — | 15.0× / 14.1× | 9.2× / 8.7× | 3.6× / 3.4× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×1.87 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 370) · Pipeline 275+0 (peak 371)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 10.4 | 26.9 | ×2.59 | ×0.98 | 2% (0.6) | 6% (2.2) | 0% (0.1) | 91% (31.4) | 1% (0.2) | match |
| arb_Arab | lang | 7.2 | 13.3 | ×1.86 | ×1.00 | 1% (0.6) | 3% (2.6) | 0% (0.0) | 98% (73.3) | 0% (0.0) | match |
| ben_Beng | lang | 9.9 | 18.1 | ×1.82 | ×0.97 | 1% (0.6) | 3% (1.7) | 0% (0.0) | 96% (50.5) | 0% (0.0) | match |
| cmn_Hani | lang | 12.2 | 33.2 | ×2.73 | ×0.99 | 2% (0.6) | 1% (0.3) | 0% (0.0) | 96% (25.9) | 0% (0.1) | match |
| ell_Grek | lang | 7.7 | 14.8 | ×1.92 | ×0.99 | 1% (0.6) | 4% (2.5) | 0% (0.0) | 94% (61.9) | 1% (0.7) | match |
| eng_Latn | lang | 3.8 | 5.4 | ×1.42 | ×0.99 | 1% (2.1) | 3% (5.0) | 0% (0.0) | 96% (170.6) | 0% (0.8) | match |
| heb_Hebr | lang | 8.1 | 16.7 | ×2.07 | ×1.00 | 1% (0.6) | 5% (2.7) | 0% (0.0) | 96% (55.5) | 0% (0.0) | match |
| hin_Deva | lang | 9.5 | 17.8 | ×1.87 | ×1.00 | 1% (0.6) | 4% (2.3) | 0% (0.0) | 95% (50.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 12.4 | 28.6 | ×2.30 | ×0.99 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 97% (32.1) | 0% (0.0) | match |
| kat_Geor | lang | 11.8 | 24.5 | ×2.07 | ×1.00 | 2% (0.6) | 4% (1.4) | 0% (0.0) | 95% (36.8) | 0% (0.0) | match |
| kor_Hang | lang | 9.6 | 25.3 | ×2.64 | ×1.00 | 2% (0.6) | 7% (2.6) | 0% (0.0) | 91% (33.5) | 0% (0.1) | match |
| rus_Cyrl | lang | 7.1 | 10.9 | ×1.53 | ×0.98 | 1% (0.6) | 3% (2.3) | 0% (0.0) | 96% (87.1) | 0% (0.4) | match |
| tam_Taml | lang | 10.9 | 19.3 | ×1.78 | ×0.99 | 1% (0.6) | 3% (1.3) | 0% (0.0) | 96% (47.8) | 0% (0.1) | match |
| tha_Thai | lang | 12.8 | 23.6 | ×1.84 | ×0.99 | 2% (0.6) | 2% (0.7) | 0% (0.0) | 97% (38.7) | 0% (0.1) | match |
| added_normalized_dense | modalities | 5.1 | 7.3 | ×1.43 | ×0.98 | 1% (0.8) | 2% (2.9) | 0% (0.1) | 105% (139.8) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.7 | 6.5 | ×1.38 | ×0.98 | 1% (1.4) | 3% (4.6) | 0% (0.0) | 96% (142.7) | 0% (0.4) | match |
| added_special_dense | modalities | 4.7 | 19.4 | ×4.10 | ×0.96 | 20% (9.5) | 18% (8.6) | 15% (7.3) | 48% (23.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 7.0 | 9.7 | ×1.39 | ×0.99 | 5% (5.1) | 9% (8.8) | 5% (4.5) | 81% (81.8) | 0% (0.2) | match |
| agentic-traces | modalities | 4.2 | 6.3 | ×1.49 | ×0.98 | 1% (1.9) | 3% (4.6) | 0% (0.0) | 96% (147.1) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 6.9 | ×1.69 | ×1.00 | 1% (1.3) | 5% (7.4) | 0% (0.0) | 94% (132.4) | 0% (0.0) | match |
| code_mixed | modalities | 4.1 | 6.5 | ×1.57 | ×0.99 | 1% (1.7) | 4% (6.2) | 0% (0.0) | 94% (140.7) | 1% (0.8) | match |
| math_latex | modalities | 4.1 | 5.9 | ×1.44 | ×0.97 | 1% (2.1) | 3% (4.6) | 0% (0.0) | 96% (157.7) | 0% (0.6) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×8.22 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 27+0 (peak 27)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 44.7 | ×11.80 | ×0.92 | 3% (0.7) | 0% (0.0) | 18% (3.6) | 79% (16.2) | 0% (0.0) | match |
| arb_Arab | lang | 3.6 | 25.5 | ×7.04 | ×0.99 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 92% (35.2) | 0% (0.1) | match |
| ben_Beng | lang | 2.8 | 46.2 | ×16.50 | ×1.04 | 3% (0.6) | 0% (0.0) | 14% (3.0) | 83% (17.3) | 0% (0.0) | match |
| cmn_Hani | lang | 3.5 | 28.6 | ×8.13 | ×0.99 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (32.4) | 0% (0.1) | match |
| ell_Grek | lang | 4.0 | 28.4 | ×7.11 | ×1.00 | 2% (0.6) | 0% (0.0) | 6% (2.2) | 92% (31.3) | 0% (0.1) | match |
| eng_Latn | lang | 3.3 | 13.8 | ×4.25 | ×0.98 | 3% (2.1) | 0% (0.2) | 4% (2.8) | 93% (64.7) | 0% (0.0) | match |
| heb_Hebr | lang | 3.7 | 30.1 | ×8.06 | ×1.04 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (29.6) | 0% (0.1) | match |
| hin_Deva | lang | 2.9 | 39.7 | ×13.51 | ×0.98 | 2% (0.6) | 0% (0.0) | 12% (3.1) | 85% (20.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.1 | 21.9 | ×5.32 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (41.4) | 0% (0.1) | match |
| kat_Geor | lang | 4.5 | 70.7 | ×15.73 | ×1.09 | 4% (0.6) | 0% (0.0) | 15% (2.0) | 81% (11.0) | 0% (0.0) | match |
| kor_Hang | lang | 3.2 | 42.3 | ×13.26 | ×0.97 | 3% (0.6) | 0% (0.0) | 11% (2.5) | 87% (19.7) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.0 | 26.8 | ×6.77 | ×0.97 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 92% (33.4) | 0% (0.1) | match |
| tam_Taml | lang | 2.7 | 71.3 | ×26.81 | ×0.99 | 4% (0.6) | 0% (0.0) | 20% (2.7) | 76% (10.4) | 0% (0.0) | match |
| tha_Thai | lang | 3.4 | 37.9 | ×11.29 | ×1.07 | 2% (0.6) | 0% (0.0) | 10% (2.5) | 88% (22.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 25.6 | ×4.47 | ×1.01 | 2% (0.7) | 0% (0.0) | 3% (1.2) | 95% (35.2) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.0 | 21.5 | ×4.34 | ×1.00 | 3% (1.4) | 0% (0.0) | 4% (1.9) | 93% (41.5) | 0% (0.0) | match |
| added_special_dense | modalities | 4.0 | 45.9 | ×11.44 | ×0.96 | 25% (5.1) | 1% (0.1) | 19% (3.8) | 56% (11.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.1 | 23.5 | ×5.72 | ×0.99 | 8% (3.2) | 0% (0.1) | 11% (4.3) | 81% (32.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.0 | 16.3 | ×5.51 | ×1.01 | 3% (1.9) | 0% (0.0) | 6% (3.5) | 91% (54.2) | 0% (0.0) | match |
| agentic_swe | modalities | 3.3 | 24.9 | ×7.50 | ×1.04 | 3% (1.3) | 0% (0.0) | 6% (2.4) | 90% (35.2) | 0% (0.1) | match |
| code_mixed | modalities | 3.4 | 20.7 | ×6.13 | ×1.01 | 3% (1.6) | 0% (0.0) | 6% (2.9) | 90% (42.5) | 0% (0.1) | match |
| math_latex | modalities | 3.1 | 15.2 | ×4.94 | ×1.00 | 3% (2.1) | 0% (0.1) | 5% (3.2) | 92% (58.8) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.07 | 3.65 | 4.10 | 28.4 | 21.8 | 5.9 | 4.7 | 7.8× / 6.9× | 6.0× / 5.3× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 2.76 | 2.27 | 4.02 | 33.2 | 26.9 | 6.8 | 5.0 | 14.6× / 8.2× | 11.8× / 6.7× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.46 | 2.58 | 3.00 | 4.12 | 69.0 | 59.9 | 14.5 | 4.1 | 23.0× / 16.8× | 20.0× / 14.6× | 4.8× / 3.5× | 1.4× / 1.0× |
| cmn_Hani | 1.12 | 1.99 | 2.32 | 3.18 | 27.0 | 22.0 | 5.9 | 2.4 | 11.7× / 8.5× | 9.5× / 6.9× | 2.6× / 1.9× | 1.0× / 0.8× |
| ell_Grek | 0.59 | 2.78 | 2.18 | 4.37 | 29.3 | 23.0 | 6.2 | 4.7 | 13.5× / 6.7× | 10.6× / 5.3× | 2.8× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.10 | 0.90 | 2.84 | 3.64 | 45.9 | 45.2 | 12.3 | 3.7 | 16.2× / 12.6× | 15.9× / 12.4× | 4.3× / 3.4× | 1.3× / 1.0× |
| heb_Hebr | 1.00 | 2.81 | 2.29 | 4.10 | 32.6 | 27.3 | 6.9 | 3.0 | 14.2× / 8.0× | 11.9× / 6.7× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 2.77 | 3.06 | 4.47 | 65.1 | 58.1 | 13.7 | 4.3 | 21.2× / 14.6× | 19.0× / 13.0× | 4.5× / 3.1× | 1.4× / 1.0× |
| jpn_Jpan | 1.56 | 3.16 | 2.13 | 3.73 | 24.3 | 18.1 | 5.0 | 3.8 | 11.4× / 6.5× | 8.5× / 4.9× | 2.4× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.26 | 2.04 | 2.92 | 19.0 | 14.9 | 4.3 | 2.0 | 9.3× / 6.5× | 7.3× / 5.1× | 2.1× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.08 | 2.40 | 2.45 | 3.77 | 33.2 | 29.8 | 7.5 | 3.6 | 13.5× / 8.8× | 12.1× / 7.9× | 3.1× / 2.0× | 1.5× / 1.0× |
| rus_Cyrl | 1.02 | 2.75 | 2.09 | 3.82 | 28.1 | 22.1 | 5.9 | 2.5 | 13.4× / 7.3× | 10.5× / 5.8× | 2.8× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.92 | 2.62 | 2.71 | 4.41 | 72.0 | 60.5 | 14.5 | 3.8 | 26.5× / 16.3× | 22.3× / 13.7× | 5.3× / 3.3× | 1.4× / 0.9× |
| tha_Thai | 1.36 | 2.24 | 2.50 | 3.38 | 41.3 | 32.9 | 8.9 | 3.2 | 16.5× / 12.2× | 13.2× / 9.7× | 3.6× / 2.6× | 1.3× / 1.0× |
| added_normalized_dense | 0.06 | 0.88 | 1.19 | 2.01 | 24.5 | 24.0 | 6.4 | 1.8 | 20.6× / 12.2× | 20.2× / 11.9× | 5.4× / 3.2× | 1.5× / 0.9× |
| added_normalized_sparse | 0.06 | 0.88 | 1.88 | 2.70 | 32.3 | 32.7 | 8.6 | 2.5 | 17.2× / 11.9× | 17.4× / 12.1× | 4.6× / 3.2× | 1.3× / 0.9× |
| added_special_dense | 0.06 | 0.88 | 3.79 | 4.62 | 96.6 | 100.1 | 20.8 | 2.8 | 25.5× / 20.9× | 26.4× / 21.7× | 5.5× / 4.5× | 0.7× / 0.6× |
| added_special_sparse | 0.06 | 0.88 | 4.33 | 5.15 | 62.8 | 63.2 | 14.7 | 3.4 | 14.5× / 12.2× | 14.6× / 12.3× | 3.4× / 2.9× | 0.8× / 0.7× |
| agentic-traces | 0.57 | 0.93 | 3.52 | 3.88 | 61.2 | 62.9 | 15.9 | 4.6 | 17.4× / 15.8× | 17.9× / 16.2× | 4.5× / 4.1× | 1.3× / 1.2× |
| agentic_swe | 0.55 | 0.87 | 2.40 | 2.72 | 61.7 | 71.6 | 15.1 | 3.4 | 25.8× / 22.7× | 29.9× / 26.3× | 6.3× / 5.5× | 1.4× / 1.3× |
| code_mixed | 0.07 | 0.87 | 2.92 | 3.72 | 60.9 | 69.4 | 15.6 | 3.9 | 20.9× / 16.4× | 23.8× / 18.7× | 5.3× / 4.2× | 1.4× / 1.1× |
| math_latex | 0.57 | 0.92 | 3.21 | 3.57 | 54.5 | 53.4 | 14.3 | 4.1 | 17.0× / 15.3× | 16.6× / 15.0× | 4.4× / 4.0× | 1.3× / 1.2× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×4.96 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 24.3 | ×6.32 | ×1.05 | 2% (0.7) | 0% (0.0) | 12% (4.7) | 86% (33.3) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 18.0 | ×4.05 | ×1.04 | 1% (0.6) | 0% (0.0) | 6% (3.2) | 93% (49.4) | 0% (0.0) | match |
| ben_Beng | lang | 6.6 | 17.8 | ×2.70 | ×1.01 | 1% (0.6) | 0% (0.0) | 7% (3.6) | 92% (49.9) | 1% (0.3) | match |
| cmn_Hani | lang | 4.5 | 11.9 | ×2.66 | ×0.98 | 1% (0.6) | 0% (0.0) | 4% (3.4) | 95% (77.9) | 1% (0.4) | match |
| ell_Grek | lang | 4.9 | 15.9 | ×3.21 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 93% (56.5) | 1% (0.5) | match |
| eng_Latn | lang | 3.7 | 40.5 | ×10.89 | ×0.95 | 9% (2.1) | 0% (0.0) | 21% (4.7) | 69% (15.8) | 1% (0.2) | match |
| heb_Hebr | lang | 4.4 | 17.1 | ×3.86 | ×1.03 | 1% (0.6) | 0% (0.0) | 6% (3.3) | 97% (54.2) | 0% (0.0) | match |
| hin_Deva | lang | 6.8 | 26.8 | ×3.94 | ×1.03 | 2% (0.6) | 0% (0.0) | 11% (3.7) | 88% (31.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.3 | 12.7 | ×2.40 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (3.1) | 95% (73.6) | 1% (0.4) | match |
| kat_Geor | lang | 6.5 | 14.0 | ×2.16 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (3.0) | 97% (68.3) | 0% (0.0) | match |
| kor_Hang | lang | 3.9 | 15.0 | ×3.87 | ×0.98 | 1% (0.6) | 0% (0.0) | 5% (3.6) | 95% (63.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.0 | 15.5 | ×3.08 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (3.2) | 94% (59.5) | 0% (0.2) | match |
| tam_Taml | lang | 6.8 | 13.0 | ×1.91 | ×0.98 | 1% (0.6) | 0% (0.0) | 4% (3.2) | 95% (71.0) | 0% (0.0) | match |
| tha_Thai | lang | 7.5 | 11.3 | ×1.51 | ×0.98 | 1% (0.6) | 0% (0.0) | 4% (3.2) | 96% (82.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.3 | 25.5 | ×4.79 | ×1.00 | 2% (0.7) | 0% (0.0) | 6% (2.2) | 92% (35.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 41.7 | ×7.93 | ×0.99 | 6% (1.4) | 0% (0.0) | 14% (3.2) | 81% (18.6) | 0% (0.0) | match |
| added_special_dense | modalities | 4.2 | 71.2 | ×16.95 | ×0.94 | 41% (5.1) | 0% (0.0) | 39% (5.0) | 19% (2.4) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.3 | 75.2 | ×17.35 | ×0.97 | 27% (3.2) | 0% (0.1) | 47% (5.7) | 26% (3.2) | 0% (0.0) | match |
| agentic-traces | modalities | 3.7 | 37.5 | ×10.23 | ×0.97 | 7% (1.9) | 0% (0.0) | 20% (5.1) | 72% (18.0) | 0% (0.1) | match |
| agentic_swe | modalities | 3.8 | 27.5 | ×7.26 | ×0.99 | 4% (1.3) | 0% (0.0) | 11% (3.8) | 86% (29.8) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 49.5 | ×12.65 | ×0.98 | 9% (1.6) | 0% (0.0) | 25% (4.5) | 66% (12.1) | 0% (0.0) | match |
| math_latex | modalities | 3.4 | 37.2 | ×10.80 | ×0.97 | 8% (2.0) | 0% (0.1) | 20% (4.9) | 71% (17.3) | 1% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.09 | 4.68 | 5.15 | 33.4 | 14.6 | 7.1 | 4.7 | 7.1× / 6.5× | 3.1× / 2.8× | 1.5× / 1.4× | 1.0× / 0.9× |
| arb_Arab | 1.01 | 2.74 | 3.22 | 4.95 | 38.0 | 16.5 | 7.5 | 5.1 | 11.8× / 7.7× | 5.1× / 3.3× | 2.3× / 1.5× | 1.6× / 1.0× |
| ben_Beng | 1.46 | 2.58 | 3.63 | 4.75 | 26.4 | 11.7 | 5.6 | 2.8 | 7.3× / 5.6× | 3.2× / 2.5× | 1.5× / 1.2× | 0.8× / 0.6× |
| cmn_Hani | 1.13 | 1.97 | 3.39 | 4.23 | 24.1 | 11.0 | 5.5 | 2.4 | 7.1× / 5.7× | 3.2× / 2.6× | 1.6× / 1.3× | 0.7× / 0.6× |
| ell_Grek | 0.58 | 2.76 | 3.26 | 5.44 | 34.2 | 15.9 | 7.0 | 5.1 | 10.5× / 6.3× | 4.9× / 2.9× | 2.1× / 1.3× | 1.6× / 0.9× |
| eng_Latn | 0.10 | 0.93 | 4.73 | 5.56 | 50.7 | 30.7 | 13.9 | 4.2 | 10.7× / 9.1× | 6.5× / 5.5× | 2.9× / 2.5× | 0.9× / 0.7× |
| heb_Hebr | 1.01 | 2.82 | 3.30 | 5.10 | 38.3 | 18.0 | 8.1 | 2.9 | 11.6× / 7.5× | 5.5× / 3.5× | 2.5× / 1.6× | 0.9× / 0.6× |
| hin_Deva | 1.36 | 2.73 | 3.72 | 5.10 | 29.4 | 13.3 | 6.5 | 3.2 | 7.9× / 5.8× | 3.6× / 2.6× | 1.7× / 1.3× | 0.9× / 0.6× |
| jpn_Jpan | 1.57 | 3.17 | 3.11 | 4.71 | 22.3 | 9.6 | 4.8 | 3.8 | 7.2× / 4.7× | 3.1× / 2.0× | 1.6× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.38 | 2.27 | 2.96 | 3.85 | 21.5 | 10.5 | 4.6 | 2.2 | 7.3× / 5.6× | 3.6× / 2.7× | 1.6× / 1.2× | 0.7× / 0.6× |
| kor_Hang | 1.09 | 2.50 | 3.64 | 5.05 | 38.5 | 20.2 | 9.1 | 3.6 | 10.6× / 7.6× | 5.5× / 4.0× | 2.5× / 1.8× | 1.0× / 0.7× |
| rus_Cyrl | 1.02 | 2.71 | 3.19 | 4.88 | 32.4 | 15.4 | 6.9 | 4.8 | 10.2× / 6.6× | 4.8× / 3.2× | 2.2× / 1.4× | 1.5× / 1.0× |
| tam_Taml | 0.92 | 2.68 | 3.17 | 4.92 | 21.0 | 9.3 | 4.3 | 2.9 | 6.6× / 4.3× | 2.9× / 1.9× | 1.3× / 0.9× | 0.9× / 0.6× |
| tha_Thai | 1.36 | 2.22 | 3.16 | 4.02 | 14.1 | 5.9 | 2.8 | 2.3 | 4.5× / 3.5× | 1.9× / 1.5× | 0.9× / 0.7× | 0.7× / 0.6× |
| added_normalized_dense | 0.06 | 0.88 | 2.16 | 2.99 | 36.2 | 18.0 | 11.2 | 2.0 | 16.8× / 12.1× | 8.3× / 6.0× | 5.2× / 3.7× | 0.9× / 0.7× |
| added_normalized_sparse | 0.06 | 0.88 | 3.19 | 4.01 | 40.1 | 21.3 | 11.5 | 2.8 | 12.6× / 10.0× | 6.7× / 5.3× | 3.6× / 2.9× | 0.9× / 0.7× |
| added_special_dense | 0.06 | 0.88 | 4.98 | 5.81 | 99.7 | 70.5 | 23.9 | 3.2 | 20.0× / 17.2× | 14.1× / 12.1× | 4.8× / 4.1× | 0.6× / 0.6× |
| added_special_sparse | 0.06 | 0.88 | 5.66 | 6.49 | 65.8 | 43.1 | 16.5 | 3.5 | 11.6× / 10.1× | 7.6× / 6.6× | 2.9× / 2.5× | 0.6× / 0.5× |
| agentic-traces | 0.56 | 0.92 | 5.15 | 5.50 | 60.7 | 44.1 | 17.5 | 4.9 | 11.8× / 11.0× | 8.6× / 8.0× | 3.4× / 3.2× | 1.0× / 0.9× |
| agentic_swe | 0.53 | 0.87 | 3.80 | 4.13 | 60.8 | 51.3 | 17.4 | 3.6 | 16.0× / 14.7× | 13.5× / 12.4× | 4.6× / 4.2× | 0.9× / 0.9× |
| code_mixed | 0.07 | 0.86 | 4.50 | 5.30 | 60.0 | 49.2 | 17.4 | 4.2 | 13.3× / 11.3× | 10.9× / 9.3× | 3.9× / 3.3× | 0.9× / 0.8× |
| math_latex | 0.56 | 0.92 | 4.93 | 5.29 | 57.9 | 37.9 | 16.2 | 4.5 | 11.7× / 10.9× | 7.7× / 7.2× | 3.3× / 3.1× | 0.9× / 0.9× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×6.29 vs v0.23.1 · ×0.98 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 43.1 | ×10.69 | ×0.90 | 6% (1.2) | 0% (0.0) | 17% (3.8) | 78% (16.9) | 0% (0.0) | match |
| arb_Arab | lang | 4.5 | 17.5 | ×3.85 | ×0.98 | 2% (1.2) | 0% (0.0) | 4% (2.4) | 93% (51.2) | 1% (0.5) | match |
| ben_Beng | lang | 4.2 | 27.0 | ×6.36 | ×1.01 | 3% (1.2) | 0% (0.0) | 9% (3.1) | 88% (31.2) | 0% (0.0) | match |
| cmn_Hani | lang | 4.8 | 14.1 | ×2.93 | ×0.97 | 2% (1.2) | 0% (0.0) | 4% (2.4) | 98% (66.0) | 0% (0.0) | match |
| ell_Grek | lang | 5.1 | 19.5 | ×3.83 | ×1.00 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 94% (46.6) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 42.3 | ×10.95 | ×0.95 | 14% (2.8) | 0% (0.0) | 15% (3.0) | 73% (15.0) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 24.3 | ×5.77 | ×0.95 | 3% (1.2) | 0% (0.0) | 6% (2.4) | 92% (36.2) | 0% (0.0) | match |
| hin_Deva | lang | 3.9 | 30.5 | ×7.88 | ×1.02 | 4% (1.2) | 0% (0.0) | 10% (3.2) | 86% (27.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.6 | 15.1 | ×2.71 | ×0.97 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 95% (59.1) | 0% (0.0) | match |
| kat_Geor | lang | 6.4 | 22.4 | ×3.51 | ×1.01 | 3% (1.2) | 0% (0.0) | 5% (2.1) | 96% (40.9) | 0% (0.0) | match |
| kor_Hang | lang | 3.9 | 17.9 | ×4.53 | ×0.96 | 2% (1.2) | 0% (0.0) | 5% (2.5) | 93% (48.5) | 0% (0.1) | match |
| rus_Cyrl | lang | 4.9 | 17.9 | ×3.62 | ×0.95 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 94% (48.8) | 0% (0.0) | match |
| tam_Taml | lang | 3.8 | 36.4 | ×9.53 | ×1.03 | 4% (1.2) | 0% (0.0) | 10% (2.7) | 86% (23.1) | 0% (0.0) | match |
| tha_Thai | lang | 4.9 | 21.5 | ×4.36 | ×1.02 | 3% (1.2) | 0% (0.0) | 6% (2.7) | 92% (41.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.0 | 26.8 | ×4.43 | ×0.99 | 4% (1.3) | 0% (0.0) | 3% (1.1) | 94% (34.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.5 | 39.1 | ×7.17 | ×0.93 | 8% (2.0) | 0% (0.0) | 9% (2.1) | 84% (19.5) | 0% (0.0) | match |
| added_special_dense | modalities | 4.2 | 46.6 | ×11.08 | ×0.98 | 60% (12.8) | 0% (0.0) | 26% (5.5) | 12% (2.6) | 3% (0.5) | match |
| added_special_sparse | modalities | 4.3 | 55.6 | ×12.80 | ×0.96 | 41% (7.0) | 0% (0.0) | 32% (5.4) | 28% (4.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.4 | 35.2 | ×10.32 | ×0.99 | 10% (2.6) | 0% (0.0) | 16% (4.0) | 76% (19.7) | 0% (0.0) | match |
| agentic_swe | modalities | 3.7 | 27.3 | ×7.30 | ×0.98 | 6% (2.0) | 0% (0.0) | 8% (2.9) | 87% (30.1) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 44.2 | ×11.38 | ×0.97 | 11% (2.3) | 0% (0.0) | 16% (3.3) | 74% (15.2) | 0% (0.0) | match |
| math_latex | modalities | 3.7 | 37.7 | ×10.26 | ×0.97 | 11% (2.6) | 0% (0.0) | 15% (3.5) | 76% (18.1) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.09 | 3.77 | 4.25 | 27.2 | 16.3 | 6.1 | 4.8 | 7.2× / 6.4× | 4.3× / 3.8× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 2.74 | 2.38 | 4.13 | 30.9 | 19.7 | 6.9 | 5.1 | 13.0× / 7.5× | 8.3× / 4.8× | 2.9× / 1.7× | 2.1× / 1.2× |
| ben_Beng | 1.46 | 2.56 | 3.13 | 4.24 | 45.1 | 28.4 | 10.7 | 3.7 | 14.4× / 10.6× | 9.1× / 6.7× | 3.4× / 2.5× | 1.2× / 0.9× |
| cmn_Hani | 1.13 | 2.02 | 2.40 | 3.29 | 19.8 | 11.9 | 4.7 | 2.4 | 8.3× / 6.0× | 4.9× / 3.6× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.76 | 2.22 | 4.40 | 28.3 | 17.4 | 6.1 | 4.7 | 12.8× / 6.4× | 7.8× / 3.9× | 2.8× / 1.4× | 2.1× / 1.1× |
| eng_Latn | 0.12 | 0.90 | 3.04 | 3.81 | 43.3 | 34.1 | 12.4 | 3.9 | 14.3× / 11.4× | 11.2× / 8.9× | 4.1× / 3.3× | 1.3× / 1.0× |
| heb_Hebr | 1.00 | 2.79 | 2.35 | 4.14 | 30.6 | 19.8 | 6.9 | 2.9 | 13.0× / 7.4× | 8.4× / 4.8× | 3.0× / 1.7× | 1.2× / 0.7× |
| hin_Deva | 1.36 | 2.74 | 3.25 | 4.62 | 47.6 | 31.4 | 11.7 | 4.0 | 14.7× / 10.3× | 9.7× / 6.8× | 3.6× / 2.5× | 1.2× / 0.9× |
| jpn_Jpan | 1.58 | 3.11 | 2.20 | 3.73 | 18.2 | 10.0 | 4.1 | 3.9 | 8.3× / 4.9× | 4.5× / 2.7× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.39 | 2.29 | 2.12 | 3.03 | 16.9 | 11.7 | 4.3 | 2.0 | 8.0× / 5.6× | 5.5× / 3.9× | 2.0× / 1.4× | 0.9× / 0.6× |
| kor_Hang | 1.09 | 2.39 | 2.53 | 3.84 | 31.0 | 21.7 | 7.6 | 3.7 | 12.2× / 8.1× | 8.6× / 5.6× | 3.0× / 2.0× | 1.4× / 1.0× |
| rus_Cyrl | 1.02 | 2.72 | 2.18 | 3.89 | 26.7 | 16.6 | 5.9 | 2.4 | 12.3× / 6.9× | 7.6× / 4.3× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.92 | 2.62 | 2.73 | 4.43 | 44.4 | 28.4 | 10.3 | 3.3 | 16.3× / 10.0× | 10.4× / 6.4× | 3.8× / 2.3× | 1.2× / 0.7× |
| tha_Thai | 1.35 | 2.23 | 2.69 | 3.57 | 28.1 | 16.7 | 6.8 | 2.9 | 10.5× / 7.9× | 6.2× / 4.7× | 2.5× / 1.9× | 1.1× / 0.8× |
| added_normalized_dense | 0.06 | 0.88 | 1.13 | 1.96 | 22.9 | 17.1 | 6.5 | 1.9 | 20.2× / 11.7× | 15.1× / 8.7× | 5.8× / 3.3× | 1.7× / 1.0× |
| added_normalized_sparse | 0.06 | 0.88 | 2.08 | 2.91 | 31.0 | 22.7 | 8.7 | 2.6 | 14.9× / 10.6× | 10.9× / 7.8× | 4.2× / 3.0× | 1.3× / 0.9× |
| added_special_dense | 0.06 | 0.88 | 5.47 | 6.30 | 93.5 | 75.0 | 21.9 | 3.1 | 17.1× / 14.9× | 13.7× / 11.9× | 4.0× / 3.5× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 0.88 | 5.39 | 6.22 | 59.1 | 46.6 | 15.6 | 3.5 | 11.0× / 9.5× | 8.6× / 7.5× | 2.9× / 2.5× | 0.6× / 0.6× |
| agentic-traces | 0.57 | 0.92 | 4.03 | 4.38 | 52.2 | 46.7 | 15.3 | 4.8 | 13.0× / 11.9× | 11.6× / 10.7× | 3.8× / 3.5× | 1.2× / 1.1× |
| agentic_swe | 0.53 | 0.86 | 2.88 | 3.22 | 54.0 | 53.0 | 15.7 | 3.5 | 18.7× / 16.8× | 18.4× / 16.5× | 5.5× / 4.9× | 1.2× / 1.1× |
| code_mixed | 0.07 | 0.87 | 3.27 | 4.08 | 51.5 | 51.4 | 15.2 | 4.1 | 15.7× / 12.6× | 15.7× / 12.6× | 4.6× / 3.7× | 1.3× / 1.0× |
| math_latex | 0.58 | 0.92 | 3.54 | 3.87 | 50.3 | 40.6 | 14.2 | 4.3 | 14.2× / 13.0× | 11.5× / 10.5× | 4.0× / 3.7× | 1.2× / 1.1× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.58 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.7 | 39.2 | ×8.41 | ×0.98 | 0% (0.0) | 12% (2.8) | 0% (0.0) | 88% (20.6) | 0% (0.0) | match |
| arb_Arab | lang | 10.3 | 48.4 | ×4.71 | ×0.99 | 0% (0.0) | 17% (3.2) | 0% (0.0) | 83% (16.4) | 0% (0.0) | match |
| ben_Beng | lang | 11.1 | 78.4 | ×7.09 | ×1.04 | 0% (0.0) | 19% (2.2) | 0% (0.0) | 82% (9.6) | 0% (0.0) | match |
| cmn_Hani | lang | 9.2 | 61.4 | ×6.66 | ×0.99 | 0% (0.1) | 3% (0.5) | 0% (0.0) | 97% (14.2) | 0% (0.0) | match |
| ell_Grek | lang | 10.3 | 54.6 | ×5.31 | ×0.99 | 0% (0.0) | 18% (3.1) | 0% (0.0) | 81% (13.9) | 0% (0.0) | match |
| eng_Latn | lang | 4.1 | 6.3 | ×1.53 | ×0.98 | 0% (0.1) | 4% (7.0) | 0% (0.0) | 95% (148.9) | 0% (0.2) | match |
| heb_Hebr | lang | 10.2 | 57.9 | ×5.69 | ×0.99 | 0% (0.0) | 21% (3.3) | 0% (0.0) | 79% (12.9) | 0% (0.0) | match |
| hin_Deva | lang | 12.1 | 75.1 | ×6.23 | ×1.02 | 0% (0.0) | 23% (2.9) | 0% (0.0) | 77% (9.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.0 | 79.3 | ×6.12 | ×1.00 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 96% (10.6) | 0% (0.0) | match |
| kat_Geor | lang | 14.3 | 86.0 | ×6.01 | ×1.01 | 0% (0.0) | 18% (1.9) | 0% (0.0) | 82% (8.7) | 0% (0.0) | match |
| kor_Hang | lang | 7.3 | 48.3 | ×6.61 | ×0.97 | 0% (0.1) | 17% (3.3) | 0% (0.0) | 83% (16.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 8.0 | 16.0 | ×2.00 | ×1.00 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (58.3) | 0% (0.0) | match |
| tam_Taml | lang | 12.7 | 84.9 | ×6.69 | ×1.02 | 0% (0.0) | 16% (1.7) | 0% (0.0) | 84% (9.0) | 0% (0.0) | match |
| tha_Thai | lang | 15.5 | 81.5 | ×5.27 | ×0.99 | 0% (0.0) | 9% (1.0) | 0% (0.0) | 91% (10.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.4 | 8.6 | ×1.60 | ×0.98 | 0% (0.1) | 3% (3.8) | 0% (0.0) | 97% (111.5) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.8 | 7.3 | ×1.54 | ×0.99 | 0% (0.0) | 5% (6.1) | 0% (0.0) | 96% (124.1) | 0% (0.0) | match |
| added_special_dense | modalities | 3.8 | 19.8 | ×5.27 | ×0.98 | 10% (5.0) | 33% (15.6) | 3% (1.3) | 54% (25.7) | 1% (0.2) | match |
| added_special_sparse | modalities | 5.2 | 10.1 | ×1.95 | ×0.99 | 2% (2.1) | 15% (14.2) | 0% (0.4) | 82% (79.2) | 0% (0.1) | match |
| agentic-traces | modalities | 4.5 | 6.9 | ×1.55 | ×0.98 | 0% (0.1) | 5% (6.2) | 0% (0.0) | 95% (131.7) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 6.8 | ×1.72 | ×0.98 | 0% (0.0) | 7% (9.8) | 0% (0.0) | 93% (131.2) | 0% (0.0) | match |
| code_mixed | modalities | 4.2 | 6.8 | ×1.64 | ×0.97 | 0% (0.0) | 6% (8.0) | 0% (0.0) | 94% (132.7) | 1% (1.1) | match |
| math_latex | modalities | 4.3 | 6.6 | ×1.51 | ×0.97 | 0% (0.1) | 4% (6.5) | 0% (0.0) | 96% (139.0) | 0% (0.0) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×6.90 vs v0.23.1 · ×0.98 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 94)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 46.4 | ×10.58 | ×0.96 | 3% (0.7) | 0% (0.0) | 19% (3.7) | 78% (15.4) | 1% (0.1) | match |
| arb_Arab | lang | 4.7 | 17.4 | ×3.69 | ×0.97 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 94% (52.2) | 0% (0.2) | match |
| ben_Beng | lang | 4.1 | 32.0 | ×7.79 | ×1.02 | 2% (0.6) | 0% (0.0) | 10% (3.2) | 88% (27.1) | 0% (0.0) | match |
| cmn_Hani | lang | 5.2 | 16.6 | ×3.21 | ×0.99 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 94% (53.7) | 1% (0.4) | match |
| ell_Grek | lang | 5.3 | 18.8 | ×3.57 | ×0.97 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 94% (48.0) | 1% (0.4) | match |
| eng_Latn | lang | 4.1 | 44.3 | ×10.81 | ×0.96 | 11% (2.1) | 0% (0.1) | 16% (3.1) | 75% (14.5) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 25.3 | ×5.95 | ×0.97 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 91% (35.0) | 1% (0.3) | match |
| hin_Deva | lang | 4.1 | 72.6 | ×17.78 | ×0.95 | 5% (0.6) | 0% (0.0) | 27% (3.2) | 70% (8.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.8 | 16.3 | ×2.78 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (56.7) | 0% (0.1) | match |
| kat_Geor | lang | 5.7 | 36.8 | ×6.50 | ×0.99 | 2% (0.6) | 0% (0.0) | 8% (2.1) | 90% (23.2) | 0% (0.0) | match |
| kor_Hang | lang | 4.1 | 18.7 | ×4.61 | ×0.98 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 96% (48.9) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.9 | 16.3 | ×3.32 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 96% (57.1) | 0% (0.0) | match |
| tam_Taml | lang | 4.0 | 35.7 | ×9.01 | ×1.01 | 2% (0.6) | 0% (0.0) | 10% (2.7) | 88% (23.8) | 0% (0.0) | match |
| tha_Thai | lang | 5.2 | 20.1 | ×3.88 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (2.6) | 93% (44.8) | 0% (0.2) | match |
| added_normalized_dense | modalities | 6.2 | 26.2 | ×4.24 | ×0.96 | 2% (0.7) | 0% (0.0) | 3% (1.1) | 95% (33.9) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.5 | 42.6 | ×7.75 | ×1.00 | 6% (1.3) | 0% (0.0) | 9% (2.0) | 85% (19.6) | 0% (0.1) | match |
| added_special_dense | modalities | 4.2 | 67.3 | ×15.90 | ×0.89 | 38% (5.0) | 1% (0.1) | 39% (5.1) | 22% (2.9) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 69.9 | ×15.76 | ×0.96 | 26% (3.4) | 0% (0.0) | 39% (5.1) | 34% (4.5) | 1% (0.1) | match |
| agentic-traces | modalities | 3.6 | 37.1 | ×10.38 | ×0.99 | 7% (1.9) | 0% (0.0) | 15% (3.8) | 77% (19.7) | 1% (0.1) | match |
| agentic_swe | modalities | 4.0 | 28.5 | ×7.16 | ×1.00 | 4% (1.3) | 0% (0.0) | 8% (2.8) | 87% (30.3) | 1% (0.3) | match |
| code_mixed | modalities | 4.1 | 46.2 | ×11.19 | ×0.98 | 8% (1.6) | 0% (0.0) | 16% (3.3) | 77% (15.7) | 0% (0.0) | match |
| math_latex | modalities | 3.7 | 39.6 | ×10.70 | ×0.97 | 9% (2.0) | 0% (0.1) | 15% (3.5) | 76% (17.7) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.08 | 3.69 | 4.15 | 26.0 | 17.3 | 6.0 | 4.8 | 7.1× / 6.3× | 4.7× / 4.2× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.01 | 2.76 | 2.32 | 4.07 | 29.8 | 19.9 | 6.8 | 5.1 | 12.8× / 7.3× | 8.6× / 4.9× | 2.9× / 1.7× | 2.2× / 1.3× |
| ben_Beng | 1.46 | 2.56 | 3.15 | 4.25 | 43.2 | 28.7 | 10.5 | 3.7 | 13.7× / 10.2× | 9.1× / 6.7× | 3.3× / 2.5× | 1.2× / 0.9× |
| cmn_Hani | 1.13 | 1.97 | 2.39 | 3.23 | 19.0 | 11.7 | 4.7 | 2.4 | 8.0× / 5.9× | 4.9× / 3.6× | 2.0× / 1.5× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.76 | 2.21 | 4.39 | 27.0 | 17.4 | 6.1 | 4.8 | 12.2× / 6.2× | 7.8× / 4.0× | 2.8× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.10 | 0.90 | 3.13 | 3.93 | 41.3 | 34.0 | 12.4 | 3.9 | 13.2× / 10.5× | 10.9× / 8.6× | 3.9× / 3.1× | 1.3× / 1.0× |
| heb_Hebr | 1.00 | 2.80 | 2.34 | 4.15 | 29.2 | 19.9 | 6.9 | 2.9 | 12.4× / 7.0× | 8.5× / 4.8× | 2.9× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 2.73 | 3.22 | 4.58 | 45.7 | 31.1 | 11.7 | 4.0 | 14.2× / 10.0× | 9.6× / 6.8× | 3.6× / 2.6× | 1.2× / 0.9× |
| jpn_Jpan | 1.56 | 3.09 | 2.19 | 3.72 | 17.9 | 9.9 | 4.1 | 3.9 | 8.2× / 4.8× | 4.5× / 2.7× | 1.9× / 1.1× | 1.8× / 1.0× |
| kat_Geor | 1.38 | 2.26 | 2.11 | 3.00 | 16.3 | 11.5 | 4.3 | 2.0 | 7.7× / 5.4× | 5.4× / 3.8× | 2.0× / 1.4× | 1.0× / 0.7× |
| kor_Hang | 1.08 | 2.40 | 2.53 | 3.86 | 29.6 | 21.4 | 7.7 | 3.6 | 11.7× / 7.7× | 8.5× / 5.6× | 3.1× / 2.0× | 1.4× / 0.9× |
| rus_Cyrl | 1.02 | 2.75 | 2.18 | 3.92 | 25.7 | 17.0 | 5.9 | 2.5 | 11.8× / 6.6× | 7.8× / 4.3× | 2.7× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.92 | 2.61 | 2.70 | 4.39 | 42.3 | 27.3 | 10.1 | 3.4 | 15.7× / 9.6× | 10.1× / 6.2× | 3.7× / 2.3× | 1.2× / 0.8× |
| tha_Thai | 1.36 | 2.25 | 2.58 | 3.47 | 27.2 | 16.5 | 6.9 | 3.0 | 10.5× / 7.8× | 6.4× / 4.7× | 2.7× / 2.0× | 1.1× / 0.9× |
| added_normalized_dense | 0.06 | 0.88 | 1.07 | 1.89 | 21.8 | 17.1 | 6.4 | 1.9 | 20.4× / 11.5× | 16.0× / 9.0× | 6.0× / 3.4× | 1.8× / 1.0× |
| added_normalized_sparse | 0.06 | 0.88 | 1.98 | 2.81 | 29.1 | 23.2 | 8.7 | 2.6 | 14.6× / 10.3× | 11.7× / 8.2× | 4.4× / 3.1× | 1.3× / 0.9× |
| added_special_dense | 0.06 | 0.88 | 5.08 | 5.90 | 88.1 | 74.5 | 21.1 | 3.1 | 17.4× / 14.9× | 14.7× / 12.6× | 4.2× / 3.6× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 0.88 | 5.14 | 5.97 | 56.5 | 46.2 | 15.2 | 3.5 | 11.0× / 9.5× | 9.0× / 7.7× | 2.9× / 2.5× | 0.7× / 0.6× |
| agentic-traces | 0.57 | 0.92 | 3.78 | 4.13 | 49.7 | 46.2 | 15.2 | 4.7 | 13.2× / 12.0× | 12.2× / 11.2× | 4.0× / 3.7× | 1.3× / 1.1× |
| agentic_swe | 0.51 | 0.86 | 2.84 | 3.19 | 51.6 | 53.1 | 15.8 | 3.5 | 18.2× / 16.2× | 18.7× / 16.6× | 5.6× / 5.0× | 1.2× / 1.1× |
| code_mixed | 0.07 | 0.88 | 3.28 | 4.09 | 49.6 | 51.6 | 15.4 | 4.1 | 15.1× / 12.1× | 15.7× / 12.6× | 4.7× / 3.8× | 1.2× / 1.0× |
| math_latex | 0.58 | 0.92 | 3.46 | 3.80 | 47.8 | 40.0 | 14.3 | 4.3 | 13.8× / 12.6× | 11.5× / 10.5× | 4.1× / 3.8× | 1.2× / 1.1× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×5.43 vs v0.23.1 · ×1.55 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 194) · Pipeline 108+0 (peak 194)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.7 | 41.6 | ×11.19 | ×1.37 | 6% (1.2) | 0% (0.0) | 22% (4.7) | 70% (15.1) | 3% (0.6) | match |
| arb_Arab | lang | 4.6 | 21.8 | ×4.69 | ×1.27 | 3% (1.2) | 0% (0.0) | 8% (3.2) | 89% (37.7) | 1% (0.5) | match |
| ben_Beng | lang | 6.7 | 19.0 | ×2.84 | ×1.10 | 2% (1.2) | 0% (0.0) | 7% (3.6) | 90% (46.0) | 0% (0.1) | match |
| cmn_Hani | lang | 4.9 | 17.6 | ×3.57 | ×1.13 | 2% (1.2) | 0% (0.0) | 6% (3.3) | 89% (49.9) | 3% (1.6) | match |
| ell_Grek | lang | 5.1 | 18.7 | ×3.68 | ×1.22 | 2% (1.2) | 0% (0.0) | 6% (3.1) | 90% (46.8) | 2% (0.9) | match |
| eng_Latn | lang | 3.7 | 38.6 | ×10.40 | ×2.02 | 12% (2.6) | 0% (0.0) | 20% (4.5) | 68% (15.5) | 1% (0.2) | match |
| heb_Hebr | lang | 4.6 | 16.3 | ×3.55 | ×1.17 | 2% (1.2) | 0% (0.0) | 6% (3.3) | 90% (53.0) | 3% (1.5) | match |
| hin_Deva | lang | 6.5 | 26.2 | ×4.04 | ×1.22 | 3% (1.2) | 0% (0.0) | 10% (3.7) | 86% (31.4) | 1% (0.3) | match |
| jpn_Jpan | lang | 5.5 | 16.3 | ×2.94 | ×1.07 | 2% (1.2) | 0% (0.0) | 5% (3.1) | 91% (53.4) | 2% (1.1) | match |
| kat_Geor | lang | 6.5 | 15.4 | ×2.35 | ×1.08 | 2% (1.2) | 0% (0.0) | 4% (2.8) | 93% (58.1) | 1% (0.7) | match |
| kor_Hang | lang | 4.0 | 19.6 | ×4.84 | ×1.29 | 2% (1.2) | 0% (0.0) | 7% (3.6) | 88% (43.1) | 2% (0.8) | match |
| rus_Cyrl | lang | 4.8 | 16.6 | ×3.49 | ×1.17 | 2% (1.2) | 0% (0.0) | 5% (3.0) | 92% (52.4) | 0% (0.3) | match |
| tam_Taml | lang | 6.7 | 15.1 | ×2.25 | ×1.03 | 2% (1.2) | 0% (0.0) | 5% (3.2) | 94% (60.3) | 0% (0.0) | match |
| tha_Thai | lang | 7.9 | 14.8 | ×1.87 | ×0.98 | 2% (1.2) | 0% (0.0) | 5% (3.3) | 94% (61.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 29.4 | ×5.16 | ×1.43 | 4% (1.3) | 0% (0.0) | 6% (2.1) | 89% (29.3) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.4 | 43.3 | ×8.05 | ×1.74 | 9% (1.9) | 0% (0.0) | 14% (3.0) | 78% (17.2) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 71.1 | ×16.46 | ×4.28 | 38% (5.1) | 0% (0.0) | 39% (5.2) | 23% (3.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.5 | 64.1 | ×14.18 | ×2.93 | 25% (3.7) | 0% (0.0) | 40% (5.7) | 35% (5.0) | 0% (0.0) | match |
| agentic-traces | modalities | 3.4 | 34.2 | ×10.20 | ×2.31 | 9% (2.5) | 0% (0.0) | 19% (5.1) | 72% (19.0) | 0% (0.0) | match |
| agentic_swe | modalities | 3.4 | 25.3 | ×7.51 | ×2.26 | 5% (1.9) | 0% (0.0) | 10% (3.9) | 83% (31.9) | 1% (0.5) | match |
| code_mixed | modalities | 3.7 | 42.9 | ×11.59 | ×2.88 | 10% (2.2) | 0% (0.0) | 20% (4.3) | 69% (14.8) | 0% (0.0) | match |
| math_latex | modalities | 3.4 | 39.4 | ×11.62 | ×2.28 | 11% (2.6) | 0% (0.0) | 21% (4.7) | 70% (15.9) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.08 | 4.68 | 5.14 | 27.2 | 14.2 | 6.7 | — | 5.8× / 5.3× | 3.0× / 2.8× | 1.4× / 1.3× | — |
| arb_Arab | 1.00 | 2.75 | 3.20 | 4.95 | 31.3 | 16.8 | 7.2 | — | 9.8× / 6.3× | 5.2× / 3.4× | 2.3× / 1.5× | — |
| ben_Beng | 1.46 | 2.56 | 3.61 | 4.71 | 21.9 | 11.1 | 5.3 | — | 6.1× / 4.7× | 3.1× / 2.4× | 1.5× / 1.1× | — |
| cmn_Hani | 1.13 | 1.98 | 3.30 | 4.15 | 20.9 | 11.6 | 5.5 | — | 6.3× / 5.0× | 3.5× / 2.8× | 1.7× / 1.3× | — |
| ell_Grek | 0.58 | 2.79 | 3.13 | 5.34 | 27.5 | 15.5 | 6.9 | — | 8.8× / 5.1× | 4.9× / 2.9× | 2.2× / 1.3× | — |
| eng_Latn | 0.10 | 0.91 | 4.47 | 5.28 | 38.5 | 30.5 | 13.4 | — | 8.6× / 7.3× | 6.8× / 5.8× | 3.0× / 2.5× | — |
| heb_Hebr | 1.00 | 2.82 | 3.28 | 5.09 | 30.6 | 18.1 | 7.7 | — | 9.3× / 6.0× | 5.5× / 3.6× | 2.3× / 1.5× | — |
| hin_Deva | 1.36 | 2.73 | 3.72 | 5.09 | 23.6 | 13.2 | 6.2 | — | 6.4× / 4.6× | 3.6× / 2.6× | 1.7× / 1.2× | — |
| jpn_Jpan | 1.57 | 3.33 | 3.09 | 4.85 | 19.6 | 9.6 | 4.8 | — | 6.3× / 4.0× | 3.1× / 2.0× | 1.5× / 1.0× | — |
| kat_Geor | 1.39 | 2.25 | 2.78 | 3.65 | 17.7 | 10.2 | 4.5 | — | 6.4× / 4.9× | 3.7× / 2.8× | 1.6× / 1.2× | — |
| kor_Hang | 1.08 | 2.41 | 3.61 | 4.94 | 30.9 | 20.0 | 8.7 | — | 8.6× / 6.3× | 5.6× / 4.1× | 2.4× / 1.8× | — |
| rus_Cyrl | 1.02 | 2.74 | 3.04 | 4.77 | 26.5 | 15.2 | 6.4 | — | 8.7× / 5.5× | 5.0× / 3.2× | 2.1× / 1.3× | — |
| tam_Taml | 0.92 | 2.60 | 3.16 | 4.84 | 17.9 | 9.1 | 4.2 | — | 5.7× / 3.7× | 2.9× / 1.9× | 1.3× / 0.9× | — |
| tha_Thai | 1.36 | 2.23 | 3.25 | 4.12 | 12.8 | 6.0 | 2.8 | — | 3.9× / 3.1× | 1.8× / 1.5× | 0.9× / 0.7× | — |
| added_normalized_dense | 0.06 | 0.88 | 2.11 | 2.93 | 28.8 | 17.5 | 11.4 | — | 13.7× / 9.8× | 8.3× / 6.0× | 5.4× / 3.9× | — |
| added_normalized_sparse | 0.06 | 0.88 | 3.01 | 3.83 | 30.3 | 20.7 | 11.3 | — | 10.1× / 7.9× | 6.9× / 5.4× | 3.7× / 2.9× | — |
| added_special_dense | 0.06 | 0.88 | 5.19 | 6.02 | 76.0 | 68.9 | 23.5 | — | 14.6× / 12.6× | 13.3× / 11.5× | 4.5× / 3.9× | — |
| added_special_sparse | 0.06 | 0.88 | 5.70 | 6.52 | 49.2 | 41.3 | 16.3 | — | 8.6× / 7.5× | 7.3× / 6.3× | 2.9× / 2.5× | — |
| agentic-traces | 0.56 | 0.92 | 5.14 | 5.49 | 48.6 | 45.3 | 16.9 | — | 9.5× / 8.9× | 8.8× / 8.2× | 3.3× / 3.1× | — |
| agentic_swe | 0.52 | 0.86 | 3.94 | 4.28 | 52.5 | 56.3 | 18.2 | — | 13.3× / 12.3× | 14.3× / 13.2× | 4.6× / 4.3× | — |
| code_mixed | 0.07 | 0.87 | 4.34 | 5.14 | 48.6 | 49.9 | 17.2 | — | 11.2× / 9.4× | 11.5× / 9.7× | 4.0× / 3.4× | — |
| math_latex | 0.58 | 0.93 | 4.69 | 5.04 | 45.6 | 38.3 | 15.7 | — | 9.7× / 9.1× | 8.2× / 7.6× | 3.4× / 3.1× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30403869342-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
