### PR TITLE
perf: chunk sentencepiece

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -767,6 +767,17 @@ impl PipelineBPE {
         })
     }
 
+    /// Does this model look the whole text up in the vocabulary before merging it?
+    pub(crate) fn ignore_merges(&self) -> bool {
+        self.ignore_merges
+    }
+
+    /// Every piece of the vocabulary, as bytes. Used at build time to work out how the text may be
+    /// cut into words; not cheap, so call it once.
+    pub(crate) fn vocab_bytes(&self) -> Vec<(Vec<u8>, u32)> {
+        self.vocab.byte_content()
+    }
+
     fn merge_word(
         &self,
         sequence: &str,

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -103,6 +103,11 @@ impl Replace {
             search,
         })
     }
+
+    /// What this normalizer looks for.
+    pub fn pattern(&self) -> &ReplacePattern {
+        &self.pattern
+    }
 }
 
 impl Normalizer for Replace {

--- a/tokenizers/tk-encode/src/pre_tokenizers/mod.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/mod.rs
@@ -4,6 +4,7 @@ pub mod delimiter;
 pub mod digits;
 pub mod fixed_length;
 pub mod metaspace;
+pub mod proven_cuts;
 pub mod punctuation;
 pub mod sequence;
 pub mod split;

--- a/tokenizers/tk-encode/src/pre_tokenizers/proven_cuts.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/proven_cuts.rs
@@ -165,12 +165,66 @@ fn space_replacement(replace: &Replace) -> Option<char> {
 /// How many veto pieces we put up with before giving up on cutting at all.
 const MAX_VETO_PIECES: usize = 32;
 
+/// Width of one padded half of a veto piece. Whatever length the halves really are, they are compared
+/// a full `u128` at a time.
+const HALF_WIDTH: usize = size_of::<u128>();
+
+/// One half of a [`VetoPiece`], padded out to [`HALF_WIDTH`] bytes.
+///
+/// The halves are a byte or two long, but their length is only known once the vocabulary is read, and
+/// comparing a run-time number of bytes means calling `memcmp`. Padding to a fixed width instead
+/// turns the compare into a couple of register operations, which is worth it in a loop that runs once
+/// per word.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Half {
+    bytes: u128,
+    /// `0xff` over the bytes of the half, `0` over the padding.
+    mask: u128,
+}
+
+impl Half {
+    /// The half at the end of the window, where the bytes running up to a cut land.
+    fn ending(half: &[u8]) -> Option<Self> {
+        Self::padded(half, HALF_WIDTH.checked_sub(half.len())?)
+    }
+
+    /// The half at the start of the window, where the bytes following a cut land.
+    fn starting(half: &[u8]) -> Option<Self> {
+        Self::padded(half, 0)
+    }
+
+    /// `None` when the half is wider than the window.
+    fn padded(half: &[u8], at: usize) -> Option<Self> {
+        let mut bytes = [0u8; HALF_WIDTH];
+        let mut mask = [0u8; HALF_WIDTH];
+        bytes.get_mut(at..at + half.len())?.copy_from_slice(half);
+        mask[at..at + half.len()].fill(0xff);
+        Some(Self {
+            bytes: u128::from_le_bytes(bytes),
+            mask: u128::from_le_bytes(mask),
+        })
+    }
+
+    fn matches(&self, window: u128) -> bool {
+        (window ^ self.bytes) & self.mask == 0
+    }
+}
+
 /// A vocabulary piece holding a delimiter that is not at its start, split at that delimiter: `>▁</`
 /// becomes `VetoPiece { before: ">", after: "</" }`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct VetoPiece {
-    before: Vec<u8>,
-    after: Vec<u8>,
+    before: Half,
+    after: Half,
+}
+
+impl VetoPiece {
+    fn new(before: &[u8], after: &[u8]) -> Option<Self> {
+        Some(Self {
+            before: Half::ending(before)?,
+            after: Half::starting(after)?,
+        })
+    }
 }
 
 /// The cuts a vocabulary does not allow.
@@ -182,8 +236,11 @@ struct VetoPiece {
 struct Veto {
     /// Empty means no merge can reach across a cut, so every cut is allowed.
     pieces: Vec<VetoPiece>,
+    /// Last bytes of the `before` halves, as a 256-bit set. A cut with any other byte in front of it
+    /// fits no piece, which is how most cuts get away without a single comparison.
+    bytes_before: [u64; 4],
     /// Length of the delimiter the pieces were split at. Every `after` half starts at the byte right
-    /// behind the delimiter, so the text is compared to it from there.
+    /// behind the delimiter, so the window compared to it has to start there too.
     delimiter_len: usize,
 }
 
@@ -191,13 +248,14 @@ impl Veto {
     /// Reads the vocabulary and collects the pieces a merge could use to reach across a cut.
     ///
     /// `None` turns cutting off: either this is not a SentencePiece vocabulary (no delimiter piece in
-    /// it), or its veto pieces are too many or too tangled to rule out cheaply.
+    /// it), or its veto pieces are too many, too long or too tangled to rule out cheaply.
     fn build(vocab: &[(Vec<u8>, u32)], delimiter: &Literal) -> Option<Self> {
         let pattern = delimiter.pattern();
         if !vocab.iter().any(|(piece, _)| piece.as_slice() == pattern) {
             return None;
         }
         let mut pieces = Vec::new();
+        let mut bytes_before = [0u64; 4];
         for (piece, _) in vocab {
             for at in delimiter.matches(piece) {
                 // A piece starting with a delimiter sits right after a cut, not across it, and a
@@ -215,26 +273,60 @@ impl Veto {
                 {
                     return None;
                 }
-                pieces.push(VetoPiece {
-                    before: before.to_vec(),
-                    after: after.to_vec(),
-                });
+                let previous = *before.last().expect("`at` is past the start of the piece");
+                bytes_before[(previous >> 6) as usize] |= 1 << (previous & 63);
+                pieces.push(VetoPiece::new(before, after)?);
             }
         }
         Some(Self {
             pieces,
+            bytes_before,
             delimiter_len: pattern.len(),
         })
     }
 
     /// Could a piece cover the delimiter at `at`, so that a merge reaches over a cut placed there? A
     /// match only means such a merge is possible, not that the model performs it — either way we
-    /// leave the text in one piece.
+    /// leave the text in one piece. `at` is past the start of the text, so there is a byte in front
+    /// of it.
     fn forbids(&self, text: &[u8], at: usize) -> bool {
-        let after = &text[at + self.delimiter_len..];
+        let previous = text[at - 1];
+        if self.bytes_before[(previous >> 6) as usize] & (1 << (previous & 63)) == 0 {
+            return false;
+        }
+        // Both windows are padded with zeros, so a half can only match beyond the ends of `text` if
+        // the half itself holds a zero byte — and one match too many only leaves the text uncut.
+        let before = window_ending(&text[..at]);
+        let after = window_starting(&text[at + self.delimiter_len..]);
         self.pieces
             .iter()
-            .any(|piece| text[..at].ends_with(&piece.before) && after.starts_with(&piece.after))
+            .any(|piece| piece.before.matches(before) && piece.after.matches(after))
+    }
+}
+
+/// The last [`HALF_WIDTH`] bytes of `bytes`, padded on the left when there are fewer, packed the way
+/// [`Half::ending`] packs a half.
+fn window_ending(bytes: &[u8]) -> u128 {
+    match bytes.last_chunk() {
+        Some(window) => u128::from_le_bytes(*window),
+        None => {
+            let mut window = [0u8; HALF_WIDTH];
+            window[HALF_WIDTH - bytes.len()..].copy_from_slice(bytes);
+            u128::from_le_bytes(window)
+        }
+    }
+}
+
+/// The first [`HALF_WIDTH`] bytes of `bytes`, padded on the right when there are fewer, packed the way
+/// [`Half::starting`] packs a half.
+fn window_starting(bytes: &[u8]) -> u128 {
+    match bytes.first_chunk() {
+        Some(window) => u128::from_le_bytes(*window),
+        None => {
+            let mut window = [0u8; HALF_WIDTH];
+            window[..bytes.len()].copy_from_slice(bytes);
+            u128::from_le_bytes(window)
+        }
     }
 }
 
@@ -396,10 +488,7 @@ mod tests {
         assert!(veto_of(&["▁", "▁hello", "▁▁"]).unwrap().pieces.is_empty());
         assert_eq!(
             veto_of(&["▁", "p▁"]).unwrap().pieces,
-            [VetoPiece {
-                before: b"p".to_vec(),
-                after: Vec::new(),
-            }]
+            [VetoPiece::new(b"p", b"").unwrap()]
         );
     }
 
@@ -412,6 +501,22 @@ mod tests {
         vocab.extend((0..=MAX_VETO_PIECES).map(|i| format!("{i}▁x")));
         let vocab: Vec<&str> = vocab.iter().map(String::as_str).collect();
         assert!(veto_of(&vocab).is_none());
+        // A half that does not fit the fixed-width compare.
+        let wide = "a".repeat(HALF_WIDTH + 1);
+        assert!(veto_of(&["▁", &format!("{wide}▁x")]).is_none());
+        assert!(veto_of(&["▁", &format!("a▁{wide}")]).is_none());
+    }
+
+    #[test]
+    fn veto_matches_a_half_that_fills_the_window() {
+        let before = "a".repeat(HALF_WIDTH);
+        let veto = || veto_of(&["▁", &format!("{before}▁x"), "▁x"]).unwrap();
+        let text = format!("{before}▁x");
+        assert_eq!(split_on(veto(), &text), [text.as_str()]);
+        // One byte short of the half: the window pads with a zero the half does not hold, so the
+        // piece cannot form and the cut stands.
+        let short = &before[1..];
+        assert_eq!(split_on(veto(), &format!("{short}▁x")), [short, "▁x"]);
     }
 
     mod for_tokenizer {

--- a/tokenizers/tk-encode/src/pre_tokenizers/proven_cuts.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/proven_cuts.rs
@@ -1,0 +1,536 @@
+//! Cutting a whole SentencePiece text into words, where the vocabulary proves it is harmless.
+//!
+//! SentencePiece vocabularies (gemma, llama-2, …) write a space as `▁` (U+2581), so `"tell me"`
+//! reaches the model as `"▁tell▁me"`. That character both opens a word and separates two, which is
+//! why the code calls it the delimiter.
+//!
+//! Some of these tokenizers ship a [`Metaspace`] pre-tokenizer, which writes the delimiters and cuts
+//! before every one of them. Those cuts are the tokenizer's own output, so
+//! [`super::metaspace::to_normalizer_and_split`] reproduces them exactly and there is nothing to
+//! decide.
+//!
+//! The tokenizers here are the other kind: their normalizer writes the delimiters and they ship no
+//! pre-tokenizer that cuts, so the model receives the whole text in one piece. Cutting it into words
+//! is only a speed-up — merging a long text costs more than merging its words one after another, and
+//! short words are friendlier to the cache. But a speed-up is worthless if it changes the tokens, so
+//! here every cut has to be proven harmless first. Two rules do that:
+//!
+//! 1. A group of delimiters stays with the word that follows it (`a▁▁▁b` → `a`, `▁▁▁b`).
+//!    Vocabularies hold pieces made of several delimiters (`▁▁`, `▁▁▁`), and cutting inside a group
+//!    would stop those from forming.
+//! 2. A cut is dropped when a vocabulary piece could merge across it. A merge only ever produces a
+//!    piece that is in the vocabulary, so this can only happen if some piece holds a delimiter that
+//!    is not at its start. gemma has exactly one such piece: `>▁</`. See [`Veto`].
+//!
+//! [`Metaspace`]: super::metaspace::Metaspace
+
+use atomsplit::literal::Literal;
+
+use crate::normalizers::NormalizerWrapper;
+use crate::normalizers::replace::{Replace, ReplacePattern};
+use crate::pre_tokenizers::PreTokenizerWrapper;
+use crate::pre_tokenizers::split::SplitPattern;
+use crate::tokenizer::Result;
+use crate::tokenizer::pipeline::{self, PipelineModel, Span};
+
+/// Splits `▁`-spelled text into words, at the delimiters the vocabulary allows. See the module docs.
+#[derive(Debug, Clone)]
+pub struct ProvenCuts {
+    /// The character words start with, `▁` unless the tokenizer picked another one.
+    delimiter: Literal,
+    veto: Veto,
+}
+
+/// Hand-written because the prepared search inside `Literal` has no equality of its own — and needs
+/// none, since it is built from the delimiter.
+impl PartialEq for ProvenCuts {
+    fn eq(&self, other: &Self) -> bool {
+        self.delimiter.pattern() == other.delimiter.pattern() && self.veto == other.veto
+    }
+}
+
+impl ProvenCuts {
+    fn new(delimiter: Literal, veto: Veto) -> Self {
+        Self { delimiter, veto }
+    }
+}
+
+impl pipeline::PreTokenizer for ProvenCuts {
+    fn pre_tokenize(&self, text: &str, out: &mut Vec<Span>) -> Result<()> {
+        let delimiter = self.delimiter.pattern();
+        let bytes = text.as_bytes();
+        // The word being built runs from `start` to the next delimiter we cut at.
+        let mut start = 0usize;
+        for at in self.delimiter.matches(bytes) {
+            // A delimiter at `start` is the cut we just made, or the text opens with one: either way
+            // the word would be empty.
+            if at == start {
+                continue;
+            }
+            // A delimiter right in front of this one means we are inside a group of them, and a group
+            // stays whole with the word after it.
+            if bytes[..at].ends_with(delimiter) || self.veto.forbids(bytes, at) {
+                continue;
+            }
+            out.push(Span::new(start as u32, at as u32));
+            start = at;
+        }
+        if start < bytes.len() {
+            out.push(Span::new(start as u32, bytes.len() as u32));
+        }
+        Ok(())
+    }
+}
+
+/// The splitter for a tokenizer whose text reaches the model in one piece, or `None` when the text
+/// has to stay that way — because something already cuts it, because no normalizer provably writes
+/// the delimiters, or because the vocabulary cannot prove the cuts.
+pub(crate) fn for_tokenizer(
+    normalizer: Option<&NormalizerWrapper>,
+    pre_tokenizer: Option<&PreTokenizerWrapper>,
+    model: &PipelineModel,
+) -> Option<ProvenCuts> {
+    if !leaves_the_text_whole(pre_tokenizer) {
+        return None;
+    }
+    let delimiter = delimiter_from_normalizer(normalizer?)?;
+    let delimiter = Literal::new(delimiter.to_string().as_bytes()).expect("a char is never empty");
+    let veto = veto_from_model(model, &delimiter)?;
+    Some(ProvenCuts::new(delimiter, veto))
+}
+
+/// Does this pre-tokenizer leave the text in one piece? Only the two shapes below do, and anything
+/// else is refused rather than guessed at: cutting text a tokenizer meant to keep whole changes the
+/// tokens it produces.
+fn leaves_the_text_whole(pre_tokenizer: Option<&PreTokenizerWrapper>) -> bool {
+    match pre_tokenizer {
+        // Nothing cuts the text at all. llama-2 ships this shape.
+        None => true,
+        // A `Split` that can never match, because the normalizer already replaced every space it
+        // looks for. With nothing to match, every behaviour it could carry leaves the text in one
+        // piece. gemma ships this shape.
+        Some(PreTokenizerWrapper::Split(split)) => {
+            !split.invert
+                && matches!(&split.pattern, SplitPattern::String(pattern)
+                    if !pattern.is_empty() && pattern.chars().all(|c| c == ' '))
+        }
+        _ => false,
+    }
+}
+
+/// The cuts this model's vocabulary forbids, or `None` when it cannot be cut at all.
+fn veto_from_model(model: &PipelineModel, delimiter: &Literal) -> Option<Veto> {
+    let PipelineModel::BPE(bpe) = model else {
+        return None;
+    };
+    // With `ignore_merges` the model first looks the whole text up in the vocabulary and emits one
+    // token when it finds it. Handing it words instead would skip that lookup.
+    if bpe.ignore_merges() {
+        return None;
+    }
+    Veto::build(&bpe.vocab_bytes(), delimiter)
+}
+
+/// The character every space becomes, if the normalizer provably rewrites all of them.
+///
+/// Accepts a `Replace` on its own, or a sequence whose last step is one and whose earlier steps only
+/// prepend text — a step running after the `Replace` could bring spaces back.
+fn delimiter_from_normalizer(normalizer: &NormalizerWrapper) -> Option<char> {
+    match normalizer {
+        NormalizerWrapper::Replace(replace) => space_replacement(replace),
+        NormalizerWrapper::Sequence(sequence) => {
+            let (last, rest) = sequence.as_ref().split_last()?;
+            rest.iter()
+                .all(|step| matches!(step, NormalizerWrapper::Prepend(_)))
+                .then(|| match last {
+                    NormalizerWrapper::Replace(replace) => space_replacement(replace),
+                    _ => None,
+                })
+                .flatten()
+        }
+        _ => None,
+    }
+}
+
+/// The single character this normalizer turns every space into.
+fn space_replacement(replace: &Replace) -> Option<char> {
+    if replace.pattern() != &ReplacePattern::String(" ".to_string()) {
+        return None;
+    }
+    let mut content = replace.content.chars();
+    let delimiter = content.next()?;
+    content.next().is_none().then_some(delimiter)
+}
+
+/// How many veto pieces we put up with before giving up on cutting at all.
+const MAX_VETO_PIECES: usize = 32;
+
+/// A vocabulary piece holding a delimiter that is not at its start, split at that delimiter: `>▁</`
+/// becomes `VetoPiece { before: ">", after: "</" }`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VetoPiece {
+    before: Vec<u8>,
+    after: Vec<u8>,
+}
+
+/// The cuts a vocabulary does not allow.
+///
+/// A merge only ever produces a piece that is in the vocabulary, so a merge can only reach across a
+/// cut if some piece holds a delimiter that is not at its start. Those pieces are collected here, and
+/// a cut where one of them fits is dropped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Veto {
+    /// Empty means no merge can reach across a cut, so every cut is allowed.
+    pieces: Vec<VetoPiece>,
+    /// Length of the delimiter the pieces were split at. Every `after` half starts at the byte right
+    /// behind the delimiter, so the text is compared to it from there.
+    delimiter_len: usize,
+}
+
+impl Veto {
+    /// Reads the vocabulary and collects the pieces a merge could use to reach across a cut.
+    ///
+    /// `None` turns cutting off: either this is not a SentencePiece vocabulary (no delimiter piece in
+    /// it), or its veto pieces are too many or too tangled to rule out cheaply.
+    fn build(vocab: &[(Vec<u8>, u32)], delimiter: &Literal) -> Option<Self> {
+        let pattern = delimiter.pattern();
+        if !vocab.iter().any(|(piece, _)| piece.as_slice() == pattern) {
+            return None;
+        }
+        let mut pieces = Vec::new();
+        for (piece, _) in vocab {
+            for at in delimiter.matches(piece) {
+                // A piece starting with a delimiter sits right after a cut, not across it, and a
+                // delimiter following another one is inside a group, where we never cut.
+                if at == 0 || piece[..at].ends_with(pattern) {
+                    continue;
+                }
+                let (before, after) = (&piece[..at], &piece[at + pattern.len()..]);
+                // A piece with a second delimiter reaches across two cuts at once, and checking one
+                // cut at a time no longer proves anything. None of the vocabularies we tested has
+                // one, so drop cutting instead.
+                if pieces.len() == MAX_VETO_PIECES
+                    || delimiter.matches(before).next().is_some()
+                    || delimiter.matches(after).next().is_some()
+                {
+                    return None;
+                }
+                pieces.push(VetoPiece {
+                    before: before.to_vec(),
+                    after: after.to_vec(),
+                });
+            }
+        }
+        Some(Self {
+            pieces,
+            delimiter_len: pattern.len(),
+        })
+    }
+
+    /// Could a piece cover the delimiter at `at`, so that a merge reaches over a cut placed there? A
+    /// match only means such a merge is possible, not that the model performs it — either way we
+    /// leave the text in one piece.
+    fn forbids(&self, text: &[u8], at: usize) -> bool {
+        let after = &text[at + self.delimiter_len..];
+        self.pieces
+            .iter()
+            .any(|piece| text[..at].ends_with(&piece.before) && after.starts_with(&piece.after))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::bpe::{BPE, BpeBuilder, Merges, PipelineBPE, Vocab};
+    use crate::tokenizer::Model;
+
+    const DELIMITER: char = '▁';
+
+    fn delimiter() -> Literal {
+        Literal::new(DELIMITER.to_string().as_bytes()).unwrap()
+    }
+
+    fn split_on(veto: Veto, text: &str) -> Vec<String> {
+        let split = ProvenCuts::new(delimiter(), veto);
+        let mut spans = Vec::new();
+        pipeline::PreTokenizer::pre_tokenize(&split, text, &mut spans).unwrap();
+        spans.iter().map(|s| text[s.range()].to_string()).collect()
+    }
+
+    fn veto_of(vocab: &[&str]) -> Option<Veto> {
+        let pieces: Vec<(Vec<u8>, u32)> = vocab
+            .iter()
+            .enumerate()
+            .map(|(id, piece)| (piece.as_bytes().to_vec(), id as u32))
+            .collect();
+        Veto::build(&pieces, &delimiter())
+    }
+
+    /// A vocabulary shaped like gemma's: `>▁</` and `p▁` hold a `▁` after another character, so
+    /// cutting the text at those `▁` would drop merges the whole text would have made.
+    fn metaspace_bpe() -> BPE {
+        let vocab: Vocab = [
+            ("▁", 0u32),
+            ("<", 1),
+            (">", 2),
+            ("/", 3),
+            ("s", 4),
+            ("p", 5),
+            ("a", 6),
+            ("b", 7),
+            ("</", 8),
+            (">▁", 9),
+            (">▁</", 10),
+            ("p▁", 11),
+            ("sp", 12),
+            ("▁sp", 13),
+            ("▁a", 14),
+            ("▁b", 15),
+        ]
+        .iter()
+        .map(|(piece, id)| ((*piece).into(), *id))
+        .collect();
+        let merges: Merges = [
+            ("<", "/"),
+            (">", "▁"),
+            (">▁", "</"),
+            ("p", "▁"),
+            ("s", "p"),
+            ("▁", "sp"),
+            ("▁", "a"),
+            ("▁", "b"),
+        ]
+        .iter()
+        .map(|(a, b)| ((*a).into(), (*b).into()))
+        .collect();
+        BpeBuilder::default()
+            .vocab_and_merges(vocab, merges)
+            .build()
+            .unwrap()
+    }
+
+    /// The ids the model produces for each word, one word after another.
+    fn ids_word_by_word(model: &PipelineBPE, split: &ProvenCuts, text: &str) -> Vec<u32> {
+        let mut spans = Vec::new();
+        pipeline::PreTokenizer::pre_tokenize(split, text, &mut spans).unwrap();
+        let mut out = Vec::new();
+        let mut scratch = pipeline::Model::init_scratch(model);
+        for span in &spans {
+            pipeline::Model::tokenize_pipeline(model, &text[span.range()], &mut scratch, &mut out)
+                .unwrap();
+        }
+        out.iter().map(|token| token.id).collect()
+    }
+
+    /// The ids the model produces for the whole text at once — what the cuts must reproduce.
+    fn ids_whole_text(model: &BPE, text: &str) -> Vec<u32> {
+        model
+            .tokenize(text)
+            .unwrap()
+            .iter()
+            .map(|token| token.id)
+            .collect()
+    }
+
+    #[test]
+    fn proven_cuts_keep_the_whole_text_ids() {
+        let reference = metaspace_bpe();
+        let model = PipelineBPE::from_bpe(reference.clone(), false).unwrap();
+        let veto = Veto::build(&model.vocab_bytes(), &delimiter()).unwrap();
+        let split = ProvenCuts::new(delimiter(), veto);
+        for text in [
+            "▁a▁b",
+            "a▁b",
+            "▁▁▁a",
+            "a▁▁▁b",
+            "▁sp▁a",
+            "sp",
+            "a▁",
+            "▁",
+            "▁a▁sp▁b▁a",
+            // The veto pieces, alone and surrounded by other cuts.
+            "<b>▁</b>",
+            "▁a<b>▁</b>▁b",
+            "p▁a",
+            "▁ap▁a▁b",
+            // Starts like a veto piece but ends differently, so the cut stands.
+            "<b>▁a",
+            "q▁a",
+        ] {
+            assert_eq!(
+                ids_word_by_word(&model, &split, text),
+                ids_whole_text(&reference, text),
+                "{text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn proven_cuts_keep_delimiter_groups_whole() {
+        let veto = || veto_of(&["▁"]).unwrap();
+        assert_eq!(split_on(veto(), "a▁▁▁b"), ["a", "▁▁▁b"]);
+        assert_eq!(split_on(veto(), "▁▁▁a"), ["▁▁▁a"]);
+        assert_eq!(split_on(veto(), "hello"), ["hello"]);
+        assert_eq!(split_on(veto(), ""), Vec::<String>::new());
+    }
+
+    #[test]
+    fn proven_cuts_skip_what_the_veto_forbids() {
+        let veto = || veto_of(&["▁", ">▁</", "▁a"]).unwrap();
+        // ">▁</" can merge across the space between an HTML tag and its closing tag.
+        assert_eq!(split_on(veto(), "<b>▁</b>"), ["<b>▁</b>"]);
+        // ">" in front of the `▁` again, but "</" does not follow, so the piece cannot form.
+        assert_eq!(split_on(veto(), "<b>▁a"), ["<b>", "▁a"]);
+        // Only the cut the piece covers is dropped, not the other ones.
+        assert_eq!(split_on(veto(), "x▁<b>▁</b>▁y"), ["x", "▁<b>▁</b>", "▁y"]);
+    }
+
+    #[test]
+    fn veto_needs_the_delimiter_in_the_vocabulary() {
+        assert!(veto_of(&["a", "b"]).is_none());
+        assert!(veto_of(&["a", "▁"]).is_some());
+    }
+
+    #[test]
+    fn veto_collects_only_the_pieces_that_reach_over_a_cut() {
+        assert!(veto_of(&["▁", "▁hello", "▁▁"]).unwrap().pieces.is_empty());
+        assert_eq!(
+            veto_of(&["▁", "p▁"]).unwrap().pieces,
+            [VetoPiece {
+                before: b"p".to_vec(),
+                after: Vec::new(),
+            }]
+        );
+    }
+
+    #[test]
+    fn veto_gives_up_when_it_cannot_prove_anything() {
+        // Two delimiters in one piece would reach over two cuts at once.
+        assert!(veto_of(&["▁", "a▁b▁c"]).is_none());
+        // More pieces than the loop is willing to walk per cut.
+        let mut vocab = vec!["▁".to_string()];
+        vocab.extend((0..=MAX_VETO_PIECES).map(|i| format!("{i}▁x")));
+        let vocab: Vec<&str> = vocab.iter().map(String::as_str).collect();
+        assert!(veto_of(&vocab).is_none());
+    }
+
+    mod for_tokenizer {
+        use super::*;
+
+        /// The shapes a `▁`-spelling tokenizer ships, copied from the files in `data/`.
+        const GEMMA_NORMALIZER: &str =
+            r#"{"type":"Replace","pattern":{"String":" "},"content":"▁"}"#;
+        const GEMMA_PRE_TOKENIZER: &str = r#"{"type":"Split","pattern":{"String":" "},"behavior":"MergedWithPrevious","invert":false}"#;
+        const LLAMA_NORMALIZER: &str = r#"{"type":"Sequence","normalizers":[{"type":"Prepend","prepend":"▁"},{"type":"Replace","pattern":{"String":" "},"content":"▁"}]}"#;
+
+        fn normalizer(json: &str) -> NormalizerWrapper {
+            serde_json::from_str(json).unwrap()
+        }
+
+        fn pre_tokenizer(json: &str) -> PreTokenizerWrapper {
+            serde_json::from_str(json).unwrap()
+        }
+
+        fn bpe_model(bpe: BPE) -> PipelineModel {
+            PipelineModel::BPE(PipelineBPE::from_bpe(bpe, false).unwrap())
+        }
+
+        #[test]
+        fn the_shapes_that_leave_the_text_whole_are_cut() {
+            let model = bpe_model(metaspace_bpe());
+            for (name, normalizer_json, pre_tokenizer_json) in [
+                ("gemma", GEMMA_NORMALIZER, Some(GEMMA_PRE_TOKENIZER)),
+                ("llama-2", LLAMA_NORMALIZER, None),
+            ] {
+                let cuts = for_tokenizer(
+                    Some(&normalizer(normalizer_json)),
+                    pre_tokenizer_json.map(pre_tokenizer).as_ref(),
+                    &model,
+                )
+                .unwrap_or_else(|| panic!("{name} should be cut into words"));
+                assert_eq!(cuts.delimiter.pattern(), "▁".as_bytes(), "{name}");
+            }
+        }
+
+        #[test]
+        fn refuses_what_it_cannot_prove() {
+            let model = bpe_model(metaspace_bpe());
+            let refused: [(&str, Option<&NormalizerWrapper>, Option<&str>); 5] = [
+                ("no normalizer and no pre-tokenizer", None, None),
+                // Nothing here turns spaces into the delimiter.
+                (
+                    "a normalizer that keeps spaces",
+                    Some(&normalizer(r#"{"type":"NFC"}"#)),
+                    None,
+                ),
+                // A step running after the replace could bring spaces back.
+                (
+                    "a replace that is not the last step",
+                    Some(&normalizer(
+                        r#"{"type":"Sequence","normalizers":[{"type":"Replace","pattern":{"String":" "},"content":"▁"},{"type":"NFC"}]}"#,
+                    )),
+                    None,
+                ),
+                // This one cuts the text itself, so the model never sees it whole.
+                (
+                    "a split that does match",
+                    Some(&normalizer(GEMMA_NORMALIZER)),
+                    Some(
+                        r#"{"type":"Split","pattern":{"String":"▁"},"behavior":"MergedWithNext","invert":false}"#,
+                    ),
+                ),
+                (
+                    "a byte-level pre-tokenizer",
+                    Some(&normalizer(GEMMA_NORMALIZER)),
+                    Some(
+                        r#"{"type":"ByteLevel","add_prefix_space":false,"trim_offsets":true,"use_regex":true}"#,
+                    ),
+                ),
+            ];
+            for (name, normalizer, json) in refused {
+                let declared = json.map(pre_tokenizer);
+                assert!(
+                    for_tokenizer(normalizer, declared.as_ref(), &model).is_none(),
+                    "{name}"
+                );
+            }
+            // A vocabulary without the delimiter proves nothing about cutting on it.
+            let plain: Vocab = [("a", 0u32), ("b", 1)]
+                .iter()
+                .map(|(piece, id)| ((*piece).into(), *id))
+                .collect();
+            let plain = BpeBuilder::default()
+                .vocab_and_merges(plain, Vec::new())
+                .build()
+                .unwrap();
+            assert!(
+                for_tokenizer(Some(&normalizer(GEMMA_NORMALIZER)), None, &bpe_model(plain))
+                    .is_none(),
+                "vocabulary without the delimiter"
+            );
+        }
+
+        /// The real files, so a change to either config shape shows up here. The veto counts are the
+        /// premise the whole proof rests on — gemma-4 has one piece that can merge across a word
+        /// boundary (`>▁</`) and llama-2 has none — so they are pinned rather than described. Skipped
+        /// when the fixtures have not been fetched.
+        #[test]
+        fn the_real_fixtures_are_cut() {
+            for (file, veto_pieces) in [("gemma-4.json", 1), ("llama-2.json", 0)] {
+                let path = format!("../data/{file}");
+                if !std::path::Path::new(&path).exists() {
+                    continue; // fixture not downloaded in this environment
+                }
+                let tree = crate::Tokenizer::from_file(&path).unwrap();
+                let pipeline = crate::pipeline::PipelineTokenizer::try_from(&tree)
+                    .unwrap_or_else(|e| panic!("{file} should build a pipeline: {e}"));
+                let crate::pipeline::PipelinePreTokenizer::ProvenCuts(cuts) =
+                    pipeline.get_pre_tokenizer()
+                else {
+                    panic!("{file} should be cut into words");
+                };
+                assert_eq!(cuts.veto.pieces.len(), veto_pieces, "{file} veto pieces");
+            }
+        }
+    }
+}

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -27,6 +27,7 @@ use crate::{
         digits::Digits,
         fixed_length::FixedLength,
         metaspace,
+        proven_cuts::{self, ProvenCuts},
         punctuation::Punctuation,
         sequence::PipelineSequence,
         split::{Split as SplitPretok, SplitPattern},
@@ -139,6 +140,7 @@ pub enum PipelinePreTokenizer {
     Delimiter(CharDelimiterSplit),
     Digits(Digits),
     FixedLength(FixedLength),
+    ProvenCuts(ProvenCuts),
     Punctuation(Punctuation),
     Sequence(PipelineSequence),
     Split(SplitPretok),
@@ -162,6 +164,7 @@ impl PreTokenizer for PipelinePreTokenizer {
             Self::Delimiter(pretok) => pretok.pre_tokenize(text, out),
             Self::Digits(pretok) => pretok.pre_tokenize(text, out),
             Self::FixedLength(pretok) => pretok.pre_tokenize(text, out),
+            Self::ProvenCuts(pretok) => pretok.pre_tokenize(text, out),
             Self::Punctuation(pretok) => pretok.pre_tokenize(text, out),
             Self::Sequence(pretok) => pretok.pre_tokenize(text, out),
             Self::Split(pretok) => pretok.pre_tokenize(text, out),
@@ -635,6 +638,16 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             ModelWrapper::WordPiece(model) => PipelineModel::WordPiece(model.try_into()?),
         };
 
+        // Some tokenizers spell every space as `▁` and then cut nowhere, so the model receives the
+        // whole text in one piece. Cutting it into words is faster wherever the vocabulary proves
+        // that leaves the ids alone — and that proof reads the vocabulary, hence after the model.
+        let pre_tokenizer =
+            match proven_cuts::for_tokenizer(tok.get_normalizer(), tok.get_pre_tokenizer(), &model)
+            {
+                Some(cuts) => PipelinePreTokenizer::ProvenCuts(cuts),
+                None => pre_tokenizer,
+            };
+
         Ok(Self {
             added_vocabulary,
             normalizers,
@@ -810,6 +823,10 @@ impl PipelineTokenizer {
 
     pub fn get_model(&self) -> &PipelineModel {
         &self.model
+    }
+
+    pub fn get_pre_tokenizer(&self) -> &PipelinePreTokenizer {
+        &self.pre_tokenizer
     }
 
     /// Encode `input` into token ids.

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -26,6 +26,20 @@ use tokenizers_release::Tokenizer as Released;
 
 const PROBE: &str = "The quick brown fox jumps 123.";
 
+/// Inputs built to break word boundaries, which the natural corpora do not reach. `<b> </b>` is the
+/// one that matters most: gemma-4 merges its `>`, mark and `</` into a single token across what looks
+/// like a word boundary, so a cut placed there would change the ids.
+const HOSTILE: &[&str] = &[
+    "html-ish <b> </b> crossing > </ pieces > </ literal mark \u{2581}word",
+    "<p>one</p> <p>two</p>",
+    "The  quick   brown fox \u{2014} jumps; over, the: lazy. dog!  ",
+    "\t\tindent()\twide  spacing      here \r\nCRLF\r\n",
+    "\u{2581}\u{2581}\u{2581}already marked\u{2581}",
+    "trailing space and mark p\u{2581}q ",
+    "\u{65e5}\u{672c}\u{8a9e}\u{306e}\u{30c6}\u{30ad}\u{30b9}\u{30c8} \u{1f389} combining a\u{301}e\u{308} nbsp\u{a0}here",
+    "   leading and trailing   ",
+];
+
 fn check_model(tok_file: &str) {
     let path = Path::new(DATA).join(tok_file);
     // The legacy `Tokenizer` only *builds* the pipeline (its sole constructor
@@ -52,6 +66,42 @@ fn check_model(tok_file: &str) {
     };
 
     let mut failures = Vec::new();
+    let mut check = |case: String, chunk: &str| {
+        for add_special_tokens in [false, true] {
+            let expected = released
+                .encode_fast(chunk, add_special_tokens)
+                .unwrap()
+                .get_ids()
+                .to_vec();
+            let got: Vec<u32> = pipeline
+                .encode(chunk, add_special_tokens)
+                .wait()
+                .unwrap()
+                .first()
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect();
+            if expected != got {
+                let at = expected
+                    .iter()
+                    .zip(&got)
+                    .position(|(e, g)| e != g)
+                    .unwrap_or(expected.len().min(got.len()));
+                failures.push(format!(
+                    "{case} (add_special_tokens={add_special_tokens}): ids diverge at {at} \
+                     (expected len {}, got len {})",
+                    expected.len(),
+                    got.len(),
+                ));
+            }
+        }
+    };
+
+    for (i, chunk) in HOSTILE.iter().enumerate() {
+        check(format!("hostile/{i}"), chunk);
+    }
+
     for &(group, stem) in FIXTURES {
         let fixture = Path::new(DATA)
             .join("fixtures")
@@ -71,35 +121,7 @@ fn check_model(tok_file: &str) {
             if chunk.is_empty() {
                 continue;
             }
-            for add_special_tokens in [false, true] {
-                let expected = released
-                    .encode_fast(chunk, add_special_tokens)
-                    .unwrap()
-                    .get_ids()
-                    .to_vec();
-                let got: Vec<u32> = pipeline
-                    .encode(chunk, add_special_tokens)
-                    .wait()
-                    .unwrap()
-                    .first()
-                    .unwrap()
-                    .iter()
-                    .map(|t| t.id)
-                    .collect();
-                if expected != got {
-                    let at = expected
-                        .iter()
-                        .zip(&got)
-                        .position(|(e, g)| e != g)
-                        .unwrap_or(expected.len().min(got.len()));
-                    failures.push(format!(
-                        "{group}/{stem} ({w} B window, add_special_tokens={add_special_tokens}): \
-                         ids diverge at {at} (expected len {}, got len {})",
-                        expected.len(),
-                        got.len(),
-                    ));
-                }
-            }
+            check(format!("{group}/{stem} ({w} B window)"), chunk);
         }
     }
     assert!(


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**10 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`654326088 · 2026-08-05 13:56 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 16 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-overview.png" width="860">

**vs base branch** (`769e579e2`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×5.15 vs v0.23.1 · ×1.02 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 12) · Pipeline 8+2 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 26.8 | ×3.41 | ×1.02 | 3% (1.2) | 77% (27.6) | 13% (4.8) | 7% (2.4) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 26.6 | ×6.38 | ×1.04 | 3% (1.2) | 76% (27.8) | 8% (2.9) | 13% (4.7) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 36.9 | ×6.14 | ×1.02 | 4% (1.2) | 73% (19.2) | 11% (2.8) | 12% (3.3) | 0% (0.0) | match |
| cmn_Hani | lang | 3.8 | 19.3 | ×5.03 | ×1.01 | 2% (1.2) | 74% (37.7) | 10% (5.3) | 15% (7.8) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 25.8 | ×6.81 | ×1.03 | 3% (1.2) | 75% (28.8) | 9% (3.3) | 14% (5.5) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 19.2 | ×4.31 | ×1.02 | 5% (2.5) | 75% (39.0) | 8% (4.2) | 11% (5.9) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 20.6 | ×4.91 | ×1.03 | 2% (1.2) | 78% (37.7) | 7% (3.6) | 12% (5.9) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 28.1 | ×4.34 | ×1.01 | 3% (1.2) | 78% (27.1) | 9% (3.1) | 10% (3.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.2 | 28.2 | ×6.65 | ×1.04 | 3% (1.2) | 65% (23.3) | 13% (4.7) | 18% (6.4) | 0% (0.2) | match |
| kat_Geor | lang | 6.2 | 29.3 | ×4.76 | ×1.03 | 3% (1.2) | 78% (26.7) | 9% (3.1) | 12% (4.1) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 19.6 | ×8.09 | ×1.07 | 2% (1.2) | 64% (35.1) | 14% (7.5) | 21% (11.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.6 | 26.7 | ×7.33 | ×1.03 | 3% (1.2) | 73% (27.5) | 8% (3.1) | 16% (6.2) | 0% (0.0) | match |
| tam_Taml | lang | 7.0 | 39.5 | ×5.64 | ×1.03 | 5% (1.2) | 75% (18.7) | 10% (2.4) | 11% (2.7) | 0% (0.0) | match |
| tha_Thai | lang | 8.3 | 33.0 | ×3.98 | ×1.01 | 4% (1.2) | 85% (25.1) | 7% (2.1) | 4% (1.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.6 | 20.0 | ×3.04 | ×1.01 | 3% (1.3) | 82% (40.8) | 14% (6.9) | 2% (0.8) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 19.1 | ×3.63 | ×1.00 | 4% (1.9) | 77% (40.0) | 14% (7.1) | 6% (3.0) | 0% (0.0) | match |
| added_special_dense | modalities | 5.2 | 38.6 | ×7.36 | ×0.99 | 21% (5.1) | 41% (10.2) | 35% (8.7) | 5% (1.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 22.4 | ×5.67 | ×1.01 | 8% (3.7) | 64% (28.4) | 20% (8.8) | 8% (3.5) | 0% (0.0) | match |
| agentic-traces | modalities | 3.9 | 18.8 | ×4.87 | ×1.01 | 4% (2.4) | 72% (38.6) | 9% (4.7) | 13% (7.1) | 1% (0.4) | match |
| agentic_swe | modalities | 4.1 | 19.8 | ×4.87 | ×1.01 | 4% (1.9) | 77% (38.9) | 8% (4.1) | 11% (5.4) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 19.6 | ×4.98 | ×1.01 | 4% (2.1) | 76% (38.7) | 8% (4.1) | 11% (5.7) | 0% (0.2) | match |
| math_latex | modalities | 4.0 | 18.9 | ×4.73 | ×1.02 | 5% (2.5) | 74% (38.8) | 9% (4.6) | 14% (7.1) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×23.49 vs v0.23.1 · ×1.08 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 68) · Pipeline 82+0 (peak 82)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 91.7 | ×20.72 | ×1.13 | 7% (0.7) | 0% (0.0) | 50% (4.8) | 42% (4.0) | 1% (0.1) | match |
| arb_Arab | lang | 4.4 | 111.9 | ×25.19 | ×1.10 | 7% (0.6) | 0% (0.0) | 38% (3.5) | 56% (5.1) | 0% (0.0) | match |
| ben_Beng | lang | 6.4 | 135.8 | ×21.27 | ×1.07 | 7% (0.6) | 0% (0.0) | 36% (3.3) | 57% (5.2) | 0% (0.0) | match |
| cmn_Hani | lang | 3.8 | 111.0 | ×29.23 | ×1.15 | 3% (0.8) | 0% (0.0) | 12% (3.2) | 85% (23.5) | 0% (0.1) | match |
| ell_Grek | lang | 4.7 | 112.1 | ×23.69 | ×1.09 | 4% (0.6) | 0% (0.0) | 25% (3.5) | 71% (10.0) | 0% (0.1) | match |
| eng_Latn | lang | 3.3 | 74.9 | ×22.95 | ×1.08 | 11% (2.0) | 0% (0.0) | 27% (5.1) | 63% (12.0) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 105.3 | ×25.60 | ×1.09 | 3% (0.6) | 0% (0.0) | 19% (3.6) | 78% (14.8) | 0% (0.0) | match |
| hin_Deva | lang | 5.8 | 126.1 | ×21.65 | ×1.06 | 8% (0.8) | 0% (0.0) | 36% (3.4) | 57% (5.6) | 1% (0.1) | match |
| jpn_Jpan | lang | 4.3 | 129.2 | ×29.77 | ×1.12 | 3% (0.7) | 0% (0.0) | 14% (3.0) | 85% (18.1) | 0% (0.0) | match |
| kat_Geor | lang | 5.9 | 135.5 | ×22.83 | ×1.11 | 5% (0.6) | 0% (0.0) | 21% (2.9) | 75% (10.3) | 0% (0.0) | match |
| kor_Hang | lang | 3.8 | 88.5 | ×23.32 | ×1.13 | 3% (0.6) | 0% (0.0) | 17% (3.8) | 81% (18.4) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.5 | 116.8 | ×26.01 | ×1.09 | 3% (0.6) | 0% (0.0) | 17% (3.3) | 80% (15.4) | 0% (0.0) | match |
| tam_Taml | lang | 6.4 | 150.7 | ×23.59 | ×1.09 | 5% (0.6) | 0% (0.0) | 20% (2.8) | 77% (10.4) | 0% (0.0) | match |
| tha_Thai | lang | 7.1 | 197.1 | ×27.95 | ×1.09 | 4% (0.6) | 0% (0.0) | 15% (2.3) | 82% (12.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.0 | 152.7 | ×25.54 | ×1.07 | 12% (0.7) | 0% (0.0) | 44% (2.7) | 44% (2.7) | 1% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 110.7 | ×21.06 | ×1.04 | 14% (1.2) | 0% (0.0) | 42% (3.8) | 42% (3.7) | 3% (0.2) | match |
| added_special_dense | modalities | 3.6 | 56.5 | ×15.81 | ×1.05 | 41% (6.8) | 5% (0.8) | 35% (5.9) | 18% (3.0) | 2% (0.3) | match |
| added_special_sparse | modalities | 4.0 | 62.5 | ×15.80 | ×1.05 | 26% (4.0) | 2% (0.3) | 45% (6.8) | 25% (3.7) | 2% (0.4) | match |
| agentic-traces | modalities | 3.0 | 70.3 | ×23.44 | ×1.06 | 10% (1.8) | 0% (0.0) | 31% (5.4) | 54% (9.4) | 4% (0.6) | match |
| agentic_swe | modalities | 3.0 | 89.3 | ×29.68 | ×1.05 | 11% (1.3) | 0% (0.0) | 33% (3.9) | 57% (6.8) | 0% (0.0) | match |
| code_mixed | modalities | 3.4 | 80.9 | ×23.51 | ×1.05 | 12% (1.6) | 0% (0.0) | 35% (4.7) | 53% (7.0) | 0% (0.0) | match |
| math_latex | modalities | 2.8 | 70.5 | ×24.79 | ×1.07 | 11% (1.9) | 0% (0.0) | 31% (5.4) | 59% (10.3) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.09 | 4.82 | 5.28 | 42.2 | 19.8 | 9.1 | — | 8.8× / 8.0× | 4.1× / 3.8× | 1.9× / 1.7× | — |
| arb_Arab | 0.99 | 2.77 | 3.46 | 5.25 | 49.1 | 22.6 | 10.0 | — | 14.2× / 9.4× | 6.5× / 4.3× | 2.9× / 1.9× | — |
| ben_Beng | 1.46 | 2.61 | 3.29 | 4.44 | 36.4 | 16.1 | 7.5 | — | 11.0× / 8.2× | 4.9× / 3.6× | 2.3× / 1.7× | — |
| cmn_Hani | 1.13 | 2.01 | 3.21 | 4.09 | 61.1 | 34.6 | 14.1 | — | 19.0× / 14.9× | 10.8× / 8.5× | 4.4× / 3.4× | — |
| ell_Grek | 0.57 | 2.81 | 3.46 | 5.70 | 47.1 | 20.8 | 9.4 | — | 13.6× / 8.3× | 6.0× / 3.6× | 2.7× / 1.6× | — |
| eng_Latn | 0.12 | 1.17 | 5.14 | 6.20 | 65.9 | 40.0 | 16.2 | — | 12.8× / 10.6× | 7.8× / 6.5× | 3.2× / 2.6× | — |
| heb_Hebr | 0.99 | 2.83 | 3.65 | 5.49 | 51.1 | 23.9 | 10.5 | — | 14.0× / 9.3× | 6.5× / 4.3× | 2.9× / 1.9× | — |
| hin_Deva | 1.36 | 2.81 | 3.45 | 4.90 | 38.7 | 18.6 | 8.4 | — | 11.2× / 7.9× | 5.4× / 3.8× | 2.4× / 1.7× | — |
| jpn_Jpan | 1.56 | 3.14 | 3.01 | 4.59 | 54.8 | 27.4 | 11.8 | — | 18.2× / 11.9× | 9.1× / 6.0× | 3.9× / 2.6× | — |
| kat_Geor | 1.38 | 2.19 | 2.95 | 3.75 | 33.0 | 15.2 | 7.2 | — | 11.2× / 8.8× | 5.1× / 4.0× | 2.4× / 1.9× | — |
| kor_Hang | 1.08 | 2.50 | 3.82 | 5.25 | 50.5 | 27.1 | 11.7 | — | 13.2× / 9.6× | 7.1× / 5.2× | 3.1× / 2.2× | — |
| rus_Cyrl | 1.00 | 2.69 | 3.34 | 5.02 | 46.7 | 20.6 | 9.5 | — | 14.0× / 9.3× | 6.2× / 4.1× | 2.8× / 1.9× | — |
| tam_Taml | 0.92 | 2.61 | 2.75 | 4.44 | 31.8 | 13.7 | 6.5 | — | 11.6× / 7.2× | 5.0× / 3.1× | 2.4× / 1.5× | — |
| tha_Thai | 1.36 | 2.21 | 2.34 | 3.18 | 27.5 | 10.2 | 5.2 | — | 11.8× / 8.6× | 4.3× / 3.2× | 2.2× / 1.6× | — |
| added_normalized_dense | 0.06 | 1.18 | 2.73 | 3.85 | 42.6 | 19.9 | 9.2 | — | 15.6× / 11.1× | 7.3× / 5.2× | 3.4× / 2.4× | — |
| added_normalized_sparse | 0.06 | 1.18 | 3.76 | 4.88 | 49.1 | 25.7 | 11.3 | — | 13.1× / 10.1× | 6.8× / 5.3× | 3.0× / 2.3× | — |
| added_special_dense | 0.06 | 1.18 | 5.93 | 7.05 | 173.9 | 98.1 | 38.0 | — | 29.3× / 24.7× | 16.5× / 13.9× | 6.4× / 5.4× | — |
| added_special_sparse | 0.06 | 1.18 | 6.82 | 7.94 | 102.5 | 58.5 | 24.1 | — | 15.0× / 12.9× | 8.6× / 7.4× | 3.5× / 3.0× | — |
| agentic-traces | 0.57 | 1.18 | 5.42 | 6.03 | 80.9 | 53.2 | 20.1 | — | 14.9× / 13.4× | 9.8× / 8.8× | 3.7× / 3.3× | — |
| agentic_swe | 0.52 | 1.15 | 3.89 | 4.51 | 96.1 | 66.5 | 23.5 | — | 24.7× / 21.3× | 17.1× / 14.7× | 6.1× / 5.2× | — |
| code_mixed | 0.09 | 1.16 | 4.70 | 5.77 | 74.8 | 54.4 | 18.8 | — | 15.9× / 13.0× | 11.6× / 9.4× | 4.0× / 3.3× | — |
| math_latex | 0.56 | 1.20 | 5.41 | 6.05 | 79.1 | 47.8 | 19.5 | — | 14.6× / 13.1× | 8.8× / 7.9× | 3.6× / 3.2× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×18.78 vs v0.23.1 · ×0.48 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 371) · Pipeline 274+0 (peak 370)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 10.8 | 139.4 | ×12.92 | ×0.36 | 11% (0.7) | 21% (1.3) | 13% (0.8) | 55% (3.5) | 0% (0.0) | match |
| arb_Arab | lang | 7.0 | 127.3 | ×18.26 | ×0.35 | 6% (0.6) | 15% (1.6) | 9% (1.0) | 74% (7.8) | 0% (0.0) | match |
| ben_Beng | lang | 9.9 | 189.6 | ×19.08 | ×0.40 | 7% (0.6) | 13% (1.1) | 8% (0.6) | 77% (6.5) | 0% (0.0) | match |
| cmn_Hani | lang | 11.3 | 490.3 | ×43.33 | ×0.73 | 19% (0.6) | 6% (0.2) | 4% (0.1) | 79% (2.6) | 0% (0.0) | match |
| ell_Grek | lang | 7.6 | 132.5 | ×17.41 | ×0.38 | 4% (0.6) | 11% (1.6) | 6% (0.9) | 81% (12.4) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 77.8 | ×20.20 | ×0.46 | 6% (2.0) | 9% (3.1) | 5% (1.8) | 78% (26.5) | 2% (0.8) | match |
| heb_Hebr | lang | 8.1 | 117.6 | ×14.51 | ×0.34 | 4% (0.6) | 10% (1.7) | 6% (1.0) | 78% (12.9) | 2% (0.4) | match |
| hin_Deva | lang | 9.7 | 168.6 | ×17.47 | ×0.43 | 8% (0.6) | 17% (1.4) | 10% (0.8) | 66% (5.5) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.2 | 565.3 | ×42.94 | ×0.71 | 22% (0.6) | 6% (0.2) | 4% (0.1) | 71% (2.0) | 0% (0.0) | match |
| kat_Geor | lang | 12.2 | 192.2 | ×15.74 | ×0.38 | 5% (0.6) | 8% (0.9) | 5% (0.6) | 76% (8.6) | 6% (0.7) | match |
| kor_Hang | lang | 9.8 | 113.1 | ×11.59 | ×0.33 | 3% (0.6) | 9% (1.7) | 5% (1.0) | 82% (15.8) | 1% (0.2) | match |
| rus_Cyrl | lang | 6.6 | 144.2 | ×21.85 | ×0.37 | 3% (0.6) | 7% (1.5) | 4% (0.8) | 86% (18.2) | 1% (0.2) | match |
| tam_Taml | lang | 10.4 | 212.9 | ×20.50 | ×0.39 | 5% (0.6) | 7% (0.8) | 5% (0.6) | 82% (9.2) | 0% (0.1) | match |
| tha_Thai | lang | 12.6 | 304.1 | ×24.17 | ×0.48 | 7% (0.6) | 5% (0.5) | 4% (0.3) | 86% (7.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.1 | 143.5 | ×27.91 | ×0.49 | 10% (0.8) | 26% (1.9) | 15% (1.1) | 48% (3.5) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.6 | 99.0 | ×21.36 | ×0.50 | 11% (1.3) | 25% (2.9) | 13% (1.5) | 51% (5.9) | 0% (0.0) | match |
| added_special_dense | modalities | 4.7 | 42.1 | ×9.01 | ×1.14 | 42% (9.6) | 31% (7.2) | 13% (3.0) | 14% (3.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 6.9 | 49.7 | ×7.18 | ×1.10 | 26% (5.1) | 36% (7.0) | 16% (3.1) | 22% (4.3) | 0% (0.0) | match |
| agentic-traces | modalities | 4.0 | 82.9 | ×20.95 | ×0.45 | 6% (1.8) | 9% (2.8) | 6% (1.8) | 81% (25.9) | 0% (0.0) | match |
| agentic_swe | modalities | 3.9 | 80.9 | ×20.68 | ×0.49 | 5% (1.3) | 17% (4.1) | 14% (3.3) | 63% (15.0) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 79.9 | ×20.12 | ×0.47 | 5% (1.6) | 12% (3.5) | 9% (2.7) | 74% (22.6) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 80.1 | ×21.16 | ×0.45 | 6% (1.9) | 10% (3.0) | 6% (1.7) | 76% (22.4) | 2% (0.5) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×27.98 vs v0.23.1 · ×1.09 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 28+0 (peak 28)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 97.4 | ×25.59 | ×1.20 | 8% (0.7) | 0% (0.0) | 44% (3.7) | 51% (4.2) | 0% (0.0) | match |
| arb_Arab | lang | 3.6 | 101.6 | ×27.91 | ×1.17 | 7% (0.6) | 0% (0.0) | 25% (2.2) | 68% (6.1) | 0% (0.0) | match |
| ben_Beng | lang | 2.8 | 84.1 | ×30.11 | ×1.05 | 6% (0.6) | 0% (0.0) | 28% (3.0) | 66% (7.2) | 1% (0.1) | match |
| cmn_Hani | lang | 3.6 | 108.8 | ×30.50 | ×1.16 | 3% (0.6) | 0% (0.0) | 10% (2.3) | 103% (22.9) | 0% (0.0) | match |
| ell_Grek | lang | 4.1 | 113.4 | ×27.83 | ×1.11 | 5% (0.6) | 0% (0.0) | 19% (2.2) | 74% (8.6) | 2% (0.2) | match |
| eng_Latn | lang | 3.3 | 88.3 | ×26.54 | ×1.09 | 12% (2.0) | 0% (0.0) | 17% (2.9) | 69% (11.9) | 2% (0.4) | match |
| heb_Hebr | lang | 3.8 | 104.6 | ×27.90 | ×1.10 | 5% (0.6) | 0% (0.0) | 18% (2.3) | 82% (10.5) | 0% (0.0) | match |
| hin_Deva | lang | 3.0 | 93.5 | ×31.63 | ×1.02 | 6% (0.7) | 0% (0.0) | 29% (3.1) | 64% (6.7) | 1% (0.1) | match |
| jpn_Jpan | lang | 4.3 | 138.9 | ×32.13 | ×1.13 | 3% (0.6) | 0% (0.0) | 11% (2.1) | 89% (16.8) | 0% (0.0) | match |
| kat_Geor | lang | 4.5 | 146.3 | ×32.40 | ×1.13 | 8% (0.6) | 0% (0.0) | 28% (2.0) | 66% (4.9) | 0% (0.0) | match |
| kor_Hang | lang | 3.3 | 94.7 | ×28.86 | ×1.20 | 4% (0.6) | 0% (0.0) | 14% (2.4) | 74% (13.0) | 8% (1.4) | match |
| rus_Cyrl | lang | 4.0 | 119.3 | ×29.83 | ×1.13 | 4% (0.6) | 0% (0.0) | 15% (2.1) | 85% (11.7) | 0% (0.0) | match |
| tam_Taml | lang | 2.6 | 100.1 | ×37.88 | ×1.03 | 6% (0.6) | 0% (0.0) | 27% (2.6) | 66% (6.4) | 0% (0.0) | match |
| tha_Thai | lang | 3.5 | 108.9 | ×31.27 | ×1.12 | 5% (0.6) | 0% (0.0) | 20% (2.5) | 72% (8.9) | 3% (0.3) | match |
| added_normalized_dense | modalities | 5.8 | 187.6 | ×32.51 | ×1.04 | 28% (1.3) | 0% (0.0) | 22% (1.0) | 60% (2.9) | 2% (0.1) | match |
| added_normalized_sparse | modalities | 5.1 | 134.9 | ×26.46 | ×1.07 | 19% (1.3) | 0% (0.0) | 27% (1.9) | 52% (3.6) | 3% (0.2) | match |
| added_special_dense | modalities | 4.0 | 75.4 | ×18.90 | ×0.98 | 43% (5.1) | 2% (0.3) | 33% (4.0) | 22% (2.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.1 | 77.1 | ×18.76 | ×0.98 | 29% (3.3) | 1% (0.1) | 39% (4.5) | 31% (3.5) | 1% (0.1) | match |
| agentic-traces | modalities | 3.0 | 77.1 | ×25.94 | ×1.06 | 12% (1.8) | 0% (0.0) | 23% (3.4) | 66% (9.7) | 0% (0.0) | match |
| agentic_swe | modalities | 3.2 | 93.4 | ×28.84 | ×1.05 | 12% (1.3) | 0% (0.0) | 21% (2.4) | 66% (7.5) | 1% (0.1) | match |
| code_mixed | modalities | 3.4 | 87.1 | ×25.30 | ×1.04 | 13% (1.6) | 0% (0.0) | 24% (2.9) | 64% (7.5) | 0% (0.0) | match |
| math_latex | modalities | 3.1 | 80.6 | ×25.81 | ×1.08 | 12% (1.9) | 0% (0.0) | 21% (3.2) | 66% (10.1) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.08 | 3.65 | 4.10 | 26.3 | 21.2 | 5.8 | 4.7 | 7.2× / 6.4× | 5.8× / 5.2× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 0.99 | 2.78 | 2.22 | 4.01 | 30.9 | 26.3 | 6.9 | 5.0 | 13.9× / 7.7× | 11.8× / 6.6× | 3.1× / 1.7× | 2.3× / 1.3× |
| ben_Beng | 1.48 | 2.64 | 3.00 | 4.17 | 63.5 | 57.7 | 14.1 | 4.1 | 21.2× / 15.2× | 19.2× / 13.8× | 4.7× / 3.4× | 1.4× / 1.0× |
| cmn_Hani | 1.12 | 2.02 | 2.31 | 3.21 | 25.7 | 21.3 | 5.9 | 2.4 | 11.1× / 8.0× | 9.3× / 6.7× | 2.6× / 1.9× | 1.0× / 0.7× |
| ell_Grek | 0.57 | 2.83 | 2.15 | 4.41 | 27.2 | 22.2 | 6.0 | 4.7 | 12.6× / 6.2× | 10.3× / 5.0× | 2.8× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.12 | 1.16 | 2.91 | 3.96 | 42.4 | 43.4 | 12.3 | 3.8 | 14.6× / 10.7× | 14.9× / 11.0× | 4.2× / 3.1× | 1.3× / 1.0× |
| heb_Hebr | 0.99 | 2.85 | 2.26 | 4.12 | 30.3 | 26.6 | 6.9 | 3.1 | 13.4× / 7.4× | 11.8× / 6.4× | 3.0× / 1.7× | 1.4× / 0.8× |
| hin_Deva | 1.36 | 2.78 | 3.07 | 4.49 | 59.2 | 55.4 | 13.6 | 4.3 | 19.3× / 13.2× | 18.0× / 12.3× | 4.4× / 3.0× | 1.4× / 1.0× |
| jpn_Jpan | 1.55 | 3.13 | 2.11 | 3.68 | 23.1 | 17.8 | 5.1 | 3.8 | 11.0× / 6.3× | 8.4× / 4.8× | 2.4× / 1.4× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.22 | 2.04 | 2.87 | 16.7 | 14.5 | 4.2 | 2.1 | 8.2× / 5.8× | 7.1× / 5.0× | 2.1× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.07 | 2.50 | 2.43 | 3.86 | 30.8 | 28.7 | 7.5 | 3.6 | 12.6× / 8.0× | 11.8× / 7.4× | 3.1× / 2.0× | 1.5× / 0.9× |
| rus_Cyrl | 1.00 | 2.74 | 2.10 | 3.83 | 26.1 | 21.6 | 5.9 | 2.5 | 12.5× / 6.8× | 10.3× / 5.6× | 2.8× / 1.5× | 1.2× / 0.7× |
| tam_Taml | 0.92 | 2.65 | 2.65 | 4.37 | 66.8 | 59.0 | 14.5 | 3.8 | 25.2× / 15.3× | 22.3× / 13.5× | 5.5× / 3.3× | 1.4× / 0.9× |
| tha_Thai | 1.38 | 2.25 | 2.49 | 3.36 | 38.7 | 32.7 | 8.9 | 3.3 | 15.5× / 11.5× | 13.1× / 9.7× | 3.6× / 2.6× | 1.3× / 1.0× |
| added_normalized_dense | 0.14 | 1.18 | 1.03 | 2.07 | 22.4 | 23.0 | 6.4 | 1.8 | 21.6× / 10.8× | 22.2× / 11.1× | 6.2× / 3.1× | 1.8× / 0.9× |
| added_normalized_sparse | 0.09 | 1.18 | 1.91 | 3.00 | 29.8 | 31.3 | 8.4 | 2.6 | 15.6× / 9.9× | 16.3× / 10.4× | 4.4× / 2.8× | 1.3× / 0.9× |
| added_special_dense | 0.10 | 1.18 | 3.99 | 5.07 | 90.7 | 100.1 | 20.0 | 2.9 | 22.7× / 17.9× | 25.1× / 19.7× | 5.0× / 3.9× | 0.7× / 0.6× |
| added_special_sparse | 0.09 | 1.18 | 4.49 | 5.58 | 58.5 | 61.6 | 14.3 | 3.3 | 13.0× / 10.5× | 13.7× / 11.0× | 3.2× / 2.6× | 0.7× / 0.6× |
| agentic-traces | 0.57 | 1.18 | 3.44 | 4.06 | 56.3 | 61.9 | 15.4 | 4.6 | 16.3× / 13.9× | 18.0× / 15.3× | 4.5× / 3.8× | 1.3× / 1.1× |
| agentic_swe | 0.51 | 1.16 | 2.37 | 3.02 | 57.5 | 69.6 | 14.7 | 3.4 | 24.2× / 19.1× | 29.3× / 23.1× | 6.2× / 4.9× | 1.5× / 1.1× |
| code_mixed | 0.07 | 1.16 | 2.88 | 3.96 | 55.8 | 68.0 | 15.2 | 4.0 | 19.4× / 14.1× | 23.6× / 17.2× | 5.3× / 3.8× | 1.4× / 1.0× |
| math_latex | 0.57 | 1.29 | 3.23 | 3.94 | 50.1 | 52.2 | 14.0 | 4.1 | 15.5× / 12.7× | 16.2× / 13.2× | 4.3× / 3.6× | 1.3× / 1.1× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×22.29 vs v0.23.1 · ×1.09 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 93.0 | ×24.28 | ×1.16 | 7% (0.7) | 0% (0.0) | 50% (4.8) | 43% (4.1) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 113.6 | ×25.65 | ×1.15 | 6% (0.6) | 0% (0.0) | 33% (3.3) | 61% (6.1) | 0% (0.0) | match |
| ben_Beng | lang | 6.6 | 129.0 | ×19.58 | ×1.09 | 6% (0.6) | 0% (0.0) | 34% (3.6) | 63% (6.8) | 0% (0.0) | match |
| cmn_Hani | lang | 4.6 | 117.4 | ×25.65 | ×1.14 | 2% (0.6) | 0% (0.0) | 8% (3.3) | 92% (36.3) | 0% (0.0) | match |
| ell_Grek | lang | 5.0 | 115.9 | ×23.40 | ×1.08 | 3% (0.6) | 0% (0.0) | 18% (3.2) | 81% (14.7) | 0% (0.0) | match |
| eng_Latn | lang | 3.7 | 77.5 | ×21.11 | ×1.08 | 12% (2.0) | 0% (0.0) | 28% (4.6) | 60% (10.2) | 0% (0.1) | match |
| heb_Hebr | lang | 4.3 | 109.5 | ×25.63 | ×1.14 | 3% (0.6) | 0% (0.0) | 17% (3.4) | 79% (15.7) | 0% (0.1) | match |
| hin_Deva | lang | 6.7 | 124.5 | ×18.67 | ×1.08 | 5% (0.6) | 0% (0.0) | 33% (3.8) | 63% (7.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.2 | 134.8 | ×25.81 | ×1.09 | 2% (0.6) | 0% (0.0) | 9% (3.1) | 88% (28.7) | 1% (0.2) | match |
| kat_Geor | lang | 6.4 | 143.5 | ×22.58 | ×1.07 | 3% (0.6) | 0% (0.0) | 15% (2.9) | 79% (15.2) | 2% (0.4) | match |
| kor_Hang | lang | 3.8 | 86.9 | ×22.83 | ×1.18 | 2% (0.6) | 0% (0.0) | 11% (3.7) | 87% (28.7) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.0 | 120.4 | ×24.27 | ×1.09 | 3% (0.6) | 0% (0.0) | 14% (3.2) | 86% (19.9) | 0% (0.0) | match |
| tam_Taml | lang | 6.6 | 141.2 | ×21.45 | ×1.10 | 3% (0.6) | 0% (0.0) | 17% (3.2) | 80% (15.2) | 0% (0.0) | match |
| tha_Thai | lang | 7.6 | 166.7 | ×21.79 | ×1.10 | 3% (0.6) | 0% (0.0) | 15% (3.2) | 82% (17.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.5 | 166.6 | ×30.54 | ×1.08 | 13% (0.7) | 0% (0.0) | 38% (2.2) | 47% (2.8) | 2% (0.1) | match |
| added_normalized_sparse | modalities | 5.3 | 117.8 | ×22.06 | ×1.06 | 16% (1.3) | 0% (0.0) | 40% (3.2) | 44% (3.5) | 1% (0.1) | match |
| added_special_dense | modalities | 4.4 | 69.2 | ×15.87 | ×1.00 | 37% (5.1) | 2% (0.3) | 38% (5.2) | 21% (2.9) | 1% (0.2) | match |
| added_special_sparse | modalities | 4.4 | 70.7 | ×16.03 | ×1.04 | 24% (3.2) | 1% (0.2) | 44% (5.9) | 28% (3.8) | 2% (0.3) | match |
| agentic-traces | modalities | 3.6 | 73.0 | ×20.51 | ×1.07 | 11% (1.8) | 0% (0.0) | 32% (5.1) | 57% (9.1) | 0% (0.0) | match |
| agentic_swe | modalities | 3.6 | 89.8 | ×24.77 | ×1.04 | 11% (1.3) | 0% (0.0) | 31% (3.7) | 59% (7.1) | 0% (0.0) | match |
| code_mixed | modalities | 3.8 | 83.2 | ×22.00 | ×1.04 | 12% (1.6) | 0% (0.0) | 35% (4.4) | 54% (6.9) | 0% (0.0) | match |
| math_latex | modalities | 3.4 | 72.0 | ×21.43 | ×1.06 | 11% (1.9) | 0% (0.0) | 30% (5.0) | 62% (10.4) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.10 | 4.78 | 5.24 | 30.4 | 14.2 | 7.0 | 4.8 | 6.4× / 5.8× | 3.0× / 2.7× | 1.5× / 1.3× | 1.0× / 0.9× |
| arb_Arab | 0.99 | 2.77 | 3.32 | 5.11 | 33.6 | 16.0 | 7.7 | 5.1 | 10.1× / 6.6× | 4.8× / 3.1× | 2.3× / 1.5× | 1.5× / 1.0× |
| ben_Beng | 1.46 | 2.61 | 3.65 | 4.80 | 24.0 | 10.9 | 5.5 | 2.7 | 6.6× / 5.0× | 3.0× / 2.3× | 1.5× / 1.1× | 0.8× / 0.6× |
| cmn_Hani | 1.13 | 2.01 | 3.33 | 4.22 | 21.9 | 10.9 | 5.4 | 2.5 | 6.6× / 5.2× | 3.3× / 2.6× | 1.6× / 1.3× | 0.8× / 0.6× |
| ell_Grek | 0.57 | 2.81 | 3.23 | 5.47 | 29.9 | 15.4 | 6.9 | 5.1 | 9.2× / 5.5× | 4.7× / 2.8× | 2.1× / 1.3× | 1.6× / 0.9× |
| eng_Latn | 0.09 | 1.16 | 4.64 | 5.71 | 44.3 | 29.3 | 13.8 | 4.2 | 9.5× / 7.8× | 6.3× / 5.1× | 3.0× / 2.4× | 0.9× / 0.7× |
| heb_Hebr | 1.07 | 2.86 | 3.39 | 5.19 | 33.4 | 17.2 | 8.1 | 2.9 | 9.9× / 6.4× | 5.1× / 3.3× | 2.4× / 1.6× | 0.8× / 0.6× |
| hin_Deva | 1.37 | 2.75 | 3.82 | 5.20 | 26.2 | 12.9 | 6.5 | 3.2 | 6.9× / 5.0× | 3.4× / 2.5× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.56 | 3.10 | 3.10 | 4.65 | 20.5 | 9.2 | 4.7 | 3.8 | 6.6× / 4.4× | 3.0× / 2.0× | 1.5× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.38 | 2.20 | 2.92 | 3.73 | 19.0 | 10.2 | 4.6 | 2.1 | 6.5× / 5.1× | 3.5× / 2.7× | 1.6× / 1.2× | 0.7× / 0.6× |
| kor_Hang | 1.08 | 2.48 | 3.74 | 5.14 | 33.0 | 19.0 | 9.0 | 3.6 | 8.8× / 6.4× | 5.1× / 3.7× | 2.4× / 1.7× | 1.0× / 0.7× |
| rus_Cyrl | 1.00 | 2.75 | 3.15 | 4.89 | 28.5 | 15.0 | 6.6 | 4.8 | 9.1× / 5.8× | 4.8× / 3.1× | 2.1× / 1.4× | 1.5× / 1.0× |
| tam_Taml | 0.93 | 2.65 | 3.22 | 4.95 | 19.0 | 8.7 | 4.2 | 2.9 | 5.9× / 3.8× | 2.7× / 1.8× | 1.3× / 0.8× | 0.9× / 0.6× |
| tha_Thai | 1.37 | 2.21 | 3.22 | 4.06 | 13.2 | 5.7 | 2.8 | 2.3 | 4.1× / 3.3× | 1.8× / 1.4× | 0.9× / 0.7× | 0.7× / 0.6× |
| added_normalized_dense | 0.07 | 1.18 | 2.20 | 3.31 | 32.9 | 17.5 | 11.3 | 2.0 | 14.9× / 9.9× | 7.9× / 5.3× | 5.1× / 3.4× | 0.9× / 0.6× |
| added_normalized_sparse | 0.07 | 1.18 | 3.21 | 4.32 | 35.3 | 20.4 | 11.5 | 2.8 | 11.0× / 8.2× | 6.4× / 4.7× | 3.6× / 2.7× | 0.9× / 0.7× |
| added_special_dense | 0.07 | 1.18 | 5.22 | 6.32 | 83.1 | 66.7 | 24.5 | 3.3 | 15.9× / 13.1× | 12.8× / 10.5× | 4.7× / 3.9× | 0.6× / 0.5× |
| added_special_sparse | 0.07 | 1.18 | 5.89 | 7.00 | 56.0 | 40.4 | 16.1 | 3.8 | 9.5× / 8.0× | 6.9× / 5.8× | 2.7× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.57 | 1.18 | 5.08 | 5.68 | 52.9 | 42.9 | 17.6 | 4.9 | 10.4× / 9.3× | 8.4× / 7.5× | 3.5× / 3.1× | 1.0× / 0.9× |
| agentic_swe | 0.54 | 1.15 | 3.74 | 4.35 | 52.2 | 48.9 | 17.6 | 3.6 | 13.9× / 12.0× | 13.1× / 11.2× | 4.7× / 4.0× | 1.0× / 0.8× |
| code_mixed | 0.07 | 1.16 | 4.44 | 5.53 | 51.5 | 47.3 | 17.6 | 4.2 | 11.6× / 9.3× | 10.7× / 8.6× | 4.0× / 3.2× | 1.0× / 0.8× |
| math_latex | 0.57 | 1.20 | 4.95 | 5.58 | 49.2 | 35.3 | 15.6 | 4.5 | 9.9× / 8.8× | 7.1× / 6.3× | 3.2× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×23.43 vs v0.23.1 · ×1.01 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 91.5 | ×23.11 | ×1.03 | 13% (1.2) | 0% (0.0) | 38% (3.7) | 50% (4.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.1 | 111.7 | ×27.11 | ×1.02 | 12% (1.2) | 0% (0.0) | 24% (2.3) | 64% (6.1) | 0% (0.0) | match |
| ben_Beng | lang | 4.2 | 108.8 | ×26.21 | ×0.99 | 13% (1.2) | 0% (0.0) | 35% (3.2) | 51% (4.6) | 2% (0.2) | match |
| cmn_Hani | lang | 4.4 | 117.2 | ×26.41 | ×1.01 | 4% (1.2) | 0% (0.0) | 7% (2.4) | 88% (29.4) | 1% (0.2) | match |
| ell_Grek | lang | 4.8 | 118.0 | ×24.48 | ×1.01 | 7% (1.2) | 0% (0.0) | 14% (2.2) | 82% (13.1) | 0% (0.0) | match |
| eng_Latn | lang | 3.7 | 81.8 | ×22.31 | ×1.04 | 15% (2.6) | 0% (0.0) | 18% (3.0) | 66% (10.9) | 1% (0.1) | match |
| heb_Hebr | lang | 4.0 | 97.6 | ×24.38 | ×1.01 | 7% (1.2) | 0% (0.0) | 15% (2.3) | 79% (12.6) | 0% (0.0) | match |
| hin_Deva | lang | 3.9 | 99.7 | ×25.89 | ×0.99 | 12% (1.2) | 0% (0.0) | 32% (3.3) | 55% (5.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.4 | 137.0 | ×25.48 | ×1.01 | 4% (1.2) | 0% (0.0) | 8% (2.2) | 87% (23.7) | 1% (0.2) | match |
| kat_Geor | lang | 6.1 | 136.1 | ×22.36 | ×1.01 | 9% (1.2) | 0% (0.0) | 16% (2.1) | 78% (10.4) | 0% (0.0) | match |
| kor_Hang | lang | 3.4 | 84.5 | ×24.71 | ×1.01 | 4% (1.2) | 0% (0.0) | 9% (2.5) | 89% (25.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.5 | 122.8 | ×27.35 | ×1.02 | 5% (1.2) | 0% (0.0) | 10% (2.2) | 81% (18.4) | 5% (1.0) | match |
| tam_Taml | lang | 3.7 | 104.1 | ×28.05 | ×0.98 | 13% (1.2) | 0% (0.0) | 30% (2.8) | 59% (5.4) | 0% (0.0) | match |
| tha_Thai | lang | 4.6 | 109.8 | ×24.07 | ×1.01 | 6% (1.2) | 0% (0.0) | 14% (2.6) | 81% (14.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 172.7 | ×29.17 | ×0.99 | 27% (1.4) | 0% (0.0) | 20% (1.0) | 51% (2.6) | 3% (0.1) | match |
| added_normalized_sparse | modalities | 5.0 | 125.9 | ×25.28 | ×1.01 | 26% (1.9) | 0% (0.0) | 26% (1.9) | 46% (3.4) | 4% (0.3) | match |
| added_special_dense | modalities | 3.8 | 44.7 | ×11.60 | ×0.98 | 59% (12.9) | 1% (0.2) | 24% (5.3) | 16% (3.5) | 0% (0.1) | match |
| added_special_sparse | modalities | 4.1 | 58.5 | ×14.29 | ×0.98 | 42% (6.9) | 1% (0.1) | 31% (5.1) | 24% (3.9) | 2% (0.3) | match |
| agentic-traces | modalities | 3.2 | 74.6 | ×22.96 | ×1.04 | 16% (2.5) | 0% (0.0) | 24% (3.8) | 60% (9.2) | 0% (0.0) | match |
| agentic_swe | modalities | 3.5 | 88.9 | ×25.57 | ×1.01 | 16% (1.9) | 0% (0.0) | 24% (2.9) | 60% (7.3) | 1% (0.1) | match |
| code_mixed | modalities | 3.7 | 84.5 | ×22.78 | ×1.00 | 17% (2.2) | 0% (0.0) | 26% (3.3) | 58% (7.4) | 0% (0.0) | match |
| math_latex | modalities | 3.4 | 74.0 | ×21.47 | ×1.01 | 16% (2.5) | 0% (0.0) | 22% (3.5) | 64% (10.1) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.15 | 3.71 | 4.23 | 27.0 | 16.2 | 6.1 | 4.8 | 7.3× / 6.4× | 4.4× / 3.8× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 2.80 | 2.32 | 4.12 | 30.6 | 20.0 | 7.1 | 5.1 | 13.2× / 7.4× | 8.6× / 4.9× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.46 | 2.61 | 3.17 | 4.31 | 44.4 | 28.2 | 10.4 | 3.8 | 14.0× / 10.3× | 8.9× / 6.5× | 3.3× / 2.4× | 1.2× / 0.9× |
| cmn_Hani | 1.13 | 2.01 | 2.40 | 3.27 | 19.8 | 12.0 | 4.8 | 2.4 | 8.2× / 6.0× | 5.0× / 3.7× | 2.0× / 1.5× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 2.82 | 2.21 | 4.43 | 27.9 | 17.2 | 6.3 | 4.8 | 12.6× / 6.3× | 7.8× / 3.9× | 2.8× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.11 | 1.17 | 3.05 | 4.10 | 43.5 | 34.0 | 12.7 | 3.8 | 14.3× / 10.6× | 11.1× / 8.3× | 4.2× / 3.1× | 1.2× / 0.9× |
| heb_Hebr | 1.00 | 2.91 | 2.34 | 4.26 | 30.5 | 19.9 | 7.2 | 3.1 | 13.0× / 7.2× | 8.5× / 4.7× | 3.1× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 2.93 | 3.27 | 4.83 | 48.0 | 31.3 | 11.6 | 4.1 | 14.7× / 9.9× | 9.6× / 6.5× | 3.5× / 2.4× | 1.2× / 0.8× |
| jpn_Jpan | 1.56 | 3.12 | 2.23 | 3.79 | 18.4 | 9.9 | 4.2 | 3.8 | 8.3× / 4.9× | 4.4× / 2.6× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.39 | 2.18 | 2.11 | 2.91 | 17.0 | 11.4 | 4.2 | 2.1 | 8.0× / 5.8× | 5.4× / 3.9× | 2.0× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.08 | 2.49 | 2.53 | 3.94 | 30.8 | 22.3 | 7.7 | 3.7 | 12.2× / 7.8× | 8.8× / 5.6× | 3.0× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.00 | 2.74 | 2.17 | 3.91 | 26.5 | 16.6 | 6.0 | 2.5 | 12.2× / 6.8× | 7.6× / 4.2× | 2.8× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.94 | 2.61 | 2.76 | 4.44 | 44.2 | 27.8 | 10.5 | 3.4 | 16.0× / 10.0× | 10.1× / 6.3× | 3.8× / 2.4× | 1.2× / 0.8× |
| tha_Thai | 1.36 | 2.22 | 2.61 | 3.47 | 27.9 | 16.8 | 6.9 | 3.1 | 10.7× / 8.1× | 6.4× / 4.8× | 2.7× / 2.0× | 1.2× / 0.9× |
| added_normalized_dense | 0.08 | 1.18 | 1.03 | 2.12 | 23.2 | 16.5 | 6.5 | 1.9 | 22.6× / 10.9× | 16.1× / 7.8× | 6.4× / 3.1× | 1.9× / 0.9× |
| added_normalized_sparse | 0.09 | 1.18 | 1.91 | 3.00 | 30.7 | 22.8 | 8.7 | 2.7 | 16.1× / 10.2× | 12.0× / 7.6× | 4.5× / 2.9× | 1.4× / 0.9× |
| added_special_dense | 0.09 | 1.18 | 5.28 | 6.37 | 94.8 | 73.7 | 21.5 | 3.3 | 18.0× / 14.9× | 14.0× / 11.6× | 4.1× / 3.4× | 0.6× / 0.5× |
| added_special_sparse | 0.09 | 1.18 | 5.11 | 6.20 | 59.7 | 47.0 | 15.0 | 3.7 | 11.7× / 9.6× | 9.2× / 7.6× | 2.9× / 2.4× | 0.7× / 0.6× |
| agentic-traces | 0.58 | 1.18 | 3.78 | 4.38 | 52.5 | 48.6 | 15.6 | 4.7 | 13.9× / 12.0× | 12.9× / 11.1× | 4.1× / 3.6× | 1.2× / 1.1× |
| agentic_swe | 0.53 | 1.16 | 2.90 | 3.53 | 54.3 | 57.4 | 16.1 | 3.5 | 18.7× / 15.4× | 19.8× / 16.3× | 5.5× / 4.6× | 1.2× / 1.0× |
| code_mixed | 0.09 | 1.16 | 3.33 | 4.39 | 51.9 | 52.8 | 15.4 | 4.0 | 15.6× / 11.8× | 15.9× / 12.0× | 4.6× / 3.5× | 1.2× / 0.9× |
| math_latex | 0.57 | 1.18 | 3.48 | 4.10 | 50.2 | 40.7 | 14.7 | 4.2 | 14.4× / 12.3× | 11.7× / 9.9× | 4.2× / 3.6× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×16.91 vs v0.23.1 · ×0.45 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 18+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.5 | 116.8 | ×25.78 | ×0.34 | 1% (0.1) | 28% (1.9) | 13% (0.9) | 65% (4.4) | 0% (0.0) | match |
| arb_Arab | lang | 10.0 | 106.0 | ×10.59 | ×0.32 | 0% (0.0) | 23% (2.3) | 10% (1.0) | 65% (6.4) | 2% (0.2) | match |
| ben_Beng | lang | 10.7 | 152.7 | ×14.29 | ×0.37 | 1% (0.1) | 22% (1.6) | 10% (0.7) | 69% (4.8) | 0% (0.0) | match |
| cmn_Hani | lang | 8.9 | 499.4 | ×56.09 | ×0.62 | 3% (0.1) | 18% (0.4) | 6% (0.1) | 88% (1.9) | 0% (0.0) | match |
| ell_Grek | lang | 10.0 | 111.8 | ×11.13 | ×0.34 | 0% (0.0) | 20% (2.3) | 8% (0.9) | 72% (8.2) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 70.9 | ×18.12 | ×0.43 | 0% (0.1) | 18% (5.2) | 6% (1.8) | 76% (21.8) | 0% (0.0) | match |
| heb_Hebr | lang | 9.6 | 102.5 | ×10.64 | ×0.31 | 0% (0.0) | 19% (2.3) | 10% (1.2) | 72% (8.9) | 0% (0.0) | match |
| hin_Deva | lang | 11.3 | 133.8 | ×11.82 | ×0.37 | 1% (0.0) | 27% (2.0) | 11% (0.9) | 62% (4.7) | 0% (0.0) | match |
| jpn_Jpan | lang | 12.7 | 607.3 | ×47.81 | ×0.61 | 4% (0.1) | 20% (0.3) | 6% (0.1) | 82% (1.4) | 0% (0.0) | match |
| kat_Geor | lang | 13.7 | 164.3 | ×11.97 | ×0.36 | 1% (0.1) | 20% (1.4) | 9% (0.6) | 90% (6.2) | 0% (0.0) | match |
| kor_Hang | lang | 7.0 | 92.4 | ×13.25 | ×0.30 | 0% (0.1) | 14% (2.3) | 6% (1.0) | 88% (14.6) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.5 | 131.2 | ×17.43 | ×0.34 | 0% (0.0) | 11% (2.0) | 5% (0.8) | 84% (14.9) | 0% (0.0) | match |
| tam_Taml | lang | 12.0 | 170.8 | ×14.27 | ×0.35 | 1% (0.0) | 20% (1.3) | 8% (0.6) | 77% (5.0) | 0% (0.0) | match |
| tha_Thai | lang | 15.2 | 284.9 | ×18.74 | ×0.44 | 1% (0.1) | 18% (0.8) | 7% (0.3) | 80% (3.7) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.4 | 128.9 | ×23.93 | ×1.15 | 1% (0.1) | 36% (2.7) | 16% (1.2) | 47% (3.5) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.6 | 91.1 | ×19.77 | ×0.51 | 0% (0.0) | 38% (4.6) | 13% (1.6) | 49% (5.8) | 0% (0.0) | match |
| added_special_dense | modalities | 3.6 | 35.1 | ×9.84 | ×0.88 | 18% (5.0) | 51% (13.9) | 17% (4.8) | 14% (3.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.9 | 41.3 | ×8.46 | ×0.86 | 9% (2.2) | 53% (12.3) | 17% (4.0) | 21% (4.8) | 0% (0.1) | match |
| agentic-traces | modalities | 4.0 | 76.1 | ×19.17 | ×0.41 | 0% (0.1) | 14% (4.6) | 5% (1.8) | 68% (23.1) | 12% (4.0) | match |
| agentic_swe | modalities | 3.7 | 72.5 | ×19.68 | ×0.51 | 0% (0.1) | 27% (6.5) | 14% (3.3) | 58% (13.7) | 1% (0.1) | match |
| code_mixed | modalities | 3.9 | 74.6 | ×19.22 | ×0.45 | 0% (0.0) | 19% (5.5) | 10% (2.7) | 75% (21.4) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 75.0 | ×18.66 | ×0.42 | 0% (0.1) | 19% (4.9) | 6% (1.7) | 75% (19.5) | 0% (0.0) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×25.03 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 93+0 (peak 95)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 102.4 | ×23.48 | ×1.00 | 7% (0.7) | 0% (0.0) | 41% (3.7) | 56% (4.9) | 0% (0.0) | match |
| arb_Arab | lang | 4.6 | 126.3 | ×27.47 | ×1.00 | 7% (0.6) | 0% (0.0) | 26% (2.3) | 68% (6.1) | 0% (0.0) | match |
| ben_Beng | lang | 4.1 | 108.7 | ×26.53 | ×1.00 | 7% (0.6) | 0% (0.0) | 34% (3.1) | 59% (5.4) | 1% (0.1) | match |
| cmn_Hani | lang | 4.9 | 129.8 | ×26.45 | ×0.99 | 2% (0.6) | 0% (0.0) | 9% (2.4) | 95% (26.5) | 0% (0.0) | match |
| ell_Grek | lang | 5.1 | 132.5 | ×25.77 | ×1.00 | 4% (0.6) | 0% (0.0) | 14% (2.2) | 80% (12.4) | 2% (0.3) | match |
| eng_Latn | lang | 4.1 | 87.2 | ×21.34 | ×1.00 | 13% (2.0) | 0% (0.0) | 20% (3.0) | 67% (10.0) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 109.5 | ×25.84 | ×1.00 | 4% (0.6) | 0% (0.0) | 15% (2.3) | 80% (12.4) | 1% (0.1) | match |
| hin_Deva | lang | 4.3 | 118.4 | ×27.41 | ×0.99 | 7% (0.6) | 0% (0.0) | 38% (3.3) | 54% (4.6) | 1% (0.1) | match |
| jpn_Jpan | lang | 5.6 | 153.2 | ×27.54 | ×0.98 | 2% (0.6) | 0% (0.0) | 8% (2.2) | 88% (23.2) | 2% (0.4) | match |
| kat_Geor | lang | 5.6 | 143.9 | ×25.87 | ×0.96 | 6% (0.6) | 0% (0.0) | 20% (2.1) | 76% (8.0) | 0% (0.0) | match |
| kor_Hang | lang | 3.5 | 95.5 | ×26.95 | ×0.97 | 2% (0.6) | 0% (0.0) | 10% (2.5) | 87% (22.5) | 1% (0.2) | match |
| rus_Cyrl | lang | 4.5 | 131.6 | ×29.10 | ×0.97 | 3% (0.6) | 0% (0.0) | 10% (2.2) | 88% (18.3) | 0% (0.0) | match |
| tam_Taml | lang | 3.8 | 114.1 | ×29.84 | ×1.00 | 7% (0.6) | 0% (0.0) | 32% (2.7) | 61% (5.3) | 0% (0.0) | match |
| tha_Thai | lang | 4.9 | 131.4 | ×26.64 | ×0.98 | 3% (0.6) | 0% (0.0) | 13% (2.6) | 83% (16.5) | 1% (0.1) | match |
| added_normalized_dense | modalities | 6.0 | 196.0 | ×32.69 | ×0.98 | 17% (0.7) | 0% (0.0) | 24% (1.1) | 61% (2.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 137.8 | ×25.68 | ×1.01 | 20% (1.3) | 0% (0.0) | 28% (1.9) | 50% (3.4) | 3% (0.2) | match |
| added_special_dense | modalities | 4.1 | 70.0 | ×17.16 | ×0.98 | 38% (5.1) | 3% (0.4) | 37% (5.0) | 23% (3.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 74.4 | ×17.20 | ×0.96 | 26% (3.2) | 1% (0.1) | 41% (5.1) | 30% (3.8) | 1% (0.2) | match |
| agentic-traces | modalities | 3.4 | 80.0 | ×23.51 | ×1.00 | 12% (1.8) | 0% (0.0) | 26% (3.8) | 61% (8.9) | 2% (0.3) | match |
| agentic_swe | modalities | 3.9 | 96.9 | ×24.70 | ×1.00 | 12% (1.3) | 0% (0.0) | 26% (2.9) | 62% (6.9) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 92.0 | ×23.37 | ×1.02 | 13% (1.6) | 0% (0.0) | 27% (3.3) | 61% (7.4) | 0% (0.0) | match |
| math_latex | modalities | 3.6 | 80.4 | ×22.18 | ×1.00 | 13% (1.9) | 0% (0.0) | 23% (3.5) | 65% (9.9) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.29 | 3.66 | 4.33 | 27.5 | 16.8 | 6.0 | 4.8 | 7.5× / 6.3× | 4.6× / 3.9× | 1.6× / 1.4× | 1.3× / 1.1× |
| arb_Arab | 0.99 | 2.78 | 2.30 | 4.09 | 31.5 | 19.6 | 6.8 | 5.1 | 13.7× / 7.7× | 8.5× / 4.8× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.46 | 2.58 | 3.12 | 4.24 | 45.7 | 28.6 | 10.4 | 3.8 | 14.6× / 10.8× | 9.2× / 6.7× | 3.3× / 2.5× | 1.2× / 0.9× |
| cmn_Hani | 1.13 | 2.01 | 2.40 | 3.28 | 20.0 | 11.9 | 4.7 | 2.4 | 8.3× / 6.1× | 4.9× / 3.6× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.81 | 2.21 | 4.44 | 28.5 | 17.1 | 6.2 | 4.6 | 12.9× / 6.4× | 7.7× / 3.8× | 2.8× / 1.4× | 2.1× / 1.0× |
| eng_Latn | 0.10 | 1.16 | 3.04 | 4.11 | 45.0 | 33.1 | 12.6 | 3.8 | 14.8× / 10.9× | 10.9× / 8.1× | 4.2× / 3.1× | 1.2× / 0.9× |
| heb_Hebr | 0.99 | 2.86 | 2.32 | 4.19 | 31.3 | 20.3 | 7.0 | 3.1 | 13.5× / 7.5× | 8.8× / 4.8× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 2.76 | 3.25 | 4.64 | 49.6 | 31.1 | 11.6 | 4.1 | 15.2× / 10.7× | 9.6× / 6.7× | 3.6× / 2.5× | 1.3× / 0.9× |
| jpn_Jpan | 1.56 | 3.12 | 2.18 | 3.74 | 18.6 | 10.0 | 4.1 | 3.8 | 8.5× / 5.0× | 4.6× / 2.7× | 1.9× / 1.1× | 1.8× / 1.0× |
| kat_Geor | 1.42 | 2.19 | 2.11 | 2.88 | 17.2 | 11.4 | 4.2 | 2.0 | 8.2× / 6.0× | 5.4× / 3.9× | 2.0× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.08 | 2.49 | 2.51 | 3.91 | 31.8 | 21.9 | 7.6 | 3.7 | 12.7× / 8.1× | 8.7× / 5.6× | 3.1× / 2.0× | 1.5× / 0.9× |
| rus_Cyrl | 1.01 | 2.74 | 2.17 | 3.90 | 27.1 | 16.4 | 6.0 | 2.4 | 12.5× / 7.0× | 7.6× / 4.2× | 2.8× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.66 | 2.73 | 4.46 | 45.3 | 27.8 | 10.3 | 3.4 | 16.6× / 10.2× | 10.2× / 6.2× | 3.8× / 2.3× | 1.2× / 0.8× |
| tha_Thai | 1.36 | 2.25 | 2.59 | 3.48 | 28.5 | 16.4 | 6.9 | 3.0 | 11.0× / 8.2× | 6.3× / 4.7× | 2.7× / 2.0× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 1.18 | 1.06 | 2.18 | 23.7 | 16.8 | 6.5 | 2.0 | 22.4× / 10.9× | 15.8× / 7.7× | 6.1× / 3.0× | 1.8× / 0.9× |
| added_normalized_sparse | 0.06 | 1.20 | 1.88 | 3.02 | 31.6 | 22.7 | 8.8 | 2.7 | 16.8× / 10.5× | 12.1× / 7.5× | 4.7× / 2.9× | 1.4× / 0.9× |
| added_special_dense | 0.06 | 1.18 | 4.96 | 6.08 | 96.1 | 75.4 | 21.0 | 3.3 | 19.4× / 15.8× | 15.2× / 12.4× | 4.2× / 3.5× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.18 | 5.10 | 6.22 | 61.1 | 46.1 | 14.8 | 3.7 | 12.0× / 9.8× | 9.0× / 7.4× | 2.9× / 2.4× | 0.7× / 0.6× |
| agentic-traces | 0.57 | 1.18 | 3.76 | 4.37 | 53.6 | 46.3 | 15.3 | 4.7 | 14.3× / 12.3× | 12.3× / 10.6× | 4.1× / 3.5× | 1.2× / 1.1× |
| agentic_swe | 0.53 | 1.15 | 2.87 | 3.49 | 56.0 | 53.4 | 15.7 | 3.4 | 19.5× / 16.1× | 18.6× / 15.3× | 5.5× / 4.5× | 1.2× / 1.0× |
| code_mixed | 0.09 | 1.15 | 3.29 | 4.34 | 53.7 | 52.0 | 15.5 | 4.0 | 16.3× / 12.4× | 15.8× / 12.0× | 4.7× / 3.6× | 1.2× / 0.9× |
| math_latex | 0.57 | 1.18 | 3.45 | 4.06 | 51.7 | 39.1 | 14.7 | 4.2 | 15.0× / 12.7× | 11.3× / 9.6× | 4.2× / 3.6× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×20.24 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 194) · Pipeline 109+0 (peak 195)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 86.3 | ×22.55 | ×1.01 | 12% (1.2) | 0% (0.0) | 49% (4.9) | 40% (4.0) | 0% (0.0) | match |
| arb_Arab | lang | 4.7 | 102.4 | ×21.96 | ×0.96 | 11% (1.2) | 0% (0.0) | 35% (3.7) | 53% (5.7) | 1% (0.1) | match |
| ben_Beng | lang | 6.7 | 114.3 | ×17.14 | ×0.97 | 11% (1.2) | 0% (0.0) | 37% (3.9) | 52% (5.6) | 1% (0.1) | match |
| cmn_Hani | lang | 4.9 | 107.4 | ×21.78 | ×1.02 | 4% (1.2) | 0% (0.0) | 11% (3.4) | 84% (24.6) | 1% (0.2) | match |
| ell_Grek | lang | 5.2 | 108.2 | ×20.67 | ×0.99 | 7% (1.2) | 0% (0.0) | 20% (3.3) | 73% (11.9) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 73.5 | ×19.04 | ×1.02 | 16% (2.5) | 0% (0.0) | 29% (4.6) | 57% (9.2) | 0% (0.0) | match |
| heb_Hebr | lang | 4.5 | 97.9 | ×21.70 | ×0.97 | 6% (1.2) | 0% (0.0) | 21% (3.8) | 77% (14.2) | 0% (0.0) | match |
| hin_Deva | lang | 6.6 | 110.4 | ×16.82 | ×0.96 | 11% (1.2) | 0% (0.0) | 37% (4.0) | 56% (6.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.6 | 124.1 | ×22.32 | ×1.02 | 5% (1.2) | 0% (0.0) | 12% (3.1) | 81% (20.9) | 2% (0.5) | match |
| kat_Geor | lang | 6.5 | 131.1 | ×20.06 | ×1.00 | 7% (1.2) | 0% (0.0) | 19% (2.9) | 73% (11.5) | 1% (0.1) | match |
| kor_Hang | lang | 4.0 | 82.4 | ×20.67 | ×0.98 | 4% (1.2) | 0% (0.0) | 14% (3.8) | 80% (22.2) | 2% (0.5) | match |
| rus_Cyrl | lang | 4.7 | 111.3 | ×23.58 | ×1.00 | 6% (1.2) | 0% (0.0) | 15% (3.2) | 78% (15.9) | 1% (0.1) | match |
| tam_Taml | lang | 6.7 | 127.6 | ×19.00 | ×0.97 | 7% (1.2) | 0% (0.0) | 21% (3.5) | 71% (11.7) | 1% (0.2) | match |
| tha_Thai | lang | 8.0 | 145.3 | ×18.22 | ×0.97 | 7% (1.2) | 0% (0.0) | 20% (3.4) | 71% (11.9) | 2% (0.3) | match |
| added_normalized_dense | modalities | 5.7 | 147.2 | ×26.02 | ×0.99 | 21% (1.3) | 0% (0.0) | 35% (2.2) | 45% (2.8) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 111.0 | ×20.85 | ×1.03 | 22% (1.9) | 0% (0.0) | 35% (3.0) | 42% (3.6) | 2% (0.1) | match |
| added_special_dense | modalities | 4.2 | 69.7 | ×16.57 | ×1.00 | 39% (5.3) | 2% (0.2) | 40% (5.5) | 20% (2.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 68.4 | ×15.43 | ×0.99 | 37% (5.0) | 0% (0.0) | 45% (6.1) | 26% (3.5) | 1% (0.1) | match |
| agentic-traces | modalities | 3.4 | 68.2 | ×20.16 | ×1.01 | 15% (2.4) | 0% (0.0) | 31% (5.1) | 52% (8.4) | 2% (0.3) | match |
| agentic_swe | modalities | 3.4 | 81.0 | ×23.77 | ×1.01 | 15% (1.9) | 0% (0.0) | 30% (3.8) | 55% (7.0) | 0% (0.0) | match |
| code_mixed | modalities | 3.7 | 77.6 | ×21.14 | ×1.01 | 17% (2.2) | 0% (0.0) | 34% (4.4) | 49% (6.3) | 1% (0.1) | match |
| math_latex | modalities | 3.6 | 68.8 | ×19.28 | ×1.01 | 15% (2.5) | 0% (0.0) | 30% (4.9) | 53% (8.6) | 1% (0.2) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.08 | 4.92 | 5.37 | 29.1 | 14.3 | 7.0 | — | 5.9× / 5.4× | 2.9× / 2.7× | 1.4× / 1.3× | — |
| arb_Arab | 0.99 | 2.78 | 3.74 | 5.53 | 33.4 | 16.3 | 7.5 | — | 8.9× / 6.0× | 4.4× / 2.9× | 2.0× / 1.4× | — |
| ben_Beng | 1.46 | 2.64 | 3.93 | 5.11 | 23.6 | 10.9 | 5.3 | — | 6.0× / 4.6× | 2.8× / 2.1× | 1.3× / 1.0× | — |
| cmn_Hani | 1.12 | 2.01 | 3.36 | 4.25 | 22.2 | 11.6 | 5.6 | — | 6.6× / 5.2× | 3.5× / 2.7× | 1.7× / 1.3× | — |
| ell_Grek | 0.57 | 2.81 | 3.27 | 5.50 | 29.3 | 15.3 | 6.6 | — | 9.0× / 5.3× | 4.7× / 2.8× | 2.0× / 1.2× | — |
| eng_Latn | 0.09 | 1.16 | 4.61 | 5.68 | 43.5 | 31.0 | 13.6 | — | 9.4× / 7.7× | 6.7× / 5.5× | 3.0× / 2.4× | — |
| heb_Hebr | 0.99 | 2.85 | 3.82 | 5.68 | 32.8 | 17.3 | 7.7 | — | 8.6× / 5.8× | 4.5× / 3.0× | 2.0× / 1.4× | — |
| hin_Deva | 1.36 | 2.78 | 3.99 | 5.41 | 25.7 | 12.8 | 6.1 | — | 6.4× / 4.7× | 3.2× / 2.4× | 1.5× / 1.1× | — |
| jpn_Jpan | 1.56 | 3.10 | 3.14 | 4.68 | 20.6 | 9.5 | 4.7 | — | 6.6× / 4.4× | 3.0× / 2.0× | 1.5× / 1.0× | — |
| kat_Geor | 1.38 | 2.22 | 2.94 | 3.78 | 18.8 | 10.2 | 4.5 | — | 6.4× / 5.0× | 3.5× / 2.7× | 1.5× / 1.2× | — |
| kor_Hang | 1.07 | 2.49 | 3.82 | 5.23 | 33.3 | 19.8 | 8.6 | — | 8.7× / 6.4× | 5.2× / 3.8× | 2.3× / 1.7× | — |
| rus_Cyrl | 1.00 | 2.74 | 3.15 | 4.89 | 28.3 | 15.1 | 6.4 | — | 9.0× / 5.8× | 4.8× / 3.1× | 2.0× / 1.3× | — |
| tam_Taml | 0.92 | 2.61 | 3.47 | 5.16 | 18.9 | 8.8 | 4.1 | — | 5.4× / 3.7× | 2.5× / 1.7× | 1.2× / 0.8× | — |
| tha_Thai | 1.36 | 2.21 | 3.45 | 4.30 | 13.3 | 5.8 | 2.8 | — | 3.9× / 3.1× | 1.7× / 1.4× | 0.8× / 0.6× | — |
| added_normalized_dense | 0.06 | 1.18 | 2.22 | 3.34 | 32.0 | 17.4 | 11.5 | — | 14.4× / 9.6× | 7.8× / 5.2× | 5.2× / 3.4× | — |
| added_normalized_sparse | 0.06 | 1.18 | 3.04 | 4.15 | 33.9 | 20.1 | 11.5 | — | 11.2× / 8.2× | 6.6× / 4.8× | 3.8× / 2.8× | — |
| added_special_dense | 0.06 | 1.18 | 5.49 | 6.61 | 86.5 | 67.4 | 23.7 | — | 15.8× / 13.1× | 12.3× / 10.2× | 4.3× / 3.6× | — |
| added_special_sparse | 0.06 | 1.18 | 6.07 | 7.19 | 55.6 | 41.3 | 15.7 | — | 9.2× / 7.7× | 6.8× / 5.7× | 2.6× / 2.2× | — |
| agentic-traces | 0.58 | 1.18 | 5.05 | 5.66 | 54.6 | 44.6 | 16.9 | — | 10.8× / 9.6× | 8.8× / 7.9× | 3.3× / 3.0× | — |
| agentic_swe | 0.51 | 1.15 | 3.79 | 4.43 | 59.3 | 55.6 | 18.4 | — | 15.6× / 13.4× | 14.7× / 12.5× | 4.9× / 4.2× | — |
| code_mixed | 0.06 | 1.18 | 4.40 | 5.51 | 54.3 | 48.4 | 17.3 | — | 12.3× / 9.8× | 11.0× / 8.8× | 3.9× / 3.1× | — |
| math_latex | 0.55 | 1.18 | 4.88 | 5.51 | 50.9 | 36.9 | 15.5 | — | 10.4× / 9.2× | 7.6× / 6.7× | 3.2× / 2.8× | — |

</details>

<details><summary><b>t5-base</b> — Unigram + Metaspace · ×5.83 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="t5-base speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-t5-base.png" width="860">

<img alt="t5-base stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-t5-base-stages.png" width="860">

<img alt="t5-base thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-t5-base-threads.png" width="860">

<img alt="t5-base decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-t5-base-decode.png" width="860">

<img alt="t5-base decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31011536387-t5-base-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 34+2 (peak 36) · Pipeline 60+0 (peak 65)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.2 | 35.4 | ×6.76 | ×1.00 | 2% (0.7) | 78% (21.7) | 8% (2.3) | 12% (3.2) | 0% (0.0) | match |
| arb_Arab | lang | 3.9 | 29.1 | ×7.50 | ×0.99 | 2% (0.6) | 70% (27.0) | 7% (2.7) | 23% (8.9) | 0% (0.0) | match |
| ben_Beng | lang | 6.7 | 33.9 | ×5.06 | ×1.00 | 2% (0.6) | 74% (24.8) | 5% (1.8) | 19% (6.4) | 0% (0.0) | match |
| cmn_Hani | lang | 11.9 | 51.0 | ×4.28 | ×0.99 | 2% (0.6) | 59% (16.7) | 2% (0.6) | 36% (10.2) | 1% (0.2) | match |
| ell_Grek | lang | 4.2 | 29.3 | ×6.93 | ×0.99 | 1% (0.6) | 58% (27.2) | 6% (2.6) | 33% (15.3) | 2% (1.2) | match |
| eng_Latn | lang | 2.4 | 18.5 | ×7.77 | ×1.00 | 2% (2.0) | 39% (41.2) | 4% (4.4) | 52% (54.8) | 3% (2.6) | match |
| heb_Hebr | lang | 4.0 | 32.0 | ×7.97 | ×1.00 | 1% (0.6) | 51% (24.2) | 5% (2.5) | 44% (20.7) | 0% (0.0) | match |
| hin_Deva | lang | 5.9 | 33.2 | ×5.64 | ×1.00 | 2% (0.6) | 70% (24.5) | 8% (2.8) | 19% (6.6) | 1% (0.3) | match |
| jpn_Jpan | lang | 13.3 | 44.4 | ×3.33 | ×1.00 | 2% (0.6) | 63% (20.0) | 1% (0.4) | 34% (10.8) | 0% (0.0) | match |
| kat_Geor | lang | 7.9 | 42.7 | ×5.38 | ×1.01 | 2% (0.6) | 55% (18.8) | 4% (1.4) | 39% (13.3) | 0% (0.1) | match |
| kor_Hang | lang | 4.2 | 30.1 | ×7.18 | ×1.00 | 1% (0.6) | 46% (24.4) | 5% (2.9) | 49% (26.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.0 | 28.4 | ×7.12 | ×0.99 | 1% (0.6) | 40% (26.9) | 3% (2.1) | 57% (38.2) | 0% (0.0) | match |
| tam_Taml | lang | 8.6 | 42.9 | ×5.01 | ×0.99 | 2% (0.6) | 60% (19.1) | 3% (1.1) | 36% (11.4) | 0% (0.0) | match |
| tha_Thai | lang | 12.0 | 45.7 | ×3.81 | ×1.00 | 2% (0.6) | 56% (19.1) | 1% (0.5) | 40% (13.5) | 0% (0.1) | match |
| added_normalized_dense | modalities | 4.1 | 22.8 | ×5.56 | ×1.00 | 2% (0.8) | 79% (38.0) | 5% (2.2) | 15% (7.3) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 3.7 | 20.5 | ×5.50 | ×0.99 | 2% (1.3) | 72% (39.8) | 6% (3.3) | 20% (11.1) | 0% (0.0) | match |
| added_special_dense | modalities | 6.2 | 36.8 | ×5.91 | ×1.01 | 19% (5.0) | 64% (17.2) | 11% (2.9) | 6% (1.5) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 19.1 | ×4.84 | ×0.96 | 6% (3.3) | 65% (33.8) | 21% (10.7) | 8% (4.1) | 0% (0.0) | match |
| agentic-traces | modalities | 2.7 | 19.4 | ×7.17 | ×1.00 | 2% (1.8) | 43% (40.6) | 3% (3.2) | 51% (48.7) | 1% (0.9) | match |
| agentic_swe | modalities | 4.0 | 22.4 | ×5.58 | ×0.99 | 2% (1.3) | 56% (37.9) | 3% (1.9) | 39% (26.1) | 0% (0.3) | match |
| code_mixed | modalities | 3.5 | 20.9 | ×5.90 | ×1.00 | 2% (1.6) | 50% (39.5) | 3% (2.5) | 46% (36.2) | 0% (0.0) | match |
| math_latex | modalities | 2.5 | 18.5 | ×7.36 | ×1.00 | 2% (1.9) | 42% (41.4) | 4% (4.4) | 50% (49.1) | 2% (1.6) | match |

</details>
<!-- pipeline-bench:end -->

