### PR TITLE
experiment(ai): faster cache

### DIFF
--- a/tokenizers/atomsplit/src/fsm.rs
+++ b/tokenizers/atomsplit/src/fsm.rs
@@ -237,7 +237,7 @@ mod byte_level;
 mod cl100k;
 mod deepseek;
 mod o200k;
-pub use byte_level::fsm_byte_level;
+pub use byte_level::{fsm_byte_level, scan_byte_level};
 pub use cl100k::{fsm_cl100k, fsm_cl100k_cap};
 pub use deepseek::fsm_deepseek;
 pub use o200k::fsm_o200k;

--- a/tokenizers/atomsplit/src/fsm.rs
+++ b/tokenizers/atomsplit/src/fsm.rs
@@ -238,7 +238,7 @@ mod cl100k;
 mod deepseek;
 mod o200k;
 pub use byte_level::{fsm_byte_level, scan_byte_level};
-pub use cl100k::{fsm_cl100k, fsm_cl100k_cap};
+pub use cl100k::{fsm_cl100k, fsm_cl100k_cap, scan_cl100k_cap};
 pub use deepseek::fsm_deepseek;
 pub use o200k::fsm_o200k;
 

--- a/tokenizers/atomsplit/src/fsm/byte_level.rs
+++ b/tokenizers/atomsplit/src/fsm/byte_level.rs
@@ -8,6 +8,36 @@ use super::*;
 #[must_use]
 pub fn fsm_byte_level(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
     debug_assert!(out.len() >= text.len() && tags.len() >= text.len());
+    let mut w = 0usize;
+    scan_byte_level(text, tags, 0, |span| {
+        // SAFETY: spans partition the input, so `w < #spans <= text.len() <= out.len()`.
+        unsafe { *out.get_unchecked_mut(w) = span };
+        w += 1;
+        true
+    });
+    w
+}
+
+/// The same scan, handing each span to `emit` as it is cut and stopping early when
+/// `emit` returns `false`. Returns the offset to resume from, which is the end of
+/// the last span emitted.
+///
+/// This is what lets a caller do something per span *while the scan is at it* —
+/// the pipeline builds each word's cache key here, where the word's bytes are
+/// still in L1 and its bounds are still in registers, rather than walking the
+/// spans again afterwards. `emit` is a closure so it is inlined into the loop and
+/// this file needs to know nothing about what the caller does with a span.
+///
+/// Stopping early is what keeps a batch of spans small enough to stay in cache:
+/// the caller fills a fixed-size batch, consumes it, and resumes here.
+#[inline]
+pub fn scan_byte_level(
+    text: &[u8],
+    tags: &[u8],
+    from: usize,
+    mut emit: impl FnMut(Span) -> bool,
+) -> usize {
+    debug_assert!(tags.len() >= text.len());
     let end = text.len();
     // Tie `tags.len() == end` so the optimizer drops the per-byte bounds check on every interior
     // `tags[i]` in this fsm + its `run_end`/`letter_*` scans. (Callers guarantee `tags.len() >= end`.)
@@ -26,8 +56,7 @@ pub fn fsm_byte_level(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
         }
     };
 
-    let mut i = 0;
-    let mut w = 0usize;
+    let mut i = from;
     while i < end {
         let start = i;
         match tags[i] & 0x0F {
@@ -68,14 +97,12 @@ pub fn fsm_byte_level(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
             // Sentinel / MultiByte / Cont — never a char-start atom; emit one char defensively.
             _ => i += char_len(text[i]),
         }
-        // SAFETY: tokens partition the input, so `w < #tokens <= end < out.len()` (out ≥ text.len()+? ; callers size n+1).
-        unsafe {
-            *out.get_unchecked_mut(w) = Span {
-                start: start as u32,
-                end: i as u32,
-            }
-        };
-        w += 1;
+        if !emit(Span {
+            start: start as u32,
+            end: i as u32,
+        }) {
+            return i;
+        }
     }
-    w
+    i
 }

--- a/tokenizers/atomsplit/src/fsm/cl100k.rs
+++ b/tokenizers/atomsplit/src/fsm/cl100k.rs
@@ -14,10 +14,28 @@ pub fn fsm_cl100k(text: &[u8], tags: &[u8], out: &mut [Span]) -> usize {
 #[must_use]
 pub fn fsm_cl100k_cap(text: &[u8], tags: &[u8], out: &mut [Span], digit_cap: usize) -> usize {
     debug_assert!(out.len() >= text.len() && tags.len() >= text.len());
-    cl100k(text, tags, out, digit_cap)
+    let mut w = 0usize;
+    scan_cl100k_cap(text, tags, 0, digit_cap, |span| {
+        // SAFETY: spans partition the input, so `w < #spans <= text.len() <= out.len()`.
+        unsafe { *out.get_unchecked_mut(w) = span };
+        w += 1;
+        true
+    });
+    w
 }
 
-fn cl100k(text: &[u8], tags: &[u8], out: &mut [Span], digit_cap: usize) -> usize {
+/// The same scan, handing each span to `emit` as it is cut and stopping early when
+/// `emit` returns `false`. Returns the offset to resume from. See
+/// [`scan_byte_level`](super::scan_byte_level) for what this is for.
+#[inline]
+pub fn scan_cl100k_cap(
+    text: &[u8],
+    tags: &[u8],
+    from: usize,
+    digit_cap: usize,
+    mut emit: impl FnMut(Span) -> bool,
+) -> usize {
+    debug_assert!(tags.len() >= text.len());
     // Leading-atom values, as `const` so the `match` below is a dense jump table (not an if-cascade):
     // the dispatch is O(1) and a token never pays for a rule it can't start (e.g. non-number tokens
     // never test the number rule — which is what the POC's const-gating removed by hand; here it's free).
@@ -40,8 +58,7 @@ fn cl100k(text: &[u8], tags: &[u8], out: &mut [Span], digit_cap: usize) -> usize
     // rules 5-7 (`\s*[\r\n] | \s+(?!\S) | \s+`) → the shared `ws_tail`.
     let ws = |i: usize| -> usize { ws_tail(text, tags, i, end) };
 
-    let mut i = 0;
-    let mut w = 0usize;
+    let mut i = from;
     while i < end {
         let start = i;
         let b = text[i];
@@ -105,14 +122,12 @@ fn cl100k(text: &[u8], tags: &[u8], out: &mut [Span], digit_cap: usize) -> usize
             // Sentinel / MultiByte / Cont — never a char-start atom; emit one char defensively.
             _ => i += char_len(b),
         }
-        // SAFETY: tokens partition the input, so `w < #tokens <= end < out.len()` (out ≥ text.len()+? ; callers size n+1).
-        unsafe {
-            *out.get_unchecked_mut(w) = Span {
-                start: start as u32,
-                end: i as u32,
-            }
-        };
-        w += 1;
+        if !emit(Span {
+            start: start as u32,
+            end: i as u32,
+        }) {
+            return i;
+        }
     }
-    w
+    i
 }

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -82,6 +82,9 @@ http = ["hf-hub"]
 unstable_wasm = ["fancy-regex", "getrandom/wasm_js"]
 rustls-tls = ["hf-hub?/rustls-tls"]
 bench-baseline = ["dep:tokenizers-release", "dep:onig", "dep:pcre2", "dep:logos", "fancy-regex"]
+# Opens up internals that only `examples/word_cache_bench.rs` needs. Off in every
+# build that ships.
+bench-internals = []
 
 [dev-dependencies]
 criterion = "0.6"
@@ -93,6 +96,10 @@ tracing-subscriber = "0.3.18"
 [[bench]]
 name = "pipeline_benchmark"
 harness = false
+
+[[example]]
+name = "word_cache_bench"
+required-features = ["bench-internals"]
 
 [[example]]
 name = "fixture_bench"

--- a/tokenizers/tk-encode/examples/keyed_span_ab.rs
+++ b/tokenizers/tk-encode/examples/keyed_span_ab.rs
@@ -37,10 +37,7 @@ const MAX_CHUNKS: usize = 100;
 /// Models whose pre-tokenizer cuts the text into words, so the word cache is on
 /// the path: gpt2 splits on the ByteLevel regex, llama-3 on the cl100k one and
 /// takes whole-word vocabulary hits (`ignore_merges`) on top.
-const MODELS: [(&str, &str); 2] = [
-    ("gpt2", "gpt2.json"),
-    ("llama-3", "llama-3-tokenizer.json"),
-];
+const MODELS: [(&str, &str); 2] = [("gpt2", "gpt2.json"), ("llama-3", "llama-3-tokenizer.json")];
 
 /// One script per writing system the split behaves differently on: English words
 /// are long and repeat, agentic code is mostly punctuation and indentation, and

--- a/tokenizers/tk-encode/examples/keyed_span_ab.rs
+++ b/tokenizers/tk-encode/examples/keyed_span_ab.rs
@@ -1,0 +1,130 @@
+//! End-to-end throughput of [`PipelineTokenizer::encode`] on a fixed set of
+//! (model, fixture) pairs, for comparing two builds of the crate.
+//!
+//! ```text
+//!   cargo run --release --example keyed_span_ab
+//!   cargo run --release --example keyed_span_ab -- --reps 9
+//! ```
+//!
+//! One line per pair: `model fixture MB/s(median) MB/s(min) MB/s(max) checksum`.
+//!
+//! # How to read two runs against each other
+//!
+//! This harness prints numbers for one build. A difference between two builds is
+//! only a result if it beats what the *same* code shows when built twice, which
+//! on an M3 Max has been worth up to 7% from binary layout alone. So: build the
+//! unchanged crate in two separate worktrees plus the changed one in a third, run
+//! all three alternately, and read the unchanged pair's gap as the noise floor.
+//!
+//! The `checksum` column is order-sensitive over the whole id stream. Two builds
+//! that disagree on it are not comparable, whatever their throughput says.
+//!
+//! Every pair starts from a cold tokenizer, so the word cache fills from this
+//! corpus and no other — then one warm-up pass, then the timed reps. That is the
+//! state a plain `.encode()` loop over a corpus reaches.
+
+use std::hint::black_box;
+use std::path::Path;
+use std::time::Instant;
+
+use tk_encode::Tokenizer;
+use tk_encode::pipeline::PipelineTokenizer;
+
+const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
+const CHUNK_BYTES: usize = 10 * 1024;
+const MAX_CHUNKS: usize = 100;
+
+/// Models whose pre-tokenizer cuts the text into words, so the word cache is on
+/// the path: gpt2 splits on the ByteLevel regex, llama-3 on the cl100k one and
+/// takes whole-word vocabulary hits (`ignore_merges`) on top.
+const MODELS: [(&str, &str); 2] = [
+    ("gpt2", "gpt2.json"),
+    ("llama-3", "llama-3-tokenizer.json"),
+];
+
+/// One script per writing system the split behaves differently on: English words
+/// are long and repeat, agentic code is mostly punctuation and indentation, and
+/// Chinese has no spaces at all.
+const FIXTURES: [(&str, &str); 3] = [
+    ("eng_Latn", "fixtures/lang/eng_Latn.txt"),
+    ("agentic_swe", "fixtures/modalities/agentic_swe.txt"),
+    ("cmn_Hani", "fixtures/lang/cmn_Hani.txt"),
+];
+
+fn make_chunks(text: &str) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut cur = String::new();
+    for line in text.lines().filter(|l| !l.trim().is_empty()) {
+        if !cur.is_empty() {
+            cur.push('\n');
+        }
+        cur.push_str(line);
+        if cur.len() >= CHUNK_BYTES {
+            chunks.push(std::mem::take(&mut cur));
+            if chunks.len() == MAX_CHUNKS {
+                return chunks;
+            }
+        }
+    }
+    if !cur.is_empty() {
+        chunks.push(cur);
+    }
+    chunks
+}
+
+/// FNV-1a over the id stream, so a build that tokenizes differently cannot pass
+/// as a faster one.
+fn checksum(ids: &[u32]) -> u64 {
+    let mut h = 0xcbf2_9ce4_8422_2325u64;
+    for id in ids {
+        for byte in id.to_le_bytes() {
+            h = (h ^ byte as u64).wrapping_mul(0x100_0000_01b3);
+        }
+    }
+    h
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let reps: usize = match args.iter().position(|a| a == "--reps") {
+        Some(i) => args[i + 1].parse().expect("--reps takes a number"),
+        None => 5,
+    };
+
+    for (model_name, model_file) in MODELS {
+        let tokenizer = Tokenizer::from_file(Path::new(DATA_DIR).join(model_file)).unwrap();
+        for (fixture_name, fixture_file) in FIXTURES {
+            let text = std::fs::read_to_string(Path::new(DATA_DIR).join(fixture_file)).unwrap();
+            let chunks = make_chunks(&text);
+            let bytes: usize = chunks.iter().map(String::len).sum();
+
+            // Rebuilt per fixture: a fresh pipeline is a fresh word cache.
+            let pipeline = PipelineTokenizer::try_from(&tokenizer).unwrap();
+            let mut ids = Vec::new();
+            let mut pass = || {
+                ids.clear();
+                for chunk in &chunks {
+                    ids.extend(pipeline.encode(chunk, true).unwrap().iter().map(|t| t.id));
+                }
+                ids.len()
+            };
+
+            pass();
+            let mut rates: Vec<f64> = Vec::with_capacity(reps);
+            for _ in 0..reps {
+                let start = Instant::now();
+                black_box(pass());
+                rates.push(bytes as f64 / start.elapsed().as_secs_f64() / 1e6);
+            }
+            rates.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+            println!(
+                "{model_name}\t{fixture_name}\t{:.1}\t{:.1}\t{:.1}\t{:016x}",
+                rates[reps / 2],
+                rates[0],
+                rates[reps - 1],
+                checksum(&ids),
+            );
+        }
+    }
+}

--- a/tokenizers/tk-encode/examples/split_stages.rs
+++ b/tokenizers/tk-encode/examples/split_stages.rs
@@ -1,0 +1,139 @@
+//! Where the pre-tokenize budget goes, per stage, for the gpt2 (ByteLevel) split.
+//!
+//! ```text
+//!   cargo run --release --example split_stages
+//! ```
+//!
+//! The stages are the ones `PipelineTokenizer` runs, in order, and each row is
+//! cumulative over the row above it, so a stage's own cost is the difference
+//! between the two. The last row adds what the model does before it can use a
+//! span: build the word-cache key for it.
+//!
+//! ns/byte, so the numbers line up with the per-byte breakdowns in the profiles.
+
+use std::hint::black_box;
+use std::path::Path;
+use std::time::Instant;
+
+use atomsplit::classify::classify;
+use atomsplit::fsm::{Span, fsm_byte_level};
+use tk_encode::utils::word_cache::WordCache;
+
+const DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
+const CHUNK_BYTES: usize = 10 * 1024;
+const MAX_CHUNKS: usize = 100;
+const REPS: usize = 9;
+
+const FIXTURES: [(&str, &str); 3] = [
+    ("eng_Latn", "fixtures/lang/eng_Latn.txt"),
+    ("agentic_swe", "fixtures/modalities/agentic_swe.txt"),
+    ("cmn_Hani", "fixtures/lang/cmn_Hani.txt"),
+];
+
+fn make_chunks(text: &str) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut cur = String::new();
+    for line in text.lines().filter(|l| !l.trim().is_empty()) {
+        if !cur.is_empty() {
+            cur.push('\n');
+        }
+        cur.push_str(line);
+        if cur.len() >= CHUNK_BYTES {
+            chunks.push(std::mem::take(&mut cur));
+            if chunks.len() == MAX_CHUNKS {
+                return chunks;
+            }
+        }
+    }
+    if !cur.is_empty() {
+        chunks.push(cur);
+    }
+    chunks
+}
+
+fn ns_per_byte(bytes: usize, mut run: impl FnMut() -> usize) -> f64 {
+    run();
+    let mut samples: Vec<f64> = (0..REPS)
+        .map(|_| {
+            let start = Instant::now();
+            black_box(run());
+            start.elapsed().as_secs_f64()
+        })
+        .collect();
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    samples[REPS / 2] * 1e9 / bytes as f64
+}
+
+fn main() {
+    println!("fixture\tB/word\ttags\t+fsm\t+copy\t+keys");
+    for (name, file) in FIXTURES {
+        let text = std::fs::read_to_string(Path::new(DATA_DIR).join(file)).unwrap();
+        let chunks = make_chunks(&text);
+        let bytes: usize = chunks.iter().map(String::len).sum();
+
+        let widest = chunks.iter().map(String::len).max().unwrap();
+        let mut tags = vec![0u8; widest];
+        let mut spans = vec![Span::default(); widest + 1];
+        let mut out: Vec<Span> = Vec::with_capacity(widest + 1);
+        let cache = WordCache::new(1 << 16);
+
+        let tags_only = ns_per_byte(bytes, || {
+            let mut n = 0;
+            for chunk in &chunks {
+                let b = chunk.as_bytes();
+                classify(b, &mut tags[..b.len()]);
+                n += tags[b.len() - 1] as usize;
+            }
+            n
+        });
+        let with_fsm = ns_per_byte(bytes, || {
+            let mut n = 0;
+            for chunk in &chunks {
+                let b = chunk.as_bytes();
+                classify(b, &mut tags[..b.len()]);
+                n += fsm_byte_level(b, &tags[..b.len()], &mut spans[..b.len() + 1]);
+            }
+            n
+        });
+        let with_copy = ns_per_byte(bytes, || {
+            let mut n = 0;
+            for chunk in &chunks {
+                let b = chunk.as_bytes();
+                classify(b, &mut tags[..b.len()]);
+                let k = fsm_byte_level(b, &tags[..b.len()], &mut spans[..b.len() + 1]);
+                out.clear();
+                out.extend_from_slice(&spans[..k]);
+                n += out.len();
+            }
+            n
+        });
+        let with_keys = ns_per_byte(bytes, || {
+            let mut n = 0;
+            for chunk in &chunks {
+                let b = chunk.as_bytes();
+                classify(b, &mut tags[..b.len()]);
+                let k = fsm_byte_level(b, &tags[..b.len()], &mut spans[..b.len() + 1]);
+                out.clear();
+                out.extend_from_slice(&spans[..k]);
+                for span in &out {
+                    n += !cache.key(&b[span.range()]).is_none() as usize;
+                }
+            }
+            n
+        });
+
+        let words: usize = chunks
+            .iter()
+            .map(|chunk| {
+                let b = chunk.as_bytes();
+                classify(b, &mut tags[..b.len()]);
+                fsm_byte_level(b, &tags[..b.len()], &mut spans[..b.len() + 1])
+            })
+            .sum();
+
+        println!(
+            "{name}\t{:.1}\t{tags_only:.3}\t{with_fsm:.3}\t{with_copy:.3}\t{with_keys:.3}",
+            bytes as f64 / words as f64,
+        );
+    }
+}

--- a/tokenizers/tk-encode/examples/unigram_cache_ab.rs
+++ b/tokenizers/tk-encode/examples/unigram_cache_ab.rs
@@ -1,0 +1,89 @@
+//! Times the Unigram model stage alone, the way `PipelineTokenizer` drives it: one
+//! `tokenize_pipeline` call per pre-token, one scratch reused for the whole corpus.
+//!
+//! `PipelineTokenizer` cannot build a real Unigram tokenizer yet (no `Metaspace`
+//! support), so this feeds the model what such a pipeline would: whitespace-split
+//! words with the SentencePiece delimiter in front. Ids are therefore not a model's
+//! real output — the point is the cost of the model stage.
+//!
+//! One cache capacity per process, one model per process, and an empty cache for every
+//! timed repetition. Sharing a warm cache between repetitions times re-encoding a corpus
+//! that has already been encoded, which reads as a large win on corpora that in truth
+//! have nothing to hit (a Japanese corpus measured 1.6x that way, with 0.2% of its bytes
+//! in repeated pre-tokens). To A/B, run it once per capacity:
+//!
+//!   cargo run --release --example unigram_cache_ab -- data/albert-base-v1-tokenizer.json 0
+//!   cargo run --release --example unigram_cache_ab -- data/albert-base-v1-tokenizer.json 65536
+
+use std::time::Instant;
+
+use tk_encode::models::unigram::Unigram;
+use tk_encode::pipeline::{Model, PipelineToken};
+
+const REPS: usize = 3;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: unigram_cache_ab <tokenizer.json> <cache capacity> [corpus...]");
+    let capacity: usize = args.next().expect("cache capacity").parse().unwrap();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    let mut model: Unigram = serde_json::from_value(json["model"].clone()).unwrap();
+    model.resize_cache(capacity);
+
+    let corpora: Vec<String> = args.collect();
+    let corpora = if corpora.is_empty() {
+        vec![
+            "data/big.txt".to_string(),
+            "data/unigram_wagahaiwa_nekodearu.txt".to_string(),
+        ]
+    } else {
+        corpora
+    };
+
+    println!("capacity {capacity}");
+    for corpus_path in corpora {
+        let text = std::fs::read_to_string(&corpus_path).unwrap();
+        let corpus: Vec<String> = text
+            .split_whitespace()
+            .map(|word| format!("\u{2581}{word}"))
+            .collect();
+        let bytes: usize = corpus.iter().map(String::len).sum();
+
+        // Every rep starts with an empty cache, model-side and scratch-side. Timing reps
+        // that share one warm cache measures re-encoding a corpus you have already
+        // encoded, which no caller does: a corpus gets one pass, and the only hits it
+        // can have are its own repeats.
+        let encode = |model: &Unigram| {
+            let mut scratch = model.init_scratch();
+            let mut output: Vec<PipelineToken> = Vec::with_capacity(1024);
+            let mut ids = 0;
+            for word in &corpus {
+                output.clear();
+                model
+                    .tokenize_pipeline(word, &mut scratch, &mut output)
+                    .unwrap();
+                ids += output.len();
+            }
+            ids
+        };
+
+        encode(&model);
+        let mut best = f64::INFINITY;
+        let mut ids = 0;
+        for _ in 0..REPS {
+            model.clear_cache();
+            let start = Instant::now();
+            ids = encode(&model);
+            best = best.min(start.elapsed().as_secs_f64());
+        }
+        println!(
+            "  {corpus_path}: {:.1} MB/s ({} pre-tokens, {ids} ids)",
+            bytes as f64 / best / 1e6,
+            corpus.len(),
+        );
+    }
+}

--- a/tokenizers/tk-encode/examples/word_cache_bench.rs
+++ b/tokenizers/tk-encode/examples/word_cache_bench.rs
@@ -1,0 +1,557 @@
+//! Per-operation timings for [`WordCache`], the table that remembers what a word
+//! encoded to.
+//!
+//! ```text
+//!   cargo run --release --features bench-internals --example word_cache_bench
+//! ```
+//!
+//! # Comparing two versions of the cache
+//!
+//! Save a run, change the cache, run again against what you saved:
+//!
+//! ```text
+//!   cargo run … --example word_cache_bench -- --save before.tsv
+//!   # edit src/utils/word_cache.rs
+//!   cargo run … --example word_cache_bench -- --baseline before.tsv
+//! ```
+//!
+//! The second run prints a delta column. **Read it with the noise floor in
+//! hand**, which the harness measures for you and prints at the top: one
+//! scenario is run twice, from two call sites in the same binary, so the gap
+//! between those two rows is the same work timed twice and nothing else.
+//! Rebuilding moves code around, and on an M3 Max that alone has been worth 8%
+//! to 13% on a single row. A delta smaller than the floor is not a result.
+//!
+//! If you need to resolve something smaller than that, this harness cannot do
+//! it. Put both versions of the cache in one binary and alternate between them,
+//! so neither gets to be the lucky one.
+//!
+//! # Reading the numbers
+//!
+//! Every row goes through the same loop, and the first row prices that loop on
+//! its own — subtract it before quoting anything as the cost of an operation.
+//!
+//! The scenarios are named after the state the table is in, because that is what
+//! decides the answer. A lookup spends most of its time waiting for memory, so
+//! the same call costs two or three times as much against a table too big for
+//! the last-level cache as against one that fits, and the big-table rows are
+//! also the least repeatable — how the kernel maps those pages differs from one
+//! process to the next. Give them `--reps 21` before believing a small
+//! difference, or compare their `min` rather than their median.
+//!
+//! ```text
+//!   --reps N           runs per scenario (default 7)
+//!   --filter SUBSTR    only scenarios whose name contains SUBSTR
+//!   --save PATH        write the results as TSV
+//!   --baseline PATH    compare against a TSV written earlier
+//! ```
+
+use std::collections::HashMap;
+use std::hint::black_box;
+use std::time::Instant;
+use tk_encode::utils::word_cache::{Lookup, WordCache};
+
+/// Runs of one scenario. The median is the headline; the spread says whether to
+/// believe it. Raise it with `--reps` for the memory-bound rows, which need more.
+const DEFAULT_REPS: usize = 7;
+
+/// Fixed-length words in one flat buffer, plus the scrambled order to walk them
+/// in. One buffer rather than a `Vec` of `Vec`s so reading the next word costs
+/// the measurement as little as possible, and scrambled so the hardware
+/// prefetcher cannot do the table's work for it.
+struct Pool {
+    data: Vec<u8>,
+    stride: usize,
+    order: Vec<u32>,
+}
+
+impl Pool {
+    /// `count` distinct words of exactly `stride` bytes. Two pools built with
+    /// different `offset`s share no words, which is how the "this word is not in
+    /// the table" scenarios get words that really are not in it.
+    fn new(count: usize, stride: usize, offset: usize) -> Self {
+        let mut data = Vec::with_capacity(count * stride);
+        for i in 0..count {
+            let word = format!("{n:0stride$}", n = i + offset);
+            assert_eq!(word.len(), stride, "word {i} is not {stride} bytes");
+            data.extend_from_slice(word.as_bytes());
+        }
+        let mut order: Vec<u32> = (0..count as u32).collect();
+        let mut state = 0x9E37_79B9_7F4A_7C15u64;
+        for i in (1..count).rev() {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            order.swap(i, (state % (i as u64 + 1)) as usize);
+        }
+        Pool {
+            data,
+            stride,
+            order,
+        }
+    }
+
+    fn word(&self, i: usize) -> &[u8] {
+        &self.data[i * self.stride..(i + 1) * self.stride]
+    }
+
+    fn count(&self) -> usize {
+        self.data.len() / self.stride
+    }
+}
+
+/// Look a word up and store what it encoded to, the two calls a caller that
+/// misses always makes together.
+fn store(cache: &mut WordCache, word: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
+    let at = match cache.lookup(word) {
+        Lookup::Miss(at) => at,
+        Lookup::Hit(_) => None,
+    };
+    if let Some(at) = at {
+        cache.insert(at, ids);
+    }
+}
+
+fn hit<'c>(lookup: Lookup<'c, '_>) -> Option<&'c [u32]> {
+    match lookup {
+        Lookup::Hit(ids) => Some(ids),
+        Lookup::Miss(_) => None,
+    }
+}
+
+/// A table with every slot taken, which is the state that makes a lookup walk
+/// its whole window and an insert evict somebody.
+fn saturated(slots: usize, ids: usize) -> WordCache {
+    let filler = Pool::new(slots * 8, 8, 0);
+    let mut cache = WordCache::new(slots);
+    for i in 0..filler.count() {
+        store(
+            &mut cache,
+            filler.word(i),
+            (0..ids as u32).map(|k| k + i as u32),
+        );
+    }
+    assert_eq!(
+        cache.bench_occupancy(),
+        slots,
+        "the table is not saturated, so the walks below would stop early"
+    );
+    cache
+}
+
+struct Row {
+    name: String,
+    min: f64,
+    median: f64,
+    max: f64,
+}
+
+impl Row {
+    fn new(name: String, mut ns: Vec<f64>) -> Self {
+        ns.sort_by(f64::total_cmp);
+        Row {
+            name,
+            min: ns[0],
+            median: ns[ns.len() / 2],
+            max: ns[ns.len() - 1],
+        }
+    }
+}
+
+/// Collects rows and prints them, against a saved run when there is one.
+struct Bench {
+    rows: Vec<Row>,
+    reps: usize,
+    filter: Option<String>,
+    baseline: HashMap<String, (f64, f64, f64)>,
+}
+
+impl Bench {
+    fn wanted(&self, name: &str) -> bool {
+        self.filter
+            .as_ref()
+            .is_none_or(|needle| name.contains(needle.as_str()))
+    }
+
+    /// Time `op(iters)` `self.reps` times and keep the ns per operation. `op`
+    /// returns a value that is fed to `black_box`, so the compiler cannot delete
+    /// the work.
+    fn run(&mut self, name: impl Into<String>, iters: usize, mut op: impl FnMut(usize) -> u64) {
+        let name = name.into();
+        if !self.wanted(&name) {
+            return;
+        }
+        let mut ns = Vec::with_capacity(self.reps);
+        for _ in 0..self.reps {
+            let start = Instant::now();
+            let sink = op(iters);
+            let elapsed = start.elapsed();
+            black_box(sink);
+            ns.push(elapsed.as_nanos() as f64 / iters as f64);
+        }
+        self.rows.push(Row::new(name, ns));
+    }
+
+    fn print(&self) {
+        let width = self.rows.iter().map(|r| r.name.len()).max().unwrap_or(0);
+        println!(
+            "\n  {:<width$} {:>8} {:>8} {:>8}{}",
+            "",
+            "min",
+            "median",
+            "max",
+            if self.baseline.is_empty() {
+                String::new()
+            } else {
+                format!("{:>10}", "vs base")
+            }
+        );
+        for row in &self.rows {
+            let delta = self.baseline.get(&row.name).map(|&(min, median, max)| {
+                // Two runs are only telling you something different if their
+                // spreads do not overlap. A median that has moved but still sits
+                // inside the old run's range has not moved.
+                let apart = row.min > max || row.max < min;
+                let pct = (row.median - median) / median * 100.0;
+                format!("{:>9.1}%{}", pct, if apart { " *" } else { "" })
+            });
+            println!(
+                "  {:<width$} {:>8.2} {:>8.2} {:>8.2}{}",
+                row.name,
+                row.min,
+                row.median,
+                row.max,
+                delta.unwrap_or_default()
+            );
+        }
+        if !self.baseline.is_empty() {
+            println!(
+                "\n  * = the two runs' min..max ranges do not overlap. Everything else \
+                 is inside\n      the spread of one run, whatever the median says."
+            );
+        }
+    }
+
+    fn tsv(&self) -> String {
+        let mut out = String::new();
+        for row in &self.rows {
+            out.push_str(&format!(
+                "{}\t{:.4}\t{:.4}\t{:.4}\n",
+                row.name, row.min, row.median, row.max
+            ));
+        }
+        out
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let flag = |name: &str| {
+        args.iter()
+            .position(|a| a == name)
+            .and_then(|i| args.get(i + 1))
+            .cloned()
+    };
+    let save = flag("--save");
+    let baseline_path = flag("--baseline");
+    let baseline = baseline_path
+        .as_ref()
+        .map(|path| {
+            std::fs::read_to_string(path)
+                .unwrap_or_else(|e| panic!("cannot read baseline {path}: {e}"))
+                .lines()
+                .filter_map(|line| {
+                    let mut fields = line.split('\t');
+                    let name = fields.next()?.to_string();
+                    let min = fields.next()?.parse().ok()?;
+                    let median = fields.next()?.parse().ok()?;
+                    let max = fields.next()?.parse().ok()?;
+                    Some((name, (min, median, max)))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut bench = Bench {
+        rows: Vec::new(),
+        reps: flag("--reps").map_or(DEFAULT_REPS, |n| n.parse().expect("--reps wants a number")),
+        filter: flag("--filter"),
+        baseline,
+    };
+
+    // Price the loop before anything else: this is what every row below carries.
+    {
+        let pool = Pool::new(1 << 14, 8, 0);
+        let mut next = 0;
+        bench.run("the loop, no cache call", 5_000_000, |iters| {
+            let mut sink = 0;
+            for _ in 0..iters {
+                let word = pool.word(pool.order[next] as usize);
+                next = if next + 1 == pool.count() {
+                    0
+                } else {
+                    next + 1
+                };
+                sink += black_box(word)[0] as u64;
+            }
+            sink
+        });
+    }
+    {
+        let pool = Pool::new(1 << 14, 8, 0);
+        let cache = WordCache::new(1 << 16);
+        let mut next = 0;
+        bench.run("+ pack the word and hash it", 5_000_000, |iters| {
+            let mut sink = 0;
+            for _ in 0..iters {
+                let word = pool.word(pool.order[next] as usize);
+                next = if next + 1 == pool.count() {
+                    0
+                } else {
+                    next + 1
+                };
+                sink += black_box(&cache).bench_slot_key(black_box(word));
+            }
+            sink
+        });
+    }
+
+    // Hits, over tables that fit in successively slower levels of the memory
+    // hierarchy. Same code every time — the spread is all memory.
+    for &(slots, label) in &[
+        (1usize << 12, "hit, 2 ids in the slot   (4k slots, 128 KB)"),
+        (1 << 16, "hit, 2 ids in the slot   (64k slots, 2 MB)"),
+        // The same scenario a second time, from a second call site, so the gap
+        // between the two rows prices this build's code layout. See the floor.
+        (1 << 16, "  the row above again (control twin)"),
+        (1 << 20, "hit, 2 ids in the slot   (1M slots, 32 MB)"),
+    ] {
+        let live = slots * 6 / 10;
+        let pool = Pool::new(live, 8, 0);
+        let mut cache = WordCache::new(slots);
+        for i in 0..live {
+            store(&mut cache, pool.word(i), [i as u32, 7].into_iter());
+        }
+        let mut next = 0;
+        bench.run(label, 500_000, |iters| {
+            let mut sink = 0;
+            for _ in 0..iters {
+                let word = pool.word(pool.order[next] as usize);
+                next = if next + 1 == live { 0 } else { next + 1 };
+                if let Some(ids) = hit(cache.lookup(black_box(word))) {
+                    sink += ids[0] as u64;
+                }
+            }
+            sink
+        });
+    }
+    // Hits again, on the shapes that cost more than the common one: ids in the
+    // arena, and a word too long to live in its own key.
+    for &(stride, ids, label) in &[
+        (8usize, 8usize, "hit, 8 ids in the arena  (64k slots)"),
+        (24, 2, "hit, 24-byte word, hashed key  (64k slots)"),
+        (24, 8, "hit, 24-byte word + 8 ids in the arena"),
+    ] {
+        let slots = 1 << 16;
+        let live = slots * 6 / 10;
+        let pool = Pool::new(live, stride, 0);
+        let mut cache = WordCache::new(slots);
+        for i in 0..live {
+            store(
+                &mut cache,
+                pool.word(i),
+                (0..ids as u32).map(|k| k + i as u32),
+            );
+        }
+        let mut next = 0;
+        bench.run(label, 500_000, |iters| {
+            let mut sink = 0;
+            for _ in 0..iters {
+                let word = pool.word(pool.order[next] as usize);
+                next = if next + 1 == live { 0 } else { next + 1 };
+                if let Some(found) = hit(cache.lookup(black_box(word))) {
+                    sink += found[0] as u64;
+                }
+            }
+            sink
+        });
+    }
+
+    // Misses. Nothing is stored, so the walk is the whole cost — and how far it
+    // walks is the difference between these two rows.
+    {
+        let slots = 1 << 16;
+        let live = slots / 4;
+        let resident = Pool::new(live, 8, 0);
+        let absent = Pool::new(1 << 16, 8, 10_000_000);
+        let mut cache = WordCache::new(slots);
+        for i in 0..live {
+            store(&mut cache, resident.word(i), [i as u32, 7].into_iter());
+        }
+        let mut next = 0;
+        bench.run(
+            "miss, walk stops at an empty slot  (25% full)",
+            500_000,
+            |iters| {
+                let mut sink = 0;
+                for _ in 0..iters {
+                    let word = absent.word(next);
+                    next = if next + 1 == absent.count() {
+                        0
+                    } else {
+                        next + 1
+                    };
+                    sink += u64::from(hit(cache.lookup(black_box(word))).is_none());
+                }
+                sink
+            },
+        );
+    }
+    {
+        let mut cache = saturated(1 << 12, 2);
+        let absent = Pool::new(1 << 16, 8, 10_000_000);
+        let mut next = 0;
+        bench.run(
+            "miss, all 16 walked and scored  (saturated)",
+            500_000,
+            |iters| {
+                let mut sink = 0;
+                for _ in 0..iters {
+                    let word = absent.word(next);
+                    next = if next + 1 == absent.count() {
+                        0
+                    } else {
+                        next + 1
+                    };
+                    sink += u64::from(hit(cache.lookup(black_box(word))).is_none());
+                }
+                sink
+            },
+        );
+    }
+
+    // What a word costs the first time it is ever seen: the miss above, plus
+    // storing what the model worked out. Subtract the matching miss row to see
+    // what the insert itself adds.
+    {
+        let iters = 60_000;
+        let pool = Pool::new(iters, 8, 0);
+        let mut ns = Vec::with_capacity(bench.reps);
+        let name = "miss + insert, free slot, 2 ids  (46% full)";
+        if bench.wanted(name) {
+            for _ in 0..bench.reps {
+                // Building the table is not part of the measurement.
+                let mut cache = WordCache::new(1 << 17);
+                let start = Instant::now();
+                for i in 0..iters {
+                    store(&mut cache, pool.word(i), [i as u32, 7].into_iter());
+                }
+                ns.push(start.elapsed().as_nanos() as f64 / iters as f64);
+                black_box(&cache);
+            }
+            bench.rows.push(Row::new(name.to_string(), ns));
+        }
+    }
+    for &(stride, ids, label) in &[
+        (
+            8usize,
+            2usize,
+            "miss + insert, evicting, 2 ids  (saturated)",
+        ),
+        (8, 8, "miss + insert, evicting, 8 ids to the arena"),
+        (24, 8, "miss + insert, evicting, 24-byte word + 8 ids"),
+    ] {
+        let mut cache = saturated(1 << 12, ids);
+        let fresh = Pool::new(1 << 17, stride, 10_000_000);
+        let mut next = 0;
+        bench.run(label, 200_000, |iters| {
+            for _ in 0..iters {
+                let word = fresh.word(next);
+                next = if next + 1 == fresh.count() {
+                    0
+                } else {
+                    next + 1
+                };
+                store(
+                    &mut cache,
+                    black_box(word),
+                    (0..ids as u32).map(|k| k + next as u32),
+                );
+            }
+            0
+        });
+        // An arena with nothing left in it turns inserts away, and a run of
+        // refusals would time as something far cheaper than an eviction.
+        let last = if next == 0 {
+            fresh.count() - 1
+        } else {
+            next - 1
+        };
+        assert!(
+            hit(cache.lookup(fresh.word(last))).is_some(),
+            "{label}: the last insert did not land — the arena ran out"
+        );
+    }
+
+    // Keeping the counters honest. Neither of these is on the path of a lookup;
+    // the question is only whether they are cheap enough to ignore.
+    {
+        let mut cache = saturated(1 << 12, 2);
+        bench.run(
+            "fade(), the bumps that do not start over",
+            5_000_000,
+            |iters| {
+                for _ in 0..iters {
+                    black_box(&mut cache).bench_fade();
+                }
+                0
+            },
+        );
+    }
+    {
+        let slots = 1 << 16;
+        let live = slots * 6 / 10;
+        let pool = Pool::new(live, 8, 0);
+        let mut cache = WordCache::new(slots);
+        for i in 0..live {
+            store(&mut cache, pool.word(i), [i as u32, 7].into_iter());
+        }
+        bench.run(
+            "settle(), one whole-table pass  (64k slots)",
+            200,
+            |iters| {
+                for _ in 0..iters {
+                    black_box(&mut cache).bench_settle();
+                }
+                0
+            },
+        );
+    }
+
+    // The floor: identical work at two call sites in this same binary. Anything
+    // smaller than this is telling you about code layout, not about the cache.
+    let timed = |name: &str| {
+        bench
+            .rows
+            .iter()
+            .find(|row| row.name == name)
+            .map(|row| row.median)
+    };
+    // Nothing to price the build with if --filter dropped one of the pair.
+    if let (Some(once), Some(twice)) = (
+        timed("hit, 2 ids in the slot   (64k slots, 2 MB)"),
+        timed("  the row above again (control twin)"),
+    ) {
+        let pct = (twice - once).abs() / once * 100.0;
+        println!(
+            "\nnoise floor for this build: {pct:.1}% (one scenario, two call sites, one binary)"
+        );
+    }
+    bench.print();
+
+    if let Some(path) = save {
+        std::fs::write(&path, bench.tsv()).unwrap_or_else(|e| panic!("cannot write {path}: {e}"));
+        println!("\nsaved to {path} — rerun with --baseline {path} after changing the cache");
+    }
+    println!();
+}

--- a/tokenizers/tk-encode/examples/word_cache_bench.rs
+++ b/tokenizers/tk-encode/examples/word_cache_bench.rs
@@ -517,11 +517,11 @@ fn main() {
             store(&mut cache, pool.word(i), [i as u32, 7].into_iter());
         }
         bench.run(
-            "settle(), one whole-table pass  (64k slots)",
+            "restart_epochs(), one whole-table pass  (64k slots)",
             200,
             |iters| {
                 for _ in 0..iters {
-                    black_box(&mut cache).bench_settle();
+                    black_box(&mut cache).bench_restart_epochs();
                 }
                 0
             },

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1438,6 +1438,24 @@ mod tests {
             assert!(pipeline_ids(&pipeline, "").is_empty());
         }
 
+        // The pool hands the SAME scratch to successive encodes. State left behind by one
+        // call — an undrained merge queue, a stale word buffer — would corrupt every call
+        // after it. Drive several inputs through one scratch and check each still matches
+        // the reference model.
+        #[test]
+        fn reused_scratch_matches_fresh() {
+            let bpe = hello_builder().build().unwrap();
+            let reference = bpe.clone();
+            let model = PipelineBPE::from_bpe(bpe, false).unwrap();
+            let mut scratch = model.init_scratch();
+            for input in ["hello", "hell", "helo", "oleh", "hello", "", "hxe"] {
+                let mut out = Vec::new();
+                pipeline::Model::tokenize_pipeline(&model, input, &mut scratch, &mut out).unwrap();
+                let got: Vec<u32> = out.iter().map(|t| t.id).collect();
+                assert_eq!(got, reference_ids(&reference, input), "{input:?}");
+            }
+        }
+
         #[test]
         fn unknown_char_without_unk_is_dropped() {
             let bpe = hello_builder().build().unwrap();

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -850,13 +850,12 @@ impl pipeline::Model for PipelineBPE {
                 Lookup::Miss(at) => placement = at,
             }
         }
-        // Experiment: skip vocab lookup
-        // if self.ignore_merges
-        //     && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
-        // {
-        //     output.push(PipelineToken { id });
-        //     return Ok(());
-        // }
+        if self.ignore_merges
+            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
+        {
+            output.push(PipelineToken { id });
+            return Ok(());
+        }
 
         self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,6 +1,6 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::models::bpe::Merge;
-use crate::pipeline::{self, ModelScratch, PipelineToken};
+use crate::pipeline::{self, ModelScratch, PipelineToken, Span};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
@@ -676,6 +676,14 @@ impl Model for BPE {
     }
 }
 
+/// Pre-tokens keyed and prefetched together in
+/// [`PipelineBPE::tokenize_spans`](pipeline::Model::tokenize_spans).
+///
+/// It has to be large enough that the keying loop covers the wait for a slot,
+/// and small enough that a batch of keys stays in L1. Anything in that range
+/// will do; 32 keys is 1 kB.
+const SPAN_BATCH: usize = 32;
+
 pub struct PipelineBPE {
     atoms: Atoms,
     vocab: BucketVocabStore,
@@ -816,6 +824,33 @@ impl PipelineBPE {
         };
         word.merge_all(&self.merges, None, merge_queue, skip);
     }
+
+    /// Tokenize one word the cache could not answer, appending its ids to
+    /// `output`.
+    ///
+    /// `true` when the ids came out of `word` and so can be stored in the cache.
+    /// The other case is `ignore_merges`: a word the vocabulary holds whole takes
+    /// that id and skips merging entirely, and since `word` is then untouched
+    /// there is nothing to store. Those words keep missing the cache — see
+    /// [`WordCache`] on what a miss costs.
+    fn tokenize_word(
+        &self,
+        sequence: &str,
+        merge_queue: &mut QuaternaryHeap<Merge>,
+        skip: &mut Vec<Merge>,
+        word: &mut Word,
+        output: &mut Vec<PipelineToken>,
+    ) -> bool {
+        if self.ignore_merges
+            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
+        {
+            output.push(PipelineToken { id });
+            return false;
+        }
+        self.merge_word(sequence, merge_queue, skip, word);
+        output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+        true
+    }
 }
 
 impl pipeline::Model for PipelineBPE {
@@ -850,21 +885,79 @@ impl pipeline::Model for PipelineBPE {
                 Lookup::Miss(at) => placement = at,
             }
         }
-        if self.ignore_merges
-            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
-        {
-            output.push(PipelineToken { id });
-            return Ok(());
-        }
-
-        self.merge_word(sequence, merge_queue, skip, word);
-        output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
-        if let Some(cache) = word_cache.as_mut()
+        let merged = self.tokenize_word(sequence, merge_queue, skip, word, output);
+        if merged
+            && let Some(cache) = word_cache.as_mut()
             && let Some(at) = placement
         {
             cache.insert(at, word.get_chars_iter());
         }
 
+        Ok(())
+    }
+
+    /// Two loops per batch of pre-tokens: the first builds every word's cache key
+    /// and asks for the slot it will land in, the second probes those slots and
+    /// tokenizes what missed. Splitting them is what gives the prefetches
+    /// something to hide behind — by the time the second loop probes a word, the
+    /// first loop has moved on far enough for its line to have arrived.
+    ///
+    /// Keys come off `chunk.as_bytes()` rather than a `&str` slice per span. The
+    /// cache reads bytes, so a hit here never pays for the two boundary checks
+    /// that slicing a `str` costs; only a miss needs the text.
+    fn tokenize_spans(
+        &self,
+        chunk: &str,
+        spans: &[Span],
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        let BpeScratch {
+            merge_queue,
+            skip,
+            word,
+            word_cache,
+        } = scratch;
+        let Some(cache) = word_cache.as_mut() else {
+            for span in spans {
+                self.tokenize_word(&chunk[span.range()], merge_queue, skip, word, output);
+            }
+            return Ok(());
+        };
+
+        let bytes = chunk.as_bytes();
+        let mut keys = [None; SPAN_BATCH];
+        for batch in spans.chunks(SPAN_BATCH) {
+            for (key, span) in keys.iter_mut().zip(batch) {
+                *key = cache.key(&bytes[span.range()]);
+                if let Some(key) = key {
+                    cache.prefetch(*key);
+                }
+            }
+            for (key, span) in keys.iter().zip(batch) {
+                let Some(key) = *key else {
+                    // No key means no slot: an empty span, or a word past what the
+                    // cache stores. A tokenizer with no pre-tokenizer hands whole
+                    // documents over this way.
+                    self.tokenize_word(&chunk[span.range()], merge_queue, skip, word, output);
+                    continue;
+                };
+                // The lookup also picks the slot this word would go in, so the
+                // insert below has no window to walk of its own.
+                let placement = match cache.lookup_keyed(&bytes[span.range()], key) {
+                    Lookup::Hit(ids) => {
+                        output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                        continue;
+                    }
+                    Lookup::Miss(at) => at,
+                };
+                let merged =
+                    self.tokenize_word(&chunk[span.range()], merge_queue, skip, word, output);
+                if merged && let Some(at) = placement {
+                    cache.insert(at, word.get_chars_iter());
+                }
+            }
+        }
         Ok(())
     }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -676,6 +676,15 @@ impl Model for BPE {
     }
 }
 
+/// Where one word's ids came from, which decides what the cache stores for it.
+enum WordIds {
+    /// The whole word is a vocabulary entry and `ignore_merges` says to prefer
+    /// that id over merging — this is the id, and `word` was left untouched.
+    Whole(u32),
+    /// The merge loop ran and filled `word`.
+    Merged,
+}
+
 /// Pre-tokens keyed and prefetched together in
 /// [`PipelineBPE::tokenize_spans`](pipeline::Model::tokenize_spans).
 ///
@@ -826,13 +835,7 @@ impl PipelineBPE {
     }
 
     /// Tokenize one word the cache could not answer, appending its ids to
-    /// `output`.
-    ///
-    /// `true` when the ids came out of `word` and so can be stored in the cache.
-    /// The other case is `ignore_merges`: a word the vocabulary holds whole takes
-    /// that id and skips merging entirely, and since `word` is then untouched
-    /// there is nothing to store. Those words keep missing the cache — see
-    /// [`WordCache`] on what a miss costs.
+    /// `output` and saying where they came from so the caller can store them.
     fn tokenize_word(
         &self,
         sequence: &str,
@@ -840,16 +843,16 @@ impl PipelineBPE {
         skip: &mut Vec<Merge>,
         word: &mut Word,
         output: &mut Vec<PipelineToken>,
-    ) -> bool {
+    ) -> WordIds {
         if self.ignore_merges
             && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
         {
             output.push(PipelineToken { id });
-            return false;
+            return WordIds::Whole(id);
         }
         self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
-        true
+        WordIds::Merged
     }
 }
 
@@ -885,12 +888,14 @@ impl pipeline::Model for PipelineBPE {
                 Lookup::Miss(at) => placement = at,
             }
         }
-        let merged = self.tokenize_word(sequence, merge_queue, skip, word, output);
-        if merged
-            && let Some(cache) = word_cache.as_mut()
+        let ids = self.tokenize_word(sequence, merge_queue, skip, word, output);
+        if let Some(cache) = word_cache.as_mut()
             && let Some(at) = placement
         {
-            cache.insert(at, word.get_chars_iter());
+            match ids {
+                WordIds::Whole(id) => cache.insert(at, std::iter::once(id)),
+                WordIds::Merged => cache.insert(at, word.get_chars_iter()),
+            }
         }
 
         Ok(())
@@ -951,10 +956,12 @@ impl pipeline::Model for PipelineBPE {
                     }
                     Lookup::Miss(at) => at,
                 };
-                let merged =
-                    self.tokenize_word(&chunk[span.range()], merge_queue, skip, word, output);
-                if merged && let Some(at) = placement {
-                    cache.insert(at, word.get_chars_iter());
+                let ids = self.tokenize_word(&chunk[span.range()], merge_queue, skip, word, output);
+                if let Some(at) = placement {
+                    match ids {
+                        WordIds::Whole(id) => cache.insert(at, std::iter::once(id)),
+                        WordIds::Merged => cache.insert(at, word.get_chars_iter()),
+                    }
                 }
             }
         }
@@ -1726,6 +1733,73 @@ mod tests {
                     "{input:?} vs reference"
                 );
             }
+        }
+
+        /// `hello` is in the vocabulary but the merges stop one pair short of
+        /// reaching it, so merging gives `[6, 3]` where the whole-word id is `7`.
+        /// Every `ignore_merges` assertion below rests on that difference.
+        fn unreachable_whole_word() -> BpeBuilder {
+            BpeBuilder::default()
+                .vocab_and_merges(v(HELLO_VOCAB), m(&[("h", "e"), ("he", "l"), ("hel", "l")]))
+                .ignore_merges(true)
+        }
+
+        /// The ids of one chunk, cut into `spans` and run through the batch entry
+        /// the pipeline uses.
+        fn spans_ids(model: &PipelineBPE, words: &[&str]) -> Vec<u32> {
+            let chunk = words.concat();
+            let mut spans = Vec::new();
+            let mut at = 0u32;
+            for word in words {
+                spans.push(Span {
+                    start: at,
+                    end: at + word.len() as u32,
+                });
+                at += word.len() as u32;
+            }
+            let mut out = Vec::new();
+            let mut scratch = model.init_scratch();
+            PipelineModel::tokenize_spans(model, &chunk, &spans, &mut scratch, &mut out).unwrap();
+            out.iter().map(|t| t.id).collect()
+        }
+
+        /// The batch entry is the only one the pipeline calls, and every other test
+        /// here goes through the one-word entry. They have to agree — including on
+        /// the repeat, which the second time round is answered by the cache.
+        #[test]
+        fn batch_entry_agrees_with_one_word_at_a_time() {
+            let words = ["hello", "helo", "hell", "o", "hello"];
+            for builder in [hello_builder(), unreachable_whole_word()] {
+                let pipeline = PipelineBPE::from_bpe(builder.build().unwrap(), false).unwrap();
+                let one_at_a_time: Vec<u32> = {
+                    let mut out = Vec::new();
+                    let mut scratch = pipeline.init_scratch();
+                    for word in words {
+                        PipelineModel::tokenize_pipeline(&pipeline, word, &mut scratch, &mut out)
+                            .unwrap();
+                    }
+                    out.iter().map(|t| t.id).collect()
+                };
+                assert_eq!(spans_ids(&pipeline, &words), one_at_a_time);
+            }
+        }
+
+        /// A word `ignore_merges` answers from the vocabulary is stored like any
+        /// other, so the next ask for it is a cache hit rather than a second walk
+        /// through the vocabulary.
+        #[test]
+        fn whole_word_vocab_hit_is_cached() {
+            let pipeline =
+                PipelineBPE::from_bpe(unreachable_whole_word().build().unwrap(), false).unwrap();
+            let mut scratch = pipeline.init_scratch();
+            let mut out = Vec::new();
+            PipelineModel::tokenize_pipeline(&pipeline, "hello", &mut scratch, &mut out).unwrap();
+
+            assert_eq!(out.iter().map(|t| t.id).collect::<Vec<_>>(), vec![7]);
+            assert_eq!(
+                scratch.word_cache.as_mut().unwrap().lookup(b"hello").hit(),
+                Some(&[7u32][..])
+            );
         }
 
         #[test]

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -850,12 +850,13 @@ impl pipeline::Model for PipelineBPE {
                 Lookup::Miss(at) => placement = at,
             }
         }
-        if self.ignore_merges
-            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
-        {
-            output.push(PipelineToken { id });
-            return Ok(());
-        }
+        // Experiment: skip vocab lookup
+        // if self.ignore_merges
+        //     && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
+        // {
+        //     output.push(PipelineToken { id });
+        //     return Ok(());
+        // }
 
         self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -1,6 +1,6 @@
 use super::{super::OrderedVocabIter, Error, Pair, Word};
 use crate::models::bpe::Merge;
-use crate::pipeline::{self, ModelScratch, PipelineToken, Span};
+use crate::pipeline::{self, KeyedSpan, ModelScratch, PipelineToken, Span};
 use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
@@ -901,19 +901,61 @@ impl pipeline::Model for PipelineBPE {
         Ok(())
     }
 
-    /// Two loops per batch of pre-tokens: the first builds every word's cache key
-    /// and asks for the slot it will land in, the second probes those slots and
-    /// tokenizes what missed. Splitting them is what gives the prefetches
-    /// something to hide behind — by the time the second loop probes a word, the
-    /// first loop has moved on far enough for its line to have arrived.
+    /// Key a batch of pre-tokens, ask for the slots they will land in, and hand the
+    /// batch to [`Self::tokenize_keyed_spans`]. Keying a batch ahead is what gives
+    /// the prefetches something to hide behind.
+    ///
+    /// A pre-tokenizer with a [`Scan`](pipeline::Scan) keys each word inside the
+    /// scan that cuts it and calls [`Self::tokenize_keyed_spans`] itself; this is
+    /// the path for the ones that hand over a whole chunk's spans at once.
     ///
     /// Keys come off `chunk.as_bytes()` rather than a `&str` slice per span. The
-    /// cache reads bytes, so a hit here never pays for the two boundary checks
-    /// that slicing a `str` costs; only a miss needs the text.
+    /// cache reads bytes, so a hit never pays for the two boundary checks that
+    /// slicing a `str` costs; only a miss needs the text.
     fn tokenize_spans(
         &self,
         chunk: &str,
         spans: &[Span],
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        if scratch.word_cache.is_none() {
+            let BpeScratch {
+                merge_queue,
+                skip,
+                word,
+                ..
+            } = scratch;
+            for span in spans {
+                self.tokenize_word(&chunk[span.range()], merge_queue, skip, word, output);
+            }
+            return Ok(());
+        }
+
+        let bytes = chunk.as_bytes();
+        let mut batch = [KeyedSpan::default(); SPAN_BATCH];
+        for group in spans.chunks(SPAN_BATCH) {
+            {
+                let cache = scratch.word_cache.as_ref().expect("checked above");
+                for (keyed, span) in batch.iter_mut().zip(group) {
+                    let key = cache.key(&bytes[span.range()]);
+                    if !key.is_none() {
+                        cache.prefetch(key);
+                    }
+                    *keyed = KeyedSpan { span: *span, key };
+                }
+            }
+            self.tokenize_keyed_spans(chunk, &batch[..group.len()], scratch, output)?;
+        }
+        Ok(())
+    }
+
+    /// The keyed path: the scan already built each word's key, so this is only the
+    /// probe and what a miss needs.
+    fn tokenize_keyed_spans(
+        &self,
+        chunk: &str,
+        spans: &[KeyedSpan],
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
@@ -923,45 +965,26 @@ impl pipeline::Model for PipelineBPE {
             word,
             word_cache,
         } = scratch;
-        let Some(cache) = word_cache.as_mut() else {
-            for span in spans {
-                self.tokenize_word(&chunk[span.range()], merge_queue, skip, word, output);
-            }
-            return Ok(());
-        };
-
+        let cache = word_cache
+            .as_mut()
+            .expect("the keyed path is only taken when there is a cache");
         let bytes = chunk.as_bytes();
-        let mut keys = [None; SPAN_BATCH];
-        for batch in spans.chunks(SPAN_BATCH) {
-            for (key, span) in keys.iter_mut().zip(batch) {
-                *key = cache.key(&bytes[span.range()]);
-                if let Some(key) = key {
-                    cache.prefetch(*key);
-                }
-            }
-            for (key, span) in keys.iter().zip(batch) {
-                let Some(key) = *key else {
-                    // No key means no slot: an empty span, or a word past what the
-                    // cache stores. A tokenizer with no pre-tokenizer hands whole
-                    // documents over this way.
-                    self.tokenize_word(&chunk[span.range()], merge_queue, skip, word, output);
+        for keyed in spans {
+            // The lookup also picks the slot this word would go in, so the insert
+            // below has no window to walk of its own.
+            let placement = match cache.lookup_keyed(&bytes[keyed.span.range()], keyed.key) {
+                Lookup::Hit(ids) => {
+                    output.extend(ids.iter().map(|&id| PipelineToken { id }));
                     continue;
-                };
-                // The lookup also picks the slot this word would go in, so the
-                // insert below has no window to walk of its own.
-                let placement = match cache.lookup_keyed(&bytes[span.range()], key) {
-                    Lookup::Hit(ids) => {
-                        output.extend(ids.iter().map(|&id| PipelineToken { id }));
-                        continue;
-                    }
-                    Lookup::Miss(at) => at,
-                };
-                let ids = self.tokenize_word(&chunk[span.range()], merge_queue, skip, word, output);
-                if let Some(at) = placement {
-                    match ids {
-                        WordIds::Whole(id) => cache.insert(at, std::iter::once(id)),
-                        WordIds::Merged => cache.insert(at, word.get_chars_iter()),
-                    }
+                }
+                Lookup::Miss(at) => at,
+            };
+            let ids =
+                self.tokenize_word(&chunk[keyed.span.range()], merge_queue, skip, word, output);
+            if let Some(at) = placement {
+                match ids {
+                    WordIds::Whole(id) => cache.insert(at, std::iter::once(id)),
+                    WordIds::Merged => cache.insert(at, word.get_chars_iter()),
                 }
             }
         }
@@ -986,7 +1009,11 @@ pub struct BpeScratch {
     /// some text, so it must outlive the encode call that filled it.
     pub(crate) word_cache: Option<WordCache>,
 }
-impl ModelScratch for BpeScratch {}
+impl ModelScratch for BpeScratch {
+    fn word_cache(&mut self) -> Option<&mut WordCache> {
+        self.word_cache.as_mut()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -5,6 +5,7 @@ use crate::tokenizer::{Model, Result, Token};
 use crate::utils::byte_level::{self};
 use crate::utils::cache::{DEFAULT_CACHE_CAPACITY, MAX_LENGTH};
 use crate::utils::iter::ResultShunt;
+use crate::utils::word_cache::{Lookup, WordCache};
 use crate::vocab::bucket_vocab_store::BucketVocabStore;
 use crate::vocab_store::VocabStore;
 use ahash::AHashMap;
@@ -680,6 +681,8 @@ pub struct PipelineBPE {
     vocab: BucketVocabStore,
     merges: MergeMap,
     ignore_merges: bool,
+    /// `None` when the tokenizer asked for no cache.
+    cache_capacity: Option<usize>,
 }
 
 enum Atoms {
@@ -760,6 +763,7 @@ impl PipelineBPE {
             ignore_merges,
             merges,
             vocab,
+            cache_capacity: model.cache.map(|c| c.capacity).filter(|&c| c > 0),
         })
     }
 
@@ -827,6 +831,25 @@ impl pipeline::Model for PipelineBPE {
             return Ok(());
         }
 
+        let BpeScratch {
+            merge_queue,
+            skip,
+            word,
+            word_cache,
+        } = scratch;
+
+        // The lookup also picks the slot this word would go in, so the insert
+        // below has no window to walk of its own.
+        let mut placement = None;
+        if let Some(cache) = word_cache.as_mut() {
+            match cache.lookup(sequence.as_bytes()) {
+                Lookup::Hit(ids) => {
+                    output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                    return Ok(());
+                }
+                Lookup::Miss(at) => placement = at,
+            }
+        }
         if self.ignore_merges
             && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
         {
@@ -834,16 +857,13 @@ impl pipeline::Model for PipelineBPE {
             return Ok(());
         }
 
-        // TODO: persistent cache mapping &str -> &[u32]
-
-        let BpeScratch {
-            merge_queue,
-            skip,
-            word,
-        } = scratch;
-
         self.merge_word(sequence, merge_queue, skip, word);
         output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
+        if let Some(cache) = word_cache.as_mut()
+            && let Some(at) = placement
+        {
+            cache.insert(at, word.get_chars_iter());
+        }
 
         Ok(())
     }
@@ -853,6 +873,7 @@ impl pipeline::Model for PipelineBPE {
             merge_queue: QuaternaryHeap::with_capacity(64),
             word: Word::with_capacity(64),
             skip: Vec::new(),
+            word_cache: self.cache_capacity.map(WordCache::new),
         }
     }
 }
@@ -861,6 +882,9 @@ pub struct BpeScratch {
     pub(crate) merge_queue: QuaternaryHeap<Merge>,
     pub(crate) skip: Vec<Merge>,
     pub(crate) word: Word,
+    /// Kept for the life of the scratch: a cache is only worth having once it has seen
+    /// some text, so it must outlive the encode call that filled it.
+    pub(crate) word_cache: Option<WordCache>,
 }
 impl ModelScratch for BpeScratch {}
 
@@ -1453,6 +1477,36 @@ mod tests {
                 pipeline::Model::tokenize_pipeline(&model, input, &mut scratch, &mut out).unwrap();
                 let got: Vec<u32> = out.iter().map(|t| t.id).collect();
                 assert_eq!(got, reference_ids(&reference, input), "{input:?}");
+            }
+        }
+
+        // A cache may forget a word, but it must never change one. Run every word twice
+        // through one scratch — the second time answered from the cache — against a model
+        // built with no cache at all.
+        #[test]
+        fn cached_ids_match_uncached() {
+            let cached = PipelineBPE::from_bpe(hello_builder().build().unwrap(), false).unwrap();
+            let uncached =
+                PipelineBPE::from_bpe(hello_builder().cache_capacity(0).build().unwrap(), false)
+                    .unwrap();
+
+            let mut scratch = cached.init_scratch();
+            assert!(scratch.word_cache.is_some(), "nothing is being cached");
+            for _ in 0..2 {
+                for word in [
+                    "hello",
+                    "hell",
+                    "o",
+                    "hellohello",
+                    "hello-a-word-past-fifteen-bytes",
+                    "hxe",
+                ] {
+                    let mut out = Vec::new();
+                    pipeline::Model::tokenize_pipeline(&cached, word, &mut scratch, &mut out)
+                        .unwrap();
+                    let got: Vec<u32> = out.iter().map(|t| t.id).collect();
+                    assert_eq!(got, pipeline_ids(&uncached, word), "{word:?}");
+                }
             }
         }
 

--- a/tokenizers/tk-encode/src/models/bpe/word.rs
+++ b/tokenizers/tk-encode/src/models/bpe/word.rs
@@ -276,7 +276,7 @@ impl Word {
         self.get_chars_iter().collect()
     }
 
-    pub fn get_chars_iter(&self) -> impl Iterator<Item = u32> + '_ {
+    pub fn get_chars_iter(&self) -> impl ExactSizeIterator<Item = u32> + '_ {
         self.symbols.iter().map(|s| s.c)
     }
 

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -3,6 +3,7 @@ use super::{
     trie::{Trie, TrieBuilder},
 };
 use crate::utils::cache::{Cache, MAX_LENGTH};
+use crate::utils::word_cache::{Lookup, WordCache};
 use crate::vocab_store::VocabStore;
 use crate::{
     pipeline::{self, PipelineToken},
@@ -239,23 +240,33 @@ impl Unigram {
         if sentence.is_empty() {
             return Ok(vec![]);
         }
-        if self.alpha.is_none() || self.alpha == Some(0.0) {
-            if let Some(result) = self.cache.get(sentence) {
-                Ok(result.to_vec())
-            } else {
-                let result = if self.is_optimized {
-                    self.encode_optimized(sentence)?
-                } else {
-                    self.encode_unoptimized(sentence)?
-                };
-                if sentence.len() < MAX_LENGTH {
-                    self.cache.set(sentence.to_owned(), result.clone());
-                }
-                Ok(result)
-            }
+        if self.samples() {
+            return self.encode_uncached(sentence);
+        }
+        if let Some(result) = self.cache.get(sentence) {
+            return Ok(result.to_vec());
+        }
+        let result = self.encode_uncached(sentence)?;
+        if sentence.len() < MAX_LENGTH {
+            self.cache.set(sentence.to_owned(), result.clone());
+        }
+        Ok(result)
+    }
+
+    /// Whether [`Unigram::alpha`] asks for a tokenization drawn at random from the
+    /// lattice instead of its best path. Such a result is one draw out of many, so no
+    /// cache may hold it.
+    fn samples(&self) -> bool {
+        matches!(self.alpha, Some(alpha) if alpha != 0.0)
+    }
+
+    /// What `sentence` encodes to, worked out rather than looked up: the lattice's
+    /// best path, or a draw from it when [`Unigram::samples`].
+    fn encode_uncached(&self, sentence: &str) -> Result<Vec<String>> {
+        if self.is_optimized && !self.samples() {
+            self.encode_optimized(sentence)
         } else {
-            let result = self.encode_unoptimized(sentence)?;
-            Ok(result)
+            self.encode_unoptimized(sentence)
         }
     }
 
@@ -503,7 +514,11 @@ impl Model for Unigram {
     }
 }
 
-pub struct UnigramScratch {}
+pub struct UnigramScratch {
+    /// Kept for the life of the scratch: a cache is only worth having once it has seen
+    /// some text, so it must outlive the encode call that filled it.
+    pub(crate) word_cache: Option<WordCache>,
+}
 
 impl pipeline::ModelScratch for UnigramScratch {}
 
@@ -511,18 +526,44 @@ impl pipeline::Model for Unigram {
     type Scratch = UnigramScratch;
 
     fn init_scratch(&self) -> Self::Scratch {
-        Self::Scratch {}
+        Self::Scratch {
+            word_cache: match self.cache.capacity {
+                0 => None,
+                capacity => Some(WordCache::new(capacity)),
+            },
+        }
     }
 
+    /// The pipeline asks for ids and nothing else, so this path caches ids, where
+    /// [`Unigram::encode`] has to hand back the pieces themselves and caches those. A hit
+    /// skips the lattice, the `String` every piece is built into, and the vocabulary
+    /// lookup that turns each one back into an id.
     fn tokenize_pipeline(
         &self,
         sequence: &str,
-        _scratch: &mut Self::Scratch,
+        scratch: &mut Self::Scratch,
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
-        let str_tokens = self.encode(sequence)?;
+        if sequence.is_empty() {
+            return Ok(());
+        }
+        // The lookup also picks the slot this sequence would go in, so the
+        // insert below has no window to walk of its own.
+        let mut placement = None;
+        if !self.samples()
+            && let Some(cache) = scratch.word_cache.as_mut()
+        {
+            match cache.lookup(sequence.as_bytes()) {
+                Lookup::Hit(ids) => {
+                    output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                    return Ok(());
+                }
+                Lookup::Miss(at) => placement = at,
+            }
+        }
 
-        for string in str_tokens {
+        let start = output.len();
+        for string in self.encode_uncached(sequence)? {
             match self.token_to_ids.token_to_id(&string) {
                 Some(id) => {
                     output.push(PipelineToken { id });
@@ -546,6 +587,15 @@ impl pipeline::Model for Unigram {
                     });
                 }
             };
+        }
+
+        // A sampled tokenization never produced a placement, so it is never
+        // stored: remembering one draw would turn every later call on the same
+        // text into that same draw.
+        if let Some(cache) = scratch.word_cache.as_mut()
+            && let Some(at) = placement
+        {
+            cache.insert(at, output[start..].iter().map(|token| token.id));
         }
         Ok(())
     }
@@ -709,5 +759,124 @@ mod tests {
 
         let tokens = unigram.tokenize("?é").unwrap();
         assert_eq!(tokens[0].id, 0);
+    }
+
+    /// Ids 0..=8 are `<unk>`, `a`, `b`, `c`, `d`, `cd`, `ab`, `abc`, `abcd`.
+    fn abcd_vocab() -> Vocab {
+        vec![
+            ("<unk>".to_string(), 0.0),
+            ("a".to_string(), 0.0),
+            ("b".to_string(), 0.0),
+            ("c".to_string(), 0.0),
+            ("d".to_string(), 0.0),
+            ("cd".to_string(), 1.0),
+            ("ab".to_string(), 2.0),
+            ("abc".to_string(), 5.0),
+            ("abcd".to_string(), 10.0),
+        ]
+    }
+
+    fn pipeline_ids(model: &Unigram, sequence: &str, scratch: &mut UnigramScratch) -> Vec<u32> {
+        let mut output = vec![];
+        pipeline::Model::tokenize_pipeline(model, sequence, scratch, &mut output).unwrap();
+        output.iter().map(|token| token.id).collect()
+    }
+
+    #[test]
+    fn pipeline_remembers_what_a_sequence_encoded_to() {
+        let model = Unigram::from(abcd_vocab(), Some(0), false).unwrap();
+        let mut scratch = pipeline::Model::init_scratch(&model);
+
+        let ids = pipeline_ids(&model, "abcd", &mut scratch);
+
+        let cache = scratch
+            .word_cache
+            .as_mut()
+            .expect("Unigram encodes with a cache");
+        assert_eq!(cache.lookup(b"abcd").hit(), Some(&ids[..]));
+    }
+
+    #[test]
+    fn cache_hits_agree_with_a_cold_run() {
+        let model = Unigram::from(abcd_vocab(), Some(0), false).unwrap();
+        let long = "abcd".repeat(400);
+        let corpus = [
+            "abcdacdxx",
+            "ab",
+            // The same sequence again, so this one is served from the cache.
+            "abcdacdxx",
+            // Out of the vocabulary, and multibyte.
+            "東京",
+            // 1600 bytes, past the longest word the cache will store.
+            long.as_str(),
+            "abcdacdxx",
+        ];
+
+        let mut warm_scratch = pipeline::Model::init_scratch(&model);
+        let warm = corpus.map(|sequence| pipeline_ids(&model, sequence, &mut warm_scratch));
+        let cold = corpus.map(|sequence| {
+            let mut scratch = pipeline::Model::init_scratch(&model);
+            pipeline_ids(&model, sequence, &mut scratch)
+        });
+
+        assert_eq!(warm, cold);
+    }
+
+    #[test]
+    fn caches_only_the_ids_this_sequence_produced() {
+        // Every sequence the pipeline hands the model appends to one output buffer,
+        // so a sequence has to remember its own ids, not everything the buffer holds.
+        let model = Unigram::from(abcd_vocab(), Some(0), false).unwrap();
+        let mut scratch = pipeline::Model::init_scratch(&model);
+        let mut output = vec![];
+        pipeline::Model::tokenize_pipeline(&model, "ab", &mut scratch, &mut output).unwrap();
+        pipeline::Model::tokenize_pipeline(&model, "cd", &mut scratch, &mut output).unwrap();
+
+        let ids: Vec<u32> = output.iter().map(|token| token.id).collect();
+        assert_eq!(ids, [6, 5]);
+        let cache = scratch.word_cache.as_mut().unwrap();
+        assert_eq!(cache.lookup(b"cd").hit(), Some(&[5u32][..]));
+    }
+
+    #[test]
+    fn byte_fallback_ids_survive_the_cache() {
+        // A piece the vocabulary has no id for becomes one id per byte. The cache
+        // stores what came out, so a hit has to replay all of them.
+        let vocab = vec![
+            ("<unk>".to_string(), 0.0),
+            ("<0xC3>".to_string(), -0.01),
+            ("<0xA9>".to_string(), -0.03),
+        ];
+        let model = Unigram::from(vocab, Some(0), true).unwrap();
+        let mut scratch = pipeline::Model::init_scratch(&model);
+
+        let ids = pipeline_ids(&model, "é", &mut scratch);
+
+        assert_eq!(ids, [1, 2]);
+        assert_eq!(pipeline_ids(&model, "é", &mut scratch), ids);
+    }
+
+    #[test]
+    fn sampling_is_never_cached() {
+        // A sampled tokenization is one draw out of many. Remembering it would turn
+        // every later call on the same text into that same draw.
+        let mut model = Unigram::from(abcd_vocab(), Some(0), false).unwrap();
+        model.alpha = Some(0.5);
+        let mut scratch = pipeline::Model::init_scratch(&model);
+
+        pipeline_ids(&model, "abcd", &mut scratch);
+
+        let cache = scratch.word_cache.as_mut().unwrap();
+        assert_eq!(cache.lookup(b"abcd").hit(), None);
+    }
+
+    #[test]
+    fn a_capacity_of_zero_turns_the_cache_off() {
+        let mut model = Unigram::from(abcd_vocab(), Some(0), false).unwrap();
+        model.resize_cache(0);
+        let mut scratch = pipeline::Model::init_scratch(&model);
+
+        assert_eq!(pipeline_ids(&model, "abcd", &mut scratch), [8]);
+        assert!(scratch.word_cache.is_none());
     }
 }

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -520,7 +520,11 @@ pub struct UnigramScratch {
     pub(crate) word_cache: Option<WordCache>,
 }
 
-impl pipeline::ModelScratch for UnigramScratch {}
+impl pipeline::ModelScratch for UnigramScratch {
+    fn word_cache(&mut self) -> Option<&mut WordCache> {
+        self.word_cache.as_mut()
+    }
+}
 
 impl pipeline::Model for Unigram {
     type Scratch = UnigramScratch;

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -323,7 +323,11 @@ pub struct WordPieceScratch {
     word_cache: WordCache,
 }
 
-impl pipeline::ModelScratch for WordPieceScratch {}
+impl pipeline::ModelScratch for WordPieceScratch {
+    fn word_cache(&mut self) -> Option<&mut WordCache> {
+        Some(&mut self.word_cache)
+    }
+}
 
 pub struct PipelineWordPiece {
     vocab_trie: yada::DoubleArray<Vec<u8>>,

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -4,6 +4,8 @@
 use crate::models::bpe::BPE;
 use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::{Model, Result, Token};
+use crate::utils::cache::DEFAULT_CACHE_CAPACITY;
+use crate::utils::word_cache::{Lookup, WordCache};
 use ahash::AHashMap;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -316,6 +318,9 @@ impl Model for WordPiece {
 
 pub struct WordPieceScratch {
     candidate_str: String,
+    /// Kept for the life of the scratch: a cache is only worth having once it has seen
+    /// some text, so it must outlive the encode call that filled it.
+    word_cache: WordCache,
 }
 
 impl pipeline::ModelScratch for WordPieceScratch {}
@@ -353,23 +358,18 @@ impl TryFrom<WordPiece> for PipelineWordPiece {
     }
 }
 
-impl pipeline::Model for PipelineWordPiece {
-    type Scratch = WordPieceScratch;
-
-    fn init_scratch(&self) -> Self::Scratch {
-        Self::Scratch {
-            candidate_str: String::with_capacity(self.max_input_chars_per_word),
-        }
-    }
-
-    fn tokenize_pipeline(
+impl PipelineWordPiece {
+    /// One word, greedily: the longest vocabulary entry it starts with, then the
+    /// longest entry the rest of it starts with once the continuing-subword prefix
+    /// is put in front, and so on. A piece with no entry at all anywhere in the
+    /// word makes the whole word one unk token.
+    fn tokenize_word(
         &self,
         sequence: &str,
-        scratch: &mut Self::Scratch,
-        output: &mut Vec<pipeline::PipelineToken>,
+        candidate: &mut String,
+        output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
         let checkpoint = output.len();
-        let candidate = &mut scratch.candidate_str;
 
         let char_len = sequence.chars().count();
         if char_len > self.max_input_chars_per_word {
@@ -411,6 +411,51 @@ impl pipeline::Model for PipelineWordPiece {
     }
 }
 
+impl pipeline::Model for PipelineWordPiece {
+    type Scratch = WordPieceScratch;
+
+    fn init_scratch(&self) -> Self::Scratch {
+        Self::Scratch {
+            candidate_str: String::with_capacity(self.max_input_chars_per_word),
+            word_cache: WordCache::new(DEFAULT_CACHE_CAPACITY),
+        }
+    }
+
+    /// A hit skips [`Self::tokenize_word`]: one trie search per piece of the word,
+    /// each over a fresh copy of what is left to match.
+    fn tokenize_pipeline(
+        &self,
+        sequence: &str,
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<pipeline::PipelineToken>,
+    ) -> Result<()> {
+        if sequence.is_empty() {
+            return Ok(());
+        }
+        let WordPieceScratch {
+            candidate_str,
+            word_cache,
+        } = scratch;
+
+        // The lookup also picks the slot this word would go in, so the insert
+        // below has no window to walk of its own.
+        let placement = match word_cache.lookup(sequence.as_bytes()) {
+            Lookup::Hit(ids) => {
+                output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                return Ok(());
+            }
+            Lookup::Miss(at) => at,
+        };
+
+        let start = output.len();
+        self.tokenize_word(sequence, candidate_str, output)?;
+        if let Some(at) = placement {
+            word_cache.insert(at, output[start..].iter().map(|token| token.id));
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -418,5 +463,94 @@ mod tests {
     #[test]
     fn test_error_display() {
         assert!(format!("{}", Error::MissingUnkToken).contains("Missing [UNK] token"));
+    }
+
+    /// `hello` is in the vocabulary whole and as `hell` + `##o`, so the
+    /// longest-match walk has something to choose; `world` gives a second
+    /// one-token word.
+    fn pipeline_wordpiece() -> PipelineWordPiece {
+        let vocab: Vocab = [
+            ("[UNK]", 0u32),
+            ("hell", 1),
+            ("##o", 2),
+            ("hello", 3),
+            ("world", 4),
+        ]
+        .into_iter()
+        .map(|(token, id)| (token.to_string(), id))
+        .collect();
+        let model = WordPiece::builder()
+            .vocab(vocab)
+            .max_input_chars_per_word(8)
+            .build()
+            .unwrap();
+        PipelineWordPiece::try_from(model).unwrap()
+    }
+
+    fn pipeline_ids(
+        model: &PipelineWordPiece,
+        sequence: &str,
+        scratch: &mut WordPieceScratch,
+    ) -> Vec<u32> {
+        let mut output = vec![];
+        pipeline::Model::tokenize_pipeline(model, sequence, scratch, &mut output).unwrap();
+        output.iter().map(|token| token.id).collect()
+    }
+
+    #[test]
+    fn pipeline_remembers_what_a_word_encoded_to() {
+        let model = pipeline_wordpiece();
+        let mut scratch = pipeline::Model::init_scratch(&model);
+
+        let ids = pipeline_ids(&model, "hello", &mut scratch);
+
+        assert_eq!(scratch.word_cache.lookup(b"hello").hit(), Some(&ids[..]));
+    }
+
+    #[test]
+    fn cache_hits_agree_with_a_cold_run() {
+        let model = pipeline_wordpiece();
+        let long = "hello".repeat(300);
+        let corpus = [
+            "hello",
+            // No id for `##w`, so the whole word is one unk token.
+            "hellow",
+            // Both again, so these two are served from the cache.
+            "hello",
+            "hellow",
+            // Past `max_input_chars_per_word`, which is another unk token.
+            "hellohello",
+            "hellohello",
+            // Out of the vocabulary, and multibyte.
+            "東京",
+            "東京",
+            // 1500 bytes, past the longest word the cache will store.
+            long.as_str(),
+            long.as_str(),
+        ];
+
+        let mut warm_scratch = pipeline::Model::init_scratch(&model);
+        let warm = corpus.map(|sequence| pipeline_ids(&model, sequence, &mut warm_scratch));
+        let cold = corpus.map(|sequence| {
+            let mut scratch = pipeline::Model::init_scratch(&model);
+            pipeline_ids(&model, sequence, &mut scratch)
+        });
+
+        assert_eq!(warm, cold);
+    }
+
+    #[test]
+    fn caches_only_the_ids_this_word_produced() {
+        // Every word the pipeline hands the model appends to one output buffer,
+        // so a word has to remember its own ids, not everything the buffer holds.
+        let model = pipeline_wordpiece();
+        let mut scratch = pipeline::Model::init_scratch(&model);
+        let mut output = vec![];
+        pipeline::Model::tokenize_pipeline(&model, "hello", &mut scratch, &mut output).unwrap();
+        pipeline::Model::tokenize_pipeline(&model, "world", &mut scratch, &mut output).unwrap();
+
+        let ids: Vec<u32> = output.iter().map(|token| token.id).collect();
+        assert_eq!(ids, [3, 4]);
+        assert_eq!(scratch.word_cache.lookup(b"world").hit(), Some(&[4u32][..]));
     }
 }

--- a/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
@@ -154,6 +154,25 @@ impl pipeline::PreTokenizer for PipelineSequence {
         out.extend_from_slice(&current);
         Ok(())
     }
+
+    /// The lone child's scan, under the same rule
+    /// [`pre_tokenize`](pipeline::PreTokenizer::pre_tokenize) collapses on: a
+    /// `Sequence[Split(regex), ByteLevel(use_regex=false)]` is that `Split`, since
+    /// the byte-map `ByteLevel` converts to an identity pass. This is what puts
+    /// llama-3 on the keyed path — its pre-tokenizer ships in exactly that shape.
+    fn scan(&self) -> Option<pipeline::Scan> {
+        if self.is_deepseek() {
+            return None;
+        }
+        let mut work = self
+            .pre_tokenizers
+            .iter()
+            .filter(|c| !matches!(c, PipelinePreTokenizer::None));
+        match (work.next(), work.next()) {
+            (Some(only), None) => only.scan(),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -197,8 +197,9 @@ impl pipeline::PreTokenizer for Split {
             .filter(|_| !self.invert && self.behavior == SplitDelimiterBehavior::Isolated)
         {
             Some(GptFsm::Gpt2) => Some(pipeline::Scan::ByteLevel),
-            // cl100k and o200k have no resumable scan yet, so they keep filling a
-            // whole chunk's spans through `pre_tokenize`.
+            Some(GptFsm::Cl100k { digit_cap }) => Some(pipeline::Scan::Cl100k { digit_cap }),
+            // o200k has no resumable scan yet, so it keeps filling a whole chunk's
+            // spans through `pre_tokenize`.
             _ => None,
         }
     }
@@ -425,10 +426,10 @@ mod tests {
     }
 
     /// The resumable scan is what routes a chunk through the keyed path, so which
-    /// patterns have one is worth pinning: gpt2 does, and the two FSMs without a
-    /// resumable scan yet must say so rather than be routed there.
+    /// patterns have one is worth pinning — o200k has none yet and must say so
+    /// rather than be routed there.
     #[test]
-    fn only_gpt2_offers_a_resumable_scan() {
+    fn gpt2_and_cl100k_offer_a_resumable_scan() {
         use crate::pipeline::PreTokenizer as _;
         let scan_of = |pattern: &str, behavior, invert| {
             Split::new(SplitPattern::Regex(pattern.into()), behavior, invert)
@@ -437,7 +438,7 @@ mod tests {
                 .is_some()
         };
         assert!(scan_of(atomsplit::regexes::GPT2, Isolated, false));
-        assert!(!scan_of(atomsplit::regexes::CL100K, Isolated, false));
+        assert!(scan_of(atomsplit::regexes::CL100K, Isolated, false));
         assert!(!scan_of(atomsplit::regexes::O200K, Isolated, false));
         // Not the canonical usage the FSM covers, so there is nothing to resume.
         // (An unrecognized pattern cannot even be built without a system-regex

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -190,6 +190,18 @@ impl pipeline::PreTokenizer for Split {
         pipeline::split_matches(out, matches, self.behavior);
         Ok(())
     }
+
+    fn scan(&self) -> Option<pipeline::Scan> {
+        match self
+            .fsm
+            .filter(|_| !self.invert && self.behavior == SplitDelimiterBehavior::Isolated)
+        {
+            Some(GptFsm::Gpt2) => Some(pipeline::Scan::ByteLevel),
+            // cl100k and o200k have no resumable scan yet, so they keep filling a
+            // whole chunk's spans through `pre_tokenize`.
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -410,6 +422,27 @@ mod tests {
             pipeline_split(SplitPattern::Regex(gpt2.into()), Isolated, false, corpus),
             legacy,
         );
+    }
+
+    /// The resumable scan is what routes a chunk through the keyed path, so which
+    /// patterns have one is worth pinning: gpt2 does, and the two FSMs without a
+    /// resumable scan yet must say so rather than be routed there.
+    #[test]
+    fn only_gpt2_offers_a_resumable_scan() {
+        use crate::pipeline::PreTokenizer as _;
+        let scan_of = |pattern: &str, behavior, invert| {
+            Split::new(SplitPattern::Regex(pattern.into()), behavior, invert)
+                .unwrap()
+                .scan()
+                .is_some()
+        };
+        assert!(scan_of(atomsplit::regexes::GPT2, Isolated, false));
+        assert!(!scan_of(atomsplit::regexes::CL100K, Isolated, false));
+        assert!(!scan_of(atomsplit::regexes::O200K, Isolated, false));
+        // Not the canonical usage the FSM covers, so there is nothing to resume.
+        // (An unrecognized pattern cannot even be built without a system-regex
+        // backend, so there is no case for it here.)
+        assert!(!scan_of(atomsplit::regexes::GPT2, Removed, true));
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,5 +1,7 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
+use std::mem;
+use std::sync::{Mutex, PoisonError};
 use std::{borrow::Cow, convert::TryFrom};
 
 use atomsplit::classify::classify;
@@ -391,6 +393,73 @@ pub struct PipelineTokenizer {
     pre_tokenizer: PipelinePreTokenizer,
     model: PipelineModel,
     post_processor: PipelinePostProcessor,
+    scratch_pool: ScratchPool,
+}
+
+/// Working space for encoding, lent out and taken back.
+///
+/// Encoding needs buffers to build tokens in, and building them per call means asking the
+/// allocator for the same things over and over. So they are borrowed instead: a caller
+/// takes a scratch, hands it back when it is done, and the next caller gets one whose
+/// buffers are already as big as the last encode needed. A model empties what it uses as
+/// it goes, so a scratch comes back ready to use.
+///
+/// A tokenizer encodes through `&self` and several threads may be in it at once, so a
+/// scratch cannot simply live in the tokenizer — each thread needs its own. The pool ends
+/// up holding one per thread that has encoded at the same time as the others, and frees
+/// them all with the tokenizer. A single thread encoding in a loop — the common case —
+/// borrows and returns the same one every time.
+struct ScratchPool(Mutex<Vec<PipelineModelScratch>>);
+
+impl ScratchPool {
+    fn new() -> Self {
+        Self(Mutex::new(Vec::new()))
+    }
+
+    /// Borrow a scratch; dropping the guard gives it back. The lock is held just long
+    /// enough to move one out, never while encoding.
+    fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
+        let taken = self.0.lock().unwrap_or_else(PoisonError::into_inner).pop();
+        ScratchGuard {
+            scratch: taken.unwrap_or_else(|| model.init_scratch()),
+            pool: self,
+        }
+    }
+
+    #[cfg(test)]
+    fn stored_scratches(&self) -> usize {
+        self.0.lock().unwrap_or_else(PoisonError::into_inner).len()
+    }
+}
+
+/// Gives the scratch back to the pool when it goes out of scope.
+struct ScratchGuard<'a> {
+    scratch: PipelineModelScratch,
+    pool: &'a ScratchPool,
+}
+
+impl Drop for ScratchGuard<'_> {
+    fn drop(&mut self) {
+        let scratch = mem::take(&mut self.scratch);
+        self.pool
+            .0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(scratch);
+    }
+}
+
+impl std::ops::Deref for ScratchGuard<'_> {
+    type Target = PipelineModelScratch;
+    fn deref(&self) -> &PipelineModelScratch {
+        &self.scratch
+    }
+}
+
+impl std::ops::DerefMut for ScratchGuard<'_> {
+    fn deref_mut(&mut self) -> &mut PipelineModelScratch {
+        &mut self.scratch
+    }
 }
 
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
@@ -493,6 +562,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
                 .map(PipelinePostProcessor::try_from)
                 .transpose()?
                 .unwrap_or_default(),
+            scratch_pool: ScratchPool::new(),
         })
     }
 }
@@ -523,7 +593,7 @@ impl PipelineTokenizer {
     pub fn encode(&self, input: &str, add_special_tokens: bool) -> Result<Vec<PipelineToken>> {
         let mut output = Vec::new();
         let mut pre_tokens = Vec::new();
-        let mut scratch = self.model.init_scratch();
+        let mut scratch = self.scratch_pool.get(&self.model);
 
         self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(
             input,
@@ -972,11 +1042,16 @@ impl Model for PipelineModel {
     }
 }
 
+#[derive(Default)]
 pub enum PipelineModelScratch {
     BPE(BpeScratch),
     WordLevel(()),
     WordPiece(WordPieceScratch),
     Unigram(UnigramScratch),
+    /// Costs nothing to build, and stands in for the real scratch while a guard is
+    /// handing it back to the pool.
+    #[default]
+    None,
 }
 
 impl ModelScratch for PipelineModelScratch {}
@@ -1313,5 +1388,102 @@ mod tests {
         );
         let err = conversion_error(&tok);
         assert!(err.contains("not supported"), "{}", err);
+    }
+
+    /// A BPE pipeline that merges "hello" into the single id 7.
+    fn hello_pipeline() -> PipelineTokenizer {
+        use crate::models::bpe::{BpeBuilder, Merges, Vocab};
+
+        let vocab: Vocab = [
+            ("h", 0u32),
+            ("e", 1),
+            ("l", 2),
+            ("o", 3),
+            ("he", 4),
+            ("hel", 5),
+            ("hell", 6),
+            ("hello", 7),
+        ]
+        .into_iter()
+        .map(|(s, i)| (s.to_string(), i))
+        .collect();
+        let merges: Merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+            ("hel".to_string(), "l".to_string()),
+            ("hell".to_string(), "o".to_string()),
+        ];
+        let bpe = BpeBuilder::default()
+            .vocab_and_merges(vocab, merges)
+            .build()
+            .unwrap();
+        PipelineTokenizer::try_from(&Tokenizer::new(bpe)).unwrap()
+    }
+
+    // The pool exists so ONE `&self` tokenizer can be shared across rayon workers. Encode
+    // the same input from thousands of threads through a single instance; each must get a
+    // private scratch and produce the sequential result. Two threads sharing a scratch
+    // would corrupt some of them — and this only compiles if `PipelineTokenizer: Sync`,
+    // which the pool has to preserve.
+    #[test]
+    fn encode_shared_across_threads() {
+        use rayon::prelude::*;
+
+        let pipeline = hello_pipeline();
+
+        let want: Vec<u32> = pipeline
+            .encode("hello", false)
+            .unwrap()
+            .iter()
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(want, vec![7]);
+
+        let all_match = (0..10_000u32).into_par_iter().all(|_| {
+            pipeline
+                .encode("hello", false)
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect::<Vec<_>>()
+                == want
+        });
+        assert!(all_match);
+    }
+
+    // Reusing scratches is the whole point of the pool, so it must not build one per call:
+    // one thread encoding in a loop has to keep coming back to the same scratch, and a
+    // burst of N threads must leave at most N behind for later calls to use.
+    #[test]
+    fn scratches_are_reused_rather_than_piling_up() {
+        use std::sync::Barrier;
+
+        let pipeline = hello_pipeline();
+        for _ in 0..1000 {
+            pipeline.encode("hello", false).unwrap();
+        }
+        assert_eq!(pipeline.scratch_pool.stored_scratches(), 1);
+
+        let threads = 64;
+        let all_holding = Barrier::new(threads);
+        std::thread::scope(|scope| {
+            for _ in 0..threads {
+                scope.spawn(|| {
+                    let scratch = pipeline.scratch_pool.get(&pipeline.model);
+                    all_holding.wait();
+                    drop(scratch);
+                });
+            }
+        });
+
+        let after_burst = pipeline.scratch_pool.stored_scratches();
+        assert!(
+            after_burst <= threads,
+            "{after_burst} scratches kept for {threads} threads"
+        );
+        for _ in 0..1000 {
+            pipeline.encode("hello", false).unwrap();
+        }
+        assert_eq!(pipeline.scratch_pool.stored_scratches(), after_burst);
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -72,6 +72,7 @@ pub(crate) fn classify_into_spans(
 #[derive(Clone, Copy)]
 pub enum Scan {
     ByteLevel,
+    Cl100k { digit_cap: usize },
 }
 
 /// A pre-token together with the word-cache key for its bytes, built by the scan
@@ -99,6 +100,25 @@ impl KeyedSpan {
 /// the model works through it.
 const KEYED_BATCH: usize = 32;
 
+/// Key the word `span` covers and store the pair at `out[n]`, reporting whether
+/// there is room for another. The body of every scan's `emit`.
+#[inline(always)]
+fn key_into(
+    out: &mut [KeyedSpan],
+    n: &mut usize,
+    cache: &WordCache,
+    bytes: &[u8],
+    span: Span,
+) -> bool {
+    let key = cache.key(&bytes[span.range()]);
+    if !key.is_none() {
+        cache.prefetch(key);
+    }
+    out[*n] = KeyedSpan { span, key };
+    *n += 1;
+    *n < out.len()
+}
+
 /// Cut the next spans of `text` from `at`, keying each word as it is cut, and
 /// report how many spans landed in `out` and where the scan stopped. A stop at
 /// `bytes.len()` means the text is done.
@@ -111,16 +131,18 @@ fn fill_keyed_spans(
     out: &mut [KeyedSpan],
 ) -> (usize, usize) {
     let mut n = 0;
+    // Each arm builds its own closure and passes it by value, so the keying is
+    // inlined into that scan's loop. Handing both arms one `&mut` closure instead
+    // costs gpt2 a third of its gain — the body stops being inlined.
     let stopped = match scan {
         Scan::ByteLevel => atomsplit::fsm::scan_byte_level(bytes, tags, at, |span| {
-            let key = cache.key(&bytes[span.range()]);
-            if !key.is_none() {
-                cache.prefetch(key);
-            }
-            out[n] = KeyedSpan { span, key };
-            n += 1;
-            n < out.len()
+            key_into(out, &mut n, cache, bytes, span)
         }),
+        Scan::Cl100k { digit_cap } => {
+            atomsplit::fsm::scan_cl100k_cap(bytes, tags, at, digit_cap, |span| {
+                key_into(out, &mut n, cache, bytes, span)
+            })
+        }
     };
     (n, stopped)
 }
@@ -185,6 +207,8 @@ impl PreTokenizer for PipelinePreTokenizer {
     fn scan(&self) -> Option<Scan> {
         match self {
             Self::Split(pretok) => pretok.scan(),
+            // A sequence can still reduce to a single Split — llama-3's does.
+            Self::Sequence(pretok) => pretok.scan(),
             _ => None,
         }
     }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -13,6 +13,7 @@ use crate::models::wordpiece::{PipelineWordPiece, WordPieceScratch};
 use crate::processors::bert::BertProcessing;
 use crate::processors::roberta::RobertaProcessing;
 use crate::utils::byte_level::GPT2_REGEX_STR;
+use crate::utils::word_cache::{WordCache, WordKey};
 use crate::vocab::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
@@ -61,6 +62,69 @@ pub(crate) fn classify_into_spans(
     });
 }
 
+/// A pre-tokenizer whose scan can be stopped and picked up again, so the encode
+/// loop can take its spans a batch at a time instead of a whole chunk at once.
+///
+/// That is what lets each word be keyed for the word cache at the point it is cut
+/// out of the text, while its bytes are still in cache — see [`KeyedSpan`]. Only
+/// the ByteLevel (gpt2) FSM has one so far; every other pre-tokenizer fills a
+/// chunk's spans in one call and the model keys the words itself.
+#[derive(Clone, Copy)]
+pub enum Scan {
+    ByteLevel,
+}
+
+/// A pre-token together with the word-cache key for its bytes, built by the scan
+/// that cut it.
+///
+/// The key is [`WordKey::NONE`] for a word the cache will not store, which the
+/// model tokenizes without probing.
+#[derive(Clone, Copy, Default)]
+pub struct KeyedSpan {
+    pub span: Span,
+    pub key: WordKey,
+}
+
+impl KeyedSpan {
+    /// An empty span with no key, for building the batch buffer in a `const`
+    /// context — [`Default`] is not usable there.
+    const ZERO: Self = Self {
+        span: Span { start: 0, end: 0 },
+        key: WordKey::NONE,
+    };
+}
+
+/// Spans per batch on the keyed path. Large enough to amortize resuming the scan,
+/// small enough that the batch and the lines it prefetched are still in cache when
+/// the model works through it.
+const KEYED_BATCH: usize = 32;
+
+/// Cut the next spans of `text` from `at`, keying each word as it is cut, and
+/// report how many spans landed in `out` and where the scan stopped. A stop at
+/// `bytes.len()` means the text is done.
+fn fill_keyed_spans(
+    scan: Scan,
+    bytes: &[u8],
+    tags: &[u8],
+    at: usize,
+    cache: &WordCache,
+    out: &mut [KeyedSpan],
+) -> (usize, usize) {
+    let mut n = 0;
+    let stopped = match scan {
+        Scan::ByteLevel => atomsplit::fsm::scan_byte_level(bytes, tags, at, |span| {
+            let key = cache.key(&bytes[span.range()]);
+            if !key.is_none() {
+                cache.prefetch(key);
+            }
+            out[n] = KeyedSpan { span, key };
+            n += 1;
+            n < out.len()
+        }),
+    };
+    (n, stopped)
+}
+
 pub trait Normalizer {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>>;
 }
@@ -70,6 +134,12 @@ pub trait Normalizer {
 pub trait PreTokenizer {
     /// Split `text` into pre-tokens, appending to `out`. Ranges are into `text`.
     fn pre_tokenize(&self, text: &str, out: &mut Vec<Span>) -> Result<()>;
+
+    /// This pre-tokenizer's resumable scan, when it has one. `None` means the
+    /// encode loop uses [`PreTokenizer::pre_tokenize`].
+    fn scan(&self) -> Option<Scan> {
+        None
+    }
 }
 
 /// The pre-tokenizers a [`PipelineTokenizer`] can run.
@@ -109,6 +179,13 @@ impl PreTokenizer for PipelinePreTokenizer {
             Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, out),
             Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
             Self::WhitespaceSplit(pretok) => pretok.pre_tokenize(text, out),
+        }
+    }
+
+    fn scan(&self) -> Option<Scan> {
+        match self {
+            Self::Split(pretok) => pretok.scan(),
+            _ => None,
         }
     }
 }
@@ -701,18 +778,30 @@ impl PipelineTokenizer {
                                 output.push(PipelineToken { id: token });
                             }
                             Segment::Text(normalized_chunk) => {
-                                if STAGE >= Self::STAGE_SPLIT {
-                                    // Pre-tokenize the chunk of normalized text
-                                    pre_tokens.clear();
-                                    self.pre_tokenizer
-                                        .pre_tokenize(normalized_chunk, pre_tokens)?;
-                                    if STAGE >= Self::STAGE_MODEL {
-                                        self.model.tokenize_spans(
-                                            normalized_chunk,
-                                            pre_tokens,
-                                            scratch,
-                                            output,
-                                        )?;
+                                if STAGE < Self::STAGE_SPLIT {
+                                    continue;
+                                }
+                                // The keyed path needs both halves: a pre-tokenizer
+                                // whose scan can be resumed, and a model with a
+                                // cache for the keys to be worth building.
+                                match self.pre_tokenizer.scan().filter(|_| {
+                                    STAGE >= Self::STAGE_MODEL && scratch.word_cache().is_some()
+                                }) {
+                                    Some(scan) => {
+                                        self.encode_keyed(scan, normalized_chunk, scratch, output)?
+                                    }
+                                    None => {
+                                        pre_tokens.clear();
+                                        self.pre_tokenizer
+                                            .pre_tokenize(normalized_chunk, pre_tokens)?;
+                                        if STAGE >= Self::STAGE_MODEL {
+                                            self.model.tokenize_spans(
+                                                normalized_chunk,
+                                                pre_tokens,
+                                                scratch,
+                                                output,
+                                            )?;
+                                        }
                                     }
                                 }
                             }
@@ -726,6 +815,51 @@ impl PipelineTokenizer {
             output.extend_from_slice(suffix);
         }
         Ok(())
+    }
+
+    /// Split and tokenize one chunk a batch of pre-tokens at a time, keying each
+    /// word inside the scan that cuts it.
+    ///
+    /// The alternative — the path every other pre-tokenizer takes — cuts the whole
+    /// chunk into a span list, then walks that list to key each word, reading every
+    /// byte of the chunk a second time. Here the key is built while the scan is
+    /// still standing on the word. Batching is what keeps that possible without
+    /// holding a key for every span of the chunk at once.
+    ///
+    /// The tags are still a pass of their own. Fusing them in would save 0.08 ns
+    /// per byte of English, measured — the scan itself costs 1.8.
+    fn encode_keyed(
+        &self,
+        scan: Scan,
+        chunk: &str,
+        scratch: &mut PipelineModelScratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        thread_local! {
+            static SCRATCH: RefCell<(Vec<u8>, [KeyedSpan; KEYED_BATCH])> =
+                const { RefCell::new((Vec::new(), [KeyedSpan::ZERO; KEYED_BATCH])) };
+        }
+        let bytes = chunk.as_bytes();
+        SCRATCH.with(|cell| {
+            let (tags, batch) = &mut *cell.borrow_mut();
+            if tags.len() < bytes.len() {
+                tags.resize(bytes.len(), 0);
+            }
+            let tags = &mut tags[..bytes.len()];
+            classify(bytes, tags);
+
+            let mut at = 0;
+            while at < bytes.len() {
+                let cache = scratch
+                    .word_cache()
+                    .expect("checked before taking the keyed path");
+                let (n, stopped) = fill_keyed_spans(scan, bytes, tags, at, cache, batch);
+                self.model
+                    .tokenize_keyed_spans(chunk, &batch[..n], scratch, output)?;
+                at = stopped;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -983,7 +1117,13 @@ pub fn split_matches(
     }
 }
 
-pub trait ModelScratch {}
+pub trait ModelScratch {
+    /// The word cache this scratch holds, when the model has one. The encode loop
+    /// needs it to key each word as the scan cuts it, before the model sees it.
+    fn word_cache(&mut self) -> Option<&mut WordCache> {
+        None
+    }
+}
 
 pub trait Model {
     type Scratch: ModelScratch;
@@ -1010,6 +1150,25 @@ pub trait Model {
     ) -> Result<()> {
         for span in spans {
             self.tokenize_pipeline(&chunk[span.range()], scratch, output)?;
+        }
+        Ok(())
+    }
+
+    /// Tokenize one batch of pre-tokens whose keys are already built, which is how
+    /// a model with a word cache is fed when the pre-tokenizer has a [`Scan`].
+    ///
+    /// The default throws the keys away and goes through
+    /// [`Model::tokenize_spans`], which is right for a model with no cache to
+    /// probe with them.
+    fn tokenize_keyed_spans(
+        &self,
+        chunk: &str,
+        spans: &[KeyedSpan],
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        for keyed in spans {
+            self.tokenize_pipeline(&chunk[keyed.span.range()], scratch, output)?;
         }
         Ok(())
     }
@@ -1049,6 +1208,30 @@ impl Model for PipelineModel {
             }
             (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
                 model.tokenize_pipeline(sequence, scratch, output)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn tokenize_keyed_spans(
+        &self,
+        chunk: &str,
+        spans: &[KeyedSpan],
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        match (self, scratch) {
+            (Self::BPE(model), PipelineModelScratch::BPE(scratch)) => {
+                model.tokenize_keyed_spans(chunk, spans, scratch, output)
+            }
+            (Self::Unigram(model), PipelineModelScratch::Unigram(scratch)) => {
+                model.tokenize_keyed_spans(chunk, spans, scratch, output)
+            }
+            (Self::WordLevel(model), PipelineModelScratch::WordLevel(scratch)) => {
+                model.tokenize_keyed_spans(chunk, spans, scratch, output)
+            }
+            (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
+                model.tokenize_keyed_spans(chunk, spans, scratch, output)
             }
             _ => unreachable!(),
         }
@@ -1111,7 +1294,16 @@ pub enum PipelineModelScratch {
     None,
 }
 
-impl ModelScratch for PipelineModelScratch {}
+impl ModelScratch for PipelineModelScratch {
+    fn word_cache(&mut self) -> Option<&mut WordCache> {
+        match self {
+            Self::BPE(scratch) => scratch.word_cache(),
+            Self::WordPiece(scratch) => scratch.word_cache(),
+            Self::Unigram(scratch) => scratch.word_cache(),
+            Self::WordLevel(_) | Self::None => None,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -396,19 +396,14 @@ pub struct PipelineTokenizer {
     scratch_pool: ScratchPool,
 }
 
-/// Working space for encoding, lent out and taken back.
+/// A pool of [`PipelineModelScratch`].
 ///
-/// Encoding needs buffers to build tokens in, and building them per call means asking the
-/// allocator for the same things over and over. So they are borrowed instead: a caller
-/// takes a scratch, hands it back when it is done, and the next caller gets one whose
-/// buffers are already as big as the last encode needed. A model empties what it uses as
-/// it goes, so a scratch comes back ready to use.
+/// When calling [`PipelineTokenizer::encode`], an instance of [`PipelineModelScratch`] is taken out of this pool
+/// and given to the tokenizer. When the encoding is done, the scratch buffer is returned to the pool and can be
+/// reused by later calls.
 ///
-/// A tokenizer encodes through `&self` and several threads may be in it at once, so a
-/// scratch cannot simply live in the tokenizer — each thread needs its own. The pool ends
-/// up holding one per thread that has encoded at the same time as the others, and frees
-/// them all with the tokenizer. A single thread encoding in a loop — the common case —
-/// borrows and returns the same one every time.
+/// The reusability matters because the scratch buffer may hold cache structures which are more useful when reused,
+/// and less importantly it saves an extra allocation for an fresh buffer every time.
 struct ScratchPool(Mutex<Vec<PipelineModelScratch>>);
 
 impl ScratchPool {
@@ -416,23 +411,31 @@ impl ScratchPool {
         Self(Mutex::new(Vec::new()))
     }
 
-    /// Borrow a scratch; dropping the guard gives it back. The lock is held just long
-    /// enough to move one out, never while encoding.
+    /// Get a scratch buffer from the pool, wrapped in a [`ScratchGuard`].
+    /// When the [`ScratchGuard`] gets dropped, the scratch buffer is pushed back to the pool.
     fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
+        // The Mutex lock is held just long enough to pop the scratch out of the pool
         let taken = self.0.lock().unwrap_or_else(PoisonError::into_inner).pop();
         ScratchGuard {
+            // If there was no scratch buffer available in the pool, we build.a fresh one
             scratch: taken.unwrap_or_else(|| model.init_scratch()),
             pool: self,
         }
     }
 
     #[cfg(test)]
-    fn stored_scratches(&self) -> usize {
+    fn len(&self) -> usize {
         self.0.lock().unwrap_or_else(PoisonError::into_inner).len()
     }
 }
 
-/// Gives the scratch back to the pool when it goes out of scope.
+/// A wrapper around [`PipelineModelScratch`].
+/// Implements [`Deref`] and [`DerefMut`], so it behaves as [`PipelineModelScratch`].
+///
+/// When it gets dropped, it pushes [`Self::scratch`] back into the shared [`Self::pool`] so it can
+/// get reused by a later call to [`PipelineTokenizer::encode`].
+///
+/// TODO @McPatate : The Mutex can create contention, to be replaced by a better access pattern
 struct ScratchGuard<'a> {
     scratch: PipelineModelScratch,
     pool: &'a ScratchPool,
@@ -440,7 +443,9 @@ struct ScratchGuard<'a> {
 
 impl Drop for ScratchGuard<'_> {
     fn drop(&mut self) {
+        // Steals the scratch buffer from self, replaces it with PipelineModelScratch::default()
         let scratch = mem::take(&mut self.scratch);
+        // Push the scratch back in the pool
         self.pool
             .0
             .lock()
@@ -1042,14 +1047,17 @@ impl Model for PipelineModel {
     }
 }
 
+/// A set of buffers and other state the model needs to encode efficiently,
+/// reused among calls to [`PipelineTokenizer::encode`].
+///
+/// Each model gets its own variant.
 #[derive(Default)]
 pub enum PipelineModelScratch {
     BPE(BpeScratch),
     WordLevel(()),
     WordPiece(WordPieceScratch),
     Unigram(UnigramScratch),
-    /// Costs nothing to build, and stands in for the real scratch while a guard is
-    /// handing it back to the pool.
+    /// We need a default value to able to use [`mem::take`] in [`ScratchGuard::drop`]
     #[default]
     None,
 }
@@ -1462,7 +1470,7 @@ mod tests {
         for _ in 0..1000 {
             pipeline.encode("hello", false).unwrap();
         }
-        assert_eq!(pipeline.scratch_pool.stored_scratches(), 1);
+        assert_eq!(pipeline.scratch_pool.len(), 1);
 
         let threads = 64;
         let all_holding = Barrier::new(threads);
@@ -1476,7 +1484,7 @@ mod tests {
             }
         });
 
-        let after_burst = pipeline.scratch_pool.stored_scratches();
+        let after_burst = pipeline.scratch_pool.len();
         assert!(
             after_burst <= threads,
             "{after_burst} scratches kept for {threads} threads"
@@ -1484,6 +1492,6 @@ mod tests {
         for _ in 0..1000 {
             pipeline.encode("hello", false).unwrap();
         }
-        assert_eq!(pipeline.scratch_pool.stored_scratches(), after_burst);
+        assert_eq!(pipeline.scratch_pool.len(), after_burst);
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -707,14 +707,12 @@ impl PipelineTokenizer {
                                     self.pre_tokenizer
                                         .pre_tokenize(normalized_chunk, pre_tokens)?;
                                     if STAGE >= Self::STAGE_MODEL {
-                                        // Tokenize each chunk
-                                        for pre_token in pre_tokens.iter() {
-                                            self.model.tokenize_pipeline(
-                                                &normalized_chunk[pre_token.range()],
-                                                scratch,
-                                                output,
-                                            )?;
-                                        }
+                                        self.model.tokenize_spans(
+                                            normalized_chunk,
+                                            pre_tokens,
+                                            scratch,
+                                            output,
+                                        )?;
                                     }
                                 }
                             }
@@ -997,6 +995,25 @@ pub trait Model {
         output: &mut Vec<PipelineToken>,
     ) -> Result<()>;
 
+    /// Tokenize every pre-token of one chunk, `spans` being ranges into `chunk`.
+    ///
+    /// The default runs [`Model::tokenize_pipeline`] over them one at a time. A
+    /// model overrides this when there is something to gain from holding the
+    /// whole batch: [`PipelineBPE`] keys a batch of words against its word cache
+    /// and asks for their slots before probing the first one.
+    fn tokenize_spans(
+        &self,
+        chunk: &str,
+        spans: &[Span],
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        for span in spans {
+            self.tokenize_pipeline(&chunk[span.range()], scratch, output)?;
+        }
+        Ok(())
+    }
+
     fn init_scratch(&self) -> Self::Scratch;
 }
 
@@ -1032,6 +1049,32 @@ impl Model for PipelineModel {
             }
             (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
                 model.tokenize_pipeline(sequence, scratch, output)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// The match below is why this override exists: it runs once per chunk rather
+    /// than once per pre-token. LLVM does not lift it out of the loop by itself.
+    fn tokenize_spans(
+        &self,
+        chunk: &str,
+        spans: &[Span],
+        scratch: &mut Self::Scratch,
+        output: &mut Vec<PipelineToken>,
+    ) -> Result<()> {
+        match (self, scratch) {
+            (Self::BPE(model), PipelineModelScratch::BPE(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
+            }
+            (Self::Unigram(model), PipelineModelScratch::Unigram(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
+            }
+            (Self::WordLevel(model), PipelineModelScratch::WordLevel(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
+            }
+            (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
+                model.tokenize_spans(chunk, spans, scratch, output)
             }
             _ => unreachable!(),
         }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -787,7 +787,7 @@ pub enum SplitPolicy {
     Isolate,
 }
 
-/// Splits `text` into same-class groups, emitting each as a [`Split`]
+/// Splits `text` into same-class groups, emitting each as a [`Span`]
 /// according to its [`SplitPolicy`].
 ///
 /// `classify` maps each char to a small `Copy + Eq` class, the current
@@ -1051,6 +1051,12 @@ impl Model for PipelineModel {
 /// reused among calls to [`PipelineTokenizer::encode`].
 ///
 /// Each model gets its own variant.
+//
+// The BPE variant holds the word cache, which makes this enum far bigger than the other
+// variants need. Boxing it would add a pointer to follow on every single pre-token, to save
+// moving those bytes twice per encode call. The cache itself is on the heap either way, so
+// moving the enum never copies it.
+#[allow(clippy::large_enum_variant)]
 #[derive(Default)]
 pub enum PipelineModelScratch {
     BPE(BpeScratch),
@@ -1493,5 +1499,21 @@ mod tests {
             pipeline.encode("hello", false).unwrap();
         }
         assert_eq!(pipeline.scratch_pool.len(), after_burst);
+    }
+
+    // Why a scratch is worth passing around at all: the word cache is only useful once it
+    // has seen some text, so it has to outlive the call that filled it. The scratch coming
+    // back from the pool must already know the words of the last encode.
+    #[test]
+    fn the_word_cache_outlives_the_encode_call() {
+        let pipeline = hello_pipeline();
+        pipeline.encode("hello", false).unwrap();
+
+        let mut scratch = pipeline.scratch_pool.get(&pipeline.model);
+        let PipelineModelScratch::BPE(bpe) = &mut *scratch else {
+            panic!("a BPE pipeline encodes with a BPE scratch");
+        };
+        let cache = bpe.word_cache.as_mut().expect("BPE encodes with a cache");
+        assert_eq!(cache.lookup(b"hello").hit(), Some(&[7u32][..]));
     }
 }

--- a/tokenizers/tk-encode/src/utils/cache.rs
+++ b/tokenizers/tk-encode/src/utils/cache.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use std::sync::RwLock;
 
 /// The default capacity for a `BPE`'s internal cache.
-pub static DEFAULT_CACHE_CAPACITY: usize = 10_000;
+pub static DEFAULT_CACHE_CAPACITY: usize = 65_536;
 /// The maximum length we should cache in a model
 /// Strings that are too long have minimal chances to cache hit anyway
 pub static MAX_LENGTH: usize = 256;

--- a/tokenizers/tk-encode/src/utils/mod.rs
+++ b/tokenizers/tk-encode/src/utils/mod.rs
@@ -1,6 +1,13 @@
 pub(crate) mod cache;
 #[cfg(feature = "http")]
 pub(crate) mod from_pretrained;
+// Public only so `examples/word_cache_bench.rs` can reach it. Hidden because
+// this is not API: the encoder gets at the cache through the models.
+#[cfg(feature = "bench-internals")]
+#[doc(hidden)]
+pub mod word_cache;
+#[cfg(not(feature = "bench-internals"))]
+pub(crate) mod word_cache;
 
 // Optional system-regex backend for arbitrary (non-atomsplit) patterns. With `fancy-regex` off a
 // stub compiles and arbitrary-regex features error at load — the atomsplit-native pre-tokenizers

--- a/tokenizers/tk-encode/src/utils/word_cache.rs
+++ b/tokenizers/tk-encode/src/utils/word_cache.rs
@@ -8,12 +8,13 @@
 //! cheaper than encoding the word, and a miss has to cost close to nothing, because
 //! every word pays for one the first time it is seen.
 //!
-//! There are three pieces. The table is `N` fixed-size slots, `N` being the
-//! requested capacity rounded up to a power of two; beside it two arenas hold what
-//! a slot is too small for:
+//! There are four pieces. The table is `N` fixed-size slots, `N` being the
+//! requested capacity rounded up to a power of two; beside it a small control byte
+//! per slot, and two arenas holding what a slot is too small for:
 //!
 //! ```text
 //!   slots     [Slot; N]      32 bytes each, one word per slot
+//!   sidecar   [Ctrl; N]      3 bytes each, everything a search reads
 //!   key_bytes Slab<u8>       the bytes of words longer than 15
 //!   ids       Slab<u32>      id runs longer than 3
 //! ```
@@ -47,40 +48,79 @@
 //! [`Placement`], which the caller returns to [`WordCache::insert`] once the
 //! model has encoded the word. So a miss costs one walk over the window, not
 //! two. Picking a slot needs exactly the reads that failing to find the word has
-//! already done, and doing it afterwards instead would mean sixteen slots and
-//! eight cache lines of repetition, plus hashing the word a second time. The
-//! caller can also drop the placement and store nothing: nothing has changed
-//! yet, and an entry only loses its slot when something is written over it.
+//! already done, and doing it afterwards instead would mean reading the window
+//! again and hashing the word a second time. The caller can also drop the
+//! placement and store nothing: nothing has changed yet, and an entry only loses
+//! its slot when something is written over it.
+//!
+//! ## The walk never reads a slot it does not need
+//!
+//! Done slot by slot, that walk reads two things from each: the key, to see
+//! whether this is the word, and a use counter, to see who should give way if
+//! none of them is. They sit at either end of a 32-byte slot, so walking a
+//! window drags 512 bytes through the cache to answer a question that is nearly
+//! always "no".
+//!
+//! So neither of them lives in the slot. Each slot has a three-byte [`Ctrl`] in
+//! the *sidecar*, and a window's worth of those is 48 bytes — one load:
+//!
+//! ```text
+//!   sidecar   ┌─────┬─────┬─────┬─────┬─  …  ─┬─────┐   48 bytes for a window
+//!             │T C E│T C E│T C E│T C E│       │T C E│
+//!             └─────┴─────┴─────┴─────┴───────┴─────┘
+//!               4     5     6     7              19
+//!
+//!     T  tag      seven bits of the word's hash, 0 when the slot is empty
+//!     C  counter  how much the word is being used
+//!     E  epoch    when that counter was written — see below
+//! ```
+//!
+//! A walk asks three questions of a window, and each is answered for all sixteen
+//! slots at once rather than one slot at a time: which slots carry this word's
+//! tag, which are empty, and — when the window is full and something has to give
+//! way — which holds the lowest score. A slot is read only once its tag has said
+//! the word might be in it. A tag is seven bits, so for a word the table does not
+//! hold, that is no slot at all about 127 times in 128.
+//!
+//! On AArch64 the load is `LD3`, which takes the 48 bytes and hands back the
+//! tags, the counters and the epochs already separated into three registers.
+//! Everywhere else a plain loop answers the same three questions. Both live in
+//! [`Window`] and hand their answers back in the same form, so the walk does not
+//! know which one ran.
+//!
+//! A tag comes from the *high* bits of the hash. The low bits already chose the
+//! home slot, so tags built from them would be equal across a window and would
+//! tell a walk nothing.
 //!
 //! # What a slot holds
 //!
-//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and a `u32` of
-//! bookkeeping called `meta`. It takes one of three shapes, depending on how long
-//! the word is and how many ids it encoded to. The first is the common case for
-//! English or code — a short word encoding to one or two tokens — and it touches
-//! nothing but the slot itself:
+//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and a byte
+//! counting how many of those payload words are token ids. It takes one of three
+//! shapes, depending on how long the word is and how many ids it encoded to. The
+//! first is the common case for English or code — a short word encoding to one or
+//! two tokens — and it touches nothing but the slot itself:
 //!
 //! ```text
 //!  (1) at most 15 bytes, at most 3 ids — the slot holds everything
 //!
 //!     b"tion" → [5378, 262]
-//!    key     │ t  i  o  n  00 … 00 │ 4 │  the word, length in the top byte
-//!    payload │ 5378 │ 262 │  ·  │         the ids, right here
-//!    meta    │ tag │ counter │ 2 │        2 of the 3 payload words are ids
+//!    key        │ t  i  o  n  00 … 00 │ 4 │  the word, length in the top byte
+//!    payload    │ 5378 │ 262 │  ·  │         the ids, right here
+//!    inline_ids │ 2 │                        2 of the 3 payload words are ids
 //!
 //!  (2) at most 15 bytes, more than 3 ids — the ids move to the arena
 //!
 //!     b"电脑" (6 bytes) → 8 ids
-//!    key     │ e7 94 b5 e8 84 91 … │ 6 │  still the word itself
-//!    payload │  ·  │  40  │ 0:8 │         8 ids, in the ids arena at 40
-//!    meta    │ tag │ counter │ SPILLED │  payload is coordinates, not ids
+//!    key        │ e7 94 b5 e8 84 91 … │ 6 │  still the word itself
+//!    payload    │  ·  │  40  │ 0:8 │         8 ids, in the ids arena at 40
+//!    inline_ids │ SPILLED │                  payload is coordinates, not ids
 //!
 //!  (3) over 15 bytes — the bytes move too, and the key becomes a hash
 //!
 //!     b"unbelievabilities" (17 bytes) → 6 ids
-//!    key     │ hash(word) │ LONG_TAG │   no room for 17 bytes
-//!    payload │  12  │  40  │ 17:6 │      17 bytes at 12, 6 ids at 40
-//!    meta    │ tag │ counter │ SPILLED │
+//!    key        │ hash(word) │ LONG_TAG │   no room for 17 bytes
+//!    payload    │  12  │  40  │ 17:6 │      17 bytes at 12, 6 ids at 40
+//!    inline_ids │ SPILLED │
 //! ```
 //!
 //! Shape (3) is the only one where a matching `key` is not proof: two different
@@ -91,12 +131,10 @@
 //! Both spilled shapes need to record two lengths — how many bytes are in
 //! `key_bytes` and how many ids are in `ids` — and both are capped by
 //! [`MAX_LENGTH`], so eleven bits each is enough and the two share `payload[2]`.
-//! Packing them there is what leaves `meta` room for the sixteen-bit `tag` the
-//! next section needs.
 //!
 //! # How an entry earns its place
 //!
-//! Every slot carries a *counter* of how much its word is being used, bumped on
+//! Every entry carries a *counter* of how much its word is being used, bumped on
 //! each hit. When a word arrives and all [`WINDOW`] slots of its window are taken,
 //! the lowest counter loses its slot.
 //!
@@ -108,13 +146,12 @@
 //! fade.
 //!
 //! Fading them by hand is the expensive way: every eviction would rewrite all
-//! sixteen counters of a window, and sixteen slots is eight cache lines. So
-//! nothing is rewritten. The cache keeps a single number — the *epoch* — and
-//! bumps it every so often; each slot records the epoch it was last written in,
-//! its *tag*. A counter is then read as
+//! sixteen counters of a window. So nothing is rewritten. The cache keeps a
+//! single number — the *epoch* — and bumps it every so often; each [`Ctrl`]
+//! records the epoch its counter was written in. A counter is then read as
 //!
 //! ```text
-//!   score = counter >> (epoch - tag)        "halved once per epoch I have missed"
+//!   score = counter >> (epoch - written_in)   "halved once per epoch I have missed"
 //! ```
 //!
 //! No stored number changes. What changes is what a stored number is worth. Two
@@ -123,16 +160,16 @@
 //! ```text
 //!   the cache is at epoch 9
 //!
-//!     A   counter 32, tag 9   →  0 epochs missed  →  score 32
-//!     B   counter 32, tag 5   →  4 epochs missed  →  score 32 >> 4 = 2
-//!                                                          ▲ B was hot once and
-//!                                                            has coasted since
+//!     A   counter 32, written in 9  →  0 epochs missed  →  score 32
+//!     B   counter 32, written in 5  →  4 epochs missed  →  score 32 >> 4 = 2
+//!                                                              ▲ B was hot once
+//!                                                                and has coasted
 //! ```
 //!
 //! A counter is one byte, so eight missed epochs take any entry to zero however
 //! hot it once was; that ceiling is [`MAX_DECAY`]. Whenever an entry *is*
-//! written — a hit, or a fresh insert — it is settled up first: its score
-//! becomes its new counter and its tag becomes the current epoch.
+//! written — a hit, or a fresh insert — it is settled up first: its score becomes
+//! its new counter, written in the current epoch.
 //!
 //! ## How often the epoch moves
 //!
@@ -150,21 +187,20 @@
 //!
 //! ## Starting the count again
 //!
-//! A tag has sixteen bits, so the epoch runs out of numbers after 65536 bumps and
-//! has to start over at zero. The moment it does, every tag written before the
-//! restart is a number larger than the epoch, and `epoch - tag` stops meaning
-//! anything: an entry idle for the whole lap would read as freshly written, at
-//! full strength, and could never be evicted again. That is dead weight forever —
-//! the exact failure fading exists to prevent.
+//! An epoch is a byte, so the count runs out of numbers after 256 bumps and has
+//! to start over at zero. The moment it does, every epoch written before the
+//! restart is a number larger than the current one, and the difference between
+//! them stops meaning anything: an entry idle for the whole lap would read as
+//! freshly written, at full strength, and could never be evicted again. That is
+//! dead weight forever — the exact failure fading exists to prevent.
 //!
 //! So the last bump of a lap does not restart the count on its own. It first
-//! walks the table, writing each live entry's score into its counter, and then
-//! puts the epoch and every tag back to zero together (see
+//! walks the sidecar, writing each live entry's score into its counter, and then
+//! puts the epoch and every [`Ctrl`] back to zero together (see
 //! [`WordCache::settle`]). No entry moves up or down against another; the
 //! differences are just cashed in while they can still be read. It is one pass
-//! over a few
-//! megabytes, once every 65536 bumps — at the default capacity, once every
-//! quarter of a billion evictions.
+//! over the sidecar every 256 bumps — at the default capacity, once every million
+//! evictions.
 //!
 //! # Where an evicted entry's space goes
 //!
@@ -249,29 +285,31 @@
 //!   Here an insert writes into space that already exists.
 //! - **A hit is two more random loads.** The key bytes and the value both live
 //!   in their own heap blocks, elsewhere in memory from the table that pointed
-//!   at them. A slot here answers the common word out of the 32 bytes the probe
-//!   has already read.
+//!   at them. A slot here answers the common word out of the 32 bytes the walk
+//!   has already decided to read.
 //! - **It cannot make room.** A `HashMap` grows until something stops it, and
 //!   the only thing it can do when stopped is refuse: the legacy cache inserts
 //!   `while local.len() < capacity`, so the words from the first pages of text
 //!   keep their places forever, however useless they turn out to be. Choosing
 //!   *which* entry to drop needs evidence about how much each one is used, and
-//!   somewhere to keep it — the counter in every slot.
+//!   somewhere to keep it — the counter in every [`Ctrl`].
 //! - **Entries cost more than twice the memory.** 24 bytes for the `String` and
 //!   24 for the value's vector inside the table, before the two heap blocks they
-//!   point at, against 32 bytes here for the common word.
+//!   point at, against 35 bytes here for the common word.
 //!
 //! A *shared* map costs more again: [`crate::utils::cache::Cache`], which the
 //! Unigram model still uses, wraps one in an `RwLock` and then has to
 //! `try_read`/`try_write` and silently drop the read or the write whenever
 //! another thread holds it.
 
-// These docs are written for someone reading the source, and link freely to the
-// module's own internals. Under `bench-internals` the module is `pub`, which
-// otherwise turns every one of those links into a rustdoc warning.
-#![allow(rustdoc::private_intra_doc_links)]
-
 use ahash::RandomState;
+
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::{
+    uint8x16_t, vceqq_u8, vdupq_n_u8, vget_lane_u64, vld3q_u8, vminq_u8, vminvq_u8, vnegq_s8,
+    vreinterpret_u64_u8, vreinterpretq_s8_u8, vreinterpretq_u16_u8, vshlq_u8, vshrn_n_u16,
+    vsubq_u8,
+};
 
 /// Longest word the cache will store, in bytes.
 ///
@@ -285,6 +323,9 @@ const MAX_LENGTH: usize = 1024;
 /// Slots searched from a word's home position. Linear probing normally settles
 /// in one or two, but the walk has to stop somewhere: nothing is ever removed,
 /// so a saturated table would otherwise scan forever looking for an empty slot.
+///
+/// Sixteen is also how many bytes a vector register holds, so a window's worth
+/// of [`Ctrl`] tags is one comparison rather than sixteen — see [`Window`].
 const WINDOW: usize = 16;
 /// Ids carried in the slot itself — three `u32`s is what fits beside the key.
 /// Enough for 80-96% of lookups on English or code, but only about a quarter of
@@ -293,28 +334,29 @@ const WINDOW: usize = 16;
 const INLINE_IDS: usize = 3;
 /// Set in `key` when it holds the hash of a long word instead of the word
 /// itself. Packed keys carry their length (1..=15) in the top byte, so a hashed
-/// key can never be mistaken for a packed one, and neither can be 0 — the
-/// empty-slot marker.
+/// key can never be mistaken for a packed one.
 const LONG_TAG: u128 = 1 << 127;
 
-/// The id count in `Slot::meta` when the ids did not fit in the slot and went
-/// to the arena instead.
+/// The id count in [`Slot::inline_ids`] when the ids did not fit in the slot and
+/// went to the arena instead.
 const SPILLED: u8 = u8::MAX;
-/// Where `counter` starts in `Slot::meta`. It is a byte wide, hence
-/// [`MAX_DECAY`].
-const COUNTER_SHIFT: u32 = 8;
-/// Highest counter an entry can reach. Hits past this are not counted; an entry
-/// that busy is in no danger anyway.
-const COUNTER_MAX: u32 = u8::MAX as u32;
 /// What a newly stored entry's counter starts at.
-const NEWBORN: u32 = 1;
-/// Where `tag` starts in `Slot::meta`, and the highest epoch one can hold —
-/// a lap of 65536, after which [`WordCache::settle`] starts the count again.
-const TAG_SHIFT: u32 = 16;
-const TAG_MASK: u32 = 0xFFFF;
+const NEWBORN: u8 = 1;
+/// Highest epoch a [`Ctrl`] can hold — a lap of 256, after which
+/// [`WordCache::settle`] starts the count again.
+const EPOCH_MAX: u8 = u8::MAX;
 /// Missing this many epochs takes any counter to zero, because a counter is a
-/// byte. Shifting further would be both pointless and undefined.
-const MAX_DECAY: u32 = 8;
+/// byte.
+const MAX_DECAY: u8 = 8;
+
+/// The [`Ctrl::tag`] of a slot nothing has ever been stored in.
+const EMPTY: u8 = 0;
+/// Set in [`Ctrl::tag`] beside the hash bits, so a live entry's tag is never
+/// [`EMPTY`].
+const OCCUPIED: u8 = 0x80;
+/// How many bits of the hash a tag carries. Seven, because the eighth is
+/// [`OCCUPIED`]; a walk therefore reads a slot it did not want once in 128.
+const TAG_BITS: u32 = 7;
 
 /// Bits per length in a spilled entry's `payload[2]`, which packs the key's byte
 /// count above the id count. Both are capped by [`MAX_LENGTH`].
@@ -342,70 +384,67 @@ fn pack_word(word: &[u8]) -> Option<u128> {
     Some(u128::from_le_bytes(lanes) | ((len as u128) << 120))
 }
 
+/// The [`Ctrl::tag`] a hash gives its slot.
+///
+/// The top of the hash, because the bottom of it already chose the home slot: a
+/// tag built from those bits would be the same for every slot the word can reach
+/// and would tell a walk nothing.
+fn ctrl_tag(hash: u64) -> u8 {
+    OCCUPIED | (hash >> (u64::BITS - TAG_BITS)) as u8
+}
+
+/// What a walk reads, kept out of [`Slot`] so that reading it is not reading the
+/// slots. There is one per slot, in [`WordCache::sidecar`].
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+#[repr(C)]
+struct Ctrl {
+    /// Bits of the word's hash, or [`EMPTY`]. See [`ctrl_tag`].
+    tag: u8,
+    /// How much the word is being used, as of `epoch`.
+    counter: u8,
+    /// The epoch `counter` was written in.
+    epoch: u8,
+}
+
+const _: () = assert!(std::mem::size_of::<Ctrl>() == 3);
+
+impl Ctrl {
+    /// What this entry's counter is worth at `epoch`: what was written down,
+    /// halved once for every epoch that has gone by since.
+    ///
+    /// `self.epoch` is never ahead of `epoch` — both are reset together by
+    /// [`WordCache::settle`] — so the subtraction cannot go below zero.
+    fn score(&self, epoch: u8) -> u8 {
+        // Widened because shifting a `u8` by MAX_DECAY is shifting it by its own
+        // width, which Rust leaves undefined.
+        (self.counter as u32 >> (epoch - self.epoch).min(MAX_DECAY)) as u8
+    }
+}
+
 /// One entry, in the three shapes the module docs draw out. In short:
 ///
 /// - `key` is the word itself when it fits in 15 bytes, otherwise its hash with
 ///   [`LONG_TAG`] set.
-/// - `payload` is the token ids while `meta`'s low byte counts them, and becomes
+/// - `payload` is the token ids while `inline_ids` counts them, and becomes
 ///   `[key_off, ids_off, packed lengths]` once that byte is [`SPILLED`] — which
 ///   is what the `key_off`/`ids_off`/`key_len`/`ids_len` readers below are for.
-/// - `meta` also carries how much the entry is being used, as the counter and
-///   tag the module docs describe.
 ///
-/// That the size is 32 bytes is the point of the layout — a hit reads the key,
-/// the ids and the bookkeeping in one go, and two slots share a cache line.
+/// Nothing in here is read until the slot's [`Ctrl`] has said the word might be
+/// in it.
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
 struct Slot {
     key: u128,
     payload: [u32; INLINE_IDS],
-    /// Three fields in one word:
-    ///
-    /// ```text
-    ///  bit 31            16 15         8 7          0
-    ///     │ tag        16 │ counter   8 │ ids      8 │
-    /// ```
-    meta: u32,
+    /// How many of `payload`'s words are token ids, or [`SPILLED`].
+    inline_ids: u8,
 }
 
 const _: () = assert!(std::mem::size_of::<Slot>() == 32);
 
 impl Slot {
-    fn is_empty(&self) -> bool {
-        self.key == 0
-    }
-
-    /// How many of `payload`'s words are token ids, or [`SPILLED`].
-    fn inline_ids(&self) -> u8 {
-        self.meta as u8
-    }
-
     fn spilled(&self) -> bool {
-        self.inline_ids() == SPILLED
-    }
-
-    fn counter(&self) -> u32 {
-        (self.meta >> COUNTER_SHIFT) & COUNTER_MAX
-    }
-
-    fn tag(&self) -> u32 {
-        self.meta >> TAG_SHIFT
-    }
-
-    /// What this entry's counter is worth at `epoch`: what was written down,
-    /// halved once for every epoch that has gone by since.
-    ///
-    /// A tag is never ahead of the epoch — both are reset together by
-    /// [`WordCache::settle`] — so the subtraction cannot go below zero.
-    fn score(&self, epoch: u32) -> u32 {
-        let missed = epoch - self.tag();
-        self.counter() >> missed.min(MAX_DECAY)
-    }
-
-    /// Write down a counter and the epoch it was written in, leaving the id
-    /// count alone.
-    fn stamp(&mut self, counter: u32, epoch: u32) {
-        self.meta = self.inline_ids() as u32 | counter << COUNTER_SHIFT | epoch << TAG_SHIFT;
+        self.inline_ids == SPILLED
     }
 
     fn key_off(&self) -> u32 {
@@ -422,6 +461,132 @@ impl Slot {
 
     fn key_len(&self) -> usize {
         (self.payload[2] >> PACKED_LEN_BITS) as usize
+    }
+}
+
+/// The first step a window's answer is `true` for, or [`WINDOW`] when it is
+/// true for none.
+///
+/// Every [`Window`] question comes back as one nibble per slot, `0xF` for true
+/// and `0` for false, lowest slot in the lowest nibble. A nibble each rather
+/// than a bit each because that is what AArch64 can narrow a vector comparison
+/// to in one instruction, and answering in the same form on both targets is what
+/// keeps the walk itself free of either.
+fn first_step(mask: u64) -> usize {
+    mask.trailing_zeros() as usize / 4
+}
+
+/// Clears the nibble `step` holds.
+fn without_step(mask: u64, step: usize) -> u64 {
+    mask & !(0xF << (step * 4))
+}
+
+/// The [`Ctrl`]s of one window, and the three questions a walk asks of them.
+///
+/// Every question is answered for all [`WINDOW`] slots at once. On AArch64 that
+/// is [`NeonWindow`]; everywhere else [`ScalarWindow`] loops. The two are held to
+/// the same answers by `the_neon_window_answers_what_the_scalar_one_does`.
+#[cfg(target_arch = "aarch64")]
+type Window = NeonWindow;
+#[cfg(not(target_arch = "aarch64"))]
+type Window = ScalarWindow;
+
+/// Compiled on AArch64 too, where only the test above uses it: it is what
+/// [`NeonWindow`] is checked against, and a copy that never builds would rot.
+#[cfg_attr(target_arch = "aarch64", cfg(test))]
+struct ScalarWindow([Ctrl; WINDOW]);
+
+#[cfg_attr(target_arch = "aarch64", cfg(test))]
+impl ScalarWindow {
+    /// One nibble per slot, in the order [`first_step`] reads them.
+    fn nibbles(&self, holds: impl Fn(&Ctrl) -> bool) -> u64 {
+        (0..WINDOW).fold(0, |mask, i| {
+            if holds(&self.0[i]) {
+                mask | 0xF << (i * 4)
+            } else {
+                mask
+            }
+        })
+    }
+
+    fn load(ctrl: &[Ctrl; WINDOW]) -> Self {
+        Self(*ctrl)
+    }
+
+    fn matching(&self, tag: u8) -> u64 {
+        self.nibbles(|ctrl| ctrl.tag == tag)
+    }
+
+    fn empty(&self) -> u64 {
+        self.nibbles(|ctrl| ctrl.tag == EMPTY)
+    }
+
+    fn coldest(&self, epoch: u8) -> usize {
+        // `min_by_key` keeps the first of equal keys, which is what sends a tie
+        // to the slot nearest home.
+        (0..WINDOW).min_by_key(|&i| self.0[i].score(epoch)).unwrap()
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+struct NeonWindow {
+    tags: uint8x16_t,
+    counters: uint8x16_t,
+    epochs: uint8x16_t,
+}
+
+#[cfg(target_arch = "aarch64")]
+impl NeonWindow {
+    /// Vector instructions are part of the AArch64 baseline, so there is nothing
+    /// to detect and no run-time choice to make between this and
+    /// [`ScalarWindow`].
+    fn load(ctrl: &[Ctrl; WINDOW]) -> Self {
+        // SAFETY: `LD3` reads three lanes of sixteen bytes, and a `Ctrl` is three
+        // bytes with no padding, so a `[Ctrl; WINDOW]` is exactly those 48 bytes.
+        let window = unsafe { vld3q_u8(ctrl.as_ptr().cast()) };
+        Self {
+            tags: window.0,
+            counters: window.1,
+            epochs: window.2,
+        }
+    }
+
+    /// A comparison result in the form [`first_step`] reads.
+    ///
+    /// AArch64 has no instruction that collects one bit per lane. `SHRN` narrows
+    /// the sixteen `0xFF`/`0x00` lanes into sixteen nibbles of one 64-bit
+    /// register, which is the same answer in the same order — and is why the
+    /// answers are nibbles rather than bits.
+    fn mask(compared: uint8x16_t) -> u64 {
+        unsafe {
+            vget_lane_u64::<0>(vreinterpret_u64_u8(vshrn_n_u16::<4>(vreinterpretq_u16_u8(
+                compared,
+            ))))
+        }
+    }
+
+    fn matching(&self, tag: u8) -> u64 {
+        unsafe { Self::mask(vceqq_u8(self.tags, vdupq_n_u8(tag))) }
+    }
+
+    fn empty(&self) -> u64 {
+        unsafe { Self::mask(vceqq_u8(self.tags, vdupq_n_u8(EMPTY))) }
+    }
+
+    fn coldest(&self, epoch: u8) -> usize {
+        unsafe {
+            let missed = vminq_u8(
+                vsubq_u8(vdupq_n_u8(epoch), self.epochs),
+                vdupq_n_u8(MAX_DECAY),
+            );
+            // `USHL` shifts right on a negative count, and gives zero once that
+            // count reaches the lane width — the same ceiling MAX_DECAY sets.
+            let score = vshlq_u8(self.counters, vnegq_s8(vreinterpretq_s8_u8(missed)));
+            let lowest = vdupq_n_u8(vminvq_u8(score));
+            // The first lane holding the minimum, so a tie goes to the slot
+            // nearest home exactly as it does in `ScalarWindow::coldest`.
+            first_step(Self::mask(vceqq_u8(score, lowest)))
+        }
     }
 }
 
@@ -506,14 +671,15 @@ impl<'c> Lookup<'c, '_> {
 
 /// Where a word that missed will go, and what [`WordCache::insert`] needs to put
 /// it there. Found by the walk that missed, so storing the word costs no second
-/// hash and no second walk over its window.
+/// hash and no second read of the window.
 ///
 /// It carries the word rather than letting `insert` take it again, because the
-/// slot and the key inside were chosen for *this* word: handing back a different
-/// one would file its ids under the first word's name.
+/// slot, the key and the tag inside were chosen for *this* word: handing back a
+/// different one would file its ids under the first word's name.
 pub struct Placement<'w> {
     index: usize,
     key: u128,
+    tag: u8,
     word: &'w [u8],
 }
 
@@ -528,17 +694,21 @@ enum Probe {
 pub struct WordCache {
     hasher: RandomState,
     slots: Box<[Slot]>,
+    /// One [`Ctrl`] per slot, and then a copy of the first [`WINDOW`] of them, so
+    /// that the window of any home is `WINDOW` entries in a row and can be read
+    /// with a single load. [`WordCache::write_ctrl`] keeps the copy in step.
+    sidecar: Box<[Ctrl]>,
     key_bytes: Slab<u8>,
     ids: Slab<u32>,
     /// `slots.len() - 1`. The table is a power of two, so this folds a hash into
     /// a slot index.
     mask: usize,
-    /// Where the fade count stands, from 0 to [`TAG_MASK`] and no higher. A
-    /// slot's `tag` is what this held when the slot was last written, so
-    /// `epoch - tag` is how many fades that entry has sat through.
-    /// [`WordCache::settle`] puts the epoch and every tag back to zero together
+    /// Where the fade count stands, from 0 to [`EPOCH_MAX`] and no higher. A
+    /// [`Ctrl::epoch`] is what this held when that entry was last written, so the
+    /// difference between them is how many fades it has sat through.
+    /// [`WordCache::settle`] puts this and every `Ctrl` back to zero together
     /// when the count runs out of room.
-    epoch: u32,
+    epoch: u8,
     /// Evictions still to come before the next `epoch` bump.
     countdown: u32,
     /// Evictions per `epoch` bump — see the module docs on how often the epoch
@@ -553,6 +723,7 @@ impl WordCache {
         Self {
             hasher: RandomState::new(),
             slots: vec![Slot::default(); n_slots].into_boxed_slice(),
+            sidecar: vec![Ctrl::default(); n_slots + WINDOW].into_boxed_slice(),
             // Ceilings, not reservations: the arenas grow only as far as the live
             // set takes them. Deliberately generous, so that the slot table is
             // what runs out first — an arena that turns inserts away while slots
@@ -581,37 +752,59 @@ impl WordCache {
         let index = match self.probe(key, hash, word) {
             Probe::Hit(index) => {
                 let epoch = self.epoch;
-                let counter = (self.slots[index].score(epoch) + 1).min(COUNTER_MAX);
-                self.slots[index].stamp(counter, epoch);
+                let ctrl = self.sidecar[index];
+                // Saturating, so hits past what a byte holds are not counted. An
+                // entry that busy is in no danger of eviction anyway.
+                let counter = ctrl.score(epoch).saturating_add(1);
+                self.write_ctrl(
+                    index,
+                    Ctrl {
+                        counter,
+                        epoch,
+                        ..ctrl
+                    },
+                );
                 let slot = self.slots[index];
                 return Lookup::Hit(if slot.spilled() {
                     self.ids.get(slot.ids_off(), slot.ids_len())
                 } else {
-                    &self.slots[index].payload[..slot.inline_ids() as usize]
+                    &self.slots[index].payload[..slot.inline_ids as usize]
                 });
             }
             Probe::Miss(index) => index,
         };
-        Lookup::Miss(Some(Placement { index, key, word }))
+        Lookup::Miss(Some(Placement {
+            index,
+            key,
+            tag: ctrl_tag(hash),
+            word,
+        }))
     }
 
     /// Remember what the word encoded to, in the slot its [`WordCache::lookup`]
     /// picked out. Silently does nothing when an arena is full: a cache is free
     /// to forget, and the caller has the ids either way.
     pub fn insert(&mut self, at: Placement<'_>, ids: impl ExactSizeIterator<Item = u32>) {
-        let Some(mut entry) = self.build_entry(at.key, at.word, ids) else {
+        let Some(entry) = self.build_entry(at.key, at.word, ids) else {
             return;
         };
         // A slot that is not empty belongs to somebody else, so this is an
         // eviction: give the arena runs back and charge the table one round of
         // fading. Both wait until here, so a lookup whose caller decides not to
         // store anything after all costs the entry sitting there nothing.
-        if !self.slots[at.index].is_empty() {
+        if self.sidecar[at.index].tag != EMPTY {
             self.reclaim(at.index);
             self.fade();
         }
         // Fading moves the epoch, so stamp the new entry after it.
-        entry.stamp(NEWBORN, self.epoch);
+        self.write_ctrl(
+            at.index,
+            Ctrl {
+                tag: at.tag,
+                counter: NEWBORN,
+                epoch: self.epoch,
+            },
+        );
         self.slots[at.index] = entry;
     }
 
@@ -633,49 +826,60 @@ impl WordCache {
         }
     }
 
-    /// One walk of `word`'s window, from its home position, answering both
+    /// The [`Ctrl`]s of the window starting at `home`, in the form a walk reads
+    /// them. The mirrored tail of `sidecar` is what makes the slice contiguous
+    /// for every `home`.
+    fn window(&self, home: usize) -> Window {
+        let ctrl: &[Ctrl; WINDOW] = self.sidecar[home..home + WINDOW].try_into().unwrap();
+        Window::load(ctrl)
+    }
+
+    /// One walk over `word`'s window, from its home position, answering both
     /// questions a lookup has: which slot holds the word, and — if none does —
     /// which slot it should take.
     ///
-    /// The second answer is free. Finding the word means reading every slot in
-    /// the window until it turns up, and the slot a miss wants is the first empty
-    /// one or the lowest-scoring one, both of which fall out of the same reads.
-    /// Working it out later would mean walking the same sixteen slots again, and
-    /// sixteen slots is eight cache lines.
+    /// The second answer is free. Both come out of the window's [`Ctrl`]s, which
+    /// are one load; working the second one out afterwards would mean reading
+    /// them again and hashing the word again.
     ///
     /// Stopping at the first empty slot is safe because slots never go back to
     /// being empty: an empty one means the word was never stored.
     fn probe(&self, key: u128, hash: u64, word: &[u8]) -> Probe {
+        let home = hash as usize & self.mask;
+        let window = self.window(home);
+        let empty = window.empty();
+        // Nothing past the first empty slot can hold the word: the walk that
+        // stored it would have stopped there and taken that slot.
+        let before_empty = 1u64
+            .checked_shl(empty.trailing_zeros())
+            .map_or(u64::MAX, |bit| bit - 1);
+        let mut candidates = window.matching(ctrl_tag(hash)) & before_empty;
         // Only a hashed key can turn out to belong to a different word, and
         // whether this one is hashed is settled before the walk starts — the
         // caller built the key out of the word it is looking for.
         let hashed = key & LONG_TAG != 0;
-        let mut coldest = hash as usize & self.mask;
-        let mut lowest = u32::MAX;
-        for step in 0..WINDOW {
-            let index = (hash as usize + step) & self.mask;
+        while candidates != 0 {
+            let step = first_step(candidates);
+            let index = (home + step) & self.mask;
             let slot = &self.slots[index];
-            if slot.is_empty() {
-                return Probe::Miss(index);
-            }
             if slot.key == key
                 && (!hashed || self.key_bytes.get(slot.key_off(), slot.key_len()) == word)
             {
                 return Probe::Hit(index);
             }
-            let score = slot.score(self.epoch);
-            if score < lowest {
-                lowest = score;
-                coldest = index;
-            }
+            candidates = without_step(candidates, step);
         }
-        Probe::Miss(coldest)
+        let step = if empty == 0 {
+            window.coldest(self.epoch)
+        } else {
+            first_step(empty)
+        };
+        Probe::Miss((home + step) & self.mask)
     }
 
     /// The entry to store, with whatever does not fit in a slot copied into the
-    /// arenas, and `meta` holding only the id count — [`WordCache::insert`]
-    /// stamps the rest. `None` when an arena is full, so a rejected insert leaves
-    /// the table and the arenas exactly as they were.
+    /// arenas. `None` when an arena is full, so a rejected insert leaves the
+    /// table and the arenas exactly as they were.
     fn build_entry(
         &mut self,
         key: u128,
@@ -692,7 +896,7 @@ impl WordCache {
             return Some(Slot {
                 key,
                 payload,
-                meta: ids_len as u32,
+                inline_ids: ids_len as u8,
             });
         }
         // A short word stays in the key, which is a zero-length run here.
@@ -708,8 +912,17 @@ impl WordCache {
         Some(Slot {
             key,
             payload: [key_off, ids_off, lengths],
-            meta: SPILLED as u32,
+            inline_ids: SPILLED,
         })
+    }
+
+    /// Write a slot's [`Ctrl`], and the copy of it in the mirrored tail when the
+    /// slot is one of the first [`WINDOW`].
+    fn write_ctrl(&mut self, index: usize, ctrl: Ctrl) {
+        self.sidecar[index] = ctrl;
+        if index < WINDOW {
+            self.sidecar[self.slots.len() + index] = ctrl;
+        }
     }
 
     /// One eviction's worth of fading: step the countdown, and move the epoch on
@@ -720,7 +933,7 @@ impl WordCache {
             return;
         }
         self.countdown = self.epoch_length;
-        if self.epoch == TAG_MASK {
+        if self.epoch == EPOCH_MAX {
             self.settle();
         } else {
             self.epoch += 1;
@@ -728,21 +941,24 @@ impl WordCache {
     }
 
     /// Spend every entry's outstanding fade and start the count again: each live
-    /// entry's score becomes its counter, and the epoch and every tag go back to
-    /// zero.
+    /// entry's score becomes its counter, and the epoch and every [`Ctrl`] go
+    /// back to zero.
     ///
-    /// Run on the last epoch a tag can hold, and only then. The epoch has to
-    /// start over at some point, and the moment it does, `epoch - tag` stops
-    /// meaning anything for entries stamped before the restart. So the
-    /// differences are cashed in first, while they are still readable.
+    /// Run on the last epoch a `Ctrl` can hold, and only then. The epoch has to
+    /// start over at some point, and the moment it does, the difference between
+    /// it and a stored epoch stops meaning anything for entries written before
+    /// the restart. So the differences are cashed in first, while they can still
+    /// be read.
     fn settle(&mut self) {
         let epoch = self.epoch;
-        for slot in self.slots.iter_mut() {
-            if slot.is_empty() {
+        // The mirrored tail is a copy of the front, so one pass over the whole
+        // sidecar leaves the two in step without a second walk.
+        for ctrl in self.sidecar.iter_mut() {
+            if ctrl.tag == EMPTY {
                 continue;
             }
-            let score = slot.score(epoch);
-            slot.stamp(score, 0);
+            ctrl.counter = ctrl.score(epoch);
+            ctrl.epoch = 0;
         }
         self.epoch = 0;
     }
@@ -787,7 +1003,10 @@ impl WordCache {
     /// How many slots hold an entry. Equal to the capacity once the table is
     /// saturated, which is the state the eviction measurements need.
     pub fn bench_occupancy(&self) -> usize {
-        self.slots.iter().filter(|slot| !slot.is_empty()).count()
+        self.sidecar[..self.slots.len()]
+            .iter()
+            .filter(|ctrl| ctrl.tag != EMPTY)
+            .count()
     }
 }
 
@@ -797,11 +1016,7 @@ mod tests {
 
     /// Look a word up and store what it encoded to, for tests that care about
     /// what the table ends up holding rather than about the two steps.
-    pub(super) fn store(
-        cache: &mut WordCache,
-        word: &[u8],
-        ids: impl ExactSizeIterator<Item = u32>,
-    ) {
+    fn store(cache: &mut WordCache, word: &[u8], ids: impl ExactSizeIterator<Item = u32>) {
         let at = match cache.lookup(word) {
             Lookup::Miss(at) => at,
             Lookup::Hit(_) => None,
@@ -831,19 +1046,26 @@ mod tests {
         assert_eq!(cache.lookup(b"hell").hit(), None);
     }
 
-    /// The three properties the whole key encoding rests on: a packed key is
-    /// unique per word, is never `0` (the empty-slot marker), and never looks
-    /// like a hashed key.
+    /// The two properties the key encoding rests on: a packed key is unique per
+    /// word, and never looks like a hashed one.
     #[test]
     fn packed_keys_are_unique_and_tagged() {
         assert_ne!(pack_word(b"a"), pack_word(b"a\0"));
-        assert_ne!(pack_word(&[0u8; 15]), Some(0));
         assert_eq!(pack_word(&[0u8; 15]).unwrap() & LONG_TAG, 0);
         assert_eq!(pack_word(b""), None);
         assert_eq!(pack_word(&[b'x'; 16]), None);
     }
 
-    /// A short word's placement now comes out of its packed key rather than its
+    /// A live entry's tag has to be something [`EMPTY`] is not, or a walk reads
+    /// an occupied slot as the end of the chain and stores on top of it.
+    #[test]
+    fn a_live_tag_is_never_the_empty_marker() {
+        for hash in [0u64, 1, u64::MAX, 1 << 57, u64::MAX >> TAG_BITS] {
+            assert_ne!(ctrl_tag(hash), EMPTY, "hash {hash:#x}");
+        }
+    }
+
+    /// A short word's placement comes out of its packed key rather than its
     /// bytes, which leaves the hash doing all of the mixing. Words that differ in
     /// one byte pack to keys that differ in one byte, so an index taken from those
     /// bits as they are — `packed as u64` — drops most of these on one slot.
@@ -905,10 +1127,39 @@ mod tests {
         assert_eq!(cache.lookup(&word).hit(), Some(&ids[..]));
     }
 
+    /// A tag is seven bits, so one slot in 128 answers for a word that is not in
+    /// it. That is too rare to wait for, so forge one: put a word's tag on a slot
+    /// holding a different key, and demand the walk look past it rather than
+    /// treat the tag as the answer.
+    #[test]
+    fn a_tag_collision_is_confirmed_against_the_key() {
+        let mut cache = WordCache::new(WINDOW);
+        let (_, hash) = cache.slot_key(b"beta");
+        let decoy = hash as usize & cache.mask;
+        cache.write_ctrl(
+            decoy,
+            Ctrl {
+                tag: ctrl_tag(hash),
+                counter: NEWBORN,
+                epoch: 0,
+            },
+        );
+        // Any key that is not beta's. A packed key always carries a length in its
+        // top byte, so 1 cannot be one.
+        cache.slots[decoy] = Slot {
+            key: 1,
+            payload: [7, 0, 0],
+            inline_ids: 1,
+        };
+
+        store(&mut cache, b"beta", [2u32].into_iter());
+        assert_eq!(cache.lookup(b"beta").hit(), Some(&[2u32][..]));
+    }
+
     /// Two long words can hash to the same key, and then only their bytes tell
     /// them apart. Real hash collisions are too rare to write a test around, so
-    /// forge one: park another word's entry on this word's home slot and stamp
-    /// this word's key on it. The lookup has to walk past it.
+    /// forge one: park another word's entry on this word's home slot, stamp this
+    /// word's key and tag on it, and demand the walk look past it.
     #[test]
     fn a_hashed_key_is_confirmed_against_the_word_bytes() {
         let mut cache = WordCache::new(1 << 8);
@@ -916,12 +1167,22 @@ mod tests {
         let theirs = vec![b'b'; 40];
 
         store(&mut cache, &theirs, [7u32].into_iter());
-        let their_slot = cache.slots[slot_of(&cache, &theirs).unwrap()];
+        let their_index = slot_of(&cache, &theirs).unwrap();
+        let their_slot = cache.slots[their_index];
+        let their_ctrl = cache.sidecar[their_index];
         let (my_key, my_hash) = cache.slot_key(&mine);
-        cache.slots[my_hash as usize & cache.mask] = Slot {
+        let my_home = my_hash as usize & cache.mask;
+        cache.slots[my_home] = Slot {
             key: my_key,
             ..their_slot
         };
+        cache.write_ctrl(
+            my_home,
+            Ctrl {
+                tag: ctrl_tag(my_hash),
+                ..their_ctrl
+            },
+        );
 
         store(&mut cache, &mine, [1u32, 2].into_iter());
         assert_eq!(cache.lookup(&mine).hit(), Some(&[1u32, 2][..]));
@@ -964,38 +1225,59 @@ mod tests {
     fn an_abandoned_entry_fades_without_being_touched() {
         let mut cache = WordCache::new(WINDOW);
         store(&mut cache, b"hot", [1u32].into_iter());
-        for _ in 0..COUNTER_MAX {
+        for _ in 0..u8::MAX {
             cache.lookup(b"hot").hit();
         }
         let index = slot_of(&cache, b"hot").unwrap();
-        assert_eq!(cache.slots[index].score(cache.epoch), COUNTER_MAX);
+        assert_eq!(cache.sidecar[index].score(cache.epoch), u8::MAX);
 
         for _ in 0..MAX_DECAY {
             cache.fade();
         }
-        assert_eq!(cache.slots[index].score(cache.epoch), 0);
+        assert_eq!(cache.sidecar[index].score(cache.epoch), 0);
     }
 
-    /// A tag is sixteen bits, so the epoch has to start over at zero every 65536
-    /// bumps. An entry stamped before the restart carries a tag larger than the
-    /// epoch, and left to itself the coldest thing in the table would come out
-    /// reading as the hottest and could never be evicted again.
+    /// An epoch is a byte, so the count has to start over at zero every 256
+    /// bumps. An entry written before the restart carries an epoch larger than
+    /// the current one, and left to itself the coldest thing in the table would
+    /// come out reading as the hottest and could never be evicted again.
     #[test]
     fn a_lap_of_the_epoch_does_not_make_a_stale_entry_look_hot() {
         let mut cache = WordCache::new(WINDOW);
         store(&mut cache, b"stale", [1u32].into_iter());
-        for _ in 0..COUNTER_MAX {
+        for _ in 0..u8::MAX {
             cache.lookup(b"stale").hit();
         }
         let index = slot_of(&cache, b"stale").unwrap();
 
         // One slot per window here, so one eviction is one epoch.
         assert_eq!(cache.epoch_length, 1);
-        for _ in 0..=TAG_MASK {
+        for _ in 0..=EPOCH_MAX {
             cache.fade();
         }
         assert_eq!(cache.epoch, 0, "the lap did not start over");
-        assert_eq!(cache.slots[index].score(cache.epoch), 0);
+        assert_eq!(cache.sidecar[index].score(cache.epoch), 0);
+    }
+
+    /// The tail of the sidecar is a copy of its first [`WINDOW`] entries, so that
+    /// a window starting near the end of the table is still `WINDOW` entries in a
+    /// row. Every write has to keep the two in step, or a walk whose window
+    /// crosses the seam reads control bytes that no longer describe the slots.
+    #[test]
+    fn the_mirrored_tail_tracks_the_front() {
+        let mut cache = WordCache::new(64);
+        let n = cache.slots.len();
+        for i in 0..500usize {
+            store(
+                &mut cache,
+                format!("w{i}").as_bytes(),
+                [i as u32].into_iter(),
+            );
+            assert_eq!(cache.sidecar[..WINDOW], cache.sidecar[n..], "insert {i}");
+        }
+        // A settle rewrites every live entry, and has to leave the two in step too.
+        cache.settle();
+        assert_eq!(cache.sidecar[..WINDOW], cache.sidecar[n..], "after settle");
     }
 
     /// Reusing an evicted entry's arena run is where this design can go wrong:
@@ -1048,5 +1330,60 @@ mod tests {
         );
         assert!(cache.key_bytes.data.len() <= 65 * 35);
         assert!(cache.ids.data.len() <= 65 * 8);
+    }
+
+    /// Control bytes covering what a window can present: empty slots, repeated
+    /// tags, counters at both ends, and epochs far enough back to reach
+    /// [`MAX_DECAY`].
+    fn sample_window(seed: u64) -> [Ctrl; WINDOW] {
+        let mut state = seed | 1;
+        let mut next = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        std::array::from_fn(|_| {
+            let n = next();
+            Ctrl {
+                tag: if n % 5 == 0 {
+                    EMPTY
+                } else {
+                    n as u8 | OCCUPIED
+                },
+                counter: (n >> 8) as u8,
+                epoch: ((n >> 16) % 200) as u8,
+            }
+        })
+    }
+
+    /// [`ScalarWindow`] is the definition and [`NeonWindow`] is an implementation
+    /// of it, so anything they disagree about is a bug in the vector path that no
+    /// other test would separate from a bug in the walk.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn the_neon_window_answers_what_the_scalar_one_does() {
+        for seed in 0..64u64 {
+            let ctrl = sample_window(seed);
+            let neon = NeonWindow::load(&ctrl);
+            let scalar = ScalarWindow::load(&ctrl);
+            assert_eq!(neon.empty(), scalar.empty(), "empty, seed {seed}");
+            for tag in [EMPTY, OCCUPIED, 0xC3, 0xFF, ctrl[0].tag, ctrl[9].tag] {
+                assert_eq!(
+                    neon.matching(tag),
+                    scalar.matching(tag),
+                    "matching {tag:#x}, seed {seed}"
+                );
+            }
+            // `sample_window` stops at 199, so every epoch here is at or past
+            // every entry's and the decay subtraction stays in range.
+            for epoch in [200u8, 201, EPOCH_MAX] {
+                assert_eq!(
+                    neon.coldest(epoch),
+                    scalar.coldest(epoch),
+                    "coldest at {epoch}, seed {seed}"
+                );
+            }
+        }
     }
 }

--- a/tokenizers/tk-encode/src/utils/word_cache.rs
+++ b/tokenizers/tk-encode/src/utils/word_cache.rs
@@ -1,0 +1,1052 @@
+//! Remembers the token ids a word encodes to, so a model only has to work it out once.
+//!
+//! Text repeats itself: a few thousand distinct words usually cover nearly every
+//! word of a document, and turning one of them into ids — merging pairs in BPE,
+//! searching the lattice in Unigram — is the most expensive thing a model does. So
+//! the second time a word shows up, the answer should come from a table instead of
+//! from the model. Both sides of that table are on the hot path: a hit has to be far
+//! cheaper than encoding the word, and a miss has to cost close to nothing, because
+//! every word pays for one the first time it is seen.
+//!
+//! There are three pieces. The table is `N` fixed-size slots, `N` being the
+//! requested capacity rounded up to a power of two; beside it two arenas hold what
+//! a slot is too small for:
+//!
+//! ```text
+//!   slots     [Slot; N]      32 bytes each, one word per slot
+//!   key_bytes Slab<u8>       the bytes of words longer than 15
+//!   ids       Slab<u32>      id runs longer than 3
+//! ```
+//!
+//! One `WordCache` lives in one scratch buffer, so it is owned by a single
+//! thread: no sharing, no locking, no atomics.
+//!
+//! # Looking a word up
+//!
+//! A word's hash picks its *home* slot. If another word is already sitting
+//! there, the search steps forward one slot at a time — this is open addressing
+//! with linear probing — for at most [`WINDOW`] slots:
+//!
+//! ```text
+//!   lookup(b"tion")   home = hash(b"tion") & (N - 1) = 4
+//!
+//!     slot 3  │ "port"  │
+//!     slot 4  │ "ation" │ ← home, but another word got here first: step forward
+//!     slot 5  │ "tion"  │ ← the key matches: hit, hand back its ids
+//!     slot 6  │  empty  │
+//!     slot 7  │ "the"   │
+//!
+//!   lookup(b"xyz")    home = 4 → not "ation", not "tion", slot 6 is empty → miss
+//! ```
+//!
+//! A walk may stop at that empty slot instead of going the full [`WINDOW`],
+//! because no slot ever goes back to being empty once it has been used: an empty
+//! slot means nothing was ever stored beyond it.
+//!
+//! A miss hands back the slot the word *would* go in — slot 6 above — as a
+//! [`Placement`], which the caller returns to [`WordCache::insert`] once the
+//! model has encoded the word. So a miss costs one walk over the window, not
+//! two. Picking a slot needs exactly the reads that failing to find the word has
+//! already done, and doing it afterwards instead would mean sixteen slots and
+//! eight cache lines of repetition, plus hashing the word a second time. The
+//! caller can also drop the placement and store nothing: nothing has changed
+//! yet, and an entry only loses its slot when something is written over it.
+//!
+//! # What a slot holds
+//!
+//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and a `u32` of
+//! bookkeeping called `meta`. It takes one of three shapes, depending on how long
+//! the word is and how many ids it encoded to. The first is the common case for
+//! English or code — a short word encoding to one or two tokens — and it touches
+//! nothing but the slot itself:
+//!
+//! ```text
+//!  (1) at most 15 bytes, at most 3 ids — the slot holds everything
+//!
+//!     b"tion" → [5378, 262]
+//!    key     │ t  i  o  n  00 … 00 │ 4 │  the word, length in the top byte
+//!    payload │ 5378 │ 262 │  ·  │         the ids, right here
+//!    meta    │ tag │ counter │ 2 │        2 of the 3 payload words are ids
+//!
+//!  (2) at most 15 bytes, more than 3 ids — the ids move to the arena
+//!
+//!     b"电脑" (6 bytes) → 8 ids
+//!    key     │ e7 94 b5 e8 84 91 … │ 6 │  still the word itself
+//!    payload │  ·  │  40  │ 0:8 │         8 ids, in the ids arena at 40
+//!    meta    │ tag │ counter │ SPILLED │  payload is coordinates, not ids
+//!
+//!  (3) over 15 bytes — the bytes move too, and the key becomes a hash
+//!
+//!     b"unbelievabilities" (17 bytes) → 6 ids
+//!    key     │ hash(word) │ LONG_TAG │   no room for 17 bytes
+//!    payload │  12  │  40  │ 17:6 │      17 bytes at 12, 6 ids at 40
+//!    meta    │ tag │ counter │ SPILLED │
+//! ```
+//!
+//! Shape (3) is the only one where a matching `key` is not proof: two different
+//! long words can hash alike, so a hit there also compares the bytes in
+//! `key_bytes`. Shapes (1) and (2) carry the word itself in the key, so an equal
+//! key *is* an equal word — one register-wide comparison, no memory to chase.
+//!
+//! Both spilled shapes need to record two lengths — how many bytes are in
+//! `key_bytes` and how many ids are in `ids` — and both are capped by
+//! [`MAX_LENGTH`], so eleven bits each is enough and the two share `payload[2]`.
+//! Packing them there is what leaves `meta` room for the sixteen-bit `tag` the
+//! next section needs.
+//!
+//! # How an entry earns its place
+//!
+//! Every slot carries a *counter* of how much its word is being used, bumped on
+//! each hit. When a word arrives and all [`WINDOW`] slots of its window are taken,
+//! the lowest counter loses its slot.
+//!
+//! A counter that only ever went up would measure the wrong thing. The first page
+//! of a document can make `"the"` the most-used word in the table; fifty pages
+//! later the text has moved on to something else entirely, but `"the"` still holds
+//! the highest count and nothing can ever catch up with it. What decides an
+//! eviction should be how much a word is being used *lately*, so counters have to
+//! fade.
+//!
+//! Fading them by hand is the expensive way: every eviction would rewrite all
+//! sixteen counters of a window, and sixteen slots is eight cache lines. So
+//! nothing is rewritten. The cache keeps a single number — the *epoch* — and
+//! bumps it every so often; each slot records the epoch it was last written in,
+//! its *tag*. A counter is then read as
+//!
+//! ```text
+//!   score = counter >> (epoch - tag)        "halved once per epoch I have missed"
+//! ```
+//!
+//! No stored number changes. What changes is what a stored number is worth. Two
+//! entries with the same counter:
+//!
+//! ```text
+//!   the cache is at epoch 9
+//!
+//!     A   counter 32, tag 9   →  0 epochs missed  →  score 32
+//!     B   counter 32, tag 5   →  4 epochs missed  →  score 32 >> 4 = 2
+//!                                                          ▲ B was hot once and
+//!                                                            has coasted since
+//! ```
+//!
+//! A counter is one byte, so eight missed epochs take any entry to zero however
+//! hot it once was; that ceiling is [`MAX_DECAY`]. Whenever an entry *is*
+//! written — a hit, or a fresh insert — it is settled up first: its score
+//! becomes its new counter and its tag becomes the current epoch.
+//!
+//! ## How often the epoch moves
+//!
+//! One bump fades every counter in the table at once, and the table is far
+//! bigger than a window. So bumping on every eviction would fade all of it at
+//! the speed of whichever window happens to be churning hardest: counters would
+//! sit at zero and every eviction would be an arbitrary pick.
+//!
+//! The rate that matches is one bump per `slots / WINDOW` evictions. A slot can be
+//! reached from [`WINDOW`] different homes, so it belongs to [`WINDOW`] of the
+//! table's `slots` windows, and an eviction somewhere in the table lands in one of
+//! them with probability `WINDOW / slots`. Bumping at that rate gives every slot
+//! the same average fade as if each window faded only itself, only when it
+//! evicted.
+//!
+//! ## Starting the count again
+//!
+//! A tag has sixteen bits, so the epoch runs out of numbers after 65536 bumps and
+//! has to start over at zero. The moment it does, every tag written before the
+//! restart is a number larger than the epoch, and `epoch - tag` stops meaning
+//! anything: an entry idle for the whole lap would read as freshly written, at
+//! full strength, and could never be evicted again. That is dead weight forever —
+//! the exact failure fading exists to prevent.
+//!
+//! So the last bump of a lap does not restart the count on its own. It first
+//! walks the table, writing each live entry's score into its counter, and then
+//! puts the epoch and every tag back to zero together (see
+//! [`WordCache::settle`]). No entry moves up or down against another; the
+//! differences are just cashed in while they can still be read. It is one pass
+//! over a few
+//! megabytes, once every 65536 bumps — at the default capacity, once every
+//! quarter of a billion evictions.
+//!
+//! # Where an evicted entry's space goes
+//!
+//! Whatever an evicted entry had in the arenas is handed back when it is
+//! overwritten, and the next word of the same shape takes it. Runs are never
+//! moved and never rounded up, because there is a free list for every length a
+//! run can have (see [`Slab`], and [`MAX_LENGTH`] for why that is finite):
+//!
+//! ```text
+//!   the ids arena, just after A — which had 6 ids at offset 12 — was evicted
+//!
+//!     data  ┌─────┬────────────────────────────┬─────┐
+//!           │  …  │ A's 6 ids, at offset 12    │  …  │   nothing is moved
+//!           └─────┴────────────────────────────┴─────┘
+//!
+//!     free  len 6 → [ 12 ]   the next word with 6 ids is handed offset 12
+//!           len 8 → [ ]      one list per length, 0 … MAX_LENGTH
+//! ```
+//!
+//! So the arenas hold the live set rather than every word ever seen. Without
+//! reuse they could only grow, and reclaiming them would mean copying every live
+//! entry into a second buffer — twice the memory for the same number of entries.
+//!
+//! Overwriting the victim where it lies is also what keeps the table itself
+//! small. Removing an entry from an open-addressed table normally needs a
+//! tombstone or a backward shift, because a probe walk stops at the first empty
+//! slot and a hole in the middle of a chain would cut the walk short. Here
+//! nothing is ever removed: a slot goes from empty to occupied once and after
+//! that only ever changes owner. That is what lets a lookup stop at the first
+//! empty slot, and it is why the window has to be bounded — in a saturated table,
+//! that bound is all that stops a walk from running over the whole table.
+//!
+//! # Why open addressing, and not fixed buckets
+//!
+//! The obvious alternative is 4-way set associativity: cut the table into buckets
+//! of four slots and let a word live only in the one bucket its hash picks. That
+//! is a single load per lookup and easy to reason about, but a word whose four
+//! slots are taken can never be cached at all, however empty the rest of the
+//! table is:
+//!
+//! ```text
+//!   4-way buckets — a word belongs to exactly one bucket of four
+//!
+//!     bucket 0        bucket 1        bucket 2
+//!     │●│●│●│●│       │●│·│·│·│       │·│·│·│·│
+//!      ▲
+//!      └ full, so this word goes uncached — the free slots one
+//!        bucket over may as well not exist
+//!
+//!   open addressing — the word walks on to the next free slot
+//!
+//!     │●│●│●│●│·│·│·│·│·│·│·│·│·│·│·│·│
+//!      ▲       ▲
+//!      home    └ stored here instead; only WINDOW slots taken in a
+//!                row can turn a word away
+//! ```
+//!
+//! With buckets that small, being locked out starts happening long before the
+//! table is genuinely full. On our multilingual fixtures it cost between 0.1% and
+//! 4% of all lookups, worst on Korean and Chinese, where a document holds far
+//! more distinct words.
+//!
+//! Probing a window closes that gap: on the same fixtures those misses went to
+//! ~0, and in the encoder (`examples/fixture_bench.rs`) the many-distinct-word
+//! scripts spent 10-40% less time in the model stage. English and code came out
+//! inside the noise — and the noise there is wide: running one binary against
+//! *itself* swings the model stage by ±30%, so measure that floor before
+//! believing anything smaller.
+//!
+//! # Why not a `HashMap`
+//!
+//! The legacy BPE model in `model.rs` caches in a thread-local
+//! `AHashMap<String, Word>` (`BPE_LOCAL_CACHE`), so the comparison is concrete.
+//! On a warm benchmark, where every word is already in the map, a hash map is
+//! not far off this table — it has no bucket conflicts either. What it cannot do
+//! is the rest of the job:
+//!
+//! - **Every word it accepts goes to the allocator.** The map owns its keys, so
+//!   an accepted word is copied into a fresh `String`, and each value keeps a
+//!   heap buffer of its own alive. That cost lands on misses, which is where a
+//!   cache can least afford it: a word misses the first time it is ever seen.
+//!   Here an insert writes into space that already exists.
+//! - **A hit is two more random loads.** The key bytes and the value both live
+//!   in their own heap blocks, elsewhere in memory from the table that pointed
+//!   at them. A slot here answers the common word out of the 32 bytes the probe
+//!   has already read.
+//! - **It cannot make room.** A `HashMap` grows until something stops it, and
+//!   the only thing it can do when stopped is refuse: the legacy cache inserts
+//!   `while local.len() < capacity`, so the words from the first pages of text
+//!   keep their places forever, however useless they turn out to be. Choosing
+//!   *which* entry to drop needs evidence about how much each one is used, and
+//!   somewhere to keep it — the counter in every slot.
+//! - **Entries cost more than twice the memory.** 24 bytes for the `String` and
+//!   24 for the value's vector inside the table, before the two heap blocks they
+//!   point at, against 32 bytes here for the common word.
+//!
+//! A *shared* map costs more again: [`crate::utils::cache::Cache`], which the
+//! Unigram model still uses, wraps one in an `RwLock` and then has to
+//! `try_read`/`try_write` and silently drop the read or the write whenever
+//! another thread holds it.
+
+// These docs are written for someone reading the source, and link freely to the
+// module's own internals. Under `bench-internals` the module is `pub`, which
+// otherwise turns every one of those links into a rustdoc warning.
+#![allow(rustdoc::private_intra_doc_links)]
+
+use ahash::RandomState;
+
+/// Longest word the cache will store, in bytes.
+///
+/// Long words are rare and rarely repeat, so storing them buys little, and the
+/// lookup for one is a hash over every byte to learn nothing. The cap is also
+/// what makes the arenas' free lists possible (one list per length) and what
+/// bounds a run's size at all: a tokenizer with no pre-tokenizer hands this
+/// model whole documents as single "words", and uncapped the cache would
+/// cheerfully memoize documents.
+const MAX_LENGTH: usize = 1024;
+/// Slots searched from a word's home position. Linear probing normally settles
+/// in one or two, but the walk has to stop somewhere: nothing is ever removed,
+/// so a saturated table would otherwise scan forever looking for an empty slot.
+const WINDOW: usize = 16;
+/// Ids carried in the slot itself — three `u32`s is what fits beside the key.
+/// Enough for 80-96% of lookups on English or code, but only about a quarter of
+/// them on Chinese or Korean, where a vocabulary holding none of those scripts
+/// spends ten ids or more on one word.
+const INLINE_IDS: usize = 3;
+/// Set in `key` when it holds the hash of a long word instead of the word
+/// itself. Packed keys carry their length (1..=15) in the top byte, so a hashed
+/// key can never be mistaken for a packed one, and neither can be 0 — the
+/// empty-slot marker.
+const LONG_TAG: u128 = 1 << 127;
+
+/// The id count in `Slot::meta` when the ids did not fit in the slot and went
+/// to the arena instead.
+const SPILLED: u8 = u8::MAX;
+/// Where `counter` starts in `Slot::meta`. It is a byte wide, hence
+/// [`MAX_DECAY`].
+const COUNTER_SHIFT: u32 = 8;
+/// Highest counter an entry can reach. Hits past this are not counted; an entry
+/// that busy is in no danger anyway.
+const COUNTER_MAX: u32 = u8::MAX as u32;
+/// What a newly stored entry's counter starts at.
+const NEWBORN: u32 = 1;
+/// Where `tag` starts in `Slot::meta`, and the highest epoch one can hold —
+/// a lap of 65536, after which [`WordCache::settle`] starts the count again.
+const TAG_SHIFT: u32 = 16;
+const TAG_MASK: u32 = 0xFFFF;
+/// Missing this many epochs takes any counter to zero, because a counter is a
+/// byte. Shifting further would be both pointless and undefined.
+const MAX_DECAY: u32 = 8;
+
+/// Bits per length in a spilled entry's `payload[2]`, which packs the key's byte
+/// count above the id count. Both are capped by [`MAX_LENGTH`].
+const PACKED_LEN_BITS: u32 = 11;
+const PACKED_LEN_MASK: u32 = (1 << PACKED_LEN_BITS) - 1;
+const _: () = assert!(MAX_LENGTH <= PACKED_LEN_MASK as usize);
+
+/// A word of 1..=15 bytes packed into a `u128`: bytes in the low lanes, length
+/// in the top byte. Including the length keeps `"a"` and `"a\0"` apart, and the
+/// whole key comparison becomes one register-wide equality instead of a
+/// `memcmp` against bytes somewhere else in memory.
+///
+/// TODO: the copy is a call into `memcpy` — about a third of what building a key
+/// costs — because `len` is only known at run time, and LLVM folds a copy into a
+/// load only when the length is a constant. A caller that knows what surrounds the
+/// word could pass the 16 bytes starting where the word does instead, turning the
+/// copy into one load plus a mask for the surplus bytes.
+fn pack_word(word: &[u8]) -> Option<u128> {
+    let len = word.len();
+    if len == 0 || len > 15 {
+        return None;
+    }
+    let mut lanes = [0u8; 16];
+    lanes[..len].copy_from_slice(word);
+    Some(u128::from_le_bytes(lanes) | ((len as u128) << 120))
+}
+
+/// One entry, in the three shapes the module docs draw out. In short:
+///
+/// - `key` is the word itself when it fits in 15 bytes, otherwise its hash with
+///   [`LONG_TAG`] set.
+/// - `payload` is the token ids while `meta`'s low byte counts them, and becomes
+///   `[key_off, ids_off, packed lengths]` once that byte is [`SPILLED`] — which
+///   is what the `key_off`/`ids_off`/`key_len`/`ids_len` readers below are for.
+/// - `meta` also carries how much the entry is being used, as the counter and
+///   tag the module docs describe.
+///
+/// That the size is 32 bytes is the point of the layout — a hit reads the key,
+/// the ids and the bookkeeping in one go, and two slots share a cache line.
+#[derive(Clone, Copy, Default)]
+#[repr(C)]
+struct Slot {
+    key: u128,
+    payload: [u32; INLINE_IDS],
+    /// Three fields in one word:
+    ///
+    /// ```text
+    ///  bit 31            16 15         8 7          0
+    ///     │ tag        16 │ counter   8 │ ids      8 │
+    /// ```
+    meta: u32,
+}
+
+const _: () = assert!(std::mem::size_of::<Slot>() == 32);
+
+impl Slot {
+    fn is_empty(&self) -> bool {
+        self.key == 0
+    }
+
+    /// How many of `payload`'s words are token ids, or [`SPILLED`].
+    fn inline_ids(&self) -> u8 {
+        self.meta as u8
+    }
+
+    fn spilled(&self) -> bool {
+        self.inline_ids() == SPILLED
+    }
+
+    fn counter(&self) -> u32 {
+        (self.meta >> COUNTER_SHIFT) & COUNTER_MAX
+    }
+
+    fn tag(&self) -> u32 {
+        self.meta >> TAG_SHIFT
+    }
+
+    /// What this entry's counter is worth at `epoch`: what was written down,
+    /// halved once for every epoch that has gone by since.
+    ///
+    /// A tag is never ahead of the epoch — both are reset together by
+    /// [`WordCache::settle`] — so the subtraction cannot go below zero.
+    fn score(&self, epoch: u32) -> u32 {
+        let missed = epoch - self.tag();
+        self.counter() >> missed.min(MAX_DECAY)
+    }
+
+    /// Write down a counter and the epoch it was written in, leaving the id
+    /// count alone.
+    fn stamp(&mut self, counter: u32, epoch: u32) {
+        self.meta = self.inline_ids() as u32 | counter << COUNTER_SHIFT | epoch << TAG_SHIFT;
+    }
+
+    fn key_off(&self) -> u32 {
+        self.payload[0]
+    }
+
+    fn ids_off(&self) -> u32 {
+        self.payload[1]
+    }
+
+    fn ids_len(&self) -> usize {
+        (self.payload[2] & PACKED_LEN_MASK) as usize
+    }
+
+    fn key_len(&self) -> usize {
+        (self.payload[2] >> PACKED_LEN_BITS) as usize
+    }
+}
+
+/// A grow-only arena that reuses the space of evicted entries instead of
+/// compacting.
+///
+/// Freed runs go on a free list per exact length. That is only practical because
+/// `MAX_LENGTH` bounds every run: there is a list for every length a run can
+/// have, so a freed run is always reusable by the next word of the same shape
+/// and no length is ever rounded up to a bigger class. The price is
+/// `MAX_LENGTH + 1` empty `Vec`s per arena.
+struct Slab<T> {
+    data: Vec<T>,
+    free: Box<[Vec<u32>]>,
+    /// Ceiling on `data`, not a reservation.
+    budget: usize,
+}
+
+impl<T: Copy + Default> Slab<T> {
+    fn new(budget: usize) -> Self {
+        Self {
+            data: Vec::new(),
+            free: (0..=MAX_LENGTH).map(|_| Vec::new()).collect(),
+            budget,
+        }
+    }
+
+    /// A run of `len` items, or `None` once the budget is spent.
+    fn alloc(&mut self, len: usize) -> Option<u32> {
+        if let Some(off) = self.free[len].pop() {
+            return Some(off);
+        }
+        if self.data.len() + len > self.budget {
+            return None;
+        }
+        let off = self.data.len() as u32;
+        self.data.resize(self.data.len() + len, T::default());
+        Some(off)
+    }
+
+    fn release(&mut self, off: u32, len: usize) {
+        self.free[len].push(off);
+    }
+
+    fn get(&self, off: u32, len: usize) -> &[T] {
+        &self.data[off as usize..off as usize + len]
+    }
+
+    fn fill(&mut self, off: u32, len: usize, values: impl Iterator<Item = T>) {
+        for (dst, value) in self.data[off as usize..off as usize + len]
+            .iter_mut()
+            .zip(values)
+        {
+            *dst = value;
+        }
+    }
+}
+
+/// What [`WordCache::lookup`] found.
+pub enum Lookup<'c, 'w> {
+    /// The ids the word encoded to last time.
+    Hit(&'c [u32]),
+    /// The word is not in the table. The [`Placement`] is the slot it should go
+    /// in — hand it to [`WordCache::insert`] once the model has done the work,
+    /// or drop it and nothing is stored. `None` when the word is too long to be
+    /// worth a slot at all.
+    Miss(Option<Placement<'w>>),
+}
+
+impl<'c> Lookup<'c, '_> {
+    /// The ids, throwing the [`Placement`] away. Every caller in the encoder
+    /// wants the placement — this is for tests asserting on what the table
+    /// holds.
+    #[cfg(test)]
+    pub fn hit(self) -> Option<&'c [u32]> {
+        match self {
+            Lookup::Hit(ids) => Some(ids),
+            Lookup::Miss(_) => None,
+        }
+    }
+}
+
+/// Where a word that missed will go, and what [`WordCache::insert`] needs to put
+/// it there. Found by the walk that missed, so storing the word costs no second
+/// hash and no second walk over its window.
+///
+/// It carries the word rather than letting `insert` take it again, because the
+/// slot and the key inside were chosen for *this* word: handing back a different
+/// one would file its ids under the first word's name.
+pub struct Placement<'w> {
+    index: usize,
+    key: u128,
+    word: &'w [u8],
+}
+
+/// How a walk over a word's window ended: the slot the word is in, or the slot
+/// it should take if the caller decides to store it.
+enum Probe {
+    Hit(usize),
+    Miss(usize),
+}
+
+/// Word bytes to token ids. See the module docs for the design.
+pub struct WordCache {
+    hasher: RandomState,
+    slots: Box<[Slot]>,
+    key_bytes: Slab<u8>,
+    ids: Slab<u32>,
+    /// `slots.len() - 1`. The table is a power of two, so this folds a hash into
+    /// a slot index.
+    mask: usize,
+    /// Where the fade count stands, from 0 to [`TAG_MASK`] and no higher. A
+    /// slot's `tag` is what this held when the slot was last written, so
+    /// `epoch - tag` is how many fades that entry has sat through.
+    /// [`WordCache::settle`] puts the epoch and every tag back to zero together
+    /// when the count runs out of room.
+    epoch: u32,
+    /// Evictions still to come before the next `epoch` bump.
+    countdown: u32,
+    /// Evictions per `epoch` bump — see the module docs on how often the epoch
+    /// moves.
+    epoch_length: u32,
+}
+
+impl WordCache {
+    pub fn new(capacity: usize) -> Self {
+        let n_slots = capacity.next_power_of_two().max(WINDOW);
+        let epoch_length = (n_slots / WINDOW) as u32;
+        Self {
+            hasher: RandomState::new(),
+            slots: vec![Slot::default(); n_slots].into_boxed_slice(),
+            // Ceilings, not reservations: the arenas grow only as far as the live
+            // set takes them. Deliberately generous, so that the slot table is
+            // what runs out first — an arena that turns inserts away while slots
+            // sit empty is a capacity limit in disguise, and tighter numbers here
+            // measured exactly that (tens of thousands of words refused at 35%
+            // occupancy). The worst case they have to cover is a vocabulary with
+            // no CJK in it, which spends ~17 ids on a single Chinese word.
+            key_bytes: Slab::new(n_slots * 48),
+            ids: Slab::new(n_slots * 16),
+            mask: n_slots - 1,
+            epoch: 0,
+            countdown: epoch_length,
+            epoch_length,
+        }
+    }
+
+    /// The ids `word` encoded to last time, or the slot to put them in when the
+    /// model has worked them out.
+    ///
+    /// Takes `&mut self` because a hit is also a vote for keeping the entry.
+    pub fn lookup<'c, 'w>(&'c mut self, word: &'w [u8]) -> Lookup<'c, 'w> {
+        if word.len() > MAX_LENGTH {
+            return Lookup::Miss(None);
+        }
+        let (key, hash) = self.slot_key(word);
+        let index = match self.probe(key, hash, word) {
+            Probe::Hit(index) => {
+                let epoch = self.epoch;
+                let counter = (self.slots[index].score(epoch) + 1).min(COUNTER_MAX);
+                self.slots[index].stamp(counter, epoch);
+                let slot = self.slots[index];
+                return Lookup::Hit(if slot.spilled() {
+                    self.ids.get(slot.ids_off(), slot.ids_len())
+                } else {
+                    &self.slots[index].payload[..slot.inline_ids() as usize]
+                });
+            }
+            Probe::Miss(index) => index,
+        };
+        Lookup::Miss(Some(Placement { index, key, word }))
+    }
+
+    /// Remember what the word encoded to, in the slot its [`WordCache::lookup`]
+    /// picked out. Silently does nothing when an arena is full: a cache is free
+    /// to forget, and the caller has the ids either way.
+    pub fn insert(&mut self, at: Placement<'_>, ids: impl ExactSizeIterator<Item = u32>) {
+        let Some(mut entry) = self.build_entry(at.key, at.word, ids) else {
+            return;
+        };
+        // A slot that is not empty belongs to somebody else, so this is an
+        // eviction: give the arena runs back and charge the table one round of
+        // fading. Both wait until here, so a lookup whose caller decides not to
+        // store anything after all costs the entry sitting there nothing.
+        if !self.slots[at.index].is_empty() {
+            self.reclaim(at.index);
+            self.fade();
+        }
+        // Fading moves the epoch, so stamp the new entry after it.
+        entry.stamp(NEWBORN, self.epoch);
+        self.slots[at.index] = entry;
+    }
+
+    /// The value a slot stores in its `key`, and the hash that places it. A short
+    /// word is its own key; a longer one keys on a tagged hash and has to be
+    /// confirmed against `key_bytes`, since two long words can hash alike.
+    ///
+    /// A packed key is hashed as one `u128`, not as the word's bytes it was built
+    /// from. Hashing a slice makes aHash mix the length in and then branch on it to
+    /// choose a read width; a `u128` is one fixed-width fold with nothing to decide.
+    /// The key already carries the length, so nothing is lost.
+    fn slot_key(&self, word: &[u8]) -> (u128, u64) {
+        match pack_word(word) {
+            Some(packed) => (packed, self.hasher.hash_one(packed)),
+            None => {
+                let hash = self.hasher.hash_one(word);
+                ((hash as u128) | LONG_TAG, hash)
+            }
+        }
+    }
+
+    /// One walk of `word`'s window, from its home position, answering both
+    /// questions a lookup has: which slot holds the word, and — if none does —
+    /// which slot it should take.
+    ///
+    /// The second answer is free. Finding the word means reading every slot in
+    /// the window until it turns up, and the slot a miss wants is the first empty
+    /// one or the lowest-scoring one, both of which fall out of the same reads.
+    /// Working it out later would mean walking the same sixteen slots again, and
+    /// sixteen slots is eight cache lines.
+    ///
+    /// Stopping at the first empty slot is safe because slots never go back to
+    /// being empty: an empty one means the word was never stored.
+    fn probe(&self, key: u128, hash: u64, word: &[u8]) -> Probe {
+        // Only a hashed key can turn out to belong to a different word, and
+        // whether this one is hashed is settled before the walk starts — the
+        // caller built the key out of the word it is looking for.
+        let hashed = key & LONG_TAG != 0;
+        let mut coldest = hash as usize & self.mask;
+        let mut lowest = u32::MAX;
+        for step in 0..WINDOW {
+            let index = (hash as usize + step) & self.mask;
+            let slot = &self.slots[index];
+            if slot.is_empty() {
+                return Probe::Miss(index);
+            }
+            if slot.key == key
+                && (!hashed || self.key_bytes.get(slot.key_off(), slot.key_len()) == word)
+            {
+                return Probe::Hit(index);
+            }
+            let score = slot.score(self.epoch);
+            if score < lowest {
+                lowest = score;
+                coldest = index;
+            }
+        }
+        Probe::Miss(coldest)
+    }
+
+    /// The entry to store, with whatever does not fit in a slot copied into the
+    /// arenas, and `meta` holding only the id count — [`WordCache::insert`]
+    /// stamps the rest. `None` when an arena is full, so a rejected insert leaves
+    /// the table and the arenas exactly as they were.
+    fn build_entry(
+        &mut self,
+        key: u128,
+        word: &[u8],
+        ids: impl ExactSizeIterator<Item = u32>,
+    ) -> Option<Slot> {
+        let long = key & LONG_TAG != 0;
+        let ids_len = ids.len();
+        if !long && ids_len <= INLINE_IDS {
+            let mut payload = [0u32; INLINE_IDS];
+            for (dst, id) in payload.iter_mut().zip(ids) {
+                *dst = id;
+            }
+            return Some(Slot {
+                key,
+                payload,
+                meta: ids_len as u32,
+            });
+        }
+        // A short word stays in the key, which is a zero-length run here.
+        let key_len = if long { word.len() } else { 0 };
+        let key_off = self.key_bytes.alloc(key_len)?;
+        let Some(ids_off) = self.ids.alloc(ids_len) else {
+            self.key_bytes.release(key_off, key_len);
+            return None;
+        };
+        self.key_bytes.fill(key_off, key_len, word.iter().copied());
+        self.ids.fill(ids_off, ids_len, ids);
+        let lengths = (key_len as u32) << PACKED_LEN_BITS | ids_len as u32;
+        Some(Slot {
+            key,
+            payload: [key_off, ids_off, lengths],
+            meta: SPILLED as u32,
+        })
+    }
+
+    /// One eviction's worth of fading: step the countdown, and move the epoch on
+    /// when it runs out.
+    fn fade(&mut self) {
+        self.countdown -= 1;
+        if self.countdown > 0 {
+            return;
+        }
+        self.countdown = self.epoch_length;
+        if self.epoch == TAG_MASK {
+            self.settle();
+        } else {
+            self.epoch += 1;
+        }
+    }
+
+    /// Spend every entry's outstanding fade and start the count again: each live
+    /// entry's score becomes its counter, and the epoch and every tag go back to
+    /// zero.
+    ///
+    /// Run on the last epoch a tag can hold, and only then. The epoch has to
+    /// start over at some point, and the moment it does, `epoch - tag` stops
+    /// meaning anything for entries stamped before the restart. So the
+    /// differences are cashed in first, while they are still readable.
+    fn settle(&mut self) {
+        let epoch = self.epoch;
+        for slot in self.slots.iter_mut() {
+            if slot.is_empty() {
+                continue;
+            }
+            let score = slot.score(epoch);
+            slot.stamp(score, 0);
+        }
+        self.epoch = 0;
+    }
+
+    /// Hand an overwritten entry's arena runs back, so the next entry can use
+    /// them.
+    ///
+    /// `#[inline]` because this exists to give a step of `insert` a name, not to
+    /// be called: left out of line it costs `insert` a call and the pointers it
+    /// had already loaded.
+    #[inline]
+    fn reclaim(&mut self, index: usize) {
+        let slot = self.slots[index];
+        if !slot.spilled() {
+            return;
+        }
+        self.key_bytes.release(slot.key_off(), slot.key_len());
+        self.ids.release(slot.ids_off(), slot.ids_len());
+    }
+}
+
+/// Handles for `examples/word_cache_bench.rs`, which times the parts of the
+/// cache the encoder never calls directly. Compiled out of every build that
+/// does not ask for them.
+#[cfg(feature = "bench-internals")]
+impl WordCache {
+    /// Just the key building at the front of a lookup: pack the word, hash it.
+    pub fn bench_slot_key(&self, word: &[u8]) -> u64 {
+        self.slot_key(word).1
+    }
+
+    /// One eviction's worth of fading, without an eviction.
+    pub fn bench_fade(&mut self) {
+        self.fade()
+    }
+
+    /// The whole-table pass that starts the epoch count again.
+    pub fn bench_settle(&mut self) {
+        self.settle()
+    }
+
+    /// How many slots hold an entry. Equal to the capacity once the table is
+    /// saturated, which is the state the eviction measurements need.
+    pub fn bench_occupancy(&self) -> usize {
+        self.slots.iter().filter(|slot| !slot.is_empty()).count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Look a word up and store what it encoded to, for tests that care about
+    /// what the table ends up holding rather than about the two steps.
+    pub(super) fn store(
+        cache: &mut WordCache,
+        word: &[u8],
+        ids: impl ExactSizeIterator<Item = u32>,
+    ) {
+        let at = match cache.lookup(word) {
+            Lookup::Miss(at) => at,
+            Lookup::Hit(_) => None,
+        };
+        if let Some(at) = at {
+            cache.insert(at, ids);
+        }
+    }
+
+    /// The slot a word is in, or `None` if the table does not hold it.
+    fn slot_of(cache: &WordCache, word: &[u8]) -> Option<usize> {
+        let (key, hash) = cache.slot_key(word);
+        match cache.probe(key, hash, word) {
+            Probe::Hit(index) => Some(index),
+            Probe::Miss(_) => None,
+        }
+    }
+
+    #[test]
+    fn roundtrip() {
+        let mut cache = WordCache::new(1 << 8);
+        assert_eq!(cache.lookup(b"hello").hit(), None);
+        store(&mut cache, b"hello", [1u32, 2, 3].into_iter());
+        store(&mut cache, b"world", [4u32].into_iter());
+        assert_eq!(cache.lookup(b"hello").hit(), Some(&[1u32, 2, 3][..]));
+        assert_eq!(cache.lookup(b"world").hit(), Some(&[4u32][..]));
+        assert_eq!(cache.lookup(b"hell").hit(), None);
+    }
+
+    /// The three properties the whole key encoding rests on: a packed key is
+    /// unique per word, is never `0` (the empty-slot marker), and never looks
+    /// like a hashed key.
+    #[test]
+    fn packed_keys_are_unique_and_tagged() {
+        assert_ne!(pack_word(b"a"), pack_word(b"a\0"));
+        assert_ne!(pack_word(&[0u8; 15]), Some(0));
+        assert_eq!(pack_word(&[0u8; 15]).unwrap() & LONG_TAG, 0);
+        assert_eq!(pack_word(b""), None);
+        assert_eq!(pack_word(&[b'x'; 16]), None);
+    }
+
+    /// A short word's placement now comes out of its packed key rather than its
+    /// bytes, which leaves the hash doing all of the mixing. Words that differ in
+    /// one byte pack to keys that differ in one byte, so an index taken from those
+    /// bits as they are — `packed as u64` — drops most of these on one slot.
+    #[test]
+    fn short_words_spread_across_the_table() {
+        let cache = WordCache::new(1 << 12);
+        let homes: std::collections::HashSet<usize> = (0..1000)
+            .map(|i| {
+                let (_, hash) = cache.slot_key(format!("tok{i}").as_bytes());
+                hash as usize & cache.mask
+            })
+            .collect();
+        // 1000 words over 4096 slots share homes by chance alone; ~887 distinct is
+        // as good as a perfect hash gets, so the floor is well under it.
+        assert!(homes.len() > 820, "only {} distinct homes", homes.len());
+    }
+
+    #[test]
+    fn oversized_words_are_ignored() {
+        let mut cache = WordCache::new(1 << 8);
+        let big = vec![7u8; MAX_LENGTH + 1];
+        store(&mut cache, &big, [1u32].into_iter());
+        assert_eq!(cache.lookup(&big).hit(), None);
+    }
+
+    /// Both sides of the 15-byte packing boundary and both sides of the inline/
+    /// arena boundary have to survive a round trip, including the long word whose
+    /// stored `key` is only a hash and needs the byte comparison to confirm it.
+    #[test]
+    fn every_slot_shape_round_trips() {
+        let mut cache = WordCache::new(1 << 8);
+        let long = vec![b'x'; 200];
+        let cases: [(&[u8], Vec<u32>); 6] = [
+            (b"short", vec![1]),
+            (b"short-wide", (0..40).collect()),
+            (b"fifteen-bytes.", vec![2]),
+            (b"sixteen-bytes.aa", vec![3]),
+            (&long, vec![9]),
+            (&long[..64], (0..64).collect()),
+        ];
+        for (word, ids) in &cases {
+            store(&mut cache, word, ids.clone().into_iter());
+        }
+        for (word, ids) in &cases {
+            assert_eq!(cache.lookup(word).hit(), Some(&ids[..]), "{word:?}");
+        }
+    }
+
+    /// A spilled entry keeps the word's byte count and its id count in eleven bits
+    /// each, side by side in one `u32`. The longest word the cache accepts, when it
+    /// encodes to one id per byte, is the largest either of them can get — and if
+    /// they ever overlapped, the entry would come back as a different word's.
+    #[test]
+    fn a_word_at_the_length_limit_round_trips() {
+        let mut cache = WordCache::new(1 << 8);
+        let word = vec![b'q'; MAX_LENGTH];
+        let ids: Vec<u32> = (0..MAX_LENGTH as u32).collect();
+        store(&mut cache, &word, ids.clone().into_iter());
+        assert_eq!(cache.lookup(&word).hit(), Some(&ids[..]));
+    }
+
+    /// Two long words can hash to the same key, and then only their bytes tell
+    /// them apart. Real hash collisions are too rare to write a test around, so
+    /// forge one: park another word's entry on this word's home slot and stamp
+    /// this word's key on it. The lookup has to walk past it.
+    #[test]
+    fn a_hashed_key_is_confirmed_against_the_word_bytes() {
+        let mut cache = WordCache::new(1 << 8);
+        let mine = vec![b'a'; 40];
+        let theirs = vec![b'b'; 40];
+
+        store(&mut cache, &theirs, [7u32].into_iter());
+        let their_slot = cache.slots[slot_of(&cache, &theirs).unwrap()];
+        let (my_key, my_hash) = cache.slot_key(&mine);
+        cache.slots[my_hash as usize & cache.mask] = Slot {
+            key: my_key,
+            ..their_slot
+        };
+
+        store(&mut cache, &mine, [1u32, 2].into_iter());
+        assert_eq!(cache.lookup(&mine).hit(), Some(&[1u32, 2][..]));
+    }
+
+    /// A word that hashes into a full window takes the lowest-scoring slot rather
+    /// than being turned away, and the words that were actually used keep their
+    /// place.
+    #[test]
+    fn a_full_window_evicts_its_coldest_entry() {
+        let mut cache = WordCache::new(WINDOW);
+        let words: Vec<Vec<u8>> = (0..WINDOW as u8).map(|i| vec![i; 4]).collect();
+        for (i, word) in words.iter().enumerate() {
+            store(&mut cache, word, [i as u32].into_iter());
+        }
+        // Every word but the first earns a hit, leaving one clear coldest slot.
+        for word in &words[1..] {
+            assert!(cache.lookup(word).hit().is_some());
+        }
+        store(&mut cache, b"newcomer", [999u32].into_iter());
+        assert_eq!(cache.lookup(b"newcomer").hit(), Some(&[999u32][..]));
+        assert_eq!(
+            cache.lookup(&words[0]).hit(),
+            None,
+            "the unused entry should have gone"
+        );
+        for (i, word) in words.iter().enumerate().skip(1) {
+            assert_eq!(
+                cache.lookup(word).hit(),
+                Some(&[i as u32][..]),
+                "used entry {i} was dropped"
+            );
+        }
+    }
+
+    /// An entry that stops being used has to fade even though nothing ever writes
+    /// to it. Here one word is hit until its counter saturates and then abandoned,
+    /// while other words keep the table busy.
+    #[test]
+    fn an_abandoned_entry_fades_without_being_touched() {
+        let mut cache = WordCache::new(WINDOW);
+        store(&mut cache, b"hot", [1u32].into_iter());
+        for _ in 0..COUNTER_MAX {
+            cache.lookup(b"hot").hit();
+        }
+        let index = slot_of(&cache, b"hot").unwrap();
+        assert_eq!(cache.slots[index].score(cache.epoch), COUNTER_MAX);
+
+        for _ in 0..MAX_DECAY {
+            cache.fade();
+        }
+        assert_eq!(cache.slots[index].score(cache.epoch), 0);
+    }
+
+    /// A tag is sixteen bits, so the epoch has to start over at zero every 65536
+    /// bumps. An entry stamped before the restart carries a tag larger than the
+    /// epoch, and left to itself the coldest thing in the table would come out
+    /// reading as the hottest and could never be evicted again.
+    #[test]
+    fn a_lap_of_the_epoch_does_not_make_a_stale_entry_look_hot() {
+        let mut cache = WordCache::new(WINDOW);
+        store(&mut cache, b"stale", [1u32].into_iter());
+        for _ in 0..COUNTER_MAX {
+            cache.lookup(b"stale").hit();
+        }
+        let index = slot_of(&cache, b"stale").unwrap();
+
+        // One slot per window here, so one eviction is one epoch.
+        assert_eq!(cache.epoch_length, 1);
+        for _ in 0..=TAG_MASK {
+            cache.fade();
+        }
+        assert_eq!(cache.epoch, 0, "the lap did not start over");
+        assert_eq!(cache.slots[index].score(cache.epoch), 0);
+    }
+
+    /// Reusing an evicted entry's arena run is where this design can go wrong:
+    /// hand one run to two live entries and a hit starts returning another word's
+    /// ids. Churn a table far too small for the input and demand the invariant
+    /// that matters — an entry may be evicted, but a hit is never wrong.
+    #[test]
+    fn a_hit_never_returns_another_words_ids() {
+        let mut cache = WordCache::new(64);
+        let mut expected: Vec<(Vec<u8>, Vec<u32>)> = Vec::new();
+        for i in 0..2000usize {
+            let word = match i % 4 {
+                0 => format!("w{i}"),
+                1 => format!("a-long-word-past-fifteen-bytes-{i}"),
+                2 => format!("k{i}xxxxxxxxxxxx"),
+                _ => format!("{}-{i}", "z".repeat(i % 40)),
+            }
+            .into_bytes();
+            let ids: Vec<u32> = (0..=(i % 9) as u32).map(|k| i as u32 * 16 + k).collect();
+            store(&mut cache, &word, ids.clone().into_iter());
+            expected.push((word, ids));
+        }
+        let mut live = 0;
+        for (word, ids) in &expected {
+            if let Some(hit) = cache.lookup(word).hit() {
+                assert_eq!(hit, &ids[..], "{word:?}");
+                live += 1;
+            }
+        }
+        assert!(live > 0, "everything was evicted — the test proves nothing");
+    }
+
+    /// Freed runs have to come back. Without reuse the arenas grow with every
+    /// insert until their budget is spent, and from then on the cache silently
+    /// stops accepting words even though the table has room for them.
+    #[test]
+    fn arenas_hold_the_live_set_not_every_insert() {
+        let mut cache = WordCache::new(64);
+        // Same length every time, so one free list serves every word and the
+        // bounds below are exact: 64 slots, plus the run reserved for the insert
+        // in flight before the entry it replaces gives its own run back.
+        let word = |i: usize| format!("a-long-word-past-fifteen-bytes-{i:04}");
+        for i in 0..5000usize {
+            store(&mut cache, word(i).as_bytes(), [i as u32; 8].into_iter());
+        }
+        assert_eq!(
+            cache.lookup(word(4999).as_bytes()).hit(),
+            Some(&[4999u32; 8][..]),
+            "inserts stopped landing — the arenas ran out"
+        );
+        assert!(cache.key_bytes.data.len() <= 65 * 35);
+        assert!(cache.ids.data.len() <= 65 * 8);
+    }
+}

--- a/tokenizers/tk-encode/src/utils/word_cache.rs
+++ b/tokenizers/tk-encode/src/utils/word_cache.rs
@@ -872,6 +872,44 @@ impl<'c> Lookup<'c, '_> {
     }
 }
 
+/// A word's key and the hash that places it, from [`WordCache::key`].
+#[derive(Clone, Copy)]
+pub struct WordKey {
+    key: u128,
+    hash: u64,
+}
+
+/// Ask the memory system for the cache line holding `p`, on the architectures
+/// that have an instruction for it. A prefetch changes nothing a reader can
+/// observe, which is why any address is allowed and why this needs no more care
+/// than passing a pointer we already hold.
+///
+/// The two-flavour version of this in [gigatoken]'s `pretoken_cache` is what
+/// suggested it — it separates an L2 hint issued a chunk ahead from an L1 hint a
+/// few probes ahead. Only the L1 hint is worth having here, because our callers
+/// run a batch of words ahead of the probes, not a whole chunk.
+///
+/// [gigatoken]: https://github.com/marcelroed/gigatoken
+#[inline(always)]
+fn prefetch_line<T>(p: *const T) {
+    #[cfg(target_arch = "x86_64")]
+    // SAFETY: a prefetch has no memory effects, so any address is accepted.
+    unsafe {
+        core::arch::x86_64::_mm_prefetch(p as *const i8, core::arch::x86_64::_MM_HINT_T0);
+    }
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: as above. `prfm` is unconditionally available on aarch64.
+    unsafe {
+        core::arch::asm!(
+            "prfm pldl1keep, [{p}]",
+            p = in(reg) p,
+            options(nostack, preserves_flags, readonly)
+        );
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    let _ = p;
+}
+
 /// Where a word that missed will go, and what [`WordCache::insert`] needs to put
 /// it there. Found by the probe that missed, so storing the word costs no second
 /// hash and no second read of the window.
@@ -955,10 +993,43 @@ impl WordCache {
     ///
     /// Takes `&mut self` because a hit is also a vote for keeping the entry.
     pub fn lookup<'c, 'w>(&'c mut self, word: &'w [u8]) -> Lookup<'c, 'w> {
-        if word.len() > MAX_WORD_BYTES {
-            return Lookup::Miss(None);
+        match self.key(word) {
+            Some(key) => self.lookup_keyed(word, key),
+            None => Lookup::Miss(None),
+        }
+    }
+
+    /// The key for `word`, or `None` for a word the table will not store: an
+    /// empty one, or one longer than [`MAX_WORD_BYTES`].
+    ///
+    /// Split out of [`WordCache::lookup`] so that a caller holding several words
+    /// can key them all and [`WordCache::prefetch`] their slots before probing
+    /// the first one.
+    pub fn key(&self, word: &[u8]) -> Option<WordKey> {
+        if word.is_empty() || word.len() > MAX_WORD_BYTES {
+            return None;
         }
         let (key, hash) = self.slot_key(word);
+        Some(WordKey { key, hash })
+    }
+
+    /// Ask for the two lines a [`WordCache::lookup_keyed`] on this key reads: the
+    /// window of tags it probes, and the slot at home, where a word that is in
+    /// the table usually sits.
+    ///
+    /// Whether the wait for those lines costs anything depends on how much of the
+    /// table is in cache, so this is the caller's call rather than something the
+    /// probe does for itself — it pays only when the caller still has work left
+    /// to cover the latency with.
+    pub fn prefetch(&self, key: WordKey) {
+        let home = key.hash as usize & self.index_mask;
+        prefetch_line(&self.tags[home]);
+        prefetch_line(&self.slots[home]);
+    }
+
+    /// [`WordCache::lookup`] with the key already built by [`WordCache::key`].
+    pub fn lookup_keyed<'c, 'w>(&'c mut self, word: &'w [u8], key: WordKey) -> Lookup<'c, 'w> {
+        let WordKey { key, hash } = key;
         let index = match self.probe(key, hash, word) {
             Probe::Hit(index) => {
                 let epoch = self.epoch;
@@ -1298,6 +1369,38 @@ mod tests {
         // 1000 words over 4096 slots share homes by chance alone; ~887 distinct is
         // as good as a perfect hash gets, so the floor is well under it.
         assert!(homes.len() > 820, "only {} distinct homes", homes.len());
+    }
+
+    /// The batch path keys a word, prefetches its slot, and probes later; it has
+    /// to land on the same answer as looking the word up in one go. Both key
+    /// shapes are covered: `hello` packs into its key, the 24-byte word keys on a
+    /// hash and is confirmed against its stored bytes.
+    #[test]
+    fn keyed_lookup_matches_lookup() {
+        let long = &[b'z'; 24][..];
+        let mut cache = WordCache::new(1 << 8);
+        store(&mut cache, b"hello", [1u32, 2, 3].into_iter());
+        store(&mut cache, long, [4u32].into_iter());
+
+        for (word, ids) in [
+            (&b"hello"[..], Some(&[1u32, 2, 3][..])),
+            (long, Some(&[4u32][..])),
+            (&b"absent"[..], None),
+        ] {
+            let key = cache.key(word).expect("word is cacheable");
+            cache.prefetch(key);
+            assert_eq!(cache.lookup_keyed(word, key).hit(), ids, "{word:?}");
+        }
+    }
+
+    /// A word with no key is one the caller has to tokenize itself, so the two
+    /// cases have to be the same ones [`WordCache::lookup`] refuses.
+    #[test]
+    fn words_the_table_will_not_store_have_no_key() {
+        let cache = WordCache::new(1 << 8);
+        assert!(cache.key(b"").is_none());
+        assert!(cache.key(&vec![7u8; MAX_WORD_BYTES + 1]).is_none());
+        assert!(cache.key(&vec![7u8; MAX_WORD_BYTES]).is_some());
     }
 
     #[test]

--- a/tokenizers/tk-encode/src/utils/word_cache.rs
+++ b/tokenizers/tk-encode/src/utils/word_cache.rs
@@ -8,13 +8,15 @@
 //! cheaper than encoding the word, and a miss has to cost close to nothing, because
 //! every word pays for one the first time it is seen.
 //!
-//! There are four pieces. The table is `N` fixed-size slots, `N` being the
-//! requested capacity rounded up to a power of two; beside it a small control byte
-//! per slot, and two arenas holding what a slot is too small for:
+//! There are five pieces. The table is `N` fixed-size slots, `N` being the
+//! requested capacity rounded up to a power of two; beside it two small arrays a
+//! search reads instead of the slots, and two arenas holding what a slot is too
+//! small for:
 //!
 //! ```text
 //!   slots     [Slot; N]      32 bytes each, one word per slot
-//!   sidecar   [Ctrl; N]      3 bytes each, everything a search reads
+//!   tags      [u8; N]        1 byte each, what a search reads
+//!   usage     [Usage; N]     2 bytes each, what decides who gives way
 //!   key_bytes Slab<u8>       the bytes of words longer than 15
 //!   ids       Slab<u32>      id runs longer than 3
 //! ```
@@ -55,38 +57,39 @@
 //!
 //! ## The walk never reads a slot it does not need
 //!
-//! Done slot by slot, that walk reads two things from each: the key, to see
-//! whether this is the word, and a use counter, to see who should give way if
-//! none of them is. They sit at either end of a 32-byte slot, so walking a
-//! window drags 512 bytes through the cache to answer a question that is nearly
-//! always "no".
+//! Done slot by slot, that walk asks one question of each slot it passes: is this
+//! the word? Reading a slot to ask it drags 32 bytes through the cache for an
+//! answer that is nearly always "no", and a window of them is 512 bytes.
 //!
-//! So neither of them lives in the slot. Each slot has a three-byte [`Ctrl`] in
-//! the *sidecar*, and a window's worth of those is 48 bytes — one load:
+//! So the question is asked somewhere else. Every slot has a one-byte *tag* — a
+//! few bits of its word's hash — in an array of its own, and a window's worth of
+//! those is sixteen bytes, which is one `u128`:
 //!
 //! ```text
-//!   sidecar   ┌─────┬─────┬─────┬─────┬─  …  ─┬─────┐   48 bytes for a window
-//!             │T C E│T C E│T C E│T C E│       │T C E│
-//!             └─────┴─────┴─────┴─────┴───────┴─────┘
-//!               4     5     6     7              19
+//!   tags   ┌──┬──┬──┬──┬──┬──┬──┬──┬─ … ─┬──┐   16 bytes for a window
+//!          │A3│00│F1│A3│5C│00│00│B8│     │2E│
+//!          └──┴──┴──┴──┴──┴──┴──┴──┴─────┴──┘
+//!            4  5  6  7  8  9 10 11       19
 //!
-//!     T  tag      seven bits of the word's hash, 0 when the slot is empty
-//!     C  counter  how much the word is being used
-//!     E  epoch    when that counter was written — see below
+//!          0 marks a slot nothing was ever stored in.
 //! ```
 //!
-//! A walk asks three questions of a window, and each is answered for all sixteen
-//! slots at once rather than one slot at a time: which slots carry this word's
-//! tag, which are empty, and — when the window is full and something has to give
-//! way — which holds the lowest score. A slot is read only once its tag has said
-//! the word might be in it. A tag is seven bits, so for a word the table does not
-//! hold, that is no slot at all about 127 times in 128.
+//! Read as one integer, a window answers a question for all sixteen slots at once
+//! by ordinary arithmetic — see [`matching`] and [`empty`]. A slot is read only
+//! after its tag has said the word might be in it, and a tag is seven bits, so
+//! for a word the table does not hold that is no slot at all about 127 times in
+//! 128.
 //!
-//! On AArch64 the load is `LD3`, which takes the 48 bytes and hands back the
-//! tags, the counters and the epochs already separated into three registers.
-//! Everywhere else a plain loop answers the same three questions. Both live in
-//! [`Window`] and hand their answers back in the same form, so the walk does not
-//! know which one ran.
+//! There is no vector code here and nothing target-specific. Sixteen bytes is one
+//! `u128` on every machine this builds for, and the hand-written SIMD that would
+//! replace it measured about three times fewer instructions on the two targets it
+//! could be written for — against a doubling of this module and a second
+//! implementation to keep honest.
+//!
+//! What is *not* in a tag is how much its entry is being used, which only two
+//! paths need: a hit, which has already found its slot, and a full window, which
+//! has to give one up. That lives in [`Usage`], one array further out, and a walk
+//! that finds nothing never touches it.
 //!
 //! A tag comes from the *high* bits of the hash. The low bits already chose the
 //! home slot, so tags built from them would be equal across a window and would
@@ -147,7 +150,7 @@
 //!
 //! Fading them by hand is the expensive way: every eviction would rewrite all
 //! sixteen counters of a window. So nothing is rewritten. The cache keeps a
-//! single number — the *epoch* — and bumps it every so often; each [`Ctrl`]
+//! single number — the *epoch* — and bumps it every so often; each [`Usage`]
 //! records the epoch its counter was written in. A counter is then read as
 //!
 //! ```text
@@ -195,11 +198,11 @@
 //! dead weight forever — the exact failure fading exists to prevent.
 //!
 //! So the last bump of a lap does not restart the count on its own. It first
-//! walks the sidecar, writing each live entry's score into its counter, and then
-//! puts the epoch and every [`Ctrl`] back to zero together (see
+//! walks `usage`, writing each entry's score into its counter, and then puts
+//! the epoch and every [`Usage`] back to zero together (see
 //! [`WordCache::settle`]). No entry moves up or down against another; the
 //! differences are just cashed in while they can still be read. It is one pass
-//! over the sidecar every 256 bumps — at the default capacity, once every million
+//! over `usage` every 256 bumps — at the default capacity, once every million
 //! evictions.
 //!
 //! # Where an evicted entry's space goes
@@ -292,7 +295,7 @@
 //!   `while local.len() < capacity`, so the words from the first pages of text
 //!   keep their places forever, however useless they turn out to be. Choosing
 //!   *which* entry to drop needs evidence about how much each one is used, and
-//!   somewhere to keep it — the counter in every [`Ctrl`].
+//!   somewhere to keep it — the counter in every [`Usage`].
 //! - **Entries cost more than twice the memory.** 24 bytes for the `String` and
 //!   24 for the value's vector inside the table, before the two heap blocks they
 //!   point at, against 35 bytes here for the common word.
@@ -303,13 +306,6 @@
 //! another thread holds it.
 
 use ahash::RandomState;
-
-#[cfg(target_arch = "aarch64")]
-use std::arch::aarch64::{
-    uint8x16_t, vceqq_u8, vdupq_n_u8, vget_lane_u64, vld3q_u8, vminq_u8, vminvq_u8, vnegq_s8,
-    vreinterpret_u64_u8, vreinterpretq_s8_u8, vreinterpretq_u16_u8, vshlq_u8, vshrn_n_u16,
-    vsubq_u8,
-};
 
 /// Longest word the cache will store, in bytes.
 ///
@@ -325,7 +321,8 @@ const MAX_LENGTH: usize = 1024;
 /// so a saturated table would otherwise scan forever looking for an empty slot.
 ///
 /// Sixteen is also how many bytes a vector register holds, so a window's worth
-/// of [`Ctrl`] tags is one comparison rather than sixteen — see [`Window`].
+/// of tags is one `u128`, so a window is asked a question in one go rather
+/// than sixteen — see [`matching`].
 const WINDOW: usize = 16;
 /// Ids carried in the slot itself — three `u32`s is what fits beside the key.
 /// Enough for 80-96% of lookups on English or code, but only about a quarter of
@@ -342,17 +339,17 @@ const LONG_TAG: u128 = 1 << 127;
 const SPILLED: u8 = u8::MAX;
 /// What a newly stored entry's counter starts at.
 const NEWBORN: u8 = 1;
-/// Highest epoch a [`Ctrl`] can hold — a lap of 256, after which
+/// Highest epoch a [`Usage`] can hold — a lap of 256, after which
 /// [`WordCache::settle`] starts the count again.
 const EPOCH_MAX: u8 = u8::MAX;
 /// Missing this many epochs takes any counter to zero, because a counter is a
 /// byte.
 const MAX_DECAY: u8 = 8;
 
-/// The [`Ctrl::tag`] of a slot nothing has ever been stored in.
+/// The tag of a slot nothing has ever been stored in.
 const EMPTY: u8 = 0;
-/// Set in [`Ctrl::tag`] beside the hash bits, so a live entry's tag is never
-/// [`EMPTY`].
+/// Set in a tag beside the hash bits, so a live entry's tag is never [`EMPTY`]
+/// — which is also what makes [`empty`] a single `and`.
 const OCCUPIED: u8 = 0x80;
 /// How many bits of the hash a tag carries. Seven, because the eighth is
 /// [`OCCUPIED`]; a walk therefore reads a slot it did not want once in 128.
@@ -384,31 +381,27 @@ fn pack_word(word: &[u8]) -> Option<u128> {
     Some(u128::from_le_bytes(lanes) | ((len as u128) << 120))
 }
 
-/// The [`Ctrl::tag`] a hash gives its slot.
+/// The tag a hash gives its slot.
 ///
 /// The top of the hash, because the bottom of it already chose the home slot: a
 /// tag built from those bits would be the same for every slot the word can reach
 /// and would tell a walk nothing.
-fn ctrl_tag(hash: u64) -> u8 {
+fn slot_tag(hash: u64) -> u8 {
     OCCUPIED | (hash >> (u64::BITS - TAG_BITS)) as u8
 }
 
-/// What a walk reads, kept out of [`Slot`] so that reading it is not reading the
-/// slots. There is one per slot, in [`WordCache::sidecar`].
+/// How much an entry is being used, and when that was last written down. One per
+/// slot, in [`WordCache::usage`].
 #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
 #[repr(C)]
-struct Ctrl {
-    /// Bits of the word's hash, or [`EMPTY`]. See [`ctrl_tag`].
-    tag: u8,
+struct Usage {
     /// How much the word is being used, as of `epoch`.
     counter: u8,
     /// The epoch `counter` was written in.
     epoch: u8,
 }
 
-const _: () = assert!(std::mem::size_of::<Ctrl>() == 3);
-
-impl Ctrl {
+impl Usage {
     /// What this entry's counter is worth at `epoch`: what was written down,
     /// halved once for every epoch that has gone by since.
     ///
@@ -429,8 +422,8 @@ impl Ctrl {
 ///   `[key_off, ids_off, packed lengths]` once that byte is [`SPILLED`] — which
 ///   is what the `key_off`/`ids_off`/`key_len`/`ids_len` readers below are for.
 ///
-/// Nothing in here is read until the slot's [`Ctrl`] has said the word might be
-/// in it.
+/// Nothing in here is read until the slot's tag has said the word might be in
+/// it.
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
 struct Slot {
@@ -464,130 +457,74 @@ impl Slot {
     }
 }
 
-/// The first step a window's answer is `true` for, or [`WINDOW`] when it is
-/// true for none.
+/// Every byte of one of these is `0x01`, or `0x80`. Broadcasting a value over
+/// all [`WINDOW`] lanes and testing every lane's top bit is what turns a window
+/// into arithmetic — see [`Answer`].
+const ONES: u128 = u128::from_le_bytes([0x01; WINDOW]);
+const HIGHS: u128 = u128::from_le_bytes([0x80; WINDOW]);
+
+/// One window's worth of yes-or-no, as the top bit of each of a `u128`'s bytes:
+/// byte `step` answers for the slot `step` places along from home.
 ///
-/// Every [`Window`] question comes back as one nibble per slot, `0xF` for true
-/// and `0` for false, lowest slot in the lowest nibble. A nibble each rather
-/// than a bit each because that is what AArch64 can narrow a vector comparison
-/// to in one instruction, and answering in the same form on both targets is what
-/// keeps the walk itself free of either.
-fn first_step(mask: u64) -> usize {
-    mask.trailing_zeros() as usize / 4
+/// A window is [`WINDOW`] tags, which is sixteen bytes, which is one `u128`. So
+/// the questions a walk asks are answered for the whole window by ordinary
+/// integer arithmetic, in about as many instructions as it takes to ask one of
+/// them of one slot. No vector types, nothing target-specific: the same handful
+/// of `and`s and `xor`s on every machine this builds for.
+type Answer = u128;
+
+/// The first slot a window answers `true` for, as a step from home, or
+/// [`WINDOW`] when it answers `true` for none.
+fn first_step(answer: Answer) -> usize {
+    (answer.trailing_zeros() / 8) as usize
 }
 
-/// Clears the nibble `step` holds.
-fn without_step(mask: u64, step: usize) -> u64 {
-    mask & !(0xF << (step * 4))
+/// The same answer with `step` taken out of it.
+fn without_step(answer: Answer, step: usize) -> Answer {
+    answer & !(0x80 << (step * 8))
 }
 
-/// The [`Ctrl`]s of one window, and the three questions a walk asks of them.
+/// Everything an answer says about the slots before the first one `bound`
+/// answers for. All of it when `bound` answers for none.
 ///
-/// Every question is answered for all [`WINDOW`] slots at once. On AArch64 that
-/// is [`NeonWindow`]; everywhere else [`ScalarWindow`] loops. The two are held to
-/// the same answers by `the_neon_window_answers_what_the_scalar_one_does`.
-#[cfg(target_arch = "aarch64")]
-type Window = NeonWindow;
-#[cfg(not(target_arch = "aarch64"))]
-type Window = ScalarWindow;
-
-/// Compiled on AArch64 too, where only the test above uses it: it is what
-/// [`NeonWindow`] is checked against, and a copy that never builds would rot.
-#[cfg_attr(target_arch = "aarch64", cfg(test))]
-struct ScalarWindow([Ctrl; WINDOW]);
-
-#[cfg_attr(target_arch = "aarch64", cfg(test))]
-impl ScalarWindow {
-    /// One nibble per slot, in the order [`first_step`] reads them.
-    fn nibbles(&self, holds: impl Fn(&Ctrl) -> bool) -> u64 {
-        (0..WINDOW).fold(0, |mask, i| {
-            if holds(&self.0[i]) {
-                mask | 0xF << (i * 4)
-            } else {
-                mask
-            }
-        })
-    }
-
-    fn load(ctrl: &[Ctrl; WINDOW]) -> Self {
-        Self(*ctrl)
-    }
-
-    fn matching(&self, tag: u8) -> u64 {
-        self.nibbles(|ctrl| ctrl.tag == tag)
-    }
-
-    fn empty(&self) -> u64 {
-        self.nibbles(|ctrl| ctrl.tag == EMPTY)
-    }
-
-    fn coldest(&self, epoch: u8) -> usize {
-        // `min_by_key` keeps the first of equal keys, which is what sends a tie
-        // to the slot nearest home.
-        (0..WINDOW).min_by_key(|&i| self.0[i].score(epoch)).unwrap()
-    }
+/// `bound - 1` clears the lowest set bit and sets every bit below it, and `!
+/// bound` drops the higher ones it left alone — so this is branchless, and the
+/// all-of-it case falls out of `0 - 1` being all ones.
+fn before(bound: Answer) -> Answer {
+    bound.wrapping_sub(1) & !bound
 }
 
-#[cfg(target_arch = "aarch64")]
-struct NeonWindow {
-    tags: uint8x16_t,
-    counters: uint8x16_t,
-    epochs: uint8x16_t,
+/// The tags of one window, read as a single value.
+///
+/// `from_le_bytes` puts the tag of the slot `step` places from home in byte
+/// `step`, on a big-endian machine as much as on a little-endian one, so
+/// [`first_step`] means the same thing everywhere.
+fn window(tags: &[u8; WINDOW]) -> u128 {
+    u128::from_le_bytes(*tags)
 }
 
-#[cfg(target_arch = "aarch64")]
-impl NeonWindow {
-    /// Vector instructions are part of the AArch64 baseline, so there is nothing
-    /// to detect and no run-time choice to make between this and
-    /// [`ScalarWindow`].
-    fn load(ctrl: &[Ctrl; WINDOW]) -> Self {
-        // SAFETY: `LD3` reads three lanes of sixteen bytes, and a `Ctrl` is three
-        // bytes with no padding, so a `[Ctrl; WINDOW]` is exactly those 48 bytes.
-        let window = unsafe { vld3q_u8(ctrl.as_ptr().cast()) };
-        Self {
-            tags: window.0,
-            counters: window.1,
-            epochs: window.2,
-        }
-    }
+/// Which slots of the window are empty.
+///
+/// Exact, and one instruction: a live tag always carries [`OCCUPIED`] and
+/// [`EMPTY`] is zero, so "empty" is precisely "top bit clear".
+fn empty(window: u128) -> Answer {
+    !window & HIGHS
+}
 
-    /// A comparison result in the form [`first_step`] reads.
-    ///
-    /// AArch64 has no instruction that collects one bit per lane. `SHRN` narrows
-    /// the sixteen `0xFF`/`0x00` lanes into sixteen nibbles of one 64-bit
-    /// register, which is the same answer in the same order — and is why the
-    /// answers are nibbles rather than bits.
-    fn mask(compared: uint8x16_t) -> u64 {
-        unsafe {
-            vget_lane_u64::<0>(vreinterpret_u64_u8(vshrn_n_u16::<4>(vreinterpretq_u16_u8(
-                compared,
-            ))))
-        }
-    }
-
-    fn matching(&self, tag: u8) -> u64 {
-        unsafe { Self::mask(vceqq_u8(self.tags, vdupq_n_u8(tag))) }
-    }
-
-    fn empty(&self) -> u64 {
-        unsafe { Self::mask(vceqq_u8(self.tags, vdupq_n_u8(EMPTY))) }
-    }
-
-    fn coldest(&self, epoch: u8) -> usize {
-        unsafe {
-            let missed = vminq_u8(
-                vsubq_u8(vdupq_n_u8(epoch), self.epochs),
-                vdupq_n_u8(MAX_DECAY),
-            );
-            // `USHL` shifts right on a negative count, and gives zero once that
-            // count reaches the lane width — the same ceiling MAX_DECAY sets.
-            let score = vshlq_u8(self.counters, vnegq_s8(vreinterpretq_s8_u8(missed)));
-            let lowest = vdupq_n_u8(vminvq_u8(score));
-            // The first lane holding the minimum, so a tie goes to the slot
-            // nearest home exactly as it does in `ScalarWindow::coldest`.
-            first_step(Self::mask(vceqq_u8(score, lowest)))
-        }
-    }
+/// Which slots of the window could hold the word `tag` belongs to.
+///
+/// The xor is zero exactly in the lanes that match, and the rest is the standard
+/// hunt for a zero byte: subtracting one from every lane borrows out of a zero
+/// lane into its top bit, and `!x` keeps only the lanes that were small enough
+/// for that top bit to be news.
+///
+/// A borrow can run on into the next lane, so a lane holding exactly `tag ^ 1`
+/// directly above a match is answered `true` as well. It cannot go the other
+/// way — a matching lane is never missed — and the walk confirms every answer
+/// against the key anyway, so the cost of the rare extra one is a slot read.
+fn matching(window: u128, tag: u8) -> Answer {
+    let x = window ^ u128::from_le_bytes([tag; WINDOW]);
+    x.wrapping_sub(ONES) & !x & HIGHS
 }
 
 /// A grow-only arena that reuses the space of evicted entries instead of
@@ -694,19 +631,23 @@ enum Probe {
 pub struct WordCache {
     hasher: RandomState,
     slots: Box<[Slot]>,
-    /// One [`Ctrl`] per slot, and then a copy of the first [`WINDOW`] of them, so
-    /// that the window of any home is `WINDOW` entries in a row and can be read
-    /// with a single load. [`WordCache::write_ctrl`] keeps the copy in step.
-    sidecar: Box<[Ctrl]>,
+    /// One tag per slot, and then a copy of the first [`WINDOW`] of them, so that
+    /// the window of any home is `WINDOW` bytes in a row and can be read as one
+    /// `u128`. [`WordCache::write_tag`] keeps the copy in step.
+    tags: Box<[u8]>,
+    /// One [`Usage`] per slot, mirrored like `tags`. Read only once a tag has
+    /// answered for its slot, or when a full window has to give one up, so it is
+    /// kept out of `tags`: a walk that finds nothing never touches it.
+    usage: Box<[Usage]>,
     key_bytes: Slab<u8>,
     ids: Slab<u32>,
     /// `slots.len() - 1`. The table is a power of two, so this folds a hash into
     /// a slot index.
     mask: usize,
     /// Where the fade count stands, from 0 to [`EPOCH_MAX`] and no higher. A
-    /// [`Ctrl::epoch`] is what this held when that entry was last written, so the
-    /// difference between them is how many fades it has sat through.
-    /// [`WordCache::settle`] puts this and every `Ctrl` back to zero together
+    /// A [`Usage::epoch`] is what this held when that entry was last written, so
+    /// the difference between them is how many fades it has sat through.
+    /// [`WordCache::settle`] puts this and every `Usage` back to zero together
     /// when the count runs out of room.
     epoch: u8,
     /// Evictions still to come before the next `epoch` bump.
@@ -723,7 +664,8 @@ impl WordCache {
         Self {
             hasher: RandomState::new(),
             slots: vec![Slot::default(); n_slots].into_boxed_slice(),
-            sidecar: vec![Ctrl::default(); n_slots + WINDOW].into_boxed_slice(),
+            tags: vec![EMPTY; n_slots + WINDOW].into_boxed_slice(),
+            usage: vec![Usage::default(); n_slots + WINDOW].into_boxed_slice(),
             // Ceilings, not reservations: the arenas grow only as far as the live
             // set takes them. Deliberately generous, so that the slot table is
             // what runs out first — an arena that turns inserts away while slots
@@ -752,18 +694,10 @@ impl WordCache {
         let index = match self.probe(key, hash, word) {
             Probe::Hit(index) => {
                 let epoch = self.epoch;
-                let ctrl = self.sidecar[index];
                 // Saturating, so hits past what a byte holds are not counted. An
                 // entry that busy is in no danger of eviction anyway.
-                let counter = ctrl.score(epoch).saturating_add(1);
-                self.write_ctrl(
-                    index,
-                    Ctrl {
-                        counter,
-                        epoch,
-                        ..ctrl
-                    },
-                );
+                let counter = self.usage[index].score(epoch).saturating_add(1);
+                self.write_usage(index, Usage { counter, epoch });
                 let slot = self.slots[index];
                 return Lookup::Hit(if slot.spilled() {
                     self.ids.get(slot.ids_off(), slot.ids_len())
@@ -776,7 +710,7 @@ impl WordCache {
         Lookup::Miss(Some(Placement {
             index,
             key,
-            tag: ctrl_tag(hash),
+            tag: slot_tag(hash),
             word,
         }))
     }
@@ -792,15 +726,15 @@ impl WordCache {
         // eviction: give the arena runs back and charge the table one round of
         // fading. Both wait until here, so a lookup whose caller decides not to
         // store anything after all costs the entry sitting there nothing.
-        if self.sidecar[at.index].tag != EMPTY {
+        if self.tags[at.index] != EMPTY {
             self.reclaim(at.index);
             self.fade();
         }
         // Fading moves the epoch, so stamp the new entry after it.
-        self.write_ctrl(
+        self.write_tag(at.index, at.tag);
+        self.write_usage(
             at.index,
-            Ctrl {
-                tag: at.tag,
+            Usage {
                 counter: NEWBORN,
                 epoch: self.epoch,
             },
@@ -826,34 +760,45 @@ impl WordCache {
         }
     }
 
-    /// The [`Ctrl`]s of the window starting at `home`, in the form a walk reads
-    /// them. The mirrored tail of `sidecar` is what makes the slice contiguous
-    /// for every `home`.
-    fn window(&self, home: usize) -> Window {
-        let ctrl: &[Ctrl; WINDOW] = self.sidecar[home..home + WINDOW].try_into().unwrap();
-        Window::load(ctrl)
+    /// The tags of the window starting at `home`. The mirrored tail of `tags` is
+    /// what makes the slice contiguous for every `home`.
+    fn tag_window(&self, home: usize) -> u128 {
+        window(self.tags[home..home + WINDOW].try_into().unwrap())
+    }
+
+    /// The step of the window's lowest-scoring slot, ties going to the slot
+    /// nearest home.
+    ///
+    /// Reads the window as one flat slice, which is what the mirrored tail of
+    /// `usage` is for. Folding each step back into the table instead costs an
+    /// `and` per slot and leaves nothing for the compiler to widen.
+    fn coldest(&self, home: usize, epoch: u8) -> usize {
+        let window = &self.usage[home..home + WINDOW];
+        // `min_by_key` keeps the first of equal keys, which is what sends a tie
+        // to the slot nearest home.
+        (0..WINDOW)
+            .min_by_key(|&step| window[step].score(epoch))
+            .unwrap()
     }
 
     /// One walk over `word`'s window, from its home position, answering both
     /// questions a lookup has: which slot holds the word, and — if none does —
     /// which slot it should take.
     ///
-    /// The second answer is free. Both come out of the window's [`Ctrl`]s, which
-    /// are one load; working the second one out afterwards would mean reading
-    /// them again and hashing the word again.
+    /// The second answer is nearly free: both come out of the window's tags,
+    /// which are one load, and only a full window needs anything more. Working
+    /// it out afterwards would mean reading them again and hashing the word
+    /// again.
     ///
     /// Stopping at the first empty slot is safe because slots never go back to
     /// being empty: an empty one means the word was never stored.
     fn probe(&self, key: u128, hash: u64, word: &[u8]) -> Probe {
         let home = hash as usize & self.mask;
-        let window = self.window(home);
-        let empty = window.empty();
+        let window = self.tag_window(home);
+        let empty = empty(window);
         // Nothing past the first empty slot can hold the word: the walk that
         // stored it would have stopped there and taken that slot.
-        let before_empty = 1u64
-            .checked_shl(empty.trailing_zeros())
-            .map_or(u64::MAX, |bit| bit - 1);
-        let mut candidates = window.matching(ctrl_tag(hash)) & before_empty;
+        let mut candidates = matching(window, slot_tag(hash)) & before(empty);
         // Only a hashed key can turn out to belong to a different word, and
         // whether this one is hashed is settled before the walk starts — the
         // caller built the key out of the word it is looking for.
@@ -870,7 +815,7 @@ impl WordCache {
             candidates = without_step(candidates, step);
         }
         let step = if empty == 0 {
-            window.coldest(self.epoch)
+            self.coldest(home, self.epoch)
         } else {
             first_step(empty)
         };
@@ -916,12 +861,20 @@ impl WordCache {
         })
     }
 
-    /// Write a slot's [`Ctrl`], and the copy of it in the mirrored tail when the
-    /// slot is one of the first [`WINDOW`].
-    fn write_ctrl(&mut self, index: usize, ctrl: Ctrl) {
-        self.sidecar[index] = ctrl;
+    /// Write a slot's tag, and the copy of it in the mirrored tail when the slot
+    /// is one of the first [`WINDOW`].
+    fn write_tag(&mut self, index: usize, tag: u8) {
+        self.tags[index] = tag;
         if index < WINDOW {
-            self.sidecar[self.slots.len() + index] = ctrl;
+            self.tags[self.slots.len() + index] = tag;
+        }
+    }
+
+    /// The same, for a slot's [`Usage`].
+    fn write_usage(&mut self, index: usize, usage: Usage) {
+        self.usage[index] = usage;
+        if index < WINDOW {
+            self.usage[self.slots.len() + index] = usage;
         }
     }
 
@@ -941,24 +894,21 @@ impl WordCache {
     }
 
     /// Spend every entry's outstanding fade and start the count again: each live
-    /// entry's score becomes its counter, and the epoch and every [`Ctrl`] go
+    /// entry's score becomes its counter, and the epoch and every [`Usage`] go
     /// back to zero.
     ///
-    /// Run on the last epoch a `Ctrl` can hold, and only then. The epoch has to
+    /// Run on the last epoch a `Usage` can hold, and only then. The epoch has to
     /// start over at some point, and the moment it does, the difference between
     /// it and a stored epoch stops meaning anything for entries written before
     /// the restart. So the differences are cashed in first, while they can still
     /// be read.
     fn settle(&mut self) {
         let epoch = self.epoch;
-        // The mirrored tail is a copy of the front, so one pass over the whole
-        // sidecar leaves the two in step without a second walk.
-        for ctrl in self.sidecar.iter_mut() {
-            if ctrl.tag == EMPTY {
-                continue;
-            }
-            ctrl.counter = ctrl.score(epoch);
-            ctrl.epoch = 0;
+        // Tags are untouched, and the mirrored tail of `usage` gets the same pass
+        // as the front, so both stay in step without a second walk.
+        for usage in self.usage.iter_mut() {
+            usage.counter = usage.score(epoch);
+            usage.epoch = 0;
         }
         self.epoch = 0;
     }
@@ -1003,9 +953,9 @@ impl WordCache {
     /// How many slots hold an entry. Equal to the capacity once the table is
     /// saturated, which is the state the eviction measurements need.
     pub fn bench_occupancy(&self) -> usize {
-        self.sidecar[..self.slots.len()]
+        self.tags[..self.slots.len()]
             .iter()
-            .filter(|ctrl| ctrl.tag != EMPTY)
+            .filter(|&&tag| tag != EMPTY)
             .count()
     }
 }
@@ -1061,7 +1011,7 @@ mod tests {
     #[test]
     fn a_live_tag_is_never_the_empty_marker() {
         for hash in [0u64, 1, u64::MAX, 1 << 57, u64::MAX >> TAG_BITS] {
-            assert_ne!(ctrl_tag(hash), EMPTY, "hash {hash:#x}");
+            assert_ne!(slot_tag(hash), EMPTY, "hash {hash:#x}");
         }
     }
 
@@ -1136,10 +1086,10 @@ mod tests {
         let mut cache = WordCache::new(WINDOW);
         let (_, hash) = cache.slot_key(b"beta");
         let decoy = hash as usize & cache.mask;
-        cache.write_ctrl(
+        cache.write_tag(decoy, slot_tag(hash));
+        cache.write_usage(
             decoy,
-            Ctrl {
-                tag: ctrl_tag(hash),
+            Usage {
                 counter: NEWBORN,
                 epoch: 0,
             },
@@ -1169,20 +1119,15 @@ mod tests {
         store(&mut cache, &theirs, [7u32].into_iter());
         let their_index = slot_of(&cache, &theirs).unwrap();
         let their_slot = cache.slots[their_index];
-        let their_ctrl = cache.sidecar[their_index];
+        let their_usage = cache.usage[their_index];
         let (my_key, my_hash) = cache.slot_key(&mine);
         let my_home = my_hash as usize & cache.mask;
         cache.slots[my_home] = Slot {
             key: my_key,
             ..their_slot
         };
-        cache.write_ctrl(
-            my_home,
-            Ctrl {
-                tag: ctrl_tag(my_hash),
-                ..their_ctrl
-            },
-        );
+        cache.write_tag(my_home, slot_tag(my_hash));
+        cache.write_usage(my_home, their_usage);
 
         store(&mut cache, &mine, [1u32, 2].into_iter());
         assert_eq!(cache.lookup(&mine).hit(), Some(&[1u32, 2][..]));
@@ -1229,12 +1174,12 @@ mod tests {
             cache.lookup(b"hot").hit();
         }
         let index = slot_of(&cache, b"hot").unwrap();
-        assert_eq!(cache.sidecar[index].score(cache.epoch), u8::MAX);
+        assert_eq!(cache.usage[index].score(cache.epoch), u8::MAX);
 
         for _ in 0..MAX_DECAY {
             cache.fade();
         }
-        assert_eq!(cache.sidecar[index].score(cache.epoch), 0);
+        assert_eq!(cache.usage[index].score(cache.epoch), 0);
     }
 
     /// An epoch is a byte, so the count has to start over at zero every 256
@@ -1256,10 +1201,10 @@ mod tests {
             cache.fade();
         }
         assert_eq!(cache.epoch, 0, "the lap did not start over");
-        assert_eq!(cache.sidecar[index].score(cache.epoch), 0);
+        assert_eq!(cache.usage[index].score(cache.epoch), 0);
     }
 
-    /// The tail of the sidecar is a copy of its first [`WINDOW`] entries, so that
+    /// The tail of `tags` is a copy of its first [`WINDOW`] entries, so that
     /// a window starting near the end of the table is still `WINDOW` entries in a
     /// row. Every write has to keep the two in step, or a walk whose window
     /// crosses the seam reads control bytes that no longer describe the slots.
@@ -1273,11 +1218,18 @@ mod tests {
                 format!("w{i}").as_bytes(),
                 [i as u32].into_iter(),
             );
-            assert_eq!(cache.sidecar[..WINDOW], cache.sidecar[n..], "insert {i}");
+            assert_eq!(cache.tags[..WINDOW], cache.tags[n..], "tags, insert {i}");
+            assert_eq!(cache.usage[..WINDOW], cache.usage[n..], "usage, insert {i}");
         }
-        // A settle rewrites every live entry, and has to leave the two in step too.
+        // A settle rewrites every live entry's usage and no tag at all, so the
+        // two must still agree afterwards.
         cache.settle();
-        assert_eq!(cache.sidecar[..WINDOW], cache.sidecar[n..], "after settle");
+        assert_eq!(cache.tags[..WINDOW], cache.tags[n..], "tags, after settle");
+        assert_eq!(
+            cache.usage[..WINDOW],
+            cache.usage[n..],
+            "usage, after settle"
+        );
     }
 
     /// Reusing an evicted entry's arena run is where this design can go wrong:
@@ -1310,6 +1262,75 @@ mod tests {
         assert!(live > 0, "everything was evicted — the test proves nothing");
     }
 
+    /// Every step a window answers for, so a mask can be read against a picture
+    /// of the window it came from.
+    fn steps(answer: Answer) -> Vec<usize> {
+        let mut left = answer;
+        let mut found = Vec::new();
+        while left != 0 {
+            let step = first_step(left);
+            found.push(step);
+            left = without_step(left, step);
+        }
+        found
+    }
+
+    /// The arithmetic in [`matching`], [`empty`] and [`before`] read back as the
+    /// slots they are talking about.
+    #[test]
+    fn a_window_answers_for_the_slots_it_should() {
+        let mut tags = [EMPTY; WINDOW];
+        tags[0] = 0x81;
+        tags[3] = 0xC4;
+        tags[5] = 0x81;
+        tags[9] = 0x81;
+        let window = window(&tags);
+
+        assert_eq!(steps(matching(window, 0x81)), [0, 5, 9]);
+        assert_eq!(steps(matching(window, 0xC4)), [3]);
+        assert_eq!(
+            steps(empty(window)),
+            [1, 2, 4, 6, 7, 8, 10, 11, 12, 13, 14, 15]
+        );
+        // Slot 1 is empty, so slots 5 and 9 are out of reach: whatever put a word
+        // there would have stopped at slot 1 and taken it.
+        assert_eq!(steps(matching(window, 0x81) & before(empty(window))), [0]);
+    }
+
+    /// A full window has no empty slot to stop at, so every match stays in reach.
+    #[test]
+    fn a_full_window_bounds_nothing() {
+        let tags = [OCCUPIED | 0x11; WINDOW];
+        let window = window(&tags);
+        assert_eq!(empty(window), 0);
+        assert_eq!(
+            steps(matching(window, OCCUPIED | 0x11) & before(0)).len(),
+            WINDOW
+        );
+    }
+
+    /// [`matching`] hunts for a zero byte by subtracting one from every lane, and
+    /// a borrow out of a matching lane can run on into the one above it — so a
+    /// slot holding `tag ^ 1` just above a match is answered for as well. That
+    /// costs one slot read, which the key comparison then rejects.
+    ///
+    /// What it must never do is the other thing. A tag that is really there and
+    /// goes unanswered is a word that reads as absent, and the table would grow a
+    /// second entry for it.
+    #[test]
+    fn matching_never_misses_a_tag() {
+        for tag in OCCUPIED..=u8::MAX {
+            for step in 0..WINDOW {
+                let mut tags = [OCCUPIED; WINDOW];
+                tags[step] = tag;
+                assert!(
+                    steps(matching(window(&tags), tag)).contains(&step),
+                    "tag {tag:#x} at step {step} went unanswered"
+                );
+            }
+        }
+    }
+
     /// Freed runs have to come back. Without reuse the arenas grow with every
     /// insert until their budget is spent, and from then on the cache silently
     /// stops accepting words even though the table has room for them.
@@ -1330,60 +1351,5 @@ mod tests {
         );
         assert!(cache.key_bytes.data.len() <= 65 * 35);
         assert!(cache.ids.data.len() <= 65 * 8);
-    }
-
-    /// Control bytes covering what a window can present: empty slots, repeated
-    /// tags, counters at both ends, and epochs far enough back to reach
-    /// [`MAX_DECAY`].
-    fn sample_window(seed: u64) -> [Ctrl; WINDOW] {
-        let mut state = seed | 1;
-        let mut next = || {
-            state ^= state << 13;
-            state ^= state >> 7;
-            state ^= state << 17;
-            state
-        };
-        std::array::from_fn(|_| {
-            let n = next();
-            Ctrl {
-                tag: if n % 5 == 0 {
-                    EMPTY
-                } else {
-                    n as u8 | OCCUPIED
-                },
-                counter: (n >> 8) as u8,
-                epoch: ((n >> 16) % 200) as u8,
-            }
-        })
-    }
-
-    /// [`ScalarWindow`] is the definition and [`NeonWindow`] is an implementation
-    /// of it, so anything they disagree about is a bug in the vector path that no
-    /// other test would separate from a bug in the walk.
-    #[cfg(target_arch = "aarch64")]
-    #[test]
-    fn the_neon_window_answers_what_the_scalar_one_does() {
-        for seed in 0..64u64 {
-            let ctrl = sample_window(seed);
-            let neon = NeonWindow::load(&ctrl);
-            let scalar = ScalarWindow::load(&ctrl);
-            assert_eq!(neon.empty(), scalar.empty(), "empty, seed {seed}");
-            for tag in [EMPTY, OCCUPIED, 0xC3, 0xFF, ctrl[0].tag, ctrl[9].tag] {
-                assert_eq!(
-                    neon.matching(tag),
-                    scalar.matching(tag),
-                    "matching {tag:#x}, seed {seed}"
-                );
-            }
-            // `sample_window` stops at 199, so every epoch here is at or past
-            // every entry's and the decay subtraction stays in range.
-            for epoch in [200u8, 201, EPOCH_MAX] {
-                assert_eq!(
-                    neon.coldest(epoch),
-                    scalar.coldest(epoch),
-                    "coldest at {epoch}, seed {seed}"
-                );
-            }
-        }
     }
 }

--- a/tokenizers/tk-encode/src/utils/word_cache.rs
+++ b/tokenizers/tk-encode/src/utils/word_cache.rs
@@ -1,167 +1,345 @@
-//! Remembers the token ids a word encodes to, so a model only has to work it out once.
+//! A table that remembers which token ids a word encodes to, so a model only has
+//! to work it out once.
 //!
-//! Text repeats itself: a few thousand distinct words usually cover nearly every
-//! word of a document, and turning one of them into ids — merging pairs in BPE,
-//! searching the lattice in Unigram — is the most expensive thing a model does. So
-//! the second time a word shows up, the answer should come from a table instead of
-//! from the model. Both sides of that table are on the hot path: a hit has to be far
-//! cheaper than encoding the word, and a miss has to cost close to nothing, because
-//! every word pays for one the first time it is seen.
+//! # What this is for
 //!
-//! There are five pieces. The table is `N` fixed-size slots, `N` being the
-//! requested capacity rounded up to a power of two; beside it two small arrays a
-//! search reads instead of the slots, and two arenas holding what a slot is too
-//! small for:
+//! A tokenizer turns text into *token ids*: the small integers a language model
+//! reads. It gets there in three stages. It **normalizes** the text (lowercasing
+//! it, say), it **pre-tokenizes** it — cuts it into small pieces, which are
+//! usually words or fragments of words — and then it runs a **model** over each
+//! piece to produce ids. This module calls one of those pieces a *word*, because
+//! that is what it nearly always is.
+//!
+//! The model stage is the expensive one, and it pays that cost for every word:
+//!
+//! - **BPE** (byte-pair encoding) starts from the word's individual bytes and
+//!   repeatedly glues the best-ranked neighbouring pair together, until no pair
+//!   left in the word can be merged. Every merge changes the word and the search
+//!   for the next best pair starts again.
+//! - **Unigram** considers the many ways of cutting the word into pieces the
+//!   vocabulary knows, scores them, and keeps the best. That is a search over a
+//!   lattice of candidate cuts.
+//! - **WordPiece** walks the word from the front, taking the longest piece the
+//!   vocabulary holds, then carries on from where that piece ended. That is one
+//!   search per piece of the word.
+//!
+//! Both are pure: the same word and the same vocabulary always give the same ids.
+//! And words repeat, relentlessly — a few thousand distinct words cover nearly
+//! every word of a document, and a few dozen cover a large share of it on their
+//! own. So the second time a word shows up, its ids should come out of a table
+//! rather than out of the model. Storing the answer to a pure function and
+//! reusing it is called *memoization*, and this module is where the answers go:
 //!
 //! ```text
-//!   slots     [Slot; N]      32 bytes each, one word per slot
-//!   tags      [u8; N]        1 byte each, what a search reads
-//!   usage     [Usage; N]     2 bytes each, what decides who gives way
-//!   key_bytes Slab<u8>       the bytes of words longer than 15
-//!   ids       Slab<u32>      id runs longer than 3
+//!            "the cat sat on the mat"
+//!                       │
+//!                       │  normalize, then pre-tokenize
+//!                       ▼
+//!         "the"   "cat"   "sat"   "on"   "the"   "mat"
+//!            │       │       │      │       │      │
+//!            ▼       ▼       ▼      ▼       ▼      ▼
+//!         ┌────────────────────────────────────────────┐
+//!         │  WordCache — have I encoded this word yet? │
+//!         └────────────────────────────────────────────┘
+//!            │ hit                         │ miss
+//!            │ (the ids, from the table)   ▼
+//!            │                     the model works it out,
+//!            │                     and the ids are stored here
+//!            ▼                             ▼
+//!          [12]    [87]    [43]    [9]    [12]   [64]   ← ids, made up here
+//!                                          ▲
+//!                                          └ second "the": a hit
 //! ```
 //!
-//! One `WordCache` lives in one scratch buffer, so it is owned by a single
-//! thread: no sharing, no locking, no atomics.
+//! The payoff is large. On `big.txt` in 4 KB chunks, one thread encoding with
+//! GPT-2's tokenizer goes from 27 MB/s to 230 MB/s with this table in place.
+//! Llama-3 gains less — 78 to 116 MB/s — because its config sets `ignore_merges`,
+//! which looks the whole word up in the vocabulary before any merging happens, so
+//! the work a hit saves there is a vocabulary lookup rather than a merge loop.
+//!
+//! ## What "cache" buys, and what it costs
+//!
+//! A cache is not a complete record. It has a fixed memory budget, it is allowed
+//! to forget a word (the model can always encode it again), and it is *not*
+//! allowed to be wrong: a hit must return the ids that word really encodes to,
+//! never another word's. Those three sentences decide most of what follows.
+//!
+//! Both sides of the table sit on the hot path, so both have to be cheap:
+//!
+//! - a **hit** has to be far cheaper than encoding the word, or the cache is
+//!   just overhead;
+//! - a **miss** has to cost close to nothing, because every word pays for one the
+//!   first time it is seen, and the set of distinct words in a document has no
+//!   upper bound — Korean and Chinese text keeps producing words nobody has seen
+//!   before.
+//!
+//! One `WordCache` belongs to one encoding scratch buffer, which belongs to one
+//! thread at a time. Nothing here is shared between threads, so there are no
+//! locks, no atomics, and no memory ordering to reason about.
+//!
+//! ## Words to know
+//!
+//! The design borrows its words from hash tables and from CPU caches. Everything
+//! below uses these ones and no synonyms:
+//!
+//! | word | meaning |
+//! |---|---|
+//! | **slot** | one fixed-size place in the table, holding one word's entry |
+//! | **home** | the slot a word's hash picks out; where a probe starts |
+//! | **probe** | walking forward from home, slot by slot, looking for the word |
+//! | **window** | the [`WINDOW`] slots from home onward — as far as a probe goes |
+//! | **step** | how far along the window something is, `0` being home itself |
+//! | **tag** | one byte per slot, a few bits of its word's hash, kept apart from the slot |
+//! | **spill** | move part of an entry out of its slot, into an arena |
+//! | **arena** | one flat buffer holding the parts that did not fit in slots |
+//! | **counter** | how much an entry is being used; the lowest one is evicted first |
+//! | **epoch** | the table's clock; used to fade counters without rewriting them |
+//!
+//! # The five pieces
+//!
+//! The table is `N` slots, `N` being the requested capacity rounded up to a power
+//! of two. Beside the slots are two small arrays — a probe reads *those* rather
+//! than the slots — and two arenas for what a slot is too small to hold. Sizes
+//! below are for the default capacity of 65,536 slots
+//! ([`crate::utils::cache::DEFAULT_CACHE_CAPACITY`]):
+//!
+//! ```text
+//!   slots       [Slot;  N]     32 B each    one word's entry per slot     2 MiB
+//!   tags        [u8;    N+W]    1 B each    what a probe reads           64 KiB
+//!   usage       [Usage; N+W]    2 B each    what decides who gives way  128 KiB
+//!   key_arena   Arena<u8>                   bytes of words over 15 B    grows to
+//!   id_arena    Arena<u32>                  id runs longer than 3       the live set
+//!
+//!   W = WINDOW = 16. The two arrays are N+W long, not N: see "the seam" below.
+//! ```
+//!
+//! Every byte of every entry lives in one of those five. There are no per-entry
+//! heap allocations, which is what makes a miss cheap — storing a word writes
+//! into space that already exists.
 //!
 //! # Looking a word up
 //!
-//! A word's hash picks its *home* slot. If another word is already sitting
-//! there, the search steps forward one slot at a time — this is open addressing
-//! with linear probing — for at most [`WINDOW`] slots:
+//! Hash the word, and the low bits of the hash pick its home slot. The table is a
+//! power of two, so "fold the hash into a slot number" is one bitwise `and` with
+//! `N - 1` ([`WordCache::index_mask`]) rather than a division.
+//!
+//! Two words can easily want the same home. When that happens the loser moves
+//! along: a probe checks home, then home + 1, then home + 2, up to [`WINDOW`]
+//! slots. This is *open addressing with linear probing* — "open" because a word
+//! is not confined to one place, "linear" because it walks one slot at a time.
 //!
 //! ```text
-//!   lookup(b"tion")   home = hash(b"tion") & (N - 1) = 4
+//!   lookup(b"tion")    home = hash(b"tion") & (N - 1) = 4
 //!
 //!     slot 3  │ "port"  │
-//!     slot 4  │ "ation" │ ← home, but another word got here first: step forward
+//!     slot 4  │ "ation" │ ← home, but another word got here first: step on
 //!     slot 5  │ "tion"  │ ← the key matches: hit, hand back its ids
 //!     slot 6  │  empty  │
 //!     slot 7  │ "the"   │
 //!
-//!   lookup(b"xyz")    home = 4 → not "ation", not "tion", slot 6 is empty → miss
+//!   lookup(b"xyz")     home = 4 → not "ation", not "tion", slot 6 is empty → miss
 //! ```
 //!
-//! A walk may stop at that empty slot instead of going the full [`WINDOW`],
-//! because no slot ever goes back to being empty once it has been used: an empty
-//! slot means nothing was ever stored beyond it.
+//! A probe may stop at an empty slot rather than walking the full window. Nothing
+//! here ever empties a slot again once it has been used — eviction overwrites, it
+//! does not delete — so an empty slot proves that no word was ever stored past it.
+//! That one property saves this table more than the early exit; the section on
+//! eviction below spells out the rest.
 //!
-//! A miss hands back the slot the word *would* go in — slot 6 above — as a
-//! [`Placement`], which the caller returns to [`WordCache::insert`] once the
-//! model has encoded the word. So a miss costs one walk over the window, not
-//! two. Picking a slot needs exactly the reads that failing to find the word has
-//! already done, and doing it afterwards instead would mean reading the window
-//! again and hashing the word a second time. The caller can also drop the
-//! placement and store nothing: nothing has changed yet, and an entry only loses
-//! its slot when something is written over it.
+//! ## A miss hands back the slot to use
 //!
-//! ## The walk never reads a slot it does not need
+//! A miss returns a [`Placement`]: the slot the word *would* go in — slot 6
+//! above — which the caller passes to [`WordCache::insert`] once the model has
+//! encoded the word. Choosing that slot needs exactly the reads that failing to
+//! find the word has already done, so it comes for free here, whereas doing it
+//! inside `insert` would mean hashing the word and reading the window a second
+//! time.
 //!
-//! Done slot by slot, that walk asks one question of each slot it passes: is this
-//! the word? Reading a slot to ask it drags 32 bytes through the cache for an
-//! answer that is nearly always "no", and a window of them is 512 bytes.
+//! The caller may also drop the placement and store nothing. Nothing has changed
+//! yet: an entry only loses its slot when something is written over it.
 //!
-//! So the question is asked somewhere else. Every slot has a one-byte *tag* — a
-//! few bits of its word's hash — in an array of its own, and a window's worth of
-//! those is sixteen bytes, which is one `u128`:
+//! ## A probe does not read the slots
+//!
+//! Done slot by slot, a probe asks one question of each slot it passes: *is this my
+//! word?* Reading a slot to ask it drags 32 bytes through the CPU's caches for an
+//! answer that is nearly always "no". A whole window of them is 512 bytes, spread
+//! over eight cache lines.
+//!
+//! So the question is asked somewhere else. Every slot has a one-byte **tag** in
+//! an array of its own, carrying [`TAG_BITS`] bits of its word's hash. A window's
+//! worth of tags is sixteen bytes — which is exactly one `u128`:
 //!
 //! ```text
-//!   tags   ┌──┬──┬──┬──┬──┬──┬──┬──┬─ … ─┬──┐   16 bytes for a window
+//!   tags   ┌──┬──┬──┬──┬──┬──┬──┬──┬─ … ─┬──┐   16 tags = 16 bytes = one u128
 //!          │A3│00│F1│A3│5C│00│00│B8│     │2E│
 //!          └──┴──┴──┴──┴──┴──┴──┴──┴─────┴──┘
-//!            4  5  6  7  8  9 10 11       19
+//!     slot   4  5  6  7  8  9 10 11       19
+//!     step   0  1  2  3  4  5  6  7       15
 //!
-//!          0 marks a slot nothing was ever stored in.
+//!          00 marks a slot nothing was ever stored in.
 //! ```
 //!
-//! Read as one integer, a window answers a question for all sixteen slots at once
-//! by ordinary arithmetic — see [`matching`] and [`empty`]. A slot is read only
-//! after its tag has said the word might be in it, and a tag is seven bits, so
-//! for a word the table does not hold that is no slot at all about 127 times in
-//! 128.
+//! Read as one integer, that window answers a question about all sixteen slots at
+//! once, using nothing but ordinary arithmetic — see [`tag_matches`] and
+//! [`empty_slots`]. A slot is read only after its tag has said the word might be in
+//! it, and a tag holds seven bits of hash: a word the table does not hold reads no
+//! slot at all, about 127 times in 128.
 //!
-//! There is no vector code here and nothing target-specific. Sixteen bytes is one
-//! `u128` on every machine this builds for, and the hand-written SIMD that would
-//! replace it measured about three times fewer instructions on the two targets it
-//! could be written for — against a doubling of this module and a second
-//! implementation to keep honest.
+//! This is the [Swiss Tables] design, from Google's Abseil, which Rust's own
+//! `HashMap` also uses through [hashbrown]: one control byte per slot, holding one
+//! flag bit and seven bits of hash, tested sixteen at a time.
 //!
-//! What is *not* in a tag is how much its entry is being used, which only two
-//! paths need: a hit, which has already found its slot, and a full window, which
-//! has to give one up. That lives in [`Usage`], one array further out, and a walk
-//! that finds nothing never touches it.
+//! ### Sixteen answers out of one subtraction
 //!
-//! A tag comes from the *high* bits of the hash. The low bits already chose the
-//! home slot, so tags built from them would be equal across a window and would
-//! tell a walk nothing.
+//! Abseil and hashbrown test their sixteen bytes with SIMD instructions — *Single
+//! Instruction, Multiple Data*, the CPU's vector unit, which applies one operation
+//! to sixteen lanes of a register at once. There is no SIMD in this module. It
+//! uses SWAR instead — *SIMD Within A Register* — where a plain integer is treated
+//! as a row of lanes and ordinary arithmetic does the work.
+//!
+//! The trick is the classic hunt for a zero byte. Take the window, `xor` it with the
+//! tag being looked for, and a lane goes to zero exactly where the tag matches.
+//! Then subtract one from every lane — that is [`ONES`], `01` in all sixteen
+//! lanes — because only a zero lane has to borrow, and borrowing flips its top bit
+//! on. Finally keep nothing but those top bits, which is [`HIGHS`]. Worked through
+//! four lanes, looking for tag `A3`:
+//!
+//! ```text
+//!     step              0     1     2     3
+//!     tags             A3    81    00    A3
+//!     x = tags ^ A3    00    22    A3    00    ← zero exactly where the tag matches
+//!     x - ONES         FF    20    A2    FF    ← the zero lanes borrowed: top bit on
+//!     & !x             FF    00    00    FF    ← drops lanes that were already ≥ 80
+//!     & HIGHS          80    00    00    80    ← "maybe" at steps 0 and 3
+//! ```
+//!
+//! The `& !x` step earns its place: a lane whose `xor` came out `80` or more already
+//! has its top bit set without borrowing anything, and `!x` throws exactly those
+//! away. The whole test is `(x - ONES) & !x & HIGHS`, three instructions on one
+//! register. It is the expression Alan Mycroft posted to a newsgroup in 1987 (see
+//! [Bit Twiddling Hacks]), and the one hashbrown itself falls back to on targets
+//! without SIMD.
+//!
+//! Two consequences of doing it this way are worth knowing:
+//!
+//! - **A borrow can cross into the lane above.** The subtraction is one operation on
+//!   one register, so a lane holding exactly `tag ^ 1` directly above a match is
+//!   answered "maybe" as well, and so is a run of them. That costs one slot read
+//!   each, which the key comparison then rejects. It can never go the other way — a
+//!   tag that is really there is never missed — and that direction is the one that
+//!   would be a bug, so the `tag_matches_never_misses_a_tag` test pins it.
+//! - **No vector types, nothing target-specific.** Sixteen bytes is one `u128` on
+//!   every machine this builds for. Hand-written SIMD was tried: it came out at
+//!   roughly a third of the instructions on the two targets it could be written
+//!   for, against doubling the size of this module and keeping two
+//!   implementations honest with each other. Not worth it here, where the probe
+//!   is waiting on memory rather than on arithmetic.
+//!
+//! ### Why the *high* bits of the hash
+//!
+//! The low bits of the hash already chose the home slot. Two words that share a
+//! home share those bits, so tags built from them would be equal across the whole
+//! window and would tell a probe nothing. The high bits are the ones still free to
+//! differ — see [`slot_tag`].
+//!
+//! ### Why usage is a third array
+//!
+//! What a tag deliberately does *not* carry is how much its entry is being used.
+//! Only two paths need that: a hit, which has already found its slot, and a full
+//! window, which has to give one up. Keeping it one array further out means a
+//! probe that finds nothing never touches it. Widening the tags to hold it would
+//! instead double the bytes every probe reads.
+//!
+//! ### The seam
+//!
+//! A window starting at slot `N - 3` runs off the end of the table and wraps
+//! around to slot 0. Reading sixteen tags "in a row" would then need two reads and
+//! a join. Instead both arrays are `N + WINDOW` long, and the last [`WINDOW`]
+//! entries mirror the first [`WINDOW`]. Every window is contiguous, and every
+//! write keeps the mirror in step ([`WordCache::write_tag`],
+//! [`WordCache::write_usage`]). The slot *index* still wraps with `index_mask`;
+//! only the reads of tags and usage use the mirror.
 //!
 //! # What a slot holds
 //!
-//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and a byte
-//! counting how many of those payload words are token ids. It takes one of three
+//! A slot is 32 bytes: a 16-byte `key`, three `u32`s of `payload`, and one byte
+//! saying how many of those payload words are token ids. It takes one of three
 //! shapes, depending on how long the word is and how many ids it encoded to. The
-//! first is the common case for English or code — a short word encoding to one or
-//! two tokens — and it touches nothing but the slot itself:
+//! first shape is the common case for English or code — a short word encoding to
+//! one or two tokens — and it touches nothing outside the slot:
 //!
 //! ```text
 //!  (1) at most 15 bytes, at most 3 ids — the slot holds everything
 //!
 //!     b"tion" → [5378, 262]
-//!    key        │ t  i  o  n  00 … 00 │ 4 │  the word, length in the top byte
-//!    payload    │ 5378 │ 262 │  ·  │         the ids, right here
-//!    inline_ids │ 2 │                        2 of the 3 payload words are ids
+//!    key             │ t  i  o  n  00 … 00 │ 4 │   the word, length in the top byte
+//!    payload         │ 5378 │ 262 │  ·  │          the ids, right here
+//!    inline_id_count │ 2 │                         2 of the 3 payload words are ids
 //!
-//!  (2) at most 15 bytes, more than 3 ids — the ids move to the arena
+//!  (2) at most 15 bytes, more than 3 ids — the ids move to an arena
 //!
 //!     b"电脑" (6 bytes) → 8 ids
-//!    key        │ e7 94 b5 e8 84 91 … │ 6 │  still the word itself
-//!    payload    │  ·  │  40  │ 0:8 │         8 ids, in the ids arena at 40
-//!    inline_ids │ SPILLED │                  payload is coordinates, not ids
+//!    key             │ e7 94 b5 e8 84 91 … │ 6 │   still the word itself
+//!    payload         │  ·  │  40  │ 0:8 │          8 ids, in the id arena at 40
+//!    inline_id_count │ SPILLED │                   payload is coordinates, not ids
 //!
 //!  (3) over 15 bytes — the bytes move too, and the key becomes a hash
 //!
 //!     b"unbelievabilities" (17 bytes) → 6 ids
-//!    key        │ hash(word) │ LONG_TAG │   no room for 17 bytes
-//!    payload    │  12  │  40  │ 17:6 │      17 bytes at 12, 6 ids at 40
-//!    inline_ids │ SPILLED │
+//!    key             │ hash(word) │ KEY_IS_HASH │  no room for 17 bytes
+//!    payload         │  12  │  40  │ 17:6 │        17 bytes at 12, 6 ids at 40
+//!    inline_id_count │ SPILLED │
 //! ```
 //!
-//! Shape (3) is the only one where a matching `key` is not proof: two different
-//! long words can hash alike, so a hit there also compares the bytes in
-//! `key_bytes`. Shapes (1) and (2) carry the word itself in the key, so an equal
-//! key *is* an equal word — one register-wide comparison, no memory to chase.
+//! Shapes (1) and (2) carry the word itself in the key, so an equal key *is* an
+//! equal word: one register-wide comparison, no memory to chase. Packing the
+//! length into the top byte is what keeps `"a"` and `"a\0"` apart, and it is also
+//! what lets shape (3) be told apart from the others — a hashed key sets
+//! [`KEY_IS_HASH`], the top bit, which no length in `1..=15` can reach. Shape (3)
+//! is therefore the one case where a matching key is not proof: two long words can
+//! hash alike, so a hit there also compares the bytes in the key arena.
 //!
-//! Both spilled shapes need to record two lengths — how many bytes are in
-//! `key_bytes` and how many ids are in `ids` — and both are capped by
-//! [`MAX_LENGTH`], so eleven bits each is enough and the two share `payload[2]`.
+//! Both spilled shapes have two lengths to record — how many bytes are in the key
+//! arena, and how many ids are in the id arena — and both are bounded by
+//! [`MAX_WORD_BYTES`], so [`PACKED_LEN_BITS`] bits each is enough and the two
+//! share `payload[2]`.
+//!
+//! [gigatoken]'s pre-token cache is built from the same two parts — a word of up to
+//! 15 bytes packed into a `u128` with its length in the top byte, and a
+//! self-contained 32-byte entry with the ids inline. We replicated it to measure
+//! against this table while designing it, and it is also where the reasoning
+//! diverges: its table holds over a million pre-tokens, far more than any CPU cache
+//! can, so it spends its effort on touching exactly one cache line per probe
+//! (entries in line-aligned pairs, software prefetching, huge pages) and it never
+//! evicts — it doubles in size instead.
 //!
 //! # How an entry earns its place
 //!
-//! Every entry carries a *counter* of how much its word is being used, bumped on
+//! Every entry carries a **counter** of how much its word is being used, bumped on
 //! each hit. When a word arrives and all [`WINDOW`] slots of its window are taken,
 //! the lowest counter loses its slot.
 //!
 //! A counter that only ever went up would measure the wrong thing. The first page
 //! of a document can make `"the"` the most-used word in the table; fifty pages
-//! later the text has moved on to something else entirely, but `"the"` still holds
-//! the highest count and nothing can ever catch up with it. What decides an
-//! eviction should be how much a word is being used *lately*, so counters have to
-//! fade.
+//! later the text has moved on to another subject entirely, but `"the"` still holds
+//! the highest count and nothing can ever catch up with it. What should decide an
+//! eviction is how much a word is being used *lately*. So counters have to fade.
+//!
+//! ## Fading without writing anything
 //!
 //! Fading them by hand is the expensive way: every eviction would rewrite all
-//! sixteen counters of a window. So nothing is rewritten. The cache keeps a
-//! single number — the *epoch* — and bumps it every so often; each [`Usage`]
-//! records the epoch its counter was written in. A counter is then read as
+//! sixteen counters of a window. So nothing is rewritten. The table keeps a single
+//! number — the **epoch** — and bumps it every so often. Each [`Usage`] records
+//! the epoch its counter was written in, and a counter is *read* as
 //!
 //! ```text
-//!   score = counter >> (epoch - written_in)   "halved once per epoch I have missed"
+//!   score = counter >> (epoch - written_in)     halve it once per epoch missed
 //! ```
 //!
-//! No stored number changes. What changes is what a stored number is worth. Two
-//! entries with the same counter:
+//! No stored number changes. What changes is what a stored number is worth:
 //!
 //! ```text
-//!   the cache is at epoch 9
+//!   the table is at epoch 9
 //!
 //!     A   counter 32, written in 9  →  0 epochs missed  →  score 32
 //!     B   counter 32, written in 5  →  4 epochs missed  →  score 32 >> 4 = 2
@@ -169,80 +347,116 @@
 //!                                                                and has coasted
 //! ```
 //!
-//! A counter is one byte, so eight missed epochs take any entry to zero however
-//! hot it once was; that ceiling is [`MAX_DECAY`]. Whenever an entry *is*
-//! written — a hit, or a fresh insert — it is settled up first: its score becomes
-//! its new counter, written in the current epoch.
+//! A counter is one byte, so [`MAX_HALVINGS`] missed epochs take any entry to
+//! zero, however hot it once was. Whenever an entry *is* written — a hit, or a
+//! fresh insert — its outstanding fade is applied first: the score becomes the new
+//! counter, stamped with the current epoch.
+//!
+//! Redis solves the same problem the same way: an eight-bit counter per key plus a
+//! decay period, so a key nobody reads any more loses its count without anything
+//! having to sweep the keyspace. Caffeine, the reference implementation of TinyLFU,
+//! takes the other route and physically halves every counter in its sketch once a
+//! sample of accesses has gone by. Both are linked at the end.
 //!
 //! ## How often the epoch moves
 //!
-//! One bump fades every counter in the table at once, and the table is far
-//! bigger than a window. So bumping on every eviction would fade all of it at
-//! the speed of whichever window happens to be churning hardest: counters would
-//! sit at zero and every eviction would be an arbitrary pick.
+//! One bump fades every counter in the table at once, and the table is far bigger
+//! than a window. Bumping on every eviction would therefore fade all of it at the
+//! speed of whichever window happens to be churning hardest: counters would sit at
+//! zero and every eviction would be an arbitrary pick.
 //!
-//! The rate that matches is one bump per `slots / WINDOW` evictions. A slot can be
-//! reached from [`WINDOW`] different homes, so it belongs to [`WINDOW`] of the
-//! table's `slots` windows, and an eviction somewhere in the table lands in one of
-//! them with probability `WINDOW / slots`. Bumping at that rate gives every slot
-//! the same average fade as if each window faded only itself, only when it
-//! evicted.
+//! The rate that matches is one bump per `N / WINDOW` evictions
+//! ([`WordCache::evictions_per_epoch`]). A slot can be reached from [`WINDOW`]
+//! different homes, so it sits in [`WINDOW`] of the table's `N` windows, and an
+//! eviction somewhere in the table lands in one of them with probability
+//! `WINDOW / N`. Bumping at that rate gives each window, on average, one fade per
+//! eviction of its own — which is what fading a window by hand would have done.
 //!
 //! ## Starting the count again
 //!
-//! An epoch is a byte, so the count runs out of numbers after 256 bumps and has
-//! to start over at zero. The moment it does, every epoch written before the
-//! restart is a number larger than the current one, and the difference between
-//! them stops meaning anything: an entry idle for the whole lap would read as
-//! freshly written, at full strength, and could never be evicted again. That is
+//! An epoch is a byte, so after [`LAST_EPOCH`] bumps the count runs out of numbers
+//! and has to start over at zero. The moment it does, every epoch written before
+//! the restart is a *larger* number than the current one, and the difference
+//! between them stops meaning anything: an entry idle for the whole lap would read
+//! as freshly written, at full strength, and could never be evicted again. That is
 //! dead weight forever — the exact failure fading exists to prevent.
 //!
-//! So the last bump of a lap does not restart the count on its own. It first
-//! walks `usage`, writing each entry's score into its counter, and then puts
-//! the epoch and every [`Usage`] back to zero together (see
-//! [`WordCache::settle`]). No entry moves up or down against another; the
-//! differences are just cashed in while they can still be read. It is one pass
-//! over `usage` every 256 bumps — at the default capacity, once every million
-//! evictions.
+//! So the last bump of a lap does not restart the count on its own. It first walks
+//! `usage`, writing each entry's current score into its counter, and only then puts
+//! the epoch and every [`Usage`] back to zero together — see
+//! [`WordCache::restart_epochs`]. No entry moves up or down against another; the
+//! differences are simply cashed in while they can still be read. That is one pass
+//! over `usage` every 256 bumps, which at the default capacity is once every
+//! million evictions.
 //!
 //! # Where an evicted entry's space goes
 //!
-//! Whatever an evicted entry had in the arenas is handed back when it is
-//! overwritten, and the next word of the same shape takes it. Runs are never
-//! moved and never rounded up, because there is a free list for every length a
-//! run can have (see [`Slab`], and [`MAX_LENGTH`] for why that is finite):
+//! Whatever an evicted entry held in the arenas is handed back when it is
+//! overwritten, and the next word of the same shape takes it. Runs are never moved
+//! and never rounded up to a bigger size, because there is a free list for every
+//! length a run can have — which is only possible because [`MAX_WORD_BYTES`] makes
+//! that a finite list of lengths (see [`Arena`]):
 //!
 //! ```text
-//!   the ids arena, just after A — which had 6 ids at offset 12 — was evicted
+//!   the id arena, just after A — which had 6 ids at offset 12 — was evicted
 //!
 //!     data  ┌─────┬────────────────────────────┬─────┐
 //!           │  …  │ A's 6 ids, at offset 12    │  …  │   nothing is moved
 //!           └─────┴────────────────────────────┴─────┘
 //!
 //!     free  len 6 → [ 12 ]   the next word with 6 ids is handed offset 12
-//!           len 8 → [ ]      one list per length, 0 … MAX_LENGTH
+//!           len 8 → [    ]   one list per length, 0 … MAX_WORD_BYTES
 //! ```
 //!
-//! So the arenas hold the live set rather than every word ever seen. Without
-//! reuse they could only grow, and reclaiming them would mean copying every live
-//! entry into a second buffer — twice the memory for the same number of entries.
+//! So the arenas hold the live set rather than every word ever seen. Without reuse
+//! they could only grow, and reclaiming them would mean copying every live entry
+//! into a second buffer — twice the memory for the same number of entries.
 //!
-//! Overwriting the victim where it lies is also what keeps the table itself
-//! small. Removing an entry from an open-addressed table normally needs a
-//! tombstone or a backward shift, because a probe walk stops at the first empty
-//! slot and a hole in the middle of a chain would cut the walk short. Here
-//! nothing is ever removed: a slot goes from empty to occupied once and after
-//! that only ever changes owner. That is what lets a lookup stop at the first
-//! empty slot, and it is why the window has to be bounded — in a saturated table,
-//! that bound is all that stops a walk from running over the whole table.
+//! Overwriting the victim where it lies is also what keeps the table itself small.
+//! Removing an entry from an open-addressed table normally needs a *tombstone* — a
+//! marker saying "something was here, keep walking" — or a backward shift of the
+//! entries after it, because a probe stops at the first empty slot and a hole in
+//! the middle of a chain would cut it short. Here nothing is ever removed: a slot
+//! goes from empty to occupied once, and after that it only ever changes owner.
+//! That is what lets a probe stop at the first empty slot, and it is also why the
+//! window has to be bounded — in a saturated table, that bound is the only thing
+//! stopping a probe from walking the whole table.
 //!
-//! # Why open addressing, and not fixed buckets
+//! # The dials, and what each one decides
 //!
-//! The obvious alternative is 4-way set associativity: cut the table into buckets
-//! of four slots and let a word live only in the one bucket its hash picks. That
-//! is a single load per lookup and easy to reason about, but a word whose four
-//! slots are taken can never be cached at all, however empty the rest of the
-//! table is:
+//! | constant | value | what it decides |
+//! |---|---|---|
+//! | [`WINDOW`] | 16 | slots a probe covers; also how many tags fit in one `u128` |
+//! | [`TAG_BITS`] | 7 | hash bits per tag; a probe reads a slot it did not want once in 128 |
+//! | [`INLINE_IDS`] | 3 | ids that fit beside the key, so a hit reads only the slot |
+//! | [`MAX_WORD_BYTES`] | 1024 | longest word stored; bounds every arena run |
+//! | [`MAX_HALVINGS`] | 8 | halvings that take a one-byte counter to zero |
+//! | [`LAST_EPOCH`] | 255 | bumps in one lap, after which the count restarts |
+//! | [`INITIAL_COUNTER`] | 1 | what a freshly stored entry's counter starts at |
+//! | [`PACKED_LEN_BITS`] | 11 | bits per length in a spilled entry; 2047 ≥ `MAX_WORD_BYTES` |
+//! | capacity | 65,536 | slots, passed in by the caller; the arenas are sized from it |
+//!
+//! Every other constant in this file is a marker rather than a dial — [`EMPTY`],
+//! [`OCCUPIED`], [`SPILLED`], [`KEY_IS_HASH`], [`ONES`], [`HIGHS`] — and each one's
+//! value is fixed by what it has to stay distinguishable from. Their own docs say
+//! from what.
+//!
+//! Capacity is the one dial with a real cost, and it is paid in memory: 2.2 MiB of
+//! arrays per cache at 65,536 slots, plus arenas, once per thread that encodes.
+//! Every doubling up to that point still bought throughput on the last sweep
+//! (gpt2 over `big.txt`, 256-byte chunks, 16 threads: 389 MB/s at 1,024 slots, 594
+//! at 8,192, 903 at 65,536), so shrinking the table is not a cheap way to save
+//! memory.
+//!
+//! # Designs measured and not kept
+//!
+//! ## Fixed buckets instead of open addressing
+//!
+//! The obvious alternative is what CPU caches do — *4-way set associativity*: cut
+//! the table into buckets of four slots, and let a word live only in the one bucket
+//! its hash picks. That is a single load per lookup and easy to reason about. But a
+//! word whose four slots are taken can never be cached at all, however empty the
+//! rest of the table is:
 //!
 //! ```text
 //!   4-way buckets — a word belongs to exactly one bucket of four
@@ -253,7 +467,7 @@
 //!      └ full, so this word goes uncached — the free slots one
 //!        bucket over may as well not exist
 //!
-//!   open addressing — the word walks on to the next free slot
+//!   open addressing — the word moves along to the next free slot
 //!
 //!     │●│●│●│●│·│·│·│·│·│·│·│·│·│·│·│·│
 //!      ▲       ▲
@@ -263,114 +477,164 @@
 //!
 //! With buckets that small, being locked out starts happening long before the
 //! table is genuinely full. On our multilingual fixtures it cost between 0.1% and
-//! 4% of all lookups, worst on Korean and Chinese, where a document holds far
-//! more distinct words.
+//! 4% of all lookups, worst on Korean and Chinese, where a document holds far more
+//! distinct words. Probing a window closed that gap: those misses went to ~0, and
+//! in the encoder (`examples/fixture_bench.rs`) the many-distinct-word scripts
+//! spent 10-40% less time in the model stage. English and code came out inside the
+//! noise — and the noise there is wide. Running one binary against *itself* swings
+//! the model stage by ±30%, so measure that floor before believing anything
+//! smaller.
 //!
-//! Probing a window closes that gap: on the same fixtures those misses went to
-//! ~0, and in the encoder (`examples/fixture_bench.rs`) the many-distinct-word
-//! scripts spent 10-40% less time in the model stage. English and code came out
-//! inside the noise — and the noise there is wide: running one binary against
-//! *itself* swings the model stage by ±30%, so measure that floor before
-//! believing anything smaller.
+//! ## A `HashMap`
 //!
-//! # Why not a `HashMap`
+//! The comparison is concrete, because the crate still contains two of them: the
+//! legacy BPE model in `models/bpe/model.rs` caches in a thread-local
+//! `AHashMap<String, Word>` (`BPE_LOCAL_CACHE`), and [`crate::utils::cache::Cache`]
+//! wraps another one in an `RwLock` for the legacy Unigram model.
 //!
-//! The legacy BPE model in `model.rs` caches in a thread-local
-//! `AHashMap<String, Word>` (`BPE_LOCAL_CACHE`), so the comparison is concrete.
-//! On a warm benchmark, where every word is already in the map, a hash map is
-//! not far off this table — it has no bucket conflicts either. What it cannot do
-//! is the rest of the job:
+//! On a warm benchmark, where every word is already in the map, a hash map is not
+//! far off this table — it has no bucket conflicts either. What it cannot do is
+//! the rest of the job:
 //!
-//! - **Every word it accepts goes to the allocator.** The map owns its keys, so
-//!   an accepted word is copied into a fresh `String`, and each value keeps a
-//!   heap buffer of its own alive. That cost lands on misses, which is where a
-//!   cache can least afford it: a word misses the first time it is ever seen.
-//!   Here an insert writes into space that already exists.
-//! - **A hit is two more random loads.** The key bytes and the value both live
-//!   in their own heap blocks, elsewhere in memory from the table that pointed
-//!   at them. A slot here answers the common word out of the 32 bytes the walk
-//!   has already decided to read.
-//! - **It cannot make room.** A `HashMap` grows until something stops it, and
-//!   the only thing it can do when stopped is refuse: the legacy cache inserts
-//!   `while local.len() < capacity`, so the words from the first pages of text
-//!   keep their places forever, however useless they turn out to be. Choosing
-//!   *which* entry to drop needs evidence about how much each one is used, and
-//!   somewhere to keep it — the counter in every [`Usage`].
-//! - **Entries cost more than twice the memory.** 24 bytes for the `String` and
-//!   24 for the value's vector inside the table, before the two heap blocks they
-//!   point at, against 35 bytes here for the common word.
+//! - **Every word it accepts goes to the allocator.** The map owns its keys, so an
+//!   accepted word is copied into a fresh `String`, and each value keeps a heap
+//!   buffer of its own alive. That cost lands on misses, which is where a cache can
+//!   least afford it: a word misses the first time it is ever seen. An insert here
+//!   writes into space that already exists.
+//! - **A hit is two more random loads.** The key bytes and the value each live in
+//!   their own heap block, elsewhere in memory from the table that pointed at them.
+//!   A slot here answers the common word out of the 32 bytes the probe has already
+//!   decided to read.
+//! - **It cannot make room.** A `HashMap` grows until something stops it, and the
+//!   only thing it can do when stopped is refuse: the legacy cache inserts
+//!   `while local.len() < capacity`, so the words from the first pages of text keep
+//!   their places forever, however useless they turn out to be. Choosing *which*
+//!   entry to drop needs evidence about how much each one is used, and somewhere to
+//!   keep it — the counter in every [`Usage`].
+//! - **Entries cost more than twice the memory.** 24 bytes for the `String` and 24
+//!   for the value's vector, inside the table, before the two heap blocks they point
+//!   at — against 35 bytes here for the common word (32 of slot, 1 of tag, 2 of
+//!   usage).
 //!
-//! A *shared* map costs more again: [`crate::utils::cache::Cache`], which the
-//! Unigram model still uses, wraps one in an `RwLock` and then has to
-//! `try_read`/`try_write` and silently drop the read or the write whenever
-//! another thread holds it.
+//! Sharing one map between threads costs more again: `Cache` has to `try_read` /
+//! `try_write` and silently drop the read or the write whenever another thread
+//! holds the lock.
+//!
+//! # Where the ideas come from
+//!
+//! - [Swiss Tables] — Abseil's design notes: one control byte per slot, holding a
+//!   flag bit and seven bits of hash, sixteen tested at a time.
+//! - [hashbrown] — the hash map behind Rust's `std::collections::HashMap`. Its
+//!   portable fallback tests a group of control bytes with the same
+//!   `(x - ONES) & !x & HIGHS` arithmetic used in [`tag_matches`].
+//! - [Bit Twiddling Hacks] — that expression on its own, credited to Alan Mycroft,
+//!   1987.
+//! - [gigatoken] — a BPE tokenizer with a pre-token cache built from the same
+//!   parts: `u128` packed keys with the length in the top byte, self-contained
+//!   32-byte entries, ids inline. It never evicts (it doubles at 3/4 load) and
+//!   leans on huge pages and prefetching, because its table is sized for DRAM
+//!   rather than for a CPU cache.
+//! - [Redis key eviction] — an eight-bit counter per key plus a decay period,
+//!   which is the same shape as [`Usage`].
+//! - [TinyLFU] (Einziger, Friedman & Manes) and its reference implementation,
+//!   [Caffeine], which ages counters by halving all of them at once
+//!   (`table[i] = (table[i] >>> 1) & RESET_MASK`) rather than by dating them.
+//! - [huggingface/tokenizers#2234] — an open-addressed cache for this same encode
+//!   pipeline, arrived at in parallel, fused into the pre-tokenizer's split loop.
+//!
+//! [Swiss Tables]: https://abseil.io/about/design/swisstables
+//! [hashbrown]: https://github.com/rust-lang/hashbrown/blob/master/src/control/group/generic.rs
+//! [Bit Twiddling Hacks]: https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
+//! [gigatoken]: https://github.com/marcelroed/gigatoken
+//! [Redis key eviction]: https://redis.io/docs/latest/develop/reference/eviction/
+//! [TinyLFU]: https://arxiv.org/abs/1512.00727
+//! [Caffeine]: https://github.com/ben-manes/caffeine/blob/master/caffeine/src/main/java/com/github/benmanes/caffeine/cache/FrequencySketch.java
+//! [huggingface/tokenizers#2234]: https://github.com/huggingface/tokenizers/pull/2234
 
 use ahash::RandomState;
 
 /// Longest word the cache will store, in bytes.
 ///
 /// Long words are rare and rarely repeat, so storing them buys little, and the
-/// lookup for one is a hash over every byte to learn nothing. The cap is also
-/// what makes the arenas' free lists possible (one list per length) and what
-/// bounds a run's size at all: a tokenizer with no pre-tokenizer hands this
-/// model whole documents as single "words", and uncapped the cache would
-/// cheerfully memoize documents.
-const MAX_LENGTH: usize = 1024;
-/// Slots searched from a word's home position. Linear probing normally settles
-/// in one or two, but the walk has to stop somewhere: nothing is ever removed,
-/// so a saturated table would otherwise scan forever looking for an empty slot.
+/// lookup for one is a hash over every byte to learn nothing. Sweeps over 64,
+/// 256 and 1024 came out flat, so the exact value does not matter for speed —
+/// what the cap is really for is the pathological input. A tokenizer with no
+/// pre-tokenizer hands the model whole documents as single "words", and uncapped
+/// the cache would cheerfully memoize documents. 1024 sits far above every
+/// pre-token we have measured (median 3-4 bytes on code, 5 on English, 14 on
+/// Korean) and far below a document.
 ///
-/// Sixteen is also how many bytes a vector register holds, so a window's worth
-/// of tags is one `u128`, so a window is asked a question in one go rather
-/// than sixteen — see [`matching`].
+/// It is also what makes the arenas' free lists possible — one list per length —
+/// and what bounds an id run: a token covers at least one byte of its word, so a
+/// word this long cannot encode to more than this many ids.
+const MAX_WORD_BYTES: usize = 1024;
+/// Slots a probe covers, counting from the word's home.
+///
+/// The probe has to stop somewhere: nothing is ever removed from this table, so
+/// in a saturated one a probe looking for an empty slot would otherwise scan
+/// forever. Linear probing normally settles in one or two slots — mean probe
+/// length measured at 1.27 — and sixteen is a bound, not a typical cost.
+///
+/// Sixteen is also how many bytes a `u128` holds, so a window's worth of tags is
+/// one integer, so a window is asked a question in one go rather than sixteen —
+/// see [`tag_matches`].
 const WINDOW: usize = 16;
-/// Ids carried in the slot itself — three `u32`s is what fits beside the key.
+/// Ids carried in the slot itself — three `u32`s is what fits beside the key in
+/// 32 bytes.
+///
 /// Enough for 80-96% of lookups on English or code, but only about a quarter of
 /// them on Chinese or Korean, where a vocabulary holding none of those scripts
-/// spends ten ids or more on one word.
+/// spends ten ids or more on a single word.
 const INLINE_IDS: usize = 3;
 /// Set in `key` when it holds the hash of a long word instead of the word
-/// itself. Packed keys carry their length (1..=15) in the top byte, so a hashed
-/// key can never be mistaken for a packed one.
-const LONG_TAG: u128 = 1 << 127;
+/// itself. It is the top bit, and a packed key carries its length (`1..=15`) in
+/// the top byte, so a hashed key can never be mistaken for a packed one.
+const KEY_IS_HASH: u128 = 1 << 127;
 
-/// The id count in [`Slot::inline_ids`] when the ids did not fit in the slot and
-/// went to the arena instead.
+/// The id count in [`Slot::inline_id_count`] when the ids did not fit in the slot
+/// and went to the arena instead.
 const SPILLED: u8 = u8::MAX;
-/// What a newly stored entry's counter starts at.
-const NEWBORN: u8 = 1;
-/// Highest epoch a [`Usage`] can hold — a lap of 256, after which
-/// [`WordCache::settle`] starts the count again.
-const EPOCH_MAX: u8 = u8::MAX;
+/// What a newly stored entry's counter starts at. One rather than zero, so that a
+/// fresh entry outranks anything that has already faded to zero — otherwise a word
+/// could lose its slot before it is ever looked up again. One hit then lifts it
+/// above its untouched neighbours, which start here too.
+const INITIAL_COUNTER: u8 = 1;
+/// Highest epoch a [`Usage`] can hold, which makes a lap 256 bumps long. On the
+/// last one, [`WordCache::restart_epochs`] starts the count again.
+const LAST_EPOCH: u8 = u8::MAX;
 /// Missing this many epochs takes any counter to zero, because a counter is a
-/// byte.
-const MAX_DECAY: u8 = 8;
+/// byte and each missed epoch halves it.
+const MAX_HALVINGS: u8 = 8;
 
 /// The tag of a slot nothing has ever been stored in.
 const EMPTY: u8 = 0;
-/// Set in a tag beside the hash bits, so a live entry's tag is never [`EMPTY`]
-/// — which is also what makes [`empty`] a single `and`.
+/// Set in a tag beside the hash bits, so that a live entry's tag is never
+/// [`EMPTY`] — which is also what makes [`empty_slots`] a single `and`.
 const OCCUPIED: u8 = 0x80;
 /// How many bits of the hash a tag carries. Seven, because the eighth is
-/// [`OCCUPIED`]; a walk therefore reads a slot it did not want once in 128.
+/// [`OCCUPIED`]; a probe therefore reads a slot it did not want once in 128.
 const TAG_BITS: u32 = 7;
 
 /// Bits per length in a spilled entry's `payload[2]`, which packs the key's byte
-/// count above the id count. Both are capped by [`MAX_LENGTH`].
+/// count above the id count. Eleven, because both are bounded by
+/// [`MAX_WORD_BYTES`] and two of them have to share one `u32`.
 const PACKED_LEN_BITS: u32 = 11;
 const PACKED_LEN_MASK: u32 = (1 << PACKED_LEN_BITS) - 1;
-const _: () = assert!(MAX_LENGTH <= PACKED_LEN_MASK as usize);
+const _: () = assert!(MAX_WORD_BYTES <= PACKED_LEN_MASK as usize);
 
-/// A word of 1..=15 bytes packed into a `u128`: bytes in the low lanes, length
+/// A word of `1..=15` bytes packed into a `u128`: bytes in the low lanes, length
 /// in the top byte. Including the length keeps `"a"` and `"a\0"` apart, and the
-/// whole key comparison becomes one register-wide equality instead of a
-/// `memcmp` against bytes somewhere else in memory.
+/// whole key comparison becomes one register-wide equality instead of a `memcmp`
+/// against bytes somewhere else in memory.
+///
+/// `None` for anything longer, which is the caller's signal to key on a hash
+/// instead.
 ///
 /// TODO: the copy is a call into `memcpy` — about a third of what building a key
 /// costs — because `len` is only known at run time, and LLVM folds a copy into a
-/// load only when the length is a constant. A caller that knows what surrounds the
-/// word could pass the 16 bytes starting where the word does instead, turning the
-/// copy into one load plus a mask for the surplus bytes.
+/// load only when the length is a constant. A caller that knows what surrounds
+/// the word could pass the 16 bytes starting where the word does instead,
+/// turning the copy into one load plus a mask for the surplus bytes.
 fn pack_word(word: &[u8]) -> Option<u128> {
     let len = word.len();
     if len == 0 || len > 15 {
@@ -385,7 +649,7 @@ fn pack_word(word: &[u8]) -> Option<u128> {
 ///
 /// The top of the hash, because the bottom of it already chose the home slot: a
 /// tag built from those bits would be the same for every slot the word can reach
-/// and would tell a walk nothing.
+/// and would tell a probe nothing.
 fn slot_tag(hash: u64) -> u8 {
     OCCUPIED | (hash >> (u64::BITS - TAG_BITS)) as u8
 }
@@ -406,38 +670,37 @@ impl Usage {
     /// halved once for every epoch that has gone by since.
     ///
     /// `self.epoch` is never ahead of `epoch` — both are reset together by
-    /// [`WordCache::settle`] — so the subtraction cannot go below zero.
+    /// [`WordCache::restart_epochs`] — so the subtraction cannot go below zero.
     fn score(&self, epoch: u8) -> u8 {
-        // Widened because shifting a `u8` by MAX_DECAY is shifting it by its own
-        // width, which Rust leaves undefined.
-        (self.counter as u32 >> (epoch - self.epoch).min(MAX_DECAY)) as u8
+        // Widened because shifting a `u8` by MAX_HALVINGS is shifting it by its
+        // own width, which Rust leaves undefined.
+        (self.counter as u32 >> (epoch - self.epoch).min(MAX_HALVINGS)) as u8
     }
 }
 
 /// One entry, in the three shapes the module docs draw out. In short:
 ///
 /// - `key` is the word itself when it fits in 15 bytes, otherwise its hash with
-///   [`LONG_TAG`] set.
-/// - `payload` is the token ids while `inline_ids` counts them, and becomes
+///   [`KEY_IS_HASH`] set.
+/// - `payload` is the token ids while `inline_id_count` counts them, and becomes
 ///   `[key_off, ids_off, packed lengths]` once that byte is [`SPILLED`] — which
 ///   is what the `key_off`/`ids_off`/`key_len`/`ids_len` readers below are for.
 ///
-/// Nothing in here is read until the slot's tag has said the word might be in
-/// it.
+/// Nothing in here is read until the slot's tag has said the word might be in it.
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
 struct Slot {
     key: u128,
     payload: [u32; INLINE_IDS],
     /// How many of `payload`'s words are token ids, or [`SPILLED`].
-    inline_ids: u8,
+    inline_id_count: u8,
 }
 
 const _: () = assert!(std::mem::size_of::<Slot>() == 32);
 
 impl Slot {
     fn spilled(&self) -> bool {
-        self.inline_ids == SPILLED
+        self.inline_id_count == SPILLED
     }
 
     fn key_off(&self) -> u32 {
@@ -457,9 +720,9 @@ impl Slot {
     }
 }
 
-/// Every byte of one of these is `0x01`, or `0x80`. Broadcasting a value over
-/// all [`WINDOW`] lanes and testing every lane's top bit is what turns a window
-/// into arithmetic — see [`Answer`].
+/// Every byte of one of these is `0x01`, or `0x80`. Broadcasting a value over all
+/// [`WINDOW`] lanes and testing every lane's top bit is what turns a window into
+/// arithmetic — see [`StepMask`].
 const ONES: u128 = u128::from_le_bytes([0x01; WINDOW]);
 const HIGHS: u128 = u128::from_le_bytes([0x80; WINDOW]);
 
@@ -467,30 +730,34 @@ const HIGHS: u128 = u128::from_le_bytes([0x80; WINDOW]);
 /// byte `step` answers for the slot `step` places along from home.
 ///
 /// A window is [`WINDOW`] tags, which is sixteen bytes, which is one `u128`. So
-/// the questions a walk asks are answered for the whole window by ordinary
+/// the questions a probe asks are answered for the whole window by ordinary
 /// integer arithmetic, in about as many instructions as it takes to ask one of
 /// them of one slot. No vector types, nothing target-specific: the same handful
 /// of `and`s and `xor`s on every machine this builds for.
-type Answer = u128;
+type StepMask = u128;
 
-/// The first slot a window answers `true` for, as a step from home, or
-/// [`WINDOW`] when it answers `true` for none.
-fn first_step(answer: Answer) -> usize {
-    (answer.trailing_zeros() / 8) as usize
-}
-
-/// The same answer with `step` taken out of it.
-fn without_step(answer: Answer, step: usize) -> Answer {
-    answer & !(0x80 << (step * 8))
-}
-
-/// Everything an answer says about the slots before the first one `bound`
-/// answers for. All of it when `bound` answers for none.
+/// The first step a mask answers `true` for, or [`WINDOW`] when it answers `true`
+/// for none.
 ///
-/// `bound - 1` clears the lowest set bit and sets every bit below it, and `!
-/// bound` drops the higher ones it left alone — so this is branchless, and the
+/// A flagged step `s` has its bit at `8 * s + 7`, so the count of trailing zeros
+/// divided by eight is the step — and an empty mask counts 128 zeros, which
+/// divides to [`WINDOW`] and reads as "nothing".
+fn first_step(mask: StepMask) -> usize {
+    (mask.trailing_zeros() / 8) as usize
+}
+
+/// The same mask with `step` taken out of it.
+fn clear_step(mask: StepMask, step: usize) -> StepMask {
+    mask & !(0x80 << (step * 8))
+}
+
+/// Everything a mask says about the steps *before* the first one `bound` answers
+/// for. All of it when `bound` answers for none.
+///
+/// `bound - 1` clears the lowest set bit and sets every bit below it, and
+/// `!bound` drops the higher ones it left alone — so this is branchless, and the
 /// all-of-it case falls out of `0 - 1` being all ones.
-fn before(bound: Answer) -> Answer {
+fn steps_before(bound: StepMask) -> StepMask {
     bound.wrapping_sub(1) & !bound
 }
 
@@ -499,54 +766,54 @@ fn before(bound: Answer) -> Answer {
 /// `from_le_bytes` puts the tag of the slot `step` places from home in byte
 /// `step`, on a big-endian machine as much as on a little-endian one, so
 /// [`first_step`] means the same thing everywhere.
-fn window(tags: &[u8; WINDOW]) -> u128 {
+fn read_window(tags: &[u8; WINDOW]) -> u128 {
     u128::from_le_bytes(*tags)
 }
 
-/// Which slots of the window are empty.
+/// Which steps of the window are empty slots.
 ///
 /// Exact, and one instruction: a live tag always carries [`OCCUPIED`] and
 /// [`EMPTY`] is zero, so "empty" is precisely "top bit clear".
-fn empty(window: u128) -> Answer {
+fn empty_slots(window: u128) -> StepMask {
     !window & HIGHS
 }
 
-/// Which slots of the window could hold the word `tag` belongs to.
+/// Which steps of the window could hold the word `tag` belongs to.
 ///
-/// The xor is zero exactly in the lanes that match, and the rest is the standard
-/// hunt for a zero byte: subtracting one from every lane borrows out of a zero
-/// lane into its top bit, and `!x` keeps only the lanes that were small enough
-/// for that top bit to be news.
+/// The `xor` is zero exactly in the lanes that match, and the rest is the
+/// standard hunt for a zero byte: subtracting one from every lane borrows out of
+/// a zero lane into its top bit, and `!x` keeps only the lanes that were small
+/// enough for that top bit to be news.
 ///
 /// A borrow can run on into the next lane, so a lane holding exactly `tag ^ 1`
 /// directly above a match is answered `true` as well. It cannot go the other
-/// way — a matching lane is never missed — and the walk confirms every answer
+/// way — a matching lane is never missed — and the probe confirms every answer
 /// against the key anyway, so the cost of the rare extra one is a slot read.
-fn matching(window: u128, tag: u8) -> Answer {
+fn tag_matches(window: u128, tag: u8) -> StepMask {
     let x = window ^ u128::from_le_bytes([tag; WINDOW]);
     x.wrapping_sub(ONES) & !x & HIGHS
 }
 
-/// A grow-only arena that reuses the space of evicted entries instead of
+/// A grow-only buffer that reuses the space of evicted entries instead of
 /// compacting.
 ///
 /// Freed runs go on a free list per exact length. That is only practical because
-/// `MAX_LENGTH` bounds every run: there is a list for every length a run can
-/// have, so a freed run is always reusable by the next word of the same shape
+/// [`MAX_WORD_BYTES`] bounds every run: there is a list for every length a run
+/// can have, so a freed run is always reusable by the next word of the same shape
 /// and no length is ever rounded up to a bigger class. The price is
-/// `MAX_LENGTH + 1` empty `Vec`s per arena.
-struct Slab<T> {
+/// `MAX_WORD_BYTES + 1` empty `Vec`s per arena.
+struct Arena<T> {
     data: Vec<T>,
     free: Box<[Vec<u32>]>,
     /// Ceiling on `data`, not a reservation.
     budget: usize,
 }
 
-impl<T: Copy + Default> Slab<T> {
+impl<T: Copy + Default> Arena<T> {
     fn new(budget: usize) -> Self {
         Self {
             data: Vec::new(),
-            free: (0..=MAX_LENGTH).map(|_| Vec::new()).collect(),
+            free: (0..=MAX_WORD_BYTES).map(|_| Vec::new()).collect(),
             budget,
         }
     }
@@ -587,16 +854,15 @@ pub enum Lookup<'c, 'w> {
     /// The ids the word encoded to last time.
     Hit(&'c [u32]),
     /// The word is not in the table. The [`Placement`] is the slot it should go
-    /// in — hand it to [`WordCache::insert`] once the model has done the work,
-    /// or drop it and nothing is stored. `None` when the word is too long to be
+    /// in — hand it to [`WordCache::insert`] once the model has done the work, or
+    /// drop it and nothing is stored. `None` when the word is too long to be
     /// worth a slot at all.
     Miss(Option<Placement<'w>>),
 }
 
 impl<'c> Lookup<'c, '_> {
     /// The ids, throwing the [`Placement`] away. Every caller in the encoder
-    /// wants the placement — this is for tests asserting on what the table
-    /// holds.
+    /// wants the placement — this is for tests asserting on what the table holds.
     #[cfg(test)]
     pub fn hit(self) -> Option<&'c [u32]> {
         match self {
@@ -607,7 +873,7 @@ impl<'c> Lookup<'c, '_> {
 }
 
 /// Where a word that missed will go, and what [`WordCache::insert`] needs to put
-/// it there. Found by the walk that missed, so storing the word costs no second
+/// it there. Found by the probe that missed, so storing the word costs no second
 /// hash and no second read of the window.
 ///
 /// It carries the word rather than letting `insert` take it again, because the
@@ -620,7 +886,7 @@ pub struct Placement<'w> {
     word: &'w [u8],
 }
 
-/// How a walk over a word's window ended: the slot the word is in, or the slot
+/// How a probe over a word's window ended: the slot the word is in, or the slot
 /// it should take if the caller decides to store it.
 enum Probe {
     Hit(usize),
@@ -637,30 +903,32 @@ pub struct WordCache {
     tags: Box<[u8]>,
     /// One [`Usage`] per slot, mirrored like `tags`. Read only once a tag has
     /// answered for its slot, or when a full window has to give one up, so it is
-    /// kept out of `tags`: a walk that finds nothing never touches it.
+    /// kept out of `tags`: a probe that finds nothing never touches it.
     usage: Box<[Usage]>,
-    key_bytes: Slab<u8>,
-    ids: Slab<u32>,
+    /// The bytes of words too long to fit in a key.
+    key_arena: Arena<u8>,
+    /// The id runs too long to fit in a slot.
+    id_arena: Arena<u32>,
     /// `slots.len() - 1`. The table is a power of two, so this folds a hash into
     /// a slot index.
-    mask: usize,
-    /// Where the fade count stands, from 0 to [`EPOCH_MAX`] and no higher. A
-    /// A [`Usage::epoch`] is what this held when that entry was last written, so
+    index_mask: usize,
+    /// Where the fade count stands, from 0 to [`LAST_EPOCH`] and no higher. A
+    /// [`Usage::epoch`] is what this held when that entry was last written, so
     /// the difference between them is how many fades it has sat through.
-    /// [`WordCache::settle`] puts this and every `Usage` back to zero together
-    /// when the count runs out of room.
+    /// [`WordCache::restart_epochs`] puts this and every `Usage` back to zero
+    /// together when the count runs out of room.
     epoch: u8,
     /// Evictions still to come before the next `epoch` bump.
-    countdown: u32,
+    evictions_left: u32,
     /// Evictions per `epoch` bump — see the module docs on how often the epoch
     /// moves.
-    epoch_length: u32,
+    evictions_per_epoch: u32,
 }
 
 impl WordCache {
     pub fn new(capacity: usize) -> Self {
         let n_slots = capacity.next_power_of_two().max(WINDOW);
-        let epoch_length = (n_slots / WINDOW) as u32;
+        let evictions_per_epoch = (n_slots / WINDOW) as u32;
         Self {
             hasher: RandomState::new(),
             slots: vec![Slot::default(); n_slots].into_boxed_slice(),
@@ -673,12 +941,12 @@ impl WordCache {
             // measured exactly that (tens of thousands of words refused at 35%
             // occupancy). The worst case they have to cover is a vocabulary with
             // no CJK in it, which spends ~17 ids on a single Chinese word.
-            key_bytes: Slab::new(n_slots * 48),
-            ids: Slab::new(n_slots * 16),
-            mask: n_slots - 1,
+            key_arena: Arena::new(n_slots * 48),
+            id_arena: Arena::new(n_slots * 16),
+            index_mask: n_slots - 1,
             epoch: 0,
-            countdown: epoch_length,
-            epoch_length,
+            evictions_left: evictions_per_epoch,
+            evictions_per_epoch,
         }
     }
 
@@ -687,7 +955,7 @@ impl WordCache {
     ///
     /// Takes `&mut self` because a hit is also a vote for keeping the entry.
     pub fn lookup<'c, 'w>(&'c mut self, word: &'w [u8]) -> Lookup<'c, 'w> {
-        if word.len() > MAX_LENGTH {
+        if word.len() > MAX_WORD_BYTES {
             return Lookup::Miss(None);
         }
         let (key, hash) = self.slot_key(word);
@@ -700,9 +968,9 @@ impl WordCache {
                 self.write_usage(index, Usage { counter, epoch });
                 let slot = self.slots[index];
                 return Lookup::Hit(if slot.spilled() {
-                    self.ids.get(slot.ids_off(), slot.ids_len())
+                    self.id_arena.get(slot.ids_off(), slot.ids_len())
                 } else {
-                    &self.slots[index].payload[..slot.inline_ids as usize]
+                    &self.slots[index].payload[..slot.inline_id_count as usize]
                 });
             }
             Probe::Miss(index) => index,
@@ -716,8 +984,8 @@ impl WordCache {
     }
 
     /// Remember what the word encoded to, in the slot its [`WordCache::lookup`]
-    /// picked out. Silently does nothing when an arena is full: a cache is free
-    /// to forget, and the caller has the ids either way.
+    /// picked out. Silently does nothing when an arena is full: a cache is free to
+    /// forget, and the caller has the ids either way.
     pub fn insert(&mut self, at: Placement<'_>, ids: impl ExactSizeIterator<Item = u32>) {
         let Some(entry) = self.build_entry(at.key, at.word, ids) else {
             return;
@@ -735,7 +1003,7 @@ impl WordCache {
         self.write_usage(
             at.index,
             Usage {
-                counter: NEWBORN,
+                counter: INITIAL_COUNTER,
                 epoch: self.epoch,
             },
         );
@@ -744,18 +1012,18 @@ impl WordCache {
 
     /// The value a slot stores in its `key`, and the hash that places it. A short
     /// word is its own key; a longer one keys on a tagged hash and has to be
-    /// confirmed against `key_bytes`, since two long words can hash alike.
+    /// confirmed against `key_arena`, since two long words can hash alike.
     ///
     /// A packed key is hashed as one `u128`, not as the word's bytes it was built
-    /// from. Hashing a slice makes aHash mix the length in and then branch on it to
-    /// choose a read width; a `u128` is one fixed-width fold with nothing to decide.
-    /// The key already carries the length, so nothing is lost.
+    /// from. Hashing a slice makes aHash mix the length in and then branch on it
+    /// to choose a read width; a `u128` is one fixed-width fold with nothing to
+    /// decide. The key already carries the length, so nothing is lost.
     fn slot_key(&self, word: &[u8]) -> (u128, u64) {
         match pack_word(word) {
             Some(packed) => (packed, self.hasher.hash_one(packed)),
             None => {
                 let hash = self.hasher.hash_one(word);
-                ((hash as u128) | LONG_TAG, hash)
+                ((hash as u128) | KEY_IS_HASH, hash)
             }
         }
     }
@@ -763,7 +1031,7 @@ impl WordCache {
     /// The tags of the window starting at `home`. The mirrored tail of `tags` is
     /// what makes the slice contiguous for every `home`.
     fn tag_window(&self, home: usize) -> u128 {
-        window(self.tags[home..home + WINDOW].try_into().unwrap())
+        read_window(self.tags[home..home + WINDOW].try_into().unwrap())
     }
 
     /// The step of the window's lowest-scoring slot, ties going to the slot
@@ -781,57 +1049,56 @@ impl WordCache {
             .unwrap()
     }
 
-    /// One walk over `word`'s window, from its home position, answering both
+    /// One probe over `word`'s window, from its home position, answering both
     /// questions a lookup has: which slot holds the word, and — if none does —
     /// which slot it should take.
     ///
     /// The second answer is nearly free: both come out of the window's tags,
-    /// which are one load, and only a full window needs anything more. Working
-    /// it out afterwards would mean reading them again and hashing the word
-    /// again.
+    /// which are one load, and only a full window needs anything more. Working it
+    /// out afterwards would mean reading them again and hashing the word again.
     ///
     /// Stopping at the first empty slot is safe because slots never go back to
     /// being empty: an empty one means the word was never stored.
     fn probe(&self, key: u128, hash: u64, word: &[u8]) -> Probe {
-        let home = hash as usize & self.mask;
+        let home = hash as usize & self.index_mask;
         let window = self.tag_window(home);
-        let empty = empty(window);
-        // Nothing past the first empty slot can hold the word: the walk that
+        let empty = empty_slots(window);
+        // Nothing past the first empty slot can hold the word: the probe that
         // stored it would have stopped there and taken that slot.
-        let mut candidates = matching(window, slot_tag(hash)) & before(empty);
+        let mut candidates = tag_matches(window, slot_tag(hash)) & steps_before(empty);
         // Only a hashed key can turn out to belong to a different word, and
-        // whether this one is hashed is settled before the walk starts — the
+        // whether this one is hashed is settled before the probe starts — the
         // caller built the key out of the word it is looking for.
-        let hashed = key & LONG_TAG != 0;
+        let hashed = key & KEY_IS_HASH != 0;
         while candidates != 0 {
             let step = first_step(candidates);
-            let index = (home + step) & self.mask;
+            let index = (home + step) & self.index_mask;
             let slot = &self.slots[index];
             if slot.key == key
-                && (!hashed || self.key_bytes.get(slot.key_off(), slot.key_len()) == word)
+                && (!hashed || self.key_arena.get(slot.key_off(), slot.key_len()) == word)
             {
                 return Probe::Hit(index);
             }
-            candidates = without_step(candidates, step);
+            candidates = clear_step(candidates, step);
         }
         let step = if empty == 0 {
             self.coldest(home, self.epoch)
         } else {
             first_step(empty)
         };
-        Probe::Miss((home + step) & self.mask)
+        Probe::Miss((home + step) & self.index_mask)
     }
 
     /// The entry to store, with whatever does not fit in a slot copied into the
-    /// arenas. `None` when an arena is full, so a rejected insert leaves the
-    /// table and the arenas exactly as they were.
+    /// arenas. `None` when an arena is full, so a rejected insert leaves the table
+    /// and the arenas exactly as they were.
     fn build_entry(
         &mut self,
         key: u128,
         word: &[u8],
         ids: impl ExactSizeIterator<Item = u32>,
     ) -> Option<Slot> {
-        let long = key & LONG_TAG != 0;
+        let long = key & KEY_IS_HASH != 0;
         let ids_len = ids.len();
         if !long && ids_len <= INLINE_IDS {
             let mut payload = [0u32; INLINE_IDS];
@@ -841,23 +1108,23 @@ impl WordCache {
             return Some(Slot {
                 key,
                 payload,
-                inline_ids: ids_len as u8,
+                inline_id_count: ids_len as u8,
             });
         }
         // A short word stays in the key, which is a zero-length run here.
         let key_len = if long { word.len() } else { 0 };
-        let key_off = self.key_bytes.alloc(key_len)?;
-        let Some(ids_off) = self.ids.alloc(ids_len) else {
-            self.key_bytes.release(key_off, key_len);
+        let key_off = self.key_arena.alloc(key_len)?;
+        let Some(ids_off) = self.id_arena.alloc(ids_len) else {
+            self.key_arena.release(key_off, key_len);
             return None;
         };
-        self.key_bytes.fill(key_off, key_len, word.iter().copied());
-        self.ids.fill(ids_off, ids_len, ids);
+        self.key_arena.fill(key_off, key_len, word.iter().copied());
+        self.id_arena.fill(ids_off, ids_len, ids);
         let lengths = (key_len as u32) << PACKED_LEN_BITS | ids_len as u32;
         Some(Slot {
             key,
             payload: [key_off, ids_off, lengths],
-            inline_ids: SPILLED,
+            inline_id_count: SPILLED,
         })
     }
 
@@ -881,28 +1148,28 @@ impl WordCache {
     /// One eviction's worth of fading: step the countdown, and move the epoch on
     /// when it runs out.
     fn fade(&mut self) {
-        self.countdown -= 1;
-        if self.countdown > 0 {
+        self.evictions_left -= 1;
+        if self.evictions_left > 0 {
             return;
         }
-        self.countdown = self.epoch_length;
-        if self.epoch == EPOCH_MAX {
-            self.settle();
+        self.evictions_left = self.evictions_per_epoch;
+        if self.epoch == LAST_EPOCH {
+            self.restart_epochs();
         } else {
             self.epoch += 1;
         }
     }
 
-    /// Spend every entry's outstanding fade and start the count again: each live
-    /// entry's score becomes its counter, and the epoch and every [`Usage`] go
-    /// back to zero.
+    /// Spend every entry's outstanding fade and start the epoch count again: each
+    /// live entry's score becomes its counter, and the epoch and every [`Usage`]
+    /// go back to zero.
     ///
     /// Run on the last epoch a `Usage` can hold, and only then. The epoch has to
-    /// start over at some point, and the moment it does, the difference between
-    /// it and a stored epoch stops meaning anything for entries written before
-    /// the restart. So the differences are cashed in first, while they can still
-    /// be read.
-    fn settle(&mut self) {
+    /// start over at some point, and the moment it does, the difference between it
+    /// and a stored epoch stops meaning anything for entries written before the
+    /// restart. So the differences are cashed in first, while they can still be
+    /// read.
+    fn restart_epochs(&mut self) {
         let epoch = self.epoch;
         // Tags are untouched, and the mirrored tail of `usage` gets the same pass
         // as the front, so both stay in step without a second walk.
@@ -925,14 +1192,14 @@ impl WordCache {
         if !slot.spilled() {
             return;
         }
-        self.key_bytes.release(slot.key_off(), slot.key_len());
-        self.ids.release(slot.ids_off(), slot.ids_len());
+        self.key_arena.release(slot.key_off(), slot.key_len());
+        self.id_arena.release(slot.ids_off(), slot.ids_len());
     }
 }
 
-/// Handles for `examples/word_cache_bench.rs`, which times the parts of the
-/// cache the encoder never calls directly. Compiled out of every build that
-/// does not ask for them.
+/// Handles for `examples/word_cache_bench.rs`, which times the parts of the cache
+/// the encoder never calls directly. Compiled out of every build that does not
+/// ask for them.
 #[cfg(feature = "bench-internals")]
 impl WordCache {
     /// Just the key building at the front of a lookup: pack the word, hash it.
@@ -946,8 +1213,8 @@ impl WordCache {
     }
 
     /// The whole-table pass that starts the epoch count again.
-    pub fn bench_settle(&mut self) {
-        self.settle()
+    pub fn bench_restart_epochs(&mut self) {
+        self.restart_epochs()
     }
 
     /// How many slots hold an entry. Equal to the capacity once the table is
@@ -999,14 +1266,14 @@ mod tests {
     /// The two properties the key encoding rests on: a packed key is unique per
     /// word, and never looks like a hashed one.
     #[test]
-    fn packed_keys_are_unique_and_tagged() {
+    fn packed_keys_are_unique_and_never_look_hashed() {
         assert_ne!(pack_word(b"a"), pack_word(b"a\0"));
-        assert_eq!(pack_word(&[0u8; 15]).unwrap() & LONG_TAG, 0);
+        assert_eq!(pack_word(&[0u8; 15]).unwrap() & KEY_IS_HASH, 0);
         assert_eq!(pack_word(b""), None);
         assert_eq!(pack_word(&[b'x'; 16]), None);
     }
 
-    /// A live entry's tag has to be something [`EMPTY`] is not, or a walk reads
+    /// A live entry's tag has to be something [`EMPTY`] is not, or a probe reads
     /// an occupied slot as the end of the chain and stores on top of it.
     #[test]
     fn a_live_tag_is_never_the_empty_marker() {
@@ -1025,7 +1292,7 @@ mod tests {
         let homes: std::collections::HashSet<usize> = (0..1000)
             .map(|i| {
                 let (_, hash) = cache.slot_key(format!("tok{i}").as_bytes());
-                hash as usize & cache.mask
+                hash as usize & cache.index_mask
             })
             .collect();
         // 1000 words over 4096 slots share homes by chance alone; ~887 distinct is
@@ -1036,7 +1303,7 @@ mod tests {
     #[test]
     fn oversized_words_are_ignored() {
         let mut cache = WordCache::new(1 << 8);
-        let big = vec![7u8; MAX_LENGTH + 1];
+        let big = vec![7u8; MAX_WORD_BYTES + 1];
         store(&mut cache, &big, [1u32].into_iter());
         assert_eq!(cache.lookup(&big).hit(), None);
     }
@@ -1071,26 +1338,26 @@ mod tests {
     #[test]
     fn a_word_at_the_length_limit_round_trips() {
         let mut cache = WordCache::new(1 << 8);
-        let word = vec![b'q'; MAX_LENGTH];
-        let ids: Vec<u32> = (0..MAX_LENGTH as u32).collect();
+        let word = vec![b'q'; MAX_WORD_BYTES];
+        let ids: Vec<u32> = (0..MAX_WORD_BYTES as u32).collect();
         store(&mut cache, &word, ids.clone().into_iter());
         assert_eq!(cache.lookup(&word).hit(), Some(&ids[..]));
     }
 
     /// A tag is seven bits, so one slot in 128 answers for a word that is not in
     /// it. That is too rare to wait for, so forge one: put a word's tag on a slot
-    /// holding a different key, and demand the walk look past it rather than
+    /// holding a different key, and demand the probe look past it rather than
     /// treat the tag as the answer.
     #[test]
     fn a_tag_collision_is_confirmed_against_the_key() {
         let mut cache = WordCache::new(WINDOW);
         let (_, hash) = cache.slot_key(b"beta");
-        let decoy = hash as usize & cache.mask;
+        let decoy = hash as usize & cache.index_mask;
         cache.write_tag(decoy, slot_tag(hash));
         cache.write_usage(
             decoy,
             Usage {
-                counter: NEWBORN,
+                counter: INITIAL_COUNTER,
                 epoch: 0,
             },
         );
@@ -1099,7 +1366,7 @@ mod tests {
         cache.slots[decoy] = Slot {
             key: 1,
             payload: [7, 0, 0],
-            inline_ids: 1,
+            inline_id_count: 1,
         };
 
         store(&mut cache, b"beta", [2u32].into_iter());
@@ -1109,7 +1376,7 @@ mod tests {
     /// Two long words can hash to the same key, and then only their bytes tell
     /// them apart. Real hash collisions are too rare to write a test around, so
     /// forge one: park another word's entry on this word's home slot, stamp this
-    /// word's key and tag on it, and demand the walk look past it.
+    /// word's key and tag on it, and demand the probe look past it.
     #[test]
     fn a_hashed_key_is_confirmed_against_the_word_bytes() {
         let mut cache = WordCache::new(1 << 8);
@@ -1121,7 +1388,7 @@ mod tests {
         let their_slot = cache.slots[their_index];
         let their_usage = cache.usage[their_index];
         let (my_key, my_hash) = cache.slot_key(&mine);
-        let my_home = my_hash as usize & cache.mask;
+        let my_home = my_hash as usize & cache.index_mask;
         cache.slots[my_home] = Slot {
             key: my_key,
             ..their_slot
@@ -1176,7 +1443,7 @@ mod tests {
         let index = slot_of(&cache, b"hot").unwrap();
         assert_eq!(cache.usage[index].score(cache.epoch), u8::MAX);
 
-        for _ in 0..MAX_DECAY {
+        for _ in 0..MAX_HALVINGS {
             cache.fade();
         }
         assert_eq!(cache.usage[index].score(cache.epoch), 0);
@@ -1196,17 +1463,17 @@ mod tests {
         let index = slot_of(&cache, b"stale").unwrap();
 
         // One slot per window here, so one eviction is one epoch.
-        assert_eq!(cache.epoch_length, 1);
-        for _ in 0..=EPOCH_MAX {
+        assert_eq!(cache.evictions_per_epoch, 1);
+        for _ in 0..=LAST_EPOCH {
             cache.fade();
         }
         assert_eq!(cache.epoch, 0, "the lap did not start over");
         assert_eq!(cache.usage[index].score(cache.epoch), 0);
     }
 
-    /// The tail of `tags` is a copy of its first [`WINDOW`] entries, so that
-    /// a window starting near the end of the table is still `WINDOW` entries in a
-    /// row. Every write has to keep the two in step, or a walk whose window
+    /// The tail of `tags` is a copy of its first [`WINDOW`] entries, so that a
+    /// window starting near the end of the table is still `WINDOW` entries in a
+    /// row. Every write has to keep the two in step, or a probe whose window
     /// crosses the seam reads control bytes that no longer describe the slots.
     #[test]
     fn the_mirrored_tail_tracks_the_front() {
@@ -1221,14 +1488,14 @@ mod tests {
             assert_eq!(cache.tags[..WINDOW], cache.tags[n..], "tags, insert {i}");
             assert_eq!(cache.usage[..WINDOW], cache.usage[n..], "usage, insert {i}");
         }
-        // A settle rewrites every live entry's usage and no tag at all, so the
-        // two must still agree afterwards.
-        cache.settle();
-        assert_eq!(cache.tags[..WINDOW], cache.tags[n..], "tags, after settle");
+        // Restarting the epochs rewrites every live entry's usage and no tag at
+        // all, so the two must still agree afterwards.
+        cache.restart_epochs();
+        assert_eq!(cache.tags[..WINDOW], cache.tags[n..], "tags, after restart");
         assert_eq!(
             cache.usage[..WINDOW],
             cache.usage[n..],
-            "usage, after settle"
+            "usage, after restart"
         );
     }
 
@@ -1262,21 +1529,21 @@ mod tests {
         assert!(live > 0, "everything was evicted — the test proves nothing");
     }
 
-    /// Every step a window answers for, so a mask can be read against a picture
-    /// of the window it came from.
-    fn steps(answer: Answer) -> Vec<usize> {
-        let mut left = answer;
+    /// Every step a mask answers for, so it can be read against a picture of the
+    /// window it came from.
+    fn steps(mask: StepMask) -> Vec<usize> {
+        let mut left = mask;
         let mut found = Vec::new();
         while left != 0 {
             let step = first_step(left);
             found.push(step);
-            left = without_step(left, step);
+            left = clear_step(left, step);
         }
         found
     }
 
-    /// The arithmetic in [`matching`], [`empty`] and [`before`] read back as the
-    /// slots they are talking about.
+    /// The arithmetic in [`tag_matches`], [`empty_slots`] and [`steps_before`]
+    /// read back as the slots they are talking about.
     #[test]
     fn a_window_answers_for_the_slots_it_should() {
         let mut tags = [EMPTY; WINDOW];
@@ -1284,33 +1551,36 @@ mod tests {
         tags[3] = 0xC4;
         tags[5] = 0x81;
         tags[9] = 0x81;
-        let window = window(&tags);
+        let window = read_window(&tags);
 
-        assert_eq!(steps(matching(window, 0x81)), [0, 5, 9]);
-        assert_eq!(steps(matching(window, 0xC4)), [3]);
+        assert_eq!(steps(tag_matches(window, 0x81)), [0, 5, 9]);
+        assert_eq!(steps(tag_matches(window, 0xC4)), [3]);
         assert_eq!(
-            steps(empty(window)),
+            steps(empty_slots(window)),
             [1, 2, 4, 6, 7, 8, 10, 11, 12, 13, 14, 15]
         );
         // Slot 1 is empty, so slots 5 and 9 are out of reach: whatever put a word
         // there would have stopped at slot 1 and taken it.
-        assert_eq!(steps(matching(window, 0x81) & before(empty(window))), [0]);
+        assert_eq!(
+            steps(tag_matches(window, 0x81) & steps_before(empty_slots(window))),
+            [0]
+        );
     }
 
     /// A full window has no empty slot to stop at, so every match stays in reach.
     #[test]
     fn a_full_window_bounds_nothing() {
         let tags = [OCCUPIED | 0x11; WINDOW];
-        let window = window(&tags);
-        assert_eq!(empty(window), 0);
+        let window = read_window(&tags);
+        assert_eq!(empty_slots(window), 0);
         assert_eq!(
-            steps(matching(window, OCCUPIED | 0x11) & before(0)).len(),
+            steps(tag_matches(window, OCCUPIED | 0x11) & steps_before(0)).len(),
             WINDOW
         );
     }
 
-    /// [`matching`] hunts for a zero byte by subtracting one from every lane, and
-    /// a borrow out of a matching lane can run on into the one above it — so a
+    /// [`tag_matches`] hunts for a zero byte by subtracting one from every lane,
+    /// and a borrow out of a matching lane can run on into the one above it — so a
     /// slot holding `tag ^ 1` just above a match is answered for as well. That
     /// costs one slot read, which the key comparison then rejects.
     ///
@@ -1318,13 +1588,13 @@ mod tests {
     /// goes unanswered is a word that reads as absent, and the table would grow a
     /// second entry for it.
     #[test]
-    fn matching_never_misses_a_tag() {
+    fn tag_matches_never_misses_a_tag() {
         for tag in OCCUPIED..=u8::MAX {
             for step in 0..WINDOW {
                 let mut tags = [OCCUPIED; WINDOW];
                 tags[step] = tag;
                 assert!(
-                    steps(matching(window(&tags), tag)).contains(&step),
+                    steps(tag_matches(read_window(&tags), tag)).contains(&step),
                     "tag {tag:#x} at step {step} went unanswered"
                 );
             }
@@ -1349,7 +1619,7 @@ mod tests {
             Some(&[4999u32; 8][..]),
             "inserts stopped landing — the arenas ran out"
         );
-        assert!(cache.key_bytes.data.len() <= 65 * 35);
-        assert!(cache.ids.data.len() <= 65 * 8);
+        assert!(cache.key_arena.data.len() <= 65 * 35);
+        assert!(cache.id_arena.data.len() <= 65 * 8);
     }
 }

--- a/tokenizers/tk-encode/src/utils/word_cache.rs
+++ b/tokenizers/tk-encode/src/utils/word_cache.rs
@@ -873,10 +873,26 @@ impl<'c> Lookup<'c, '_> {
 }
 
 /// A word's key and the hash that places it, from [`WordCache::key`].
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct WordKey {
     key: u128,
     hash: u64,
+}
+
+impl WordKey {
+    /// The key of a word the table will not store, which every operation here
+    /// treats as an immediate miss.
+    ///
+    /// A key of zero cannot come from a word: [`pack_word`] puts the length in the
+    /// top byte and no word is zero bytes long, and a hashed key always has
+    /// [`KEY_IS_HASH`] set. So zero is free to mean "no slot", which keeps this a
+    /// plain `u128` — an `Option` would push a keyed span past the 32 bytes that
+    /// let a batch of them stay in cache.
+    pub const NONE: Self = Self { key: 0, hash: 0 };
+
+    pub fn is_none(self) -> bool {
+        self.key == 0
+    }
 }
 
 /// Ask the memory system for the cache line holding `p`, on the architectures
@@ -993,24 +1009,21 @@ impl WordCache {
     ///
     /// Takes `&mut self` because a hit is also a vote for keeping the entry.
     pub fn lookup<'c, 'w>(&'c mut self, word: &'w [u8]) -> Lookup<'c, 'w> {
-        match self.key(word) {
-            Some(key) => self.lookup_keyed(word, key),
-            None => Lookup::Miss(None),
-        }
+        self.lookup_keyed(word, self.key(word))
     }
 
-    /// The key for `word`, or `None` for a word the table will not store: an
-    /// empty one, or one longer than [`MAX_WORD_BYTES`].
+    /// The key for `word`, or [`WordKey::NONE`] for a word the table will not
+    /// store: an empty one, or one longer than [`MAX_WORD_BYTES`].
     ///
-    /// Split out of [`WordCache::lookup`] so that a caller holding several words
-    /// can key them all and [`WordCache::prefetch`] their slots before probing
-    /// the first one.
-    pub fn key(&self, word: &[u8]) -> Option<WordKey> {
+    /// Split out of [`WordCache::lookup`] so that a caller can key a word at the
+    /// point it is cut out of the text, while its bytes are still in cache, and
+    /// probe for it later.
+    pub fn key(&self, word: &[u8]) -> WordKey {
         if word.is_empty() || word.len() > MAX_WORD_BYTES {
-            return None;
+            return WordKey::NONE;
         }
         let (key, hash) = self.slot_key(word);
-        Some(WordKey { key, hash })
+        WordKey { key, hash }
     }
 
     /// Ask for the two lines a [`WordCache::lookup_keyed`] on this key reads: the
@@ -1029,6 +1042,9 @@ impl WordCache {
 
     /// [`WordCache::lookup`] with the key already built by [`WordCache::key`].
     pub fn lookup_keyed<'c, 'w>(&'c mut self, word: &'w [u8], key: WordKey) -> Lookup<'c, 'w> {
+        if key.is_none() {
+            return Lookup::Miss(None);
+        }
         let WordKey { key, hash } = key;
         let index = match self.probe(key, hash, word) {
             Probe::Hit(index) => {
@@ -1387,7 +1403,7 @@ mod tests {
             (long, Some(&[4u32][..])),
             (&b"absent"[..], None),
         ] {
-            let key = cache.key(word).expect("word is cacheable");
+            let key = cache.key(word);
             cache.prefetch(key);
             assert_eq!(cache.lookup_keyed(word, key).hit(), ids, "{word:?}");
         }
@@ -1400,7 +1416,7 @@ mod tests {
         let cache = WordCache::new(1 << 8);
         assert!(cache.key(b"").is_none());
         assert!(cache.key(&vec![7u8; MAX_WORD_BYTES + 1]).is_none());
-        assert!(cache.key(&vec![7u8; MAX_WORD_BYTES]).is_some());
+        assert!(!cache.key(&vec![7u8; MAX_WORD_BYTES]).is_none());
     }
 
     #[test]


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**9 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`b8aa9c6c5 · 2026-07-30 14:12 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 16 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-overview.png" width="860">

**vs base branch** (`28b2b9633`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.89 vs v0.23.1 · ×1.02 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 11+0 (peak 12) · Pipeline 8+2 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.7 | 25.3 | ×3.31 | ×0.92 | 3% (1.2) | 73% (27.3) | 12% (4.6) | 11% (4.2) | 0% (0.0) | match |
| arb_Arab | lang | 4.3 | 24.9 | ×5.86 | ×1.02 | 3% (1.2) | 73% (27.4) | 9% (3.3) | 15% (5.7) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 36.1 | ×6.00 | ×1.06 | 4% (1.2) | 71% (19.0) | 11% (2.9) | 13% (3.5) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 17.1 | ×4.44 | ×0.93 | 2% (1.2) | 65% (37.5) | 10% (5.5) | 23% (13.4) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 25.0 | ×6.54 | ×1.07 | 3% (1.2) | 74% (28.4) | 9% (3.4) | 14% (5.3) | 0% (0.0) | match |
| eng_Latn | lang | 4.5 | 18.3 | ×4.05 | ×1.04 | 5% (2.5) | 72% (38.1) | 8% (4.3) | 15% (8.1) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 19.8 | ×4.68 | ×1.01 | 2% (1.2) | 77% (37.0) | 8% (3.6) | 13% (6.5) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 27.4 | ×4.22 | ×1.01 | 3% (1.2) | 76% (26.6) | 9% (3.2) | 12% (4.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.2 | 25.9 | ×6.12 | ×0.96 | 3% (1.2) | 63% (23.1) | 13% (4.6) | 21% (7.8) | 0% (0.0) | match |
| kat_Geor | lang | 6.1 | 28.9 | ×4.71 | ×1.04 | 3% (1.2) | 80% (26.4) | 8% (2.7) | 9% (3.0) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 18.9 | ×7.77 | ×1.09 | 2% (1.2) | 69% (34.7) | 15% (7.3) | 14% (6.9) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.7 | 25.7 | ×6.95 | ×1.11 | 3% (1.2) | 75% (27.3) | 9% (3.1) | 14% (5.0) | 0% (0.1) | match |
| tam_Taml | lang | 7.1 | 39.2 | ×5.55 | ×1.04 | 5% (1.2) | 75% (18.5) | 10% (2.5) | 10% (2.5) | 0% (0.0) | match |
| tha_Thai | lang | 8.5 | 33.2 | ×3.90 | ×1.02 | 4% (1.2) | 85% (24.6) | 8% (2.2) | 4% (1.1) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.8 | 20.1 | ×2.95 | ×1.07 | 3% (1.3) | 81% (40.0) | 14% (6.8) | 3% (1.3) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 18.8 | ×3.52 | ×1.06 | 4% (1.9) | 75% (39.2) | 13% (6.9) | 9% (4.7) | 0% (0.0) | match |
| added_special_dense | modalities | 5.4 | 39.2 | ×7.30 | ×1.00 | 21% (5.1) | 37% (9.0) | 34% (8.3) | 8% (2.0) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 21.8 | ×5.42 | ×1.04 | 8% (3.5) | 62% (27.7) | 18% (8.2) | 12% (5.5) | 0% (0.0) | match |
| agentic-traces | modalities | 3.9 | 17.3 | ×4.43 | ×0.99 | 4% (2.3) | 67% (37.9) | 8% (4.8) | 21% (11.9) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 18.6 | ×4.45 | ×1.00 | 4% (1.9) | 72% (38.1) | 7% (3.6) | 18% (9.5) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 18.6 | ×4.64 | ×1.02 | 4% (2.2) | 72% (38.0) | 8% (4.2) | 17% (9.0) | 0% (0.0) | match |
| math_latex | modalities | 4.1 | 17.8 | ×4.34 | ×1.02 | 4% (2.4) | 69% (38.0) | 8% (4.6) | 18% (9.9) | 0% (0.1) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×23.02 vs v0.23.1 · ×5.74 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 67) · Pipeline 82+0 (peak 82)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.5 | 97.1 | ×21.69 | ×2.93 | 7% (0.7) | 0% (0.0) | 49% (4.8) | 44% (4.2) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 109.9 | ×24.71 | ×6.57 | 7% (0.6) | 0% (0.0) | 41% (3.4) | 52% (4.3) | 0% (0.0) | match |
| ben_Beng | lang | 6.4 | 140.1 | ×21.76 | ×7.87 | 9% (0.6) | 0% (0.0) | 48% (3.2) | 43% (2.8) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 117.7 | ×30.30 | ×7.19 | 10% (0.8) | 0% (0.0) | 43% (3.1) | 46% (3.4) | 0% (0.0) | match |
| ell_Grek | lang | 4.8 | 113.5 | ×23.79 | ×6.34 | 8% (0.6) | 0% (0.0) | 43% (3.4) | 49% (3.9) | 0% (0.0) | match |
| eng_Latn | lang | 3.3 | 71.6 | ×22.01 | ×5.56 | 15% (2.0) | 0% (0.0) | 38% (5.0) | 47% (6.2) | 0% (0.0) | match |
| heb_Hebr | lang | 4.2 | 107.3 | ×25.82 | ×8.32 | 7% (0.6) | 0% (0.0) | 39% (3.6) | 54% (4.9) | 0% (0.0) | match |
| hin_Deva | lang | 6.0 | 129.6 | ×21.43 | ×6.00 | 15% (1.2) | 0% (0.0) | 37% (2.8) | 46% (3.5) | 2% (0.1) | match |
| jpn_Jpan | lang | 4.4 | 138.8 | ×31.29 | ×7.81 | 11% (0.7) | 0% (0.0) | 48% (3.0) | 41% (2.6) | 0% (0.0) | match |
| kat_Geor | lang | 6.1 | 154.1 | ×25.20 | ×8.52 | 10% (0.6) | 0% (0.0) | 48% (3.0) | 42% (2.6) | 0% (0.0) | match |
| kor_Hang | lang | 3.8 | 86.4 | ×22.88 | ×4.35 | 6% (0.6) | 0% (0.0) | 36% (3.7) | 58% (5.9) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.6 | 127.6 | ×27.85 | ×8.97 | 8% (0.6) | 0% (0.0) | 44% (3.3) | 48% (3.6) | 0% (0.0) | match |
| tam_Taml | lang | 6.4 | 170.0 | ×26.38 | ×9.53 | 11% (0.6) | 0% (0.0) | 50% (2.8) | 39% (2.2) | 0% (0.0) | match |
| tha_Thai | lang | 7.2 | 232.2 | ×32.33 | ×16.05 | 15% (0.6) | 0% (0.0) | 57% (2.3) | 30% (1.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 130.9 | ×21.31 | ×5.60 | 10% (0.7) | 0% (0.0) | 39% (2.8) | 51% (3.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 99.2 | ×18.58 | ×5.08 | 13% (1.3) | 0% (0.0) | 40% (3.9) | 48% (4.6) | 0% (0.0) | match |
| added_special_dense | modalities | 3.6 | 48.3 | ×13.30 | ×1.33 | 33% (6.5) | 3% (0.5) | 30% (5.9) | 36% (7.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 56.4 | ×13.95 | ×2.73 | 23% (3.9) | 0% (0.1) | 39% (6.6) | 38% (6.4) | 0% (0.0) | match |
| agentic-traces | modalities | 3.1 | 68.7 | ×22.33 | ×4.84 | 12% (1.8) | 0% (0.0) | 37% (5.3) | 51% (7.4) | 0% (0.0) | match |
| agentic_swe | modalities | 3.1 | 80.5 | ×25.97 | ×5.35 | 11% (1.3) | 0% (0.0) | 32% (3.8) | 57% (6.7) | 0% (0.0) | match |
| code_mixed | modalities | 3.6 | 76.5 | ×21.33 | ×4.91 | 12% (1.5) | 0% (0.0) | 36% (4.6) | 52% (6.7) | 0% (0.0) | match |
| math_latex | modalities | 3.0 | 69.4 | ×23.23 | ×4.98 | 13% (1.9) | 0% (0.0) | 38% (5.4) | 48% (6.9) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.77 | 3.63 | 4.76 | 5.62 | 42.7 | 20.0 | 9.1 | — | 9.0× / 7.6× | 4.2× / 3.6× | 1.9× / 1.6× | — |
| arb_Arab | 1.15 | 3.01 | 3.43 | 5.29 | 50.1 | 22.3 | 10.1 | — | 14.6× / 9.5× | 6.5× / 4.2× | 2.9× / 1.9× | — |
| ben_Beng | 1.59 | 2.99 | 3.16 | 4.55 | 36.6 | 16.1 | 7.5 | — | 11.6× / 8.0× | 5.1× / 3.5× | 2.4× / 1.6× | — |
| cmn_Hani | 1.12 | 2.42 | 3.14 | 4.45 | 62.0 | 33.3 | 14.1 | — | 19.7× / 13.9× | 10.6× / 7.5× | 4.5× / 3.2× | — |
| ell_Grek | 0.58 | 3.00 | 3.40 | 5.82 | 48.3 | 20.8 | 9.5 | — | 14.2× / 8.3× | 6.1× / 3.6× | 2.8× / 1.6× | — |
| eng_Latn | 0.10 | 1.75 | 5.00 | 6.65 | 67.0 | 38.0 | 16.1 | — | 13.4× / 10.1× | 7.6× / 5.7× | 3.2× / 2.4× | — |
| heb_Hebr | 1.16 | 3.06 | 3.56 | 5.46 | 52.1 | 23.9 | 10.5 | — | 14.6× / 9.5× | 6.7× / 4.4× | 3.0× / 1.9× | — |
| hin_Deva | 1.50 | 3.26 | 2.81 | 4.57 | 39.4 | 18.5 | 8.4 | — | 14.0× / 8.6× | 6.6× / 4.0× | 3.0× / 1.8× | — |
| jpn_Jpan | 1.70 | 3.64 | 2.97 | 4.92 | 54.7 | 26.8 | 11.8 | — | 18.4× / 11.1× | 9.0× / 5.5× | 4.0× / 2.4× | — |
| kat_Geor | 1.52 | 2.77 | 2.97 | 4.21 | 33.0 | 14.9 | 7.2 | — | 11.1× / 7.8× | 5.0× / 3.5× | 2.4× / 1.7× | — |
| kor_Hang | 1.23 | 2.86 | 3.72 | 5.35 | 51.6 | 26.8 | 11.8 | — | 13.9× / 9.6× | 7.2× / 5.0× | 3.2× / 2.2× | — |
| rus_Cyrl | 1.17 | 2.97 | 3.29 | 5.09 | 48.2 | 20.4 | 9.4 | — | 14.7× / 9.5× | 6.2× / 4.0× | 2.9× / 1.9× | — |
| tam_Taml | 0.91 | 3.22 | 2.77 | 5.08 | 32.6 | 13.5 | 6.5 | — | 11.8× / 6.4× | 4.9× / 2.6× | 2.4× / 1.3× | — |
| tha_Thai | 1.50 | 2.73 | 2.28 | 3.51 | 28.5 | 10.1 | 5.3 | — | 12.5× / 8.1× | 4.4× / 2.9× | 2.3× / 1.5× | — |
| added_normalized_dense | 0.06 | 1.77 | 2.84 | 4.54 | 43.6 | 20.0 | 9.1 | — | 15.4× / 9.6× | 7.1× / 4.4× | 3.2× / 2.0× | — |
| added_normalized_sparse | 0.06 | 1.77 | 3.89 | 5.60 | 50.8 | 25.6 | 11.6 | — | 13.1× / 9.1× | 6.6× / 4.6× | 3.0× / 2.1× | — |
| added_special_dense | 0.06 | 1.77 | 5.91 | 7.61 | 179.2 | 96.6 | 38.6 | — | 30.4× / 23.5× | 16.4× / 12.7× | 6.5× / 5.1× | — |
| added_special_sparse | 0.06 | 1.77 | 6.60 | 8.31 | 105.8 | 57.1 | 24.0 | — | 16.0× / 12.7× | 8.7× / 6.9× | 3.6× / 2.9× | — |
| agentic-traces | 0.72 | 1.76 | 5.31 | 6.36 | 82.7 | 51.9 | 20.0 | — | 15.6× / 13.0× | 9.8× / 8.2× | 3.8× / 3.2× | — |
| agentic_swe | 0.66 | 1.73 | 3.81 | 4.88 | 98.1 | 64.1 | 23.4 | — | 25.7× / 20.1× | 16.8× / 13.1× | 6.1× / 4.8× | — |
| code_mixed | 0.08 | 1.73 | 4.57 | 6.22 | 75.6 | 52.8 | 18.5 | — | 16.5× / 12.2× | 11.5× / 8.5× | 4.0× / 3.0× | — |
| math_latex | 0.72 | 1.76 | 5.44 | 6.48 | 80.6 | 47.0 | 19.5 | — | 14.8× / 12.4× | 8.6× / 7.2× | 3.6× / 3.0× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×2.07 vs v0.23.1 · ×1.19 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 370) · Pipeline 275+0 (peak 371)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 11.2 | 29.1 | ×2.60 | ×1.10 | 2% (0.7) | 7% (2.2) | 0% (0.0) | 93% (30.5) | 0% (0.0) | match |
| arb_Arab | lang | 7.5 | 13.9 | ×1.85 | ×1.09 | 1% (0.6) | 4% (2.6) | 0% (0.0) | 94% (65.6) | 1% (0.7) | match |
| ben_Beng | lang | 10.9 | 19.7 | ×1.81 | ×1.14 | 1% (0.6) | 3% (1.7) | 0% (0.0) | 96% (47.8) | 0% (0.0) | match |
| cmn_Hani | lang | 14.0 | 38.0 | ×2.71 | ×1.14 | 2% (0.6) | 1% (0.3) | 0% (0.0) | 96% (23.9) | 0% (0.0) | match |
| ell_Grek | lang | 8.1 | 15.7 | ×1.94 | ×1.09 | 1% (0.6) | 4% (2.6) | 0% (0.1) | 94% (58.5) | 0% (0.3) | match |
| eng_Latn | lang | 4.1 | 5.9 | ×1.44 | ×1.08 | 1% (1.9) | 3% (4.9) | 0% (0.1) | 96% (159.5) | 0% (0.0) | match |
| heb_Hebr | lang | 8.4 | 17.7 | ×2.10 | ×1.08 | 1% (0.6) | 5% (2.7) | 0% (0.0) | 94% (51.9) | 0% (0.0) | match |
| hin_Deva | lang | 10.2 | 18.8 | ×1.85 | ×1.09 | 1% (0.6) | 5% (2.3) | 0% (0.0) | 95% (47.5) | 0% (0.0) | match |
| jpn_Jpan | lang | 14.1 | 32.0 | ×2.27 | ×1.14 | 2% (0.6) | 1% (0.2) | 0% (0.0) | 97% (29.3) | 0% (0.0) | match |
| kat_Geor | lang | 12.4 | 25.8 | ×2.08 | ×1.07 | 2% (0.6) | 4% (1.5) | 0% (0.0) | 95% (35.3) | 0% (0.0) | match |
| kor_Hang | lang | 10.2 | 27.4 | ×2.68 | ×1.11 | 2% (0.6) | 8% (2.7) | 0% (0.0) | 91% (31.3) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.4 | 11.6 | ×1.57 | ×1.12 | 1% (0.6) | 3% (2.3) | 0% (0.0) | 96% (79.6) | 0% (0.1) | match |
| tam_Taml | lang | 11.8 | 21.0 | ×1.78 | ×1.10 | 1% (0.6) | 3% (1.3) | 0% (0.0) | 96% (45.0) | 0% (0.0) | match |
| tha_Thai | lang | 13.6 | 25.2 | ×1.86 | ×1.09 | 2% (0.6) | 2% (0.7) | 0% (0.0) | 97% (36.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.2 | 7.8 | ×1.49 | ×1.08 | 1% (0.7) | 2% (3.0) | 0% (0.0) | 97% (125.0) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.8 | 6.8 | ×1.43 | ×1.07 | 1% (1.3) | 3% (4.4) | 0% (0.0) | 96% (138.4) | 0% (0.0) | match |
| added_special_dense | modalities | 4.8 | 30.6 | ×6.41 | ×1.58 | 30% (9.4) | 27% (8.5) | 22% (7.0) | 20% (6.2) | 0% (0.1) | match |
| added_special_sparse | modalities | 7.3 | 44.7 | ×6.11 | ×4.65 | 24% (5.2) | 40% (8.7) | 22% (4.7) | 14% (3.0) | 0% (0.0) | match |
| agentic-traces | modalities | 4.4 | 6.7 | ×1.53 | ×1.10 | 1% (1.8) | 3% (4.6) | 0% (0.0) | 96% (140.0) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 7.3 | ×1.79 | ×1.09 | 1% (1.3) | 6% (7.5) | 0% (0.1) | 93% (125.6) | 1% (0.7) | match |
| code_mixed | modalities | 4.3 | 6.9 | ×1.61 | ×1.09 | 1% (1.6) | 4% (6.1) | 0% (0.1) | 95% (134.8) | 0% (0.0) | match |
| math_latex | modalities | 4.2 | 6.3 | ×1.49 | ×1.12 | 1% (1.9) | 3% (4.6) | 0% (0.1) | 96% (149.8) | 0% (0.0) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×28.80 vs v0.23.1 · ×3.69 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 28+0 (peak 28)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 98.8 | ×26.22 | ×2.10 | 9% (0.7) | 0% (0.0) | 47% (3.6) | 44% (3.4) | 0% (0.0) | match |
| arb_Arab | lang | 3.7 | 122.5 | ×32.96 | ×4.78 | 8% (0.6) | 0% (0.0) | 31% (2.2) | 60% (4.3) | 0% (0.0) | match |
| ben_Beng | lang | 2.9 | 83.3 | ×28.69 | ×1.93 | 5% (0.6) | 0% (0.0) | 26% (3.0) | 69% (7.8) | 0% (0.0) | match |
| cmn_Hani | lang | 3.8 | 135.9 | ×36.17 | ×4.81 | 10% (0.6) | 0% (0.0) | 38% (2.3) | 52% (3.1) | 0% (0.0) | match |
| ell_Grek | lang | 4.3 | 135.6 | ×31.35 | ×4.82 | 9% (0.6) | 0% (0.0) | 33% (2.2) | 58% (3.9) | 0% (0.0) | match |
| eng_Latn | lang | 3.5 | 96.8 | ×27.48 | ×6.92 | 21% (2.0) | 0% (0.0) | 30% (2.9) | 49% (4.6) | 0% (0.0) | match |
| heb_Hebr | lang | 4.0 | 118.8 | ×29.94 | ×4.12 | 8% (0.6) | 0% (0.0) | 31% (2.3) | 61% (4.5) | 0% (0.0) | match |
| hin_Deva | lang | 3.1 | 90.9 | ×29.39 | ×2.23 | 6% (0.6) | 0% (0.0) | 29% (3.0) | 65% (6.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.5 | 158.7 | ×35.07 | ×7.38 | 12% (0.6) | 0% (0.0) | 42% (2.1) | 46% (2.3) | 0% (0.0) | match |
| kat_Geor | lang | 4.7 | 173.7 | ×36.70 | ×2.44 | 12% (0.6) | 0% (0.0) | 41% (2.0) | 47% (2.3) | 0% (0.0) | match |
| kor_Hang | lang | 3.4 | 102.4 | ×30.43 | ×2.36 | 7% (0.6) | 0% (0.0) | 30% (2.4) | 62% (5.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.2 | 140.9 | ×33.50 | ×5.27 | 9% (0.6) | 0% (0.0) | 33% (2.1) | 58% (3.7) | 0% (0.0) | match |
| tam_Taml | lang | 2.7 | 86.3 | ×31.79 | ×1.22 | 5% (0.6) | 0% (0.0) | 24% (2.6) | 70% (7.7) | 0% (0.0) | match |
| tha_Thai | lang | 3.6 | 111.9 | ×31.03 | ×3.01 | 8% (0.6) | 0% (0.0) | 33% (2.5) | 59% (4.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 179.3 | ×30.50 | ×7.15 | 15% (0.7) | 0% (0.0) | 23% (1.2) | 64% (3.2) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.1 | 132.2 | ×25.99 | ×6.16 | 19% (1.3) | 0% (0.0) | 27% (1.9) | 56% (3.9) | 0% (0.0) | match |
| added_special_dense | modalities | 4.0 | 79.7 | ×19.68 | ×1.76 | 42% (5.0) | 0% (0.0) | 32% (3.8) | 27% (3.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.2 | 81.7 | ×19.44 | ×3.47 | 28% (3.1) | 0% (0.0) | 39% (4.4) | 35% (4.0) | 0% (0.0) | match |
| agentic-traces | modalities | 3.2 | 83.4 | ×26.01 | ×5.09 | 15% (1.8) | 0% (0.0) | 30% (3.4) | 55% (6.4) | 0% (0.0) | match |
| agentic_swe | modalities | 3.4 | 89.5 | ×26.35 | ×3.62 | 12% (1.3) | 0% (0.0) | 23% (2.4) | 65% (6.8) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 89.1 | ×25.19 | ×4.29 | 14% (1.5) | 0% (0.0) | 26% (2.9) | 60% (6.5) | 0% (0.0) | match |
| math_latex | modalities | 3.3 | 91.0 | ×27.75 | ×6.01 | 18% (1.9) | 0% (0.0) | 30% (3.2) | 53% (5.6) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.76 | 3.64 | 3.60 | 4.48 | 31.1 | 21.5 | 5.9 | 4.8 | 8.6× / 6.9× | 6.0× / 4.8× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.97 | 2.25 | 4.07 | 36.8 | 26.0 | 6.8 | 5.1 | 16.4× / 9.0× | 11.6× / 6.4× | 3.0× / 1.7× | 2.3× / 1.2× |
| ben_Beng | 1.59 | 2.98 | 2.97 | 4.36 | 76.7 | 58.0 | 13.9 | 4.1 | 25.8× / 17.6× | 19.5× / 13.3× | 4.7× / 3.2× | 1.4× / 0.9× |
| cmn_Hani | 1.12 | 2.31 | 2.31 | 3.51 | 29.5 | 21.3 | 6.1 | 2.3 | 12.7× / 8.4× | 9.2× / 6.1× | 2.6× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.03 | 2.15 | 4.60 | 32.4 | 22.3 | 5.9 | 4.7 | 15.0× / 7.0× | 10.3× / 4.8× | 2.7× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.75 | 2.87 | 4.51 | 52.5 | 42.8 | 11.8 | 3.7 | 18.3× / 11.6× | 14.9× / 9.5× | 4.1× / 2.6× | 1.3× / 0.8× |
| heb_Hebr | 1.15 | 3.12 | 2.27 | 4.24 | 36.7 | 26.6 | 6.8 | 3.0 | 16.2× / 8.7× | 11.7× / 6.3× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.49 | 3.31 | 3.04 | 4.85 | 71.8 | 53.8 | 13.4 | 4.2 | 23.7× / 14.8× | 17.7× / 11.1× | 4.4× / 2.8× | 1.4× / 0.9× |
| jpn_Jpan | 1.71 | 3.41 | 2.10 | 3.81 | 25.9 | 18.1 | 5.0 | 3.7 | 12.3× / 6.8× | 8.6× / 4.8× | 2.4× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.52 | 2.60 | 2.03 | 3.11 | 20.0 | 14.6 | 4.2 | 2.0 | 9.9× / 6.4× | 7.2× / 4.7× | 2.1× / 1.3× | 1.0× / 0.7× |
| kor_Hang | 1.23 | 2.88 | 2.45 | 4.10 | 36.8 | 28.2 | 7.4 | 3.7 | 15.1× / 9.0× | 11.5× / 6.9× | 3.0× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.17 | 2.95 | 2.07 | 3.86 | 30.9 | 21.6 | 5.8 | 2.5 | 14.9× / 8.0× | 10.4× / 5.6× | 2.8× / 1.5× | 1.2× / 0.6× |
| tam_Taml | 0.91 | 3.16 | 2.63 | 4.88 | 80.2 | 60.1 | 14.1 | 3.8 | 30.5× / 16.4× | 22.8× / 12.3× | 5.4× / 2.9× | 1.4× / 0.8× |
| tha_Thai | 1.50 | 2.59 | 2.46 | 3.56 | 45.2 | 32.2 | 8.7 | 3.2 | 18.4× / 12.7× | 13.1× / 9.1× | 3.6× / 2.5× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.77 | 1.16 | 2.87 | 28.0 | 23.2 | 6.4 | 1.8 | 24.1× / 9.8× | 20.0× / 8.1× | 5.5× / 2.2× | 1.6× / 0.6× |
| added_normalized_sparse | 0.06 | 1.77 | 1.92 | 3.63 | 37.7 | 32.3 | 8.5 | 2.6 | 19.7× / 10.4× | 16.8× / 8.9× | 4.4× / 2.3× | 1.3× / 0.7× |
| added_special_dense | 0.06 | 1.77 | 3.79 | 5.50 | 113.8 | 98.7 | 20.9 | 2.9 | 30.1× / 20.7× | 26.1× / 18.0× | 5.5× / 3.8× | 0.8× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 4.36 | 6.06 | 72.8 | 62.5 | 14.7 | 3.4 | 16.7× / 12.0× | 14.4× / 10.3× | 3.4× / 2.4× | 0.8× / 0.6× |
| agentic-traces | 0.72 | 1.79 | 3.45 | 4.52 | 69.9 | 60.8 | 15.3 | 4.6 | 20.3× / 15.5× | 17.6× / 13.4× | 4.4× / 3.4× | 1.3× / 1.0× |
| agentic_swe | 0.66 | 1.74 | 2.41 | 3.48 | 70.8 | 69.4 | 14.9 | 3.5 | 29.4× / 20.3× | 28.8× / 19.9× | 6.2× / 4.3× | 1.4× / 1.0× |
| code_mixed | 0.07 | 1.73 | 2.86 | 4.52 | 69.0 | 67.2 | 15.1 | 4.0 | 24.1× / 15.3× | 23.5× / 14.9× | 5.3× / 3.3× | 1.4× / 0.9× |
| math_latex | 0.72 | 1.77 | 3.20 | 4.25 | 61.8 | 52.0 | 13.8 | 4.1 | 19.3× / 14.5× | 16.2× / 12.2× | 4.3× / 3.2× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×20.91 vs v0.23.1 · ×4.52 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 92.3 | ×22.90 | ×3.97 | 7% (0.7) | 0% (0.0) | 51% (4.9) | 42% (4.1) | 0% (0.0) | match |
| arb_Arab | lang | 4.8 | 113.0 | ×23.50 | ×6.43 | 7% (0.6) | 0% (0.0) | 43% (3.6) | 50% (4.3) | 0% (0.0) | match |
| ben_Beng | lang | 7.1 | 132.5 | ×18.70 | ×7.55 | 8% (0.6) | 0% (0.0) | 54% (3.9) | 38% (2.7) | 0% (0.0) | match |
| cmn_Hani | lang | 4.8 | 137.4 | ×28.75 | ×11.98 | 9% (0.6) | 0% (0.0) | 49% (3.3) | 50% (3.4) | 0% (0.0) | match |
| ell_Grek | lang | 5.2 | 128.1 | ×24.76 | ×8.40 | 8% (0.6) | 0% (0.0) | 43% (3.3) | 50% (3.8) | 0% (0.0) | match |
| eng_Latn | lang | 4.1 | 77.8 | ×19.14 | ×2.02 | 16% (2.0) | 0% (0.0) | 36% (4.5) | 49% (6.2) | 0% (0.0) | match |
| heb_Hebr | lang | 4.7 | 108.0 | ×22.83 | ×6.47 | 7% (0.6) | 0% (0.0) | 42% (3.9) | 51% (4.7) | 0% (0.0) | match |
| hin_Deva | lang | 7.1 | 127.9 | ×17.93 | ×4.91 | 8% (0.6) | 0% (0.0) | 53% (4.0) | 40% (3.0) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.6 | 163.1 | ×29.12 | ×13.24 | 10% (0.6) | 0% (0.0) | 52% (3.1) | 37% (2.2) | 0% (0.0) | match |
| kat_Geor | lang | 6.9 | 157.6 | ×22.98 | ×11.41 | 10% (0.6) | 0% (0.0) | 49% (2.9) | 41% (2.4) | 0% (0.0) | match |
| kor_Hang | lang | 4.1 | 92.9 | ×22.52 | ×6.36 | 6% (0.6) | 0% (0.0) | 36% (3.8) | 59% (6.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.3 | 128.3 | ×24.29 | ×8.45 | 8% (0.6) | 0% (0.0) | 44% (3.2) | 48% (3.5) | 0% (0.0) | match |
| tam_Taml | lang | 7.0 | 144.8 | ×20.77 | ×11.09 | 10% (0.6) | 0% (0.0) | 56% (3.5) | 34% (2.1) | 0% (0.0) | match |
| tha_Thai | lang | 8.1 | 175.9 | ×21.79 | ×15.47 | 12% (0.6) | 0% (0.0) | 68% (3.5) | 20% (1.0) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 138.2 | ×24.24 | ×5.52 | 11% (0.7) | 0% (0.0) | 34% (2.3) | 56% (3.8) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.5 | 106.8 | ×19.42 | ×2.59 | 14% (1.3) | 0% (0.0) | 35% (3.2) | 52% (4.6) | 0% (0.0) | match |
| added_special_dense | modalities | 4.5 | 56.6 | ×12.69 | ×0.74 | 29% (5.0) | 1% (0.1) | 31% (5.4) | 39% (6.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.6 | 62.3 | ×13.68 | ×0.81 | 20% (3.1) | 0% (0.0) | 39% (5.9) | 40% (6.2) | 0% (0.0) | match |
| agentic-traces | modalities | 3.8 | 69.2 | ×18.31 | ×1.88 | 13% (1.8) | 0% (0.0) | 36% (5.0) | 52% (7.2) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 80.9 | ×20.38 | ×2.98 | 11% (1.3) | 0% (0.0) | 31% (3.7) | 58% (6.8) | 0% (0.0) | match |
| code_mixed | modalities | 3.8 | 76.2 | ×19.87 | ×1.56 | 12% (1.5) | 0% (0.0) | 35% (4.4) | 53% (6.6) | 0% (0.0) | match |
| math_latex | modalities | 3.6 | 71.0 | ×19.87 | ×1.96 | 14% (1.9) | 0% (0.0) | 35% (4.8) | 52% (7.1) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.73 | 4.90 | 5.88 | 33.6 | 14.0 | 6.9 | 4.7 | 6.9× / 5.7× | 2.9× / 2.4× | 1.4× / 1.2× | 1.0× / 0.8× |
| arb_Arab | 1.15 | 2.96 | 3.62 | 5.43 | 38.4 | 16.2 | 7.4 | 5.2 | 10.6× / 7.1× | 4.5× / 3.0× | 2.1× / 1.4× | 1.4× / 1.0× |
| ben_Beng | 1.60 | 2.98 | 3.87 | 5.25 | 26.6 | 10.7 | 5.4 | 2.8 | 6.9× / 5.1× | 2.8× / 2.0× | 1.4× / 1.0× | 0.7× / 0.5× |
| cmn_Hani | 1.12 | 2.31 | 3.30 | 4.49 | 24.4 | 10.7 | 5.5 | 2.4 | 7.4× / 5.4× | 3.2× / 2.4× | 1.7× / 1.2× | 0.7× / 0.5× |
| ell_Grek | 0.58 | 3.04 | 3.25 | 5.71 | 33.8 | 15.0 | 6.8 | 5.1 | 10.4× / 5.9× | 4.6× / 2.6× | 2.1× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.09 | 1.75 | 4.47 | 6.12 | 51.8 | 29.3 | 13.6 | 4.1 | 11.6× / 8.5× | 6.6× / 4.8× | 3.1× / 2.2× | 0.9× / 0.7× |
| heb_Hebr | 1.15 | 3.02 | 3.85 | 5.73 | 38.4 | 17.2 | 8.2 | 2.8 | 10.0× / 6.7× | 4.5× / 3.0× | 2.1× / 1.4× | 0.7× / 0.5× |
| hin_Deva | 1.49 | 3.18 | 4.00 | 5.68 | 29.6 | 12.8 | 6.3 | 3.2 | 7.4× / 5.2× | 3.2× / 2.3× | 1.6× / 1.1× | 0.8× / 0.6× |
| jpn_Jpan | 1.70 | 3.64 | 3.06 | 5.00 | 21.9 | 9.2 | 4.8 | 3.8 | 7.2× / 4.4× | 3.0× / 1.8× | 1.6× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.52 | 2.73 | 2.90 | 4.11 | 20.8 | 10.1 | 4.5 | 2.0 | 7.2× / 5.1× | 3.5× / 2.5× | 1.6× / 1.1× | 0.7× / 0.5× |
| kor_Hang | 1.23 | 2.86 | 3.84 | 5.48 | 38.2 | 19.2 | 8.9 | 3.6 | 10.0× / 7.0× | 5.0× / 3.5× | 2.3× / 1.6× | 0.9× / 0.7× |
| rus_Cyrl | 1.17 | 2.96 | 3.17 | 4.96 | 32.1 | 15.0 | 6.5 | 4.8 | 10.1× / 6.5× | 4.7× / 3.0× | 2.1× / 1.3× | 1.5× / 1.0× |
| tam_Taml | 0.91 | 3.00 | 3.48 | 5.57 | 20.9 | 8.7 | 4.2 | 2.9 | 6.0× / 3.8× | 2.5× / 1.6× | 1.2× / 0.7× | 0.8× / 0.5× |
| tha_Thai | 1.51 | 2.69 | 3.49 | 4.67 | 13.9 | 5.7 | 2.7 | 2.3 | 4.0× / 3.0× | 1.6× / 1.2× | 0.8× / 0.6× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.77 | 2.31 | 4.02 | 37.5 | 17.8 | 11.3 | 2.1 | 16.3× / 9.3× | 7.7× / 4.4× | 4.9× / 2.8× | 0.9× / 0.5× |
| added_normalized_sparse | 0.06 | 1.77 | 3.19 | 4.90 | 41.8 | 21.1 | 11.5 | 3.0 | 13.1× / 8.5× | 6.6× / 4.3× | 3.6× / 2.3× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.77 | 5.37 | 7.08 | 101.4 | 66.1 | 24.0 | 3.1 | 18.9× / 14.3× | 12.3× / 9.3× | 4.5× / 3.4× | 0.6× / 0.4× |
| added_special_sparse | 0.06 | 1.77 | 5.95 | 7.66 | 68.0 | 41.4 | 16.7 | 3.6 | 11.4× / 8.9× | 7.0× / 5.4× | 2.8× / 2.2× | 0.6× / 0.5× |
| agentic-traces | 0.72 | 1.76 | 4.95 | 6.00 | 62.2 | 40.9 | 17.0 | 4.8 | 12.6× / 10.4× | 8.2× / 6.8× | 3.4× / 2.8× | 1.0× / 0.8× |
| agentic_swe | 0.66 | 1.73 | 3.71 | 4.78 | 62.2 | 48.7 | 17.4 | 3.5 | 16.8× / 13.0× | 13.1× / 10.2× | 4.7× / 3.6× | 1.0× / 0.7× |
| code_mixed | 0.07 | 1.73 | 4.36 | 6.02 | 61.7 | 46.5 | 17.2 | 4.2 | 14.2× / 10.3× | 10.7× / 7.7× | 4.0× / 2.9× | 1.0× / 0.7× |
| math_latex | 0.71 | 1.77 | 4.77 | 5.82 | 59.2 | 35.9 | 15.7 | 4.4 | 12.4× / 10.2× | 7.5× / 6.2× | 3.3× / 2.7× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×22.66 vs v0.23.1 · ×3.79 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.3 | 101.1 | ×23.47 | ×2.25 | 14% (1.2) | 0% (0.0) | 43% (3.7) | 43% (3.7) | 0% (0.0) | match |
| arb_Arab | lang | 4.9 | 125.6 | ×25.69 | ×7.39 | 16% (1.2) | 0% (0.0) | 32% (2.3) | 52% (3.8) | 0% (0.0) | match |
| ben_Beng | lang | 4.4 | 104.1 | ×23.84 | ×3.81 | 13% (1.2) | 0% (0.0) | 34% (3.1) | 53% (4.9) | 0% (0.0) | match |
| cmn_Hani | lang | 5.3 | 144.9 | ×27.27 | ×10.55 | 20% (1.2) | 0% (0.0) | 40% (2.4) | 41% (2.4) | 0% (0.0) | match |
| ell_Grek | lang | 5.4 | 134.1 | ×24.83 | ×7.02 | 17% (1.2) | 0% (0.0) | 33% (2.2) | 49% (3.3) | 0% (0.0) | match |
| eng_Latn | lang | 4.1 | 89.6 | ×21.67 | ×2.12 | 24% (2.5) | 0% (0.0) | 29% (3.0) | 47% (4.9) | 0% (0.0) | match |
| heb_Hebr | lang | 4.4 | 110.2 | ×24.80 | ×4.44 | 14% (1.2) | 0% (0.0) | 29% (2.3) | 57% (4.6) | 0% (0.0) | match |
| hin_Deva | lang | 4.1 | 96.3 | ×23.75 | ×3.15 | 12% (1.2) | 0% (0.0) | 33% (3.2) | 56% (5.5) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.0 | 161.2 | ×26.84 | ×10.58 | 22% (1.2) | 0% (0.0) | 42% (2.2) | 35% (1.8) | 0% (0.0) | match |
| kat_Geor | lang | 6.8 | 155.0 | ×22.90 | ×7.40 | 21% (1.2) | 0% (0.0) | 37% (2.1) | 42% (2.4) | 0% (0.0) | match |
| kor_Hang | lang | 4.2 | 96.3 | ×22.99 | ×5.29 | 13% (1.2) | 0% (0.0) | 28% (2.5) | 58% (5.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.2 | 138.1 | ×26.53 | ×7.54 | 18% (1.2) | 0% (0.0) | 35% (2.2) | 47% (3.0) | 0% (0.0) | match |
| tam_Taml | lang | 4.0 | 102.0 | ×25.49 | ×2.90 | 12% (1.2) | 0% (0.0) | 29% (2.7) | 59% (5.5) | 0% (0.0) | match |
| tha_Thai | lang | 5.2 | 131.3 | ×25.34 | ×6.11 | 16% (1.2) | 0% (0.0) | 37% (2.6) | 47% (3.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 165.9 | ×27.23 | ×6.32 | 24% (1.3) | 0% (0.0) | 20% (1.1) | 58% (3.2) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.5 | 128.0 | ×23.20 | ×3.14 | 24% (1.8) | 0% (0.0) | 26% (2.0) | 48% (3.6) | 1% (0.1) | match |
| added_special_dense | modalities | 4.2 | 47.7 | ×11.26 | ×1.02 | 61% (12.5) | 0% (0.1) | 26% (5.3) | 13% (2.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 61.9 | ×14.03 | ×1.09 | 45% (6.8) | 0% (0.0) | 33% (5.0) | 22% (3.4) | 0% (0.0) | match |
| agentic-traces | modalities | 3.7 | 79.0 | ×21.35 | ×2.23 | 20% (2.4) | 0% (0.0) | 31% (3.8) | 48% (5.8) | 1% (0.1) | match |
| agentic_swe | modalities | 4.0 | 89.6 | ×22.36 | ×3.28 | 18% (1.9) | 0% (0.0) | 27% (2.9) | 55% (5.8) | 0% (0.0) | match |
| code_mixed | modalities | 4.1 | 90.0 | ×22.01 | ×2.03 | 20% (2.2) | 0% (0.0) | 31% (3.3) | 49% (5.3) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 81.8 | ×20.63 | ×2.19 | 21% (2.4) | 0% (0.0) | 30% (3.5) | 49% (5.6) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.76 | 3.56 | 3.66 | 4.46 | 26.5 | 16.1 | 6.0 | 4.8 | 7.2× / 5.9× | 4.4× / 3.6× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.16 | 2.99 | 2.33 | 4.16 | 30.2 | 20.4 | 7.0 | 5.1 | 12.9× / 7.3× | 8.7× / 4.9× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.60 | 2.95 | 3.13 | 4.48 | 43.7 | 28.4 | 10.4 | 3.8 | 14.0× / 9.8× | 9.1× / 6.3× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.30 | 2.40 | 3.58 | 18.9 | 11.8 | 4.7 | 2.4 | 7.9× / 5.3× | 4.9× / 3.3× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.02 | 2.23 | 4.66 | 27.5 | 17.0 | 6.1 | 4.7 | 12.4× / 5.9× | 7.7× / 3.7× | 2.8× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.09 | 1.75 | 3.03 | 4.69 | 41.8 | 33.2 | 12.3 | 3.9 | 13.8× / 8.9× | 11.0× / 7.1× | 4.1× / 2.6× | 1.3× / 0.8× |
| heb_Hebr | 1.15 | 3.06 | 2.33 | 4.24 | 29.9 | 19.4 | 6.9 | 3.0 | 12.8× / 7.0× | 8.3× / 4.6× | 2.9× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.49 | 3.17 | 3.24 | 4.92 | 46.1 | 31.5 | 11.1 | 4.1 | 14.2× / 9.4× | 9.7× / 6.4× | 3.4× / 2.2× | 1.3× / 0.8× |
| jpn_Jpan | 1.69 | 3.42 | 2.20 | 3.93 | 17.8 | 10.1 | 4.1 | 3.9 | 8.1× / 4.5× | 4.6× / 2.6× | 1.8× / 1.0× | 1.7× / 1.0× |
| kat_Geor | 1.51 | 2.59 | 2.08 | 3.16 | 17.3 | 11.2 | 4.2 | 2.1 | 8.3× / 5.5× | 5.4× / 3.5× | 2.0× / 1.3× | 1.0× / 0.7× |
| kor_Hang | 1.23 | 2.79 | 2.52 | 4.09 | 29.6 | 20.8 | 7.3 | 3.7 | 11.7× / 7.2× | 8.2× / 5.1× | 2.9× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.92 | 2.17 | 3.93 | 26.1 | 16.4 | 6.3 | 2.4 | 12.0× / 6.6× | 7.5× / 4.2× | 2.9× / 1.6× | 1.1× / 0.6× |
| tam_Taml | 0.91 | 3.14 | 2.74 | 4.97 | 42.7 | 26.5 | 9.8 | 3.4 | 15.6× / 8.6× | 9.7× / 5.3× | 3.6× / 2.0× | 1.2× / 0.7× |
| tha_Thai | 1.50 | 2.61 | 2.60 | 3.72 | 27.4 | 16.7 | 6.7 | 3.0 | 10.5× / 7.4× | 6.4× / 4.5× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.77 | 1.08 | 2.79 | 22.9 | 18.0 | 6.6 | 1.9 | 21.2× / 8.2× | 16.7× / 6.5× | 6.1× / 2.4× | 1.8× / 0.7× |
| added_normalized_sparse | 0.06 | 1.77 | 1.99 | 3.70 | 29.9 | 23.0 | 9.0 | 2.7 | 15.0× / 8.1× | 11.5× / 6.2× | 4.5× / 2.4× | 1.3× / 0.7× |
| added_special_dense | 0.06 | 1.77 | 5.33 | 7.04 | 91.4 | 74.9 | 21.8 | 3.2 | 17.1× / 13.0× | 14.0× / 10.6× | 4.1× / 3.1× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 4.98 | 6.69 | 58.7 | 46.3 | 15.7 | 3.5 | 11.8× / 8.8× | 9.3× / 6.9× | 3.2× / 2.3× | 0.7× / 0.5× |
| agentic-traces | 0.72 | 1.76 | 3.76 | 4.81 | 50.4 | 43.6 | 14.9 | 4.7 | 13.4× / 10.5× | 11.6× / 9.1× | 4.0× / 3.1× | 1.2× / 1.0× |
| agentic_swe | 0.65 | 1.74 | 2.87 | 3.96 | 53.1 | 52.0 | 15.5 | 3.4 | 18.5× / 13.4× | 18.1× / 13.1× | 5.4× / 3.9× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.73 | 3.30 | 4.97 | 50.5 | 49.9 | 15.3 | 4.0 | 15.3× / 10.2× | 15.1× / 10.0× | 4.6× / 3.1× | 1.2× / 0.8× |
| math_latex | 0.72 | 1.77 | 3.47 | 4.52 | 48.7 | 40.9 | 14.0 | 4.3 | 14.0× / 10.8× | 11.8× / 9.1× | 4.0× / 3.1× | 1.2× / 0.9× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.90 vs v0.23.1 · ×1.19 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 22) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.0 | 43.7 | ×8.73 | ×1.08 | 0% (0.0) | 13% (2.8) | 0% (0.0) | 87% (19.4) | 0% (0.0) | match |
| arb_Arab | lang | 11.1 | 51.5 | ×4.65 | ×1.10 | 0% (0.0) | 17% (3.3) | 0% (0.0) | 83% (15.9) | 0% (0.0) | match |
| ben_Beng | lang | 11.8 | 85.9 | ×7.26 | ×1.11 | 0% (0.0) | 19% (2.2) | 0% (0.0) | 81% (9.2) | 0% (0.0) | match |
| cmn_Hani | lang | 9.9 | 67.3 | ×6.80 | ×1.12 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 97% (13.4) | 0% (0.0) | match |
| ell_Grek | lang | 11.1 | 58.8 | ×5.28 | ×1.07 | 0% (0.0) | 19% (3.2) | 0% (0.0) | 81% (13.5) | 0% (0.0) | match |
| eng_Latn | lang | 4.5 | 6.7 | ×1.49 | ×1.09 | 0% (0.1) | 5% (7.0) | 0% (0.0) | 95% (141.2) | 0% (0.1) | match |
| heb_Hebr | lang | 11.0 | 62.6 | ×5.70 | ×1.07 | 0% (0.0) | 21% (3.3) | 0% (0.0) | 79% (12.3) | 0% (0.0) | match |
| hin_Deva | lang | 13.0 | 82.3 | ×6.30 | ×1.14 | 0% (0.0) | 24% (2.9) | 0% (0.0) | 76% (9.0) | 0% (0.0) | match |
| jpn_Jpan | lang | 14.0 | 89.8 | ×6.43 | ×1.16 | 0% (0.0) | 3% (0.4) | 0% (0.0) | 96% (10.3) | 0% (0.0) | match |
| kat_Geor | lang | 15.2 | 91.8 | ×6.03 | ×1.10 | 0% (0.1) | 18% (1.9) | 0% (0.0) | 81% (8.6) | 0% (0.0) | match |
| kor_Hang | lang | 7.9 | 53.7 | ×6.80 | ×1.11 | 0% (0.1) | 18% (3.3) | 0% (0.0) | 82% (15.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 8.6 | 16.6 | ×1.93 | ×1.06 | 0% (0.0) | 5% (2.8) | 0% (0.0) | 95% (56.1) | 0% (0.0) | match |
| tam_Taml | lang | 13.6 | 94.6 | ×6.97 | ×1.13 | 0% (0.0) | 17% (1.7) | 0% (0.0) | 83% (8.5) | 0% (0.0) | match |
| tha_Thai | lang | 16.9 | 91.7 | ×5.44 | ×1.13 | 0% (0.0) | 9% (1.0) | 0% (0.0) | 91% (9.7) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.8 | 8.9 | ×1.54 | ×1.04 | 0% (0.0) | 3% (3.9) | 0% (0.0) | 97% (112.3) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.1 | 7.8 | ×1.53 | ×1.07 | 0% (0.0) | 5% (6.2) | 0% (0.0) | 94% (121.8) | 1% (1.2) | match |
| added_special_dense | modalities | 4.3 | 34.0 | ×7.85 | ×1.72 | 18% (5.2) | 55% (15.6) | 4% (1.2) | 22% (6.1) | 1% (0.2) | match |
| added_special_sparse | modalities | 6.1 | 46.8 | ×7.64 | ×4.63 | 11% (2.2) | 72% (14.5) | 1% (0.3) | 16% (3.2) | 0% (0.0) | match |
| agentic-traces | modalities | 4.8 | 7.4 | ×1.57 | ×1.08 | 0% (0.1) | 5% (6.3) | 0% (0.0) | 96% (127.5) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 7.2 | ×1.71 | ×1.06 | 0% (0.0) | 7% (9.9) | 0% (0.0) | 93% (127.8) | 0% (0.0) | match |
| code_mixed | modalities | 4.4 | 7.2 | ×1.64 | ×1.06 | 0% (0.0) | 6% (8.0) | 0% (0.0) | 95% (129.0) | 0% (0.0) | match |
| math_latex | modalities | 4.6 | 7.0 | ×1.53 | ×1.08 | 0% (0.1) | 5% (6.5) | 0% (0.0) | 95% (132.9) | 0% (0.1) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×25.20 vs v0.23.1 · ×3.77 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 94)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 107.6 | ×24.63 | ×2.27 | 8% (0.7) | 0% (0.0) | 47% (3.6) | 45% (3.5) | 0% (0.0) | match |
| arb_Arab | lang | 4.8 | 142.8 | ×29.67 | ×8.15 | 9% (0.6) | 0% (0.0) | 36% (2.3) | 56% (3.6) | 0% (0.0) | match |
| ben_Beng | lang | 4.1 | 107.6 | ×26.16 | ×3.39 | 7% (0.6) | 0% (0.0) | 35% (3.1) | 59% (5.2) | 0% (0.0) | match |
| cmn_Hani | lang | 5.3 | 155.4 | ×29.10 | ×9.43 | 11% (0.6) | 0% (0.0) | 45% (2.4) | 44% (2.3) | 0% (0.0) | match |
| ell_Grek | lang | 5.4 | 155.0 | ×28.59 | ×7.96 | 10% (0.6) | 0% (0.0) | 38% (2.2) | 53% (3.1) | 0% (0.0) | match |
| eng_Latn | lang | 4.3 | 98.2 | ×22.91 | ×2.29 | 20% (1.9) | 0% (0.0) | 31% (3.0) | 49% (4.7) | 0% (0.0) | match |
| heb_Hebr | lang | 4.5 | 117.5 | ×26.36 | ×4.68 | 8% (0.6) | 0% (0.0) | 32% (2.3) | 60% (4.4) | 0% (0.0) | match |
| hin_Deva | lang | 4.5 | 118.0 | ×26.28 | ×1.55 | 7% (0.6) | 0% (0.0) | 40% (3.2) | 55% (4.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.0 | 193.8 | ×32.14 | ×12.18 | 13% (0.6) | 0% (0.0) | 48% (2.2) | 39% (1.8) | 0% (0.0) | match |
| kat_Geor | lang | 5.8 | 163.6 | ×28.01 | ×4.69 | 12% (0.6) | 0% (0.0) | 41% (2.1) | 47% (2.3) | 0% (0.0) | match |
| kor_Hang | lang | 4.3 | 103.9 | ×24.38 | ×5.79 | 8% (0.6) | 0% (0.0) | 32% (2.5) | 61% (4.9) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.1 | 158.2 | ×31.02 | ×10.05 | 10% (0.6) | 0% (0.0) | 38% (2.2) | 51% (2.9) | 0% (0.0) | match |
| tam_Taml | lang | 4.2 | 109.8 | ×26.29 | ×3.16 | 7% (0.6) | 0% (0.0) | 31% (2.7) | 62% (5.4) | 0% (0.0) | match |
| tha_Thai | lang | 5.6 | 144.2 | ×25.92 | ×7.16 | 10% (0.6) | 0% (0.0) | 43% (2.6) | 47% (2.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.3 | 182.5 | ×29.21 | ×6.74 | 15% (0.7) | 0% (0.0) | 23% (1.1) | 65% (3.2) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.6 | 138.5 | ×24.91 | ×3.21 | 19% (1.3) | 0% (0.0) | 28% (1.9) | 55% (3.7) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 73.4 | ×17.24 | ×0.97 | 37% (5.0) | 1% (0.1) | 38% (5.1) | 24% (3.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.5 | 78.1 | ×17.46 | ×1.07 | 27% (3.2) | 0% (0.0) | 45% (5.2) | 29% (3.4) | 0% (0.0) | match |
| agentic-traces | modalities | 3.7 | 86.1 | ×23.39 | ×2.33 | 16% (1.7) | 0% (0.0) | 33% (3.7) | 51% (5.7) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 98.3 | ×23.32 | ×3.46 | 13% (1.3) | 0% (0.0) | 29% (2.9) | 58% (5.7) | 0% (0.0) | match |
| code_mixed | modalities | 4.4 | 93.4 | ×21.45 | ×2.02 | 15% (1.5) | 0% (0.0) | 33% (3.3) | 52% (5.3) | 0% (0.0) | match |
| math_latex | modalities | 3.9 | 89.0 | ×22.63 | ×2.20 | 17% (1.9) | 0% (0.0) | 32% (3.5) | 50% (5.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.74 | 3.51 | 3.64 | 4.41 | 27.1 | 16.2 | 5.9 | 4.7 | 7.4× / 6.1× | 4.5× / 3.7× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.15 | 2.98 | 2.32 | 4.15 | 31.0 | 19.5 | 6.9 | 5.1 | 13.4× / 7.5× | 8.4× / 4.7× | 3.0× / 1.7× | 2.2× / 1.2× |
| ben_Beng | 1.60 | 2.98 | 3.11 | 4.50 | 45.0 | 28.4 | 10.4 | 3.8 | 14.4× / 10.0× | 9.1× / 6.3× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.12 | 2.31 | 2.37 | 3.56 | 19.5 | 12.0 | 4.7 | 2.4 | 8.2× / 5.5× | 5.0× / 3.4× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.97 | 2.23 | 4.61 | 28.4 | 17.2 | 6.2 | 4.7 | 12.8× / 6.2× | 7.7× / 3.7× | 2.8× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.10 | 1.75 | 3.01 | 4.67 | 43.9 | 32.6 | 12.6 | 3.9 | 14.6× / 9.4× | 10.8× / 7.0× | 4.2× / 2.7× | 1.3× / 0.8× |
| heb_Hebr | 1.15 | 3.06 | 2.32 | 4.22 | 31.0 | 19.7 | 6.9 | 3.1 | 13.4× / 7.3× | 8.5× / 4.7× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.50 | 3.19 | 3.22 | 4.91 | 47.6 | 31.9 | 11.1 | 4.1 | 14.8× / 9.7× | 9.9× / 6.5× | 3.5× / 2.3× | 1.3× / 0.8× |
| jpn_Jpan | 1.70 | 3.49 | 2.17 | 3.96 | 18.3 | 9.8 | 4.1 | 3.9 | 8.4× / 4.6× | 4.5× / 2.5× | 1.9× / 1.0× | 1.8× / 1.0× |
| kat_Geor | 1.52 | 2.74 | 2.08 | 3.30 | 17.0 | 11.0 | 4.2 | 2.1 | 8.2× / 5.2× | 5.3× / 3.3× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.23 | 2.79 | 2.52 | 4.09 | 30.9 | 21.8 | 7.5 | 3.7 | 12.2× / 7.6× | 8.6× / 5.3× | 3.0× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.16 | 2.95 | 2.16 | 3.94 | 28.4 | 16.3 | 6.0 | 2.4 | 13.1× / 7.2× | 7.5× / 4.1× | 2.8× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.93 | 2.99 | 2.73 | 4.79 | 44.1 | 26.5 | 9.9 | 3.4 | 16.1× / 9.2× | 9.7× / 5.5× | 3.6× / 2.1× | 1.3× / 0.7× |
| tha_Thai | 1.50 | 2.59 | 2.58 | 3.67 | 28.2 | 16.1 | 6.8 | 3.0 | 10.9× / 7.7× | 6.2× / 4.4× | 2.6× / 1.8× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.77 | 1.12 | 2.83 | 23.8 | 17.0 | 6.5 | 1.9 | 21.2× / 8.4× | 15.2× / 6.0× | 5.8× / 2.3× | 1.7× / 0.7× |
| added_normalized_sparse | 0.06 | 1.77 | 1.88 | 3.58 | 31.5 | 22.7 | 9.0 | 2.7 | 16.8× / 8.8× | 12.1× / 6.3× | 4.8× / 2.5× | 1.4× / 0.7× |
| added_special_dense | 0.06 | 1.77 | 5.10 | 6.81 | 94.9 | 74.9 | 21.3 | 3.2 | 18.6× / 13.9× | 14.7× / 11.0× | 4.2× / 3.1× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 5.18 | 6.89 | 61.2 | 45.4 | 15.3 | 3.7 | 11.8× / 8.9× | 8.8× / 6.6× | 3.0× / 2.2× | 0.7× / 0.5× |
| agentic-traces | 0.72 | 1.76 | 3.71 | 4.76 | 52.8 | 44.2 | 15.1 | 4.7 | 14.2× / 11.1× | 11.9× / 9.3× | 4.1× / 3.2× | 1.3× / 1.0× |
| agentic_swe | 0.65 | 1.73 | 2.88 | 3.95 | 55.4 | 52.3 | 15.8 | 3.4 | 19.2× / 14.0× | 18.2× / 13.2× | 5.5× / 4.0× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.73 | 3.27 | 4.94 | 53.1 | 50.5 | 15.3 | 4.0 | 16.2× / 10.7× | 15.4× / 10.2× | 4.7× / 3.1× | 1.2× / 0.8× |
| math_latex | 0.71 | 1.77 | 3.49 | 4.55 | 50.8 | 39.1 | 14.3 | 4.2 | 14.5× / 11.2× | 11.2× / 8.6× | 4.1× / 3.1× | 1.2× / 0.9× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×7.69 vs v0.23.1 · ×1.51 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 193) · Pipeline 109+0 (peak 194)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 47.5 | ×11.98 | ×1.13 | 6% (1.2) | 0% (0.0) | 73% (14.2) | 21% (4.0) | 0% (0.0) | match |
| arb_Arab | lang | 5.0 | 45.3 | ×9.03 | ×2.16 | 5% (1.2) | 0% (0.0) | 77% (16.4) | 18% (3.8) | 0% (0.0) | match |
| ben_Beng | lang | 7.0 | 65.0 | ×9.28 | ×3.44 | 8% (1.2) | 0% (0.0) | 73% (10.8) | 18% (2.7) | 1% (0.1) | match |
| cmn_Hani | lang | 5.2 | 60.7 | ×11.70 | ×3.54 | 8% (1.2) | 0% (0.0) | 74% (11.5) | 18% (2.8) | 0% (0.1) | match |
| ell_Grek | lang | 5.4 | 48.5 | ×9.03 | ×2.60 | 6% (1.2) | 0% (0.0) | 75% (15.1) | 18% (3.7) | 1% (0.1) | match |
| eng_Latn | lang | 4.0 | 24.9 | ×6.22 | ×0.66 | 7% (2.5) | 0% (0.0) | 77% (29.7) | 16% (6.1) | 1% (0.3) | match |
| heb_Hebr | lang | 4.8 | 42.3 | ×8.77 | ×2.50 | 5% (1.2) | 0% (0.0) | 75% (17.2) | 19% (4.5) | 1% (0.1) | match |
| hin_Deva | lang | 6.9 | 56.1 | ×8.12 | ×2.16 | 7% (1.2) | 0% (0.0) | 75% (12.8) | 18% (3.0) | 1% (0.1) | match |
| jpn_Jpan | lang | 5.8 | 70.5 | ×12.12 | ×4.31 | 9% (1.2) | 0% (0.0) | 75% (9.7) | 16% (2.1) | 0% (0.0) | match |
| kat_Geor | lang | 6.9 | 69.4 | ×10.12 | ×4.62 | 8% (1.2) | 0% (0.0) | 74% (10.2) | 17% (2.3) | 0% (0.1) | match |
| kor_Hang | lang | 4.4 | 36.3 | ×8.34 | ×2.00 | 5% (1.2) | 0% (0.0) | 74% (19.2) | 21% (5.5) | 1% (0.1) | match |
| rus_Cyrl | lang | 5.1 | 48.8 | ×9.49 | ×3.08 | 6% (1.2) | 0% (0.0) | 77% (15.1) | 17% (3.4) | 0% (0.0) | match |
| tam_Taml | lang | 7.2 | 79.4 | ×10.95 | ×5.38 | 10% (1.2) | 0% (0.0) | 74% (8.8) | 16% (1.9) | 1% (0.1) | match |
| tha_Thai | lang | 8.3 | 112.5 | ×13.56 | ×7.62 | 14% (1.2) | 0% (0.0) | 72% (5.8) | 13% (1.1) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 42.4 | ×7.47 | ×1.45 | 6% (1.3) | 0% (0.0) | 77% (17.2) | 17% (3.8) | 1% (0.1) | match |
| added_normalized_sparse | modalities | 5.5 | 35.8 | ×6.55 | ×0.83 | 7% (1.8) | 0% (0.0) | 75% (20.4) | 18% (4.9) | 0% (0.1) | match |
| added_special_dense | modalities | 4.3 | 15.3 | ×3.59 | ×0.22 | 8% (5.2) | 0% (0.0) | 80% (52.3) | 11% (7.0) | 2% (1.0) | match |
| added_special_sparse | modalities | 4.6 | 21.3 | ×4.60 | ×0.33 | 8% (3.5) | 0% (0.0) | 77% (35.4) | 15% (6.8) | 1% (0.4) | match |
| agentic-traces | modalities | 3.5 | 18.7 | ×5.28 | ×0.56 | 4% (2.4) | 0% (0.0) | 81% (42.5) | 15% (7.9) | 0% (0.0) | match |
| agentic_swe | modalities | 3.6 | 15.4 | ×4.24 | ×0.62 | 3% (1.9) | 0% (0.0) | 84% (52.9) | 12% (7.6) | 1% (0.5) | match |
| code_mixed | modalities | 3.9 | 17.3 | ×4.46 | ×0.41 | 4% (2.1) | 0% (0.0) | 83% (47.5) | 12% (6.8) | 1% (0.7) | match |
| math_latex | modalities | 3.7 | 21.1 | ×5.68 | ×0.54 | 5% (2.4) | 0% (0.0) | 79% (36.5) | 15% (7.1) | 0% (0.2) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.76 | 3.52 | 14.17 | 14.94 | 27.4 | 14.1 | 6.6 | — | 1.9× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| arb_Arab | 1.15 | 2.98 | 16.35 | 18.18 | 32.0 | 16.7 | 7.3 | — | 2.0× / 1.8× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| ben_Beng | 1.60 | 3.02 | 10.79 | 12.21 | 22.2 | 10.9 | 5.2 | — | 2.1× / 1.8× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| cmn_Hani | 1.12 | 2.30 | 11.53 | 12.71 | 20.8 | 11.6 | 5.5 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| ell_Grek | 0.59 | 3.03 | 15.10 | 17.54 | 27.8 | 15.8 | 6.5 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| eng_Latn | 0.09 | 1.75 | 29.70 | 31.36 | 40.0 | 30.8 | 13.2 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| heb_Hebr | 1.15 | 3.06 | 17.25 | 19.16 | 30.7 | 17.1 | 7.7 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| hin_Deva | 1.49 | 3.17 | 12.77 | 14.45 | 23.9 | 13.2 | 6.0 | — | 1.9× / 1.7× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| jpn_Jpan | 1.70 | 3.42 | 9.73 | 11.45 | 19.6 | 9.8 | 4.8 | — | 2.0× / 1.7× | 1.0× / 0.9× | 0.5× / 0.4× | — |
| kat_Geor | 1.52 | 2.63 | 10.17 | 11.28 | 17.6 | 10.2 | 4.4 | — | 1.7× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| kor_Hang | 1.23 | 2.87 | 19.17 | 20.81 | 30.7 | 19.4 | 8.6 | — | 1.6× / 1.5× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| rus_Cyrl | 1.17 | 2.97 | 15.11 | 16.91 | 27.1 | 15.3 | 6.3 | — | 1.8× / 1.6× | 1.0× / 0.9× | 0.4× / 0.4× | — |
| tam_Taml | 0.92 | 3.00 | 8.79 | 10.87 | 18.0 | 8.8 | 4.2 | — | 2.0× / 1.7× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| tha_Thai | 1.50 | 2.57 | 5.84 | 6.92 | 12.8 | 5.8 | 2.8 | — | 2.2× / 1.9× | 1.0× / 0.8× | 0.5× / 0.4× | — |
| added_normalized_dense | 0.24 | 1.77 | 17.18 | 18.70 | 30.9 | 18.6 | 11.3 | — | 1.8× / 1.7× | 1.1× / 1.0× | 0.7× / 0.6× | — |
| added_normalized_sparse | 0.24 | 1.77 | 20.39 | 21.91 | 32.2 | 20.5 | 11.2 | — | 1.6× / 1.5× | 1.0× / 0.9× | 0.5× / 0.5× | — |
| added_special_dense | 0.24 | 1.77 | 52.25 | 53.77 | 80.5 | 68.2 | 23.3 | — | 1.5× / 1.5× | 1.3× / 1.3× | 0.4× / 0.4× | — |
| added_special_sparse | 0.24 | 1.77 | 35.44 | 36.96 | 50.1 | 41.7 | 16.1 | — | 1.4× / 1.4× | 1.2× / 1.1× | 0.5× / 0.4× | — |
| agentic-traces | 0.72 | 1.77 | 42.48 | 43.52 | 50.6 | 42.8 | 16.8 | — | 1.2× / 1.2× | 1.0× / 1.0× | 0.4× / 0.4× | — |
| agentic_swe | 0.65 | 1.75 | 52.92 | 54.01 | 55.4 | 54.4 | 17.9 | — | 1.0× / 1.0× | 1.0× / 1.0× | 0.3× / 0.3× | — |
| code_mixed | 0.08 | 1.73 | 47.53 | 49.18 | 50.2 | 48.2 | 17.2 | — | 1.1× / 1.0× | 1.0× / 1.0× | 0.4× / 0.3× | — |
| math_latex | 0.72 | 1.77 | 36.46 | 37.51 | 47.0 | 36.9 | 15.3 | — | 1.3× / 1.3× | 1.0× / 1.0× | 0.4× / 0.4× | — |

</details>

<details><summary><b>Not yet supported:</b> <code>t5-base</code></summary>

<table>
<tr>
<td align="center" valign="top">
<img alt="t5-base not supported" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30549577501-t5-base.png" width="420">
</td>
</tr>
</table>

</details>
<!-- pipeline-bench:end -->
