### PR TITLE
feat(atomsplit): offload literal patterns to atomsplit

### DIFF
--- a/tokenizers/atomsplit/Cargo.toml
+++ b/tokenizers/atomsplit/Cargo.toml
@@ -25,7 +25,7 @@ name = "atomsplit"
 path = "src/lib.rs"
 
 [dependencies]
-memchr = "2.8.2" # SIMD single-byte search; used only in CharDelimiterSplit (1.4–23× vs scalar).
+memchr = "2.8.2" # SIMD search: used for single-byte  search in CharDelimiterSplit (1.4–23× vs scalar), or multi-byte string pattern search in `literal`.
 # NOTE: classify tables live in src/atom_tables.rs (committed, generated). Regenerate after any atom
 # scheme change with `cargo run -p bitmap_gen`. No build script / build-dep — atomsplit builds clean.
 # onig is C (Oniguruma) and fancy-regex pulls it in transitively for benches only — neither

--- a/tokenizers/atomsplit/src/lib.rs
+++ b/tokenizers/atomsplit/src/lib.rs
@@ -7,6 +7,10 @@
 //! Mistral's tekken are exposed as the [`fsm::fsm_o200k`] / [`fsm::fsm_tekken`] functions rather than
 //! recipe structs).
 //!
+//! For pre-tokenizers that split on single characters (such as the Metaspace `▁` delimiter),
+//! we skip the atom classification pass entirely and search for the raw  bytes instead.
+//! See [`literal`].
+//!
 //! Design: every fsm is *no-push* — it writes spans into a caller-preallocated `&mut [fsm::Span]`
 //! (length ≥ `text.len()`) and returns the token count; there is no `Vec`/allocation on the hot path.
 //!
@@ -17,6 +21,7 @@
 mod atom_tables;
 pub mod classify;
 pub mod fsm;
+pub mod literal;
 pub mod regexes;
 #[cfg(target_arch = "x86_64")]
 mod simd_avx_classify;

--- a/tokenizers/atomsplit/src/literal.rs
+++ b/tokenizers/atomsplit/src/literal.rs
@@ -22,9 +22,12 @@ impl fmt::Display for EmptyPattern {
 impl std::error::Error for EmptyPattern {}
 
 /// A literal string to split on.
+///
+/// The finder is boxed because it is large — a few hundred bytes of prefilter state on x86_64 — and
+/// callers store it inside enums whose other variants are tiny.
 #[derive(Debug, Clone)]
 pub struct Literal {
-    finder: memmem::Finder<'static>,
+    finder: Box<memmem::Finder<'static>>,
 }
 
 impl Literal {
@@ -35,7 +38,7 @@ impl Literal {
             return Err(EmptyPattern);
         }
         Ok(Self {
-            finder: memmem::Finder::new(pattern).into_owned(),
+            finder: Box::new(memmem::Finder::new(pattern).into_owned()),
         })
     }
 

--- a/tokenizers/atomsplit/src/literal.rs
+++ b/tokenizers/atomsplit/src/literal.rs
@@ -1,0 +1,53 @@
+//! Searching for a literal string, for pre-tokenizers that cut on one exact character.
+//!
+//! The rest of the crate works off atom tags: one SIMD pass gives every character a class, and the
+//! FSMs cut where the class changes ([`crate::fsm`]).
+//!
+//! The atom classification is unnecessary for pre-tokenizers splitting on an exact character or literal string:
+//! We can use a simpler byte search looking at 16 bytes at a time.
+
+use memchr::memmem;
+use std::fmt;
+
+/// The pattern handed to [`Literal::new`] was empty.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmptyPattern;
+
+impl fmt::Display for EmptyPattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("an empty pattern matches everywhere")
+    }
+}
+
+impl std::error::Error for EmptyPattern {}
+
+/// A literal string to split on.
+#[derive(Debug, Clone)]
+pub struct Literal {
+    finder: memmem::Finder<'static>,
+}
+
+impl Literal {
+    /// # Errors
+    /// If `pattern` is empty, which would match everywhere.
+    pub fn new(pattern: &[u8]) -> Result<Self, EmptyPattern> {
+        if pattern.is_empty() {
+            return Err(EmptyPattern);
+        }
+        Ok(Self {
+            finder: memmem::Finder::new(pattern).into_owned(),
+        })
+    }
+
+    /// The string being searched for.
+    #[must_use]
+    pub fn pattern(&self) -> &[u8] {
+        self.finder.needle()
+    }
+
+    /// Byte offset of every match, left to right. Matches never overlap, so `"aa"` is found once in
+    /// `"aaa"` — the same matches a regex engine would report.
+    pub fn matches<'t>(&'t self, text: &'t [u8]) -> impl Iterator<Item = usize> + 't {
+        self.finder.find_iter(text)
+    }
+}

--- a/tokenizers/atomsplit/tests/literal.rs
+++ b/tokenizers/atomsplit/tests/literal.rs
@@ -1,0 +1,39 @@
+//! Tests for the literal search. Kept out of `src/` so the core stays production-only.
+use atomsplit::literal::{EmptyPattern, Literal};
+
+#[test]
+fn finds_every_match_and_nothing_else() {
+    let literal = Literal::new(b"-").unwrap();
+    assert_eq!(literal.matches(b"a-b--c").collect::<Vec<_>>(), [1, 3, 4]);
+    assert_eq!(literal.matches(b"none here").count(), 0);
+    assert_eq!(literal.matches(b"").count(), 0);
+    assert_eq!(literal.pattern(), b"-");
+}
+
+#[test]
+fn a_multi_byte_pattern_only_matches_whole() {
+    // `▁` is U+2581 = E2 96 81. The other characters here share its first byte and nothing else, so a
+    // search for that byte alone would report all of them.
+    let literal = Literal::new("▁".as_bytes()).unwrap();
+    let text = "a—b“c…d▁e";
+    assert_eq!(
+        literal.matches(text.as_bytes()).collect::<Vec<_>>(),
+        [text.find('▁').unwrap()]
+    );
+}
+
+#[test]
+fn matches_do_not_overlap() {
+    let literal = Literal::new(b"aa").unwrap();
+    assert_eq!(literal.matches(b"aaa").collect::<Vec<_>>(), [0]);
+    assert_eq!(literal.matches(b"aaaa").collect::<Vec<_>>(), [0, 2]);
+}
+
+#[test]
+fn an_empty_pattern_is_rejected() {
+    assert_eq!(Literal::new(b"").unwrap_err(), EmptyPattern);
+    assert_eq!(
+        EmptyPattern.to_string(),
+        "an empty pattern matches everywhere"
+    );
+}

--- a/tokenizers/atomsplit/tests/literal.rs
+++ b/tokenizers/atomsplit/tests/literal.rs
@@ -29,6 +29,17 @@ fn matches_do_not_overlap() {
     assert_eq!(literal.matches(b"aaaa").collect::<Vec<_>>(), [0, 2]);
 }
 
+/// A `Literal` is stored inline in the normalizer and decoder enums, where every other variant is a
+/// handful of bytes. `memmem::Finder` itself is a few hundred, so it has to stay behind a pointer.
+#[test]
+fn a_literal_is_pointer_sized() {
+    assert_eq!(
+        size_of::<Literal>(),
+        size_of::<*const u8>(),
+        "a Literal must not carry its finder inline"
+    );
+}
+
 #[test]
 fn an_empty_pattern_is_rejected() {
     assert_eq!(Literal::new(b"").unwrap_err(), EmptyPattern);

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -73,10 +73,11 @@ pcre2 = { version = "0.2", optional = true }
 logos = { version = "0.15", optional = true } # compile-time DFA lexer reference (pure Rust)
 
 [features]
-# `fancy-regex` is the OPTIONAL system-regex backend, needed ONLY for a `Split` pre-tokenizer with an
-# arbitrary (non-GPT) regex or the `Replace` normalizer — the atomsplit-native pre-tokenizers (GPT-2,
-# cl100k, deepseek, the class family, char-delimiter) need no backend. Without it a stub compiles and
-# those arbitrary-regex paths error at load. Enable with `--features fancy-regex`.
+# `fancy-regex` is the OPTIONAL system-regex backend, needed ONLY for a *regex* pattern in a `Split`
+# pre-tokenizer or a `Replace` normalizer — the atomsplit-native pre-tokenizers (GPT-2, cl100k,
+# deepseek, the class family, char-delimiter) need no backend, and a plain string pattern is searched
+# for directly. Without it a stub compiles and those regex paths error at load. Enable with
+# `--features fancy-regex`.
 default = ["progressbar"]
 progressbar = ["indicatif"]
 http = ["hf-hub"]

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -5,6 +5,7 @@ use crate::tokenizer::Decoder;
 use crate::tokenizer::pattern::Pattern;
 use crate::tokenizer::{NormalizedString, Normalizer, Result};
 use crate::utils::SysRegex;
+use atomsplit::literal::Literal;
 use serde::{Deserialize, Serialize};
 
 /// Represents the different patterns that `Replace` can use
@@ -26,7 +27,7 @@ impl From<&str> for ReplacePattern {
     }
 }
 
-/// We use this custom deserializer to provide the value for `regex` for `Replace`
+/// We use this custom deserializer to build the search for `Replace`
 #[doc(hidden)]
 #[derive(Deserialize)]
 #[serde(tag = "type")]
@@ -43,6 +44,27 @@ impl std::convert::TryFrom<ReplaceDeserializer> for Replace {
     }
 }
 
+/// How a [`Replace`] looks for its pattern.
+#[derive(Debug)]
+enum Search {
+    /// A plain string, scanned for directly — no regex engine involved, so this works in every build.
+    Literal(Literal),
+    /// A real regex, which needs the system backend (the `fancy-regex` feature).
+    Regex(SysRegex),
+    /// The empty string, which matches nothing.
+    Nothing,
+}
+
+impl Search {
+    fn find_matches(&self, inside: &str) -> Result<Vec<((usize, usize), bool)>> {
+        match self {
+            Self::Literal(literal) => literal.find_matches(inside),
+            Self::Regex(regex) => regex.find_matches(inside),
+            Self::Nothing => Ok(vec![((0, inside.len()), false)]),
+        }
+    }
+}
+
 /// This normalizer will take a `pattern` (for now only a String)
 /// and replace every occurrence with `content`.
 #[derive(Debug, Serialize, Deserialize)]
@@ -51,7 +73,7 @@ pub struct Replace {
     pattern: ReplacePattern,
     pub content: String,
     #[serde(skip)]
-    regex: SysRegex,
+    search: Search,
 }
 
 impl Clone for Replace {
@@ -69,45 +91,68 @@ impl PartialEq for Replace {
 impl Replace {
     pub fn new<I: Into<ReplacePattern>, C: Into<String>>(pattern: I, content: C) -> Result<Self> {
         let pattern: ReplacePattern = pattern.into();
-        let regex = match &pattern {
-            ReplacePattern::String(s) => SysRegex::new(&regex::escape(s))?,
-            ReplacePattern::Regex(r) => SysRegex::new(r)?,
+        let search = match &pattern {
+            ReplacePattern::String(s) if s.is_empty() => Search::Nothing,
+            ReplacePattern::String(s) => Search::Literal(Literal::new(s.as_bytes())?),
+            ReplacePattern::Regex(r) => Search::Regex(SysRegex::new(r)?),
         };
 
         Ok(Self {
             pattern,
             content: content.into(),
-            regex,
+            search,
         })
     }
 }
 
 impl Normalizer for Replace {
     fn normalize(&self, normalized: &mut NormalizedString) -> Result<()> {
-        normalized.replace(&self.regex, &self.content)
+        match &self.search {
+            Search::Literal(literal) => normalized.replace(literal, &self.content),
+            Search::Regex(regex) => normalized.replace(regex, &self.content),
+            Search::Nothing => Ok(()),
+        }
+    }
+}
+
+/// Builds the text with every match swapped for `content`. Borrows the input back untouched when
+/// nothing matched, which is what keeps the common case free of allocation.
+fn replace_matches<'a>(
+    input: &'a str,
+    content: &str,
+    matches: impl Iterator<Item = (usize, usize)>,
+) -> Cow<'a, str> {
+    let mut replaced: Option<String> = None;
+    let mut last_end = 0;
+    for (start, end) in matches {
+        let replaced: &mut String =
+            replaced.get_or_insert_with(|| String::with_capacity(input.len()));
+        replaced.push_str(&input[last_end..start]);
+        replaced.push_str(content);
+        last_end = end;
+    }
+    match replaced {
+        Some(mut replaced) => {
+            replaced.push_str(&input[last_end..]);
+            Cow::Owned(replaced)
+        }
+        None => Cow::Borrowed(input),
     }
 }
 
 impl pipeline::Normalizer for Replace {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>> {
-        let iter = self.regex.find_iter(input);
-        let mut replaced: Option<String> = None;
-        let mut last_end = 0;
-
-        for (start, end) in iter {
-            let replaced: &mut String =
-                replaced.get_or_insert_with(|| String::with_capacity(input.len()));
-            replaced.push_str(&input[last_end..start]);
-            replaced.push_str(&self.content);
-            last_end = end;
-        }
-        if let Some(mut replaced) = replaced {
-            if last_end < input.len() {
-                replaced.push_str(&input[last_end..]);
+        Ok(match &self.search {
+            Search::Literal(literal) => {
+                let width = literal.pattern().len();
+                let matches = literal
+                    .matches(input.as_bytes())
+                    .map(|start| (start, start + width));
+                replace_matches(input, &self.content, matches)
             }
-            return Ok(Cow::Owned(replaced));
-        }
-        Ok(input.into())
+            Search::Regex(regex) => replace_matches(input, &self.content, regex.find_iter(input)),
+            Search::Nothing => Cow::Borrowed(input),
+        })
     }
 }
 
@@ -118,7 +163,7 @@ impl Decoder for Replace {
             .map(|token| -> Result<String> {
                 let mut new_token = "".to_string();
 
-                for ((start, stop), is_match) in (&self.regex).find_matches(&token)? {
+                for ((start, stop), is_match) in self.search.find_matches(&token)? {
                     if is_match {
                         new_token.push_str(&self.content);
                     } else {
@@ -131,8 +176,7 @@ impl Decoder for Replace {
     }
 }
 
-// `Replace` needs a system-regex backend (SysRegex) for every test here.
-#[cfg(all(test, feature = "fancy-regex"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -148,6 +192,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "fancy-regex")] // a regex pattern needs a system-regex backend
     fn test_replace_regex() {
         let original = "This     is   a         test";
         let normalized = "This is a test";
@@ -162,6 +207,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "fancy-regex")] // the regex half of this needs a system-regex backend
     fn serialization() {
         let replace = Replace::new("Hello", "Hey").unwrap();
         let replace_s = r#"{"type":"Replace","pattern":{"String":"Hello"},"content":"Hey"}"#;
@@ -174,6 +220,37 @@ mod tests {
         assert_eq!(serde_json::from_str::<Replace>(replace_s).unwrap(), replace);
     }
 
+    /// The goal of the literal path: a plain string pattern builds and runs with no regex backend.
+    #[test]
+    fn a_string_pattern_needs_no_backend() {
+        let replace = Replace::new(" ", "▁").unwrap();
+        assert_eq!(
+            pipeline::Normalizer::normalize(&replace, "a b  c").unwrap(),
+            "a▁b▁▁c"
+        );
+        // Nothing to replace: the input is handed back as it is, with nothing allocated.
+        assert!(matches!(
+            pipeline::Normalizer::normalize(&replace, "abc").unwrap(),
+            Cow::Borrowed("abc")
+        ));
+        // An empty pattern would match everywhere, so it matches nowhere instead.
+        let empty = Replace::new("", "x").unwrap();
+        assert_eq!(
+            pipeline::Normalizer::normalize(&empty, "abc").unwrap(),
+            "abc"
+        );
+    }
+
+    /// A config spelling its pattern as a string must also *deserialize* with no backend — the
+    /// regex half of `serialization` above can only run once one is compiled.
+    #[test]
+    fn a_string_pattern_deserializes_with_no_backend() {
+        let replace_s = r#"{"type":"Replace","pattern":{"String":"Hello"},"content":"Hey"}"#;
+        let replace = Replace::new("Hello", "Hey").unwrap();
+        assert_eq!(serde_json::from_str::<Replace>(replace_s).unwrap(), replace);
+        assert_eq!(serde_json::to_string(&replace).unwrap(), replace_s);
+    }
+
     #[test]
     fn test_replace_decode() {
         let original = vec!["hello".to_string(), "_hello".to_string()];
@@ -184,26 +261,27 @@ mod tests {
         );
     }
 
+    fn assert_pipeline_matches_legacy(n: &Replace, inputs: &[&str]) {
+        for input in inputs {
+            let mut ns = NormalizedString::from(*input);
+            Normalizer::normalize(n, &mut ns).unwrap(); // legacy oracle
+            assert_eq!(
+                ns.get(),
+                &*pipeline::Normalizer::normalize(n, input).unwrap()
+            );
+        }
+    }
+
     #[test]
     fn pipeline_replace_matches_legacy() {
         let n = Replace::new("''", "\"").unwrap();
-        for input in &["This is a ''test''", "no quotes", ""] {
-            let mut ns = NormalizedString::from(*input);
-            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(
-                ns.get(),
-                &*pipeline::Normalizer::normalize(&n, input).unwrap()
-            );
-        }
+        assert_pipeline_matches_legacy(&n, &["This is a ''test''", "no quotes", ""]);
+    }
 
+    #[test]
+    #[cfg(feature = "fancy-regex")] // a regex pattern needs a system-regex backend
+    fn pipeline_replace_matches_legacy_for_a_regex() {
         let n = Replace::new(ReplacePattern::Regex(r"\s+".into()), " ").unwrap();
-        for input in &["a   b   c", "single", ""] {
-            let mut ns = NormalizedString::from(*input);
-            Normalizer::normalize(&n, &mut ns).unwrap(); // legacy oracle
-            assert_eq!(
-                ns.get(),
-                &*pipeline::Normalizer::normalize(&n, input).unwrap()
-            );
-        }
+        assert_pipeline_matches_legacy(&n, &["a   b   c", "single", ""]);
     }
 }

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -1,5 +1,6 @@
 use crate::pipeline;
 use crate::utils::{GptFsm, GptFsmPattern, SysRegex, gpt_fsm};
+use atomsplit::literal::Literal;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::tokenizer::{
@@ -26,15 +27,26 @@ impl From<&str> for SplitPattern {
     }
 }
 
+/// How a [`Split`] looks for its pattern.
+#[derive(Debug)]
+pub enum Search {
+    /// A plain string, scanned for directly — no regex engine involved, so this works in every build.
+    Literal(Literal),
+    /// A real regex, which needs the system backend (the `fancy-regex` feature).
+    Regex(SysRegex),
+    /// No way to search: no backend is compiled and the pattern is a regex. Splitting then only works
+    /// through the native FSM below, and errors otherwise.
+    Unavailable,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(tag = "type")]
 pub struct Split {
     pub pattern: SplitPattern,
-    /// System-regex backend for the pattern. `None` only when no backend is compiled *and* the
-    /// pattern is a recognized GPT regex handled natively by `fsm` — so no backend is needed.
-    /// With `fancy-regex` enabled this is always `Some`; the default build has no backend (`fsm` only).
+    /// How the pattern is found. A plain string never needs a backend; a regex does, unless it is one
+    /// of the GPT patterns the native FSM below covers.
     #[serde(skip)]
-    pub regex: Option<SysRegex>,
+    pub search: Search,
     pub behavior: SplitDelimiterBehavior,
     pub invert: bool,
     /// Native `atomsplit` FSM for a recognized GPT regex (gpt2 / cl100k-Llama-3 / o200k), used on the
@@ -93,22 +105,21 @@ impl Split {
             SplitPattern::String(_) => None,
             SplitPattern::Regex(r) => gpt_fsm(r),
         };
-        // Compile a system-regex backend for the pattern. With `fancy-regex` enabled this succeeds and
-        // the legacy path is unchanged; with no backend (the default) it's only fatal when atomsplit
-        // can't cover the pattern (i.e. an arbitrary regex, not a recognized GPT one).
-        let compiled = match &pattern {
-            SplitPattern::String(s) => SysRegex::new(&regex::escape(s)),
-            SplitPattern::Regex(r) => SysRegex::new(r),
-        };
-        let regex = match compiled {
-            Ok(re) => Some(re),
-            Err(_) if fsm.is_some() => None,
-            Err(e) => return Err(e),
+        let search = match &pattern {
+            SplitPattern::String(s) => Search::Literal(Literal::new(s.as_bytes())?),
+            // A regex needs the system backend. Missing it is only fatal when the native FSM cannot
+            // cover this pattern either — which `pre_tokenize` reports, since a recognized GPT
+            // pattern in its usual form splits without any backend.
+            SplitPattern::Regex(r) => match SysRegex::new(r) {
+                Ok(regex) => Search::Regex(regex),
+                Err(_) if fsm.is_some() => Search::Unavailable,
+                Err(e) => return Err(e),
+            },
         };
 
         Ok(Self {
             pattern,
-            regex,
+            search,
             behavior,
             invert,
             fsm,
@@ -133,15 +144,27 @@ impl Split {
 
 impl PreTokenizer for Split {
     fn pre_tokenize(&self, pretokenized: &mut PreTokenizedString) -> Result<()> {
-        if let Some(regex) = &self.regex {
-            return if self.invert {
-                pretokenized.split(|_, normalized| normalized.split(Invert(regex), self.behavior))
-            } else {
-                pretokenized.split(|_, normalized| normalized.split(regex, self.behavior))
-            };
+        match &self.search {
+            Search::Literal(literal) => {
+                return if self.invert {
+                    pretokenized
+                        .split(|_, normalized| normalized.split(Invert(literal), self.behavior))
+                } else {
+                    pretokenized.split(|_, normalized| normalized.split(literal, self.behavior))
+                };
+            }
+            Search::Regex(regex) => {
+                return if self.invert {
+                    pretokenized
+                        .split(|_, normalized| normalized.split(Invert(regex), self.behavior))
+                } else {
+                    pretokenized.split(|_, normalized| normalized.split(regex, self.behavior))
+                };
+            }
+            Search::Unavailable => {}
         }
-        // No system-regex backend: only a recognized GPT pattern in its canonical usage (Isolated,
-        // not inverted — how these regexes always ship) can split, via the native atomsplit FSM.
+        // No way to search for the pattern: only a recognized GPT pattern in its canonical usage
+        // (Isolated, not inverted — how these regexes always ship) can split, via the native FSM.
         let fsm = self
             .fsm
             .filter(|_| !self.invert && self.behavior == SplitDelimiterBehavior::Isolated)
@@ -178,15 +201,18 @@ impl pipeline::PreTokenizer for Split {
             );
             return Ok(());
         }
-        // Not a natively-routed GPT regex: fall back to the system-regex backend.
-        let regex = self.regex.as_ref().ok_or_else(|| -> crate::tokenizer::Error {
-            "this `Split` pattern needs a system-regex backend; enable the `fancy-regex` feature"
-                .into()
-        })?;
-        let matches = if self.invert {
-            Invert(regex).find_matches(text)?
-        } else {
-            regex.find_matches(text)?
+        // Not a natively-routed GPT regex: fall-back to Literal or Regex search
+        let matches = match (&self.search, self.invert) {
+            (Search::Literal(literal), false) => literal.find_matches(text)?,
+            (Search::Literal(literal), true) => Invert(literal).find_matches(text)?,
+            (Search::Regex(regex), false) => regex.find_matches(text)?,
+            (Search::Regex(regex), true) => Invert(regex).find_matches(text)?,
+            (Search::Unavailable, _) => {
+                return Err(
+                    "this `Split` pattern needs a system-regex backend; enable the `fancy-regex` feature"
+                        .into(),
+                );
+            }
         };
         pipeline::split_matches(out, matches, self.behavior);
         Ok(())
@@ -523,6 +549,41 @@ mod tests {
         );
     }
 
+    /// The goal of the literal path: a plain string pattern splits with no regex backend, on both the
+    /// legacy and the pipeline path.
+    #[test]
+    fn a_string_pattern_needs_no_backend() {
+        let pretok = Split::new("-", SplitDelimiterBehavior::Removed, false).unwrap();
+        let mut legacy = PreTokenizedString::from("a-b--c");
+        pretok.pre_tokenize(&mut legacy).unwrap();
+        let words: Vec<&str> = legacy
+            .get_splits(OffsetReferential::Original, OffsetType::Byte)
+            .iter()
+            .map(|(word, _, _)| *word)
+            .collect();
+        assert_eq!(words, ["a", "b", "c"]);
+        assert_eq!(
+            pipeline_split(
+                SplitPattern::String("-".into()),
+                SplitDelimiterBehavior::Removed,
+                false,
+                "a-b--c"
+            ),
+            [("a", (0, 1)), ("b", (2, 3)), ("c", (5, 6))]
+        );
+    }
+
+    /// A config spelling its pattern as a string must also *deserialize* with no backend — the
+    /// regex half of `serialization` below can only run once one is compiled.
+    #[test]
+    fn a_string_pattern_deserializes_with_no_backend() {
+        let split_s =
+            r#"{"type":"Split","pattern":{"String":"Hello"},"behavior":"Removed","invert":true}"#;
+        let split = Split::new("Hello", SplitDelimiterBehavior::Removed, true).unwrap();
+        assert_eq!(serde_json::from_str::<Split>(split_s).unwrap(), split);
+        assert_eq!(serde_json::to_string(&split).unwrap(), split_s);
+    }
+
     #[cfg(feature = "fancy-regex")] // needs a system-regex backend
     #[test]
     fn regex_string() {
@@ -548,7 +609,6 @@ mod tests {
         assert_eq!(pretok_str_for_regex, pretok_str_for_string);
     }
 
-    #[cfg(feature = "fancy-regex")] // needs a system-regex backend
     #[test]
     fn invert() {
         let mut pretok_str = PreTokenizedString::from("Hello Hello Hello");

--- a/tokenizers/tk-encode/src/tokenizer/normalizer.rs
+++ b/tokenizers/tk-encode/src/tokenizer/normalizer.rs
@@ -1022,6 +1022,7 @@ impl From<&str> for NormalizedString {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use atomsplit::literal::Literal;
     use regex::Regex;
     use unicode_categories::UnicodeCategories;
 
@@ -1479,7 +1480,7 @@ mod tests {
 
         // Overlapping
         let mut s = NormalizedString::from("aaaab");
-        s.replace("aaa", "b").unwrap();
+        s.replace(&Literal::new(b"aaa").unwrap(), "b").unwrap();
         assert_eq!(s.get(), "bab");
 
         // Regex

--- a/tokenizers/tk-encode/src/tokenizer/pattern.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pattern.rs
@@ -1,5 +1,6 @@
 use crate::utils::SysRegex;
 use crate::{Offsets, Result};
+use atomsplit::literal::Literal;
 use regex::Regex;
 
 /// Pattern used to split a NormalizedString
@@ -19,25 +20,6 @@ impl Pattern for char {
     }
 }
 
-impl Pattern for &str {
-    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
-        if self.is_empty() {
-            // If we try to find the matches with an empty string, just don't match anything
-            return Ok(vec![((0, inside.chars().count()), false)]);
-        }
-
-        let re = Regex::new(&regex::escape(self))?;
-        (&re).find_matches(inside)
-    }
-}
-
-impl Pattern for &String {
-    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
-        let s: &str = self;
-        s.find_matches(inside)
-    }
-}
-
 impl Pattern for &Regex {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
         if inside.is_empty() {
@@ -52,6 +34,30 @@ impl Pattern for &Regex {
             }
             splits.push(((m.start(), m.end()), true));
             prev = m.end();
+        }
+        if prev != inside.len() {
+            splits.push(((prev, inside.len()), false))
+        }
+        Ok(splits)
+    }
+}
+
+/// Searching for a plain string, does not need a regex engine: [`Literal`] scans the bytes.
+impl Pattern for &Literal {
+    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
+        if inside.is_empty() {
+            return Ok(vec![((0, 0), false)]);
+        }
+
+        let mut prev = 0;
+        let mut splits = Vec::with_capacity(inside.len());
+        for start in self.matches(inside.as_bytes()) {
+            let end = start + self.pattern().len();
+            if prev != start {
+                splits.push(((prev, start), false));
+            }
+            splits.push(((start, end), true));
+            prev = end;
         }
         if prev != inside.len() {
             splits.push(((prev, inside.len()), false))
@@ -168,17 +174,28 @@ mod tests {
     }
 
     #[test]
-    fn str() {
-        do_test!("aba", "a" => vec![((0, 1), true), ((1, 2), false), ((2, 3), true)]);
-        do_test!("bbbba", "a" => vec![((0, 4), false), ((4, 5), true)]);
-        do_test!("aabbb", "a" => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
-        do_test!("aabbb", "ab" => vec![((0, 1), false), ((1, 3), true), ((3, 5), false)]);
-        do_test!("aabbab", "ab" =>
+    fn literal() {
+        let a = Literal::new(b"a").unwrap();
+        do_test!("aba", &a => vec![((0, 1), true), ((1, 2), false), ((2, 3), true)]);
+        do_test!("bbbba", &a => vec![((0, 4), false), ((4, 5), true)]);
+        do_test!("aabbb", &a => vec![((0, 1), true), ((1, 2), true), ((2, 5), false)]);
+        do_test!("", &a => vec![((0, 0), false)]);
+
+        let ab = Literal::new(b"ab").unwrap();
+        do_test!("aabbb", &ab => vec![((0, 1), false), ((1, 3), true), ((3, 5), false)]);
+        do_test!("aabbab", &ab =>
             vec![((0, 1), false), ((1, 3), true), ((3, 4), false), ((4, 6), true)]
         );
-        do_test!("", "" => vec![((0, 0), false)]);
-        do_test!("aaa", "" => vec![((0, 3), false)]);
-        do_test!("aaa", "b" => vec![((0, 3), false)]);
+
+        let b = Literal::new(b"b").unwrap();
+        do_test!("aaa", &b => vec![((0, 3), false)]);
+
+        // Offsets are byte offsets, over the whole input a multi-byte pattern covers.
+        let metaspace = Literal::new("▁".as_bytes()).unwrap();
+        do_test!("a▁b", &metaspace => vec![((0, 1), false), ((1, 4), true), ((4, 5), false)]);
+
+        // An empty pattern would match everywhere, so there is no `Literal` for it.
+        assert!(Literal::new(b"").is_err());
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/tokenizer/pattern.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pattern.rs
@@ -66,6 +66,25 @@ impl Pattern for &Literal {
     }
 }
 
+/// A plain string is one [`Literal`], built here because the pattern only lives for this call. Prefer
+/// keeping a [`Literal`] around when the same pattern is searched for repeatedly.
+impl Pattern for &str {
+    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
+        match Literal::new(self.as_bytes()) {
+            Ok(literal) => (&literal).find_matches(inside),
+            // An empty pattern would match everywhere, so it matches nowhere instead.
+            Err(_) => Ok(vec![((0, inside.len()), false)]),
+        }
+    }
+}
+
+impl Pattern for &String {
+    fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
+        let s: &str = self;
+        s.find_matches(inside)
+    }
+}
+
 impl Pattern for &SysRegex {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
         if inside.is_empty() {
@@ -196,6 +215,21 @@ mod tests {
 
         // An empty pattern would match everywhere, so there is no `Literal` for it.
         assert!(Literal::new(b"").is_err());
+    }
+
+    #[test]
+    fn str() {
+        do_test!("aba", "a" => vec![((0, 1), true), ((1, 2), false), ((2, 3), true)]);
+        do_test!("aabbab", "ab" =>
+            vec![((0, 1), false), ((1, 3), true), ((3, 4), false), ((4, 6), true)]
+        );
+        do_test!("aaa", "b" => vec![((0, 3), false)]);
+        do_test!("", "" => vec![((0, 0), false)]);
+        // An empty pattern would match everywhere, so it matches nowhere instead.
+        do_test!("aaa", "" => vec![((0, 3), false)]);
+
+        let owned = String::from("ab");
+        do_test!("aabbb", &owned => vec![((0, 1), false), ((1, 3), true), ((3, 5), false)]);
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1004,6 +1004,34 @@ mod tests {
         }
     }
 
+    /// Test the literal only replace and splits can be run without the fancy-regex feature
+    #[cfg(not(feature = "fancy-regex"))]
+    #[test]
+    fn string_pattern_config_loads_and_encodes_with_no_regex_backend() {
+        let normalizer: NormalizerWrapper =
+            serde_json::from_str(r#"{"type":"Replace","pattern":{"String":" "},"content":"▁"}"#)
+                .unwrap();
+        let pre_tokenizer: PreTokenizerWrapper = serde_json::from_str(
+            r#"{"type":"Split","pattern":{"String":"▁"},"behavior":"MergedWithPrevious","invert":false}"#,
+        )
+        .unwrap();
+
+        let mut tok = wordlevel_tokenizer(vec![("<unk>", 0), ("hello▁", 1), ("world", 2)], None);
+        tok.with_normalizer(Some(normalizer)).unwrap();
+        tok.with_pre_tokenizer(Some(pre_tokenizer));
+
+        let ids: Vec<u32> = PipelineTokenizer::try_from(&tok)
+            .unwrap()
+            .encode("hello world", false)
+            .unwrap()
+            .iter()
+            .map(|t| t.id)
+            .collect();
+        // Not the unk id: both the `Replace` and the `Split` really ran on the literal path.
+        assert_eq!(ids, [1, 2]);
+        assert_pipeline_matches_reference(&tok, "hello world");
+    }
+
     #[test]
     fn segment_iterator_yields_text_and_specials_in_order() {
         let input = "aa<s>bb<s>cc";

--- a/tokenizers/tk-encode/src/utils/mod.rs
+++ b/tokenizers/tk-encode/src/utils/mod.rs
@@ -2,9 +2,10 @@ pub(crate) mod cache;
 #[cfg(feature = "http")]
 pub(crate) mod from_pretrained;
 
-// Optional system-regex backend for arbitrary (non-atomsplit) patterns. With `fancy-regex` off a
-// stub compiles and arbitrary-regex features error at load — the atomsplit-native pre-tokenizers
-// work regardless, so `fancy-regex` is only needed for custom `Split` regexes / `Replace`.
+// Optional system-regex backend, needed only for a *regex* pattern that atomsplit does not cover.
+// With `fancy-regex` off a stub compiles and those patterns error at load. Everything else works
+// regardless: the atomsplit-native pre-tokenizers, and any `Split` or `Replace` whose pattern is a
+// plain string (searched for directly, see `atomsplit::literal`).
 #[cfg(feature = "fancy-regex")]
 mod fancy;
 #[cfg(feature = "fancy-regex")]

--- a/tokenizers/tk-encode/src/utils/no_regex.rs
+++ b/tokenizers/tk-encode/src/utils/no_regex.rs
@@ -1,9 +1,10 @@
 //! Stub `SysRegex` for builds with **no** system-regex backend (`fancy-regex` off — the default).
 //!
-//! The type stays present so `Split` / `Replace` still compile, but construction always fails: the
-//! atomsplit-native pre-tokenizers (GPT-2, cl100k, deepseek, the class family, char-delimiter) need
-//! no backend, while a `Split` with an *arbitrary* regex or the `Replace` normalizer error at load
-//! time with a clear message. Enable `fancy-regex` to get a real backend.
+//! The type stays present so `Split` / `Replace` still compile, but construction always fails. Only a
+//! *regex* pattern ever asks for it: the atomsplit-native pre-tokenizers (GPT-2, cl100k, deepseek, the
+//! class family, char-delimiter) need no backend, and a plain string pattern is searched for directly
+//! (`atomsplit::literal`). A regex atomsplit does not cover errors at load time with a clear message.
+//! Enable `fancy-regex` to get a real backend.
 use std::error::Error;
 
 #[derive(Debug)]
@@ -16,8 +17,9 @@ pub struct SysRegex {
 impl SysRegex {
     pub fn new(_regex_str: &str) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
         Err(
-            "no system-regex backend compiled: enable the `fancy-regex` feature \
-             to use a `Split` pre-tokenizer with a custom regex, or the `Replace` normalizer"
+            "no system-regex backend compiled: enable the `fancy-regex` feature to use a regex \
+             pattern in a `Split` pre-tokenizer or a `Replace` normalizer (a plain string pattern \
+             needs no backend)"
                 .into(),
         )
     }

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -107,10 +107,6 @@ fn check_model(tok_file: &str) {
     );
 }
 
-// The decode oracle's model set (one per decoder archetype) plus mistral-small-4, whose
-// tekken pre-tokenizer is its own encode archetype; whichever files a given checkout has
-// get run (bert-wiki + llama-3 ship with `make test`; the rest with `make bench-models`).
-// Unsupported models skip, not fail.
 #[test]
 fn bert_wiki() {
     check_model("bert-wiki.json");
@@ -134,6 +130,11 @@ fn llama3() {
 #[test]
 fn llama2() {
     check_model("llama-2.json");
+}
+
+#[test]
+fn gemma4() {
+    check_model("gemma-4.json");
 }
 
 #[test]


### PR DESCRIPTION
Preliminary work for Metaspace pre-tokenizers, one more step towards supporting most models without fancy-regex

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`ebf1e7219 · 2026-07-29 15:44 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-overview.png" width="860">

**vs base branch** (`28b2b9633`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×5.01 vs v0.23.1 · ×1.02 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 11+0 (peak 12) · Pipeline 8+0 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 27.5 | ×3.50 | ×1.00 | 3% (1.2) | 76% (27.5) | 13% (4.8) | 7% (2.5) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 24.9 | ×5.96 | ×1.02 | 3% (1.2) | 69% (27.6) | 8% (3.3) | 20% (7.8) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 34.7 | ×5.83 | ×1.02 | 4% (1.2) | 67% (19.2) | 12% (3.4) | 17% (4.8) | 1% (0.2) | match |
| cmn_Hani | lang | 3.8 | 18.8 | ×4.95 | ×1.03 | 2% (1.2) | 72% (37.8) | 9% (4.9) | 17% (8.7) | 0% (0.0) | match |
| ell_Grek | lang | 3.7 | 23.7 | ×6.33 | ×1.02 | 3% (1.2) | 68% (28.7) | 8% (3.4) | 21% (8.6) | 0% (0.1) | match |
| eng_Latn | lang | 4.4 | 18.4 | ×4.19 | ×1.05 | 5% (2.6) | 72% (38.6) | 8% (4.4) | 15% (8.3) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 19.9 | ×4.74 | ×1.02 | 2% (1.2) | 75% (37.2) | 7% (3.7) | 15% (7.5) | 1% (0.3) | match |
| hin_Deva | lang | 6.5 | 27.5 | ×4.26 | ×1.02 | 3% (1.2) | 74% (26.8) | 10% (3.6) | 13% (4.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.2 | 27.3 | ×6.56 | ×1.01 | 3% (1.2) | 65% (23.4) | 12% (4.5) | 20% (7.3) | 0% (0.0) | match |
| kat_Geor | lang | 6.1 | 28.1 | ×4.60 | ×1.01 | 3% (1.2) | 74% (26.3) | 9% (3.0) | 14% (4.8) | 0% (0.1) | match |
| kor_Hang | lang | 2.2 | 17.7 | ×8.01 | ×1.02 | 2% (1.2) | 63% (35.1) | 13% (7.1) | 23% (12.7) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.6 | 23.7 | ×6.59 | ×1.02 | 3% (1.2) | 66% (27.5) | 8% (3.2) | 24% (10.0) | 0% (0.1) | match |
| tam_Taml | lang | 6.9 | 38.3 | ×5.53 | ×1.02 | 4% (1.2) | 72% (18.7) | 11% (2.8) | 12% (3.2) | 0% (0.0) | match |
| tha_Thai | lang | 8.2 | 33.4 | ×4.06 | ×1.02 | 4% (1.2) | 84% (25.2) | 7% (2.1) | 4% (1.3) | 1% (0.3) | match |
| added_normalized_dense | modalities | 6.7 | 19.7 | ×2.93 | ×1.04 | 3% (1.3) | 81% (40.6) | 15% (7.3) | 1% (0.6) | 0% (0.1) | match |
| added_normalized_sparse | modalities | 5.2 | 18.4 | ×3.50 | ×1.03 | 4% (2.0) | 74% (39.8) | 14% (7.3) | 8% (4.4) | 0% (0.2) | match |
| added_special_dense | modalities | 5.3 | 38.2 | ×7.21 | ×0.98 | 20% (5.1) | 36% (9.0) | 37% (9.2) | 7% (1.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 21.3 | ×5.40 | ×1.01 | 8% (3.6) | 61% (28.1) | 19% (8.8) | 12% (5.5) | 0% (0.0) | match |
| agentic-traces | modalities | 3.8 | 18.2 | ×4.84 | ×1.04 | 4% (2.4) | 67% (41.4) | 3% (1.9) | 14% (8.9) | 11% (7.0) | match |
| agentic_swe | modalities | 4.0 | 19.4 | ×4.85 | ×1.04 | 4% (2.0) | 75% (38.6) | 7% (3.7) | 13% (6.8) | 0% (0.1) | match |
| code_mixed | modalities | 3.9 | 19.0 | ×4.91 | ×1.04 | 4% (2.1) | 74% (38.7) | 8% (4.1) | 14% (7.4) | 0% (0.0) | match |
| math_latex | modalities | 3.9 | 18.2 | ×4.65 | ×1.04 | 5% (2.5) | 71% (38.5) | 9% (4.8) | 16% (8.8) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×4.19 vs v0.23.1 · ×0.97 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 67) · Pipeline 82+0 (peak 82)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 32.6 | ×7.56 | ×0.98 | 2% (0.7) | 0% (0.0) | 16% (4.8) | 82% (24.0) | 0% (0.0) | match |
| arb_Arab | lang | 4.0 | 16.2 | ×4.06 | ×0.97 | 1% (0.6) | 0% (0.0) | 6% (3.5) | 94% (57.5) | 0% (0.0) | match |
| ben_Beng | lang | 6.2 | 17.3 | ×2.79 | ×0.97 | 1% (0.6) | 0% (0.0) | 6% (3.2) | 93% (52.3) | 0% (0.0) | match |
| cmn_Hani | lang | 3.6 | 15.7 | ×4.39 | ×0.96 | 1% (0.8) | 0% (0.0) | 5% (3.2) | 93% (57.6) | 0% (0.2) | match |
| ell_Grek | lang | 4.5 | 16.8 | ×3.73 | ×0.94 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (51.9) | 0% (0.1) | match |
| eng_Latn | lang | 2.9 | 12.5 | ×4.38 | ×0.97 | 3% (2.0) | 0% (0.0) | 6% (5.1) | 91% (71.3) | 0% (0.2) | match |
| heb_Hebr | lang | 3.6 | 12.6 | ×3.47 | ×0.98 | 1% (0.6) | 0% (0.0) | 5% (3.6) | 94% (72.1) | 0% (0.0) | match |
| hin_Deva | lang | 5.7 | 20.9 | ×3.69 | ×0.97 | 1% (0.6) | 0% (0.0) | 7% (3.5) | 91% (42.3) | 0% (0.1) | match |
| jpn_Jpan | lang | 4.0 | 17.2 | ×4.31 | ×0.97 | 1% (0.7) | 0% (0.0) | 5% (3.1) | 93% (51.8) | 1% (0.3) | match |
| kat_Geor | lang | 5.9 | 17.3 | ×2.95 | ×0.96 | 1% (0.6) | 0% (0.0) | 5% (3.0) | 94% (52.4) | 0% (0.0) | match |
| kor_Hang | lang | 3.3 | 19.1 | ×5.87 | ×0.96 | 1% (0.6) | 0% (0.0) | 7% (3.8) | 91% (45.8) | 0% (0.2) | match |
| rus_Cyrl | lang | 4.1 | 14.1 | ×3.47 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (3.6) | 94% (64.7) | 0% (0.0) | match |
| tam_Taml | lang | 6.1 | 17.2 | ×2.83 | ×0.97 | 1% (0.6) | 0% (0.0) | 5% (2.8) | 97% (54.5) | 0% (0.0) | match |
| tha_Thai | lang | 6.7 | 14.2 | ×2.11 | ×0.98 | 1% (0.6) | 0% (0.0) | 3% (2.3) | 96% (67.6) | 0% (0.1) | match |
| added_normalized_dense | modalities | 6.0 | 22.4 | ×3.75 | ×0.96 | 2% (0.9) | 0% (0.0) | 7% (2.8) | 97% (41.2) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 19.0 | ×3.55 | ×0.97 | 3% (1.4) | 0% (0.0) | 8% (3.9) | 90% (46.1) | 0% (0.0) | match |
| added_special_dense | modalities | 3.6 | 36.6 | ×10.05 | ×1.00 | 25% (6.4) | 2% (0.4) | 24% (6.2) | 49% (12.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 20.1 | ×5.10 | ×0.97 | 8% (4.0) | 0% (0.1) | 14% (6.7) | 77% (36.9) | 0% (0.1) | match |
| agentic-traces | modalities | 2.7 | 13.9 | ×5.06 | ×0.98 | 3% (1.8) | 0% (0.0) | 8% (5.4) | 90% (62.0) | 0% (0.0) | match |
| agentic_swe | modalities | 2.9 | 14.6 | ×4.98 | ×0.97 | 2% (1.3) | 0% (0.0) | 6% (3.8) | 93% (64.1) | 0% (0.0) | match |
| code_mixed | modalities | 3.4 | 15.2 | ×4.46 | ×0.98 | 3% (1.6) | 0% (0.0) | 7% (4.6) | 90% (57.7) | 0% (0.0) | match |
| math_latex | modalities | 2.7 | 13.6 | ×5.09 | ×0.97 | 3% (1.9) | 0% (0.0) | 8% (5.5) | 90% (65.7) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.10 | 4.80 | 5.27 | 41.0 | 20.2 | 9.4 | — | 8.6× / 7.8× | 4.2× / 3.8× | 2.0× / 1.8× | — |
| arb_Arab | 1.00 | 2.86 | 3.47 | 5.33 | 48.3 | 22.9 | 10.5 | — | 13.9× / 9.1× | 6.6× / 4.3× | 3.0× / 2.0× | — |
| ben_Beng | 1.46 | 2.62 | 3.23 | 4.39 | 35.2 | 16.3 | 7.7 | — | 10.9× / 8.0× | 5.0× / 3.7× | 2.4× / 1.7× | — |
| cmn_Hani | 1.13 | 2.03 | 3.18 | 4.09 | 58.9 | 34.0 | 14.5 | — | 18.5× / 14.4× | 10.7× / 8.3× | 4.5× / 3.5× | — |
| ell_Grek | 0.57 | 2.81 | 3.44 | 5.68 | 46.1 | 21.1 | 9.7 | — | 13.4× / 8.1× | 6.1× / 3.7× | 2.8× / 1.7× | — |
| eng_Latn | 0.09 | 1.17 | 5.09 | 6.17 | 64.4 | 39.0 | 29.2 | — | 12.6× / 10.4× | 7.6× / 6.3× | 5.7× / 4.7× | — |
| heb_Hebr | 0.99 | 2.84 | 3.64 | 5.50 | 50.1 | 23.9 | 10.8 | — | 13.8× / 9.1× | 6.6× / 4.4× | 3.0× / 2.0× | — |
| hin_Deva | 1.36 | 2.78 | 3.46 | 4.88 | 37.3 | 18.6 | 8.7 | — | 10.8× / 7.6× | 5.4× / 3.8× | 2.5× / 1.8× | — |
| jpn_Jpan | 1.56 | 3.10 | 3.05 | 4.60 | 51.6 | 27.4 | 12.0 | — | 16.9× / 11.2× | 9.0× / 6.0× | 3.9× / 2.6× | — |
| kat_Geor | 1.38 | 2.16 | 2.97 | 3.75 | 31.4 | 15.2 | 7.3 | — | 10.6× / 8.4× | 5.1× / 4.1× | 2.4× / 1.9× | — |
| kor_Hang | 1.08 | 2.51 | 3.77 | 5.20 | 48.7 | 27.6 | 12.1 | — | 12.9× / 9.4× | 7.3× / 5.3× | 3.2× / 2.3× | — |
| rus_Cyrl | 1.01 | 2.75 | 3.64 | 5.39 | 46.1 | 20.8 | 9.7 | — | 12.7× / 8.6× | 5.7× / 3.9× | 2.7× / 1.8× | — |
| tam_Taml | 0.92 | 2.61 | 2.76 | 4.45 | 31.0 | 13.7 | 6.7 | — | 11.2× / 7.0× | 5.0× / 3.1× | 2.4× / 1.5× | — |
| tha_Thai | 1.35 | 2.26 | 2.32 | 3.22 | 26.7 | 10.1 | 5.4 | — | 11.5× / 8.3× | 4.4× / 3.1× | 2.3× / 1.7× | — |
| added_normalized_dense | 0.09 | 1.18 | 2.81 | 3.90 | 41.8 | 20.0 | 9.1 | — | 14.9× / 10.7× | 7.1× / 5.1× | 3.2× / 2.3× | — |
| added_normalized_sparse | 0.08 | 1.18 | 3.88 | 4.98 | 47.9 | 25.0 | 11.2 | — | 12.4× / 9.6× | 6.5× / 5.0× | 2.9× / 2.3× | — |
| added_special_dense | 0.09 | 1.18 | 6.22 | 7.31 | 169.5 | 97.5 | 38.5 | — | 27.2× / 23.2× | 15.7× / 13.3× | 6.2× / 5.3× | — |
| added_special_sparse | 0.06 | 1.18 | 6.69 | 7.81 | 100.2 | 57.3 | 24.1 | — | 15.0× / 12.8× | 8.6× / 7.3× | 3.6× / 3.1× | — |
| agentic-traces | 0.56 | 1.18 | 5.44 | 6.06 | 79.3 | 54.2 | 20.7 | — | 14.6× / 13.1× | 10.0× / 8.9× | 3.8× / 3.4× | — |
| agentic_swe | 0.51 | 1.15 | 3.82 | 4.46 | 94.9 | 66.4 | 24.1 | — | 24.8× / 21.3× | 17.4× / 14.9× | 6.3× / 5.4× | — |
| code_mixed | 0.07 | 1.17 | 4.60 | 5.71 | 73.4 | 55.1 | 19.2 | — | 16.0× / 12.9× | 12.0× / 9.7× | 4.2× / 3.4× | — |
| math_latex | 0.57 | 1.19 | 5.49 | 6.11 | 78.3 | 47.7 | 19.8 | — | 14.3× / 12.8× | 8.7× / 7.8× | 3.6× / 3.2× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×1.86 vs v0.23.1 · ×1.08 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 303+0 (peak 371) · Pipeline 274+0 (peak 370)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 11.3 | 29.4 | ×2.60 | ×1.12 | 2% (0.7) | 4% (1.3) | 0% (0.0) | 94% (30.5) | 0% (0.0) | match |
| arb_Arab | lang | 7.6 | 14.0 | ×1.84 | ×1.09 | 1% (0.6) | 2% (1.6) | 0% (0.0) | 97% (68.9) | 0% (0.0) | match |
| ben_Beng | lang | 11.0 | 19.1 | ×1.75 | ×1.10 | 1% (0.6) | 2% (1.0) | 0% (0.0) | 97% (49.0) | 0% (0.0) | match |
| cmn_Hani | lang | 13.8 | 37.1 | ×2.68 | ×1.11 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 97% (23.6) | 0% (0.0) | match |
| ell_Grek | lang | 8.1 | 15.5 | ×1.92 | ×1.07 | 1% (0.6) | 2% (1.6) | 0% (0.0) | 96% (61.1) | 0% (0.1) | match |
| eng_Latn | lang | 4.1 | 5.7 | ×1.37 | ×1.04 | 1% (2.0) | 2% (3.0) | 0% (0.0) | 97% (163.5) | 0% (0.3) | match |
| heb_Hebr | lang | 8.3 | 17.4 | ×2.10 | ×1.07 | 1% (0.6) | 3% (1.6) | 0% (0.0) | 95% (53.7) | 1% (0.7) | match |
| hin_Deva | lang | 10.4 | 18.9 | ×1.81 | ×1.10 | 1% (0.6) | 3% (1.4) | 0% (0.0) | 97% (49.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.8 | 30.8 | ×2.23 | ×1.09 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 98% (29.4) | 0% (0.0) | match |
| kat_Geor | lang | 12.6 | 25.7 | ×2.04 | ×1.07 | 2% (0.6) | 2% (0.9) | 0% (0.0) | 96% (36.5) | 0% (0.0) | match |
| kor_Hang | lang | 10.4 | 27.5 | ×2.63 | ×1.11 | 2% (0.6) | 5% (1.6) | 0% (0.1) | 93% (31.3) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.6 | 11.3 | ×1.50 | ×1.09 | 1% (0.6) | 2% (1.5) | 0% (0.0) | 98% (83.0) | 0% (0.0) | match |
| tam_Taml | lang | 11.7 | 20.2 | ×1.72 | ×1.06 | 1% (0.6) | 2% (0.8) | 0% (0.0) | 97% (46.5) | 0% (0.0) | match |
| tha_Thai | lang | 13.9 | 24.9 | ×1.79 | ×1.07 | 2% (0.6) | 1% (0.5) | 0% (0.0) | 99% (38.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.2 | 7.5 | ×1.44 | ×1.05 | 1% (0.8) | 1% (1.8) | 0% (0.0) | 98% (126.8) | 0% (0.3) | match |
| added_normalized_sparse | modalities | 4.8 | 6.7 | ×1.39 | ×1.05 | 1% (1.4) | 2% (2.7) | 0% (0.0) | 97% (142.2) | 0% (0.0) | match |
| added_special_dense | modalities | 4.8 | 21.8 | ×4.54 | ×1.13 | 21% (9.0) | 14% (6.1) | 14% (6.2) | 51% (22.0) | 0% (0.1) | match |
| added_special_sparse | modalities | 7.3 | 10.2 | ×1.39 | ×1.06 | 5% (5.0) | 7% (6.3) | 4% (4.2) | 84% (81.2) | 0% (0.0) | match |
| agentic-traces | modalities | 4.5 | 6.5 | ×1.45 | ×1.06 | 1% (1.8) | 2% (2.8) | 0% (0.0) | 97% (141.6) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 7.2 | ×1.69 | ×1.06 | 1% (1.3) | 3% (4.0) | 0% (0.0) | 96% (128.3) | 0% (0.5) | match |
| code_mixed | modalities | 4.4 | 6.7 | ×1.55 | ×1.06 | 1% (1.5) | 2% (3.5) | 0% (0.0) | 97% (137.7) | 0% (0.0) | match |
| math_latex | modalities | 4.3 | 6.1 | ×1.42 | ×1.09 | 1% (1.9) | 2% (2.9) | 0% (0.1) | 97% (152.0) | 0% (0.0) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×7.65 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 27+0 (peak 27)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 46.9 | ×11.58 | ×1.00 | 3% (0.7) | 0% (0.0) | 18% (3.6) | 79% (15.6) | 0% (0.0) | match |
| arb_Arab | lang | 3.9 | 24.6 | ×6.24 | ×0.96 | 2% (0.6) | 0% (0.0) | 6% (2.2) | 93% (36.5) | 0% (0.0) | match |
| ben_Beng | lang | 3.0 | 46.1 | ×15.60 | ×1.07 | 3% (0.6) | 0% (0.0) | 15% (3.0) | 82% (16.7) | 0% (0.1) | match |
| cmn_Hani | lang | 3.8 | 28.4 | ×7.46 | ×1.01 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (30.8) | 0% (0.0) | match |
| ell_Grek | lang | 4.4 | 29.3 | ×6.70 | ×1.04 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 92% (30.3) | 0% (0.0) | match |
| eng_Latn | lang | 3.5 | 13.9 | ×4.00 | ×0.99 | 3% (2.0) | 0% (0.0) | 4% (3.0) | 93% (65.0) | 0% (0.0) | match |
| heb_Hebr | lang | 3.9 | 28.3 | ×7.22 | ×0.98 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 92% (31.2) | 0% (0.0) | match |
| hin_Deva | lang | 3.1 | 39.9 | ×13.01 | ×0.98 | 2% (0.6) | 0% (0.0) | 12% (3.1) | 86% (21.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.5 | 21.7 | ×4.81 | ×1.01 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (42.3) | 0% (0.0) | match |
| kat_Geor | lang | 4.7 | 64.9 | ×13.76 | ×0.91 | 4% (0.6) | 0% (0.0) | 14% (2.0) | 82% (12.2) | 0% (0.0) | match |
| kor_Hang | lang | 3.3 | 41.3 | ×12.34 | ×0.95 | 3% (0.6) | 0% (0.0) | 10% (2.4) | 87% (20.4) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.2 | 26.7 | ×6.31 | ×1.00 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 93% (33.6) | 0% (0.0) | match |
| tam_Taml | lang | 2.7 | 68.1 | ×25.29 | ×0.96 | 4% (0.6) | 0% (0.0) | 19% (2.7) | 77% (10.8) | 0% (0.0) | match |
| tha_Thai | lang | 3.6 | 35.8 | ×9.83 | ×0.96 | 2% (0.6) | 0% (0.0) | 9% (2.5) | 88% (23.7) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 24.3 | ×4.08 | ×0.97 | 2% (0.8) | 0% (0.0) | 3% (1.1) | 96% (36.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 20.4 | ×3.96 | ×0.95 | 3% (1.3) | 0% (0.0) | 4% (1.9) | 93% (41.9) | 0% (0.1) | match |
| added_special_dense | modalities | 4.2 | 46.3 | ×11.14 | ×1.02 | 24% (4.9) | 0% (0.1) | 21% (4.3) | 55% (11.0) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.2 | 22.9 | ×5.43 | ×0.97 | 8% (3.2) | 0% (0.0) | 11% (4.6) | 81% (33.0) | 0% (0.0) | match |
| agentic-traces | modalities | 3.2 | 16.3 | ×5.13 | ×1.00 | 3% (1.8) | 0% (0.0) | 6% (3.5) | 91% (54.5) | 0% (0.0) | match |
| agentic_swe | modalities | 3.4 | 24.7 | ×7.35 | ×1.00 | 3% (1.3) | 0% (0.0) | 6% (2.4) | 91% (35.3) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 20.2 | ×5.75 | ×0.97 | 3% (1.5) | 0% (0.0) | 6% (2.9) | 91% (42.6) | 0% (0.0) | match |
| math_latex | modalities | 3.2 | 15.2 | ×4.74 | ×1.00 | 3% (1.9) | 0% (0.1) | 5% (3.2) | 92% (59.0) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.66 | 3.11 | 3.61 | 4.06 | 26.5 | 21.6 | 5.8 | 4.7 | 7.3× / 6.5× | 6.0× / 5.3× | 1.6× / 1.4× | 1.3× / 1.2× |
| arb_Arab | 0.99 | 2.78 | 2.25 | 4.04 | 30.8 | 26.0 | 6.8 | 5.0 | 13.7× / 7.6× | 11.6× / 6.4× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.46 | 2.62 | 3.00 | 4.16 | 63.2 | 56.1 | 14.0 | 4.0 | 21.1× / 15.2× | 18.7× / 13.5× | 4.7× / 3.4× | 1.3× / 1.0× |
| cmn_Hani | 1.13 | 2.01 | 2.30 | 3.18 | 25.3 | 21.4 | 5.9 | 2.4 | 11.0× / 7.9× | 9.3× / 6.7× | 2.6× / 1.9× | 1.0× / 0.7× |
| ell_Grek | 0.57 | 2.83 | 2.14 | 4.40 | 27.3 | 22.5 | 5.9 | 4.7 | 12.8× / 6.2× | 10.5× / 5.1× | 2.8× / 1.3× | 2.2× / 1.1× |
| eng_Latn | 0.12 | 1.17 | 2.97 | 4.02 | 42.2 | 43.1 | 11.8 | 3.7 | 14.2× / 10.5× | 14.5× / 10.7× | 4.0× / 2.9× | 1.3× / 0.9× |
| heb_Hebr | 0.99 | 2.85 | 2.25 | 4.11 | 30.4 | 26.2 | 6.9 | 3.2 | 13.5× / 7.4× | 11.7× / 6.4× | 3.0× / 1.7× | 1.4× / 0.8× |
| hin_Deva | 1.37 | 2.78 | 3.07 | 4.48 | 58.5 | 54.5 | 13.6 | 4.3 | 19.1× / 13.1× | 17.8× / 12.2× | 4.4× / 3.0× | 1.4× / 0.9× |
| jpn_Jpan | 1.56 | 3.12 | 2.12 | 3.68 | 22.7 | 18.2 | 5.0 | 3.8 | 10.7× / 6.2× | 8.6× / 4.9× | 2.4× / 1.4× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.19 | 2.03 | 2.82 | 16.8 | 14.4 | 4.2 | 2.0 | 8.3× / 5.9× | 7.1× / 5.1× | 2.1× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.08 | 2.52 | 2.43 | 3.88 | 30.5 | 28.2 | 7.5 | 3.6 | 12.6× / 7.9× | 11.6× / 7.3× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.00 | 2.80 | 2.08 | 3.88 | 26.0 | 21.6 | 5.8 | 2.5 | 12.5× / 6.7× | 10.4× / 5.6× | 2.8× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.92 | 2.62 | 2.68 | 4.38 | 66.5 | 58.2 | 14.1 | 3.8 | 24.8× / 15.2× | 21.7× / 13.3× | 5.3× / 3.2× | 1.4× / 0.9× |
| tha_Thai | 1.36 | 2.22 | 2.50 | 3.37 | 38.5 | 32.0 | 8.7 | 3.2 | 15.4× / 11.4× | 12.8× / 9.5× | 3.5× / 2.6× | 1.3× / 1.0× |
| added_normalized_dense | 0.06 | 1.18 | 1.09 | 2.21 | 22.7 | 22.9 | 6.4 | 1.8 | 20.7× / 10.2× | 21.0× / 10.4× | 5.8× / 2.9× | 1.6× / 0.8× |
| added_normalized_sparse | 0.06 | 1.18 | 1.90 | 3.02 | 29.9 | 31.0 | 8.6 | 2.5 | 15.7× / 9.9× | 16.3× / 10.3× | 4.5× / 2.9× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.18 | 4.27 | 5.39 | 90.4 | 97.5 | 19.8 | 2.6 | 21.1× / 16.8× | 22.8× / 18.1× | 4.6× / 3.7× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.18 | 4.56 | 5.67 | 58.6 | 61.1 | 14.4 | 3.4 | 12.9× / 10.3× | 13.4× / 10.8× | 3.2× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.59 | 1.19 | 3.48 | 4.07 | 56.1 | 61.3 | 15.3 | 4.5 | 16.1× / 13.8× | 17.6× / 15.1× | 4.4× / 3.7× | 1.3× / 1.1× |
| agentic_swe | 0.51 | 1.20 | 2.40 | 3.08 | 57.1 | 69.0 | 15.0 | 3.4 | 23.8× / 18.5× | 28.8× / 22.4× | 6.3× / 4.9× | 1.4× / 1.1× |
| code_mixed | 0.07 | 1.15 | 2.86 | 3.94 | 55.5 | 66.1 | 15.0 | 4.0 | 19.4× / 14.1× | 23.1× / 16.8× | 5.2× / 3.8× | 1.4× / 1.0× |
| math_latex | 0.57 | 1.20 | 3.24 | 3.88 | 49.9 | 51.2 | 13.8 | 4.1 | 15.4× / 12.9× | 15.8× / 13.2× | 4.2× / 3.6× | 1.3× / 1.1× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×4.85 vs v0.23.1 · ×1.04 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 24.9 | ×6.13 | ×1.07 | 2% (0.7) | 0% (0.0) | 13% (4.8) | 85% (30.9) | 0% (0.1) | match |
| arb_Arab | lang | 4.8 | 18.5 | ×3.90 | ×1.06 | 1% (0.6) | 0% (0.0) | 6% (3.3) | 91% (47.2) | 2% (1.0) | match |
| ben_Beng | lang | 6.8 | 17.5 | ×2.58 | ×1.00 | 1% (0.6) | 0% (0.0) | 7% (3.7) | 93% (51.7) | 0% (0.0) | match |
| cmn_Hani | lang | 4.8 | 12.4 | ×2.58 | ×1.08 | 1% (0.6) | 0% (0.0) | 4% (3.3) | 95% (72.9) | 0% (0.0) | match |
| ell_Grek | lang | 5.2 | 16.2 | ×3.12 | ×1.06 | 1% (0.6) | 0% (0.0) | 6% (3.3) | 94% (55.3) | 0% (0.0) | match |
| eng_Latn | lang | 4.1 | 44.1 | ×10.85 | ×1.15 | 10% (2.0) | 0% (0.0) | 23% (4.6) | 66% (13.0) | 0% (0.1) | match |
| heb_Hebr | lang | 4.8 | 17.3 | ×3.59 | ×1.03 | 1% (0.6) | 0% (0.0) | 6% (3.4) | 93% (51.1) | 0% (0.1) | match |
| hin_Deva | lang | 7.2 | 27.2 | ×3.78 | ×1.04 | 2% (0.6) | 0% (0.0) | 11% (3.8) | 87% (30.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.6 | 12.9 | ×2.30 | ×1.05 | 1% (0.6) | 0% (0.0) | 4% (3.1) | 95% (72.0) | 0% (0.2) | match |
| kat_Geor | lang | 6.9 | 14.5 | ×2.10 | ×1.05 | 1% (0.6) | 0% (0.0) | 4% (2.9) | 95% (63.1) | 0% (0.0) | match |
| kor_Hang | lang | 4.2 | 15.6 | ×3.72 | ×1.07 | 1% (0.6) | 0% (0.0) | 6% (3.7) | 93% (56.0) | 0% (0.1) | match |
| rus_Cyrl | lang | 5.4 | 15.7 | ×2.90 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (3.2) | 94% (56.6) | 0% (0.0) | match |
| tam_Taml | lang | 7.1 | 13.0 | ×1.83 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (3.2) | 95% (70.7) | 0% (0.2) | match |
| tha_Thai | lang | 8.0 | 11.4 | ×1.43 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (3.2) | 96% (81.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.6 | 24.6 | ×4.42 | ×0.98 | 2% (0.8) | 0% (0.0) | 6% (2.2) | 92% (36.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 40.8 | ×7.65 | ×0.99 | 6% (1.3) | 0% (0.0) | 14% (3.2) | 81% (19.2) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 78.2 | ×18.95 | ×1.02 | 39% (4.9) | 1% (0.1) | 43% (5.3) | 14% (1.7) | 3% (0.4) | match |
| added_special_sparse | modalities | 4.3 | 80.4 | ×18.74 | ×1.05 | 26% (3.1) | 0% (0.0) | 49% (5.8) | 22% (2.5) | 2% (0.3) | match |
| agentic-traces | modalities | 3.8 | 39.4 | ×10.41 | ×1.07 | 8% (1.8) | 0% (0.0) | 22% (5.0) | 70% (15.9) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 27.6 | ×6.88 | ×1.02 | 4% (1.3) | 0% (0.0) | 11% (3.7) | 85% (30.3) | 0% (0.1) | match |
| code_mixed | modalities | 4.0 | 52.6 | ×13.05 | ×1.08 | 9% (1.5) | 0% (0.0) | 26% (4.4) | 64% (11.0) | 2% (0.4) | match |
| math_latex | modalities | 3.6 | 38.9 | ×10.89 | ×1.08 | 8% (1.9) | 0% (0.0) | 22% (4.9) | 70% (15.7) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.09 | 4.78 | 5.24 | 29.4 | 13.9 | 6.8 | 4.8 | 6.2× / 5.6× | 2.9× / 2.6× | 1.4× / 1.3× | 1.0× / 0.9× |
| arb_Arab | 0.99 | 2.78 | 3.29 | 5.08 | 33.8 | 15.8 | 7.5 | 5.1 | 10.3× / 6.7× | 4.8× / 3.1× | 2.3× / 1.5× | 1.6× / 1.0× |
| ben_Beng | 1.46 | 2.66 | 3.70 | 4.89 | 23.7 | 10.6 | 5.3 | 2.8 | 6.4× / 4.8× | 2.9× / 2.2× | 1.4× / 1.1× | 0.8× / 0.6× |
| cmn_Hani | 1.13 | 2.00 | 3.31 | 4.18 | 21.4 | 10.7 | 5.5 | 2.5 | 6.5× / 5.1× | 3.2× / 2.6× | 1.7× / 1.3× | 0.8× / 0.6× |
| ell_Grek | 0.57 | 2.75 | 3.26 | 5.44 | 29.8 | 14.7 | 6.7 | 5.1 | 9.1× / 5.5× | 4.5× / 2.7× | 2.1× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.11 | 1.17 | 4.60 | 5.66 | 43.0 | 28.4 | 13.6 | 4.2 | 9.4× / 7.6× | 6.2× / 5.0× | 3.0× / 2.4× | 0.9× / 0.7× |
| heb_Hebr | 1.00 | 2.85 | 3.39 | 5.24 | 33.2 | 16.7 | 7.9 | 2.8 | 9.8× / 6.3× | 4.9× / 3.2× | 2.3× / 1.5× | 0.8× / 0.5× |
| hin_Deva | 1.36 | 2.78 | 3.81 | 5.23 | 25.8 | 12.6 | 6.3 | 3.2 | 6.8× / 4.9× | 3.3× / 2.4× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.56 | 3.13 | 3.09 | 4.66 | 20.1 | 9.2 | 4.7 | 3.8 | 6.5× / 4.3× | 3.0× / 2.0× | 1.5× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.39 | 2.18 | 2.91 | 3.70 | 18.5 | 9.9 | 4.5 | 2.1 | 6.4× / 5.0× | 3.4× / 2.7× | 1.6× / 1.2× | 0.7× / 0.6× |
| kor_Hang | 1.08 | 2.55 | 3.73 | 5.21 | 32.9 | 18.6 | 8.7 | 3.7 | 8.8× / 6.3× | 5.0× / 3.6× | 2.3× / 1.7× | 1.0× / 0.7× |
| rus_Cyrl | 1.01 | 2.79 | 3.16 | 4.94 | 28.6 | 14.9 | 6.5 | 4.8 | 9.1× / 5.8× | 4.7× / 3.0× | 2.1× / 1.3× | 1.5× / 1.0× |
| tam_Taml | 0.92 | 2.63 | 3.20 | 4.91 | 18.9 | 8.7 | 4.3 | 2.9 | 5.9× / 3.9× | 2.7× / 1.8× | 1.3× / 0.9× | 0.9× / 0.6× |
| tha_Thai | 1.36 | 2.22 | 3.20 | 4.05 | 13.1 | 5.6 | 2.8 | 2.3 | 4.1× / 3.2× | 1.8× / 1.4× | 0.9× / 0.7× | 0.7× / 0.6× |
| added_normalized_dense | 0.06 | 1.18 | 2.22 | 3.34 | 33.8 | 17.1 | 11.3 | 2.0 | 15.2× / 10.1× | 7.7× / 5.1× | 5.1× / 3.4× | 0.9× / 0.6× |
| added_normalized_sparse | 0.06 | 1.18 | 3.20 | 4.32 | 35.9 | 19.9 | 11.5 | 2.8 | 11.2× / 8.3× | 6.2× / 4.6× | 3.6× / 2.7× | 0.9× / 0.7× |
| added_special_dense | 0.06 | 1.18 | 5.32 | 6.44 | 84.9 | 69.3 | 24.1 | 3.2 | 16.0× / 13.2× | 13.0× / 10.8× | 4.5× / 3.7× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.18 | 5.82 | 6.94 | 56.8 | 40.8 | 16.7 | 3.5 | 9.8× / 8.2× | 7.0× / 5.9× | 2.9× / 2.4× | 0.6× / 0.5× |
| agentic-traces | 0.57 | 1.18 | 4.97 | 5.58 | 52.1 | 40.8 | 17.0 | 4.9 | 10.5× / 9.3× | 8.2× / 7.3× | 3.4× / 3.0× | 1.0× / 0.9× |
| agentic_swe | 0.53 | 1.16 | 3.74 | 4.37 | 53.0 | 47.8 | 17.1 | 3.6 | 14.2× / 12.1× | 12.8× / 11.0× | 4.6× / 3.9× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.17 | 4.43 | 5.53 | 52.8 | 47.3 | 17.1 | 4.3 | 11.9× / 9.5× | 10.7× / 8.6× | 3.9× / 3.1× | 1.0× / 0.8× |
| math_latex | 0.58 | 1.18 | 4.88 | 5.48 | 49.6 | 35.0 | 15.6 | 4.5 | 10.2× / 9.0× | 7.2× / 6.4× | 3.2× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×6.36 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 46.1 | ×11.17 | ×1.02 | 6% (1.2) | 0% (0.0) | 18% (3.7) | 77% (15.2) | 0% (0.0) | match |
| arb_Arab | lang | 4.5 | 17.6 | ×3.90 | ×1.03 | 2% (1.2) | 0% (0.0) | 4% (2.3) | 94% (51.2) | 0% (0.0) | match |
| ben_Beng | lang | 4.3 | 26.8 | ×6.29 | ×0.98 | 3% (1.2) | 0% (0.0) | 9% (3.1) | 88% (32.0) | 0% (0.1) | match |
| cmn_Hani | lang | 4.8 | 13.8 | ×2.88 | ×1.00 | 2% (1.2) | 0% (0.0) | 3% (2.4) | 97% (66.9) | 0% (0.0) | match |
| ell_Grek | lang | 5.1 | 18.3 | ×3.58 | ×0.96 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 94% (47.7) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 43.4 | ×11.21 | ×1.03 | 12% (2.5) | 0% (0.0) | 15% (3.0) | 77% (15.8) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 24.4 | ×5.86 | ×0.98 | 3% (1.2) | 0% (0.0) | 6% (2.3) | 91% (35.8) | 0% (0.1) | match |
| hin_Deva | lang | 3.8 | 29.7 | ×7.74 | ×0.97 | 4% (1.2) | 0% (0.0) | 10% (3.3) | 86% (27.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.5 | 15.1 | ×2.73 | ×0.99 | 2% (1.2) | 0% (0.0) | 3% (2.2) | 95% (61.9) | 0% (0.0) | match |
| kat_Geor | lang | 6.4 | 21.1 | ×3.30 | ×1.01 | 3% (1.2) | 0% (0.0) | 5% (2.1) | 93% (42.8) | 0% (0.0) | match |
| kor_Hang | lang | 3.7 | 17.5 | ×4.71 | ×0.96 | 2% (1.2) | 0% (0.0) | 5% (2.5) | 92% (50.3) | 1% (0.5) | match |
| rus_Cyrl | lang | 4.8 | 17.8 | ×3.75 | ×0.97 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 91% (48.9) | 2% (1.3) | match |
| tam_Taml | lang | 3.8 | 35.0 | ×9.23 | ×0.99 | 4% (1.2) | 0% (0.0) | 10% (2.7) | 86% (23.5) | 0% (0.0) | match |
| tha_Thai | lang | 4.8 | 20.6 | ×4.31 | ×0.96 | 3% (1.2) | 0% (0.0) | 6% (2.6) | 92% (42.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 25.8 | ×4.35 | ×0.98 | 4% (1.3) | 0% (0.0) | 3% (1.1) | 93% (34.8) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 41.0 | ×7.82 | ×1.00 | 9% (1.9) | 0% (0.0) | 8% (1.9) | 84% (19.2) | 0% (0.0) | match |
| added_special_dense | modalities | 3.9 | 48.8 | ×12.54 | ×1.04 | 62% (11.8) | 0% (0.1) | 27% (5.1) | 13% (2.5) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.2 | 58.8 | ×13.84 | ×1.03 | 42% (6.7) | 0% (0.0) | 28% (4.5) | 29% (4.6) | 1% (0.2) | match |
| agentic-traces | modalities | 3.4 | 35.2 | ×10.39 | ×0.99 | 9% (2.4) | 0% (0.0) | 14% (3.8) | 78% (20.5) | 0% (0.0) | match |
| agentic_swe | modalities | 3.7 | 26.7 | ×7.16 | ×0.98 | 5% (1.9) | 0% (0.0) | 8% (2.9) | 86% (30.6) | 0% (0.1) | match |
| code_mixed | modalities | 3.9 | 44.5 | ×11.50 | ×1.00 | 11% (2.2) | 0% (0.0) | 16% (3.3) | 74% (15.3) | 0% (0.0) | match |
| math_latex | modalities | 3.6 | 37.8 | ×10.37 | ×1.01 | 11% (2.5) | 0% (0.0) | 15% (3.5) | 79% (18.6) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.09 | 3.67 | 4.13 | 28.0 | 16.6 | 6.0 | 4.8 | 7.6× / 6.8× | 4.5× / 4.0× | 1.6× / 1.5× | 1.3× / 1.2× |
| arb_Arab | 0.99 | 2.78 | 2.33 | 4.12 | 31.8 | 19.1 | 6.8 | 5.1 | 13.7× / 7.7× | 8.2× / 4.6× | 2.9× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.46 | 2.61 | 3.15 | 4.31 | 46.9 | 28.2 | 10.5 | 3.7 | 14.9× / 10.9× | 9.0× / 6.6× | 3.3× / 2.4× | 1.2× / 0.9× |
| cmn_Hani | 1.12 | 2.00 | 2.40 | 3.28 | 19.9 | 11.8 | 4.7 | 2.4 | 8.3× / 6.1× | 4.9× / 3.6× | 1.9× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.57 | 2.81 | 2.19 | 4.43 | 29.2 | 16.9 | 6.2 | 4.7 | 13.3× / 6.6× | 7.7× / 3.8× | 2.8× / 1.4× | 2.1× / 1.1× |
| eng_Latn | 0.10 | 1.16 | 3.04 | 4.11 | 46.0 | 33.7 | 12.5 | 3.9 | 15.1× / 11.2× | 11.1× / 8.2× | 4.1× / 3.0× | 1.3× / 0.9× |
| heb_Hebr | 0.99 | 3.07 | 2.32 | 4.40 | 31.9 | 19.4 | 7.0 | 2.9 | 13.7× / 7.2× | 8.4× / 4.4× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.36 | 2.79 | 3.25 | 4.68 | 49.2 | 30.7 | 11.4 | 4.0 | 15.1× / 10.5× | 9.4× / 6.6× | 3.5× / 2.4× | 1.2× / 0.9× |
| jpn_Jpan | 1.56 | 3.14 | 2.18 | 3.75 | 18.4 | 10.0 | 4.1 | 3.8 | 8.5× / 4.9× | 4.6× / 2.7× | 1.9× / 1.1× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.19 | 2.10 | 2.90 | 17.5 | 11.2 | 4.2 | 2.0 | 8.4× / 6.1× | 5.3× / 3.9× | 2.0× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.08 | 2.51 | 2.51 | 3.94 | 32.1 | 21.3 | 7.5 | 3.7 | 12.8× / 8.2× | 8.5× / 5.4× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.01 | 2.75 | 2.16 | 3.91 | 27.4 | 17.0 | 5.9 | 2.4 | 12.7× / 7.0× | 7.8× / 4.3× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.62 | 2.71 | 4.40 | 45.3 | 26.2 | 10.1 | 3.3 | 16.7× / 10.3× | 9.7× / 5.9× | 3.7× / 2.3× | 1.2× / 0.8× |
| tha_Thai | 1.36 | 2.22 | 2.61 | 3.46 | 28.9 | 17.2 | 6.7 | 3.0 | 11.1× / 8.3× | 6.6× / 5.0× | 2.6× / 1.9× | 1.1× / 0.9× |
| added_normalized_dense | 0.06 | 1.18 | 1.12 | 2.24 | 24.5 | 16.6 | 6.4 | 1.9 | 22.0× / 11.0× | 14.9× / 7.4× | 5.8× / 2.9× | 1.7× / 0.9× |
| added_normalized_sparse | 0.06 | 1.18 | 1.93 | 3.05 | 32.3 | 22.6 | 8.8 | 2.6 | 16.7× / 10.6× | 11.7× / 7.4× | 4.6× / 2.9× | 1.4× / 0.9× |
| added_special_dense | 0.06 | 1.18 | 5.08 | 6.20 | 98.8 | 71.7 | 21.1 | 3.1 | 19.4× / 15.9× | 14.1× / 11.6× | 4.2× / 3.4× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.18 | 4.49 | 5.61 | 62.8 | 44.3 | 15.1 | 3.5 | 14.0× / 11.2× | 9.9× / 7.9× | 3.4× / 2.7× | 0.8× / 0.6× |
| agentic-traces | 0.56 | 1.19 | 3.76 | 4.39 | 55.2 | 45.8 | 15.2 | 4.7 | 14.7× / 12.6× | 12.2× / 10.4× | 4.0× / 3.5× | 1.3× / 1.1× |
| agentic_swe | 0.51 | 1.17 | 2.91 | 3.57 | 57.5 | 54.4 | 15.8 | 3.5 | 19.8× / 16.1× | 18.7× / 15.2× | 5.4× / 4.4× | 1.2× / 1.0× |
| code_mixed | 0.07 | 1.17 | 3.32 | 4.42 | 55.2 | 51.5 | 15.7 | 4.1 | 16.6× / 12.5× | 15.5× / 11.6× | 4.7× / 3.5× | 1.2× / 0.9× |
| math_latex | 0.56 | 1.18 | 3.47 | 4.09 | 52.9 | 40.2 | 14.3 | 4.3 | 15.2× / 12.9× | 11.6× / 9.8× | 4.1× / 3.5× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.88 vs v0.23.1 · ×1.06 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 18+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.7 | 42.3 | ×9.09 | ×1.05 | 0% (0.0) | 9% (1.9) | 0% (0.0) | 92% (20.1) | 0% (0.0) | match |
| arb_Arab | lang | 10.1 | 51.6 | ×5.09 | ×1.10 | 0% (0.0) | 12% (2.2) | 0% (0.0) | 88% (16.1) | 0% (0.0) | match |
| ben_Beng | lang | 10.7 | 85.6 | ×8.02 | ×1.10 | 0% (0.0) | 14% (1.5) | 0% (0.0) | 85% (9.1) | 0% (0.0) | match |
| cmn_Hani | lang | 9.2 | 63.4 | ×6.92 | ×1.06 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 97% (13.7) | 0% (0.0) | match |
| ell_Grek | lang | 10.2 | 60.7 | ×5.95 | ×1.10 | 0% (0.0) | 14% (2.2) | 0% (0.0) | 85% (13.2) | 0% (0.0) | match |
| eng_Latn | lang | 4.0 | 6.3 | ×1.57 | ×1.03 | 0% (0.1) | 3% (5.1) | 0% (0.0) | 97% (148.8) | 0% (0.0) | match |
| heb_Hebr | lang | 10.0 | 64.4 | ×6.44 | ×1.10 | 0% (0.0) | 15% (2.3) | 0% (0.0) | 84% (12.4) | 0% (0.0) | match |
| hin_Deva | lang | 11.8 | 80.5 | ×6.79 | ×1.12 | 0% (0.0) | 17% (2.0) | 0% (0.0) | 82% (9.5) | 0% (0.0) | match |
| jpn_Jpan | lang | 12.6 | 82.7 | ×6.57 | ×1.06 | 0% (0.1) | 3% (0.3) | 0% (0.0) | 97% (10.4) | 0% (0.0) | match |
| kat_Geor | lang | 14.1 | 93.8 | ×6.65 | ×1.12 | 1% (0.0) | 14% (1.4) | 0% (0.0) | 86% (8.4) | 0% (0.0) | match |
| kor_Hang | lang | 7.2 | 53.6 | ×7.46 | ×1.11 | 0% (0.1) | 13% (2.3) | 0% (0.0) | 86% (15.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.7 | 16.1 | ×2.09 | ×1.02 | 0% (0.0) | 3% (2.0) | 0% (0.0) | 97% (58.2) | 0% (0.0) | match |
| tam_Taml | lang | 12.4 | 90.9 | ×7.35 | ×1.08 | 0% (0.0) | 13% (1.3) | 0% (0.0) | 86% (8.7) | 0% (0.0) | match |
| tha_Thai | lang | 15.0 | 86.0 | ×5.75 | ×1.06 | 0% (0.0) | 8% (0.8) | 0% (0.0) | 92% (9.7) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.1 | 8.9 | ×1.74 | ×1.04 | 0% (0.1) | 2% (2.6) | 0% (0.0) | 99% (111.8) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.6 | 7.5 | ×1.61 | ×1.02 | 0% (0.0) | 3% (4.5) | 0% (0.0) | 96% (125.1) | 0% (0.3) | match |
| added_special_dense | modalities | 3.7 | 21.3 | ×5.79 | ×1.08 | 12% (5.2) | 31% (13.8) | 2% (0.9) | 56% (25.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.9 | 10.4 | ×2.12 | ×1.03 | 2% (2.1) | 13% (12.0) | 0% (0.4) | 84% (78.5) | 0% (0.0) | match |
| agentic-traces | modalities | 4.3 | 7.1 | ×1.66 | ×1.03 | 0% (0.1) | 3% (4.5) | 0% (0.0) | 97% (133.4) | 0% (0.1) | match |
| agentic_swe | modalities | 3.8 | 7.1 | ×1.84 | ×1.03 | 0% (0.0) | 5% (6.3) | 0% (0.0) | 95% (132.2) | 0% (0.5) | match |
| code_mixed | modalities | 4.0 | 7.0 | ×1.74 | ×1.03 | 0% (0.0) | 4% (5.4) | 0% (0.0) | 98% (136.2) | 0% (0.0) | match |
| math_latex | modalities | 4.1 | 6.6 | ×1.60 | ×1.02 | 0% (0.1) | 3% (4.8) | 0% (0.0) | 97% (141.4) | 0% (0.1) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×6.96 vs v0.23.1 · ×1.06 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 95)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.6 | 51.1 | ×11.22 | ×1.08 | 4% (0.7) | 0% (0.0) | 20% (3.6) | 77% (14.1) | 0% (0.0) | match |
| arb_Arab | lang | 4.8 | 18.3 | ×3.78 | ×1.04 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 94% (49.7) | 0% (0.0) | match |
| ben_Beng | lang | 4.2 | 31.6 | ×7.55 | ×0.99 | 2% (0.6) | 0% (0.0) | 10% (3.1) | 88% (27.3) | 0% (0.1) | match |
| cmn_Hani | lang | 5.4 | 17.4 | ×3.20 | ×1.06 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 94% (51.5) | 0% (0.1) | match |
| ell_Grek | lang | 5.6 | 20.1 | ×3.62 | ×1.03 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 93% (45.6) | 1% (0.5) | match |
| eng_Latn | lang | 4.4 | 54.2 | ×12.41 | ×1.26 | 11% (2.0) | 0% (0.0) | 17% (3.0) | 72% (12.8) | 0% (0.1) | match |
| heb_Hebr | lang | 4.6 | 26.2 | ×5.73 | ×1.04 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 92% (33.8) | 0% (0.1) | match |
| hin_Deva | lang | 4.6 | 81.2 | ×17.56 | ×1.07 | 5% (0.6) | 0% (0.0) | 28% (3.3) | 66% (7.7) | 0% (0.1) | match |
| jpn_Jpan | lang | 6.2 | 17.0 | ×2.73 | ×1.07 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (55.4) | 0% (0.0) | match |
| kat_Geor | lang | 5.9 | 35.9 | ×6.03 | ×1.03 | 2% (0.6) | 0% (0.0) | 8% (2.1) | 90% (23.9) | 0% (0.0) | match |
| kor_Hang | lang | 4.3 | 19.6 | ×4.51 | ×1.09 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 93% (45.4) | 0% (0.2) | match |
| rus_Cyrl | lang | 5.4 | 17.0 | ×3.12 | ×1.08 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 96% (55.0) | 0% (0.0) | match |
| tam_Taml | lang | 4.1 | 35.2 | ×8.54 | ×1.01 | 2% (0.6) | 0% (0.0) | 10% (2.7) | 88% (23.9) | 0% (0.0) | match |
| tha_Thai | lang | 5.6 | 20.8 | ×3.70 | ×1.03 | 1% (0.6) | 0% (0.0) | 6% (2.6) | 93% (42.5) | 1% (0.2) | match |
| added_normalized_dense | modalities | 6.2 | 26.5 | ×4.25 | ×0.98 | 2% (0.7) | 0% (0.0) | 3% (1.1) | 94% (35.3) | 1% (0.5) | match |
| added_normalized_sparse | modalities | 5.5 | 42.6 | ×7.71 | ×0.99 | 6% (1.4) | 0% (0.0) | 8% (2.0) | 86% (19.7) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 77.3 | ×18.19 | ×1.02 | 40% (4.9) | 0% (0.0) | 41% (5.0) | 18% (2.3) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.5 | 74.5 | ×16.50 | ×1.03 | 26% (3.3) | 0% (0.0) | 38% (4.8) | 35% (4.4) | 1% (0.1) | match |
| agentic-traces | modalities | 3.7 | 40.8 | ×10.90 | ×1.10 | 8% (1.8) | 0% (0.0) | 16% (3.7) | 76% (17.7) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 29.3 | ×6.96 | ×1.03 | 4% (1.3) | 0% (0.0) | 9% (2.9) | 87% (28.4) | 0% (0.0) | match |
| code_mixed | modalities | 4.4 | 52.4 | ×12.02 | ×1.13 | 8% (1.5) | 0% (0.0) | 18% (3.3) | 74% (13.6) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 44.6 | ×11.28 | ×1.10 | 9% (1.9) | 0% (0.0) | 17% (3.5) | 74% (15.3) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.12 | 3.63 | 4.13 | 27.0 | 18.8 | 5.8 | 4.7 | 7.4× / 6.5× | 5.2× / 4.6× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 0.99 | 2.79 | 2.29 | 4.09 | 29.7 | 22.5 | 6.8 | 5.0 | 13.0× / 7.3× | 9.9× / 5.5× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.46 | 2.65 | 3.12 | 4.31 | 43.2 | 32.3 | 10.2 | 3.7 | 13.9× / 10.0× | 10.4× / 7.5× | 3.3× / 2.4× | 1.2× / 0.9× |
| cmn_Hani | 1.12 | 2.01 | 2.37 | 3.26 | 18.6 | 13.4 | 4.7 | 2.3 | 7.9× / 5.7× | 5.6× / 4.1× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.57 | 2.87 | 2.19 | 4.49 | 27.3 | 21.1 | 6.1 | 4.8 | 12.5× / 6.1× | 9.6× / 4.7× | 2.8× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.09 | 1.19 | 3.01 | 4.11 | 42.0 | 38.7 | 12.2 | 3.8 | 13.9× / 10.2× | 12.8× / 9.4× | 4.1× / 3.0× | 1.2× / 0.9× |
| heb_Hebr | 0.99 | 2.81 | 2.31 | 4.13 | 29.7 | 23.4 | 6.8 | 3.0 | 12.9× / 7.2× | 10.2× / 5.7× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.36 | 2.79 | 3.26 | 4.70 | 45.8 | 35.8 | 11.4 | 4.0 | 14.0× / 9.7× | 11.0× / 7.6× | 3.5× / 2.4× | 1.2× / 0.9× |
| jpn_Jpan | 1.56 | 3.12 | 2.17 | 3.73 | 17.5 | 11.3 | 4.1 | 3.8 | 8.1× / 4.7× | 5.2× / 3.0× | 1.9× / 1.1× | 1.8× / 1.0× |
| kat_Geor | 1.38 | 2.17 | 2.07 | 2.86 | 16.4 | 13.1 | 4.1 | 2.1 | 7.9× / 5.7× | 6.3× / 4.6× | 2.0× / 1.4× | 1.0× / 0.7× |
| kor_Hang | 1.08 | 2.48 | 2.50 | 3.90 | 29.8 | 24.8 | 7.5 | 3.7 | 11.9× / 7.6× | 9.9× / 6.3× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.01 | 2.77 | 2.15 | 3.91 | 25.7 | 19.5 | 5.9 | 2.4 | 11.9× / 6.6× | 9.1× / 5.0× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.62 | 2.71 | 4.41 | 42.4 | 31.2 | 9.9 | 3.3 | 15.6× / 9.6× | 11.5× / 7.1× | 3.6× / 2.2× | 1.2× / 0.8× |
| tha_Thai | 1.36 | 2.20 | 2.58 | 3.43 | 27.1 | 18.8 | 6.7 | 3.0 | 10.5× / 7.9× | 7.3× / 5.5× | 2.6× / 2.0× | 1.1× / 0.9× |
| added_normalized_dense | 0.06 | 1.21 | 1.07 | 2.22 | 22.8 | 20.2 | 6.7 | 1.9 | 21.2× / 10.3× | 18.8× / 9.1× | 6.2× / 3.0× | 1.8× / 0.9× |
| added_normalized_sparse | 0.06 | 1.18 | 1.95 | 3.07 | 29.9 | 27.5 | 8.9 | 2.6 | 15.3× / 9.7× | 14.1× / 8.9× | 4.6× / 2.9× | 1.3× / 0.9× |
| added_special_dense | 0.06 | 1.18 | 5.02 | 6.14 | 91.3 | 87.0 | 20.7 | 3.1 | 18.2× / 14.9× | 17.3× / 14.2× | 4.1× / 3.4× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.18 | 4.76 | 5.87 | 58.5 | 55.1 | 15.3 | 3.5 | 12.3× / 10.0× | 11.6× / 9.4× | 3.2× / 2.6× | 0.7× / 0.6× |
| agentic-traces | 0.58 | 1.18 | 3.69 | 4.30 | 50.6 | 51.4 | 14.9 | 4.7 | 13.7× / 11.8× | 13.9× / 12.0× | 4.0× / 3.5× | 1.3× / 1.1× |
| agentic_swe | 0.51 | 1.15 | 2.85 | 3.49 | 53.2 | 59.2 | 15.5 | 3.5 | 18.7× / 15.2× | 20.7× / 16.9× | 5.4× / 4.4× | 1.2× / 1.0× |
| code_mixed | 0.07 | 1.17 | 3.29 | 4.39 | 51.0 | 57.1 | 15.2 | 4.1 | 15.5× / 11.6× | 17.3× / 13.0× | 4.6× / 3.5× | 1.2× / 0.9× |
| math_latex | 0.57 | 1.20 | 3.45 | 4.08 | 48.7 | 45.2 | 14.0 | 4.2 | 14.1× / 11.9× | 13.1× / 11.1× | 4.1× / 3.4× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×5.36 vs v0.23.1 · ×1.05 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 151+0 (peak 193) · Pipeline 109+0 (peak 195)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 43.7 | ×10.95 | ×1.04 | 6% (1.2) | 0% (0.0) | 24% (4.9) | 70% (14.2) | 0% (0.0) | match |
| arb_Arab | lang | 4.9 | 22.9 | ×4.66 | ×1.09 | 3% (1.2) | 0% (0.0) | 9% (3.7) | 89% (37.6) | 0% (0.0) | match |
| ben_Beng | lang | 7.1 | 19.3 | ×2.73 | ×1.02 | 2% (1.2) | 0% (0.0) | 8% (3.9) | 90% (44.9) | 0% (0.0) | match |
| cmn_Hani | lang | 5.2 | 18.3 | ×3.53 | ×1.07 | 2% (1.2) | 0% (0.0) | 6% (3.3) | 91% (47.7) | 0% (0.0) | match |
| ell_Grek | lang | 5.4 | 19.5 | ×3.59 | ×1.05 | 2% (1.2) | 0% (0.0) | 7% (3.3) | 91% (45.5) | 0% (0.0) | match |
| eng_Latn | lang | 4.0 | 42.1 | ×10.43 | ×1.12 | 12% (2.6) | 0% (0.0) | 21% (4.5) | 67% (14.5) | 0% (0.0) | match |
| heb_Hebr | lang | 4.8 | 17.4 | ×3.64 | ×1.03 | 2% (1.2) | 0% (0.0) | 7% (3.8) | 91% (51.0) | 0% (0.0) | match |
| hin_Deva | lang | 7.0 | 26.8 | ×3.84 | ×1.03 | 3% (1.2) | 0% (0.0) | 11% (4.0) | 85% (30.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.9 | 17.1 | ×2.89 | ×1.04 | 2% (1.2) | 0% (0.0) | 5% (3.1) | 93% (52.4) | 0% (0.0) | match |
| kat_Geor | lang | 6.8 | 15.3 | ×2.24 | ×1.02 | 2% (1.2) | 0% (0.0) | 5% (2.9) | 93% (58.2) | 0% (0.0) | match |
| kor_Hang | lang | 4.3 | 20.5 | ×4.72 | ×1.13 | 3% (1.2) | 0% (0.0) | 8% (3.8) | 89% (41.7) | 0% (0.1) | match |
| rus_Cyrl | lang | 5.2 | 17.0 | ×3.26 | ×1.07 | 2% (1.2) | 0% (0.0) | 6% (3.1) | 92% (51.7) | 0% (0.0) | match |
| tam_Taml | lang | 7.2 | 15.2 | ×2.13 | ×1.03 | 2% (1.2) | 0% (0.0) | 6% (3.6) | 93% (59.7) | 0% (0.0) | match |
| tha_Thai | lang | 8.3 | 14.7 | ×1.77 | ×1.00 | 2% (1.2) | 0% (0.0) | 5% (3.5) | 93% (61.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 28.9 | ×5.07 | ×0.99 | 4% (1.3) | 0% (0.0) | 7% (2.3) | 89% (30.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 43.1 | ×7.95 | ×1.00 | 9% (1.9) | 0% (0.0) | 14% (3.1) | 78% (17.5) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 75.8 | ×17.55 | ×1.06 | 40% (5.0) | 0% (0.0) | 41% (5.2) | 19% (2.4) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.5 | 66.5 | ×14.71 | ×1.02 | 26% (3.6) | 0% (0.0) | 39% (5.4) | 35% (4.8) | 1% (0.1) | match |
| agentic-traces | modalities | 3.5 | 35.5 | ×10.28 | ×1.06 | 9% (2.4) | 0% (0.0) | 20% (5.0) | 71% (18.3) | 0% (0.0) | match |
| agentic_swe | modalities | 3.6 | 26.0 | ×7.21 | ×1.04 | 5% (1.9) | 0% (0.0) | 10% (3.8) | 84% (31.0) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 46.7 | ×12.12 | ×1.10 | 10% (2.1) | 0% (0.0) | 22% (4.4) | 68% (13.8) | 0% (0.0) | match |
| math_latex | modalities | 3.7 | 44.1 | ×12.08 | ×1.13 | 11% (2.4) | 0% (0.0) | 22% (4.9) | 66% (14.3) | 1% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.08 | 4.91 | 5.37 | 27.6 | 17.2 | 6.7 | — | 5.6× / 5.1× | 3.5× / 3.2× | 1.4× / 1.2× | — |
| arb_Arab | 1.00 | 2.78 | 3.72 | 5.50 | 31.9 | 19.6 | 7.5 | — | 8.6× / 5.8× | 5.3× / 3.6× | 2.0× / 1.4× | — |
| ben_Beng | 1.46 | 2.62 | 3.90 | 5.06 | 22.5 | 13.1 | 5.2 | — | 5.8× / 4.4× | 3.3× / 2.6× | 1.3× / 1.0× | — |
| cmn_Hani | 1.12 | 2.04 | 3.35 | 4.26 | 20.8 | 13.6 | 5.6 | — | 6.2× / 4.9× | 4.0× / 3.2× | 1.7× / 1.3× | — |
| ell_Grek | 0.58 | 2.82 | 3.28 | 5.52 | 27.9 | 18.2 | 6.6 | — | 8.5× / 5.1× | 5.5× / 3.3× | 2.0× / 1.2× | — |
| eng_Latn | 0.11 | 1.17 | 4.51 | 5.57 | 40.6 | 36.5 | 13.5 | — | 9.0× / 7.3× | 8.1× / 6.6× | 3.0× / 2.4× | — |
| heb_Hebr | 0.99 | 2.84 | 3.83 | 5.68 | 31.0 | 20.8 | 7.7 | — | 8.1× / 5.5× | 5.4× / 3.7× | 2.0× / 1.4× | — |
| hin_Deva | 1.36 | 2.82 | 4.03 | 5.49 | 23.9 | 15.6 | 6.2 | — | 5.9× / 4.4× | 3.9× / 2.8× | 1.5× / 1.1× | — |
| jpn_Jpan | 1.55 | 3.14 | 3.10 | 4.69 | 19.7 | 11.3 | 4.7 | — | 6.4× / 4.2× | 3.6× / 2.4× | 1.5× / 1.0× | — |
| kat_Geor | 1.38 | 2.20 | 2.91 | 3.73 | 17.5 | 12.1 | 4.5 | — | 6.0× / 4.7× | 4.2× / 3.3× | 1.5× / 1.2× | — |
| kor_Hang | 1.08 | 2.48 | 3.83 | 5.24 | 31.1 | 22.9 | 8.6 | — | 8.1× / 5.9× | 6.0× / 4.4× | 2.2× / 1.6× | — |
| rus_Cyrl | 1.01 | 2.76 | 3.15 | 4.90 | 27.0 | 17.9 | 6.5 | — | 8.6× / 5.5× | 5.7× / 3.7× | 2.1× / 1.3× | — |
| tam_Taml | 0.92 | 2.61 | 3.55 | 5.24 | 18.1 | 10.6 | 4.1 | — | 5.1× / 3.5× | 3.0× / 2.0× | 1.2× / 0.8× | — |
| tha_Thai | 1.36 | 2.20 | 3.51 | 4.36 | 12.8 | 6.7 | 2.8 | — | 3.7× / 2.9× | 1.9× / 1.5× | 0.8× / 0.6× | — |
| added_normalized_dense | 0.06 | 1.18 | 2.29 | 3.41 | 31.5 | 20.7 | 11.5 | — | 13.7× / 9.2× | 9.0× / 6.1× | 5.0× / 3.4× | — |
| added_normalized_sparse | 0.06 | 1.18 | 3.09 | 4.21 | 32.6 | 25.1 | 11.6 | — | 10.5× / 7.7× | 8.1× / 6.0× | 3.8× / 2.8× | — |
| added_special_dense | 0.06 | 1.18 | 5.15 | 6.27 | 80.5 | 80.6 | 23.3 | — | 15.6× / 12.8× | 15.6× / 12.8× | 4.5× / 3.7× | — |
| added_special_sparse | 0.06 | 1.18 | 5.38 | 6.50 | 52.8 | 49.5 | 16.4 | — | 9.8× / 8.1× | 9.2× / 7.6× | 3.0× / 2.5× | — |
| agentic-traces | 0.57 | 1.20 | 5.05 | 5.68 | 51.4 | 51.0 | 17.0 | — | 10.2× / 9.1× | 10.1× / 9.0× | 3.4× / 3.0× | — |
| agentic_swe | 0.54 | 1.17 | 3.76 | 4.40 | 56.4 | 63.1 | 18.6 | — | 15.0× / 12.8× | 16.8× / 14.3× | 4.9× / 4.2× | — |
| code_mixed | 0.08 | 1.15 | 4.37 | 5.45 | 51.7 | 56.6 | 17.1 | — | 11.8× / 9.5× | 12.9× / 10.4× | 3.9× / 3.1× | — |
| math_latex | 0.58 | 1.18 | 4.87 | 5.47 | 48.6 | 44.6 | 16.0 | — | 10.0× / 8.9× | 9.1× / 8.1× | 3.3× / 2.9× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30466472829-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
