### PR TITLE
perf(scratch): reuse Scratch buffers across encode() calls

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1438,6 +1438,24 @@ mod tests {
             assert!(pipeline_ids(&pipeline, "").is_empty());
         }
 
+        // The pool hands the SAME scratch to successive encodes. State left behind by one
+        // call — an undrained merge queue, a stale word buffer — would corrupt every call
+        // after it. Drive several inputs through one scratch and check each still matches
+        // the reference model.
+        #[test]
+        fn reused_scratch_matches_fresh() {
+            let bpe = hello_builder().build().unwrap();
+            let reference = bpe.clone();
+            let model = PipelineBPE::from_bpe(bpe, false).unwrap();
+            let mut scratch = model.init_scratch();
+            for input in ["hello", "hell", "helo", "oleh", "hello", "", "hxe"] {
+                let mut out = Vec::new();
+                pipeline::Model::tokenize_pipeline(&model, input, &mut scratch, &mut out).unwrap();
+                let got: Vec<u32> = out.iter().map(|t| t.id).collect();
+                assert_eq!(got, reference_ids(&reference, input), "{input:?}");
+            }
+        }
+
         #[test]
         fn unknown_char_without_unk_is_dropped() {
             let bpe = hello_builder().build().unwrap();

--- a/tokenizers/tk-encode/src/models/bpe/word.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word.rs
@@ -102,6 +102,11 @@ impl Word {
         self.symbols.len()
     }
 
+    #[cfg(test)]
+    pub(crate) fn capacity(&self) -> usize {
+        self.symbols.capacity()
+    }
+
     pub fn add(&mut self, c: u32, byte_len: usize) {
         let (prev, next) = {
             let len = self.symbols.len() as isize;

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -455,19 +455,14 @@ pub struct PipelineTokenizer {
     scratch_pool: ScratchPool,
 }
 
-/// Working space for encoding, lent out and taken back.
+/// A pool of [`PipelineModelScratch`].
 ///
-/// Encoding needs buffers to build tokens in, and building them per call means asking the
-/// allocator for the same things over and over. So they are borrowed instead: a caller
-/// takes a scratch, hands it back when it is done, and the next caller gets one whose
-/// buffers are already as big as the last encode needed. A model empties what it uses as
-/// it goes, so a scratch comes back ready to use.
+/// When calling [`PipelineTokenizer::encode`], an instance of [`PipelineModelScratch`] is taken out of this pool
+/// and given to the tokenizer. When the encoding is done, the scratch buffer is returned to the pool and can be
+/// reused by later calls.
 ///
-/// A tokenizer encodes through `&self` and several threads may be in it at once, so a
-/// scratch cannot simply live in the tokenizer — each thread needs its own. The pool ends
-/// up holding one per thread that has encoded at the same time as the others, and frees
-/// them all with the tokenizer. A single thread encoding in a loop — the common case —
-/// borrows and returns the same one every time.
+/// The reusability matters because the scratch buffer may hold cache structures which are more useful when reused,
+/// and less importantly it saves an extra allocation for an fresh buffer every time.
 struct ScratchPool(Mutex<Vec<PipelineModelScratch>>);
 
 impl ScratchPool {
@@ -475,23 +470,31 @@ impl ScratchPool {
         Self(Mutex::new(Vec::new()))
     }
 
-    /// Borrow a scratch; dropping the guard gives it back. The lock is held just long
-    /// enough to move one out, never while encoding.
+    /// Get a scratch buffer from the pool, wrapped in a [`ScratchGuard`].
+    /// When the [`ScratchGuard`] gets dropped, the scratch buffer is pushed back to the pool.
     fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
+        // The Mutex lock is held just long enough to pop the scratch out of the pool
         let taken = self.0.lock().unwrap_or_else(PoisonError::into_inner).pop();
         ScratchGuard {
+            // If there was no scratch buffer available in the pool, we build.a fresh one
             scratch: taken.unwrap_or_else(|| model.init_scratch()),
             pool: self,
         }
     }
 
     #[cfg(test)]
-    fn stored_scratches(&self) -> usize {
+    fn len(&self) -> usize {
         self.0.lock().unwrap_or_else(PoisonError::into_inner).len()
     }
 }
 
-/// Gives the scratch back to the pool when it goes out of scope.
+/// A wrapper around [`PipelineModelScratch`].
+/// Implements [`Deref`] and [`DerefMut`], so it behaves as [`PipelineModelScratch`].
+///
+/// When it gets dropped, it pushes [`Self::scratch`] back into the shared [`Self::pool`] so it can
+/// get reused by a later call to [`PipelineTokenizer::encode`].
+///
+/// TODO @McPatate : The Mutex can create contention, to be replaced by a better access pattern
 struct ScratchGuard<'a> {
     scratch: PipelineModelScratch,
     pool: &'a ScratchPool,
@@ -499,7 +502,9 @@ struct ScratchGuard<'a> {
 
 impl Drop for ScratchGuard<'_> {
     fn drop(&mut self) {
+        // Steals the scratch buffer from self, replaces it with PipelineModelScratch::default()
         let scratch = mem::take(&mut self.scratch);
+        // Push the scratch back in the pool
         self.pool
             .0
             .lock()
@@ -1287,14 +1292,17 @@ impl Model for PipelineModel {
     }
 }
 
+/// A set of buffers and other state the model needs to encode efficiently,
+/// reused among calls to [`PipelineTokenizer::encode`].
+///
+/// Each model gets its own variant.
 #[derive(Default)]
 pub enum PipelineModelScratch {
     BPE(BpeScratch),
     WordLevel(()),
     WordPiece(WordPieceScratch),
     Unigram(UnigramScratch),
-    /// Costs nothing to build, and stands in for the real scratch while a guard is
-    /// handing it back to the pool.
+    /// We need a default value to able to use [`mem::take`] in [`ScratchGuard::drop`]
     #[default]
     None,
 }
@@ -1754,7 +1762,7 @@ mod tests {
         for _ in 0..1000 {
             pipeline.encode("hello", false).wait().unwrap();
         }
-        assert_eq!(pipeline.scratch_pool.stored_scratches(), 1);
+        assert_eq!(pipeline.scratch_pool.len(), 1);
 
         let threads = 64;
         let all_holding = Barrier::new(threads);
@@ -1768,7 +1776,7 @@ mod tests {
             }
         });
 
-        let after_burst = pipeline.scratch_pool.stored_scratches();
+        let after_burst = pipeline.scratch_pool.len();
         assert!(
             after_burst <= threads,
             "{after_burst} scratches kept for {threads} threads"
@@ -1776,6 +1784,6 @@ mod tests {
         for _ in 0..1000 {
             pipeline.encode("hello", false).wait().unwrap();
         }
-        assert_eq!(pipeline.scratch_pool.stored_scratches(), after_burst);
+        assert_eq!(pipeline.scratch_pool.len(), after_burst);
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
 use std::iter::Enumerate;
+use std::mem;
+use std::sync::{Mutex, PoisonError};
 use std::vec::IntoIter;
 use std::{borrow::Cow, convert::TryFrom};
 
@@ -450,6 +452,73 @@ pub struct PipelineTokenizer {
     pre_tokenizer: PipelinePreTokenizer,
     model: PipelineModel,
     post_processor: PipelinePostProcessor,
+    scratch_pool: ScratchPool,
+}
+
+/// Working space for encoding, lent out and taken back.
+///
+/// Encoding needs buffers to build tokens in, and building them per call means asking the
+/// allocator for the same things over and over. So they are borrowed instead: a caller
+/// takes a scratch, hands it back when it is done, and the next caller gets one whose
+/// buffers are already as big as the last encode needed. A model empties what it uses as
+/// it goes, so a scratch comes back ready to use.
+///
+/// A tokenizer encodes through `&self` and several threads may be in it at once, so a
+/// scratch cannot simply live in the tokenizer — each thread needs its own. The pool ends
+/// up holding one per thread that has encoded at the same time as the others, and frees
+/// them all with the tokenizer. A single thread encoding in a loop — the common case —
+/// borrows and returns the same one every time.
+struct ScratchPool(Mutex<Vec<PipelineModelScratch>>);
+
+impl ScratchPool {
+    fn new() -> Self {
+        Self(Mutex::new(Vec::new()))
+    }
+
+    /// Borrow a scratch; dropping the guard gives it back. The lock is held just long
+    /// enough to move one out, never while encoding.
+    fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
+        let taken = self.0.lock().unwrap_or_else(PoisonError::into_inner).pop();
+        ScratchGuard {
+            scratch: taken.unwrap_or_else(|| model.init_scratch()),
+            pool: self,
+        }
+    }
+
+    #[cfg(test)]
+    fn stored_scratches(&self) -> usize {
+        self.0.lock().unwrap_or_else(PoisonError::into_inner).len()
+    }
+}
+
+/// Gives the scratch back to the pool when it goes out of scope.
+struct ScratchGuard<'a> {
+    scratch: PipelineModelScratch,
+    pool: &'a ScratchPool,
+}
+
+impl Drop for ScratchGuard<'_> {
+    fn drop(&mut self) {
+        let scratch = mem::take(&mut self.scratch);
+        self.pool
+            .0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(scratch);
+    }
+}
+
+impl std::ops::Deref for ScratchGuard<'_> {
+    type Target = PipelineModelScratch;
+    fn deref(&self) -> &PipelineModelScratch {
+        &self.scratch
+    }
+}
+
+impl std::ops::DerefMut for ScratchGuard<'_> {
+    fn deref_mut(&mut self) -> &mut PipelineModelScratch {
+        &mut self.scratch
+    }
 }
 
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
@@ -571,6 +640,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
                 .map(PipelinePostProcessor::try_from)
                 .transpose()?
                 .unwrap_or_default(),
+            scratch_pool: ScratchPool::new(),
         })
     }
 }
@@ -842,7 +912,7 @@ impl PipelineTokenizer {
     ) -> Result<Vec<PipelineToken>> {
         let mut pre_tokens = Vec::with_capacity(input.len() / 4);
         let mut output = Vec::with_capacity(input.len() / 4);
-        let mut scratch = self.model.init_scratch();
+        let mut scratch = self.scratch_pool.get(&self.model);
         let PipelinePostProcessor { prefix, suffix } = &self.post_processor;
         // Prepend prefix tokens, if any
         // todo: handle post-processing when encoding a pair of sequences (currently unsupported by the PipelineTokenizer)
@@ -1217,11 +1287,16 @@ impl Model for PipelineModel {
     }
 }
 
+#[derive(Default)]
 pub enum PipelineModelScratch {
     BPE(BpeScratch),
     WordLevel(()),
     WordPiece(WordPieceScratch),
     Unigram(UnigramScratch),
+    /// Costs nothing to build, and stands in for the real scratch while a guard is
+    /// handing it back to the pool.
+    #[default]
+    None,
 }
 
 impl ModelScratch for PipelineModelScratch {}
@@ -1601,5 +1676,106 @@ mod tests {
         );
         let err = conversion_error(&tok);
         assert!(err.contains("not supported"), "{}", err);
+    }
+
+    /// A BPE pipeline that merges "hello" into the single id 7.
+    fn hello_pipeline() -> PipelineTokenizer {
+        use crate::models::bpe::{BpeBuilder, Merges, Vocab};
+
+        let vocab: Vocab = [
+            ("h", 0u32),
+            ("e", 1),
+            ("l", 2),
+            ("o", 3),
+            ("he", 4),
+            ("hel", 5),
+            ("hell", 6),
+            ("hello", 7),
+        ]
+        .into_iter()
+        .map(|(s, i)| (s.to_string(), i))
+        .collect();
+        let merges: Merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+            ("hel".to_string(), "l".to_string()),
+            ("hell".to_string(), "o".to_string()),
+        ];
+        let bpe = BpeBuilder::default()
+            .vocab_and_merges(vocab, merges)
+            .build()
+            .unwrap();
+        PipelineTokenizer::try_from(&Tokenizer::new(bpe)).unwrap()
+    }
+
+    // The pool exists so ONE `&self` tokenizer can be shared across rayon workers. Encode
+    // the same input from thousands of threads through a single instance; each must get a
+    // private scratch and produce the sequential result. Two threads sharing a scratch
+    // would corrupt some of them — and this only compiles if `PipelineTokenizer: Sync`,
+    // which the pool has to preserve.
+    #[test]
+    fn encode_shared_across_threads() {
+        use rayon::prelude::*;
+
+        let pipeline = hello_pipeline();
+
+        let want: Vec<u32> = pipeline
+            .encode("hello", false)
+            .wait()
+            .unwrap()
+            .remove(0)
+            .iter()
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(want, vec![7]);
+
+        let all_match = (0..10_000u32).into_par_iter().all(|_| {
+            pipeline
+                .encode("hello", false)
+                .wait()
+                .unwrap()
+                .remove(0)
+                .iter()
+                .map(|t| t.id)
+                .collect::<Vec<_>>()
+                == want
+        });
+        assert!(all_match);
+    }
+
+    // Reusing scratches is the whole point of the pool, so it must not build one per call:
+    // one thread encoding in a loop has to keep coming back to the same scratch, and a
+    // burst of N threads must leave at most N behind for later calls to use.
+    #[test]
+    fn scratches_are_reused_rather_than_piling_up() {
+        use std::sync::Barrier;
+
+        let pipeline = hello_pipeline();
+        for _ in 0..1000 {
+            pipeline.encode("hello", false).wait().unwrap();
+        }
+        assert_eq!(pipeline.scratch_pool.stored_scratches(), 1);
+
+        let threads = 64;
+        let all_holding = Barrier::new(threads);
+        std::thread::scope(|scope| {
+            for _ in 0..threads {
+                scope.spawn(|| {
+                    let scratch = pipeline.scratch_pool.get(&pipeline.model);
+                    all_holding.wait();
+                    drop(scratch);
+                });
+            }
+        });
+
+        let after_burst = pipeline.scratch_pool.stored_scratches();
+        assert!(
+            after_burst <= threads,
+            "{after_burst} scratches kept for {threads} threads"
+        );
+        for _ in 0..1000 {
+            pipeline.encode("hello", false).wait().unwrap();
+        }
+        assert_eq!(pipeline.scratch_pool.stored_scratches(), after_burst);
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1786,4 +1786,48 @@ mod tests {
         }
         assert_eq!(pipeline.scratch_pool.len(), after_burst);
     }
+
+    // ScratchGuard::drop moves the scratch to the pool with mem::take, which leaves the
+    // default None variant behind in the guard. The pool must end up holding the scratch
+    // the model used: if the None leftover were pushed instead, the pool would still
+    // count one scratch, and the next encode would take it and panic in
+    // PipelineModel::tokenize_pipeline.
+    #[test]
+    fn the_pool_gets_back_the_used_scratch_not_the_none_leftover() {
+        let pipeline = hello_pipeline();
+        pipeline.encode("hello", false).wait().unwrap();
+        assert_eq!(pipeline.scratch_pool.len(), 1);
+        let scratch = pipeline.scratch_pool.get(&pipeline.model);
+        assert!(
+            matches!(*scratch, PipelineModelScratch::BPE(_)),
+            "the pooled scratch is not the BPE scratch the model used"
+        );
+    }
+
+    // Pooling is only worth it if a scratch keeps the state it built up across calls.
+    // A fresh BpeScratch has room for 64 symbols; encoding a longer sequence grows it.
+    // After a second, short encode the pooled scratch must still be the grown one,
+    // not a fresh replacement built somewhere along the way.
+    #[test]
+    fn a_reused_scratch_keeps_its_grown_buffers() {
+        let pipeline = hello_pipeline();
+        let long_input = "hello".repeat(50);
+        pipeline.encode(&long_input, false).wait().unwrap();
+        assert_eq!(pipeline.scratch_pool.len(), 1);
+
+        pipeline.encode("hello", false).wait().unwrap();
+        assert_eq!(pipeline.scratch_pool.len(), 1);
+
+        let scratch = pipeline.scratch_pool.get(&pipeline.model);
+        let PipelineModelScratch::BPE(bpe_scratch) = &*scratch else {
+            panic!("the pooled scratch is not a BPE scratch");
+        };
+        assert!(
+            bpe_scratch.word.capacity() >= long_input.len(),
+            "the pooled scratch is not the one grown by the long input: \
+             room for {} symbols after a {}-byte input",
+            bpe_scratch.word.capacity(),
+            long_input.len()
+        );
+    }
 }


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**10 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`428973821 · 2026-08-04 22:59 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 16 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-overview.png" width="860">

**vs base branch** (`f3bf3e820`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.94 vs v0.23.1 · ×1.42 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 12) · Pipeline 8+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 27.5 | ×3.48 | ×1.39 | 3% (1.2) | 76% (27.5) | 13% (4.7) | 7% (2.7) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 24.8 | ×5.89 | ×1.46 | 3% (1.2) | 68% (27.5) | 8% (3.3) | 20% (8.2) | 0% (0.2) | match |
| ben_Beng | lang | 6.0 | 34.2 | ×5.71 | ×1.40 | 4% (1.2) | 67% (19.3) | 10% (2.8) | 19% (5.5) | 0% (0.1) | match |
| cmn_Hani | lang | 3.8 | 18.8 | ×4.91 | ×1.49 | 2% (1.2) | 71% (37.7) | 10% (5.5) | 16% (8.5) | 0% (0.1) | match |
| ell_Grek | lang | 3.8 | 23.7 | ×6.31 | ×1.42 | 3% (1.2) | 68% (28.6) | 8% (3.4) | 21% (9.1) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 18.3 | ×4.20 | ×1.47 | 5% (2.5) | 71% (38.6) | 8% (4.4) | 16% (8.8) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 19.8 | ×4.72 | ×1.46 | 2% (1.2) | 74% (37.6) | 7% (3.7) | 15% (7.8) | 0% (0.2) | match |
| hin_Deva | lang | 6.5 | 27.3 | ×4.21 | ×1.40 | 3% (1.2) | 74% (26.9) | 8% (3.0) | 14% (5.3) | 1% (0.2) | match |
| jpn_Jpan | lang | 4.3 | 27.3 | ×6.40 | ×1.44 | 3% (1.2) | 64% (23.3) | 13% (4.6) | 20% (7.4) | 0% (0.1) | match |
| kat_Geor | lang | 6.1 | 28.1 | ×4.61 | ×1.45 | 3% (1.2) | 74% (26.2) | 10% (3.5) | 13% (4.5) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 17.6 | ×7.37 | ×1.52 | 2% (1.2) | 61% (34.9) | 13% (7.3) | 23% (13.2) | 1% (0.6) | match |
| rus_Cyrl | lang | 3.6 | 23.7 | ×6.52 | ×1.41 | 3% (1.2) | 65% (27.4) | 8% (3.2) | 24% (10.3) | 0% (0.1) | match |
| tam_Taml | lang | 6.9 | 38.2 | ×5.51 | ×1.42 | 4% (1.2) | 71% (18.7) | 9% (2.3) | 14% (3.7) | 1% (0.3) | match |
| tha_Thai | lang | 8.3 | 33.0 | ×3.98 | ×1.42 | 4% (1.2) | 84% (25.1) | 7% (2.2) | 5% (1.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.7 | 19.8 | ×2.94 | ×1.54 | 3% (1.3) | 81% (40.7) | 14% (7.3) | 1% (0.7) | 0% (0.2) | match |
| added_normalized_sparse | modalities | 5.3 | 18.4 | ×3.47 | ×1.48 | 4% (1.9) | 74% (39.8) | 13% (7.1) | 10% (5.2) | 0% (0.0) | match |
| added_special_dense | modalities | 5.4 | 37.6 | ×7.03 | ×1.49 | 33% (8.5) | 27% (7.1) | 33% (8.7) | 7% (1.8) | 0% (0.1) | match |
| added_special_sparse | modalities | 4.0 | 21.3 | ×5.30 | ×1.44 | 9% (4.1) | 60% (27.9) | 19% (8.8) | 13% (5.8) | 0% (0.1) | match |
| agentic-traces | modalities | 3.8 | 18.2 | ×4.73 | ×1.47 | 4% (2.4) | 70% (38.5) | 9% (5.1) | 17% (9.1) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 19.4 | ×4.80 | ×1.48 | 4% (1.9) | 75% (38.7) | 7% (3.6) | 14% (7.0) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 19.0 | ×4.91 | ×1.02 | 4% (2.1) | 73% (38.6) | 8% (4.2) | 14% (7.5) | 0% (0.2) | match |
| math_latex | modalities | 3.9 | 18.2 | ×4.65 | ×1.27 | 5% (2.5) | 71% (38.7) | 8% (4.6) | 16% (9.0) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×4.46 vs v0.23.1 · ×1.25 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 82+0 (peak 82)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 33.6 | ×8.91 | ×1.27 | 2% (0.7) | 0% (0.0) | 16% (4.7) | 82% (23.9) | 0% (0.0) | match |
| arb_Arab | lang | 3.5 | 16.0 | ×4.55 | ×1.21 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 94% (56.5) | 0% (0.0) | match |
| ben_Beng | lang | 5.9 | 16.3 | ×2.77 | ×1.22 | 1% (0.6) | 0% (0.0) | 5% (3.1) | 94% (53.3) | 0% (0.0) | match |
| cmn_Hani | lang | 3.2 | 15.6 | ×4.86 | ×1.21 | 1% (0.8) | 0% (0.0) | 5% (3.2) | 93% (55.4) | 0% (0.0) | match |
| ell_Grek | lang | 4.3 | 18.2 | ×4.19 | ×1.29 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (50.8) | 0% (0.0) | match |
| eng_Latn | lang | 2.7 | 12.5 | ×4.59 | ×0.98 | 3% (2.0) | 0% (0.0) | 7% (5.0) | 91% (68.9) | 0% (0.0) | match |
| heb_Hebr | lang | 3.2 | 13.0 | ×3.99 | ×1.23 | 1% (0.6) | 0% (0.0) | 5% (3.6) | 94% (72.1) | 0% (0.1) | match |
| hin_Deva | lang | 5.5 | 21.7 | ×3.96 | ×1.36 | 1% (0.6) | 0% (0.0) | 7% (3.3) | 92% (41.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 3.8 | 17.9 | ×4.71 | ×1.33 | 1% (0.7) | 0% (0.0) | 6% (3.0) | 94% (51.0) | 0% (0.0) | match |
| kat_Geor | lang | 5.6 | 17.8 | ×3.17 | ×1.06 | 1% (0.6) | 0% (0.0) | 5% (2.9) | 94% (52.4) | 0% (0.0) | match |
| kor_Hang | lang | 2.8 | 19.6 | ×6.98 | ×0.97 | 1% (0.6) | 0% (0.0) | 7% (3.7) | 91% (45.3) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.0 | 14.5 | ×3.60 | ×1.23 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 94% (64.7) | 0% (0.0) | match |
| tam_Taml | lang | 6.1 | 17.5 | ×2.89 | ×1.26 | 1% (0.6) | 0% (0.0) | 5% (2.7) | 94% (53.5) | 0% (0.0) | match |
| tha_Thai | lang | 6.4 | 14.5 | ×2.28 | ×1.20 | 1% (0.6) | 0% (0.0) | 3% (2.2) | 96% (65.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 23.3 | ×3.92 | ×1.45 | 2% (0.8) | 0% (0.0) | 7% (2.7) | 91% (38.1) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.3 | 19.3 | ×3.63 | ×1.38 | 3% (1.3) | 0% (0.0) | 8% (3.8) | 90% (44.8) | 0% (0.1) | match |
| added_special_dense | modalities | 3.5 | 35.2 | ×9.94 | ×1.41 | 24% (6.5) | 4% (1.0) | 24% (6.5) | 48% (12.9) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 20.3 | ×5.17 | ×1.41 | 8% (3.9) | 1% (0.3) | 14% (6.8) | 76% (36.2) | 1% (0.3) | match |
| agentic-traces | modalities | 2.7 | 14.1 | ×5.23 | ×1.26 | 3% (1.8) | 0% (0.0) | 8% (5.4) | 90% (61.9) | 0% (0.0) | match |
| agentic_swe | modalities | 2.8 | 15.1 | ×5.28 | ×1.32 | 2% (1.3) | 0% (0.0) | 6% (3.9) | 92% (60.5) | 0% (0.0) | match |
| code_mixed | modalities | 3.4 | 15.3 | ×4.56 | ×1.30 | 2% (1.6) | 0% (0.0) | 7% (4.7) | 90% (56.9) | 0% (0.1) | match |
| math_latex | modalities | 2.7 | 13.8 | ×5.19 | ×1.27 | 3% (1.9) | 0% (0.0) | 8% (5.5) | 89% (62.8) | 0% (0.3) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.76 | 3.13 | 4.67 | 5.05 | 44.8 | 20.0 | 9.2 | — | 9.6× / 8.9× | 4.3× / 3.9× | 2.0× / 1.8× | — |
| arb_Arab | 1.15 | 2.76 | 3.40 | 5.01 | 51.7 | 22.3 | 10.3 | — | 15.2× / 10.3× | 6.6× / 4.5× | 3.0× / 2.1× | — |
| ben_Beng | 1.60 | 2.64 | 3.12 | 4.15 | 37.9 | 16.0 | 7.6 | — | 12.2× / 9.1× | 5.1× / 3.9× | 2.4× / 1.8× | — |
| cmn_Hani | 1.12 | 2.01 | 3.20 | 4.09 | 65.2 | 33.3 | 14.6 | — | 20.4× / 15.9× | 10.4× / 8.1× | 4.6× / 3.6× | — |
| ell_Grek | 0.58 | 2.79 | 3.40 | 5.61 | 49.9 | 20.8 | 9.4 | — | 14.7× / 8.9× | 6.1× / 3.7× | 2.8× / 1.7× | — |
| eng_Latn | 0.10 | 1.45 | 5.05 | 6.40 | 71.1 | 37.5 | 16.1 | — | 14.1× / 11.1× | 7.4× / 5.9× | 3.2× / 2.5× | — |
| heb_Hebr | 1.15 | 2.82 | 3.61 | 5.29 | 53.7 | 23.2 | 10.6 | — | 14.9× / 10.2× | 6.4× / 4.4× | 2.9× / 2.0× | — |
| hin_Deva | 1.52 | 2.81 | 3.33 | 4.62 | 42.1 | 18.0 | 8.7 | — | 12.7× / 9.1× | 5.4× / 3.9× | 2.6× / 1.9× | — |
| jpn_Jpan | 1.70 | 3.12 | 3.01 | 4.43 | 56.2 | 26.8 | 12.0 | — | 18.6× / 12.7× | 8.9× / 6.1× | 4.0× / 2.7× | — |
| kat_Geor | 1.54 | 2.18 | 2.94 | 3.58 | 34.7 | 14.8 | 7.2 | — | 11.8× / 9.7× | 5.0× / 4.1× | 2.4× / 2.0× | — |
| kor_Hang | 1.22 | 2.53 | 3.68 | 4.99 | 53.9 | 26.2 | 12.0 | — | 14.6× / 10.8× | 7.1× / 5.3× | 3.3× / 2.4× | — |
| rus_Cyrl | 1.16 | 2.77 | 3.32 | 4.93 | 48.9 | 20.1 | 9.3 | — | 14.7× / 9.9× | 6.1× / 4.1× | 2.8× / 1.9× | — |
| tam_Taml | 0.92 | 2.69 | 2.70 | 4.46 | 33.1 | 13.4 | 6.5 | — | 12.3× / 7.4× | 5.0× / 3.0× | 2.4× / 1.5× | — |
| tha_Thai | 1.55 | 2.26 | 2.18 | 2.88 | 28.1 | 9.9 | 5.2 | — | 12.9× / 9.8× | 4.5× / 3.4× | 2.4× / 1.8× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.72 | 4.13 | 44.6 | 19.1 | 9.1 | — | 16.4× / 10.8× | 7.0× / 4.6× | 3.4× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.78 | 5.19 | 51.4 | 25.6 | 11.4 | — | 13.6× / 9.9× | 6.8× / 4.9× | 3.0× / 2.2× | — |
| added_special_dense | 0.06 | 1.47 | 6.52 | 7.93 | 190.4 | 94.8 | 38.2 | — | 29.2× / 24.0× | 14.5× / 11.9× | 5.9× / 4.8× | — |
| added_special_sparse | 0.06 | 1.47 | 6.78 | 8.20 | 111.2 | 56.5 | 23.8 | — | 16.4× / 13.6× | 8.3× / 6.9× | 3.5× / 2.9× | — |
| agentic-traces | 0.99 | 1.47 | 5.40 | 5.88 | 88.6 | 52.0 | 20.1 | — | 16.4× / 15.1× | 9.6× / 8.8× | 3.7× / 3.4× | — |
| agentic_swe | 0.66 | 1.47 | 3.90 | 4.71 | 103.1 | 63.7 | 23.4 | — | 26.5× / 21.9× | 16.4× / 13.5× | 6.0× / 5.0× | — |
| code_mixed | 0.08 | 1.43 | 4.68 | 6.03 | 79.3 | 52.9 | 18.6 | — | 16.9× / 13.1× | 11.3× / 8.8× | 4.0× / 3.1× | — |
| math_latex | 0.91 | 1.47 | 5.46 | 6.02 | 84.5 | 45.9 | 19.2 | — | 15.5× / 14.0× | 8.4× / 7.6× | 3.5× / 3.2× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×2.00 vs v0.23.1 · ×1.08 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 371) · Pipeline 274+0 (peak 370)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 9.8 | 27.3 | ×2.78 | ×1.10 | 2% (0.7) | 4% (1.3) | 0% (0.0) | 93% (32.5) | 1% (0.4) | match |
| arb_Arab | lang | 6.9 | 12.2 | ×1.76 | ×1.09 | 1% (0.6) | 2% (1.7) | 0% (0.0) | 96% (82.7) | 1% (1.0) | match |
| ben_Beng | lang | 9.1 | 17.9 | ×1.96 | ×1.11 | 1% (0.6) | 2% (1.1) | 0% (0.0) | 98% (54.1) | 0% (0.0) | match |
| cmn_Hani | lang | 11.1 | 33.8 | ×3.04 | ×1.10 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 96% (27.4) | 1% (0.4) | match |
| ell_Grek | lang | 7.2 | 14.6 | ×2.02 | ×1.05 | 1% (0.6) | 2% (1.7) | 0% (0.0) | 97% (65.4) | 0% (0.0) | match |
| eng_Latn | lang | 3.5 | 5.3 | ×1.53 | ×1.10 | 1% (2.0) | 2% (3.2) | 0% (0.0) | 98% (188.0) | 0% (0.0) | match |
| heb_Hebr | lang | 7.6 | 16.7 | ×2.21 | ×1.10 | 1% (0.6) | 3% (1.6) | 0% (0.0) | 96% (56.2) | 0% (0.1) | match |
| hin_Deva | lang | 8.6 | 17.8 | ×2.06 | ×1.12 | 1% (0.6) | 3% (1.5) | 0% (0.0) | 98% (53.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 11.5 | 28.7 | ×2.50 | ×1.14 | 2% (0.6) | 0% (0.2) | 0% (0.0) | 98% (32.8) | 0% (0.0) | match |
| kat_Geor | lang | 11.7 | 25.0 | ×2.14 | ×1.06 | 2% (0.6) | 2% (0.9) | 0% (0.0) | 96% (38.0) | 0% (0.0) | match |
| kor_Hang | lang | 8.8 | 26.1 | ×2.97 | ×1.06 | 2% (0.6) | 5% (1.7) | 0% (0.0) | 94% (34.6) | 0% (0.1) | match |
| rus_Cyrl | lang | 6.4 | 10.3 | ×1.61 | ×1.08 | 1% (0.6) | 2% (1.5) | 0% (0.0) | 99% (93.1) | 0% (0.0) | match |
| tam_Taml | lang | 10.0 | 19.2 | ×1.92 | ×1.06 | 1% (0.6) | 2% (0.9) | 0% (0.0) | 97% (49.0) | 0% (0.0) | match |
| tha_Thai | lang | 11.7 | 23.3 | ×1.99 | ×1.06 | 2% (0.6) | 1% (0.5) | 0% (0.0) | 97% (39.6) | 1% (0.3) | match |
| added_normalized_dense | modalities | 4.9 | 7.4 | ×1.51 | ×1.03 | 1% (0.8) | 1% (1.8) | 0% (0.0) | 99% (129.2) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.4 | 6.6 | ×1.48 | ×1.05 | 1% (1.4) | 2% (2.9) | 0% (0.0) | 97% (143.0) | 0% (0.0) | match |
| added_special_dense | modalities | 4.6 | 20.6 | ×4.45 | ×1.10 | 22% (9.7) | 15% (6.7) | 13% (6.0) | 50% (22.4) | 0% (0.2) | match |
| added_special_sparse | modalities | 6.7 | 9.9 | ×1.47 | ×1.03 | 5% (5.2) | 7% (6.9) | 4% (4.1) | 84% (81.5) | 0% (0.0) | match |
| agentic-traces | modalities | 3.9 | 6.2 | ×1.59 | ×1.07 | 1% (1.8) | 2% (2.9) | 0% (0.0) | 97% (159.8) | 0% (0.8) | match |
| agentic_swe | modalities | 3.9 | 6.9 | ×1.78 | ×1.07 | 1% (1.3) | 3% (4.1) | 0% (0.0) | 96% (146.9) | 0% (0.1) | match |
| code_mixed | modalities | 3.9 | 6.4 | ×1.65 | ×1.06 | 1% (1.6) | 2% (3.6) | 0% (0.0) | 99% (152.8) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 5.8 | ×1.54 | ×1.10 | 1% (1.9) | 2% (3.0) | 0% (0.0) | 98% (170.2) | 0% (0.0) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×8.60 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 27+0 (peak 28)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 44.7 | ×12.30 | ×0.96 | 3% (0.7) | 0% (0.0) | 17% (3.6) | 80% (16.9) | 0% (0.0) | match |
| arb_Arab | lang | 3.5 | 25.2 | ×7.12 | ×0.96 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 93% (35.5) | 0% (0.0) | match |
| ben_Beng | lang | 2.8 | 47.5 | ×17.23 | ×1.01 | 3% (0.6) | 0% (0.0) | 16% (3.1) | 81% (15.9) | 0% (0.0) | match |
| cmn_Hani | lang | 3.5 | 29.3 | ×8.45 | ×1.01 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (30.5) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 29.8 | ×7.78 | ×1.00 | 2% (0.6) | 0% (0.0) | 7% (2.2) | 92% (30.5) | 0% (0.0) | match |
| eng_Latn | lang | 3.2 | 14.1 | ×4.42 | ×1.00 | 3% (2.0) | 0% (0.0) | 4% (2.9) | 93% (65.3) | 0% (0.3) | match |
| heb_Hebr | lang | 3.6 | 30.0 | ×8.25 | ×1.00 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 92% (30.4) | 0% (0.0) | match |
| hin_Deva | lang | 2.8 | 41.8 | ×15.03 | ×0.99 | 3% (0.6) | 0% (0.0) | 13% (3.1) | 85% (20.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.2 | 21.8 | ×5.16 | ×0.97 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (42.9) | 0% (0.0) | match |
| kat_Geor | lang | 4.4 | 72.6 | ×16.54 | ×0.98 | 5% (0.6) | 0% (0.0) | 15% (2.1) | 82% (11.3) | 0% (0.0) | match |
| kor_Hang | lang | 3.1 | 45.1 | ×14.43 | ×1.01 | 3% (0.6) | 0% (0.0) | 11% (2.5) | 86% (18.9) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.8 | 27.7 | ×7.38 | ×1.00 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 93% (33.0) | 0% (0.0) | match |
| tam_Taml | lang | 2.4 | 66.0 | ×26.94 | ×0.96 | 4% (0.6) | 0% (0.0) | 18% (2.7) | 78% (11.6) | 0% (0.0) | match |
| tha_Thai | lang | 3.2 | 37.1 | ×11.49 | ×0.98 | 2% (0.6) | 0% (0.0) | 9% (2.5) | 88% (23.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.4 | 25.8 | ×4.76 | ×0.97 | 2% (0.8) | 0% (0.0) | 3% (1.0) | 95% (35.6) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 4.6 | 21.7 | ×4.69 | ×0.98 | 3% (1.3) | 0% (0.0) | 4% (1.9) | 93% (41.4) | 0% (0.1) | match |
| added_special_dense | modalities | 4.0 | 45.6 | ×11.44 | ×0.99 | 24% (5.0) | 2% (0.3) | 20% (4.2) | 53% (11.1) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.0 | 23.4 | ×5.84 | ×1.00 | 8% (3.2) | 1% (0.2) | 11% (4.4) | 80% (33.2) | 1% (0.4) | match |
| agentic-traces | modalities | 2.8 | 16.2 | ×5.76 | ×0.99 | 3% (1.8) | 0% (0.0) | 6% (3.5) | 91% (54.9) | 0% (0.0) | match |
| agentic_swe | modalities | 3.1 | 25.1 | ×8.03 | ×0.99 | 3% (1.3) | 0% (0.0) | 6% (2.4) | 90% (35.6) | 0% (0.1) | match |
| code_mixed | modalities | 3.2 | 20.9 | ×6.45 | ×0.99 | 3% (1.6) | 0% (0.0) | 6% (2.9) | 90% (42.9) | 0% (0.0) | match |
| math_latex | modalities | 2.8 | 14.9 | ×5.38 | ×0.97 | 3% (1.9) | 0% (0.0) | 5% (3.3) | 92% (59.6) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.76 | 3.11 | 3.63 | 3.98 | 28.3 | 21.5 | 5.9 | 4.8 | 7.8× / 7.1× | 5.9× / 5.4× | 1.6× / 1.5× | 1.3× / 1.2× |
| arb_Arab | 1.16 | 2.77 | 2.28 | 3.89 | 33.1 | 26.3 | 7.0 | 5.1 | 14.5× / 8.5× | 11.6× / 6.8× | 3.1× / 1.8× | 2.2× / 1.3× |
| ben_Beng | 1.60 | 2.64 | 3.10 | 4.14 | 69.2 | 57.5 | 14.3 | 4.0 | 22.4× / 16.7× | 18.6× / 13.9× | 4.6× / 3.5× | 1.3× / 1.0× |
| cmn_Hani | 1.12 | 2.00 | 2.32 | 3.19 | 27.0 | 22.2 | 6.1 | 2.4 | 11.7× / 8.5× | 9.6× / 7.0× | 2.6× / 1.9× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.79 | 2.18 | 4.39 | 29.1 | 22.5 | 6.3 | 4.8 | 13.3× / 6.6× | 10.3× / 5.1× | 2.9× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.10 | 1.46 | 2.90 | 4.26 | 46.2 | 43.2 | 12.5 | 3.8 | 15.9× / 10.8× | 14.9× / 10.1× | 4.3× / 2.9× | 1.3× / 0.9× |
| heb_Hebr | 1.15 | 2.78 | 2.28 | 3.91 | 32.5 | 26.7 | 7.1 | 3.0 | 14.3× / 8.3× | 11.7× / 6.8× | 3.1× / 1.8× | 1.3× / 0.8× |
| hin_Deva | 1.52 | 2.81 | 3.12 | 4.41 | 64.5 | 55.2 | 14.0 | 4.3 | 20.7× / 14.6× | 17.7× / 12.5× | 4.5× / 3.2× | 1.4× / 1.0× |
| jpn_Jpan | 1.70 | 3.14 | 2.12 | 3.56 | 24.2 | 17.8 | 5.1 | 3.9 | 11.4× / 6.8× | 8.4× / 5.0× | 2.4× / 1.4× | 1.8× / 1.1× |
| kat_Geor | 1.55 | 2.17 | 2.06 | 2.68 | 17.9 | 14.7 | 4.2 | 2.0 | 8.7× / 6.7× | 7.2× / 5.5× | 2.1× / 1.6× | 1.0× / 0.8× |
| kor_Hang | 1.23 | 2.48 | 2.47 | 3.72 | 33.2 | 28.8 | 7.7 | 3.7 | 13.5× / 8.9× | 11.7× / 7.7× | 3.1× / 2.1× | 1.5× / 1.0× |
| rus_Cyrl | 1.17 | 2.73 | 2.09 | 3.65 | 27.7 | 21.5 | 6.0 | 2.4 | 13.3× / 7.6× | 10.3× / 5.9× | 2.9× / 1.6× | 1.2× / 0.7× |
| tam_Taml | 0.92 | 2.64 | 2.73 | 4.46 | 72.1 | 60.3 | 14.7 | 3.8 | 26.4× / 16.2× | 22.0× / 13.5× | 5.4× / 3.3× | 1.4× / 0.9× |
| tha_Thai | 1.51 | 2.22 | 2.51 | 3.21 | 41.1 | 32.8 | 9.1 | 3.2 | 16.4× / 12.8× | 13.1× / 10.2× | 3.6× / 2.8× | 1.3× / 1.0× |
| added_normalized_dense | 0.06 | 1.47 | 1.04 | 2.45 | 24.1 | 23.6 | 6.4 | 2.0 | 23.3× / 9.8× | 22.8× / 9.6× | 6.2× / 2.6× | 1.9× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.85 | 3.27 | 32.2 | 31.8 | 8.6 | 2.7 | 17.4× / 9.9× | 17.2× / 9.7× | 4.7× / 2.6× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.15 | 5.57 | 97.2 | 97.6 | 20.4 | 2.9 | 23.4× / 17.5× | 23.5× / 17.5× | 4.9× / 3.7× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.39 | 5.81 | 63.2 | 60.8 | 14.4 | 3.3 | 14.4× / 10.9× | 13.9× / 10.5× | 3.3× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.74 | 1.46 | 3.53 | 4.26 | 60.8 | 60.8 | 15.9 | 4.7 | 17.2× / 14.3× | 17.2× / 14.3× | 4.5× / 3.7× | 1.3× / 1.1× |
| agentic_swe | 0.66 | 1.44 | 2.44 | 3.22 | 61.9 | 68.9 | 15.2 | 3.5 | 25.4× / 19.3× | 28.3× / 21.4× | 6.2× / 4.7× | 1.4× / 1.1× |
| code_mixed | 0.07 | 1.43 | 2.93 | 4.30 | 60.4 | 67.2 | 15.7 | 4.1 | 20.6× / 14.0× | 22.9× / 15.6× | 5.4× / 3.7× | 1.4× / 0.9× |
| math_latex | 0.73 | 1.47 | 3.30 | 4.05 | 54.5 | 51.3 | 14.2 | 4.2 | 16.5× / 13.5× | 15.5× / 12.7× | 4.3× / 3.5× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×5.11 vs v0.23.1 · ×0.98 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.4 | 23.1 | ×6.72 | ×0.99 | 2% (0.7) | 0% (0.0) | 11% (4.8) | 87% (37.0) | 0% (0.0) | match |
| arb_Arab | lang | 3.9 | 17.4 | ×4.47 | ×0.98 | 1% (0.6) | 0% (0.0) | 6% (3.3) | 93% (51.4) | 0% (0.2) | match |
| ben_Beng | lang | 6.2 | 17.2 | ×2.78 | ×0.97 | 1% (0.6) | 0% (0.0) | 7% (3.7) | 92% (52.5) | 0% (0.1) | match |
| cmn_Hani | lang | 4.3 | 11.8 | ×2.75 | ×0.99 | 1% (0.6) | 0% (0.0) | 4% (3.4) | 96% (80.7) | 0% (0.0) | match |
| ell_Grek | lang | 4.6 | 15.8 | ×3.43 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 95% (59.4) | 0% (0.0) | match |
| eng_Latn | lang | 3.6 | 37.6 | ×10.47 | ×0.91 | 8% (2.0) | 0% (0.0) | 19% (4.6) | 76% (18.4) | 0% (0.0) | match |
| heb_Hebr | lang | 4.0 | 16.8 | ×4.20 | ×1.01 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (54.2) | 1% (0.3) | match |
| hin_Deva | lang | 6.4 | 26.2 | ×4.10 | ×0.96 | 2% (0.6) | 0% (0.0) | 10% (3.8) | 88% (32.5) | 0% (0.1) | match |
| jpn_Jpan | lang | 4.9 | 12.3 | ×2.48 | ×0.99 | 1% (0.6) | 0% (0.0) | 4% (3.1) | 96% (76.4) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 14.1 | ×2.27 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (2.9) | 95% (65.6) | 0% (0.0) | match |
| kor_Hang | lang | 3.5 | 14.7 | ×4.20 | ×0.98 | 1% (0.6) | 0% (0.0) | 5% (3.8) | 93% (65.0) | 0% (0.2) | match |
| rus_Cyrl | lang | 4.7 | 15.1 | ×3.25 | ×0.97 | 1% (0.6) | 0% (0.0) | 5% (3.2) | 95% (62.5) | 0% (0.0) | match |
| tam_Taml | lang | 6.4 | 13.1 | ×2.05 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (3.2) | 95% (72.2) | 0% (0.1) | match |
| tha_Thai | lang | 7.3 | 11.1 | ×1.53 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (3.2) | 96% (85.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.1 | 25.0 | ×4.85 | ×0.98 | 2% (0.8) | 0% (0.0) | 6% (2.2) | 92% (35.9) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.3 | 41.1 | ×7.71 | ×0.99 | 5% (1.3) | 0% (0.0) | 14% (3.2) | 82% (19.0) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 69.9 | ×16.37 | ×0.96 | 38% (5.1) | 3% (0.4) | 38% (5.0) | 21% (2.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 74.9 | ×16.98 | ×0.97 | 26% (3.2) | 1% (0.2) | 48% (6.0) | 26% (3.3) | 0% (0.0) | match |
| agentic-traces | modalities | 3.5 | 36.6 | ×10.47 | ×0.98 | 7% (1.8) | 0% (0.0) | 19% (5.0) | 75% (19.5) | 0% (0.0) | match |
| agentic_swe | modalities | 3.6 | 26.5 | ×7.32 | ×0.99 | 4% (1.3) | 0% (0.0) | 10% (3.8) | 85% (31.5) | 1% (0.3) | match |
| code_mixed | modalities | 3.7 | 48.5 | ×13.00 | ×0.98 | 8% (1.6) | 0% (0.0) | 23% (4.5) | 70% (13.7) | 0% (0.0) | match |
| math_latex | modalities | 3.3 | 35.3 | ×10.86 | ×0.96 | 7% (1.9) | 0% (0.0) | 18% (5.0) | 75% (20.7) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.76 | 3.12 | 4.79 | 5.15 | 30.1 | 14.6 | 7.3 | 4.8 | 6.3× / 5.8× | 3.1× / 2.8× | 1.5× / 1.4× | 1.0× / 0.9× |
| arb_Arab | 1.15 | 2.77 | 3.30 | 4.92 | 34.1 | 16.0 | 7.8 | 5.0 | 10.3× / 6.9× | 4.9× / 3.3× | 2.4× / 1.6× | 1.5× / 1.0× |
| ben_Beng | 1.60 | 2.63 | 3.72 | 4.75 | 24.1 | 10.9 | 5.7 | 2.7 | 6.5× / 5.1× | 2.9× / 2.3× | 1.5× / 1.2× | 0.7× / 0.6× |
| cmn_Hani | 1.12 | 2.02 | 3.36 | 4.26 | 22.1 | 10.8 | 5.6 | 2.5 | 6.6× / 5.2× | 3.2× / 2.5× | 1.7× / 1.3× | 0.7× / 0.6× |
| ell_Grek | 0.58 | 2.79 | 3.28 | 5.49 | 30.6 | 15.2 | 7.2 | 5.1 | 9.3× / 5.6× | 4.6× / 2.8× | 2.2× / 1.3× | 1.6× / 0.9× |
| eng_Latn | 0.10 | 1.45 | 4.58 | 5.94 | 44.3 | 29.4 | 14.5 | 4.2 | 9.7× / 7.5× | 6.4× / 4.9× | 3.2× / 2.4× | 0.9× / 0.7× |
| heb_Hebr | 1.15 | 2.80 | 3.43 | 5.08 | 33.9 | 17.4 | 8.4 | 2.8 | 9.9× / 6.7× | 5.1× / 3.4× | 2.4× / 1.6× | 0.8× / 0.6× |
| hin_Deva | 1.52 | 2.81 | 3.81 | 5.11 | 26.5 | 12.8 | 6.5 | 3.1 | 7.0× / 5.2× | 3.4× / 2.5× | 1.7× / 1.3× | 0.8× / 0.6× |
| jpn_Jpan | 1.70 | 3.10 | 3.11 | 4.51 | 20.6 | 9.1 | 4.8 | 3.8 | 6.6× / 4.6× | 2.9× / 2.0× | 1.6× / 1.1× | 1.2× / 0.8× |
| kat_Geor | 1.54 | 2.17 | 2.94 | 3.58 | 19.3 | 10.1 | 4.8 | 2.1 | 6.6× / 5.4× | 3.4× / 2.8× | 1.6× / 1.3× | 0.7× / 0.6× |
| kor_Hang | 1.23 | 2.48 | 3.76 | 5.01 | 34.6 | 19.8 | 9.4 | 3.6 | 9.2× / 6.9× | 5.3× / 4.0× | 2.5× / 1.9× | 1.0× / 0.7× |
| rus_Cyrl | 1.17 | 2.72 | 3.18 | 4.73 | 29.0 | 15.1 | 7.0 | 4.9 | 9.1× / 6.1× | 4.8× / 3.2× | 2.2× / 1.5× | 1.5× / 1.0× |
| tam_Taml | 0.94 | 2.65 | 3.24 | 4.94 | 19.4 | 8.8 | 4.3 | 3.0 | 6.0× / 3.9× | 2.7× / 1.8× | 1.3× / 0.9× | 0.9× / 0.6× |
| tha_Thai | 1.54 | 2.32 | 3.24 | 4.02 | 13.4 | 5.7 | 2.9 | 2.2 | 4.1× / 3.3× | 1.8× / 1.4× | 0.9× / 0.7× | 0.7× / 0.6× |
| added_normalized_dense | 0.06 | 1.47 | 2.19 | 3.60 | 40.5 | 17.8 | 11.7 | 2.2 | 18.5× / 11.3× | 8.1× / 4.9× | 5.3× / 3.2× | 1.0× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.18 | 4.60 | 35.9 | 20.7 | 11.9 | 3.0 | 11.3× / 7.8× | 6.5× / 4.5× | 3.7× / 2.6× | 0.9× / 0.7× |
| added_special_dense | 0.06 | 1.47 | 5.01 | 6.43 | 85.7 | 67.7 | 25.2 | 3.3 | 17.1× / 13.3× | 13.5× / 10.5× | 5.0× / 3.9× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.95 | 7.37 | 57.3 | 40.9 | 17.0 | 3.7 | 9.6× / 7.8× | 6.9× / 5.5× | 2.9× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.72 | 1.46 | 5.04 | 5.79 | 53.8 | 42.6 | 18.1 | 5.0 | 10.7× / 9.3× | 8.4× / 7.4× | 3.6× / 3.1× | 1.0× / 0.9× |
| agentic_swe | 0.69 | 1.43 | 3.80 | 4.55 | 53.8 | 48.7 | 18.1 | 3.7 | 14.2× / 11.8× | 12.8× / 10.7× | 4.8× / 4.0× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.44 | 4.48 | 5.85 | 53.3 | 48.0 | 18.0 | 4.3 | 11.9× / 9.1× | 10.7× / 8.2× | 4.0× / 3.1× | 1.0× / 0.7× |
| math_latex | 0.93 | 1.47 | 4.96 | 5.50 | 50.9 | 35.7 | 16.9 | 4.6 | 10.2× / 9.2× | 7.2× / 6.5× | 3.4× / 3.1× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×6.67 vs v0.23.1 · ×0.98 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 46.8 | ×11.85 | ×1.04 | 6% (1.2) | 0% (0.0) | 18% (3.7) | 77% (16.0) | 0% (0.0) | match |
| arb_Arab | lang | 3.9 | 16.9 | ×4.34 | ×0.95 | 2% (1.2) | 0% (0.0) | 4% (2.4) | 94% (53.1) | 0% (0.0) | match |
| ben_Beng | lang | 4.0 | 27.5 | ×6.90 | ×0.94 | 3% (1.2) | 0% (0.0) | 9% (3.1) | 88% (31.1) | 0% (0.0) | match |
| cmn_Hani | lang | 4.3 | 13.6 | ×3.12 | ×0.98 | 2% (1.2) | 0% (0.0) | 3% (2.4) | 96% (68.7) | 0% (0.0) | match |
| ell_Grek | lang | 4.7 | 19.0 | ×4.02 | ×0.99 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 93% (48.2) | 0% (0.0) | match |
| eng_Latn | lang | 3.7 | 41.0 | ×10.98 | ×1.01 | 11% (2.5) | 0% (0.0) | 14% (3.0) | 74% (16.6) | 1% (0.1) | match |
| heb_Hebr | lang | 4.0 | 25.1 | ×6.27 | ×0.97 | 3% (1.2) | 0% (0.0) | 6% (2.3) | 92% (35.8) | 0% (0.0) | match |
| hin_Deva | lang | 3.8 | 29.8 | ×7.81 | ×0.93 | 4% (1.2) | 0% (0.0) | 10% (3.3) | 86% (28.1) | 0% (0.1) | match |
| jpn_Jpan | lang | 5.2 | 14.6 | ×2.79 | ×0.94 | 2% (1.2) | 0% (0.0) | 3% (2.2) | 95% (61.5) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 20.8 | ×3.34 | ×0.92 | 3% (1.2) | 0% (0.0) | 5% (2.1) | 93% (43.2) | 0% (0.0) | match |
| kor_Hang | lang | 3.4 | 17.9 | ×5.28 | ×0.98 | 2% (1.2) | 0% (0.0) | 5% (2.5) | 93% (51.6) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.5 | 17.9 | ×3.95 | ×1.00 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 94% (51.9) | 0% (0.0) | match |
| tam_Taml | lang | 3.6 | 35.5 | ×9.77 | ×0.95 | 4% (1.2) | 0% (0.0) | 10% (2.8) | 86% (23.8) | 0% (0.0) | match |
| tha_Thai | lang | 4.5 | 21.5 | ×4.80 | ×0.99 | 3% (1.2) | 0% (0.0) | 6% (2.6) | 92% (42.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.6 | 26.5 | ×4.74 | ×0.99 | 4% (1.3) | 0% (0.0) | 3% (1.1) | 94% (33.9) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.0 | 42.0 | ×8.44 | ×1.00 | 8% (1.8) | 0% (0.0) | 8% (1.9) | 84% (19.1) | 0% (0.0) | match |
| added_special_dense | modalities | 3.8 | 45.6 | ×11.99 | ×0.96 | 61% (12.9) | 1% (0.2) | 24% (5.1) | 14% (3.0) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.1 | 56.1 | ×13.69 | ×0.99 | 40% (6.8) | 2% (0.3) | 28% (4.7) | 30% (5.2) | 0% (0.1) | match |
| agentic-traces | modalities | 3.2 | 34.0 | ×10.46 | ×0.97 | 9% (2.5) | 0% (0.0) | 13% (3.8) | 77% (22.0) | 1% (0.2) | match |
| agentic_swe | modalities | 3.5 | 26.8 | ×7.73 | ×1.01 | 5% (2.0) | 0% (0.0) | 8% (2.9) | 86% (31.6) | 1% (0.3) | match |
| code_mixed | modalities | 3.8 | 43.5 | ×11.30 | ×0.98 | 10% (2.2) | 0% (0.0) | 15% (3.3) | 76% (16.6) | 0% (0.0) | match |
| math_latex | modalities | 3.5 | 36.3 | ×10.31 | ×0.98 | 10% (2.5) | 0% (0.0) | 14% (3.5) | 78% (20.2) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.78 | 3.13 | 3.69 | 4.04 | 26.5 | 16.0 | 6.1 | 4.8 | 7.2× / 6.6× | 4.3× / 4.0× | 1.6× / 1.5× | 1.3× / 1.2× |
| arb_Arab | 1.16 | 2.76 | 2.36 | 3.96 | 29.9 | 18.8 | 7.0 | 5.2 | 12.7× / 7.6× | 8.0× / 4.8× | 3.0× / 1.8× | 2.2× / 1.3× |
| ben_Beng | 1.61 | 2.62 | 3.13 | 4.15 | 43.3 | 27.9 | 10.6 | 3.7 | 13.8× / 10.4× | 8.9× / 6.7× | 3.4× / 2.6× | 1.2× / 0.9× |
| cmn_Hani | 1.12 | 2.03 | 2.39 | 3.30 | 19.1 | 11.7 | 4.7 | 2.4 | 8.0× / 5.8× | 4.9× / 3.5× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.80 | 2.21 | 4.43 | 27.1 | 17.1 | 6.2 | 4.7 | 12.2× / 6.1× | 7.7× / 3.9× | 2.8× / 1.4× | 2.1× / 1.1× |
| eng_Latn | 0.12 | 1.45 | 3.02 | 4.36 | 42.0 | 32.4 | 12.9 | 3.7 | 13.9× / 9.6× | 10.7× / 7.4× | 4.3× / 3.0× | 1.2× / 0.9× |
| heb_Hebr | 1.15 | 2.80 | 2.33 | 3.98 | 29.6 | 19.9 | 7.1 | 3.0 | 12.7× / 7.4× | 8.5× / 5.0× | 3.0× / 1.8× | 1.3× / 0.8× |
| hin_Deva | 1.52 | 2.78 | 3.27 | 4.53 | 46.1 | 31.0 | 11.6 | 4.0 | 14.1× / 10.2× | 9.5× / 6.8× | 3.6× / 2.6× | 1.2× / 0.9× |
| jpn_Jpan | 1.70 | 3.11 | 2.21 | 3.62 | 17.8 | 9.8 | 4.1 | 3.8 | 8.0× / 4.9× | 4.4× / 2.7× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.54 | 2.22 | 2.12 | 2.80 | 16.3 | 11.1 | 4.2 | 2.0 | 7.7× / 5.8× | 5.2× / 4.0× | 2.0× / 1.5× | 0.9× / 0.7× |
| kor_Hang | 1.22 | 2.50 | 2.53 | 3.81 | 30.2 | 21.9 | 7.8 | 3.6 | 11.9× / 7.9× | 8.7× / 5.8× | 3.1× / 2.0× | 1.4× / 1.0× |
| rus_Cyrl | 1.17 | 2.69 | 2.18 | 3.70 | 26.0 | 16.6 | 6.1 | 2.4 | 11.9× / 7.0× | 7.6× / 4.5× | 2.8× / 1.6× | 1.1× / 0.7× |
| tam_Taml | 0.92 | 2.66 | 2.75 | 4.50 | 43.0 | 25.7 | 10.4 | 3.4 | 15.6× / 9.6× | 9.3× / 5.7× | 3.8× / 2.3× | 1.2× / 0.8× |
| tha_Thai | 1.64 | 2.26 | 2.63 | 3.25 | 27.1 | 16.0 | 6.9 | 3.0 | 10.3× / 8.3× | 6.1× / 4.9× | 2.6× / 2.1× | 1.1× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.06 | 2.48 | 22.3 | 16.4 | 6.8 | 1.8 | 21.0× / 9.0× | 15.4× / 6.6× | 6.4× / 2.8× | 1.7× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.93 | 3.35 | 29.6 | 22.6 | 8.9 | 2.5 | 15.3× / 8.9× | 11.7× / 6.8× | 4.6× / 2.7× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 5.05 | 6.47 | 92.1 | 73.4 | 22.1 | 3.1 | 18.2× / 14.2× | 14.5× / 11.4× | 4.4× / 3.4× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.71 | 6.12 | 57.4 | 44.8 | 15.5 | 3.6 | 12.2× / 9.4× | 9.5× / 7.3× | 3.3× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.74 | 1.46 | 3.77 | 4.49 | 50.6 | 46.4 | 15.7 | 4.5 | 13.4× / 11.3× | 12.3× / 10.3× | 4.2× / 3.5× | 1.2× / 1.0× |
| agentic_swe | 0.66 | 1.46 | 2.93 | 3.73 | 52.7 | 54.7 | 16.4 | 3.4 | 18.0× / 14.1× | 18.7× / 14.7× | 5.6× / 4.4× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.30 | 4.67 | 50.7 | 52.4 | 15.9 | 3.9 | 15.4× / 10.9× | 15.9× / 11.2× | 4.8× / 3.4× | 1.2× / 0.8× |
| math_latex | 0.72 | 1.47 | 3.50 | 4.25 | 48.6 | 38.3 | 14.7 | 4.1 | 13.9× / 11.4× | 11.0× / 9.0× | 4.2× / 3.5× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×4.12 vs v0.23.1 · ×1.04 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 18+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 44.4 | ×10.52 | ×1.11 | 0% (0.1) | 9% (1.9) | 0% (0.0) | 91% (20.2) | 0% (0.0) | match |
| arb_Arab | lang | 9.7 | 51.3 | ×5.30 | ×1.00 | 0% (0.1) | 12% (2.3) | 0% (0.0) | 88% (16.8) | 0% (0.0) | match |
| ben_Beng | lang | 10.4 | 87.4 | ×8.42 | ×1.03 | 1% (0.1) | 14% (1.6) | 0% (0.0) | 85% (9.6) | 0% (0.0) | match |
| cmn_Hani | lang | 8.4 | 64.1 | ×7.59 | ×1.02 | 1% (0.1) | 3% (0.4) | 0% (0.0) | 98% (14.6) | 0% (0.0) | match |
| ell_Grek | lang | 9.8 | 60.4 | ×6.17 | ×1.01 | 0% (0.1) | 14% (2.3) | 0% (0.0) | 86% (14.0) | 0% (0.0) | match |
| eng_Latn | lang | 3.8 | 6.4 | ×1.67 | ×1.08 | 0% (0.1) | 3% (5.3) | 0% (0.0) | 95% (150.7) | 2% (2.8) | match |
| heb_Hebr | lang | 9.6 | 64.9 | ×6.78 | ×1.00 | 0% (0.1) | 15% (2.3) | 0% (0.0) | 85% (12.8) | 0% (0.0) | match |
| hin_Deva | lang | 10.6 | 80.6 | ×7.58 | ×0.98 | 0% (0.1) | 17% (2.0) | 0% (0.0) | 82% (9.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 11.3 | 83.9 | ×7.42 | ×1.02 | 1% (0.1) | 3% (0.3) | 0% (0.0) | 96% (10.9) | 0% (0.0) | match |
| kat_Geor | lang | 13.0 | 93.9 | ×7.24 | ×1.01 | 1% (0.1) | 15% (1.5) | 0% (0.0) | 84% (8.6) | 0% (0.0) | match |
| kor_Hang | lang | 6.8 | 53.8 | ×7.87 | ×1.01 | 0% (0.1) | 13% (2.3) | 0% (0.0) | 87% (15.7) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.5 | 16.2 | ×2.17 | ×1.00 | 0% (0.1) | 3% (2.1) | 0% (0.0) | 95% (58.7) | 1% (0.7) | match |
| tam_Taml | lang | 11.8 | 94.0 | ×7.97 | ×1.02 | 1% (0.1) | 13% (1.4) | 0% (0.0) | 86% (9.1) | 0% (0.0) | match |
| tha_Thai | lang | 14.2 | 86.1 | ×6.08 | ×1.02 | 1% (0.1) | 7% (0.8) | 0% (0.0) | 92% (10.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.0 | 8.8 | ×1.77 | ×1.05 | 0% (0.1) | 2% (2.6) | 0% (0.0) | 97% (113.3) | 1% (0.9) | match |
| added_normalized_sparse | modalities | 4.6 | 7.6 | ×1.67 | ×1.11 | 0% (0.0) | 4% (4.7) | 0% (0.0) | 94% (124.9) | 2% (3.1) | match |
| added_special_dense | modalities | 3.5 | 20.6 | ×5.88 | ×1.00 | 11% (5.1) | 30% (14.0) | 2% (1.1) | 56% (26.2) | 1% (0.6) | match |
| added_special_sparse | modalities | 4.6 | 10.4 | ×2.24 | ×0.99 | 2% (2.1) | 13% (12.5) | 0% (0.3) | 83% (79.6) | 1% (1.1) | match |
| agentic-traces | modalities | 4.0 | 7.2 | ×1.81 | ×1.08 | 0% (0.1) | 3% (4.7) | 0% (0.0) | 97% (133.7) | 0% (0.0) | match |
| agentic_swe | modalities | 3.8 | 7.1 | ×1.90 | ×1.09 | 0% (0.1) | 5% (6.5) | 0% (0.0) | 95% (132.8) | 0% (0.2) | match |
| code_mixed | modalities | 4.0 | 7.1 | ×1.78 | ×1.08 | 0% (0.0) | 4% (5.5) | 0% (0.0) | 96% (134.9) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 6.7 | ×1.70 | ×1.06 | 0% (0.1) | 3% (4.9) | 0% (0.0) | 97% (142.1) | 0% (0.0) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×7.01 vs v0.23.1 · ×0.93 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 93+0 (peak 95)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 48.4 | ×11.13 | ×0.88 | 4% (0.7) | 0% (0.0) | 20% (3.7) | 76% (14.0) | 0% (0.0) | match |
| arb_Arab | lang | 4.3 | 17.6 | ×4.13 | ×0.92 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 97% (51.8) | 0% (0.0) | match |
| ben_Beng | lang | 4.0 | 31.6 | ×7.82 | ×0.97 | 2% (0.6) | 0% (0.0) | 10% (3.1) | 87% (27.0) | 1% (0.3) | match |
| cmn_Hani | lang | 5.1 | 16.8 | ×3.27 | ×0.92 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 94% (53.8) | 0% (0.2) | match |
| ell_Grek | lang | 5.0 | 19.2 | ×3.81 | ×0.92 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (46.7) | 0% (0.0) | match |
| eng_Latn | lang | 4.0 | 44.6 | ×11.06 | ×0.84 | 11% (2.0) | 0% (0.0) | 16% (3.0) | 72% (13.3) | 1% (0.1) | match |
| heb_Hebr | lang | 4.4 | 26.0 | ×5.97 | ×0.96 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 91% (34.0) | 1% (0.4) | match |
| hin_Deva | lang | 4.5 | 77.9 | ×17.47 | ×0.90 | 5% (0.6) | 0% (0.0) | 27% (3.2) | 67% (8.0) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.9 | 16.5 | ×2.80 | ×0.93 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (55.2) | 0% (0.0) | match |
| kat_Geor | lang | 5.6 | 39.0 | ×6.98 | ×0.95 | 3% (0.6) | 0% (0.0) | 9% (2.1) | 92% (22.1) | 0% (0.0) | match |
| kor_Hang | lang | 4.0 | 18.4 | ×4.63 | ×0.89 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 93% (46.2) | 0% (0.1) | match |
| rus_Cyrl | lang | 4.9 | 16.2 | ×3.28 | ×0.92 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 94% (55.8) | 1% (0.5) | match |
| tam_Taml | lang | 4.1 | 34.9 | ×8.46 | ×0.93 | 2% (0.6) | 0% (0.0) | 10% (2.7) | 88% (23.9) | 0% (0.0) | match |
| tha_Thai | lang | 5.4 | 20.7 | ×3.85 | ×0.92 | 1% (0.6) | 0% (0.0) | 6% (2.6) | 93% (43.3) | 0% (0.2) | match |
| added_normalized_dense | modalities | 6.1 | 27.0 | ×4.43 | ×0.99 | 2% (0.7) | 0% (0.0) | 3% (1.1) | 95% (34.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.6 | 43.2 | ×7.72 | ×1.00 | 6% (1.4) | 0% (0.0) | 9% (1.9) | 86% (19.3) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 71.3 | ×17.41 | ×1.00 | 39% (5.1) | 3% (0.4) | 37% (4.9) | 22% (2.9) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.5 | 71.1 | ×15.92 | ×0.99 | 26% (3.5) | 0% (0.0) | 38% (5.0) | 38% (5.0) | 0% (0.0) | match |
| agentic-traces | modalities | 3.5 | 36.6 | ×10.43 | ×0.88 | 7% (1.8) | 0% (0.0) | 15% (3.7) | 79% (19.0) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 28.2 | ×6.96 | ×0.93 | 4% (1.3) | 0% (0.0) | 9% (2.9) | 89% (29.3) | 0% (0.0) | match |
| code_mixed | modalities | 4.2 | 47.4 | ×11.27 | ×0.90 | 8% (1.6) | 0% (0.0) | 18% (3.3) | 74% (13.8) | 0% (0.0) | match |
| math_latex | modalities | 3.9 | 40.6 | ×10.49 | ×0.86 | 9% (1.9) | 0% (0.0) | 16% (3.5) | 82% (18.2) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.12 | 3.70 | 4.07 | 26.9 | 16.1 | 6.1 | 4.7 | 7.3× / 6.6× | 4.3× / 4.0× | 1.6× / 1.5× | 1.3× / 1.2× |
| arb_Arab | 1.15 | 2.78 | 2.36 | 3.98 | 30.7 | 19.0 | 6.8 | 5.1 | 13.0× / 7.7× | 8.1× / 4.8× | 2.9× / 1.7× | 2.2× / 1.3× |
| ben_Beng | 1.60 | 2.63 | 3.10 | 4.12 | 45.0 | 26.9 | 10.4 | 3.7 | 14.5× / 10.9× | 8.7× / 6.5× | 3.4× / 2.5× | 1.2× / 0.9× |
| cmn_Hani | 1.12 | 2.02 | 2.37 | 3.27 | 19.8 | 11.5 | 4.7 | 2.4 | 8.4× / 6.1× | 4.8× / 3.5× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 2.80 | 2.19 | 4.41 | 27.9 | 17.0 | 6.1 | 4.7 | 12.7× / 6.3× | 7.7× / 3.9× | 2.8× / 1.4× | 2.1× / 1.1× |
| eng_Latn | 0.10 | 1.45 | 2.98 | 4.34 | 44.5 | 32.0 | 12.5 | 3.7 | 14.9× / 10.3× | 10.7× / 7.4× | 4.2× / 2.9× | 1.2× / 0.9× |
| heb_Hebr | 1.15 | 2.79 | 2.30 | 3.95 | 30.5 | 19.4 | 6.9 | 3.1 | 13.2× / 7.7× | 8.4× / 4.9× | 3.0× / 1.7× | 1.3× / 0.8× |
| hin_Deva | 1.52 | 2.78 | 3.23 | 4.50 | 47.6 | 29.6 | 11.3 | 4.0 | 14.7× / 10.6× | 9.2× / 6.6× | 3.5× / 2.5× | 1.2× / 0.9× |
| jpn_Jpan | 1.70 | 3.10 | 2.17 | 3.57 | 18.3 | 10.1 | 4.1 | 3.6 | 8.4× / 5.1× | 4.6× / 2.8× | 1.9× / 1.2× | 1.7× / 1.0× |
| kat_Geor | 1.53 | 2.18 | 2.10 | 2.76 | 16.7 | 11.0 | 4.2 | 2.0 | 8.0× / 6.1× | 5.2× / 4.0× | 2.0× / 1.5× | 0.9× / 0.7× |
| kor_Hang | 1.23 | 2.50 | 2.52 | 3.79 | 32.7 | 21.5 | 7.7 | 3.7 | 13.0× / 8.6× | 8.6× / 5.7× | 3.1× / 2.0× | 1.5× / 1.0× |
| rus_Cyrl | 1.16 | 2.71 | 2.16 | 3.71 | 26.5 | 16.0 | 5.9 | 2.5 | 12.3× / 7.2× | 7.4× / 4.3× | 2.8× / 1.6× | 1.1× / 0.7× |
| tam_Taml | 0.92 | 2.72 | 2.74 | 4.55 | 44.1 | 26.0 | 10.0 | 3.4 | 16.1× / 9.7× | 9.5× / 5.7× | 3.6× / 2.2× | 1.2× / 0.7× |
| tha_Thai | 1.51 | 2.25 | 2.60 | 3.34 | 28.1 | 15.8 | 6.7 | 3.0 | 10.8× / 8.4× | 6.1× / 4.7× | 2.6× / 2.0× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.06 | 2.48 | 23.3 | 16.9 | 6.6 | 1.8 | 21.9× / 9.4× | 15.9× / 6.8× | 6.2× / 2.7× | 1.7× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.92 | 3.33 | 31.7 | 22.0 | 8.8 | 2.5 | 16.6× / 9.5× | 11.5× / 6.6× | 4.6× / 2.6× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.86 | 6.27 | 94.4 | 71.7 | 21.9 | 3.4 | 19.4× / 15.0× | 14.8× / 11.4× | 4.5× / 3.5× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.99 | 6.40 | 60.2 | 45.3 | 15.3 | 3.6 | 12.1× / 9.4× | 9.1× / 7.1× | 3.1× / 2.4× | 0.7× / 0.6× |
| agentic-traces | 0.73 | 1.46 | 3.74 | 4.47 | 52.6 | 43.2 | 15.1 | 4.6 | 14.1× / 11.8× | 11.6× / 9.7× | 4.0× / 3.4× | 1.2× / 1.0× |
| agentic_swe | 0.66 | 1.43 | 2.93 | 3.71 | 55.3 | 53.0 | 16.2 | 3.4 | 18.9× / 14.9× | 18.1× / 14.3× | 5.5× / 4.4× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.43 | 3.34 | 4.71 | 52.5 | 50.2 | 15.6 | 3.9 | 15.7× / 11.1× | 15.0× / 10.7× | 4.7× / 3.3× | 1.2× / 0.8× |
| math_latex | 0.71 | 1.47 | 3.48 | 4.23 | 51.3 | 38.9 | 14.1 | 4.1 | 14.8× / 12.1× | 11.2× / 9.2× | 4.1× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×6.12 vs v0.23.1 · ×0.89 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 151+0 (peak 194) · Pipeline 109+0 (peak 195)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.2 | 42.3 | ×13.34 | ×0.84 | 6% (1.2) | 0% (0.0) | 22% (4.9) | 71% (15.8) | 1% (0.2) | match |
| arb_Arab | lang | 3.8 | 20.7 | ×5.43 | ×0.88 | 2% (1.2) | 0% (0.0) | 8% (3.8) | 89% (42.4) | 0% (0.1) | match |
| ben_Beng | lang | 6.3 | 18.3 | ×2.89 | ×0.92 | 2% (1.2) | 0% (0.0) | 8% (4.0) | 91% (48.5) | 0% (0.0) | match |
| cmn_Hani | lang | 4.3 | 17.0 | ×3.92 | ×0.89 | 2% (1.2) | 0% (0.0) | 6% (3.4) | 91% (52.6) | 2% (0.9) | match |
| ell_Grek | lang | 4.4 | 18.2 | ×4.14 | ×0.91 | 2% (1.2) | 0% (0.0) | 6% (3.3) | 93% (49.7) | 0% (0.0) | match |
| eng_Latn | lang | 3.2 | 34.4 | ×10.86 | ×0.76 | 9% (2.5) | 0% (0.0) | 17% (4.6) | 68% (18.8) | 7% (1.9) | match |
| heb_Hebr | lang | 3.4 | 16.2 | ×4.69 | ×0.88 | 2% (1.2) | 0% (0.0) | 6% (3.8) | 94% (55.6) | 0% (0.0) | match |
| hin_Deva | lang | 5.1 | 25.8 | ×5.05 | ×0.94 | 3% (1.2) | 0% (0.0) | 11% (4.1) | 86% (32.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.5 | 16.3 | ×3.59 | ×0.93 | 2% (1.2) | 0% (0.0) | 5% (3.1) | 93% (56.1) | 0% (0.0) | match |
| kat_Geor | lang | 5.7 | 14.7 | ×2.55 | ×0.90 | 2% (1.2) | 0% (0.0) | 4% (2.9) | 94% (62.7) | 0% (0.0) | match |
| kor_Hang | lang | 2.9 | 18.0 | ×6.26 | ×0.83 | 2% (1.2) | 0% (0.0) | 7% (3.8) | 90% (48.0) | 0% (0.2) | match |
| rus_Cyrl | lang | 3.7 | 15.8 | ×4.25 | ×0.88 | 2% (1.2) | 0% (0.0) | 5% (3.2) | 93% (58.0) | 0% (0.0) | match |
| tam_Taml | lang | 5.7 | 15.1 | ×2.62 | ×0.94 | 2% (1.2) | 0% (0.0) | 5% (3.6) | 93% (60.5) | 0% (0.0) | match |
| tha_Thai | lang | 7.0 | 14.6 | ×2.09 | ×0.93 | 2% (1.2) | 0% (0.0) | 5% (3.5) | 93% (63.5) | 0% (0.2) | match |
| added_normalized_dense | modalities | 4.9 | 29.3 | ×5.99 | ×0.98 | 4% (1.3) | 0% (0.0) | 7% (2.3) | 89% (30.0) | 1% (0.2) | match |
| added_normalized_sparse | modalities | 4.9 | 43.2 | ×8.75 | ×0.96 | 8% (1.8) | 0% (0.0) | 14% (3.1) | 78% (17.7) | 0% (0.0) | match |
| added_special_dense | modalities | 3.7 | 67.8 | ×18.28 | ×0.95 | 38% (5.2) | 2% (0.3) | 38% (5.2) | 24% (3.3) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 62.5 | ×14.45 | ×0.97 | 25% (3.6) | 1% (0.2) | 40% (5.9) | 35% (5.1) | 0% (0.0) | match |
| agentic-traces | modalities | 2.7 | 31.5 | ×11.81 | ×0.83 | 8% (2.4) | 0% (0.0) | 17% (5.1) | 77% (23.3) | 0% (0.0) | match |
| agentic_swe | modalities | 3.0 | 23.3 | ×7.74 | ×0.86 | 5% (1.9) | 0% (0.0) | 9% (3.8) | 86% (36.2) | 0% (0.0) | match |
| code_mixed | modalities | 3.3 | 40.9 | ×12.43 | ×0.85 | 9% (2.2) | 0% (0.0) | 19% (4.4) | 69% (16.0) | 3% (0.7) | match |
| math_latex | modalities | 3.2 | 35.8 | ×11.23 | ×0.80 | 9% (2.5) | 0% (0.0) | 18% (4.9) | 74% (19.9) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.12 | 4.91 | 5.29 | 27.9 | 14.5 | 6.9 | — | 5.7× / 5.3× | 3.0× / 2.7× | 1.4× / 1.3× | — |
| arb_Arab | 1.15 | 2.78 | 3.80 | 5.43 | 31.9 | 16.4 | 7.7 | — | 8.4× / 5.9× | 4.3× / 3.0× | 2.0× / 1.4× | — |
| ben_Beng | 1.61 | 2.63 | 4.02 | 5.05 | 22.6 | 11.0 | 5.4 | — | 5.6× / 4.5× | 2.7× / 2.2× | 1.3× / 1.1× | — |
| cmn_Hani | 1.13 | 2.04 | 3.37 | 4.29 | 20.9 | 11.5 | 5.8 | — | 6.2× / 4.9× | 3.4× / 2.7× | 1.7× / 1.3× | — |
| ell_Grek | 0.59 | 2.77 | 3.31 | 5.49 | 27.3 | 15.3 | 6.7 | — | 8.2× / 5.0× | 4.6× / 2.8× | 2.0× / 1.2× | — |
| eng_Latn | 0.09 | 1.45 | 4.60 | 5.96 | 39.3 | 30.3 | 14.3 | — | 8.5× / 6.6× | 6.6× / 5.1× | 3.1× / 2.4× | — |
| heb_Hebr | 1.15 | 2.84 | 3.75 | 5.44 | 30.3 | 17.4 | 8.0 | — | 8.1× / 5.6× | 4.6× / 3.2× | 2.1× / 1.5× | — |
| hin_Deva | 1.52 | 2.80 | 4.10 | 5.38 | 23.7 | 12.9 | 6.4 | — | 5.8× / 4.4× | 3.2× / 2.4× | 1.6× / 1.2× | — |
| jpn_Jpan | 1.71 | 3.12 | 3.13 | 4.53 | 19.6 | 9.8 | 4.8 | — | 6.3× / 4.3× | 3.1× / 2.2× | 1.5× / 1.1× | — |
| kat_Geor | 1.54 | 2.14 | 2.90 | 3.50 | 17.6 | 10.1 | 4.7 | — | 6.1× / 5.0× | 3.5× / 2.9× | 1.6× / 1.3× | — |
| kor_Hang | 1.23 | 2.48 | 3.84 | 5.09 | 30.8 | 19.7 | 9.0 | — | 8.0× / 6.0× | 5.1× / 3.9× | 2.3× / 1.8× | — |
| rus_Cyrl | 1.17 | 2.74 | 3.18 | 4.76 | 26.4 | 15.1 | 6.6 | — | 8.3× / 5.6× | 4.8× / 3.2× | 2.1× / 1.4× | — |
| tam_Taml | 0.93 | 2.62 | 3.57 | 5.26 | 17.9 | 8.9 | 4.3 | — | 5.0× / 3.4× | 2.5× / 1.7× | 1.2× / 0.8× | — |
| tha_Thai | 1.51 | 2.26 | 3.54 | 4.28 | 12.8 | 5.7 | 2.9 | — | 3.6× / 3.0× | 1.6× / 1.3× | 0.8× / 0.7× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.29 | 3.71 | 30.2 | 17.3 | 11.5 | — | 13.2× / 8.1× | 7.6× / 4.7× | 5.0× / 3.1× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.13 | 4.54 | 31.2 | 20.3 | 11.5 | — | 10.0× / 6.9× | 6.5× / 4.5× | 3.7× / 2.5× | — |
| added_special_dense | 0.06 | 1.47 | 5.22 | 6.64 | 77.8 | 67.9 | 23.9 | — | 14.9× / 11.7× | 13.0× / 10.2× | 4.6× / 3.6× | — |
| added_special_sparse | 0.06 | 1.47 | 5.86 | 7.28 | 50.0 | 40.7 | 16.3 | — | 8.5× / 6.9× | 6.9× / 5.6× | 2.8× / 2.2× | — |
| agentic-traces | 0.74 | 1.48 | 5.08 | 5.82 | 50.0 | 45.1 | 18.4 | — | 9.8× / 8.6× | 8.9× / 7.8× | 3.6× / 3.2× | — |
| agentic_swe | 0.65 | 1.46 | 3.82 | 4.62 | 54.7 | 54.8 | 19.6 | — | 14.3× / 11.8× | 14.3× / 11.8× | 5.1× / 4.2× | — |
| code_mixed | 0.07 | 1.44 | 4.40 | 5.78 | 49.8 | 49.7 | 17.8 | — | 11.3× / 8.6× | 11.3× / 8.6× | 4.0× / 3.1× | — |
| math_latex | 0.72 | 1.48 | 4.95 | 5.72 | 46.7 | 37.7 | 17.1 | — | 9.4× / 8.2× | 7.6× / 6.6× | 3.4× / 3.0× | — |

</details>

<details><summary><b>t5-base</b> — Unigram + Metaspace · ×2.51 vs v0.23.1 · ×0.94 vs base · decode pending</summary>

<img alt="t5-base speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-t5-base.png" width="860">

<img alt="t5-base stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-t5-base-stages.png" width="860">

<img alt="t5-base thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-t5-base-threads.png" width="860">

<img alt="t5-base decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-t5-base-decode.png" width="860">

<img alt="t5-base decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30957631053-t5-base-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 34+2 (peak 36) · Pipeline 61+1 (peak 66)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.8 | 15.9 | ×2.76 | ×0.89 | 1% (0.7) | 32% (21.6) | 4% (2.5) | 62% (42.0) | 1% (0.5) | match |
| arb_Arab | lang | 4.5 | 12.2 | ×2.69 | ×0.89 | 1% (0.6) | 27% (27.0) | 3% (2.9) | 70% (70.0) | 0% (0.0) | match |
| ben_Beng | lang | 7.4 | 20.6 | ×2.77 | ×0.93 | 1% (0.6) | 30% (24.2) | 2% (1.9) | 68% (53.7) | 0% (0.0) | match |
| cmn_Hani | lang | 12.6 | 23.4 | ×1.86 | ×0.97 | 1% (0.6) | 22% (16.8) | 1% (0.6) | 77% (57.9) | 0% (0.0) | match |
| ell_Grek | lang | 4.9 | 13.3 | ×2.73 | ×0.90 | 1% (0.6) | 26% (27.2) | 3% (2.6) | 69% (72.2) | 1% (1.4) | match |
| eng_Latn | lang | 2.6 | 5.9 | ×2.28 | ×0.91 | 1% (2.0) | 17% (40.5) | 3% (6.1) | 77% (188.0) | 3% (6.2) | match |
| heb_Hebr | lang | 4.5 | 12.5 | ×2.80 | ×0.90 | 1% (0.6) | 23% (23.6) | 4% (3.6) | 71% (72.0) | 2% (2.0) | match |
| hin_Deva | lang | 6.4 | 21.0 | ×3.26 | ×0.95 | 1% (0.6) | 29% (24.3) | 3% (2.4) | 69% (57.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.7 | 24.4 | ×1.79 | ×0.94 | 1% (0.6) | 24% (19.9) | 1% (0.7) | 67% (56.0) | 8% (6.6) | match |
| kat_Geor | lang | 8.4 | 21.0 | ×2.50 | ×0.99 | 1% (0.6) | 24% (19.0) | 2% (1.5) | 73% (56.8) | 0% (0.0) | match |
| kor_Hang | lang | 4.7 | 11.7 | ×2.47 | ×0.92 | 1% (0.6) | 26% (24.4) | 3% (2.9) | 70% (66.7) | 1% (0.9) | match |
| rus_Cyrl | lang | 4.5 | 8.4 | ×1.86 | ×0.94 | 0% (0.6) | 17% (26.8) | 2% (2.3) | 80% (125.4) | 1% (1.0) | match |
| tam_Taml | lang | 9.1 | 22.7 | ×2.50 | ×0.97 | 1% (0.6) | 25% (19.0) | 2% (1.2) | 71% (54.5) | 2% (1.2) | match |
| tha_Thai | lang | 13.0 | 25.1 | ×1.93 | ×0.92 | 0% (0.6) | 15% (18.8) | 1% (0.8) | 46% (58.3) | 38% (48.5) | match |
| added_normalized_dense | modalities | 4.1 | 12.3 | ×3.03 | ×0.95 | 0% (0.8) | 18% (37.4) | 2% (4.2) | 82% (166.9) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 3.8 | 12.4 | ×3.27 | ×0.94 | 1% (1.4) | 21% (38.5) | 3% (6.0) | 78% (141.8) | 0% (0.0) | match |
| added_special_dense | modalities | 6.4 | 32.7 | ×5.08 | ×1.02 | 11% (5.2) | 36% (17.4) | 6% (2.8) | 47% (23.2) | 0% (0.2) | match |
| added_special_sparse | modalities | 4.2 | 16.3 | ×3.92 | ×1.00 | 3% (3.2) | 27% (34.0) | 8% (10.7) | 63% (79.6) | 0% (0.0) | match |
| agentic-traces | modalities | 3.2 | 5.9 | ×1.86 | ×0.95 | 1% (1.8) | 17% (40.0) | 2% (4.8) | 79% (186.4) | 1% (2.2) | match |
| agentic_swe | modalities | 4.7 | 8.5 | ×1.80 | ×0.93 | 1% (1.3) | 20% (37.0) | 2% (3.6) | 81% (149.1) | 0% (0.0) | match |
| code_mixed | modalities | 4.1 | 7.8 | ×1.92 | ×0.96 | 1% (1.6) | 19% (38.8) | 2% (4.0) | 77% (154.3) | 1% (1.7) | match |
| math_latex | modalities | 2.8 | 6.4 | ×2.31 | ×0.96 | 1% (1.9) | 18% (40.7) | 3% (6.0) | 78% (170.9) | 0% (1.0) | match |

</details>
<!-- pipeline-bench:end -->

