### PR TITLE
fast atomsplit::literal

### DIFF
--- a/tokenizers/atomsplit/Cargo.toml
+++ b/tokenizers/atomsplit/Cargo.toml
@@ -44,5 +44,9 @@ name = "classify"
 harness = false
 
 [[bench]]
+name = "literal"
+harness = false
+
+[[bench]]
 name = "class_runs"
 harness = false

--- a/tokenizers/atomsplit/benches/literal.rs
+++ b/tokenizers/atomsplit/benches/literal.rs
@@ -1,0 +1,65 @@
+//! `Literal::matches` (one search per match) against `Literal::matches_into` (one scan per
+//! text), across the delimiter densities pre-tokenizers see: a space about every six bytes of
+//! English, a `▁` per word after a SentencePiece replace, and a pattern the text does not
+//! contain at all (where `memmem`'s skip-ahead is at its best and the scan must keep up).
+//! Run: cargo bench --bench literal
+use atomsplit::literal::Literal;
+use std::hint::black_box;
+use std::time::Instant;
+
+fn best_ns_per_byte(text_len: usize, mut pass: impl FnMut() -> usize) -> f64 {
+    let iters = (16_000_000 / text_len.max(1)).clamp(4, 400) as u32;
+    for _ in 0..3 {
+        black_box(pass());
+    }
+    let mut best = f64::INFINITY;
+    for _ in 0..9 {
+        let t = Instant::now();
+        for _ in 0..iters {
+            black_box(pass());
+        }
+        best = best.min(t.elapsed().as_nanos() as f64 / (iters as usize * text_len) as f64);
+    }
+    best
+}
+
+fn main() {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let english =
+        std::fs::read_to_string(format!("{manifest}/../data/big.txt")).unwrap_or_default();
+    let english: String = english.chars().take(2_000_000).collect();
+    if english.is_empty() {
+        println!("empty corpus — data/big.txt missing? (make test downloads it)");
+        return;
+    }
+    let metaspaced = english.replace(' ', "\u{2581}");
+
+    println!(
+        "{:<22} {:>9} {:>12} {:>12} {:>9}",
+        "", "matches", "iterator", "batch", "speedup"
+    );
+    for (label, text, pattern) in [
+        ("space in English", english.as_bytes(), " "),
+        ("▁ in metaspaced", metaspaced.as_bytes(), "\u{2581}"),
+        ("▁ absent", english.as_bytes(), "\u{2581}"),
+    ] {
+        let literal = Literal::new(pattern.as_bytes()).unwrap();
+        let mut offsets: Vec<usize> = Vec::with_capacity(text.len());
+        let mut buffer = vec![0u32; text.len() + 4];
+
+        let count = literal.matches(text).count();
+        let iterator = best_ns_per_byte(text.len(), || {
+            offsets.clear();
+            offsets.extend(literal.matches(text));
+            offsets.len()
+        });
+        let batch = best_ns_per_byte(text.len(), || literal.matches_into(text, &mut buffer));
+
+        println!(
+            "{label:<22} {count:>9} {:>7.2} GB/s {:>7.2} GB/s {:>8.2}x",
+            1.0 / iterator,
+            1.0 / batch,
+            iterator / batch
+        );
+    }
+}

--- a/tokenizers/atomsplit/benches/literal.rs
+++ b/tokenizers/atomsplit/benches/literal.rs
@@ -35,8 +35,8 @@ fn main() {
     let metaspaced = english.replace(' ', "\u{2581}");
 
     println!(
-        "{:<22} {:>9} {:>12} {:>12} {:>9}",
-        "", "matches", "iterator", "batch", "speedup"
+        "{:<22} {:>9} {:>12} {:>12} {:>9} {:>12}",
+        "", "matches", "iterator", "batch", "speedup", "count-only"
     );
     for (label, text, pattern) in [
         ("space in English", english.as_bytes(), " "),
@@ -54,12 +54,14 @@ fn main() {
             offsets.len()
         });
         let batch = best_ns_per_byte(text.len(), || literal.matches_into(text, &mut buffer));
+        let counting = best_ns_per_byte(text.len(), || literal.count_matches(text));
 
         println!(
-            "{label:<22} {count:>9} {:>7.2} GB/s {:>7.2} GB/s {:>8.2}x",
+            "{label:<22} {count:>9} {:>7.2} GB/s {:>7.2} GB/s {:>8.2}x {:>7.2} GB/s",
             1.0 / iterator,
             1.0 / batch,
-            iterator / batch
+            iterator / batch,
+            1.0 / counting
         );
     }
 }

--- a/tokenizers/atomsplit/src/lib.rs
+++ b/tokenizers/atomsplit/src/lib.rs
@@ -28,6 +28,12 @@ mod simd_avx_classify;
 #[cfg(target_arch = "aarch64")]
 mod simd_classify;
 mod simd_fsm;
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "x86_64",
+    all(target_arch = "wasm32", target_feature = "simd128")
+))]
+mod simd_literal;
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 mod simd_wasm_classify;
 pub mod tables;

--- a/tokenizers/atomsplit/src/literal.rs
+++ b/tokenizers/atomsplit/src/literal.rs
@@ -79,21 +79,18 @@ impl Literal {
             u32::try_from(text.len()).is_ok(),
             "matches_into writes u32 offsets"
         );
-        // The SIMD scan emits every position where the pattern matches, with no ordering check
-        // between them. That is only the non-overlapping match list when the pattern cannot
-        // overlap itself, which one byte comparison per length decides: a two-byte pattern
-        // overlaps itself when both bytes are equal, a three-byte one when last equals first.
-        // Longer or self-overlapping patterns fall through to the iterator.
         #[cfg(any(
             target_arch = "aarch64",
             target_arch = "x86_64",
             all(target_arch = "wasm32", target_feature = "simd128")
         ))]
-        match *self.pattern() {
-            [a] => return crate::simd_literal::matches_into([a], text, out),
-            [a, b] if a != b => return crate::simd_literal::matches_into([a, b], text, out),
-            [a, b, c] if a != c => return crate::simd_literal::matches_into([a, b, c], text, out),
-            _ => {}
+        if self.scannable() {
+            match *self.pattern() {
+                [a] => return crate::simd_literal::matches_into([a], text, out),
+                [a, b] => return crate::simd_literal::matches_into([a, b], text, out),
+                [a, b, c] => return crate::simd_literal::matches_into([a, b, c], text, out),
+                _ => unreachable!("scannable patterns are one to three bytes"),
+            }
         }
         let mut count = 0;
         for position in self.finder.find_iter(text) {
@@ -101,5 +98,98 @@ impl Literal {
             count += 1;
         }
         count
+    }
+
+    /// How many matches [`Literal::matches`] would report. Counting runs the compare step
+    /// without producing any offsets, so it is several times faster than a full scan; count
+    /// first to size an output exactly, then fill it with a [`Literal::for_each_match`] pass.
+    #[must_use]
+    pub fn count_matches(&self, text: &[u8]) -> usize {
+        #[cfg(any(
+            target_arch = "aarch64",
+            target_arch = "x86_64",
+            all(target_arch = "wasm32", target_feature = "simd128")
+        ))]
+        if self.scannable() {
+            match *self.pattern() {
+                [a] => return crate::simd_literal::count_matches([a], text),
+                [a, b] => return crate::simd_literal::count_matches([a, b], text),
+                [a, b, c] => return crate::simd_literal::count_matches([a, b, c], text),
+                _ => unreachable!("scannable patterns are one to three bytes"),
+            }
+        }
+        self.finder.find_iter(text).count()
+    }
+
+    /// Calls `on_match` with the byte offset of every match, left to right: the same offsets
+    /// as [`Literal::matches`] at batch-scan speed, with no buffer for the caller to provide.
+    /// The scan streams through a small stack window, so its footprint stays flat however
+    /// long the text is.
+    pub fn for_each_match(&self, text: &[u8], mut on_match: impl FnMut(usize)) {
+        if !self.scannable() {
+            for position in self.finder.find_iter(text) {
+                on_match(position);
+            }
+            return;
+        }
+        self.scan_windows(text, |base, matches| {
+            for &position in matches {
+                on_match(base + position as usize);
+            }
+        });
+    }
+
+    /// Whether the batch scan covers this pattern. The scan emits every position where the
+    /// pattern matches, with no ordering check between them; that is only the non-overlapping
+    /// match list when the pattern cannot overlap itself, which one byte comparison per
+    /// length decides: a two-byte pattern overlaps itself when both bytes are equal, a
+    /// three-byte one when last equals first. Longer or self-overlapping patterns search
+    /// through the [`memmem`] engine instead.
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "x86_64",
+        all(target_arch = "wasm32", target_feature = "simd128")
+    ))]
+    fn scannable(&self) -> bool {
+        match *self.pattern() {
+            [_] => true,
+            [a, b] => a != b,
+            [a, _, c] => a != c,
+            _ => false,
+        }
+    }
+
+    /// Without a SIMD kernel there is no batch scan; everything searches through [`memmem`].
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "x86_64",
+        all(target_arch = "wasm32", target_feature = "simd128")
+    )))]
+    fn scannable(&self) -> bool {
+        false
+    }
+
+    /// Streams the batch scan window by window: [`Literal::matches_into`] fills a stack
+    /// buffer for one stretch of text, `on_window` consumes it (offsets are relative to the
+    /// window's `base`), and the next window starts where a match could no longer fit in the
+    /// previous one, so nothing at a window edge is missed or reported twice.
+    fn scan_windows(&self, text: &[u8], mut on_window: impl FnMut(usize, &[u32])) {
+        // 4KB of stack; a window of (1024 - 4) * pattern.len() bytes fills it exactly.
+        let mut buffer = [0u32; 1024];
+        let width = self.pattern().len();
+        let window = (buffer.len() - 4) * width;
+        let mut base = 0;
+        loop {
+            let end = usize::min(base + window, text.len());
+            let count = self.matches_into(&text[base..end], &mut buffer);
+            on_window(base, &buffer[..count]);
+            if end == text.len() {
+                return;
+            }
+            // A match crossing `end` was not reported; the next window re-covers its
+            // possible starts. Matches of a scannable pattern never overlap, so the reports
+            // stay disjoint.
+            base = end - (width - 1);
+        }
     }
 }

--- a/tokenizers/atomsplit/src/literal.rs
+++ b/tokenizers/atomsplit/src/literal.rs
@@ -11,8 +11,8 @@
 //! - [`Literal::matches_into`] scans the whole text once and writes every offset into a caller
 //!   buffer. Pre-tokenizer delimiters are the opposite of rare (running English text has a space
 //!   about every six bytes), and at that density the per-match restarts dominate the iterator.
-//!   The scan builds one match bitmask per block of text and decodes the set bits into offsets;
-//!   `simd_literal.rs` holds the kernel.
+//!   The scan answers a whole block of text at once and turns the answers into offsets;
+//!   `simd_literal.rs` explains how, step by step.
 
 use memchr::memmem;
 use std::fmt;

--- a/tokenizers/atomsplit/src/literal.rs
+++ b/tokenizers/atomsplit/src/literal.rs
@@ -4,7 +4,15 @@
 //! FSMs cut where the class changes ([`crate::fsm`]).
 //!
 //! The atom classification is unnecessary for pre-tokenizers splitting on an exact character or literal string:
-//! We can use a simpler byte search looking at 16 bytes at a time.
+//! a plain byte search finds the same cuts. Two searches cover the two match densities:
+//!
+//! - [`Literal::matches`] iterates with [`memmem`], which is built for needles that are rare in
+//!   the haystack: it skips ahead fast and restarts after every match.
+//! - [`Literal::matches_into`] scans the whole text once and writes every offset into a caller
+//!   buffer. Pre-tokenizer delimiters are the opposite of rare (running English text has a space
+//!   about every six bytes), and at that density the per-match restarts dominate the iterator.
+//!   The scan builds one match bitmask per block of text and decodes the set bits into offsets;
+//!   `simd_literal.rs` holds the kernel.
 
 use memchr::memmem;
 use std::fmt;
@@ -52,5 +60,46 @@ impl Literal {
     /// `"aaa"` — the same matches a regex engine would report.
     pub fn matches<'t>(&'t self, text: &'t [u8]) -> impl Iterator<Item = usize> + 't {
         self.finder.find_iter(text)
+    }
+
+    /// The same offsets as [`Literal::matches`], written into `out[..count]` in one scan of
+    /// `text`; returns the count. Use this when matches are frequent: the iterator restarts its
+    /// search machinery after every match, the scan never stops.
+    ///
+    /// # Preconditions
+    /// - `out.len() >= text.len() / pattern.len() + 4` (asserted). The division is the most
+    ///   matches the text can hold; the `+ 4` is slack the SIMD path writes past the last match.
+    /// - `text.len()` must fit in `u32` (asserted), so that every offset does too.
+    pub fn matches_into(&self, text: &[u8], out: &mut [u32]) -> usize {
+        assert!(
+            out.len() >= text.len() / self.pattern().len() + 4,
+            "matches_into needs out.len() >= text.len() / pattern.len() + 4"
+        );
+        assert!(
+            u32::try_from(text.len()).is_ok(),
+            "matches_into writes u32 offsets"
+        );
+        // The SIMD scan emits every position where the pattern matches, with no ordering check
+        // between them. That is only the non-overlapping match list when the pattern cannot
+        // overlap itself, which one byte comparison per length decides: a two-byte pattern
+        // overlaps itself when both bytes are equal, a three-byte one when last equals first.
+        // Longer or self-overlapping patterns fall through to the iterator.
+        #[cfg(any(
+            target_arch = "aarch64",
+            target_arch = "x86_64",
+            all(target_arch = "wasm32", target_feature = "simd128")
+        ))]
+        match *self.pattern() {
+            [a] => return crate::simd_literal::matches_into([a], text, out),
+            [a, b] if a != b => return crate::simd_literal::matches_into([a, b], text, out),
+            [a, b, c] if a != c => return crate::simd_literal::matches_into([a, b, c], text, out),
+            _ => {}
+        }
+        let mut count = 0;
+        for position in self.finder.find_iter(text) {
+            out[count] = position as u32;
+            count += 1;
+        }
+        count
     }
 }

--- a/tokenizers/atomsplit/src/simd_literal.rs
+++ b/tokenizers/atomsplit/src/simd_literal.rs
@@ -85,6 +85,10 @@
 //! on bit `4 * j`. `SHIFT` is that spacing (`bit position >> SHIFT` recovers the offset),
 //! and it is the only difference the shared code ever sees.
 //!
+//! On x86 the 16-byte baseline is SSE2, which every x86_64 CPU has; when the CPU reports
+//! wider vectors, [`matches_into`] and [`count_matches`] pick a faster front end per call
+//! (the `wide` module: AVX2 and AVX-512).
+//!
 //! The wasm layer is compile-checked but not run in CI; the other targets run the full
 //! `tests/literal.rs` parity suite.
 
@@ -287,6 +291,10 @@ pub(crate) fn count_matches<const K: usize>(pattern: [u8; K], text: &[u8]) -> us
     if len < K {
         return 0;
     }
+    #[cfg(target_arch = "x86_64")]
+    if let Some(count) = wide::count_matches_wide::<K>(pattern, text) {
+        return count;
+    }
     let p = text.as_ptr();
     let mut pattern_chunks = [arch::splat(0); K];
     for (chunk, &byte) in pattern_chunks.iter_mut().zip(&pattern) {
@@ -315,20 +323,37 @@ pub(crate) fn count_matches<const K: usize>(pattern: [u8; K], text: &[u8]) -> us
         i += 64;
     }
 
+    count + unsafe { count_tail::<K>(pattern, &pattern_chunks, text, i) }
+}
+
+/// The counting twin of [`scan_tail`]: 16-byte rounds from `i`, the overlapped final block,
+/// or the byte-by-byte walk for texts shorter than one block.
+///
+/// # Safety
+/// Reads are bounded by the loop conditions, exactly as in [`scan_tail`]. Nothing writes.
+unsafe fn count_tail<const K: usize>(
+    pattern: [u8; K],
+    pattern_chunks: &[arch::Chunk; K],
+    text: &[u8],
+    mut i: usize,
+) -> usize {
+    let len = text.len();
+    let p = text.as_ptr();
+    let mut count = 0usize;
+
     // SAFETY: reads end at `i + 16 + (K - 1) <= len`.
     while i + 16 + (K - 1) <= len {
-        let starts = unsafe { arch::match_starts::<K>(p.add(i), &pattern_chunks) };
+        let starts = unsafe { arch::match_starts::<K>(p.add(i), pattern_chunks) };
         count += arch::bits(starts).count_ones() as usize;
         i += 16;
     }
 
     if i + K <= len {
         if len >= 16 + (K - 1) {
-            // The overlapped final block, exactly as in `scan`: bits below `i` were counted
-            // by the loops above and are masked off.
+            // The overlapped final block: bits below `i` were counted above and are masked off.
             // SAFETY: the block reads `base .. base + 16 + K - 1`, which ends exactly at `len`.
             let base = len - 16 - (K - 1);
-            let starts = unsafe { arch::match_starts::<K>(p.add(base), &pattern_chunks) };
+            let starts = unsafe { arch::match_starts::<K>(p.add(base), pattern_chunks) };
             let bits = arch::bits(starts) & (!0u64 << ((i - base) << arch::SHIFT));
             count += bits.count_ones() as usize;
         } else {
@@ -339,6 +364,276 @@ pub(crate) fn count_matches<const K: usize>(pattern: [u8; K], text: &[u8]) -> us
         }
     }
     count
+}
+
+/// The wider x86 front ends. Every x86_64 CPU has the SSE2 baseline above; these two rungs
+/// are picked per call when the CPU reports the feature:
+///
+/// - **AVX2** compares 32 bytes per instruction, so one round covers 64 bytes with two
+///   compares and one combined mask.
+/// - **AVX-512** compares 64 bytes straight into a bit mask (`_mm512_cmpeq_epi8_mask`, no
+///   separate mask step) and decodes with `vpcompressd`: the CPU packs the matching offsets
+///   itself, 16 at a time, replacing the whole count-trailing-zeros loop.
+///
+/// Each rung is its own function because `#[target_feature]` applies per function; the bodies
+/// mirror [`scan`] and [`count_matches`] round for round and share [`decode`], [`scan_tail`]
+/// and [`count_tail`]. The AVX2 rung is exercised by the `tests/literal.rs` suite on any
+/// AVX2 machine or emulator; the AVX-512 rung runs the same suite only on hardware that has
+/// it, so run the tests on such a machine before trusting changes to it.
+#[cfg(target_arch = "x86_64")]
+mod wide {
+    use super::{arch, count_tail, decode, scan_tail};
+    use core::arch::x86_64::*;
+
+    /// Runs the widest scan this CPU supports; `None` means only the baseline exists.
+    #[inline]
+    pub(super) fn matches_into_wide<const K: usize>(
+        pattern: [u8; K],
+        text: &[u8],
+        out: &mut [u32],
+    ) -> Option<usize> {
+        if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512bw") {
+            // SAFETY: the features were just detected; the buffer contract is the caller's.
+            return Some(unsafe { scan_avx512::<K>(pattern, text, out) });
+        }
+        if is_x86_feature_detected!("avx2") {
+            // SAFETY: the feature was just detected; the buffer contract is the caller's.
+            return Some(unsafe { scan_avx2::<K>(pattern, text, out) });
+        }
+        None
+    }
+
+    /// The counting twin of [`matches_into_wide`].
+    #[inline]
+    pub(super) fn count_matches_wide<const K: usize>(
+        pattern: [u8; K],
+        text: &[u8],
+    ) -> Option<usize> {
+        if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512bw") {
+            // SAFETY: the features were just detected. Counting never writes.
+            return Some(unsafe { count_avx512::<K>(pattern, text) });
+        }
+        if is_x86_feature_detected!("avx2") {
+            // SAFETY: the feature was just detected. Counting never writes.
+            return Some(unsafe { count_avx2::<K>(pattern, text) });
+        }
+        None
+    }
+
+    /// All-ones per lane where a whole `K`-byte match starts, for 32 positions at `p`.
+    ///
+    /// # Safety
+    /// AVX2 must be available, and `p .. p + 32 + K - 1` must be readable.
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn match_starts32<const K: usize>(p: *const u8, pattern: &[__m256i; K]) -> __m256i {
+        // SAFETY: the caller's contract above; each load of 32 bytes from `p + k`, `k < K`,
+        // stays inside that readable range.
+        let mut starts = _mm256_cmpeq_epi8(unsafe { _mm256_loadu_si256(p.cast()) }, pattern[0]);
+        for (k, &byte) in pattern.iter().enumerate().skip(1) {
+            starts = _mm256_and_si256(
+                starts,
+                _mm256_cmpeq_epi8(unsafe { _mm256_loadu_si256(p.add(k).cast()) }, byte),
+            );
+        }
+        starts
+    }
+
+    /// One byte copied into every lane, and the baseline chunks [`scan_tail`] wants.
+    #[target_feature(enable = "avx2")]
+    fn splat32<const K: usize>(pattern: [u8; K]) -> ([__m256i; K], [arch::Chunk; K]) {
+        let mut wide = [_mm256_set1_epi8(0); K];
+        let mut baseline = [arch::splat(0); K];
+        for k in 0..K {
+            wide[k] = _mm256_set1_epi8(pattern[k] as i8);
+            baseline[k] = arch::splat(pattern[k]);
+        }
+        (wide, baseline)
+    }
+
+    /// [`scan`](super::scan) with the AVX2 front end: 64 bytes per round as two 32-byte
+    /// compares, one combined mask, decoded in the same 16-bit quarters as the baseline so
+    /// [`decode`]'s four-slot unroll stays matched to typical match density.
+    ///
+    /// # Safety
+    /// AVX2 must be available, and `out` must satisfy
+    /// [`matches_into`](super::matches_into)'s buffer bound, which it asserts.
+    #[target_feature(enable = "avx2")]
+    unsafe fn scan_avx2<const K: usize>(pattern: [u8; K], text: &[u8], out: &mut [u32]) -> usize {
+        let len = text.len();
+        if len < K {
+            return 0;
+        }
+        let p = text.as_ptr();
+        let (pattern_chunks, baseline) = splat32::<K>(pattern);
+        let start = out.as_mut_ptr();
+        // SAFETY: one past the buffer's last slot is a valid address to form (never read).
+        let end = unsafe { start.add(out.len()) } as *const u32;
+        let mut cursor = start;
+        let mut i = 0usize;
+
+        // SAFETY: reads end at `i + 32 + 32 + (K - 1) <= len`; writes are the buffer
+        // contract, handed to `decode` as `end`.
+        while i + 64 + (K - 1) <= len {
+            let (s0, s1) = unsafe {
+                (
+                    match_starts32::<K>(p.add(i), &pattern_chunks),
+                    match_starts32::<K>(p.add(i + 32), &pattern_chunks),
+                )
+            };
+            let bits = (_mm256_movemask_epi8(s0) as u32 as u64)
+                | ((_mm256_movemask_epi8(s1) as u32 as u64) << 32);
+            if bits != 0 {
+                unsafe {
+                    cursor = decode(bits & 0xFFFF, i as u32, cursor, end);
+                    cursor = decode((bits >> 16) & 0xFFFF, i as u32 + 16, cursor, end);
+                    cursor = decode((bits >> 32) & 0xFFFF, i as u32 + 32, cursor, end);
+                    cursor = decode(bits >> 48, i as u32 + 48, cursor, end);
+                }
+            }
+            i += 64;
+        }
+        // SAFETY: `scan_tail` continues under the same contract.
+        cursor = unsafe { scan_tail::<K>(pattern, &baseline, text, i, cursor, end) };
+        // SAFETY: `cursor` and `start` both point into `out`'s buffer.
+        unsafe { cursor.offset_from(start) as usize }
+    }
+
+    /// The counting twin of [`scan_avx2`].
+    ///
+    /// # Safety
+    /// AVX2 must be available.
+    #[target_feature(enable = "avx2")]
+    unsafe fn count_avx2<const K: usize>(pattern: [u8; K], text: &[u8]) -> usize {
+        let len = text.len();
+        if len < K {
+            return 0;
+        }
+        let p = text.as_ptr();
+        let (pattern_chunks, baseline) = splat32::<K>(pattern);
+        let mut count = 0usize;
+        let mut i = 0usize;
+
+        // SAFETY: reads end at `i + 64 + (K - 1) <= len`. Nothing writes.
+        while i + 64 + (K - 1) <= len {
+            let (s0, s1) = unsafe {
+                (
+                    match_starts32::<K>(p.add(i), &pattern_chunks),
+                    match_starts32::<K>(p.add(i + 32), &pattern_chunks),
+                )
+            };
+            count += (_mm256_movemask_epi8(s0).count_ones() + _mm256_movemask_epi8(s1).count_ones())
+                as usize;
+            i += 64;
+        }
+        // SAFETY: `count_tail` continues under the same read bounds.
+        count + unsafe { count_tail::<K>(pattern, &baseline, text, i) }
+    }
+
+    /// The 64-byte match mask, straight from the compares: AVX-512 byte compares produce a
+    /// bit per lane natively, so there is no separate mask step to pay for.
+    ///
+    /// # Safety
+    /// AVX-512 F and BW must be available, and `p .. p + 64 + K - 1` must be readable.
+    #[inline]
+    #[target_feature(enable = "avx512f,avx512bw")]
+    unsafe fn match_bits64<const K: usize>(p: *const u8, pattern: &[__m512i; K]) -> u64 {
+        // SAFETY: the caller's contract above; each load of 64 bytes from `p + k`, `k < K`,
+        // stays inside that readable range.
+        let mut bits = _mm512_cmpeq_epi8_mask(unsafe { _mm512_loadu_si512(p.cast()) }, pattern[0]);
+        for (k, &byte) in pattern.iter().enumerate().skip(1) {
+            bits &= _mm512_cmpeq_epi8_mask(unsafe { _mm512_loadu_si512(p.add(k).cast()) }, byte);
+        }
+        bits
+    }
+
+    /// One byte copied into every lane, and the baseline chunks the shared tails want.
+    #[target_feature(enable = "avx512f")]
+    fn splat64<const K: usize>(pattern: [u8; K]) -> ([__m512i; K], [arch::Chunk; K]) {
+        let mut wide = [_mm512_set1_epi8(0); K];
+        let mut baseline = [arch::splat(0); K];
+        for k in 0..K {
+            wide[k] = _mm512_set1_epi8(pattern[k] as i8);
+            baseline[k] = arch::splat(pattern[k]);
+        }
+        (wide, baseline)
+    }
+
+    /// [`scan`](super::scan) with the AVX-512 front end. The decode is `vpcompressd`
+    /// (`_mm512_mask_compressstoreu_epi32`): give the CPU sixteen candidate offsets and a
+    /// mask, and it stores exactly the matching ones, packed. The count-trailing-zeros loop
+    /// and its density concerns disappear; four compress-stores cover a 64-byte round.
+    ///
+    /// # Safety
+    /// AVX-512 F and BW must be available, and `out` must satisfy
+    /// [`matches_into`](super::matches_into)'s buffer bound, which it asserts.
+    #[target_feature(enable = "avx512f,avx512bw")]
+    unsafe fn scan_avx512<const K: usize>(pattern: [u8; K], text: &[u8], out: &mut [u32]) -> usize {
+        let len = text.len();
+        if len < K {
+            return 0;
+        }
+        let p = text.as_ptr();
+        let (pattern_chunks, baseline) = splat64::<K>(pattern);
+        let start = out.as_mut_ptr();
+        // SAFETY: one past the buffer's last slot is a valid address to form (never read).
+        let end = unsafe { start.add(out.len()) } as *const u32;
+        let mut cursor = start;
+        let mut i = 0usize;
+        // Lane numbers 0..16, the base of every offset vector.
+        let lanes = _mm512_set_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+
+        // SAFETY: reads end at `i + 64 + (K - 1) <= len`. Each compress-store writes exactly
+        // the matches of its quarter, within the buffer contract.
+        while i + 64 + (K - 1) <= len {
+            let bits = unsafe { match_bits64::<K>(p.add(i), &pattern_chunks) };
+            if bits != 0 {
+                let base = _mm512_add_epi32(lanes, _mm512_set1_epi32(i as i32));
+                for quarter in 0..4 {
+                    let mask = ((bits >> (16 * quarter)) & 0xFFFF) as __mmask16;
+                    let offsets = _mm512_add_epi32(base, _mm512_set1_epi32(16 * quarter));
+                    debug_assert!(
+                        end as usize - cursor as usize
+                            >= mask.count_ones() as usize * size_of::<u32>(),
+                        "compress-store would write past the match buffer"
+                    );
+                    unsafe {
+                        _mm512_mask_compressstoreu_epi32(cursor.cast(), mask, offsets);
+                        cursor = cursor.add(mask.count_ones() as usize);
+                    }
+                }
+            }
+            i += 64;
+        }
+        // SAFETY: `scan_tail` continues under the same contract.
+        cursor = unsafe { scan_tail::<K>(pattern, &baseline, text, i, cursor, end) };
+        // SAFETY: `cursor` and `start` both point into `out`'s buffer.
+        unsafe { cursor.offset_from(start) as usize }
+    }
+
+    /// The counting twin of [`scan_avx512`].
+    ///
+    /// # Safety
+    /// AVX-512 F and BW must be available.
+    #[target_feature(enable = "avx512f,avx512bw")]
+    unsafe fn count_avx512<const K: usize>(pattern: [u8; K], text: &[u8]) -> usize {
+        let len = text.len();
+        if len < K {
+            return 0;
+        }
+        let p = text.as_ptr();
+        let (pattern_chunks, baseline) = splat64::<K>(pattern);
+        let mut count = 0usize;
+        let mut i = 0usize;
+
+        // SAFETY: reads end at `i + 64 + (K - 1) <= len`. Nothing writes.
+        while i + 64 + (K - 1) <= len {
+            count += unsafe { match_bits64::<K>(p.add(i), &pattern_chunks) }.count_ones() as usize;
+            i += 64;
+        }
+        // SAFETY: `count_tail` continues under the same read bounds.
+        count + unsafe { count_tail::<K>(pattern, &baseline, text, i) }
+    }
 }
 
 /// One-pass scan: writes the start offset of every match of `pattern` in `text` into `out` and
@@ -364,6 +659,10 @@ pub(crate) fn matches_into<const K: usize>(
         out.len() >= text.len() / K + 4,
         "the match buffer must hold text.len() / pattern.len() + 4 offsets"
     );
+    #[cfg(target_arch = "x86_64")]
+    if let Some(count) = wide::matches_into_wide::<K>(pattern, text, out) {
+        return count;
+    }
     // SAFETY: the assert above is exactly `scan`'s buffer contract.
     unsafe { scan::<K>(pattern, text, out) }
 }
@@ -414,12 +713,35 @@ unsafe fn scan<const K: usize>(pattern: [u8; K], text: &[u8], out: &mut [u32]) -
         i += 64;
     }
 
+    cursor = unsafe { scan_tail::<K>(pattern, &pattern_chunks, text, i, cursor, end) };
+    // SAFETY: `cursor` and `start` both point into `out`'s buffer.
+    unsafe { cursor.offset_from(start) as usize }
+}
+
+/// The remainder every scan front end shares, once its 64-byte rounds got to `i`: 16-byte
+/// rounds, then one overlapped final block, or a byte-by-byte walk when the whole text is
+/// shorter than a block. Returns the advanced cursor.
+///
+/// # Safety
+/// Same contract as [`scan`]: reads are bounded by the loop conditions, and `cursor .. end`
+/// must have room for every remaining match plus `decode`'s four-slot slack.
+unsafe fn scan_tail<const K: usize>(
+    pattern: [u8; K],
+    pattern_chunks: &[arch::Chunk; K],
+    text: &[u8],
+    mut i: usize,
+    mut cursor: *mut u32,
+    end: *const u32,
+) -> *mut u32 {
+    let len = text.len();
+    let p = text.as_ptr();
+
     // 16 bytes per round over what the 64-byte rounds left.
-    // SAFETY: reads end at `i + 16 + (K - 1) <= len`; writes as above.
+    // SAFETY: reads end at `i + 16 + (K - 1) <= len`; writes as in [`scan`].
     while i + 16 + (K - 1) <= len {
         cursor = unsafe {
             decode(
-                arch::bits(arch::match_starts::<K>(p.add(i), &pattern_chunks)),
+                arch::bits(arch::match_starts::<K>(p.add(i), pattern_chunks)),
                 i as u32,
                 cursor,
                 end,
@@ -431,13 +753,13 @@ unsafe fn scan<const K: usize>(pattern: [u8; K], text: &[u8], out: &mut [u32]) -
     if i + K <= len {
         if len >= 16 + (K - 1) {
             // One last 16-byte block, moved back to end flush with the last position a match
-            // can still start at. Its low bits re-cover positions the loops above already
+            // can still start at. Its low bits re-cover positions the rounds above already
             // decoded, so they are masked off.
             // SAFETY: the block reads `base .. base + 16 + K - 1`, which ends exactly at `len`;
-            // writes as above.
+            // writes as in [`scan`].
             let base = len - 16 - (K - 1);
             unsafe {
-                let mut bits = arch::bits(arch::match_starts::<K>(p.add(base), &pattern_chunks));
+                let mut bits = arch::bits(arch::match_starts::<K>(p.add(base), pattern_chunks));
                 bits &= !0u64 << ((i - base) << arch::SHIFT);
                 cursor = decode(bits, base as u32, cursor, end);
             }
@@ -457,6 +779,5 @@ unsafe fn scan<const K: usize>(pattern: [u8; K], text: &[u8], out: &mut [u32]) -
             }
         }
     }
-    // SAFETY: `cursor` and `start` both point into `out`'s buffer.
-    unsafe { cursor.offset_from(start) as usize }
+    cursor
 }

--- a/tokenizers/atomsplit/src/simd_literal.rs
+++ b/tokenizers/atomsplit/src/simd_literal.rs
@@ -1,0 +1,368 @@
+//! Finds every place a short pattern (up to three bytes) occurs in a text, in one pass.
+//! This is the engine behind [`Literal::matches_into`](crate::literal::Literal::matches_into);
+//! [`crate::literal`] explains when it is picked over the plain iterator.
+//!
+//! # Why a dedicated scan
+//!
+//! A pre-tokenizer splits on a delimiter that shows up every few bytes: running English text
+//! has a space about every six bytes, SentencePiece text has a `▁` at every word. A
+//! next-match engine like `memmem` is built for the opposite case, a needle that is rare, so
+//! at this density it spends most of its time stopping and restarting: every match returns to
+//! the caller, and every call re-enters the search machinery. This scan never stops. It
+//! answers "where are ALL the matches in these 16 bytes?" with a handful of instructions,
+//! block after block.
+//!
+//! # How: compare, mask, decode
+//!
+//! **Step 1, compare.** A SIMD register compares 16 bytes at once. Compare the text against
+//! the pattern's first byte, the text shifted by one against the second byte, and so on, then
+//! AND the answers together: a position that passed every compare is the start of a whole
+//! match, and nothing needs a second look. Searching for `▁` (three bytes, `E2 96 81`) in
+//! `"a…b▁c"`, where the `…` (`E2 80 A6`) shares a first byte with `▁` and acts as the decoy:
+//!
+//! ```text
+//!   offset               0    1    2    3    4    5    6    7    8
+//!   text                 a    E2   80   A6   b    E2   96   81   c
+//!                             └── … ──────┘       └── ▁ ──────┘
+//!   text[j]   == E2 ?    ·    ✓    ·    ·    ·    ✓    ·    ·    ·
+//!   text[j+1] == 96 ?    ·    ·    ·    ·    ·    ✓    ·    ·    ·
+//!   text[j+2] == 81 ?    ·    ·    ·    ·    ·    ✓    ·    ·    ·
+//!   AND of the three     ·    ·    ·    ·    ·    ✓    ·    ·    ·
+//! ```
+//!
+//! Only offset 5 passes all three rows: a match starts at 5, and the decoy at 1 is out after
+//! the second row.
+//!
+//! **Step 2, mask.** The 16 yes/no answers are squeezed into one integer, one bit (or one
+//! nibble) per position. Each target has a one-or-two instruction way to do this; for the
+//! example above the mask is `0b100000`, bit 5.
+//!
+//! **Step 3, decode.** Count-trailing-zeros on the mask gives the lowest set bit, which is the
+//! next match offset; clear that bit and repeat. The one twist is that the code decodes four
+//! offsets *without checking whether any bits are left*. Say this block had matches at
+//! offsets 2 and 5:
+//!
+//! ```text
+//!   mask 0b100100  trailing zeros = 2   write base + 2   clear bit → 0b100000
+//!   mask 0b100000  trailing zeros = 5   write base + 5   clear bit → 0
+//!   mask 0       trailing zeros = 64  write garbage    (slot 3)
+//!   mask 0       trailing zeros = 64  write garbage    (slot 4)
+//!                                      cursor += 2      (the popcount of the mask)
+//! ```
+//!
+//! The two garbage slots sit past the cursor, so the next block's writes (or nothing) land on
+//! them and they never reach the caller. The honest alternative, checking "still something
+//! left?" before each decode, puts a branch in the hottest loop; with a match every four to
+//! eight bytes that branch guesses wrong about once per block, which costs more than all the
+//! compares together.
+//!
+//! Sparse text takes none of this: one instruction per 64-byte block answers "nothing here"
+//! (see `any`), so a pattern that is rare or absent stays close to `memmem` speed.
+//!
+//! The compare trick is Wojciech Muła's ("SIMD-friendly algorithms for substring searching"),
+//! the branch-free decode is how simdjson reads its structural-character masks, and the NEON
+//! `shrn` mask is Danila Kutenin's movemask substitute.
+//!
+//! # The per-target layer
+//!
+//! Everything from the mask on is plain `u64` arithmetic and is shared. A target only
+//! provides the four primitives in its `arch` module: `splat`, `match_starts`, `any` and
+//! `bits`. The masks differ in spacing, which `SHIFT` records: NEON's `shrn` yields a nibble
+//! per position (bit `4 * j` for offset `j`), x86's `movemask` and wasm's `bitmask` yield one
+//! bit per position. The wasm layer is compile-checked but not run in CI; the other targets
+//! run the full `tests/literal.rs` parity suite.
+
+#[cfg(target_arch = "aarch64")]
+mod arch {
+    use core::arch::aarch64::*;
+
+    /// 16 bytes of text in one register.
+    pub(super) type Chunk = uint8x16_t;
+    /// Mask bits are a nibble apart: offset `j` sits at bit `4 * j`.
+    pub(super) const SHIFT: u32 = 2;
+
+    #[inline(always)]
+    pub(super) fn splat(byte: u8) -> Chunk {
+        unsafe { vdupq_n_u8(byte) }
+    }
+
+    /// All-ones in every lane where a whole `K`-byte match starts.
+    ///
+    /// # Safety
+    /// `p .. p + 16 + K - 1` must be readable: the shifted compares load 16 bytes from each
+    /// of `p`, `p + 1`, .., `p + K - 1`.
+    #[inline(always)]
+    pub(super) unsafe fn match_starts<const K: usize>(p: *const u8, pattern: &[Chunk; K]) -> Chunk {
+        // SAFETY: the caller's contract above; each load of 16 bytes from `p + k`, `k < K`,
+        // stays inside that readable range.
+        let mut starts = unsafe { vceqq_u8(vld1q_u8(p), pattern[0]) };
+        for (k, &byte) in pattern.iter().enumerate().skip(1) {
+            starts = unsafe { vandq_u8(starts, vceqq_u8(vld1q_u8(p.add(k)), byte)) };
+        }
+        starts
+    }
+
+    /// `true` when anything matched in the four chunks.
+    #[inline(always)]
+    pub(super) fn any(s0: Chunk, s1: Chunk, s2: Chunk, s3: Chunk) -> bool {
+        unsafe { vmaxvq_u8(vorrq_u8(vorrq_u8(s0, s1), vorrq_u8(s2, s3))) != 0 }
+    }
+
+    /// The lane mask as bits, one nibble per lane (`shrn` narrows each 16-bit pair to its
+    /// middle nibble); keeping the low bit of each nibble puts offset `j` at bit `4 * j`.
+    #[inline(always)]
+    pub(super) fn bits(starts: Chunk) -> u64 {
+        unsafe {
+            let nibbles = vshrn_n_u16::<4>(vreinterpretq_u16_u8(starts));
+            vget_lane_u64::<0>(vreinterpret_u64_u8(nibbles)) & 0x1111_1111_1111_1111
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+mod arch {
+    use core::arch::x86_64::*;
+
+    /// 16 bytes of text in one register.
+    pub(super) type Chunk = __m128i;
+    /// `movemask` packs the lanes tight: offset `j` sits at bit `j`.
+    pub(super) const SHIFT: u32 = 0;
+
+    #[inline(always)]
+    pub(super) fn splat(byte: u8) -> Chunk {
+        unsafe { _mm_set1_epi8(byte as i8) }
+    }
+
+    /// All-ones in every lane where a whole `K`-byte match starts.
+    ///
+    /// # Safety
+    /// `p .. p + 16 + K - 1` must be readable: the shifted compares load 16 bytes from each
+    /// of `p`, `p + 1`, .., `p + K - 1`.
+    #[inline(always)]
+    pub(super) unsafe fn match_starts<const K: usize>(p: *const u8, pattern: &[Chunk; K]) -> Chunk {
+        // SAFETY: the caller's contract above; each load of 16 bytes from `p + k`, `k < K`,
+        // stays inside that readable range.
+        let mut starts = unsafe { _mm_cmpeq_epi8(_mm_loadu_si128(p.cast()), pattern[0]) };
+        for (k, &byte) in pattern.iter().enumerate().skip(1) {
+            starts = unsafe {
+                _mm_and_si128(
+                    starts,
+                    _mm_cmpeq_epi8(_mm_loadu_si128(p.add(k).cast()), byte),
+                )
+            };
+        }
+        starts
+    }
+
+    /// `true` when anything matched in the four chunks.
+    #[inline(always)]
+    pub(super) fn any(s0: Chunk, s1: Chunk, s2: Chunk, s3: Chunk) -> bool {
+        unsafe { _mm_movemask_epi8(_mm_or_si128(_mm_or_si128(s0, s1), _mm_or_si128(s2, s3))) != 0 }
+    }
+
+    /// The lane mask as bits: `movemask` takes each lane's top bit, so offset `j` is bit `j`.
+    #[inline(always)]
+    pub(super) fn bits(starts: Chunk) -> u64 {
+        unsafe { _mm_movemask_epi8(starts) as u32 as u64 }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+mod arch {
+    use core::arch::wasm32::*;
+
+    /// 16 bytes of text in one register.
+    pub(super) type Chunk = v128;
+    /// `bitmask` packs the lanes tight: offset `j` sits at bit `j`.
+    pub(super) const SHIFT: u32 = 0;
+
+    #[inline(always)]
+    pub(super) fn splat(byte: u8) -> Chunk {
+        u8x16_splat(byte)
+    }
+
+    /// All-ones in every lane where a whole `K`-byte match starts.
+    ///
+    /// # Safety
+    /// `p .. p + 16 + K - 1` must be readable: the shifted compares load 16 bytes from each
+    /// of `p`, `p + 1`, .., `p + K - 1`.
+    #[inline(always)]
+    pub(super) unsafe fn match_starts<const K: usize>(p: *const u8, pattern: &[Chunk; K]) -> Chunk {
+        // SAFETY: the caller's contract above; each load of 16 bytes from `p + k`, `k < K`,
+        // stays inside that readable range.
+        let mut starts = unsafe { u8x16_eq(v128_load(p.cast()), pattern[0]) };
+        for (k, &byte) in pattern.iter().enumerate().skip(1) {
+            starts = unsafe { v128_and(starts, u8x16_eq(v128_load(p.add(k).cast()), byte)) };
+        }
+        starts
+    }
+
+    /// `true` when anything matched in the four chunks.
+    #[inline(always)]
+    pub(super) fn any(s0: Chunk, s1: Chunk, s2: Chunk, s3: Chunk) -> bool {
+        v128_any_true(v128_or(v128_or(s0, s1), v128_or(s2, s3)))
+    }
+
+    /// The lane mask as bits: offset `j` is bit `j`.
+    #[inline(always)]
+    pub(super) fn bits(starts: Chunk) -> u64 {
+        u8x16_bitmask(starts) as u64
+    }
+}
+
+/// Decodes every set bit of `bits` into a `base + offset` value at `cursor`, and returns the
+/// cursor advanced by the true match count.
+///
+/// The first four decodes run without checking `bits` (the module docs say why): once the mask
+/// is used up, `trailing_zeros` is 64 and the slot gets a garbage offset, scratch that the
+/// count never covers and a later call overwrites. Blocks with more than four matches finish
+/// in the loop.
+///
+/// # Safety
+/// There must be room for `max(4, count_ones(bits))` writes between `cursor` and `end`: four
+/// slots for the unconditional decodes, one per match when a block has more. Debug builds
+/// check this bound before writing anything.
+#[inline(always)]
+unsafe fn decode(mut bits: u64, base: u32, cursor: *mut u32, end: *const u32) -> *mut u32 {
+    let count = bits.count_ones() as usize;
+    debug_assert!(
+        end as usize - cursor as usize >= count.max(4) * size_of::<u32>(),
+        "decode would write past the match buffer"
+    );
+    // SAFETY: the caller's contract above gives these four slots.
+    for slot in 0..4 {
+        unsafe { *cursor.add(slot) = base + (bits.trailing_zeros() >> arch::SHIFT) };
+        bits &= bits.wrapping_sub(1);
+    }
+    if bits != 0 {
+        let mut slot = 4;
+        // SAFETY: one slot per remaining match, still within the caller's `count` slots.
+        while bits != 0 {
+            unsafe { *cursor.add(slot) = base + (bits.trailing_zeros() >> arch::SHIFT) };
+            bits &= bits.wrapping_sub(1);
+            slot += 1;
+        }
+    }
+    // SAFETY: `count` slots were just written, so one past the last of them is in bounds.
+    unsafe { cursor.add(count) }
+}
+
+/// One-pass scan: writes the start offset of every match of `pattern` in `text` into `out` and
+/// returns how many. The pattern must not be able to overlap itself, so that every matching
+/// position belongs to the non-overlapping match list;
+/// [`Literal::matches_into`](crate::literal::Literal::matches_into) routes self-overlapping
+/// patterns away.
+///
+/// The buffer bound is asserted here, not trusted from the caller: everything unsafe in this
+/// module leans on it, so the check lives next to what it protects.
+pub(crate) fn matches_into<const K: usize>(
+    pattern: [u8; K],
+    text: &[u8],
+    out: &mut [u32],
+) -> usize {
+    const {
+        assert!(
+            K >= 1 && K <= 3,
+            "the scan is built for patterns of 1 to 3 bytes"
+        );
+    }
+    assert!(
+        out.len() >= text.len() / K + 4,
+        "the match buffer must hold text.len() / pattern.len() + 4 offsets"
+    );
+    // SAFETY: the assert above is exactly `scan`'s buffer contract.
+    unsafe { scan::<K>(pattern, text, out) }
+}
+
+/// # Safety
+/// `out.len() >= text.len() / K + 4` must hold; [`matches_into`] asserts it. Every match found
+/// counts one slot and matches cannot overlap, so at most `text.len() / K` slots are counted
+/// and the four extra keep `decode`'s unconditional writes inside the buffer. Reads from
+/// `text` are justified region by region below.
+unsafe fn scan<const K: usize>(pattern: [u8; K], text: &[u8], out: &mut [u32]) -> usize {
+    let len = text.len();
+    if len < K {
+        return 0;
+    }
+    let p = text.as_ptr();
+    let mut pattern_chunks = [arch::splat(0); K];
+    for (chunk, &byte) in pattern_chunks.iter_mut().zip(&pattern) {
+        *chunk = arch::splat(byte);
+    }
+    let start = out.as_mut_ptr();
+    // SAFETY: one past the buffer's last slot is a valid address to form (never read);
+    // only `decode`'s debug bound check uses it.
+    let end = unsafe { start.add(out.len()) } as *const u32;
+    let mut cursor = start;
+    let mut i = 0usize;
+
+    // 64 bytes per round; `any` lets a match-free round skip the masks and decodes.
+    // SAFETY: the loop condition keeps every read inside `text`: the furthest `match_starts`
+    // begins at `p + i + 48` and reads `16 + K - 1` bytes, ending at `i + 64 + (K - 1) <= len`.
+    // Writes are `scan`'s buffer contract, handed to `decode` as `end`.
+    while i + 64 + (K - 1) <= len {
+        let (s0, s1, s2, s3) = unsafe {
+            (
+                arch::match_starts::<K>(p.add(i), &pattern_chunks),
+                arch::match_starts::<K>(p.add(i + 16), &pattern_chunks),
+                arch::match_starts::<K>(p.add(i + 32), &pattern_chunks),
+                arch::match_starts::<K>(p.add(i + 48), &pattern_chunks),
+            )
+        };
+        if arch::any(s0, s1, s2, s3) {
+            unsafe {
+                cursor = decode(arch::bits(s0), i as u32, cursor, end);
+                cursor = decode(arch::bits(s1), i as u32 + 16, cursor, end);
+                cursor = decode(arch::bits(s2), i as u32 + 32, cursor, end);
+                cursor = decode(arch::bits(s3), i as u32 + 48, cursor, end);
+            }
+        }
+        i += 64;
+    }
+
+    // 16 bytes per round over what the 64-byte rounds left.
+    // SAFETY: reads end at `i + 16 + (K - 1) <= len`; writes as above.
+    while i + 16 + (K - 1) <= len {
+        cursor = unsafe {
+            decode(
+                arch::bits(arch::match_starts::<K>(p.add(i), &pattern_chunks)),
+                i as u32,
+                cursor,
+                end,
+            )
+        };
+        i += 16;
+    }
+
+    if i + K <= len {
+        if len >= 16 + (K - 1) {
+            // One last 16-byte block, moved back to end flush with the last position a match
+            // can still start at. Its low bits re-cover positions the loops above already
+            // decoded, so they are masked off.
+            // SAFETY: the block reads `base .. base + 16 + K - 1`, which ends exactly at `len`;
+            // writes as above.
+            let base = len - 16 - (K - 1);
+            unsafe {
+                let mut bits = arch::bits(arch::match_starts::<K>(p.add(base), &pattern_chunks));
+                bits &= !0u64 << ((i - base) << arch::SHIFT);
+                cursor = decode(bits, base as u32, cursor, end);
+            }
+        } else {
+            // The whole text is shorter than one block: byte-by-byte costs nothing here.
+            while i + K <= len {
+                if text[i..i + K] == pattern[..] {
+                    debug_assert!(end as usize - cursor as usize >= size_of::<u32>());
+                    // SAFETY: one slot per match; the buffer holds a slot for every possible
+                    // match plus four ([`matches_into`]'s assert).
+                    unsafe {
+                        *cursor = i as u32;
+                        cursor = cursor.add(1);
+                    }
+                }
+                i += 1;
+            }
+        }
+    }
+    // SAFETY: `cursor` and `start` both point into `out`'s buffer.
+    unsafe { cursor.offset_from(start) as usize }
+}

--- a/tokenizers/atomsplit/src/simd_literal.rs
+++ b/tokenizers/atomsplit/src/simd_literal.rs
@@ -273,6 +273,74 @@ unsafe fn decode(mut bits: u64, base: u32, cursor: *mut u32, end: *const u32) ->
     unsafe { cursor.add(count) }
 }
 
+/// How many matches of `pattern` are in `text`: the compare and mask steps only, counting set
+/// bits instead of decoding them, which makes counting several times faster than the full
+/// scan. Same pattern rules as [`matches_into`].
+pub(crate) fn count_matches<const K: usize>(pattern: [u8; K], text: &[u8]) -> usize {
+    const {
+        assert!(
+            K >= 1 && K <= 3,
+            "the scan is built for patterns of 1 to 3 bytes"
+        );
+    }
+    let len = text.len();
+    if len < K {
+        return 0;
+    }
+    let p = text.as_ptr();
+    let mut pattern_chunks = [arch::splat(0); K];
+    for (chunk, &byte) in pattern_chunks.iter_mut().zip(&pattern) {
+        *chunk = arch::splat(byte);
+    }
+    let mut count = 0usize;
+    let mut i = 0usize;
+
+    // The same block layout as `scan`, and the same SAFETY story for the reads: each loop
+    // condition bounds its loads inside `text`. Nothing here writes.
+    while i + 64 + (K - 1) <= len {
+        let (s0, s1, s2, s3) = unsafe {
+            (
+                arch::match_starts::<K>(p.add(i), &pattern_chunks),
+                arch::match_starts::<K>(p.add(i + 16), &pattern_chunks),
+                arch::match_starts::<K>(p.add(i + 32), &pattern_chunks),
+                arch::match_starts::<K>(p.add(i + 48), &pattern_chunks),
+            )
+        };
+        if arch::any(s0, s1, s2, s3) {
+            count += (arch::bits(s0).count_ones()
+                + arch::bits(s1).count_ones()
+                + arch::bits(s2).count_ones()
+                + arch::bits(s3).count_ones()) as usize;
+        }
+        i += 64;
+    }
+
+    // SAFETY: reads end at `i + 16 + (K - 1) <= len`.
+    while i + 16 + (K - 1) <= len {
+        let starts = unsafe { arch::match_starts::<K>(p.add(i), &pattern_chunks) };
+        count += arch::bits(starts).count_ones() as usize;
+        i += 16;
+    }
+
+    if i + K <= len {
+        if len >= 16 + (K - 1) {
+            // The overlapped final block, exactly as in `scan`: bits below `i` were counted
+            // by the loops above and are masked off.
+            // SAFETY: the block reads `base .. base + 16 + K - 1`, which ends exactly at `len`.
+            let base = len - 16 - (K - 1);
+            let starts = unsafe { arch::match_starts::<K>(p.add(base), &pattern_chunks) };
+            let bits = arch::bits(starts) & (!0u64 << ((i - base) << arch::SHIFT));
+            count += bits.count_ones() as usize;
+        } else {
+            while i + K <= len {
+                count += (text[i..i + K] == pattern[..]) as usize;
+                i += 1;
+            }
+        }
+    }
+    count
+}
+
 /// One-pass scan: writes the start offset of every match of `pattern` in `text` into `out` and
 /// returns how many. The pattern must not be able to overlap itself, so that every matching
 /// position belongs to the non-overlapping match list;

--- a/tokenizers/atomsplit/src/simd_literal.rs
+++ b/tokenizers/atomsplit/src/simd_literal.rs
@@ -1,5 +1,5 @@
 //! Finds every place a short pattern (up to three bytes) occurs in a text, in one pass.
-//! This is the engine behind [`Literal::matches_into`](crate::literal::Literal::matches_into);
+//! This is the scan behind [`Literal::matches_into`](crate::literal::Literal::matches_into);
 //! [`crate::literal`] explains when it is picked over the plain iterator.
 //!
 //! # Why a dedicated scan
@@ -14,10 +14,15 @@
 //!
 //! # How: compare, mask, decode
 //!
-//! **Step 1, compare.** A SIMD register compares 16 bytes at once. Compare the text against
-//! the pattern's first byte, the text shifted by one against the second byte, and so on, then
-//! AND the answers together: a position that passed every compare is the start of a whole
-//! match, and nothing needs a second look. Searching for `▁` (three bytes, `E2 96 81`) in
+//! Two words come up in everything below. A SIMD **register** is an extra-wide CPU value
+//! holding 16 bytes side by side; one instruction operates on all 16 at once. Each of those
+//! 16 byte slots is a **lane**. A SIMD compare answers lane by lane: a lane becomes all ones
+//! where the answer is yes, all zeros where it is no.
+//!
+//! **Step 1, compare.** Compare the text against the pattern's first byte (copied across all
+//! 16 lanes), the text shifted by one against the second byte, and so on, then AND the
+//! answers together: a lane that passed every compare is the start of a whole match, and
+//! nothing needs a second look. Searching for `▁` (three bytes, `E2 96 81`) in
 //! `"a…b▁c"`, where the `…` (`E2 80 A6`) shares a first byte with `▁` and acts as the decoy:
 //!
 //! ```text
@@ -33,21 +38,23 @@
 //! Only offset 5 passes all three rows: a match starts at 5, and the decoy at 1 is out after
 //! the second row.
 //!
-//! **Step 2, mask.** The 16 yes/no answers are squeezed into one integer, one bit (or one
-//! nibble) per position. Each target has a one-or-two instruction way to do this; for the
-//! example above the mask is `0b100000`, bit 5.
+//! **Step 2, mask.** The 16 lane answers are squeezed into one ordinary integer so plain
+//! arithmetic can take over: bit `j` set means "a match starts at offset `j`". For the
+//! example above the mask is `0b100000`, bit 5. Each target has a one-or-two instruction way
+//! to build this integer; on NEON the bits come out spaced four positions apart instead of
+//! one, a spacing the shared code carries along as `SHIFT` (the per-target layer below).
 //!
 //! **Step 3, decode.** Count-trailing-zeros on the mask gives the lowest set bit, which is the
 //! next match offset; clear that bit and repeat. The one twist is that the code decodes four
-//! offsets *without checking whether any bits are left*. Say this block had matches at
-//! offsets 2 and 5:
+//! offsets *without checking whether any bits are left*. Say a block starting at text offset
+//! `base` had matches at offsets 2 and 5 (shown with the one-bit spacing):
 //!
 //! ```text
 //!   mask 0b100100  trailing zeros = 2   write base + 2   clear bit → 0b100000
 //!   mask 0b100000  trailing zeros = 5   write base + 5   clear bit → 0
 //!   mask 0       trailing zeros = 64  write garbage    (slot 3)
 //!   mask 0       trailing zeros = 64  write garbage    (slot 4)
-//!                                      cursor += 2      (the popcount of the mask)
+//!                                      cursor += 2      (how many bits were set)
 //! ```
 //!
 //! The two garbage slots sit past the cursor, so the next block's writes (or nothing) land on
@@ -59,18 +66,27 @@
 //! Sparse text takes none of this: one instruction per 64-byte block answers "nothing here"
 //! (see `any`), so a pattern that is rare or absent stays close to `memmem` speed.
 //!
-//! The compare trick is Wojciech Muła's ("SIMD-friendly algorithms for substring searching"),
-//! the branch-free decode is how simdjson reads its structural-character masks, and the NEON
-//! `shrn` mask is Danila Kutenin's movemask substitute.
+//! The compare trick is Wojciech Muła's ("SIMD-friendly algorithms for substring searching");
+//! the branch-free decode is how simdjson reads its masks.
 //!
 //! # The per-target layer
 //!
-//! Everything from the mask on is plain `u64` arithmetic and is shared. A target only
-//! provides the four primitives in its `arch` module: `splat`, `match_starts`, `any` and
-//! `bits`. The masks differ in spacing, which `SHIFT` records: NEON's `shrn` yields a nibble
-//! per position (bit `4 * j` for offset `j`), x86's `movemask` and wasm's `bitmask` yield one
-//! bit per position. The wasm layer is compile-checked but not run in CI; the other targets
-//! run the full `tests/literal.rs` parity suite.
+//! Everything from the mask on is plain integer arithmetic and is shared. A target provides
+//! four primitives in its `arch` module:
+//!
+//! - `splat`: one byte copied into every lane, the shape a compare wants.
+//! - `match_starts`: step 1, the shifted compares ANDed together.
+//! - `any`: "did anything in these 64 bytes match?", the cheap exit for sparse text.
+//! - `bits`: step 2, lane answers to integer mask.
+//!
+//! x86 (`movemask`) and wasm (`bitmask`) each have an instruction that grabs one bit from
+//! every lane, so offset `j` lands on bit `j`. NEON has no such instruction; its standard
+//! substitute (Danila Kutenin's) leaves the bits four positions apart, so offset `j` lands
+//! on bit `4 * j`. `SHIFT` is that spacing (`bit position >> SHIFT` recovers the offset),
+//! and it is the only difference the shared code ever sees.
+//!
+//! The wasm layer is compile-checked but not run in CI; the other targets run the full
+//! `tests/literal.rs` parity suite.
 
 #[cfg(target_arch = "aarch64")]
 mod arch {
@@ -78,9 +94,10 @@ mod arch {
 
     /// 16 bytes of text in one register.
     pub(super) type Chunk = uint8x16_t;
-    /// Mask bits are a nibble apart: offset `j` sits at bit `4 * j`.
+    /// Offsets sit four bit positions apart in a mask from [`bits`]: offset `j` is bit `4 * j`.
     pub(super) const SHIFT: u32 = 2;
 
+    /// One byte copied into every lane.
     #[inline(always)]
     pub(super) fn splat(byte: u8) -> Chunk {
         unsafe { vdupq_n_u8(byte) }
@@ -108,13 +125,18 @@ mod arch {
         unsafe { vmaxvq_u8(vorrq_u8(vorrq_u8(s0, s1), vorrq_u8(s2, s3))) != 0 }
     }
 
-    /// The lane mask as bits, one nibble per lane (`shrn` narrows each 16-bit pair to its
-    /// middle nibble); keeping the low bit of each nibble puts offset `j` at bit `4 * j`.
+    /// The lane answers as one integer: one bit per lane, four bit positions apart.
+    ///
+    /// NEON cannot grab one bit from every lane in a single instruction. Instead `vshrn`
+    /// ("shift right and narrow") halves the register to 64 bits, shrinking each lane's
+    /// answer from eight bits to four (still all ones or all zeros); the `0x1111..` mask
+    /// then keeps one bit of each four, so clearing one bit in the decode drops exactly
+    /// one match.
     #[inline(always)]
     pub(super) fn bits(starts: Chunk) -> u64 {
         unsafe {
-            let nibbles = vshrn_n_u16::<4>(vreinterpretq_u16_u8(starts));
-            vget_lane_u64::<0>(vreinterpret_u64_u8(nibbles)) & 0x1111_1111_1111_1111
+            let halved = vshrn_n_u16::<4>(vreinterpretq_u16_u8(starts));
+            vget_lane_u64::<0>(vreinterpret_u64_u8(halved)) & 0x1111_1111_1111_1111
         }
     }
 }
@@ -125,9 +147,10 @@ mod arch {
 
     /// 16 bytes of text in one register.
     pub(super) type Chunk = __m128i;
-    /// `movemask` packs the lanes tight: offset `j` sits at bit `j`.
+    /// One bit per lane in a mask from [`bits`]: offset `j` is bit `j`, nothing to shift.
     pub(super) const SHIFT: u32 = 0;
 
+    /// One byte copied into every lane.
     #[inline(always)]
     pub(super) fn splat(byte: u8) -> Chunk {
         unsafe { _mm_set1_epi8(byte as i8) }
@@ -160,7 +183,8 @@ mod arch {
         unsafe { _mm_movemask_epi8(_mm_or_si128(_mm_or_si128(s0, s1), _mm_or_si128(s2, s3))) != 0 }
     }
 
-    /// The lane mask as bits: `movemask` takes each lane's top bit, so offset `j` is bit `j`.
+    /// The lane answers as one integer: `movemask` grabs each lane's top bit, so offset `j`
+    /// is bit `j`.
     #[inline(always)]
     pub(super) fn bits(starts: Chunk) -> u64 {
         unsafe { _mm_movemask_epi8(starts) as u32 as u64 }
@@ -173,9 +197,10 @@ mod arch {
 
     /// 16 bytes of text in one register.
     pub(super) type Chunk = v128;
-    /// `bitmask` packs the lanes tight: offset `j` sits at bit `j`.
+    /// One bit per lane in a mask from [`bits`]: offset `j` is bit `j`, nothing to shift.
     pub(super) const SHIFT: u32 = 0;
 
+    /// One byte copied into every lane.
     #[inline(always)]
     pub(super) fn splat(byte: u8) -> Chunk {
         u8x16_splat(byte)
@@ -203,7 +228,8 @@ mod arch {
         v128_any_true(v128_or(v128_or(s0, s1), v128_or(s2, s3)))
     }
 
-    /// The lane mask as bits: offset `j` is bit `j`.
+    /// The lane answers as one integer: `bitmask` grabs each lane's top bit, so offset `j`
+    /// is bit `j`.
     #[inline(always)]
     pub(super) fn bits(starts: Chunk) -> u64 {
         u8x16_bitmask(starts) as u64

--- a/tokenizers/atomsplit/tests/literal.rs
+++ b/tokenizers/atomsplit/tests/literal.rs
@@ -48,3 +48,132 @@ fn an_empty_pattern_is_rejected() {
         "an empty pattern matches everywhere"
     );
 }
+
+// ---- the batch scan, `matches_into` ----
+
+/// Run `matches_into` with a buffer of exactly the documented size and return what it wrote.
+fn batch(literal: &Literal, text: &[u8]) -> Vec<u32> {
+    let mut out = vec![0u32; text.len() / literal.pattern().len() + 4];
+    let count = literal.matches_into(text, &mut out);
+    out.truncate(count);
+    out
+}
+
+fn iterated(literal: &Literal, text: &[u8]) -> Vec<u32> {
+    literal.matches(text).map(|p| p as u32).collect()
+}
+
+#[test]
+fn matches_into_reports_the_iterator_positions() {
+    let dash = Literal::new(b"-").unwrap();
+    assert_eq!(batch(&dash, b"a-b--c"), [1, 3, 4]);
+    assert_eq!(batch(&dash, b"-starts and ends-"), [0, 16]);
+    assert_eq!(batch(&dash, b"none here"), []);
+    assert_eq!(batch(&dash, b""), []);
+
+    let space = Literal::new(b" ").unwrap();
+    let text = b"the quick brown fox jumps over the lazy dog".repeat(40);
+    assert_eq!(batch(&space, &text), iterated(&space, &text));
+
+    let metaspace = Literal::new("\u{2581}".as_bytes()).unwrap();
+    let text = "\u{2581}the\u{2581}quick\u{2581}brown\u{2581}fox".repeat(40);
+    assert_eq!(
+        batch(&metaspace, text.as_bytes()),
+        iterated(&metaspace, text.as_bytes())
+    );
+}
+
+/// The scan works in blocks; a match starting on either side of an internal block edge, or on
+/// the last position where the pattern still fits, must not be missed or doubled.
+#[test]
+fn matches_into_is_seamless_across_block_boundaries() {
+    for pattern in [&b"-"[..], "\u{2581}".as_bytes()] {
+        let literal = Literal::new(pattern).unwrap();
+        for start in [0, 13, 14, 15, 16, 17, 61, 62, 63, 64, 65, 127, 128] {
+            for len in [start + pattern.len(), 90, 129, 200] {
+                if start + pattern.len() > len {
+                    continue;
+                }
+                let mut text = vec![b'x'; len];
+                text[start..start + pattern.len()].copy_from_slice(pattern);
+                assert_eq!(
+                    batch(&literal, &text),
+                    [start as u32],
+                    "pattern {pattern:?} at {start} in {len} bytes"
+                );
+            }
+        }
+    }
+}
+
+/// Every position matches: the largest count a text can produce, written into a buffer of
+/// exactly the documented size.
+#[test]
+fn matches_into_handles_the_densest_text() {
+    let a = Literal::new(b"a").unwrap();
+    let text = vec![b'a'; 300];
+    assert_eq!(batch(&a, &text), (0..300).collect::<Vec<u32>>());
+
+    let metaspace = Literal::new("\u{2581}".as_bytes()).unwrap();
+    let text = "\u{2581}".repeat(100);
+    assert_eq!(
+        batch(&metaspace, text.as_bytes()),
+        (0..100).map(|i| i * 3).collect::<Vec<u32>>()
+    );
+}
+
+#[test]
+fn a_self_overlapping_pattern_keeps_non_overlapping_matches() {
+    let aa = Literal::new(b"aa").unwrap();
+    assert_eq!(batch(&aa, b"aaa"), [0]);
+    let run = [b'a'; 100];
+    assert_eq!(batch(&aa, &run), iterated(&aa, &run));
+
+    let aba = Literal::new(b"aba").unwrap();
+    assert_eq!(batch(&aba, b"ababa"), [0]);
+}
+
+#[test]
+fn a_pattern_longer_than_three_bytes_still_matches() {
+    let literal = Literal::new(b"abcd").unwrap();
+    let text = b"abcd xabcdx abcabcd".repeat(20);
+    assert_eq!(batch(&literal, &text), iterated(&literal, &text));
+}
+
+#[test]
+#[should_panic(expected = "matches_into")]
+fn an_undersized_buffer_is_rejected() {
+    let a = Literal::new(b"a").unwrap();
+    let mut out = vec![0u32; 7]; // "aaaa" needs 4 / 1 + 4 = 8
+    a.matches_into(b"aaaa", &mut out);
+}
+
+#[test]
+fn matches_into_agrees_with_the_iterator_on_random_inputs() {
+    // xorshift64: deterministic, no dev-dependency needed.
+    let mut state = 0x9E37_79B9_7F4A_7C15u64;
+    let mut next = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    let patterns: &[&[u8]] = &[
+        b"a", b"b", b"ab", b"aa", b"ba", b"aab", b"aba", b"abc", b"abca",
+    ];
+    for _ in 0..20_000 {
+        let len = (next() % 300) as usize;
+        let alphabet = 2 + (next() % 2) as u8;
+        let text: Vec<u8> = (0..len)
+            .map(|_| b'a' + (next() % alphabet as u64) as u8)
+            .collect();
+        let literal = Literal::new(patterns[(next() % patterns.len() as u64) as usize]).unwrap();
+        assert_eq!(
+            batch(&literal, &text),
+            iterated(&literal, &text),
+            "pattern {:?} text {:?}",
+            literal.pattern(),
+            text
+        );
+    }
+}

--- a/tokenizers/atomsplit/tests/literal.rs
+++ b/tokenizers/atomsplit/tests/literal.rs
@@ -148,6 +148,77 @@ fn an_undersized_buffer_is_rejected() {
     a.matches_into(b"aaaa", &mut out);
 }
 
+// ---- the streaming pair, `count_matches` + `for_each_match` ----
+
+fn streamed(literal: &Literal, text: &[u8]) -> Vec<u32> {
+    let mut out = Vec::new();
+    literal.for_each_match(text, |start| out.push(start as u32));
+    out
+}
+
+/// The streaming scan works through a fixed window; a text much longer than any plausible
+/// window must report the same matches as the iterator, including around every window edge.
+#[test]
+fn for_each_match_streams_the_iterator_offsets_across_windows() {
+    for pattern in [&b" "[..], "\u{2581}".as_bytes(), b"ab"] {
+        let literal = Literal::new(pattern).unwrap();
+        let mut text = b"word ".repeat(4_000); // ~20KB, matches every 5 bytes
+        text.extend_from_slice("\u{2581}ab".repeat(2_000).as_bytes());
+        assert_eq!(streamed(&literal, &text), iterated(&literal, &text));
+        assert_eq!(
+            literal.count_matches(&text),
+            literal.matches(&text).count(),
+            "count for {pattern:?}"
+        );
+    }
+}
+
+/// The densest possible long text: every byte starts a match, in every window.
+#[test]
+fn for_each_match_handles_dense_windows() {
+    let a = Literal::new(b"a").unwrap();
+    let text = vec![b'a'; 10_000];
+    assert_eq!(streamed(&a, &text), (0..10_000).collect::<Vec<u32>>());
+    assert_eq!(a.count_matches(&text), 10_000);
+}
+
+#[test]
+fn for_each_match_takes_the_iterator_route_for_uncovered_patterns() {
+    // Self-overlapping and longer-than-three patterns are exactly the ones the batch scan
+    // refuses; the streaming pair must still report the iterator's non-overlapping matches.
+    for pattern in [&b"aa"[..], b"aba", b"abcd"] {
+        let literal = Literal::new(pattern).unwrap();
+        let text = b"aabaabcdaaaba".repeat(2_000);
+        assert_eq!(streamed(&literal, &text), iterated(&literal, &text));
+        assert_eq!(literal.count_matches(&text), literal.matches(&text).count());
+    }
+}
+
+#[test]
+fn streaming_agrees_with_the_iterator_on_random_lengths() {
+    let mut state = 0x1234_5678_9ABC_DEF0u64;
+    let mut next = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    let patterns: &[&[u8]] = &[b"a", b"ab", b"aa", b"aba", b"abc", b"abca"];
+    for _ in 0..500 {
+        // lengths spread around plausible window sizes, so edges get hit both exactly and off by one
+        let len = (next() % 8_000) as usize;
+        let text: Vec<u8> = (0..len).map(|_| b'a' + (next() % 3) as u8).collect();
+        let literal = Literal::new(patterns[(next() % patterns.len() as u64) as usize]).unwrap();
+        assert_eq!(
+            streamed(&literal, &text),
+            iterated(&literal, &text),
+            "pattern {:?} len {len}",
+            literal.pattern()
+        );
+        assert_eq!(literal.count_matches(&text), literal.matches(&text).count());
+    }
+}
+
 #[test]
 fn matches_into_agrees_with_the_iterator_on_random_inputs() {
     // xorshift64: deterministic, no dev-dependency needed.

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -145,12 +145,22 @@ impl pipeline::Normalizer for Replace {
         Ok(match &self.search {
             Search::Literal(literal) => {
                 let width = literal.pattern().len();
-                let mut positions = vec![0u32; input.len() / width + 4];
-                let count = literal.matches_into(input.as_bytes(), &mut positions);
-                let matches = positions[..count]
-                    .iter()
-                    .map(|&start| (start as usize, start as usize + width));
-                replace_matches(input, &self.content, matches)
+                let count = literal.count_matches(input.as_bytes());
+                if count == 0 {
+                    return Ok(Cow::Borrowed(input));
+                }
+                // Counting first buys the exact output length (every match swaps `width`
+                // bytes for the content), so the build below never reallocates.
+                let exact = input.len() - count * width + count * self.content.len();
+                let mut replaced = String::with_capacity(exact);
+                let mut last_end = 0;
+                literal.for_each_match(input.as_bytes(), |start| {
+                    replaced.push_str(&input[last_end..start]);
+                    replaced.push_str(&self.content);
+                    last_end = start + width;
+                });
+                replaced.push_str(&input[last_end..]);
+                Cow::Owned(replaced)
             }
             Search::Regex(regex) => replace_matches(input, &self.content, regex.find_iter(input)),
             Search::Nothing => Cow::Borrowed(input),

--- a/tokenizers/tk-encode/src/normalizers/replace.rs
+++ b/tokenizers/tk-encode/src/normalizers/replace.rs
@@ -145,9 +145,11 @@ impl pipeline::Normalizer for Replace {
         Ok(match &self.search {
             Search::Literal(literal) => {
                 let width = literal.pattern().len();
-                let matches = literal
-                    .matches(input.as_bytes())
-                    .map(|start| (start, start + width));
+                let mut positions = vec![0u32; input.len() / width + 4];
+                let count = literal.matches_into(input.as_bytes(), &mut positions);
+                let matches = positions[..count]
+                    .iter()
+                    .map(|&start| (start as usize, start as usize + width));
                 replace_matches(input, &self.content, matches)
             }
             Search::Regex(regex) => replace_matches(input, &self.content, regex.find_iter(input)),

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -201,13 +201,33 @@ impl pipeline::PreTokenizer for Split {
             );
             return Ok(());
         }
-        // Not a natively-routed GPT regex: fall-back to Literal or Regex search
+        // A plain-string pattern streams: the batch scan hands each delimiter offset straight
+        // to the span fold, and nothing is built in between. The count pass sizes `out` for
+        // the worst case, one span per match plus the pieces around them.
+        if let Search::Literal(literal) = &self.search {
+            let width = literal.pattern().len();
+            let count = literal.count_matches(text.as_bytes());
+            out.reserve(2 * count + 1);
+            let mut fold = pipeline::SplitFold::new(out, self.behavior);
+            let mut prev = 0;
+            literal.for_each_match(text.as_bytes(), |start| {
+                if prev != start {
+                    fold.segment((prev, start), self.invert);
+                }
+                fold.segment((start, start + width), !self.invert);
+                prev = start + width;
+            });
+            if prev != text.len() {
+                fold.segment((prev, text.len()), self.invert);
+            }
+            fold.finish();
+            return Ok(());
+        }
+        // Not a natively-routed GPT regex either: fall back to the Regex search
         let matches = match (&self.search, self.invert) {
-            (Search::Literal(literal), false) => literal.find_matches(text)?,
-            (Search::Literal(literal), true) => Invert(literal).find_matches(text)?,
             (Search::Regex(regex), false) => regex.find_matches(text)?,
             (Search::Regex(regex), true) => Invert(regex).find_matches(text)?,
-            (Search::Unavailable, _) => {
+            _ => {
                 return Err(
                     "this `Split` pattern needs a system-regex backend; enable the `fancy-regex` feature"
                         .into(),
@@ -412,6 +432,84 @@ mod tests {
         assert_eq!(
             pipeline_split("-".into(), Isolated, false, "a-b"),
             vec![("a", (0, 1)), ("-", (1, 2)), ("b", (2, 3))],
+        );
+    }
+
+    /// The literal path across every behavior, on a text with a delimiter at both ends and a
+    /// consecutive pair — the shapes the span fold can get wrong.
+    #[test]
+    fn pipeline_literal_covers_every_behavior() {
+        let text = "-a--b-";
+        #[allow(clippy::type_complexity)]
+        let cases: Vec<(SplitDelimiterBehavior, Vec<(&str, (u32, u32))>)> = vec![
+            (Removed, vec![("a", (1, 2)), ("b", (4, 5))]),
+            (
+                Isolated,
+                vec![
+                    ("-", (0, 1)),
+                    ("a", (1, 2)),
+                    ("-", (2, 3)),
+                    ("-", (3, 4)),
+                    ("b", (4, 5)),
+                    ("-", (5, 6)),
+                ],
+            ),
+            (
+                MergedWithPrevious,
+                vec![("-", (0, 1)), ("a-", (1, 3)), ("-", (3, 4)), ("b-", (4, 6))],
+            ),
+            (
+                MergedWithNext,
+                vec![("-a", (0, 2)), ("-", (2, 3)), ("-b", (3, 5)), ("-", (5, 6))],
+            ),
+            (
+                Contiguous,
+                vec![
+                    ("-", (0, 1)),
+                    ("a", (1, 2)),
+                    ("--", (2, 4)),
+                    ("b", (4, 5)),
+                    ("-", (5, 6)),
+                ],
+            ),
+        ];
+        for (behavior, expected) in cases {
+            assert_eq!(
+                pipeline_split("-".into(), behavior, false, text),
+                expected,
+                "behavior: {behavior:?}",
+            );
+        }
+    }
+
+    /// Inverted literal search: the gaps between delimiters become the matches.
+    #[test]
+    fn pipeline_literal_inverts() {
+        // Removed drops the (inverted) matches, keeping each delimiter.
+        assert_eq!(
+            pipeline_split("-".into(), Removed, true, "-a--b-"),
+            vec![("-", (0, 1)), ("-", (2, 3)), ("-", (3, 4)), ("-", (5, 6))],
+        );
+        // Isolated keeps everything either way.
+        assert_eq!(
+            pipeline_split("-".into(), Isolated, true, "a-b"),
+            vec![("a", (0, 1)), ("-", (1, 2)), ("b", (2, 3))],
+        );
+    }
+
+    #[test]
+    fn pipeline_literal_edges() {
+        assert_eq!(
+            pipeline_split("-".into(), Removed, false, ""),
+            Vec::<(&str, (u32, u32))>::new(),
+        );
+        assert_eq!(
+            pipeline_split("-".into(), Removed, false, "---"),
+            Vec::<(&str, (u32, u32))>::new(),
+        );
+        assert_eq!(
+            pipeline_split("-".into(), Removed, false, "abc"),
+            vec![("abc", (0, 3))],
         );
     }
 

--- a/tokenizers/tk-encode/src/tokenizer/pattern.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pattern.rs
@@ -43,16 +43,23 @@ impl Pattern for &Regex {
 }
 
 /// Searching for a plain string, does not need a regex engine: [`Literal`] scans the bytes.
+/// The batch scan ([`Literal::matches_into`]) finds every match in one pass, and knowing the
+/// count first sizes `splits` exactly: each match adds itself and at most one gap before it,
+/// plus the final gap.
 impl Pattern for &Literal {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
         if inside.is_empty() {
             return Ok(vec![((0, 0), false)]);
         }
 
+        let width = self.pattern().len();
+        let mut positions = vec![0u32; inside.len() / width + 4];
+        let count = self.matches_into(inside.as_bytes(), &mut positions);
+
         let mut prev = 0;
-        let mut splits = Vec::with_capacity(inside.len());
-        for start in self.matches(inside.as_bytes()) {
-            let end = start + self.pattern().len();
+        let mut splits = Vec::with_capacity(2 * count + 1);
+        for &start in &positions[..count] {
+            let (start, end) = (start as usize, start as usize + width);
             if prev != start {
                 splits.push(((prev, start), false));
             }

--- a/tokenizers/tk-encode/src/tokenizer/pattern.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pattern.rs
@@ -43,9 +43,9 @@ impl Pattern for &Regex {
 }
 
 /// Searching for a plain string, does not need a regex engine: [`Literal`] scans the bytes.
-/// The batch scan ([`Literal::matches_into`]) finds every match in one pass, and knowing the
-/// count first sizes `splits` exactly: each match adds itself and at most one gap before it,
-/// plus the final gap.
+/// Two batch-scan passes: [`Literal::count_matches`] sizes `splits` exactly (each match adds
+/// itself and at most one gap before it, plus the final gap), then
+/// [`Literal::for_each_match`] streams the offsets in.
 impl Pattern for &Literal {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
         if inside.is_empty() {
@@ -53,19 +53,17 @@ impl Pattern for &Literal {
         }
 
         let width = self.pattern().len();
-        let mut positions = vec![0u32; inside.len() / width + 4];
-        let count = self.matches_into(inside.as_bytes(), &mut positions);
-
-        let mut prev = 0;
+        let count = self.count_matches(inside.as_bytes());
         let mut splits = Vec::with_capacity(2 * count + 1);
-        for &start in &positions[..count] {
-            let (start, end) = (start as usize, start as usize + width);
+        let mut prev = 0;
+        self.for_each_match(inside.as_bytes(), |start| {
+            let end = start + width;
             if prev != start {
                 splits.push(((prev, start), false));
             }
             splits.push(((start, end), true));
             prev = end;
-        }
+        });
         if prev != inside.len() {
             splits.push(((prev, inside.len()), false))
         }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1240,75 +1240,101 @@ pub fn split_matches(
     matches: Vec<((usize, usize), bool)>,
     behavior: SplitDelimiterBehavior,
 ) {
-    use SplitDelimiterBehavior::*;
+    let mut fold = SplitFold::new(out, behavior);
+    for (offsets, is_match) in matches {
+        fold.segment(offsets, is_match);
+    }
+    fold.finish();
+}
 
-    // (offsets, should_remove), mirroring `NormalizedString::split`.
-    let splits: Vec<((usize, usize), bool)> = match behavior {
-        Isolated => matches.into_iter().map(|(o, _)| (o, false)).collect(),
-        Removed => matches, // should_remove == is_match
-        Contiguous => {
-            let mut previous_match = false;
-            matches
-                .into_iter()
-                .fold(vec![], |mut acc, (offsets, is_match)| {
-                    if is_match == previous_match {
-                        if let Some(((_, end), _)) = acc.last_mut() {
-                            *end = offsets.1;
-                        } else {
-                            acc.push((offsets, false));
-                        }
-                    } else {
-                        acc.push((offsets, false));
-                    }
-                    previous_match = is_match;
-                    acc
-                })
-        }
-        MergedWithPrevious => {
-            let mut previous_match = false;
-            matches
-                .into_iter()
-                .fold(vec![], |mut acc, (offsets, is_match)| {
-                    if is_match && !previous_match {
-                        if let Some(((_, end), _)) = acc.last_mut() {
-                            *end = offsets.1;
-                        } else {
-                            acc.push((offsets, false));
-                        }
-                    } else {
-                        acc.push((offsets, false));
-                    }
-                    previous_match = is_match;
-                    acc
-                })
-        }
-        MergedWithNext => {
-            let mut previous_match = false;
-            let mut splits =
-                matches
-                    .into_iter()
-                    .rev()
-                    .fold(vec![], |mut acc, (offsets, is_match)| {
-                        if is_match && !previous_match {
-                            if let Some(((start, _), _)) = acc.last_mut() {
-                                *start = offsets.0;
-                            } else {
-                                acc.push((offsets, false));
-                            }
-                        } else {
-                            acc.push((offsets, false));
-                        }
-                        previous_match = is_match;
-                        acc
-                    });
-            splits.reverse();
-            splits
-        }
-    };
+/// The streaming form of [`split_matches`]: feed it the covering `(offsets, is_match)`
+/// segments left to right with [`SplitFold::segment`], then call [`SplitFold::finish`].
+/// Callers that produce segments one at a time (the literal path in `Split`) drive it
+/// directly and never build the segment vector.
+///
+/// One span under construction and the previous segment's flag are the only state. A span
+/// stays pending as long as the next segment might still extend it (a delimiter merging with
+/// its neighbour, a contiguous run); a segment that cannot extend it flushes it to `out` and
+/// takes its place.
+pub(crate) struct SplitFold<'a> {
+    out: &'a mut Vec<Span>,
+    behavior: SplitDelimiterBehavior,
+    pending: Option<(usize, usize)>,
+    previous_match: bool,
+}
 
-    for ((start, end), should_remove) in splits {
-        if !should_remove && start != end {
-            out.push(Span {
+impl<'a> SplitFold<'a> {
+    pub(crate) fn new(out: &'a mut Vec<Span>, behavior: SplitDelimiterBehavior) -> Self {
+        Self {
+            out,
+            behavior,
+            pending: None,
+            previous_match: false,
+        }
+    }
+
+    pub(crate) fn segment(&mut self, offsets: (usize, usize), is_match: bool) {
+        use SplitDelimiterBehavior::*;
+        match self.behavior {
+            Isolated => self.emit(Some(offsets)),
+            Removed => {
+                if !is_match {
+                    self.emit(Some(offsets));
+                }
+            }
+            // A run of equal flags becomes one span.
+            Contiguous => {
+                if is_match == self.previous_match {
+                    self.extend_pending_to(offsets);
+                } else {
+                    let done = self.pending.replace(offsets);
+                    self.emit(done);
+                }
+            }
+            // A delimiter glues onto the piece before it; in a run of delimiters only the
+            // first one glues, the rest stand alone.
+            MergedWithPrevious => {
+                if is_match && !self.previous_match {
+                    self.extend_pending_to(offsets);
+                } else {
+                    let done = self.pending.replace(offsets);
+                    self.emit(done);
+                }
+            }
+            // A delimiter glues onto the piece after it, so it stays pending until that
+            // piece arrives; a delimiter followed by another delimiter stands alone.
+            MergedWithNext => {
+                if !is_match && self.previous_match {
+                    self.extend_pending_to(offsets);
+                } else {
+                    let done = self.pending.replace(offsets);
+                    self.emit(done);
+                }
+            }
+        }
+        self.previous_match = is_match;
+    }
+
+    /// Flushes the last pending span.
+    pub(crate) fn finish(mut self) {
+        let last = self.pending.take();
+        self.emit(last);
+    }
+
+    /// Stretches the pending span to cover `offsets` too, or starts one from it.
+    fn extend_pending_to(&mut self, offsets: (usize, usize)) {
+        match &mut self.pending {
+            Some((_, end)) => *end = offsets.1,
+            None => self.pending = Some(offsets),
+        }
+    }
+
+    /// Empty pieces are dropped, matching the fold in `NormalizedString::split`.
+    fn emit(&mut self, span: Option<(usize, usize)>) {
+        if let Some((start, end)) = span
+            && start != end
+        {
+            self.out.push(Span {
                 start: start as u32,
                 end: end as u32,
             });


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**10 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`6db734a82 · 2026-07-31 15:27 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-overview.png" width="860">

**vs base branch** (`0bcf29188`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.92 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 11+0 (peak 11) · Pipeline 8+0 (peak 16)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.8 | 27.5 | ×3.51 | ×0.99 | 3% (1.2) | 76% (27.5) | 13% (4.7) | 7% (2.6) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 24.9 | ×5.93 | ×1.00 | 3% (1.2) | 69% (27.5) | 8% (3.3) | 20% (8.0) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 34.8 | ×5.77 | ×1.00 | 4% (1.2) | 67% (19.1) | 10% (2.9) | 19% (5.3) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 18.8 | ×4.86 | ×1.00 | 2% (1.2) | 72% (37.6) | 10% (5.4) | 16% (8.4) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 23.6 | ×6.26 | ×1.00 | 3% (1.2) | 69% (28.6) | 8% (3.4) | 20% (8.5) | 0% (0.0) | match |
| eng_Latn | lang | 4.5 | 18.3 | ×4.08 | ×1.00 | 5% (2.5) | 71% (38.5) | 8% (4.5) | 16% (8.8) | 0% (0.2) | match |
| heb_Hebr | lang | 4.2 | 19.9 | ×4.75 | ×1.00 | 2% (1.2) | 75% (37.5) | 8% (3.8) | 15% (7.5) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 27.6 | ×4.23 | ×1.01 | 3% (1.2) | 74% (26.9) | 9% (3.2) | 13% (4.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 27.3 | ×6.38 | ×1.00 | 3% (1.2) | 64% (23.2) | 13% (4.6) | 20% (7.2) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 28.3 | ×4.57 | ×1.00 | 3% (1.2) | 75% (26.6) | 9% (3.0) | 13% (4.6) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 17.7 | ×7.29 | ×1.00 | 2% (1.2) | 63% (35.1) | 13% (7.3) | 22% (12.6) | 0% (0.0) | match |
| rus_Cyrl | lang | 3.7 | 23.7 | ×6.49 | ×1.00 | 3% (1.2) | 65% (27.5) | 7% (3.1) | 24% (10.2) | 0% (0.1) | match |
| tam_Taml | lang | 7.0 | 38.3 | ×5.46 | ×1.00 | 5% (1.2) | 72% (18.6) | 9% (2.4) | 14% (3.7) | 0% (0.0) | match |
| tha_Thai | lang | 8.4 | 33.2 | ×3.98 | ×1.00 | 4% (1.2) | 84% (25.1) | 7% (2.1) | 6% (1.7) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.8 | 19.7 | ×2.91 | ×1.01 | 3% (1.3) | 81% (40.6) | 14% (6.8) | 2% (1.0) | 0% (0.2) | match |
| added_normalized_sparse | modalities | 5.3 | 18.3 | ×3.44 | ×0.99 | 4% (1.9) | 74% (39.8) | 13% (7.2) | 9% (4.7) | 0% (0.0) | match |
| added_special_dense | modalities | 5.3 | 39.1 | ×7.34 | ×1.01 | 21% (5.1) | 40% (10.0) | 32% (8.0) | 7% (1.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 21.3 | ×5.33 | ×1.00 | 8% (3.7) | 61% (28.3) | 18% (8.2) | 13% (6.1) | 0% (0.1) | match |
| agentic-traces | modalities | 3.9 | 18.1 | ×4.69 | ×1.00 | 4% (2.3) | 70% (38.3) | 9% (4.9) | 17% (9.2) | 0% (0.2) | match |
| agentic_swe | modalities | 4.1 | 19.4 | ×4.74 | ×1.00 | 4% (1.9) | 75% (38.4) | 7% (3.7) | 14% (7.0) | 0% (0.2) | match |
| code_mixed | modalities | 3.9 | 18.9 | ×4.81 | ×1.00 | 4% (2.1) | 73% (38.4) | 8% (4.3) | 14% (7.5) | 0% (0.2) | match |
| math_latex | modalities | 4.0 | 18.2 | ×4.52 | ×1.00 | 4% (2.5) | 70% (38.4) | 9% (4.9) | 17% (9.1) | 0% (0.1) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×4.07 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 67) · Pipeline 82+0 (peak 81)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 34.1 | ×7.82 | ×1.02 | 2% (0.6) | 0% (0.0) | 16% (4.7) | 82% (23.6) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 16.4 | ×3.74 | ×1.00 | 1% (0.6) | 0% (0.0) | 6% (3.5) | 93% (55.9) | 0% (0.0) | match |
| ben_Beng | lang | 6.3 | 17.6 | ×2.81 | ×1.00 | 1% (0.6) | 0% (0.0) | 6% (3.2) | 92% (51.6) | 2% (0.9) | match |
| cmn_Hani | lang | 3.6 | 16.2 | ×4.48 | ×0.97 | 1% (0.8) | 0% (0.0) | 5% (3.2) | 92% (53.9) | 2% (1.0) | match |
| ell_Grek | lang | 4.6 | 17.0 | ×3.68 | ×0.95 | 1% (0.6) | 0% (0.0) | 6% (3.5) | 93% (51.7) | 0% (0.0) | match |
| eng_Latn | lang | 3.1 | 12.7 | ×4.08 | ×0.99 | 3% (2.0) | 0% (0.0) | 7% (5.1) | 91% (69.7) | 0% (0.0) | match |
| heb_Hebr | lang | 4.0 | 12.9 | ×3.25 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (3.6) | 92% (72.5) | 2% (1.7) | match |
| hin_Deva | lang | 5.7 | 21.0 | ×3.65 | ×1.00 | 1% (0.6) | 0% (0.0) | 7% (3.4) | 90% (42.6) | 2% (0.8) | match |
| jpn_Jpan | lang | 4.3 | 17.5 | ×4.10 | ×1.01 | 1% (0.7) | 0% (0.0) | 6% (3.0) | 93% (50.4) | 0% (0.0) | match |
| kat_Geor | lang | 5.9 | 17.9 | ×3.02 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (3.0) | 93% (51.1) | 0% (0.1) | match |
| kor_Hang | lang | 3.6 | 19.4 | ×5.39 | ×1.01 | 1% (0.6) | 0% (0.0) | 8% (3.8) | 91% (45.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.5 | 14.2 | ×3.18 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (3.4) | 93% (64.2) | 2% (1.1) | match |
| tam_Taml | lang | 6.3 | 17.7 | ×2.82 | ×1.04 | 1% (0.6) | 0% (0.0) | 5% (2.8) | 92% (51.8) | 2% (1.0) | match |
| tha_Thai | lang | 6.9 | 14.2 | ×2.05 | ×0.99 | 1% (0.6) | 0% (0.0) | 3% (2.3) | 95% (65.3) | 1% (0.4) | match |
| added_normalized_dense | modalities | 6.0 | 22.3 | ×3.72 | ×1.03 | 2% (0.7) | 0% (0.0) | 6% (2.9) | 91% (40.0) | 1% (0.4) | match |
| added_normalized_sparse | modalities | 5.3 | 18.5 | ×3.48 | ×0.99 | 2% (1.3) | 0% (0.0) | 7% (3.8) | 90% (46.6) | 0% (0.0) | match |
| added_special_dense | modalities | 3.7 | 35.5 | ×9.73 | ×1.00 | 25% (6.6) | 2% (0.6) | 21% (5.7) | 54% (14.4) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.0 | 19.9 | ×5.01 | ×0.99 | 8% (3.9) | 0% (0.2) | 14% (6.7) | 75% (37.3) | 3% (1.4) | match |
| agentic-traces | modalities | 2.9 | 14.1 | ×4.85 | ×1.00 | 3% (1.8) | 0% (0.0) | 8% (5.4) | 89% (61.2) | 0% (0.0) | match |
| agentic_swe | modalities | 3.0 | 14.7 | ×4.84 | ×1.01 | 2% (1.3) | 0% (0.0) | 6% (3.9) | 92% (61.3) | 0% (0.0) | match |
| code_mixed | modalities | 3.5 | 15.2 | ×4.33 | ×1.02 | 2% (1.5) | 0% (0.0) | 7% (4.7) | 89% (58.4) | 1% (1.0) | match |
| math_latex | modalities | 2.8 | 13.7 | ×4.88 | ×1.00 | 3% (1.9) | 0% (0.0) | 8% (5.3) | 89% (62.4) | 0% (0.2) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.37 | 4.75 | 5.49 | 45.1 | 20.2 | 9.2 | — | 9.5× / 8.2× | 4.3× / 3.7× | 1.9× / 1.7× | — |
| arb_Arab | 1.00 | 2.99 | 3.46 | 5.45 | 53.2 | 22.6 | 10.2 | — | 15.4× / 9.8× | 6.5× / 4.1× | 2.9× / 1.9× | — |
| ben_Beng | 1.46 | 2.91 | 3.17 | 4.61 | 38.4 | 16.2 | 7.6 | — | 12.1× / 8.3× | 5.1× / 3.5× | 2.4× / 1.6× | — |
| cmn_Hani | 1.13 | 2.22 | 3.23 | 4.32 | 64.4 | 34.0 | 14.3 | — | 19.9× / 14.9× | 10.5× / 7.9× | 4.4× / 3.3× | — |
| ell_Grek | 0.58 | 2.96 | 3.45 | 5.83 | 51.5 | 21.1 | 9.7 | — | 14.9× / 8.8× | 6.1× / 3.6× | 2.8× / 1.7× | — |
| eng_Latn | 0.11 | 1.46 | 5.07 | 6.42 | 72.9 | 39.1 | 16.4 | — | 14.4× / 11.4× | 7.7× / 6.1× | 3.2× / 2.6× | — |
| heb_Hebr | 1.00 | 3.03 | 3.62 | 5.66 | 55.5 | 23.8 | 10.7 | — | 15.3× / 9.8× | 6.6× / 4.2× | 3.0× / 1.9× | — |
| hin_Deva | 1.36 | 3.09 | 3.36 | 5.09 | 41.3 | 18.7 | 8.5 | — | 12.3× / 8.1× | 5.6× / 3.7× | 2.5× / 1.7× | — |
| jpn_Jpan | 1.56 | 3.30 | 3.04 | 4.78 | 55.5 | 27.2 | 11.8 | — | 18.3× / 11.6× | 8.9× / 5.7× | 3.9× / 2.5× | — |
| kat_Geor | 1.38 | 2.58 | 2.98 | 4.18 | 34.7 | 15.1 | 7.2 | — | 11.7× / 8.3× | 5.1× / 3.6× | 2.4× / 1.7× | — |
| kor_Hang | 1.22 | 2.73 | 3.75 | 5.26 | 54.9 | 27.0 | 11.7 | — | 14.6× / 10.4× | 7.2× / 5.1× | 3.1× / 2.2× | — |
| rus_Cyrl | 1.02 | 2.94 | 3.40 | 5.32 | 51.0 | 20.6 | 9.5 | — | 15.0× / 9.6× | 6.1× / 3.9× | 2.8× / 1.8× | — |
| tam_Taml | 0.92 | 2.89 | 2.75 | 4.73 | 33.7 | 13.7 | 6.6 | — | 12.2× / 7.1× | 5.0× / 2.9× | 2.4× / 1.4× | — |
| tha_Thai | 1.35 | 2.55 | 2.30 | 3.50 | 28.4 | 10.1 | 5.2 | — | 12.3× / 8.1× | 4.4× / 2.9× | 2.3× / 1.5× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.86 | 4.27 | 46.4 | 20.2 | 9.2 | — | 16.3× / 10.9× | 7.1× / 4.7× | 3.2× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.83 | 5.24 | 53.7 | 25.7 | 11.4 | — | 14.0× / 10.2× | 6.7× / 4.9× | 3.0× / 2.2× | — |
| added_special_dense | 0.06 | 1.47 | 5.71 | 7.13 | 194.9 | 97.6 | 38.7 | — | 34.1× / 27.3× | 17.1× / 13.7× | 6.8× / 5.4× | — |
| added_special_sparse | 0.06 | 1.47 | 6.69 | 8.11 | 114.5 | 56.9 | 24.0 | — | 17.1× / 14.1× | 8.5× / 7.0× | 3.6× / 3.0× | — |
| agentic-traces | 0.57 | 1.48 | 5.39 | 6.30 | 89.2 | 52.7 | 20.3 | — | 16.6× / 14.2× | 9.8× / 8.4× | 3.8× / 3.2× | — |
| agentic_swe | 0.52 | 1.44 | 3.91 | 4.83 | 104.7 | 65.1 | 23.8 | — | 26.8× / 21.7× | 16.6× / 13.5× | 6.1× / 4.9× | — |
| code_mixed | 0.07 | 1.44 | 4.68 | 6.05 | 82.1 | 52.9 | 18.5 | — | 17.5× / 13.6× | 11.3× / 8.8× | 3.9× / 3.1× | — |
| math_latex | 0.58 | 1.48 | 5.31 | 6.21 | 87.6 | 47.9 | 19.4 | — | 16.5× / 14.1× | 9.0× / 7.7× | 3.7× / 3.1× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×1.88 vs v0.23.1 · ×0.97 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 371) · Pipeline 274+0 (peak 370)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 10.8 | 27.5 | ×2.56 | ×0.98 | 2% (0.7) | 3% (1.2) | 0% (0.1) | 92% (31.2) | 2% (0.8) | match |
| arb_Arab | lang | 7.2 | 13.5 | ×1.87 | ×0.99 | 1% (0.6) | 2% (1.4) | 0% (0.1) | 96% (70.7) | 1% (0.7) | match |
| ben_Beng | lang | 10.1 | 18.2 | ×1.80 | ×1.01 | 1% (0.6) | 2% (1.0) | 0% (0.1) | 97% (50.8) | 0% (0.0) | match |
| cmn_Hani | lang | 13.1 | 33.9 | ×2.59 | ×0.93 | 2% (0.6) | 1% (0.3) | 0% (0.1) | 100% (27.2) | 0% (0.0) | match |
| ell_Grek | lang | 7.8 | 15.0 | ×1.92 | ×0.99 | 1% (0.6) | 2% (1.4) | 0% (0.1) | 99% (62.7) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 5.7 | ×1.47 | ×0.99 | 1% (2.0) | 1% (2.3) | 0% (0.1) | 95% (161.6) | 3% (4.6) | match |
| heb_Hebr | lang | 8.1 | 17.0 | ×2.09 | ×0.99 | 1% (0.6) | 2% (1.4) | 0% (0.1) | 96% (53.7) | 1% (0.3) | match |
| hin_Deva | lang | 9.4 | 17.8 | ×1.89 | ×0.96 | 1% (0.6) | 2% (1.2) | 0% (0.1) | 98% (49.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 12.8 | 28.7 | ×2.24 | ×0.93 | 2% (0.6) | 1% (0.2) | 0% (0.1) | 95% (30.2) | 3% (0.8) | match |
| kat_Geor | lang | 12.0 | 24.6 | ×2.04 | ×0.97 | 2% (0.6) | 2% (0.9) | 0% (0.1) | 95% (36.3) | 0% (0.2) | match |
| kor_Hang | lang | 9.9 | 25.9 | ×2.62 | ×0.94 | 2% (0.6) | 4% (1.4) | 0% (0.1) | 94% (33.6) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.2 | 11.1 | ×1.55 | ×1.00 | 1% (0.6) | 2% (1.3) | 0% (0.1) | 100% (83.8) | 0% (0.0) | match |
| tam_Taml | lang | 11.2 | 19.4 | ×1.73 | ×0.97 | 1% (0.6) | 2% (0.8) | 0% (0.1) | 97% (46.4) | 0% (0.0) | match |
| tha_Thai | lang | 13.2 | 23.5 | ×1.78 | ×0.94 | 2% (0.6) | 1% (0.5) | 0% (0.1) | 97% (38.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.2 | 7.6 | ×1.46 | ×0.99 | 1% (0.7) | 1% (1.5) | 0% (0.1) | 97% (126.4) | 1% (1.6) | match |
| added_normalized_sparse | modalities | 4.7 | 6.8 | ×1.43 | ×1.00 | 1% (1.4) | 1% (2.1) | 0% (0.1) | 98% (141.9) | 0% (0.0) | match |
| added_special_dense | modalities | 4.7 | 18.5 | ×3.98 | ×0.87 | 18% (9.4) | 19% (10.0) | 17% (8.9) | 44% (22.7) | 2% (1.0) | match |
| added_special_sparse | modalities | 7.3 | 10.0 | ×1.36 | ×0.99 | 5% (5.3) | 7% (7.1) | 4% (4.2) | 83% (82.7) | 0% (0.0) | match |
| agentic-traces | modalities | 4.3 | 6.5 | ×1.52 | ×1.01 | 1% (1.8) | 1% (2.2) | 0% (0.1) | 102% (151.2) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 7.3 | ×1.78 | ×1.02 | 1% (1.3) | 2% (2.9) | 0% (0.2) | 97% (129.3) | 0% (0.0) | match |
| code_mixed | modalities | 4.1 | 6.7 | ×1.63 | ×0.98 | 1% (1.5) | 2% (2.7) | 0% (0.1) | 96% (138.1) | 1% (1.1) | match |
| math_latex | modalities | 4.1 | 6.2 | ×1.50 | ×1.00 | 1% (1.9) | 1% (2.2) | 0% (0.1) | 98% (155.2) | 0% (0.0) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×7.84 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 28+0 (peak 28)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 45.3 | ×11.50 | ×0.95 | 3% (0.6) | 0% (0.0) | 18% (3.7) | 79% (16.0) | 0% (0.0) | match |
| arb_Arab | lang | 3.8 | 25.6 | ×6.74 | ×1.02 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 92% (34.8) | 0% (0.1) | match |
| ben_Beng | lang | 2.9 | 42.6 | ×14.51 | ×0.93 | 3% (0.6) | 0% (0.0) | 14% (3.0) | 84% (18.7) | 0% (0.0) | match |
| cmn_Hani | lang | 3.7 | 28.7 | ×7.77 | ×1.01 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 92% (30.8) | 0% (0.0) | match |
| ell_Grek | lang | 4.0 | 28.6 | ×7.10 | ×1.00 | 2% (0.6) | 0% (0.0) | 6% (2.2) | 92% (31.2) | 0% (0.0) | match |
| eng_Latn | lang | 3.4 | 13.5 | ×4.01 | ×0.97 | 3% (2.0) | 0% (0.0) | 4% (2.9) | 93% (65.6) | 1% (0.4) | match |
| heb_Hebr | lang | 3.8 | 30.5 | ×7.93 | ×1.10 | 2% (0.6) | 0% (0.0) | 7% (2.3) | 91% (29.0) | 0% (0.0) | match |
| hin_Deva | lang | 3.0 | 39.2 | ×12.99 | ×0.97 | 2% (0.6) | 0% (0.0) | 13% (3.1) | 85% (20.9) | 0% (0.1) | match |
| jpn_Jpan | lang | 4.4 | 21.5 | ×4.86 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (2.1) | 94% (42.2) | 0% (0.0) | match |
| kat_Geor | lang | 4.8 | 70.6 | ×14.85 | ×1.04 | 4% (0.6) | 0% (0.0) | 15% (2.1) | 81% (11.1) | 0% (0.0) | match |
| kor_Hang | lang | 3.3 | 42.7 | ×12.77 | ×0.96 | 3% (0.6) | 0% (0.0) | 11% (2.4) | 87% (19.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.1 | 26.6 | ×6.45 | ×0.98 | 2% (0.6) | 0% (0.0) | 6% (2.1) | 93% (33.7) | 0% (0.0) | match |
| tam_Taml | lang | 2.8 | 69.7 | ×25.28 | ×0.93 | 4% (0.6) | 0% (0.0) | 20% (2.7) | 75% (10.3) | 1% (0.1) | match |
| tha_Thai | lang | 3.5 | 37.1 | ×10.48 | ×1.00 | 2% (0.6) | 0% (0.0) | 10% (2.5) | 88% (23.0) | 0% (0.1) | match |
| added_normalized_dense | modalities | 5.8 | 24.3 | ×4.19 | ×0.99 | 2% (0.7) | 0% (0.0) | 3% (1.1) | 96% (37.5) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.0 | 20.5 | ×4.13 | ×0.97 | 3% (1.3) | 0% (0.0) | 4% (2.0) | 93% (43.7) | 0% (0.0) | match |
| added_special_dense | modalities | 4.0 | 46.1 | ×11.65 | ×0.98 | 25% (5.1) | 2% (0.3) | 19% (3.9) | 56% (11.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.1 | 22.8 | ×5.63 | ×0.97 | 7% (3.2) | 0% (0.1) | 10% (4.5) | 81% (35.1) | 1% (0.2) | match |
| agentic-traces | modalities | 3.1 | 16.2 | ×5.23 | ×1.00 | 3% (1.8) | 0% (0.0) | 6% (3.5) | 92% (55.2) | 0% (0.0) | match |
| agentic_swe | modalities | 3.3 | 24.1 | ×7.24 | ×0.98 | 3% (1.3) | 0% (0.0) | 6% (2.4) | 90% (36.0) | 0% (0.1) | match |
| code_mixed | modalities | 3.5 | 20.5 | ×5.82 | ×1.00 | 3% (1.6) | 0% (0.0) | 6% (2.9) | 90% (43.1) | 1% (0.5) | match |
| math_latex | modalities | 3.3 | 15.1 | ×4.65 | ×1.00 | 3% (1.9) | 0% (0.0) | 5% (3.3) | 92% (59.6) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.35 | 3.65 | 4.37 | 25.8 | 21.2 | 5.8 | 4.8 | 7.1× / 5.9× | 5.8× / 4.8× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 2.94 | 2.27 | 4.21 | 30.1 | 25.8 | 6.8 | 5.1 | 13.3× / 7.2× | 11.4× / 6.1× | 3.0× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.46 | 2.90 | 3.04 | 4.47 | 61.4 | 58.2 | 13.7 | 4.1 | 20.2× / 13.7× | 19.2× / 13.0× | 4.5× / 3.1× | 1.4× / 0.9× |
| cmn_Hani | 1.13 | 2.25 | 2.33 | 3.45 | 25.1 | 21.2 | 6.0 | 2.4 | 10.8× / 7.3× | 9.1× / 6.2× | 2.6× / 1.7× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 2.99 | 2.18 | 4.58 | 26.9 | 22.1 | 5.9 | 4.8 | 12.4× / 5.9× | 10.1× / 4.8× | 2.7× / 1.3× | 2.2× / 1.0× |
| eng_Latn | 0.10 | 1.46 | 2.93 | 4.30 | 41.3 | 42.5 | 11.8 | 3.8 | 14.1× / 9.6× | 14.5× / 9.9× | 4.0× / 2.7× | 1.3× / 0.9× |
| heb_Hebr | 1.00 | 3.02 | 2.28 | 4.31 | 29.8 | 26.4 | 6.9 | 3.0 | 13.0× / 6.9× | 11.5× / 6.1× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.36 | 3.06 | 3.10 | 4.81 | 58.0 | 55.0 | 13.4 | 4.3 | 18.7× / 12.0× | 17.7× / 11.4× | 4.3× / 2.8× | 1.4× / 0.9× |
| jpn_Jpan | 1.56 | 3.30 | 2.13 | 3.87 | 22.5 | 18.3 | 5.0 | 3.8 | 10.6× / 5.8× | 8.6× / 4.7× | 2.3× / 1.3× | 1.8× / 1.0× |
| kat_Geor | 1.38 | 2.54 | 2.06 | 3.21 | 16.5 | 14.1 | 4.2 | 2.0 | 8.0× / 5.1× | 6.8× / 4.4× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.09 | 2.70 | 2.45 | 4.06 | 29.9 | 28.5 | 7.5 | 3.6 | 12.2× / 7.3× | 11.7× / 7.0× | 3.1× / 1.9× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.94 | 2.10 | 4.02 | 25.9 | 21.5 | 5.8 | 2.5 | 12.3× / 6.4× | 10.3× / 5.4× | 2.8× / 1.4× | 1.2× / 0.6× |
| tam_Taml | 0.92 | 2.87 | 2.70 | 4.65 | 65.1 | 60.1 | 14.4 | 3.8 | 24.1× / 14.0× | 22.2× / 12.9× | 5.3× / 3.1× | 1.4× / 0.8× |
| tha_Thai | 1.36 | 2.53 | 2.51 | 3.68 | 37.4 | 32.2 | 8.7 | 3.3 | 14.9× / 10.2× | 12.8× / 8.7× | 3.5× / 2.4× | 1.3× / 0.9× |
| added_normalized_dense | 0.06 | 1.48 | 1.07 | 2.49 | 22.0 | 23.6 | 6.3 | 1.8 | 20.6× / 8.9× | 22.2× / 9.5× | 5.9× / 2.5× | 1.7× / 0.7× |
| added_normalized_sparse | 0.06 | 1.48 | 1.95 | 3.37 | 30.8 | 31.4 | 8.4 | 2.6 | 15.8× / 9.1× | 16.1× / 9.3× | 4.3× / 2.5× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.48 | 3.92 | 5.34 | 92.7 | 99.0 | 19.6 | 2.9 | 23.7× / 17.4× | 25.3× / 18.6× | 5.0× / 3.7× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.50 | 5.92 | 58.7 | 61.2 | 14.4 | 3.3 | 13.0× / 9.9× | 13.6× / 10.3× | 3.2× / 2.4× | 0.7× / 0.6× |
| agentic-traces | 0.57 | 1.49 | 3.50 | 4.42 | 56.7 | 62.0 | 15.1 | 4.7 | 16.2× / 12.8× | 17.7× / 14.0× | 4.3× / 3.4× | 1.3× / 1.1× |
| agentic_swe | 0.52 | 1.49 | 2.42 | 3.38 | 58.9 | 69.1 | 14.5 | 3.5 | 24.4× / 17.4× | 28.6× / 20.4× | 6.0× / 4.3× | 1.4× / 1.0× |
| code_mixed | 0.07 | 1.44 | 2.90 | 4.27 | 57.3 | 68.1 | 15.3 | 4.1 | 19.8× / 13.4× | 23.5× / 16.0× | 5.3× / 3.6× | 1.4× / 1.0× |
| math_latex | 0.57 | 1.63 | 3.27 | 4.33 | 50.3 | 53.0 | 13.8 | 4.2 | 15.4× / 11.6× | 16.2× / 12.2× | 4.2× / 3.2× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×4.93 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 23.6 | ×6.08 | ×0.97 | 2% (0.6) | 0% (0.0) | 12% (4.9) | 82% (32.6) | 4% (1.7) | match |
| arb_Arab | lang | 4.4 | 18.4 | ×4.21 | ×1.04 | 1% (0.6) | 0% (0.0) | 7% (3.8) | 89% (47.7) | 3% (1.7) | match |
| ben_Beng | lang | 6.5 | 17.7 | ×2.71 | ×1.00 | 1% (0.6) | 0% (0.0) | 7% (3.9) | 93% (51.2) | 0% (0.0) | match |
| cmn_Hani | lang | 4.5 | 12.0 | ×2.64 | ×0.99 | 1% (0.6) | 0% (0.0) | 4% (3.3) | 95% (77.7) | 0% (0.0) | match |
| ell_Grek | lang | 5.0 | 16.0 | ×3.22 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (3.3) | 93% (56.8) | 1% (0.7) | match |
| eng_Latn | lang | 3.9 | 41.5 | ×10.71 | ×0.98 | 9% (2.0) | 0% (0.0) | 21% (4.5) | 76% (16.5) | 0% (0.0) | match |
| heb_Hebr | lang | 4.3 | 17.3 | ×4.06 | ×1.02 | 1% (0.6) | 0% (0.0) | 7% (3.7) | 92% (51.2) | 0% (0.0) | match |
| hin_Deva | lang | 6.8 | 26.9 | ×3.94 | ×0.98 | 2% (0.6) | 0% (0.0) | 12% (4.0) | 87% (30.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.4 | 12.7 | ×2.35 | ×1.02 | 1% (0.6) | 0% (0.0) | 4% (3.1) | 96% (71.3) | 0% (0.0) | match |
| kat_Geor | lang | 6.6 | 14.5 | ×2.20 | ×1.04 | 1% (0.6) | 0% (0.0) | 4% (2.9) | 94% (63.2) | 0% (0.2) | match |
| kor_Hang | lang | 3.9 | 14.5 | ×3.72 | ×0.95 | 1% (0.6) | 0% (0.0) | 6% (3.9) | 95% (61.7) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.0 | 15.6 | ×3.14 | ×1.03 | 1% (0.6) | 0% (0.0) | 5% (3.2) | 95% (57.1) | 0% (0.0) | match |
| tam_Taml | lang | 6.7 | 13.2 | ×1.96 | ×1.02 | 1% (0.6) | 0% (0.0) | 5% (3.5) | 95% (69.8) | 0% (0.0) | match |
| tha_Thai | lang | 8.0 | 11.4 | ×1.43 | ×1.06 | 1% (0.6) | 0% (0.0) | 4% (3.4) | 96% (82.1) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.5 | 23.5 | ×4.26 | ×0.98 | 2% (0.7) | 0% (0.0) | 6% (2.3) | 93% (37.8) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 39.6 | ×7.32 | ×1.01 | 5% (1.3) | 0% (0.0) | 13% (3.2) | 82% (19.7) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 75.0 | ×17.63 | ×1.03 | 38% (5.0) | 3% (0.4) | 40% (5.3) | 21% (2.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 74.2 | ×16.75 | ×0.98 | 26% (3.3) | 0% (0.0) | 48% (6.1) | 25% (3.2) | 1% (0.1) | match |
| agentic-traces | modalities | 3.6 | 37.5 | ×10.37 | ×1.00 | 8% (1.8) | 0% (0.0) | 21% (5.0) | 71% (16.6) | 0% (0.0) | match |
| agentic_swe | modalities | 3.6 | 27.2 | ×7.50 | ×1.00 | 4% (1.3) | 0% (0.0) | 11% (3.7) | 86% (29.5) | 0% (0.0) | match |
| code_mixed | modalities | 3.8 | 50.0 | ×13.11 | ×0.99 | 9% (1.5) | 0% (0.0) | 24% (4.3) | 72% (12.6) | 0% (0.0) | match |
| math_latex | modalities | 3.5 | 37.6 | ×10.90 | ×0.98 | 8% (1.9) | 0% (0.0) | 21% (4.8) | 76% (17.3) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.64 | 3.40 | 4.90 | 5.66 | 30.6 | 14.0 | 6.9 | 4.8 | 6.3× / 5.4× | 2.9× / 2.5× | 1.4× / 1.2× | 1.0× / 0.8× |
| arb_Arab | 1.00 | 3.02 | 3.76 | 5.77 | 35.1 | 16.7 | 7.6 | 5.1 | 9.3× / 6.1× | 4.4× / 2.9× | 2.0× / 1.3× | 1.4× / 0.9× |
| ben_Beng | 1.46 | 3.02 | 3.89 | 5.45 | 24.3 | 10.7 | 5.4 | 2.8 | 6.3× / 4.5× | 2.7× / 2.0× | 1.4× / 1.0× | 0.7× / 0.5× |
| cmn_Hani | 1.13 | 2.27 | 3.29 | 4.43 | 22.3 | 10.9 | 5.4 | 2.4 | 6.8× / 5.0× | 3.3× / 2.5× | 1.6× / 1.2× | 0.7× / 0.6× |
| ell_Grek | 0.59 | 2.99 | 3.28 | 5.67 | 32.2 | 15.2 | 6.9 | 5.2 | 9.8× / 5.7× | 4.6× / 2.7× | 2.1× / 1.2× | 1.6× / 0.9× |
| eng_Latn | 0.10 | 1.45 | 4.51 | 5.87 | 46.3 | 30.1 | 13.8 | 4.1 | 10.3× / 7.9× | 6.7× / 5.1× | 3.1× / 2.4× | 0.9× / 0.7× |
| heb_Hebr | 1.00 | 3.06 | 3.70 | 5.76 | 34.7 | 17.2 | 8.1 | 2.8 | 9.4× / 6.0× | 4.6× / 3.0× | 2.2× / 1.4× | 0.8× / 0.5× |
| hin_Deva | 1.36 | 3.05 | 4.03 | 5.71 | 27.2 | 12.8 | 6.3 | 3.2 | 6.8× / 4.8× | 3.2× / 2.2× | 1.6× / 1.1× | 0.8× / 0.6× |
| jpn_Jpan | 1.56 | 3.33 | 3.07 | 4.84 | 21.0 | 9.2 | 4.7 | 3.8 | 6.8× / 4.3× | 3.0× / 1.9× | 1.5× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.38 | 2.52 | 2.93 | 4.06 | 19.5 | 10.2 | 4.5 | 2.1 | 6.7× / 4.8× | 3.5× / 2.5× | 1.6× / 1.1× | 0.7× / 0.5× |
| kor_Hang | 1.09 | 2.77 | 3.87 | 5.56 | 35.3 | 18.9 | 8.9 | 3.7 | 9.1× / 6.4× | 4.9× / 3.4× | 2.3× / 1.6× | 0.9× / 0.7× |
| rus_Cyrl | 1.02 | 2.92 | 3.19 | 5.10 | 30.2 | 15.2 | 6.6 | 4.9 | 9.5× / 5.9× | 4.8× / 3.0× | 2.1× / 1.3× | 1.5× / 1.0× |
| tam_Taml | 0.92 | 2.95 | 3.45 | 5.48 | 19.8 | 8.9 | 4.2 | 2.9 | 5.7× / 3.6× | 2.6× / 1.6× | 1.2× / 0.8× | 0.8× / 0.5× |
| tha_Thai | 1.36 | 2.53 | 3.39 | 4.56 | 13.5 | 5.7 | 2.8 | 2.3 | 4.0× / 3.0× | 1.7× / 1.3× | 0.8× / 0.6× | 0.7× / 0.5× |
| added_normalized_dense | 0.06 | 1.47 | 2.30 | 3.72 | 34.8 | 17.6 | 11.2 | 2.1 | 15.1× / 9.4× | 7.6× / 4.7× | 4.9× / 3.0× | 0.9× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.20 | 4.61 | 37.1 | 20.6 | 11.6 | 2.9 | 11.6× / 8.0× | 6.4× / 4.5× | 3.6× / 2.5× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.47 | 5.29 | 6.70 | 99.7 | 68.4 | 23.9 | 3.3 | 18.9× / 14.9× | 12.9× / 10.2× | 4.5× / 3.6× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 6.06 | 7.47 | 63.2 | 41.0 | 16.7 | 3.8 | 10.4× / 8.5× | 6.8× / 5.5× | 2.8× / 2.2× | 0.6× / 0.5× |
| agentic-traces | 0.56 | 1.49 | 4.99 | 5.91 | 57.3 | 41.8 | 17.4 | 4.9 | 11.5× / 9.7× | 8.4× / 7.1× | 3.5× / 2.9× | 1.0× / 0.8× |
| agentic_swe | 0.51 | 1.47 | 3.68 | 4.64 | 58.9 | 49.0 | 17.4 | 3.6 | 16.0× / 12.7× | 13.3× / 10.6× | 4.7× / 3.8× | 1.0× / 0.8× |
| code_mixed | 0.10 | 1.45 | 4.32 | 5.67 | 58.7 | 47.6 | 17.3 | 4.2 | 13.6× / 10.4× | 11.0× / 8.4× | 4.0× / 3.1× | 1.0× / 0.7× |
| math_latex | 0.59 | 1.48 | 4.78 | 5.67 | 55.2 | 36.2 | 15.8 | 4.5 | 11.6× / 9.7× | 7.6× / 6.4× | 3.3× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×6.17 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 43.5 | ×10.45 | ×0.93 | 6% (1.2) | 0% (0.0) | 18% (3.7) | 79% (16.1) | 0% (0.0) | match |
| arb_Arab | lang | 4.7 | 17.8 | ×3.76 | ×1.00 | 2% (1.2) | 0% (0.0) | 4% (2.3) | 94% (50.7) | 0% (0.0) | match |
| ben_Beng | lang | 4.4 | 26.4 | ×6.05 | ×0.97 | 3% (1.2) | 0% (0.0) | 9% (3.2) | 90% (33.0) | 0% (0.0) | match |
| cmn_Hani | lang | 5.0 | 14.5 | ×2.91 | ×1.00 | 2% (1.2) | 0% (0.0) | 4% (2.4) | 99% (65.4) | 0% (0.0) | match |
| ell_Grek | lang | 5.3 | 19.5 | ×3.70 | ×1.00 | 2% (1.2) | 0% (0.0) | 5% (2.2) | 93% (45.2) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 43.6 | ×11.06 | ×1.01 | 13% (2.5) | 0% (0.0) | 15% (3.1) | 75% (15.1) | 0% (0.0) | match |
| heb_Hebr | lang | 4.3 | 25.1 | ×5.85 | ×1.04 | 3% (1.2) | 0% (0.0) | 6% (2.4) | 92% (35.1) | 0% (0.0) | match |
| hin_Deva | lang | 3.9 | 28.4 | ×7.21 | ×0.95 | 4% (1.2) | 0% (0.0) | 10% (3.2) | 88% (28.5) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.7 | 15.2 | ×2.66 | ×1.01 | 2% (1.2) | 0% (0.0) | 3% (2.2) | 94% (60.8) | 1% (0.4) | match |
| kat_Geor | lang | 6.5 | 21.1 | ×3.24 | ×0.98 | 3% (1.2) | 0% (0.0) | 5% (2.1) | 92% (42.3) | 1% (0.4) | match |
| kor_Hang | lang | 4.0 | 18.2 | ×4.55 | ×0.99 | 2% (1.2) | 0% (0.0) | 5% (2.5) | 93% (47.8) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.2 | 18.3 | ×3.52 | ×0.98 | 2% (1.2) | 0% (0.0) | 4% (2.2) | 94% (49.3) | 0% (0.1) | match |
| tam_Taml | lang | 3.8 | 34.6 | ×8.99 | ×1.04 | 4% (1.2) | 0% (0.0) | 10% (2.7) | 86% (23.9) | 0% (0.0) | match |
| tha_Thai | lang | 4.9 | 20.4 | ×4.13 | ×0.93 | 3% (1.2) | 0% (0.0) | 6% (2.6) | 91% (42.7) | 0% (0.2) | match |
| added_normalized_dense | modalities | 6.0 | 25.7 | ×4.31 | ×1.02 | 3% (1.3) | 0% (0.0) | 3% (1.1) | 94% (36.0) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 40.4 | ×7.41 | ×1.00 | 8% (1.8) | 0% (0.0) | 8% (1.9) | 84% (20.1) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 45.9 | ×11.21 | ×0.99 | 61% (12.8) | 1% (0.2) | 25% (5.4) | 13% (2.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 56.2 | ×12.96 | ×1.01 | 41% (7.0) | 0% (0.0) | 30% (5.1) | 29% (4.9) | 0% (0.1) | match |
| agentic-traces | modalities | 3.5 | 35.5 | ×10.23 | ×0.99 | 9% (2.4) | 0% (0.0) | 15% (3.8) | 78% (20.0) | 0% (0.0) | match |
| agentic_swe | modalities | 3.8 | 27.0 | ×7.11 | ×0.98 | 5% (1.9) | 0% (0.0) | 8% (2.9) | 89% (31.7) | 0% (0.0) | match |
| code_mixed | modalities | 3.9 | 44.3 | ×11.34 | ×1.00 | 11% (2.2) | 0% (0.0) | 17% (3.3) | 72% (14.2) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 39.0 | ×10.33 | ×1.02 | 11% (2.5) | 0% (0.0) | 16% (3.5) | 76% (16.9) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.36 | 3.67 | 4.41 | 26.8 | 15.8 | 5.9 | 4.8 | 7.3× / 6.1× | 4.3× / 3.6× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.01 | 2.98 | 2.34 | 4.31 | 30.6 | 19.0 | 6.9 | 5.0 | 13.1× / 7.1× | 8.1× / 4.4× | 2.9× / 1.6× | 2.1× / 1.2× |
| ben_Beng | 1.45 | 2.86 | 3.19 | 4.59 | 44.6 | 27.8 | 10.4 | 3.8 | 14.0× / 9.7× | 8.7× / 6.1× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.13 | 2.22 | 2.40 | 3.49 | 19.5 | 11.4 | 4.7 | 2.4 | 8.1× / 5.6× | 4.8× / 3.3× | 2.0× / 1.3× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 3.00 | 2.22 | 4.63 | 29.3 | 17.2 | 6.1 | 4.7 | 13.2× / 6.3× | 7.7× / 3.7× | 2.8× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.12 | 1.46 | 3.06 | 4.40 | 45.9 | 32.8 | 12.8 | 3.8 | 15.0× / 10.4× | 10.7× / 7.5× | 4.2× / 2.9× | 1.2× / 0.9× |
| heb_Hebr | 1.01 | 3.04 | 2.35 | 4.38 | 32.0 | 19.7 | 6.9 | 3.1 | 13.6× / 7.3× | 8.4× / 4.5× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.36 | 3.03 | 3.22 | 4.89 | 47.8 | 30.3 | 11.1 | 4.1 | 14.8× / 9.8× | 9.4× / 6.2× | 3.4× / 2.3× | 1.3× / 0.8× |
| jpn_Jpan | 1.57 | 3.29 | 2.20 | 3.92 | 18.7 | 9.7 | 4.1 | 3.9 | 8.5× / 4.8× | 4.4× / 2.5× | 1.9× / 1.1× | 1.8× / 1.0× |
| kat_Geor | 1.38 | 2.54 | 2.10 | 3.26 | 17.7 | 11.2 | 4.2 | 2.0 | 8.4× / 5.4× | 5.3× / 3.4× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.08 | 2.77 | 2.53 | 4.22 | 32.1 | 21.0 | 7.6 | 3.7 | 12.7× / 7.6× | 8.3× / 5.0× | 3.0× / 1.8× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.93 | 2.18 | 4.09 | 26.9 | 17.0 | 6.0 | 2.5 | 12.4× / 6.6× | 7.8× / 4.2× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.92 | 2.88 | 2.73 | 4.70 | 47.1 | 26.5 | 9.9 | 3.4 | 17.2× / 10.0× | 9.7× / 5.7× | 3.6× / 2.1× | 1.2× / 0.7× |
| tha_Thai | 1.36 | 2.51 | 2.60 | 3.75 | 28.8 | 16.4 | 6.7 | 3.0 | 11.1× / 7.7× | 6.3× / 4.4× | 2.6× / 1.8× | 1.1× / 0.8× |
| added_normalized_dense | 0.06 | 1.48 | 1.08 | 2.50 | 24.2 | 16.7 | 6.6 | 2.0 | 22.3× / 9.6× | 15.4× / 6.7× | 6.1× / 2.6× | 1.8× / 0.8× |
| added_normalized_sparse | 0.06 | 1.71 | 1.93 | 3.59 | 32.0 | 22.4 | 8.9 | 2.7 | 16.6× / 8.9× | 11.6× / 6.3× | 4.6× / 2.5× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.48 | 5.38 | 6.80 | 99.4 | 73.1 | 21.2 | 3.3 | 18.5× / 14.6× | 13.6× / 10.8× | 3.9× / 3.1× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 5.14 | 6.85 | 64.7 | 44.8 | 15.3 | 3.7 | 12.6× / 9.5× | 8.7× / 6.5× | 3.0× / 2.2× | 0.7× / 0.5× |
| agentic-traces | 0.57 | 1.48 | 3.79 | 4.70 | 56.5 | 46.1 | 15.7 | 4.8 | 14.9× / 12.0× | 12.2× / 9.8× | 4.1× / 3.3× | 1.3× / 1.0× |
| agentic_swe | 0.57 | 1.48 | 2.88 | 3.80 | 60.6 | 52.9 | 15.9 | 3.4 | 21.0× / 16.0× | 18.3× / 13.9× | 5.5× / 4.2× | 1.2× / 0.9× |
| code_mixed | 0.08 | 1.44 | 3.29 | 4.65 | 54.6 | 50.6 | 15.6 | 4.0 | 16.6× / 11.7× | 15.4× / 10.9× | 4.7× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.57 | 1.48 | 3.47 | 4.39 | 52.0 | 40.1 | 14.3 | 4.2 | 15.0× / 11.8× | 11.5× / 9.1× | 4.1× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×3.66 vs v0.23.1 · ×1.02 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 18+0 (peak 23) · Pipeline 23+0 (peak 23)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.7 | 41.9 | ×8.84 | ×1.05 | 0% (0.0) | 8% (1.8) | 0% (0.0) | 92% (20.2) | 0% (0.0) | match |
| arb_Arab | lang | 10.4 | 50.4 | ×4.87 | ×1.02 | 0% (0.0) | 11% (2.0) | 0% (0.0) | 89% (16.4) | 0% (0.0) | match |
| ben_Beng | lang | 11.0 | 81.1 | ×7.35 | ×1.00 | 0% (0.0) | 13% (1.5) | 0% (0.0) | 87% (9.6) | 0% (0.0) | match |
| cmn_Hani | lang | 9.2 | 61.3 | ×6.63 | ×1.02 | 0% (0.1) | 3% (0.4) | 0% (0.0) | 97% (13.7) | 0% (0.0) | match |
| ell_Grek | lang | 10.2 | 58.4 | ×5.70 | ×1.01 | 0% (0.0) | 13% (2.0) | 0% (0.0) | 87% (13.5) | 0% (0.1) | match |
| eng_Latn | lang | 4.3 | 6.5 | ×1.53 | ×1.04 | 0% (0.1) | 3% (4.5) | 0% (0.0) | 97% (143.1) | 0% (0.0) | match |
| heb_Hebr | lang | 10.2 | 63.0 | ×6.17 | ×1.04 | 0% (0.0) | 14% (2.0) | 0% (0.0) | 86% (12.8) | 0% (0.0) | match |
| hin_Deva | lang | 12.1 | 80.4 | ×6.63 | ×1.03 | 0% (0.0) | 16% (1.8) | 0% (0.0) | 84% (9.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.1 | 80.3 | ×6.11 | ×1.01 | 0% (0.0) | 4% (0.4) | 0% (0.0) | 97% (10.6) | 0% (0.0) | match |
| kat_Geor | lang | 14.2 | 89.0 | ×6.27 | ×1.02 | 0% (0.0) | 14% (1.4) | 0% (0.0) | 85% (8.8) | 0% (0.0) | match |
| kor_Hang | lang | 7.2 | 52.9 | ×7.34 | ×1.04 | 0% (0.1) | 12% (2.0) | 0% (0.0) | 89% (15.4) | 0% (0.0) | match |
| rus_Cyrl | lang | 8.0 | 16.1 | ×2.02 | ×1.02 | 0% (0.0) | 3% (1.8) | 0% (0.0) | 97% (57.6) | 0% (0.0) | match |
| tam_Taml | lang | 12.7 | 87.5 | ×6.92 | ×1.00 | 0% (0.0) | 12% (1.3) | 0% (0.0) | 88% (9.0) | 0% (0.0) | match |
| tha_Thai | lang | 15.4 | 82.4 | ×5.34 | ×1.01 | 0% (0.0) | 8% (0.9) | 0% (0.0) | 91% (9.9) | 1% (0.1) | match |
| added_normalized_dense | modalities | 5.5 | 8.8 | ×1.61 | ×1.01 | 0% (0.1) | 2% (2.3) | 0% (0.0) | 99% (110.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.8 | 7.5 | ×1.54 | ×1.02 | 0% (0.0) | 3% (4.0) | 0% (0.0) | 97% (122.6) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 19.5 | ×4.80 | ×0.95 | 10% (5.0) | 35% (17.1) | 2% (1.2) | 52% (25.7) | 1% (0.3) | match |
| added_special_sparse | modalities | 5.8 | 10.2 | ×1.76 | ×0.99 | 2% (2.2) | 17% (16.3) | 0% (0.2) | 80% (78.9) | 1% (0.8) | match |
| agentic-traces | modalities | 4.6 | 7.3 | ×1.59 | ×1.03 | 0% (0.1) | 3% (4.0) | 0% (0.0) | 97% (130.9) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 7.3 | ×1.81 | ×1.03 | 0% (0.0) | 4% (5.3) | 0% (0.0) | 97% (129.4) | 0% (0.0) | match |
| code_mixed | modalities | 4.3 | 7.2 | ×1.66 | ×1.02 | 0% (0.0) | 3% (4.7) | 0% (0.0) | 97% (131.3) | 0% (0.0) | match |
| math_latex | modalities | 4.5 | 6.9 | ×1.53 | ×1.03 | 0% (0.1) | 3% (4.2) | 0% (0.0) | 97% (136.6) | 0% (0.6) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×6.75 vs v0.23.1 · ×1.00 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 92+0 (peak 94)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 44.8 | ×10.55 | ×0.94 | 3% (0.7) | 0% (0.0) | 18% (3.7) | 79% (16.2) | 0% (0.0) | match |
| arb_Arab | lang | 4.6 | 17.4 | ×3.79 | ×0.97 | 1% (0.6) | 0% (0.0) | 4% (2.3) | 97% (52.3) | 0% (0.0) | match |
| ben_Beng | lang | 4.1 | 31.1 | ×7.67 | ×0.98 | 2% (0.6) | 0% (0.0) | 10% (3.2) | 88% (27.2) | 0% (0.0) | match |
| cmn_Hani | lang | 5.2 | 16.6 | ×3.21 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (2.4) | 92% (54.4) | 3% (1.6) | match |
| ell_Grek | lang | 5.4 | 18.9 | ×3.50 | ×0.98 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (47.9) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 45.4 | ×10.32 | ×1.00 | 11% (2.0) | 0% (0.0) | 17% (3.1) | 74% (13.3) | 0% (0.0) | match |
| heb_Hebr | lang | 4.4 | 25.6 | ×5.77 | ×1.00 | 2% (0.6) | 0% (0.0) | 6% (2.3) | 92% (34.5) | 0% (0.1) | match |
| hin_Deva | lang | 4.5 | 76.1 | ×16.98 | ×1.01 | 5% (0.6) | 0% (0.0) | 28% (3.3) | 67% (7.9) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.0 | 16.2 | ×2.68 | ×0.99 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 95% (56.0) | 0% (0.0) | match |
| kat_Geor | lang | 5.9 | 36.2 | ×6.17 | ×1.00 | 2% (0.6) | 0% (0.0) | 8% (2.1) | 91% (23.6) | 0% (0.0) | match |
| kor_Hang | lang | 4.2 | 18.5 | ×4.43 | ×0.99 | 1% (0.6) | 0% (0.0) | 5% (2.5) | 95% (51.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.1 | 16.4 | ×3.20 | ×1.00 | 1% (0.6) | 0% (0.0) | 4% (2.2) | 97% (56.7) | 0% (0.0) | match |
| tam_Taml | lang | 4.1 | 35.7 | ×8.69 | ×1.02 | 2% (0.6) | 0% (0.0) | 10% (2.7) | 87% (23.9) | 1% (0.3) | match |
| tha_Thai | lang | 5.3 | 19.8 | ×3.76 | ×1.00 | 1% (0.6) | 0% (0.0) | 5% (2.6) | 92% (45.0) | 1% (0.6) | match |
| added_normalized_dense | modalities | 6.3 | 25.3 | ×4.02 | ×1.00 | 2% (0.7) | 0% (0.0) | 3% (1.1) | 96% (35.7) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.6 | 41.5 | ×7.37 | ×1.02 | 6% (1.3) | 0% (0.0) | 8% (2.0) | 87% (20.2) | 0% (0.0) | match |
| added_special_dense | modalities | 4.1 | 72.6 | ×17.70 | ×0.99 | 37% (4.9) | 3% (0.4) | 38% (5.1) | 21% (2.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.5 | 70.2 | ×15.69 | ×1.00 | 24% (3.1) | 1% (0.2) | 37% (4.9) | 38% (5.1) | 0% (0.1) | match |
| agentic-traces | modalities | 3.7 | 37.6 | ×10.29 | ×1.02 | 7% (1.8) | 0% (0.0) | 15% (3.7) | 74% (18.4) | 3% (0.8) | match |
| agentic_swe | modalities | 4.1 | 27.6 | ×6.80 | ×0.99 | 4% (1.3) | 0% (0.0) | 8% (2.9) | 88% (30.5) | 0% (0.0) | match |
| code_mixed | modalities | 4.3 | 47.0 | ×10.98 | ×1.01 | 8% (1.6) | 0% (0.0) | 17% (3.3) | 75% (14.4) | 0% (0.0) | match |
| math_latex | modalities | 3.8 | 40.6 | ×10.59 | ×1.00 | 9% (1.9) | 0% (0.0) | 16% (3.5) | 78% (17.2) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.63 | 3.38 | 3.66 | 4.41 | 28.0 | 16.1 | 5.9 | 4.8 | 7.6× / 6.3× | 4.4× / 3.6× | 1.6× / 1.3× | 1.3× / 1.1× |
| arb_Arab | 1.00 | 2.93 | 2.32 | 4.25 | 31.7 | 19.2 | 6.9 | 5.0 | 13.7× / 7.5× | 8.3× / 4.5× | 3.0× / 1.6× | 2.2× / 1.2× |
| ben_Beng | 1.46 | 2.90 | 3.17 | 4.61 | 46.2 | 27.9 | 10.5 | 3.7 | 14.6× / 10.0× | 8.8× / 6.0× | 3.3× / 2.3× | 1.2× / 0.8× |
| cmn_Hani | 1.23 | 2.27 | 2.40 | 3.43 | 19.9 | 11.9 | 4.7 | 2.4 | 8.3× / 5.8× | 5.0× / 3.5× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 2.99 | 2.21 | 4.61 | 29.0 | 17.2 | 6.2 | 4.8 | 13.1× / 6.3× | 7.8× / 3.7× | 2.8× / 1.3× | 2.1× / 1.0× |
| eng_Latn | 0.09 | 1.46 | 3.08 | 4.45 | 46.0 | 34.1 | 12.4 | 3.8 | 14.9× / 10.3× | 11.0× / 7.7× | 4.0× / 2.8× | 1.2× / 0.8× |
| heb_Hebr | 1.00 | 2.97 | 2.32 | 4.29 | 32.1 | 20.0 | 7.0 | 3.1 | 13.8× / 7.5× | 8.6× / 4.6× | 3.0× / 1.6× | 1.3× / 0.7× |
| hin_Deva | 1.36 | 3.09 | 3.26 | 4.99 | 49.4 | 30.5 | 11.1 | 4.1 | 15.2× / 9.9× | 9.4× / 6.1× | 3.4× / 2.2× | 1.2× / 0.8× |
| jpn_Jpan | 1.57 | 3.35 | 2.19 | 3.97 | 18.5 | 10.0 | 4.1 | 3.8 | 8.5× / 4.7× | 4.6× / 2.5× | 1.9× / 1.0× | 1.8× / 1.0× |
| kat_Geor | 1.38 | 2.51 | 2.09 | 3.22 | 17.6 | 11.2 | 4.2 | 2.0 | 8.4× / 5.5× | 5.4× / 3.5× | 2.0× / 1.3× | 1.0× / 0.6× |
| kor_Hang | 1.13 | 2.91 | 2.53 | 4.31 | 32.3 | 21.9 | 7.5 | 3.7 | 12.8× / 7.5× | 8.6× / 5.1× | 3.0× / 1.7× | 1.5× / 0.9× |
| rus_Cyrl | 1.02 | 2.92 | 2.17 | 4.07 | 27.7 | 16.8 | 6.0 | 2.4 | 12.8× / 6.8× | 7.7× / 4.1× | 2.7× / 1.5× | 1.1× / 0.6× |
| tam_Taml | 0.92 | 2.89 | 2.70 | 4.68 | 45.3 | 27.1 | 10.2 | 3.4 | 16.8× / 9.7× | 10.0× / 5.8× | 3.8× / 2.2× | 1.2× / 0.7× |
| tha_Thai | 1.35 | 2.71 | 2.60 | 3.96 | 28.4 | 16.1 | 6.7 | 3.0 | 10.9× / 7.2× | 6.2× / 4.1× | 2.6× / 1.7× | 1.2× / 0.8× |
| added_normalized_dense | 0.06 | 1.47 | 1.12 | 2.54 | 24.1 | 17.3 | 6.6 | 1.9 | 21.5× / 9.5× | 15.5× / 6.8× | 5.9× / 2.6× | 1.7× / 0.8× |
| added_normalized_sparse | 0.06 | 1.47 | 1.97 | 3.38 | 31.7 | 22.4 | 8.9 | 2.7 | 16.1× / 9.4× | 11.4× / 6.6× | 4.5× / 2.6× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 5.06 | 6.48 | 104.0 | 72.0 | 21.1 | 3.3 | 20.6× / 16.1× | 14.2× / 11.1× | 4.2× / 3.3× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.77 | 4.91 | 6.62 | 64.9 | 45.5 | 15.2 | 3.7 | 13.2× / 9.8× | 9.3× / 6.9× | 3.1× / 2.3× | 0.8× / 0.6× |
| agentic-traces | 0.56 | 1.48 | 3.73 | 4.65 | 56.1 | 45.3 | 15.3 | 4.6 | 15.0× / 12.1× | 12.1× / 9.8× | 4.1× / 3.3× | 1.2× / 1.0× |
| agentic_swe | 0.53 | 1.44 | 2.87 | 3.78 | 58.8 | 53.3 | 15.6 | 3.4 | 20.5× / 15.6× | 18.6× / 14.1× | 5.4× / 4.1× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.46 | 3.28 | 4.67 | 56.3 | 50.6 | 15.2 | 4.0 | 17.2× / 12.1× | 15.4× / 10.8× | 4.6× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.57 | 1.52 | 3.45 | 4.40 | 53.5 | 39.9 | 14.5 | 4.2 | 15.5× / 12.1× | 11.5× / 9.1× | 4.2× / 3.3× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×5.38 vs v0.23.1 · ×1.01 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 194) · Pipeline 109+0 (peak 195)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.7 | 44.9 | ×12.26 | ×1.10 | 6% (1.2) | 0% (0.0) | 24% (4.7) | 72% (14.4) | 0% (0.0) | match |
| arb_Arab | lang | 4.6 | 21.6 | ×4.72 | ×1.03 | 3% (1.2) | 0% (0.0) | 7% (3.3) | 87% (38.5) | 3% (1.2) | match |
| ben_Beng | lang | 6.8 | 18.8 | ×2.78 | ×1.02 | 2% (1.2) | 0% (0.0) | 7% (3.6) | 91% (46.7) | 0% (0.0) | match |
| cmn_Hani | lang | 5.0 | 17.6 | ×3.50 | ×1.01 | 2% (1.2) | 0% (0.0) | 6% (3.5) | 94% (50.9) | 0% (0.0) | match |
| ell_Grek | lang | 5.2 | 18.8 | ×3.60 | ×1.01 | 2% (1.2) | 0% (0.0) | 6% (3.2) | 91% (45.9) | 1% (0.3) | match |
| eng_Latn | lang | 3.8 | 39.5 | ×10.39 | ×1.03 | 12% (2.5) | 0% (0.0) | 21% (4.5) | 68% (14.6) | 0% (0.0) | match |
| heb_Hebr | lang | 4.6 | 17.1 | ×3.70 | ×1.03 | 2% (1.2) | 0% (0.0) | 6% (3.3) | 92% (52.0) | 0% (0.0) | match |
| hin_Deva | lang | 6.3 | 25.0 | ×3.94 | ×0.98 | 3% (1.2) | 0% (0.0) | 10% (3.8) | 85% (31.7) | 1% (0.5) | match |
| jpn_Jpan | lang | 5.6 | 16.2 | ×2.92 | ×0.99 | 2% (1.2) | 0% (0.0) | 6% (3.2) | 93% (54.1) | 0% (0.0) | match |
| kat_Geor | lang | 6.5 | 15.3 | ×2.34 | ×1.02 | 2% (1.2) | 0% (0.0) | 5% (2.9) | 95% (59.2) | 0% (0.0) | match |
| kor_Hang | lang | 4.2 | 19.3 | ×4.57 | ×1.01 | 2% (1.2) | 0% (0.0) | 8% (3.7) | 89% (42.7) | 1% (0.7) | match |
| rus_Cyrl | lang | 5.0 | 16.8 | ×3.38 | ×1.04 | 2% (1.2) | 0% (0.0) | 6% (3.1) | 94% (52.4) | 0% (0.0) | match |
| tam_Taml | lang | 6.8 | 14.9 | ×2.18 | ×1.00 | 2% (1.2) | 0% (0.0) | 5% (3.2) | 95% (60.9) | 0% (0.0) | match |
| tha_Thai | lang | 8.2 | 14.8 | ×1.81 | ×1.01 | 2% (1.2) | 0% (0.0) | 5% (3.2) | 94% (62.0) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 28.4 | ×4.99 | ×1.01 | 4% (1.3) | 0% (0.0) | 6% (2.2) | 89% (30.8) | 1% (0.3) | match |
| added_normalized_sparse | modalities | 5.2 | 42.1 | ×8.08 | ×1.00 | 8% (1.9) | 0% (0.0) | 14% (3.1) | 80% (18.1) | 0% (0.0) | match |
| added_special_dense | modalities | 4.2 | 68.2 | ×16.18 | ×0.95 | 37% (5.3) | 3% (0.5) | 48% (6.9) | 12% (1.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.5 | 63.2 | ×14.16 | ×0.98 | 24% (3.7) | 1% (0.1) | 40% (6.1) | 34% (5.2) | 1% (0.1) | match |
| agentic-traces | modalities | 3.3 | 34.4 | ×10.31 | ×1.02 | 9% (2.4) | 0% (0.0) | 19% (5.0) | 75% (20.0) | 0% (0.0) | match |
| agentic_swe | modalities | 3.4 | 24.4 | ×7.19 | ×0.98 | 5% (1.9) | 0% (0.0) | 10% (3.7) | 85% (32.9) | 0% (0.0) | match |
| code_mixed | modalities | 3.7 | 43.2 | ×11.82 | ×1.03 | 10% (2.1) | 0% (0.0) | 20% (4.4) | 70% (15.0) | 0% (0.0) | match |
| math_latex | modalities | 3.4 | 39.3 | ×11.57 | ×1.00 | 11% (2.5) | 0% (0.0) | 21% (4.8) | 69% (15.4) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.67 | 3.37 | 4.74 | 5.44 | 29.0 | 14.7 | 6.7 | — | 6.1× / 5.3× | 3.1× / 2.7× | 1.4× / 1.2× | — |
| arb_Arab | 1.00 | 2.95 | 3.29 | 5.23 | 34.1 | 16.8 | 7.4 | — | 10.4× / 6.5× | 5.1× / 3.2× | 2.3× / 1.4× | — |
| ben_Beng | 1.46 | 2.86 | 3.64 | 5.04 | 23.3 | 10.8 | 5.3 | — | 6.4× / 4.6× | 3.0× / 2.1× | 1.5× / 1.1× | — |
| cmn_Hani | 1.14 | 2.25 | 3.45 | 4.57 | 22.4 | 11.5 | 5.5 | — | 6.5× / 4.9× | 3.3× / 2.5× | 1.6× / 1.2× | — |
| ell_Grek | 0.59 | 3.00 | 3.21 | 5.62 | 29.7 | 15.3 | 6.6 | — | 9.2× / 5.3× | 4.8× / 2.7× | 2.1× / 1.2× | — |
| eng_Latn | 0.11 | 1.45 | 4.48 | 5.82 | 44.9 | 30.9 | 13.4 | — | 10.0× / 7.7× | 6.9× / 5.3× | 3.0× / 2.3× | — |
| heb_Hebr | 1.00 | 3.06 | 3.34 | 5.41 | 33.0 | 17.2 | 7.8 | — | 9.9× / 6.1× | 5.1× / 3.2× | 2.3× / 1.4× | — |
| hin_Deva | 1.37 | 3.08 | 3.79 | 5.51 | 25.3 | 12.9 | 6.1 | — | 6.7× / 4.6× | 3.4× / 2.3× | 1.6× / 1.1× | — |
| jpn_Jpan | 1.57 | 3.32 | 3.21 | 4.96 | 20.7 | 9.6 | 4.8 | — | 6.5× / 4.2× | 3.0× / 1.9× | 1.5× / 1.0× | — |
| kat_Geor | 1.38 | 2.56 | 2.92 | 4.11 | 18.6 | 10.1 | 4.5 | — | 6.4× / 4.5× | 3.5× / 2.5× | 1.5× / 1.1× | — |
| kor_Hang | 1.09 | 2.70 | 3.68 | 5.30 | 33.0 | 19.4 | 8.7 | — | 9.0× / 6.2× | 5.3× / 3.7× | 2.4× / 1.6× | — |
| rus_Cyrl | 1.02 | 2.89 | 3.10 | 4.98 | 29.0 | 15.2 | 6.4 | — | 9.3× / 5.8× | 4.9× / 3.0× | 2.1× / 1.3× | — |
| tam_Taml | 0.93 | 2.90 | 3.19 | 5.17 | 18.8 | 8.9 | 4.2 | — | 5.9× / 3.6× | 2.8× / 1.7× | 1.3× / 0.8× | — |
| tha_Thai | 1.36 | 2.51 | 3.22 | 4.38 | 13.3 | 5.9 | 2.8 | — | 4.1× / 3.0× | 1.8× / 1.3× | 0.9× / 0.6× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.16 | 3.58 | 32.4 | 17.5 | 11.7 | — | 15.0× / 9.0× | 8.1× / 4.9× | 5.4× / 3.3× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.11 | 4.52 | 34.5 | 20.9 | 11.8 | — | 11.1× / 7.6× | 6.7× / 4.6× | 3.8× / 2.6× | — |
| added_special_dense | 0.06 | 1.77 | 6.93 | 8.64 | 95.6 | 68.6 | 24.0 | — | 13.8× / 11.1× | 9.9× / 7.9× | 3.5× / 2.8× | — |
| added_special_sparse | 0.06 | 1.47 | 6.07 | 7.49 | 59.8 | 41.3 | 16.3 | — | 9.8× / 8.0× | 6.8× / 5.5× | 2.7× / 2.2× | — |
| agentic-traces | 0.58 | 1.47 | 4.97 | 5.87 | 57.7 | 44.0 | 17.3 | — | 11.6× / 9.8× | 8.8× / 7.5× | 3.5× / 3.0× | — |
| agentic_swe | 0.51 | 1.45 | 3.73 | 4.67 | 63.7 | 54.9 | 18.5 | — | 17.1× / 13.6× | 14.7× / 11.8× | 5.0× / 4.0× | — |
| code_mixed | 0.06 | 1.44 | 4.36 | 5.74 | 57.5 | 49.2 | 17.6 | — | 13.2× / 10.0× | 11.3× / 8.6× | 4.0× / 3.1× | — |
| math_latex | 0.56 | 1.47 | 4.78 | 5.69 | 53.3 | 37.6 | 16.0 | — | 11.1× / 9.4× | 7.9× / 6.6× | 3.3× / 2.8× | — |

</details>

<details><summary><b>t5-base</b> — Unigram + Metaspace · ×2.53 vs v0.23.1 · ×1.09 vs base · decode pending</summary>

<img alt="t5-base speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-t5-base.png" width="860">

<img alt="t5-base stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-t5-base-stages.png" width="860">

<img alt="t5-base thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-t5-base-threads.png" width="860">

<img alt="t5-base decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-t5-base-decode.png" width="860">

<img alt="t5-base decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-30642171870-t5-base-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 34+2 (peak 36) · Pipeline 61+1 (peak 66)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 6.0 | 16.5 | ×2.74 | ×1.11 | 1% (0.6) | 33% (21.7) | 4% (2.4) | 54% (35.6) | 8% (4.9) | match |
| arb_Arab | lang | 5.0 | 13.1 | ×2.64 | ×1.06 | 1% (0.6) | 29% (27.2) | 3% (3.0) | 69% (65.5) | 0% (0.0) | match |
| ben_Beng | lang | 7.8 | 21.0 | ×2.70 | ×1.06 | 1% (0.6) | 32% (24.6) | 2% (1.7) | 64% (48.5) | 1% (0.5) | match |
| cmn_Hani | lang | 12.9 | 23.7 | ×1.84 | ×1.02 | 1% (0.6) | 24% (16.8) | 1% (0.6) | 75% (52.2) | 0% (0.0) | match |
| ell_Grek | lang | 5.2 | 14.1 | ×2.68 | ×1.07 | 1% (0.6) | 27% (27.5) | 3% (2.8) | 68% (68.2) | 2% (1.8) | match |
| eng_Latn | lang | 2.8 | 6.2 | ×2.22 | ×1.16 | 1% (2.0) | 18% (40.2) | 3% (6.2) | 77% (177.9) | 1% (3.4) | match |
| heb_Hebr | lang | 4.6 | 13.4 | ×2.91 | ×1.06 | 1% (0.6) | 25% (23.7) | 4% (3.5) | 71% (67.9) | 0% (0.0) | match |
| hin_Deva | lang | 6.7 | 21.5 | ×3.18 | ×1.09 | 1% (0.6) | 31% (24.6) | 3% (2.2) | 64% (51.0) | 1% (0.7) | match |
| jpn_Jpan | lang | 14.1 | 25.8 | ×1.83 | ×1.04 | 1% (0.6) | 28% (20.2) | 1% (0.6) | 79% (57.9) | 0% (0.0) | match |
| kat_Geor | lang | 8.5 | 21.0 | ×2.45 | ×1.05 | 1% (0.6) | 26% (18.9) | 2% (1.5) | 70% (50.0) | 1% (0.8) | match |
| kor_Hang | lang | 4.8 | 12.3 | ×2.58 | ×1.06 | 1% (0.6) | 26% (24.6) | 3% (2.7) | 68% (63.8) | 2% (2.3) | match |
| rus_Cyrl | lang | 4.5 | 8.7 | ×1.91 | ×1.03 | 0% (0.6) | 18% (27.3) | 2% (2.3) | 79% (117.5) | 0% (0.2) | match |
| tam_Taml | lang | 9.3 | 22.5 | ×2.43 | ×1.04 | 1% (0.6) | 28% (18.8) | 2% (1.4) | 72% (48.6) | 0% (0.0) | match |
| tha_Thai | lang | 13.0 | 25.7 | ×1.99 | ×1.06 | 1% (0.6) | 27% (18.9) | 1% (0.9) | 70% (48.1) | 1% (0.4) | match |
| added_normalized_dense | modalities | 4.1 | 12.8 | ×3.10 | ×1.03 | 0% (0.7) | 19% (36.7) | 3% (4.8) | 82% (157.6) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 3.8 | 13.1 | ×3.41 | ×1.66 | 1% (1.3) | 21% (38.6) | 3% (5.7) | 77% (138.7) | 0% (0.0) | match |
| added_special_dense | modalities | 6.4 | 33.2 | ×5.21 | ×0.98 | 10% (5.1) | 34% (16.4) | 8% (4.0) | 47% (23.1) | 0% (0.1) | match |
| added_special_sparse | modalities | 4.1 | 16.6 | ×4.02 | ×1.06 | 3% (3.2) | 26% (33.3) | 10% (12.6) | 62% (78.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.3 | 6.2 | ×1.88 | ×1.16 | 1% (1.8) | 17% (39.6) | 2% (5.2) | 81% (183.3) | 0% (0.0) | match |
| agentic_swe | modalities | 4.7 | 8.9 | ×1.92 | ×1.06 | 1% (1.3) | 20% (37.1) | 2% (4.2) | 77% (146.0) | 1% (1.6) | match |
| code_mixed | modalities | 4.0 | 8.1 | ×2.02 | ×1.06 | 1% (1.5) | 20% (38.9) | 2% (4.5) | 76% (150.7) | 1% (2.7) | match |
| math_latex | modalities | 3.0 | 6.4 | ×2.10 | ×1.11 | 1% (1.9) | 18% (40.4) | 3% (6.1) | 80% (179.9) | 0% (0.0) | match |

</details>
<!-- pipeline-bench:end -->
