### PR TITLE
perf(pipeline): hoist the per-span model dispatch out of the encode loop

### DIFF
--- a/tokenizers/tk-encode/examples/profile_encode.rs
+++ b/tokenizers/tk-encode/examples/profile_encode.rs
@@ -1,0 +1,212 @@
+//! Single-thread E2E encode profiler for one model on one fixture.
+//!
+//! `fixture_bench.rs` answers *how fast*; this answers *where the time goes*. The whole
+//! measured region sits under one `#[inline(never)]` frame (`hot_loop`), so a sampled
+//! profile can be collapsed to just the encode path — model load, JSON parsing and
+//! fixture I/O stay outside it and can be filtered out wholesale.
+//!
+//! Chunking matches `fixture_bench` phase 1 (10 kB inputs, ≤100 of them, warm,
+//! `add_special_tokens = true`) so the profile describes the same regime the headline
+//! MB/s numbers come from. Unlike `fixture_bench` no synthetic added tokens are
+//! injected — the model is profiled exactly as shipped.
+//!
+//! ```text
+//! cargo build --release --example profile_encode
+//! samply record --main-thread-only -r 4000 -o prof.json.gz \
+//!     -- ./target/release/examples/profile_encode data/gpt2.json data/fixtures/lang/eng_Latn.txt
+//! ```
+//!
+//! `--stages` instead prints the `encode_generic` ablation ladder (ns/byte per stage)
+//! for the same model/fixture pair, as the quantitative companion to the flamegraph.
+//! Keep it out of profiled runs: partial-stage passes would land in the same samples.
+
+use std::convert::TryFrom;
+use std::hint::black_box;
+use std::time::Instant;
+
+use tk_encode::Tokenizer;
+use tk_encode::pipeline::{Model, PipelineTokenizer};
+
+const CHUNK_BYTES: usize = 10 * 1024;
+const MAX_CHUNKS: usize = 100;
+const DEFAULT_SECONDS: f64 = 6.0;
+const REPS: usize = 5;
+
+fn make_chunks(text: &str) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut cur = String::new();
+    for line in text.lines().filter(|l| !l.trim().is_empty()) {
+        if !cur.is_empty() {
+            cur.push('\n');
+        }
+        cur.push_str(line);
+        if cur.len() >= CHUNK_BYTES {
+            chunks.push(std::mem::take(&mut cur));
+            if chunks.len() == MAX_CHUNKS {
+                return chunks;
+            }
+        }
+    }
+    if !cur.is_empty() {
+        chunks.push(cur);
+    }
+    chunks
+}
+
+/// Encode every chunk in a loop until `seconds` have elapsed; returns (passes, tokens).
+///
+/// `inline(never)` is the whole point: this frame is the filter the flamegraph post-pass
+/// keys on, so setup can be discarded without guessing which symbols belong to encode.
+#[inline(never)]
+fn hot_loop(pipeline: &PipelineTokenizer, chunks: &[String], seconds: f64) -> (usize, usize) {
+    let start = Instant::now();
+    let mut passes = 0usize;
+    let mut tokens = 0usize;
+    while start.elapsed().as_secs_f64() < seconds {
+        for chunk in chunks {
+            tokens += pipeline.encode(chunk, true).unwrap().len();
+        }
+        passes += 1;
+    }
+    black_box(tokens);
+    (passes, tokens)
+}
+
+fn median(mut v: Vec<f64>) -> f64 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    v[v.len() / 2]
+}
+
+/// Median seconds for one pass over `chunks` through `encode_generic::<STAGE>`, on a
+/// caller-owned scratch reused across chunks. Mirrors `fixture_bench::stage_secs`.
+fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) -> f64 {
+    let mut out = Vec::new();
+    let mut pre_tokens = Vec::new();
+    let mut scratch = pipeline.get_model().init_scratch();
+    let mut run = || {
+        for chunk in chunks {
+            out.clear();
+            let _ = pipeline.encode_generic::<STAGE>(
+                chunk,
+                true,
+                &mut pre_tokens,
+                &mut scratch,
+                &mut out,
+            );
+            black_box(&out);
+            black_box(&pre_tokens);
+        }
+    };
+    run();
+    let mut samples = Vec::with_capacity(REPS);
+    for _ in 0..REPS {
+        let t = Instant::now();
+        run();
+        samples.push(t.elapsed().as_secs_f64());
+    }
+    median(samples)
+}
+
+/// Order-sensitive hash of every id one pass emits, for diffing two builds of the encoder.
+fn checksum(pipeline: &PipelineTokenizer, chunks: &[String]) -> (u64, usize) {
+    let mut h: u64 = 0xcbf29ce484222325;
+    let mut n = 0;
+    for chunk in chunks {
+        for token in pipeline.encode(chunk, true).unwrap() {
+            h = (h ^ token.id as u64).wrapping_mul(0x100000001b3);
+            n += 1;
+        }
+    }
+    (h, n)
+}
+
+/// Pre-token count for one pass, so per-span costs can be quoted per word rather than as a
+/// share. `STAGE_SPLIT` stops after the pre-tokenizer, leaving its spans in `pre_tokens`.
+fn count_spans(pipeline: &PipelineTokenizer, chunks: &[String]) -> usize {
+    let mut out = Vec::new();
+    let mut pre_tokens = Vec::new();
+    let mut scratch = pipeline.get_model().init_scratch();
+    let mut spans = 0;
+    for chunk in chunks {
+        out.clear();
+        pre_tokens.clear();
+        let _ = pipeline.encode_generic::<{ PipelineTokenizer::STAGE_SPLIT }>(
+            chunk,
+            true,
+            &mut pre_tokens,
+            &mut scratch,
+            &mut out,
+        );
+        spans += pre_tokens.len();
+    }
+    spans
+}
+
+fn print_stages(pipeline: &PipelineTokenizer, chunks: &[String], bytes: usize) {
+    let t_frame = stage_secs::<{ PipelineTokenizer::STAGE_FRAME }>(pipeline, chunks);
+    let t_norm = stage_secs::<{ PipelineTokenizer::STAGE_NORMALIZE }>(pipeline, chunks);
+    let t_split = stage_secs::<{ PipelineTokenizer::STAGE_SPLIT }>(pipeline, chunks);
+    let t_model = stage_secs::<{ PipelineTokenizer::STAGE_MODEL }>(pipeline, chunks);
+    let t_post = stage_secs::<{ PipelineTokenizer::STAGE_POSTPROCESS }>(pipeline, chunks);
+    let nspb = |s: f64| s * 1e9 / bytes as f64;
+    println!("{{");
+    println!("  \"added_split\": {:.4},", nspb(t_frame));
+    println!("  \"pre_tokenize\": {:.4},", nspb(t_split - t_frame));
+    println!("  \"normalize\": {:.4},", nspb(t_norm - t_split));
+    println!("  \"model\": {:.4},", nspb(t_model - t_norm));
+    println!("  \"post_process\": {:.4},", nspb(t_post - t_model));
+    println!("  \"total\": {:.4}", nspb(t_post));
+    println!("}}");
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: profile_encode <model.json> <fixture.txt> [seconds|--stages]");
+        std::process::exit(2);
+    }
+    let stages = args.iter().any(|a| a == "--stages");
+    let seconds = args
+        .get(3)
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or(DEFAULT_SECONDS);
+
+    let tok = Tokenizer::from_file(&args[1]).expect("load tokenizer");
+    let pipeline = PipelineTokenizer::try_from(&tok).expect("build pipeline");
+    let text = std::fs::read_to_string(&args[2]).expect("read fixture");
+    let chunks = make_chunks(&text);
+    let bytes: usize = chunks.iter().map(String::len).sum();
+
+    // Warm-up, so the measured region is the steady state a plain `.encode()` loop reaches
+    // rather than first-touch page faults and a cold instruction cache.
+    for chunk in &chunks {
+        black_box(pipeline.encode(chunk, true).unwrap().len());
+    }
+
+    if args.iter().any(|a| a == "--checksum") {
+        let (h, n) = checksum(&pipeline, &chunks);
+        println!("{{\"ids\": {n}, \"checksum\": \"{h:016x}\"}}");
+        return;
+    }
+    if args.iter().any(|a| a == "--spans") {
+        let spans = count_spans(&pipeline, &chunks);
+        println!(
+            "{{\"bytes\": {bytes}, \"spans\": {spans}, \"bytes_per_span\": {:.3}}}",
+            bytes as f64 / spans as f64
+        );
+        return;
+    }
+    if stages {
+        print_stages(&pipeline, &chunks, bytes);
+        return;
+    }
+
+    let t = Instant::now();
+    let (passes, tokens) = hot_loop(&pipeline, &chunks, seconds);
+    let elapsed = t.elapsed().as_secs_f64();
+    let mbps = (bytes * passes) as f64 / elapsed / 1e6;
+    eprintln!(
+        "{} on {}: {bytes} B x {passes} passes in {elapsed:.2}s = {mbps:.1} MB/s ({tokens} tokens)",
+        args[1], args[2]
+    );
+}

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -632,14 +632,12 @@ impl PipelineTokenizer {
                                     self.pre_tokenizer
                                         .pre_tokenize(normalized_chunk, pre_tokens)?;
                                     if STAGE >= Self::STAGE_MODEL {
-                                        // Tokenize each chunk
-                                        for pre_token in pre_tokens.iter() {
-                                            self.model.tokenize_pipeline(
-                                                &normalized_chunk[pre_token.range()],
-                                                scratch,
-                                                output,
-                                            )?;
-                                        }
+                                        self.model.tokenize_spans(
+                                            normalized_chunk,
+                                            pre_tokens,
+                                            scratch,
+                                            output,
+                                        )?;
                                     }
                                 }
                             }
@@ -922,6 +920,23 @@ pub trait Model {
         output: &mut Vec<PipelineToken>,
     ) -> Result<()>;
 
+    /// `spans` are the pre-tokenizer's byte ranges into `chunk`, tokenized in order.
+    ///
+    /// The default walks them one at a time. Override it when a model pays setup that can
+    /// be hoisted out of the per-word loop.
+    fn tokenize_spans(
+        &self,
+        chunk: &str,
+        spans: &[Span],
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        for span in spans {
+            self.tokenize_pipeline(&chunk[span.range()], scratch, output)?;
+        }
+        Ok(())
+    }
+
     fn init_scratch(&self) -> Self::Scratch;
 }
 
@@ -957,6 +972,32 @@ impl Model for PipelineModel {
             }
             (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
                 model.tokenize_pipeline(sequence, scratch, output)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Pairing the model with its scratch is a 4x4 match that LLVM will not lift out of the
+    /// caller's span loop, so it runs here once per chunk instead of once per word.
+    fn tokenize_spans(
+        &self,
+        chunk: &str,
+        spans: &[Span],
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        match (self, scratch) {
+            (Self::BPE(model), PipelineModelScratch::BPE(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
+            }
+            (Self::Unigram(model), PipelineModelScratch::Unigram(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
+            }
+            (Self::WordLevel(model), PipelineModelScratch::WordLevel(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
+            }
+            (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
             }
             _ => unreachable!(),
         }


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`345377045 · 2026-07-28 22:43 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-overview.png" width="860">

**vs base branch** (`709ef7af5`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.93 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 12) · Pipeline 8+0 (peak 16)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 28.0 | ×3.57 | ×1.02 | 3% (1.2) | 77% (27.3) | 14% (5.0) | 6% (2.1) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 24.7 | ×5.85 | ×0.99 | 3% (1.2) | 68% (27.4) | 8% (3.3) | 21% (8.4) | 0% (0.0) | match |
| ben_Beng | lang | 6.1 | 34.2 | ×5.63 | ×0.98 | 4% (1.2) | 66% (19.1) | 10% (2.9) | 20% (6.0) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 19.1 | ×4.91 | ×1.02 | 2% (1.2) | 72% (37.8) | 10% (5.2) | 15% (7.9) | 0% (0.2) | match |
| ell_Grek | lang | 3.8 | 23.5 | ×6.21 | ×0.99 | 3% (1.2) | 67% (28.6) | 8% (3.4) | 22% (9.3) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 18.5 | ×4.21 | ×1.01 | 5% (2.5) | 72% (38.4) | 8% (4.4) | 15% (8.1) | 0% (0.2) | match |
| heb_Hebr | lang | 4.2 | 19.8 | ×4.72 | ×0.99 | 2% (1.2) | 74% (37.4) | 7% (3.6) | 16% (8.1) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 27.3 | ×4.22 | ×0.99 | 3% (1.2) | 74% (27.0) | 9% (3.2) | 14% (5.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 27.2 | ×6.34 | ×0.99 | 3% (1.2) | 64% (23.3) | 13% (4.6) | 20% (7.3) | 0% (0.1) | match |
| kat_Geor | lang | 6.2 | 27.9 | ×4.54 | ×1.00 | 3% (1.2) | 74% (26.4) | 9% (3.4) | 14% (4.9) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 17.1 | ×7.09 | ×0.97 | 2% (1.2) | 60% (35.0) | 13% (7.4) | 25% (14.5) | 0% (0.3) | match |
| rus_Cyrl | lang | 3.7 | 23.6 | ×6.43 | ×0.99 | 3% (1.2) | 65% (27.3) | 7% (3.1) | 25% (10.5) | 0% (0.1) | match |
| tam_Taml | lang | 7.0 | 38.1 | ×5.45 | ×1.00 | 4% (1.2) | 71% (18.5) | 10% (2.5) | 15% (3.9) | 0% (0.1) | match |
| tha_Thai | lang | 8.3 | 33.3 | ×4.01 | ×1.02 | 4% (1.2) | 82% (24.9) | 8% (2.6) | 5% (1.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.7 | 19.5 | ×2.90 | ×0.99 | 3% (1.3) | 81% (40.4) | 14% (7.0) | 3% (1.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 18.4 | ×3.44 | ×1.00 | 4% (1.9) | 74% (39.6) | 14% (7.4) | 8% (4.4) | 1% (0.3) | match |
| added_special_dense | modalities | 5.3 | 37.8 | ×7.10 | ×0.97 | 20% (5.1) | 37% (9.2) | 36% (9.1) | 7% (1.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 21.3 | ×5.37 | ×1.00 | 8% (3.7) | 61% (27.9) | 19% (8.8) | 12% (5.4) | 0% (0.1) | match |
| agentic-traces | modalities | 3.8 | 18.4 | ×4.83 | ×1.01 | 4% (2.3) | 71% (38.3) | 9% (4.9) | 16% (8.5) | 0% (0.1) | match |
| agentic_swe | modalities | 4.0 | 19.5 | ×4.85 | ×1.00 | 4% (1.9) | 76% (38.5) | 7% (3.5) | 13% (6.4) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 19.3 | ×4.93 | ×1.01 | 4% (2.1) | 74% (38.3) | 8% (4.2) | 13% (7.0) | 0% (0.2) | match |
| math_latex | modalities | 4.0 | 18.5 | ×4.62 | ×1.01 | 5% (2.5) | 71% (38.3) | 9% (4.7) | 16% (8.4) | 0% (0.1) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×4.24 vs v0.23.1 · ×1.02 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 67) · Pipeline 82+0 (peak 81)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 32.1 | ×7.49 | ×0.93 | 2% (0.7) | 0% (0.0) | 16% (4.7) | 82% (24.3) | 0% (0.0) | match |
| arb_Arab | lang | 4.1 | 16.9 | ×4.08 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (3.4) | 93% (58.5) | 1% (0.6) | match |
| ben_Beng | lang | 6.2 | 18.4 | ×2.98 | ×1.03 | 1% (0.6) | 0% (0.0) | 6% (3.1) | 93% (49.7) | 0% (0.0) | match |
| cmn_Hani | lang | 3.6 | 16.7 | ×4.57 | ×1.01 | 1% (0.8) | 0% (0.0) | 6% (3.2) | 93% (52.9) | 1% (0.3) | match |
| ell_Grek | lang | 4.6 | 18.6 | ×4.01 | ×1.04 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 92% (48.8) | 0% (0.1) | match |
| eng_Latn | lang | 3.1 | 13.2 | ×4.27 | ×1.01 | 3% (2.0) | 0% (0.0) | 7% (5.0) | 91% (66.1) | 0% (0.0) | match |
| heb_Hebr | lang | 4.0 | 13.3 | ×3.36 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (3.5) | 94% (70.0) | 0% (0.2) | match |
| hin_Deva | lang | 5.7 | 22.0 | ×3.82 | ×1.03 | 1% (0.6) | 0% (0.0) | 7% (3.3) | 91% (41.0) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 18.3 | ×4.30 | ×1.02 | 1% (0.7) | 0% (0.0) | 6% (3.0) | 93% (49.0) | 0% (0.0) | match |
| kat_Geor | lang | 6.0 | 17.3 | ×2.90 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (2.9) | 94% (51.0) | 0% (0.0) | match |
| kor_Hang | lang | 3.6 | 20.2 | ×5.56 | ×1.02 | 1% (0.6) | 0% (0.0) | 8% (3.7) | 91% (43.9) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.3 | 14.7 | ×3.38 | ×1.04 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 94% (63.1) | 0% (0.1) | match |
| tam_Taml | lang | 6.2 | 18.3 | ×2.95 | ×1.05 | 1% (0.6) | 0% (0.0) | 5% (2.7) | 94% (50.5) | 0% (0.0) | match |
| tha_Thai | lang | 7.0 | 14.8 | ×2.12 | ×1.03 | 1% (0.6) | 0% (0.0) | 3% (2.2) | 96% (68.0) | 0% (0.3) | match |
| added_normalized_dense | modalities | 6.0 | 24.3 | ×4.07 | ×1.04 | 2% (0.7) | 0% (0.0) | 7% (2.7) | 91% (36.6) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.3 | 20.3 | ×3.81 | ×1.03 | 3% (1.3) | 0% (0.0) | 8% (3.8) | 89% (42.9) | 0% (0.0) | match |
| added_special_dense | modalities | 3.6 | 36.9 | ×10.12 | ×0.99 | 25% (6.6) | 2% (0.5) | 24% (6.3) | 48% (12.4) | 1% (0.2) | match |
| added_special_sparse | modalities | 4.0 | 21.2 | ×5.31 | ×1.02 | 9% (4.0) | 0% (0.0) | 15% (6.8) | 76% (35.1) | 0% (0.1) | match |
| agentic-traces | modalities | 2.9 | 14.7 | ×5.00 | ×1.03 | 3% (1.8) | 0% (0.0) | 8% (5.4) | 90% (59.1) | 0% (0.0) | match |
| agentic_swe | modalities | 3.0 | 15.3 | ×5.07 | ×1.03 | 2% (1.3) | 0% (0.0) | 6% (3.9) | 92% (58.2) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 15.9 | ×4.59 | ×1.02 | 3% (1.5) | 0% (0.0) | 8% (4.6) | 90% (55.1) | 0% (0.1) | match |
| math_latex | modalities | 2.9 | 14.3 | ×5.01 | ×1.02 | 3% (1.9) | 0% (0.0) | 8% (5.4) | 90% (60.4) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.43 | 4.70 | 5.38 | 43.4 | 20.7 | 9.3 | — | 9.2× / 8.1× | 4.4× / 3.8× | 2.0× / 1.7× | — |
| arb_Arab | 1.18 | 3.00 | 3.38 | 5.21 | 51.1 | 23.0 | 10.2 | — | 15.1× / 9.8× | 6.8× / 4.4× | 3.0× / 2.0× | — |
| ben_Beng | 1.62 | 2.96 | 3.14 | 4.49 | 37.2 | 16.1 | 7.6 | — | 11.8× / 8.3× | 5.1× / 3.6× | 2.4× / 1.7× | — |
| cmn_Hani | 1.12 | 2.22 | 3.22 | 4.31 | 62.2 | 34.3 | 14.5 | — | 19.3× / 14.4× | 10.7× / 8.0× | 4.5× / 3.4× | — |
| ell_Grek | 0.61 | 2.94 | 3.38 | 5.72 | 49.1 | 21.3 | 9.5 | — | 14.5× / 8.6× | 6.3× / 3.7× | 2.8× / 1.7× | — |
| eng_Latn | 0.13 | 1.46 | 5.05 | 6.38 | 68.4 | 39.8 | 16.2 | — | 13.5× / 10.7× | 7.9× / 6.2× | 3.2× / 2.5× | — |
| heb_Hebr | 1.16 | 2.98 | 3.54 | 5.35 | 52.8 | 24.3 | 10.6 | — | 14.9× / 9.9× | 6.9× / 4.5× | 3.0× / 2.0× | — |
| hin_Deva | 1.53 | 3.12 | 3.29 | 4.88 | 39.6 | 18.7 | 8.5 | — | 12.0× / 8.1× | 5.7× / 3.8× | 2.6× / 1.7× | — |
| jpn_Jpan | 1.70 | 3.34 | 3.05 | 4.69 | 54.6 | 27.5 | 12.0 | — | 17.9× / 11.6× | 9.0× / 5.9× | 3.9× / 2.5× | — |
| kat_Geor | 1.55 | 2.57 | 2.93 | 3.95 | 33.5 | 15.3 | 7.2 | — | 11.4× / 8.5× | 5.2× / 3.9× | 2.5× / 1.8× | — |
| kor_Hang | 1.24 | 2.70 | 3.68 | 5.15 | 52.6 | 27.3 | 11.8 | — | 14.3× / 10.2× | 7.4× / 5.3× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.18 | 2.96 | 3.28 | 5.07 | 48.9 | 20.9 | 9.6 | — | 14.9× / 9.7× | 6.4× / 4.1× | 2.9× / 1.9× | — |
| tam_Taml | 0.93 | 2.93 | 2.69 | 4.68 | 32.6 | 13.8 | 6.6 | — | 12.1× / 7.0× | 5.1× / 2.9× | 2.5× / 1.4× | — |
| tha_Thai | 1.52 | 2.56 | 2.17 | 3.21 | 28.4 | 10.2 | 5.3 | — | 13.1× / 8.8× | 4.7× / 3.2× | 2.4× / 1.6× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.71 | 4.13 | 44.3 | 20.6 | 9.2 | — | 16.3× / 10.7× | 7.6× / 5.0× | 3.4× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.83 | 5.25 | 50.7 | 26.3 | 11.2 | — | 13.2× / 9.7× | 6.9× / 5.0× | 2.9× / 2.1× | — |
| added_special_dense | 0.06 | 1.47 | 6.31 | 7.73 | 180.8 | 100.6 | 38.2 | — | 28.7× / 23.4× | 16.0× / 13.0× | 6.1× / 4.9× | — |
| added_special_sparse | 0.06 | 1.47 | 6.78 | 8.19 | 106.1 | 59.3 | 24.0 | — | 15.7× / 12.9× | 8.7× / 7.2× | 3.5× / 2.9× | — |
| agentic-traces | 0.73 | 1.52 | 5.40 | 6.18 | 83.7 | 53.4 | 20.2 | — | 15.5× / 13.5× | 9.9× / 8.6× | 3.7× / 3.3× | — |
| agentic_swe | 0.67 | 1.46 | 3.90 | 4.69 | 99.2 | 66.6 | 24.7 | — | 25.5× / 21.2× | 17.1× / 14.2× | 6.3× / 5.3× | — |
| code_mixed | 0.10 | 1.44 | 4.60 | 5.94 | 76.9 | 54.1 | 18.4 | — | 16.7× / 13.0× | 11.7× / 9.1× | 4.0× / 3.1× | — |
| math_latex | 0.73 | 1.48 | 5.37 | 6.13 | 81.8 | 48.6 | 19.8 | — | 15.2× / 13.4× | 9.0× / 7.9× | 3.7× / 3.2× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×2.04 vs v0.23.1 · ×1.01 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 370) · Pipeline 275+0 (peak 371)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 9.7 | 27.5 | ×2.83 | ×1.00 | 2% (0.7) | 6% (2.1) | 0% (0.2) | 92% (31.1) | 0% (0.0) | match |
| arb_Arab | lang | 6.8 | 13.6 | ×2.00 | ×1.02 | 1% (0.6) | 3% (2.6) | 0% (0.2) | 98% (72.2) | 0% (0.0) | match |
| ben_Beng | lang | 9.2 | 18.2 | ×1.99 | ×0.98 | 1% (0.6) | 3% (1.7) | 0% (0.1) | 95% (49.3) | 1% (0.3) | match |
| cmn_Hani | lang | 10.7 | 34.4 | ×3.20 | ×1.02 | 2% (0.6) | 1% (0.3) | 0% (0.0) | 98% (25.4) | 0% (0.0) | match |
| ell_Grek | lang | 7.3 | 15.1 | ×2.06 | ×1.01 | 1% (0.6) | 4% (2.5) | 0% (0.2) | 95% (61.5) | 0% (0.0) | match |
| eng_Latn | lang | 3.6 | 5.5 | ×1.54 | ×1.00 | 1% (2.0) | 3% (4.8) | 0% (0.3) | 95% (167.1) | 1% (1.4) | match |
| heb_Hebr | lang | 7.5 | 17.3 | ×2.30 | ×1.04 | 1% (0.6) | 5% (2.6) | 0% (0.2) | 95% (53.0) | 0% (0.0) | match |
| hin_Deva | lang | 8.8 | 18.1 | ×2.07 | ×1.02 | 1% (0.6) | 4% (2.3) | 0% (0.1) | 93% (48.4) | 1% (0.4) | match |
| jpn_Jpan | lang | 11.2 | 29.4 | ×2.62 | ×1.02 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 97% (30.4) | 0% (0.1) | match |
| kat_Geor | lang | 11.3 | 25.3 | ×2.23 | ×1.03 | 2% (0.6) | 4% (1.4) | 0% (0.1) | 94% (35.6) | 0% (0.0) | match |
| kor_Hang | lang | 8.8 | 26.0 | ×2.95 | ×1.03 | 2% (0.6) | 8% (2.7) | 0% (0.1) | 91% (32.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 6.6 | 11.3 | ×1.70 | ×1.01 | 1% (0.6) | 3% (2.3) | 0% (0.1) | 98% (85.4) | 0% (0.0) | match |
| tam_Taml | lang | 10.2 | 19.7 | ×1.94 | ×1.01 | 1% (0.6) | 3% (1.3) | 0% (0.1) | 96% (45.8) | 0% (0.0) | match |
| tha_Thai | lang | 12.2 | 24.3 | ×1.99 | ×1.02 | 2% (0.6) | 2% (0.7) | 0% (0.0) | 97% (37.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.9 | 7.5 | ×1.54 | ×1.01 | 1% (0.7) | 2% (3.0) | 0% (0.2) | 96% (126.4) | 1% (1.2) | match |
| added_normalized_sparse | modalities | 4.3 | 6.5 | ×1.51 | ×0.99 | 1% (1.3) | 3% (4.4) | 0% (0.1) | 96% (138.6) | 0% (0.0) | match |
| added_special_dense | modalities | 4.7 | 19.6 | ×4.20 | ×0.97 | 20% (9.3) | 17% (8.0) | 16% (7.7) | 49% (22.9) | 0% (0.0) | match |
| added_special_sparse | modalities | 7.0 | 9.9 | ×1.42 | ×1.01 | 5% (5.2) | 9% (8.4) | 5% (5.0) | 81% (79.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.9 | 6.3 | ×1.60 | ×0.98 | 1% (1.8) | 3% (4.5) | 0% (0.2) | 95% (145.7) | 1% (0.9) | match |
| agentic_swe | modalities | 3.8 | 6.9 | ×1.80 | ×1.01 | 1% (1.3) | 5% (7.5) | 0% (0.5) | 93% (131.1) | 0% (0.2) | match |
| code_mixed | modalities | 3.9 | 6.5 | ×1.68 | ×1.00 | 1% (1.6) | 4% (6.2) | 0% (0.3) | 95% (138.9) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 5.9 | ×1.57 | ×0.99 | 1% (1.9) | 3% (4.6) | 0% (0.2) | 97% (157.3) | 0% (0.0) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×8.23 vs v0.23.1 · ×1.02 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 27+0 (peak 27)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 49.4 | ×13.00 | ×1.02 | 4% (0.7) | 0% (0.0) | 20% (3.6) | 77% (14.2) | 0% (0.0) | match |
| arb_Arab | lang | 3.7 | 24.8 | ×6.72 | ×0.97 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 92% (35.2) | 0% (0.0) | match |
| ben_Beng | lang | 2.8 | 46.0 | ×16.30 | ×1.04 | 3% (0.6) | 0% (0.0) | 15% (3.0) | 82% (17.0) | 0% (0.0) | match |
| cmn_Hani | lang | 3.6 | 29.1 | ×8.05 | ×1.01 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (30.0) | 0% (0.2) | match |
| ell_Grek | lang | 4.1 | 29.6 | ×7.18 | ×1.05 | 2% (0.6) | 0% (0.0) | 7% (2.2) | 91% (29.9) | 1% (0.3) | match |
| eng_Latn | lang | 3.4 | 13.9 | ×4.15 | ×0.99 | 3% (2.0) | 0% (0.0) | 4% (2.9) | 93% (63.3) | 0% (0.0) | match |
| heb_Hebr | lang | 3.8 | 30.4 | ×7.93 | ×1.05 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (29.6) | 0% (0.0) | match |
| hin_Deva | lang | 3.0 | 41.1 | ×13.71 | ×1.01 | 3% (0.6) | 0% (0.0) | 13% (3.1) | 84% (19.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.4 | 22.0 | ×5.02 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 93% (41.7) | 1% (0.3) | match |
| kat_Geor | lang | 4.6 | 68.3 | ×14.95 | ×1.05 | 4% (0.6) | 0% (0.0) | 15% (2.0) | 81% (11.3) | 0% (0.0) | match |
| kor_Hang | lang | 3.3 | 42.6 | ×12.82 | ×0.97 | 3% (0.6) | 0% (0.0) | 11% (2.4) | 86% (19.3) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.1 | 28.9 | ×7.05 | ×1.05 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 92% (31.2) | 0% (0.1) | match |
| tam_Taml | lang | 2.7 | 75.5 | ×28.42 | ×1.04 | 5% (0.6) | 0% (0.0) | 21% (2.7) | 74% (9.4) | 0% (0.0) | match |
| tha_Thai | lang | 3.5 | 39.0 | ×11.10 | ×1.10 | 2% (0.6) | 0% (0.0) | 10% (2.5) | 88% (21.7) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 26.5 | ×4.64 | ×1.04 | 2% (0.7) | 0% (0.0) | 3% (1.0) | 95% (34.3) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.0 | 22.0 | ×4.41 | ×1.02 | 3% (1.3) | 0% (0.0) | 5% (2.0) | 92% (40.2) | 0% (0.2) | match |
| added_special_dense | modalities | 4.1 | 45.9 | ×11.32 | ×0.96 | 25% (5.0) | 1% (0.2) | 20% (4.1) | 53% (10.6) | 0% (0.1) | match |
| added_special_sparse | modalities | 4.2 | 24.4 | ×5.81 | ×1.02 | 8% (3.2) | 0% (0.1) | 11% (4.4) | 80% (32.0) | 0% (0.1) | match |
| agentic-traces | modalities | 3.1 | 16.7 | ×5.45 | ×1.03 | 3% (1.8) | 0% (0.0) | 6% (3.4) | 91% (53.4) | 0% (0.0) | match |
| agentic_swe | modalities | 3.3 | 25.1 | ×7.70 | ×1.05 | 3% (1.3) | 0% (0.0) | 6% (2.4) | 90% (35.1) | 0% (0.1) | match |
| code_mixed | modalities | 3.4 | 21.1 | ×6.18 | ×1.03 | 3% (1.6) | 0% (0.0) | 6% (2.9) | 91% (42.0) | 0% (0.0) | match |
| math_latex | modalities | 3.1 | 15.6 | ×5.01 | ×1.03 | 3% (1.9) | 0% (0.0) | 5% (3.3) | 92% (57.6) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.80 | 3.42 | 3.63 | 4.25 | 27.1 | 21.8 | 5.7 | 4.8 | 7.5× / 6.4× | 6.0× / 5.1× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.20 | 2.97 | 2.28 | 4.05 | 31.7 | 27.6 | 6.8 | 5.1 | 13.9× / 7.8× | 12.1× / 6.8× | 3.0× / 1.7× | 2.3× / 1.3× |
| ben_Beng | 1.71 | 2.97 | 3.04 | 4.30 | 65.3 | 58.8 | 13.9 | 4.0 | 21.5× / 15.2× | 19.4× / 13.7× | 4.6× / 3.2× | 1.3× / 0.9× |
| cmn_Hani | 1.20 | 2.25 | 2.32 | 3.36 | 25.8 | 22.1 | 5.9 | 2.4 | 11.1× / 7.7× | 9.5× / 6.6× | 2.5× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.64 | 3.02 | 2.19 | 4.57 | 28.0 | 22.6 | 5.9 | 4.8 | 12.8× / 6.1× | 10.3× / 4.9× | 2.7× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.13 | 1.48 | 2.92 | 4.28 | 44.2 | 45.1 | 12.0 | 3.8 | 15.1× / 10.3× | 15.4× / 10.5× | 4.1× / 2.8× | 1.3× / 0.9× |
| heb_Hebr | 1.20 | 3.01 | 2.28 | 4.08 | 31.3 | 27.7 | 6.8 | 3.0 | 13.7× / 7.7× | 12.1× / 6.8× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.61 | 3.12 | 3.10 | 4.61 | 60.8 | 57.2 | 13.4 | 4.2 | 19.6× / 13.2× | 18.5× / 12.4× | 4.3× / 2.9× | 1.4× / 0.9× |
| jpn_Jpan | 1.78 | 3.39 | 2.13 | 3.73 | 23.0 | 18.2 | 5.0 | 3.9 | 10.8× / 6.2× | 8.6× / 4.9× | 2.3× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.64 | 2.52 | 2.03 | 2.92 | 17.0 | 14.8 | 4.3 | 2.0 | 8.4× / 5.8× | 7.3× / 5.1× | 2.1× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.25 | 2.68 | 2.44 | 3.87 | 31.2 | 28.9 | 7.4 | 3.6 | 12.8× / 8.1× | 11.8× / 7.5× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.22 | 2.91 | 2.10 | 3.79 | 26.8 | 22.7 | 5.8 | 2.4 | 12.8× / 7.1× | 10.8× / 6.0× | 2.7× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 1.31 | 4.51 | 2.67 | 5.87 | 67.9 | 61.5 | 14.7 | 3.8 | 25.4× / 11.6× | 23.1× / 10.5× | 5.5× / 2.5× | 1.4× / 0.6× |
| tha_Thai | 1.61 | 2.61 | 2.49 | 3.49 | 39.3 | 33.1 | 8.8 | 3.2 | 15.8× / 11.3× | 13.3× / 9.5× | 3.5× / 2.5× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.77 | 1.04 | 2.75 | 23.9 | 24.1 | 6.2 | 2.0 | 23.0× / 8.7× | 23.2× / 8.8× | 6.0× / 2.3× | 1.9× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.97 | 3.39 | 31.2 | 32.3 | 8.4 | 2.7 | 15.8× / 9.2× | 16.4× / 9.5× | 4.3× / 2.5× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.07 | 5.48 | 91.2 | 99.9 | 19.7 | 2.9 | 22.4× / 16.6× | 24.5× / 18.2× | 4.8× / 3.6× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.48 | 4.42 | 5.84 | 60.1 | 63.2 | 14.3 | 3.4 | 13.6× / 10.3× | 14.3× / 10.8× | 3.2× / 2.4× | 0.8× / 0.6× |
| agentic-traces | 0.74 | 1.47 | 3.45 | 4.17 | 57.9 | 62.1 | 15.3 | 4.6 | 16.8× / 13.9× | 18.0× / 14.9× | 4.4× / 3.7× | 1.3× / 1.1× |
| agentic_swe | 0.67 | 1.44 | 2.36 | 3.14 | 58.8 | 71.9 | 14.7 | 3.4 | 24.9× / 18.8× | 30.4× / 22.9× | 6.2× / 4.7× | 1.5× / 1.1× |
| code_mixed | 0.10 | 1.45 | 2.89 | 4.24 | 57.5 | 71.2 | 15.2 | 4.0 | 19.9× / 13.6× | 24.6× / 16.8× | 5.2× / 3.6× | 1.4× / 1.0× |
| math_latex | 0.73 | 1.48 | 3.26 | 4.02 | 51.7 | 53.0 | 13.8 | 4.2 | 15.8× / 12.9× | 16.2× / 13.2× | 4.2× / 3.4× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×5.04 vs v0.23.1 · ×1.03 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 25.9 | ×6.75 | ×1.11 | 2% (0.7) | 0% (0.0) | 13% (4.7) | 85% (30.5) | 0% (0.0) | match |
| arb_Arab | lang | 4.6 | 18.6 | ×4.09 | ×1.08 | 1% (0.6) | 0% (0.0) | 7% (3.3) | 92% (47.3) | 0% (0.1) | match |
| ben_Beng | lang | 6.6 | 17.7 | ×2.68 | ×1.01 | 1% (0.6) | 0% (0.0) | 7% (3.7) | 92% (50.6) | 0% (0.0) | match |
| cmn_Hani | lang | 4.4 | 12.1 | ×2.75 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (3.5) | 97% (74.8) | 0% (0.0) | match |
| ell_Grek | lang | 4.9 | 16.1 | ×3.26 | ×1.01 | 1% (0.6) | 0% (0.0) | 5% (3.2) | 94% (56.0) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 43.3 | ×11.05 | ×1.02 | 10% (2.0) | 0% (0.0) | 24% (4.5) | 66% (12.5) | 0% (0.1) | match |
| heb_Hebr | lang | 4.5 | 17.2 | ×3.81 | ×1.03 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 92% (50.6) | 0% (0.1) | match |
| hin_Deva | lang | 6.7 | 27.8 | ×4.13 | ×1.07 | 2% (0.6) | 0% (0.0) | 11% (3.8) | 87% (29.0) | 0% (0.1) | match |
| jpn_Jpan | lang | 5.3 | 12.7 | ×2.40 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (3.3) | 94% (71.0) | 1% (0.7) | match |
| kat_Geor | lang | 6.6 | 14.3 | ×2.18 | ×1.02 | 1% (0.6) | 0% (0.0) | 4% (2.8) | 94% (64.0) | 1% (0.9) | match |
| kor_Hang | lang | 4.0 | 15.8 | ×3.95 | ×1.03 | 1% (0.6) | 0% (0.0) | 6% (3.7) | 96% (55.6) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.2 | 16.7 | ×3.19 | ×1.07 | 1% (0.6) | 0% (0.0) | 6% (3.1) | 95% (53.0) | 0% (0.0) | match |
| tam_Taml | lang | 6.7 | 13.4 | ×1.99 | ×1.01 | 1% (0.6) | 0% (0.0) | 4% (3.2) | 95% (69.8) | 0% (0.0) | match |
| tha_Thai | lang | 7.7 | 11.5 | ×1.50 | ×1.00 | 1% (0.7) | 0% (0.0) | 4% (3.2) | 95% (80.1) | 1% (0.5) | match |
| added_normalized_dense | modalities | 5.4 | 26.1 | ×4.80 | ×1.03 | 2% (0.7) | 0% (0.0) | 6% (2.2) | 92% (34.8) | 1% (0.2) | match |
| added_normalized_sparse | modalities | 5.5 | 42.8 | ×7.78 | ×1.02 | 5% (1.3) | 0% (0.0) | 15% (3.4) | 80% (18.3) | 0% (0.0) | match |
| added_special_dense | modalities | 4.4 | 75.7 | ×17.24 | ×1.00 | 40% (5.0) | 1% (0.2) | 40% (4.9) | 19% (2.3) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.5 | 78.0 | ×17.20 | ×1.01 | 27% (3.2) | 0% (0.0) | 49% (5.8) | 25% (3.0) | 0% (0.0) | match |
| agentic-traces | modalities | 3.8 | 39.7 | ×10.52 | ×1.03 | 8% (1.8) | 0% (0.0) | 22% (5.0) | 71% (16.0) | 0% (0.0) | match |
| agentic_swe | modalities | 3.9 | 28.7 | ×7.41 | ×1.03 | 4% (1.3) | 0% (0.0) | 12% (3.8) | 85% (27.6) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 52.3 | ×13.20 | ×1.03 | 9% (1.5) | 0% (0.0) | 26% (4.4) | 64% (10.7) | 0% (0.1) | match |
| math_latex | modalities | 3.6 | 39.2 | ×11.04 | ×1.02 | 9% (1.9) | 0% (0.0) | 22% (4.8) | 69% (15.0) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.74 | 3.47 | 4.71 | 5.44 | 29.8 | 14.6 | 7.2 | 4.8 | 6.3× / 5.5× | 3.1× / 2.7× | 1.5× / 1.3× | 1.0× / 0.9× |
| arb_Arab | 1.15 | 2.98 | 3.34 | 5.18 | 34.0 | 16.3 | 7.6 | 5.0 | 10.2× / 6.6× | 4.9× / 3.2× | 2.3× / 1.5× | 1.5× / 1.0× |
| ben_Beng | 1.60 | 2.93 | 3.66 | 4.99 | 23.8 | 11.2 | 5.5 | 2.7 | 6.5× / 4.8× | 3.1× / 2.2× | 1.5× / 1.1× | 0.7× / 0.5× |
| cmn_Hani | 1.12 | 2.25 | 3.52 | 4.65 | 21.5 | 11.0 | 5.5 | 2.4 | 6.1× / 4.6× | 3.1× / 2.4× | 1.6× / 1.2× | 0.7× / 0.5× |
| ell_Grek | 0.58 | 2.97 | 3.20 | 5.59 | 30.2 | 15.4 | 7.0 | 5.1 | 9.4× / 5.4× | 4.8× / 2.8× | 2.2× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.09 | 1.46 | 4.52 | 5.89 | 44.3 | 30.2 | 13.8 | 4.2 | 9.8× / 7.5× | 6.7× / 5.1× | 3.0× / 2.3× | 0.9× / 0.7× |
| heb_Hebr | 1.14 | 3.00 | 3.39 | 5.25 | 34.9 | 17.6 | 8.1 | 2.8 | 10.3× / 6.6× | 5.2× / 3.3× | 2.4× / 1.5× | 0.8× / 0.5× |
| hin_Deva | 1.50 | 3.10 | 3.77 | 5.37 | 25.9 | 13.2 | 6.4 | 3.2 | 6.9× / 4.8× | 3.5× / 2.5× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.70 | 3.36 | 3.30 | 4.97 | 20.3 | 9.5 | 4.9 | 3.8 | 6.1× / 4.1× | 2.9× / 1.9× | 1.5× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.53 | 2.59 | 2.78 | 3.85 | 18.5 | 10.3 | 4.6 | 2.1 | 6.7× / 4.8× | 3.7× / 2.7× | 1.7× / 1.2× | 0.8× / 0.5× |
| kor_Hang | 1.23 | 2.71 | 3.72 | 5.20 | 32.8 | 19.4 | 8.9 | 3.6 | 8.8× / 6.3× | 5.2× / 3.7× | 2.4× / 1.7× | 1.0× / 0.7× |
| rus_Cyrl | 1.17 | 2.85 | 3.10 | 4.78 | 28.9 | 15.2 | 6.7 | 4.9 | 9.3× / 6.0× | 4.9× / 3.2× | 2.2× / 1.4× | 1.6× / 1.0× |
| tam_Taml | 0.91 | 2.92 | 3.18 | 5.19 | 19.0 | 9.0 | 4.3 | 3.0 | 6.0× / 3.7× | 2.8× / 1.7× | 1.4× / 0.8× | 0.9× / 0.6× |
| tha_Thai | 1.50 | 2.50 | 3.24 | 4.24 | 13.1 | 5.8 | 2.8 | 2.2 | 4.1× / 3.1× | 1.8× / 1.4× | 0.9× / 0.6× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.48 | 2.24 | 3.66 | 33.9 | 17.9 | 11.2 | 2.2 | 15.1× / 9.3× | 8.0× / 4.9× | 5.0× / 3.1× | 1.0× / 0.6× |
| added_normalized_sparse | 0.06 | 1.48 | 3.40 | 4.82 | 35.9 | 21.8 | 11.5 | 3.0 | 10.6× / 7.5× | 6.4× / 4.5× | 3.4× / 2.4× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.48 | 4.92 | 6.34 | 85.4 | 69.7 | 23.9 | 3.3 | 17.4× / 13.5× | 14.2× / 11.0× | 4.8× / 3.8× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.77 | 7.18 | 57.5 | 43.2 | 16.8 | 3.7 | 10.0× / 8.0× | 7.5× / 6.0× | 2.9× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.73 | 1.48 | 4.99 | 5.74 | 53.0 | 43.4 | 17.1 | 4.9 | 10.6× / 9.2× | 8.7× / 7.6× | 3.4× / 3.0× | 1.0× / 0.9× |
| agentic_swe | 0.67 | 1.44 | 3.77 | 4.53 | 53.8 | 50.4 | 17.2 | 3.6 | 14.3× / 11.9× | 13.4× / 11.1× | 4.6× / 3.8× | 1.0× / 0.8× |
| code_mixed | 0.06 | 1.44 | 4.38 | 5.75 | 53.1 | 48.6 | 17.3 | 4.3 | 12.1× / 9.2× | 11.1× / 8.5× | 3.9× / 3.0× | 1.0× / 0.7× |
| math_latex | 0.73 | 1.54 | 4.85 | 5.66 | 50.4 | 37.2 | 16.1 | 4.5 | 10.4× / 8.9× | 7.7× / 6.6× | 3.3× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×6.53 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 45.3 | ×11.74 | ×0.94 | 6% (1.2) | 0% (0.0) | 20% (3.8) | 73% (14.2) | 1% (0.2) | match |
| arb_Arab | lang | 4.1 | 17.4 | ×4.22 | ×0.97 | 2% (1.2) | 0% (0.0) | 4% (2.4) | 93% (49.8) | 1% (0.3) | match |
| ben_Beng | lang | 4.1 | 28.2 | ×6.79 | ×1.06 | 3% (1.2) | 0% (0.0) | 9% (3.1) | 88% (31.0) | 0% (0.0) | match |
| cmn_Hani | lang | 4.5 | 13.8 | ×3.04 | ×0.94 | 2% (1.2) | 0% (0.0) | 4% (2.4) | 96% (63.9) | 0% (0.0) | match |
| ell_Grek | lang | 4.8 | 19.5 | ×4.02 | ×1.00 | 2% (1.2) | 0% (0.0) | 5% (2.3) | 93% (45.9) | 0% (0.0) | match |
| eng_Latn | lang | 3.7 | 42.2 | ×11.34 | ×0.95 | 13% (2.5) | 0% (0.0) | 16% (3.1) | 73% (14.3) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 25.4 | ×6.18 | ×0.99 | 3% (1.2) | 0% (0.0) | 6% (2.4) | 91% (34.4) | 0% (0.0) | match |
| hin_Deva | lang | 3.9 | 30.7 | ×7.94 | ×1.03 | 4% (1.2) | 0% (0.0) | 10% (3.3) | 86% (27.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.4 | 15.4 | ×2.85 | ×0.99 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 95% (58.6) | 0% (0.0) | match |
| kat_Geor | lang | 6.3 | 22.4 | ×3.55 | ×1.01 | 3% (1.2) | 0% (0.0) | 5% (2.1) | 93% (40.2) | 0% (0.0) | match |
| kor_Hang | lang | 3.6 | 18.3 | ×5.03 | ×0.98 | 2% (1.2) | 0% (0.0) | 5% (2.6) | 94% (48.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.7 | 18.3 | ×3.86 | ×0.98 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 95% (48.7) | 0% (0.0) | match |
| tam_Taml | lang | 3.8 | 35.5 | ×9.26 | ×1.00 | 4% (1.2) | 0% (0.0) | 10% (2.7) | 86% (24.4) | 0% (0.0) | match |
| tha_Thai | lang | 5.0 | 22.0 | ×4.42 | ×1.05 | 3% (1.2) | 0% (0.0) | 6% (2.6) | 92% (40.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.2 | 27.5 | ×4.46 | ×1.02 | 4% (1.3) | 0% (0.0) | 3% (1.1) | 93% (33.2) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.4 | 42.6 | ×7.84 | ×1.02 | 8% (1.8) | 0% (0.0) | 9% (2.0) | 83% (18.8) | 0% (0.1) | match |
| added_special_dense | modalities | 4.2 | 46.3 | ×11.09 | ×0.97 | 63% (12.9) | 0% (0.0) | 26% (5.4) | 12% (2.5) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 56.8 | ×12.83 | ×0.99 | 42% (7.0) | 0% (0.1) | 30% (5.0) | 28% (4.6) | 0% (0.0) | match |
| agentic-traces | modalities | 3.5 | 36.8 | ×10.44 | ×1.03 | 10% (2.4) | 0% (0.0) | 15% (3.7) | 75% (18.8) | 1% (0.2) | match |
| agentic_swe | modalities | 3.8 | 28.0 | ×7.30 | ×1.00 | 6% (1.9) | 0% (0.0) | 8% (2.9) | 86% (29.6) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 45.9 | ×11.48 | ×1.01 | 11% (2.2) | 0% (0.0) | 17% (3.4) | 73% (14.7) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 39.8 | ×10.60 | ×1.02 | 11% (2.5) | 0% (0.0) | 15% (3.5) | 72% (16.7) | 2% (0.5) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.44 | 3.82 | 4.51 | 27.6 | 16.9 | 5.9 | 4.8 | 7.2× / 6.1× | 4.4× / 3.7× | 1.5× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.92 | 2.41 | 4.18 | 31.5 | 19.6 | 6.8 | 5.2 | 13.1× / 7.5× | 8.1× / 4.7× | 2.8× / 1.6× | 2.1× / 1.2× |
| ben_Beng | 1.60 | 2.95 | 3.15 | 4.50 | 45.9 | 28.3 | 10.5 | 3.7 | 14.6× / 10.2× | 9.0× / 6.3× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.13 | 2.21 | 2.42 | 3.50 | 19.8 | 11.8 | 4.7 | 2.3 | 8.2× / 5.7× | 4.9× / 3.4× | 1.9× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.98 | 2.32 | 4.71 | 28.9 | 17.4 | 6.2 | 4.8 | 12.5× / 6.1× | 7.5× / 3.7× | 2.7× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.11 | 1.46 | 3.08 | 4.43 | 44.8 | 33.9 | 12.6 | 3.8 | 14.5× / 10.1× | 11.0× / 7.6× | 4.1× / 2.8× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 2.98 | 2.38 | 4.22 | 31.5 | 20.3 | 6.9 | 3.0 | 13.2× / 7.5× | 8.5× / 4.8× | 2.9× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.50 | 3.12 | 3.28 | 4.89 | 48.6 | 30.9 | 11.3 | 4.0 | 14.8× / 9.9× | 9.4× / 6.3× | 3.4× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.69 | 3.34 | 2.23 | 3.88 | 18.4 | 10.0 | 4.1 | 3.7 | 8.3× / 4.7× | 4.5× / 2.6× | 1.8× / 1.1× | 1.6× / 0.9× |
| kat_Geor | 1.52 | 2.60 | 2.10 | 3.19 | 17.4 | 11.5 | 4.2 | 2.0 | 8.3× / 5.5× | 5.4× / 3.6× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.23 | 2.68 | 2.56 | 4.02 | 31.6 | 22.1 | 7.6 | 3.6 | 12.3× / 7.9× | 8.6× / 5.5× | 3.0× / 1.9× | 1.4× / 0.9× |
| rus_Cyrl | 1.16 | 2.93 | 2.20 | 3.97 | 27.3 | 16.7 | 5.9 | 2.4 | 12.4× / 6.9× | 7.6× / 4.2× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.91 | 2.95 | 2.74 | 4.78 | 44.7 | 26.9 | 9.9 | 3.4 | 16.3× / 9.3× | 9.8× / 5.6× | 3.6× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.67 | 2.55 | 2.65 | 3.53 | 28.6 | 16.8 | 6.9 | 3.0 | 10.8× / 8.1× | 6.3× / 4.8× | 2.6× / 1.9× | 1.1× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.09 | 2.51 | 24.0 | 17.3 | 6.6 | 1.8 | 22.0× / 9.6× | 15.8× / 6.9× | 6.1× / 2.6× | 1.6× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.97 | 3.38 | 31.7 | 23.5 | 8.9 | 2.6 | 16.1× / 9.4× | 11.9× / 6.9× | 4.5× / 2.6× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 5.36 | 6.78 | 96.7 | 76.2 | 21.5 | 3.2 | 18.0× / 14.3× | 14.2× / 11.2× | 4.0× / 3.2× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.98 | 6.39 | 62.1 | 47.6 | 15.7 | 3.6 | 12.5× / 9.7× | 9.6× / 7.4× | 3.1× / 2.5× | 0.7× / 0.6× |
| agentic-traces | 0.77 | 1.48 | 3.74 | 4.45 | 54.2 | 47.7 | 15.4 | 4.5 | 14.5× / 12.2× | 12.7× / 10.7× | 4.1× / 3.5× | 1.2× / 1.0× |
| agentic_swe | 0.68 | 1.45 | 2.89 | 3.67 | 56.3 | 53.9 | 16.1 | 3.4 | 19.5× / 15.4× | 18.6× / 14.7× | 5.6× / 4.4× | 1.2× / 0.9× |
| code_mixed | 0.09 | 1.45 | 3.39 | 4.74 | 56.8 | 52.6 | 15.8 | 4.0 | 16.7× / 12.0× | 15.5× / 11.1× | 4.7× / 3.3× | 1.2× / 0.8× |
| math_latex | 0.88 | 1.49 | 3.49 | 4.10 | 51.8 | 40.0 | 14.6 | 4.2 | 14.9× / 12.6× | 11.5× / 9.7× | 4.2× / 3.6× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.78 vs v0.23.1 · ×1.04 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.7 | 42.7 | ×9.09 | ×1.06 | 0% (0.0) | 13% (2.8) | 0% (0.1) | 87% (18.3) | 0% (0.0) | match |
| arb_Arab | lang | 10.2 | 51.2 | ×5.02 | ×1.05 | 0% (0.0) | 17% (3.2) | 0% (0.1) | 82% (15.1) | 0% (0.0) | match |
| ben_Beng | lang | 11.2 | 84.7 | ×7.58 | ×1.12 | 0% (0.0) | 20% (2.2) | 1% (0.1) | 79% (8.4) | 0% (0.0) | match |
| cmn_Hani | lang | 9.2 | 64.9 | ×7.08 | ×1.05 | 0% (0.1) | 4% (0.5) | 0% (0.0) | 97% (13.1) | 0% (0.0) | match |
| ell_Grek | lang | 10.2 | 58.6 | ×5.74 | ×1.06 | 0% (0.0) | 20% (3.2) | 1% (0.1) | 80% (12.7) | 0% (0.0) | match |
| eng_Latn | lang | 4.1 | 6.4 | ×1.57 | ×1.00 | 0% (0.1) | 5% (6.9) | 0% (0.2) | 96% (144.5) | 0% (0.0) | match |
| heb_Hebr | lang | 10.3 | 62.4 | ×6.05 | ×1.07 | 0% (0.0) | 22% (3.3) | 1% (0.1) | 77% (11.6) | 0% (0.0) | match |
| hin_Deva | lang | 12.1 | 81.2 | ×6.72 | ×1.10 | 0% (0.0) | 25% (2.9) | 1% (0.1) | 73% (8.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 12.8 | 85.8 | ×6.69 | ×1.08 | 1% (0.1) | 4% (0.4) | 0% (0.0) | 97% (10.0) | 0% (0.0) | match |
| kat_Geor | lang | 14.3 | 91.4 | ×6.38 | ×1.08 | 0% (0.0) | 19% (1.9) | 1% (0.1) | 80% (7.9) | 0% (0.0) | match |
| kor_Hang | lang | 7.4 | 52.1 | ×7.02 | ×1.05 | 0% (0.1) | 19% (3.3) | 1% (0.1) | 81% (14.3) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.7 | 16.4 | ×2.13 | ×1.03 | 0% (0.0) | 5% (2.8) | 0% (0.1) | 95% (56.2) | 0% (0.0) | match |
| tam_Taml | lang | 12.6 | 90.4 | ×7.17 | ×1.09 | 0% (0.0) | 18% (1.8) | 1% (0.1) | 82% (8.2) | 0% (0.0) | match |
| tha_Thai | lang | 15.4 | 89.0 | ×5.79 | ×1.08 | 0% (0.0) | 10% (1.0) | 0% (0.0) | 91% (9.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.5 | 8.8 | ×1.60 | ×0.99 | 0% (0.1) | 3% (3.8) | 0% (0.1) | 99% (108.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.8 | 7.5 | ×1.55 | ×1.01 | 0% (0.0) | 5% (6.1) | 0% (0.1) | 96% (123.0) | 0% (0.0) | match |
| added_special_dense | modalities | 3.7 | 20.3 | ×5.43 | ×1.01 | 11% (5.0) | 32% (15.0) | 3% (1.4) | 54% (25.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 5.2 | 10.4 | ×2.00 | ×1.02 | 2% (2.1) | 15% (13.9) | 1% (0.6) | 82% (76.0) | 0% (0.2) | match |
| agentic-traces | modalities | 4.4 | 7.1 | ×1.63 | ×1.01 | 0% (0.1) | 5% (6.3) | 0% (0.1) | 95% (129.2) | 0% (0.1) | match |
| agentic_swe | modalities | 4.0 | 7.0 | ×1.76 | ×1.01 | 0% (0.0) | 7% (9.7) | 0% (0.3) | 93% (129.8) | 0% (0.0) | match |
| code_mixed | modalities | 4.1 | 7.0 | ×1.70 | ×1.00 | 0% (0.0) | 6% (8.0) | 0% (0.2) | 94% (130.8) | 0% (0.1) | match |
| math_latex | modalities | 4.3 | 6.8 | ×1.59 | ×1.00 | 0% (0.1) | 5% (6.5) | 0% (0.2) | 96% (136.3) | 0% (0.0) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×7.23 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 94)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 48.8 | ×12.31 | ×1.01 | 4% (0.7) | 0% (0.0) | 21% (3.7) | 78% (13.7) | 0% (0.0) | match |
| arb_Arab | lang | 3.9 | 17.7 | ×4.57 | ×0.99 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 95% (50.5) | 0% (0.0) | match |
| ben_Beng | lang | 3.8 | 32.0 | ×8.32 | ×1.02 | 2% (0.6) | 0% (0.0) | 10% (3.1) | 88% (26.7) | 0% (0.0) | match |
| cmn_Hani | lang | 4.9 | 16.0 | ×3.28 | ×0.96 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 97% (55.0) | 0% (0.0) | match |
| ell_Grek | lang | 5.0 | 19.6 | ×3.89 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (2.2) | 94% (46.4) | 0% (0.2) | match |
| eng_Latn | lang | 4.0 | 45.3 | ×11.36 | ×0.98 | 11% (2.0) | 0% (0.0) | 17% (3.0) | 74% (13.4) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 26.0 | ×6.33 | ×1.00 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 93% (33.9) | 0% (0.0) | match |
| hin_Deva | lang | 4.4 | 78.5 | ×18.02 | ×1.02 | 5% (0.6) | 0% (0.0) | 29% (3.3) | 66% (7.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.5 | 16.2 | ×2.93 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (55.7) | 0% (0.2) | match |
| kat_Geor | lang | 5.7 | 35.5 | ×6.27 | ×0.96 | 2% (0.6) | 0% (0.0) | 8% (2.1) | 90% (23.9) | 0% (0.0) | match |
| kor_Hang | lang | 3.8 | 18.9 | ×4.98 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (2.6) | 92% (47.1) | 2% (0.8) | match |
| rus_Cyrl | lang | 4.7 | 16.3 | ×3.50 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 96% (55.9) | 0% (0.0) | match |
| tam_Taml | lang | 4.0 | 36.8 | ×9.17 | ×1.04 | 2% (0.6) | 0% (0.0) | 10% (2.7) | 88% (23.2) | 0% (0.0) | match |
| tha_Thai | lang | 5.0 | 20.7 | ×4.10 | ×1.02 | 1% (0.6) | 0% (0.0) | 6% (2.6) | 93% (43.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.3 | 27.6 | ×4.40 | ×1.02 | 2% (0.7) | 0% (0.0) | 3% (1.1) | 95% (33.2) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.6 | 43.3 | ×7.77 | ×1.02 | 6% (1.3) | 0% (0.0) | 9% (2.0) | 85% (18.8) | 0% (0.1) | match |
| added_special_dense | modalities | 4.3 | 72.0 | ×16.87 | ×0.95 | 39% (5.0) | 1% (0.2) | 39% (4.9) | 21% (2.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.5 | 70.9 | ×15.76 | ×0.98 | 25% (3.2) | 0% (0.0) | 40% (5.2) | 34% (4.5) | 1% (0.1) | match |
| agentic-traces | modalities | 3.6 | 38.7 | ×10.61 | ×1.03 | 7% (1.8) | 0% (0.0) | 15% (3.8) | 80% (19.7) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 29.0 | ×7.11 | ×1.02 | 4% (1.3) | 0% (0.0) | 9% (2.9) | 88% (28.8) | 0% (0.0) | match |
| code_mixed | modalities | 4.2 | 47.9 | ×11.30 | ×1.02 | 8% (1.6) | 0% (0.0) | 18% (3.3) | 75% (13.9) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 41.9 | ×11.02 | ×1.02 | 9% (1.9) | 0% (0.0) | 16% (3.4) | 73% (16.1) | 2% (0.5) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.77 | 3.43 | 3.65 | 4.32 | 27.4 | 16.5 | 5.9 | 4.8 | 7.5× / 6.3× | 4.5× / 3.8× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.97 | 2.33 | 4.15 | 31.3 | 19.9 | 6.9 | 5.2 | 13.4× / 7.5× | 8.5× / 4.8× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.60 | 2.98 | 3.12 | 4.51 | 45.5 | 28.6 | 10.5 | 3.7 | 14.6× / 10.1× | 9.2× / 6.3× | 3.4× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.11 | 2.24 | 2.40 | 3.53 | 19.6 | 12.2 | 4.7 | 2.4 | 8.2× / 5.6× | 5.1× / 3.5× | 1.9× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.00 | 2.23 | 4.65 | 28.6 | 17.3 | 6.1 | 4.7 | 12.8× / 6.2× | 7.8× / 3.7× | 2.7× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.12 | 1.45 | 3.05 | 4.38 | 44.7 | 34.0 | 12.6 | 3.8 | 14.7× / 10.2× | 11.2× / 7.8× | 4.1× / 2.9× | 1.2× / 0.9× |
| heb_Hebr | 1.15 | 3.03 | 2.34 | 4.22 | 31.2 | 20.5 | 7.0 | 3.0 | 13.3× / 7.4× | 8.8× / 4.9× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.50 | 3.15 | 3.27 | 4.92 | 48.1 | 31.3 | 11.3 | 4.0 | 14.7× / 9.8× | 9.6× / 6.4× | 3.4× / 2.3× | 1.2× / 0.8× |
| jpn_Jpan | 1.69 | 3.41 | 2.18 | 3.90 | 18.3 | 10.4 | 4.1 | 3.8 | 8.4× / 4.7× | 4.8× / 2.7× | 1.9× / 1.0× | 1.7× / 1.0× |
| kat_Geor | 1.53 | 2.61 | 2.09 | 3.17 | 17.2 | 11.4 | 4.2 | 2.0 | 8.2× / 5.4× | 5.5× / 3.6× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.23 | 2.73 | 2.55 | 4.06 | 31.4 | 22.2 | 7.6 | 3.7 | 12.3× / 7.7× | 8.7× / 5.5× | 3.0× / 1.9× | 1.4× / 0.9× |
| rus_Cyrl | 1.16 | 2.87 | 2.17 | 3.88 | 27.1 | 16.6 | 6.0 | 2.5 | 12.5× / 7.0× | 7.7× / 4.3× | 2.8× / 1.5× | 1.2× / 0.7× |
| tam_Taml | 0.91 | 2.96 | 2.69 | 4.73 | 44.4 | 27.5 | 10.0 | 3.4 | 16.5× / 9.4× | 10.2× / 5.8× | 3.7× / 2.1× | 1.3× / 0.7× |
| tha_Thai | 1.50 | 2.51 | 2.61 | 3.61 | 28.4 | 16.5 | 6.8 | 3.0 | 10.9× / 7.8× | 6.3× / 4.6× | 2.6× / 1.9× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.12 | 2.53 | 23.8 | 17.3 | 6.6 | 1.8 | 21.3× / 9.4× | 15.5× / 6.8× | 5.9× / 2.6× | 1.6× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.97 | 3.39 | 31.8 | 22.9 | 8.9 | 2.5 | 16.1× / 9.4× | 11.6× / 6.8× | 4.5× / 2.6× | 1.3× / 0.7× |
| added_special_dense | 0.06 | 1.48 | 4.95 | 6.37 | 95.2 | 75.5 | 21.2 | 3.1 | 19.2× / 15.0× | 15.3× / 11.9× | 4.3× / 3.3× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.16 | 6.58 | 61.0 | 45.7 | 15.1 | 3.6 | 11.8× / 9.3× | 8.9× / 6.9× | 2.9× / 2.3× | 0.7× / 0.6× |
| agentic-traces | 0.74 | 1.47 | 3.79 | 4.52 | 53.9 | 46.2 | 15.2 | 4.6 | 14.2× / 11.9× | 12.2× / 10.2× | 4.0× / 3.4× | 1.2× / 1.0× |
| agentic_swe | 0.69 | 1.45 | 2.87 | 3.63 | 56.0 | 53.3 | 15.8 | 3.4 | 19.5× / 15.4× | 18.6× / 14.7× | 5.5× / 4.3× | 1.2× / 0.9× |
| code_mixed | 0.06 | 1.44 | 3.34 | 4.71 | 54.0 | 51.8 | 15.4 | 4.0 | 16.2× / 11.5× | 15.5× / 11.0× | 4.6× / 3.3× | 1.2× / 0.8× |
| math_latex | 0.71 | 1.57 | 3.45 | 4.31 | 52.0 | 40.0 | 14.3 | 4.2 | 15.1× / 12.1× | 11.6× / 9.3× | 4.1× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×3.57 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 194) · Pipeline 108+0 (peak 194)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.7 | 30.5 | ×8.17 | ×1.01 | 4% (1.2) | 0% (0.0) | 48% (14.8) | 47% (14.3) | 1% (0.4) | match |
| arb_Arab | lang | 4.3 | 16.9 | ×3.97 | ×0.99 | 2% (1.2) | 0% (0.0) | 30% (16.7) | 67% (37.8) | 1% (0.3) | match |
| ben_Beng | lang | 6.6 | 17.2 | ×2.59 | ×1.00 | 2% (1.2) | 0% (0.0) | 20% (11.3) | 78% (44.3) | 0% (0.0) | match |
| cmn_Hani | lang | 4.8 | 15.5 | ×3.20 | ×1.00 | 2% (1.2) | 0% (0.0) | 19% (12.1) | 79% (49.5) | 0% (0.0) | match |
| ell_Grek | lang | 5.1 | 15.8 | ×3.12 | ×1.03 | 2% (1.2) | 0% (0.0) | 25% (15.6) | 73% (45.1) | 0% (0.0) | match |
| eng_Latn | lang | 3.8 | 19.1 | ×5.09 | ×1.00 | 5% (2.5) | 0% (0.0) | 60% (30.7) | 33% (17.0) | 1% (0.7) | match |
| heb_Hebr | lang | 4.4 | 14.1 | ×3.25 | ×1.01 | 2% (1.2) | 0% (0.0) | 26% (17.7) | 73% (50.5) | 0% (0.0) | match |
| hin_Deva | lang | 6.4 | 21.6 | ×3.35 | ×1.00 | 3% (1.2) | 0% (0.0) | 29% (13.2) | 68% (30.4) | 0% (0.2) | match |
| jpn_Jpan | lang | 5.4 | 15.4 | ×2.83 | ×1.01 | 2% (1.2) | 0% (0.0) | 15% (9.8) | 82% (52.6) | 0% (0.3) | match |
| kat_Geor | lang | 6.4 | 14.7 | ×2.30 | ×1.03 | 2% (1.2) | 0% (0.0) | 16% (10.9) | 82% (55.4) | 0% (0.1) | match |
| kor_Hang | lang | 3.9 | 14.8 | ×3.85 | ×0.98 | 2% (1.2) | 0% (0.0) | 30% (19.6) | 69% (44.6) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.5 | 14.0 | ×3.11 | ×0.98 | 2% (1.2) | 0% (0.0) | 22% (15.4) | 76% (52.6) | 0% (0.0) | match |
| tam_Taml | lang | 6.5 | 14.5 | ×2.21 | ×0.99 | 2% (1.2) | 0% (0.0) | 13% (9.1) | 85% (57.7) | 0% (0.0) | match |
| tha_Thai | lang | 7.8 | 15.3 | ×1.95 | ×1.01 | 2% (1.2) | 0% (0.0) | 10% (6.1) | 89% (56.7) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 20.3 | ×3.57 | ×0.98 | 3% (1.3) | 0% (0.0) | 37% (17.9) | 60% (28.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 24.6 | ×4.57 | ×0.99 | 5% (1.8) | 0% (0.0) | 54% (21.3) | 41% (16.4) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 16.3 | ×3.79 | ×0.98 | 9% (5.1) | 0% (0.0) | 86% (50.4) | 6% (3.5) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 21.6 | ×4.86 | ×0.98 | 8% (3.6) | 0% (0.0) | 80% (35.3) | 12% (5.3) | 0% (0.1) | match |
| agentic-traces | modalities | 3.3 | 14.5 | ×4.38 | ×0.98 | 4% (2.4) | 0% (0.0) | 64% (43.1) | 31% (20.7) | 2% (1.0) | match |
| agentic_swe | modalities | 3.3 | 11.4 | ×3.39 | ×1.02 | 2% (1.9) | 0% (0.0) | 60% (53.5) | 37% (32.7) | 1% (0.8) | match |
| code_mixed | modalities | 3.6 | 15.0 | ×4.13 | ×1.01 | 3% (2.1) | 0% (0.0) | 73% (48.7) | 25% (16.7) | 0% (0.0) | match |
| math_latex | modalities | 3.5 | 17.2 | ×4.89 | ×0.99 | 4% (2.5) | 0% (0.0) | 64% (38.5) | 30% (17.6) | 2% (1.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.74 | 3.42 | 14.78 | 15.45 | 27.6 | 14.3 | 6.8 | — | 1.9× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| arb_Arab | 1.15 | 2.92 | 16.74 | 18.51 | 31.8 | 16.5 | 7.4 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| ben_Beng | 1.60 | 2.91 | 11.33 | 12.64 | 22.2 | 11.0 | 5.4 | — | 2.0× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| cmn_Hani | 1.11 | 2.23 | 12.12 | 13.23 | 21.0 | 11.5 | 5.6 | — | 1.7× / 1.6× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| ell_Grek | 0.59 | 2.94 | 15.56 | 17.91 | 27.9 | 15.5 | 6.5 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| eng_Latn | 0.09 | 1.46 | 30.71 | 32.08 | 40.6 | 30.9 | 13.7 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| heb_Hebr | 1.14 | 3.05 | 17.70 | 19.61 | 30.8 | 17.0 | 7.7 | — | 1.7× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| hin_Deva | 1.50 | 3.14 | 13.19 | 14.82 | 23.9 | 13.2 | 6.2 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| jpn_Jpan | 1.70 | 3.36 | 9.82 | 11.48 | 19.9 | 9.8 | 4.9 | — | 2.0× / 1.7× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| kat_Geor | 1.53 | 2.59 | 10.85 | 11.91 | 17.5 | 10.3 | 4.6 | — | 1.6× / 1.5× | 0.9× / 0.9× | 0.4× / 0.4× | — |
| kor_Hang | 1.23 | 2.67 | 19.56 | 21.00 | 31.1 | 19.6 | 8.8 | — | 1.6× / 1.5× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| rus_Cyrl | 1.16 | 2.88 | 15.36 | 17.08 | 27.1 | 15.0 | 6.5 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| tam_Taml | 0.91 | 2.90 | 9.05 | 11.05 | 18.0 | 9.0 | 4.2 | — | 2.0× / 1.6× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| tha_Thai | 1.51 | 2.57 | 6.13 | 7.19 | 12.9 | 6.0 | 2.8 | — | 2.1× / 1.8× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| added_normalized_dense | 0.24 | 1.47 | 17.85 | 19.08 | 31.1 | 17.0 | 11.3 | — | 1.7× / 1.6× | 1.0× / 0.9× | 0.6× / 0.6× | — |
| added_normalized_sparse | 0.25 | 1.47 | 21.31 | 22.54 | 32.1 | 20.5 | 11.6 | — | 1.5× / 1.4× | 1.0× / 0.9× | 0.5× / 0.5× | — |
| added_special_dense | 0.24 | 1.47 | 50.45 | 51.68 | 80.2 | 67.3 | 23.6 | — | 1.6× / 1.6× | 1.3× / 1.3× | 0.5× / 0.5× | — |
| added_special_sparse | 0.24 | 1.47 | 35.27 | 36.50 | 52.1 | 41.7 | 16.5 | — | 1.5× / 1.4× | 1.2× / 1.1× | 0.5× / 0.5× | — |
| agentic-traces | 0.86 | 1.47 | 43.15 | 43.76 | 51.8 | 44.8 | 17.4 | — | 1.2× / 1.2× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| agentic_swe | 0.68 | 1.45 | 53.54 | 54.31 | 56.8 | 55.4 | 19.3 | — | 1.1× / 1.0× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| code_mixed | 0.07 | 1.44 | 48.67 | 50.04 | 51.3 | 48.8 | 17.6 | — | 1.1× / 1.0× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| math_latex | 0.78 | 1.48 | 38.48 | 39.17 | 48.3 | 38.2 | 16.7 | — | 1.3× / 1.2× | 1.0× / 1.0× | 0.4× / 0.4× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30404887260-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
