### PR TITLE
feat: update `encode` signature

### DIFF
--- a/tokenizers/tk-encode/benches/pipeline_benchmark.rs
+++ b/tokenizers/tk-encode/benches/pipeline_benchmark.rs
@@ -80,7 +80,13 @@ fn bench_pipeline(c: &mut Criterion) {
                     b.iter(|| {
                         let mut n = 0usize;
                         for chunk in &chunks {
-                            n += pipeline.encode(chunk, true).unwrap().len();
+                            n += pipeline
+                                .encode(chunk, true)
+                                .wait()
+                                .unwrap()
+                                .first()
+                                .unwrap()
+                                .len();
                         }
                         black_box(n)
                     })

--- a/tokenizers/tk-encode/examples/binsize_pipeline.rs
+++ b/tokenizers/tk-encode/examples/binsize_pipeline.rs
@@ -20,5 +20,14 @@ fn main() {
         .expect("usage: binsize_pipeline <tokenizer.json> <text>");
     let tok = Tokenizer::from_file(path).unwrap();
     let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
-    println!("{}", pipeline.encode(text.as_str(), false).unwrap().len());
+    println!(
+        "{}",
+        pipeline
+            .encode(text.as_str(), false)
+            .wait()
+            .unwrap()
+            .first()
+            .unwrap()
+            .len()
+    );
 }

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -59,7 +59,7 @@ use logos::Logos;
 use rayon::ThreadPoolBuilder;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde_json::{Value, json};
-use tk_encode::pipeline::{Model, PipelineTokenizer};
+use tk_encode::pipeline::PipelineTokenizer;
 use tk_encode::{AddedToken, ModelWrapper, Tokenizer};
 use tokenizers_release::{AddedToken as BaselineAddedToken, Tokenizer as BaselineTokenizer};
 
@@ -233,7 +233,15 @@ fn bench_throughput(
     let pipeline = PipelineTokenizer::try_from(oracle).expect("probed at model load");
     let base = baseline.cloned();
 
-    let pipe_enc = |s: &str| pipeline.encode(s, true).unwrap().len();
+    let pipe_enc = |s: &str| {
+        pipeline
+            .encode(s, true)
+            .wait()
+            .unwrap()
+            .first()
+            .unwrap()
+            .len()
+    };
     let base_enc = base
         .as_ref()
         .map(|b| move |s: &str| b.encode_fast(s, true).unwrap().len());
@@ -241,6 +249,9 @@ fn bench_throughput(
     let pipe_ids = |c: &String, add_special_tokens: bool| -> Vec<u32> {
         pipeline
             .encode(c, add_special_tokens)
+            .wait()
+            .unwrap()
+            .first()
             .unwrap()
             .iter()
             .map(|t| t.id)
@@ -306,21 +317,10 @@ fn bench_throughput(
 /// work, `pre_tokens` anchors the split stage, so under fat LTO no dead partial stage
 /// gets optimized away. The `black_box` lives here, in the bench — never in the library.
 fn stage_secs<const STAGE: u8>(pipeline: &PipelineTokenizer, chunks: &[String]) -> f64 {
-    let mut out = Vec::new();
-    let mut pre_tokens = Vec::new();
-    let mut scratch = pipeline.get_model().init_scratch();
-    let mut run = || {
+    let run = || {
         for chunk in chunks {
-            out.clear();
-            let _ = pipeline.encode_generic::<STAGE>(
-                chunk,
-                true,
-                &mut pre_tokens,
-                &mut scratch,
-                &mut out,
-            );
-            black_box(&out);
-            black_box(&pre_tokens);
+            let out = pipeline.encode_generic::<STAGE>(chunk, true);
+            black_box(out);
         }
     };
     run(); // warm-up
@@ -646,7 +646,15 @@ fn bench_threads(
         let b =
             baseline.map(|b| par_mbps(|s| b.encode_fast(s, true).unwrap().len(), chunks, bytes, n));
         let p = par_mbps(
-            |s| pipeline.encode(s, true).unwrap().len(),
+            |s| {
+                pipeline
+                    .encode(s, true)
+                    .wait()
+                    .unwrap()
+                    .first()
+                    .unwrap()
+                    .len()
+            },
             chunks,
             bytes,
             n,
@@ -904,7 +912,8 @@ fn memory_child(which: &str, model: &Path) {
             drop(tok);
             let after_load = rss_now().unwrap_or(0);
             for c in &chunks {
-                let enc = pipeline.encode(c, true).unwrap();
+                let results = pipeline.encode(c, true).wait().unwrap();
+                let enc = results.first().unwrap();
                 n += enc.len();
                 ids.push(enc.iter().map(|t| t.id).collect());
             }
@@ -1111,7 +1120,7 @@ fn main() {
         // and has no range-based impl. Probe once and downgrade to "unsupported"
         // (with the reason) instead of panicking partway through the bench.
         let pipeline = match PipelineTokenizer::try_from(&tok) {
-            Ok(p) => match p.encode(PROBE, false) {
+            Ok(p) => match p.encode(PROBE, false).wait() {
                 Ok(_) => p,
                 Err(e) => {
                     eprintln!("  pipeline builds but can't encode yet ({shape}): {e}");

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1,5 +1,7 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
+use std::iter::Enumerate;
+use std::vec::IntoIter;
 use std::{borrow::Cow, convert::TryFrom};
 
 use atomsplit::classify::classify;
@@ -573,6 +575,115 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
     }
 }
 
+pub enum Inputs {
+    Single(String),
+    Pair(String, String),
+    Batch(Vec<String>),
+    PairBatch(Vec<(String, String)>),
+}
+
+impl From<String> for Inputs {
+    fn from(s: String) -> Self {
+        Inputs::Single(s)
+    }
+}
+
+impl From<&str> for Inputs {
+    fn from(s: &str) -> Self {
+        Inputs::Single(s.to_owned())
+    }
+}
+
+impl From<&String> for Inputs {
+    fn from(s: &String) -> Self {
+        Inputs::Single(s.to_owned())
+    }
+}
+
+impl From<Vec<String>> for Inputs {
+    fn from(b: Vec<String>) -> Self {
+        Inputs::Batch(b)
+    }
+}
+
+impl From<&[&str]> for Inputs {
+    fn from(b: &[&str]) -> Self {
+        Inputs::Batch(b.iter().map(|s| (*s).to_owned()).collect())
+    }
+}
+
+impl From<(String, String)> for Inputs {
+    fn from(p: (String, String)) -> Self {
+        Inputs::Pair(p.0, p.1)
+    }
+}
+
+impl From<(&str, &str)> for Inputs {
+    fn from(p: (&str, &str)) -> Self {
+        Inputs::Pair(p.0.to_owned(), p.1.to_owned())
+    }
+}
+
+impl From<(&String, &String)> for Inputs {
+    fn from(p: (&String, &String)) -> Self {
+        Inputs::Pair(p.0.to_owned(), p.1.to_owned())
+    }
+}
+
+impl From<Vec<(String, String)>> for Inputs {
+    fn from(b: Vec<(String, String)>) -> Self {
+        Inputs::PairBatch(b)
+    }
+}
+
+impl From<&[(&str, &str)]> for Inputs {
+    fn from(b: &[(&str, &str)]) -> Self {
+        Inputs::PairBatch(
+            b.iter()
+                .map(|(s1, s2)| ((*s1).to_owned(), (*s2).to_owned()))
+                .collect(),
+        )
+    }
+}
+
+pub enum EncodeHandle {
+    Blocking(Enumerate<IntoIter<Result<Vec<PipelineToken>>>>),
+    // TODO:
+    // Streaming
+}
+
+impl EncodeHandle {
+    /// Fully computed results, for the serial case
+    fn blocking(results: Vec<Result<Vec<PipelineToken>>>) -> Self {
+        Self::Blocking(results.into_iter().enumerate())
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            EncodeHandle::Blocking(results) => results.len(),
+        }
+    }
+
+    pub fn wait(self) -> Result<Vec<Vec<PipelineToken>>> {
+        // XXX: `Vec::new` does not allocate anything when capacity == 0
+        let mut out = vec![Vec::new(); self.len()];
+        for (seq, res) in self {
+            out[seq] = res?;
+        }
+        Ok(out)
+    }
+}
+
+impl Iterator for EncodeHandle {
+    type Item = (usize, Result<Vec<PipelineToken>>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Blocking(it) => it.next(),
+        }
+    }
+}
+
 impl PipelineTokenizer {
     /// Stage gates for [`encode_generic`](Self::encode_generic), in execution order.
     /// Each level runs every stage up to and including itself; `STAGE_POSTPROCESS` is
@@ -596,19 +707,48 @@ impl PipelineTokenizer {
     ///
     /// This way, special / added tokens declared on raw or normalized text are both caught.
     /// The remaining text is pre-tokenized and run through the model span by span.
-    pub fn encode(&self, input: &str, add_special_tokens: bool) -> Result<Vec<PipelineToken>> {
-        let mut output = Vec::new();
-        let mut pre_tokens = Vec::new();
-        let mut scratch = self.model.init_scratch();
+    pub fn encode(&self, inputs: impl Into<Inputs>, add_special_tokens: bool) -> EncodeHandle {
+        let inputs = inputs.into();
 
-        self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(
-            input,
-            add_special_tokens,
-            &mut pre_tokens,
-            &mut scratch,
-            &mut output,
-        )?;
-        Ok(output)
+        match inputs {
+            Inputs::Single(s) => {
+                let output =
+                    self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(&s, add_special_tokens);
+                EncodeHandle::blocking(vec![output])
+            }
+            // TODO: proper post-processor logic, this is temporary
+            Inputs::Pair(s1, s2) => {
+                let p1 =
+                    self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(&s1, add_special_tokens);
+                let p2 =
+                    self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(&s2, add_special_tokens);
+                EncodeHandle::blocking(vec![p1, p2])
+            }
+            Inputs::Batch(b) => {
+                let mut output = Vec::with_capacity(b.len());
+                for seq in b {
+                    output.push(
+                        self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(
+                            &seq,
+                            add_special_tokens,
+                        ),
+                    );
+                }
+                EncodeHandle::blocking(output)
+            }
+            Inputs::PairBatch(pb) => {
+                let mut output = Vec::with_capacity(pb.len() * 2);
+                for (s1, s2) in pb {
+                    output.push(
+                        self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(&s1, add_special_tokens),
+                    );
+                    output.push(
+                        self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(&s2, add_special_tokens),
+                    );
+                }
+                EncodeHandle::blocking(output)
+            }
+        }
     }
 
     /// Decode token ids back to a `String`.
@@ -667,10 +807,10 @@ impl PipelineTokenizer {
         &self,
         input: &str,
         add_special_tokens: bool,
-        pre_tokens: &mut Vec<Span>,
-        scratch: &mut PipelineModelScratch,
-        output: &mut Vec<PipelineToken>,
-    ) -> Result<()> {
+    ) -> Result<Vec<PipelineToken>> {
+        let mut pre_tokens = Vec::with_capacity(input.len() / 4);
+        let mut output = Vec::with_capacity(input.len() / 4);
+        let mut scratch = self.model.init_scratch();
         let PipelinePostProcessor { prefix, suffix } = &self.post_processor;
         // Prepend prefix tokens, if any
         // todo: handle post-processing when encoding a pair of sequences (currently unsupported by the PipelineTokenizer)
@@ -703,14 +843,14 @@ impl PipelineTokenizer {
                                     // Pre-tokenize the chunk of normalized text
                                     pre_tokens.clear();
                                     self.pre_tokenizer
-                                        .pre_tokenize(normalized_chunk, pre_tokens)?;
+                                        .pre_tokenize(normalized_chunk, &mut pre_tokens)?;
                                     if STAGE >= Self::STAGE_MODEL {
                                         // Tokenize each chunk
                                         for pre_token in pre_tokens.iter() {
                                             self.model.tokenize_pipeline(
                                                 &normalized_chunk[pre_token.range()],
-                                                scratch,
-                                                output,
+                                                &mut scratch,
+                                                &mut output,
                                             )?;
                                         }
                                     }
@@ -725,7 +865,7 @@ impl PipelineTokenizer {
         if add_special_tokens && STAGE >= Self::STAGE_POSTPROCESS {
             output.extend_from_slice(suffix);
         }
-        Ok(())
+        Ok(output)
     }
 }
 
@@ -1096,6 +1236,9 @@ mod tests {
         let ids: Vec<u32> = PipelineTokenizer::try_from(&tok)
             .unwrap()
             .encode("hello world", false)
+            .wait()
+            .unwrap()
+            .first()
             .unwrap()
             .iter()
             .map(|t| t.id)
@@ -1198,6 +1341,9 @@ mod tests {
                 .to_vec();
             let got: Vec<u32> = pipeline
                 .encode(input, add_special_tokens)
+                .wait()
+                .unwrap()
+                .first()
                 .unwrap()
                 .iter()
                 .map(|t| t.id)
@@ -1220,13 +1366,19 @@ mod tests {
         assert_pipeline_matches_reference(&tok, "hello world");
 
         let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
-        let ids = |enc: Vec<PipelineToken>| enc.iter().map(|t| t.id).collect::<Vec<_>>();
+        let ids = |enc: Vec<Vec<PipelineToken>>| {
+            enc.first()
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect::<Vec<_>>()
+        };
         assert_eq!(
-            ids(pipeline.encode("hello world", true).unwrap()),
+            ids(pipeline.encode("hello world", true).wait().unwrap()),
             vec![0, 2, 3, 1]
         );
         assert_eq!(
-            ids(pipeline.encode("hello world", false).unwrap()),
+            ids(pipeline.encode("hello world", false).wait().unwrap()),
             vec![2, 3]
         );
     }
@@ -1304,6 +1456,9 @@ mod tests {
         let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
         let ids: Vec<u32> = pipeline
             .encode("hello world", true)
+            .wait()
+            .unwrap()
+            .first()
             .unwrap()
             .iter()
             .map(|t| t.id)

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -39,7 +39,7 @@ fn check_model(tok_file: &str) {
         return;
     };
     // Build constraints can be met while encode is still unimplemented for this shape.
-    if pipeline.encode(PROBE, false).is_err() {
+    if pipeline.encode(PROBE, false).wait().is_err() {
         eprintln!("skip {tok_file}: pipeline can't encode this model yet");
         return;
     }
@@ -79,6 +79,9 @@ fn check_model(tok_file: &str) {
                     .to_vec();
                 let got: Vec<u32> = pipeline
                     .encode(chunk, add_special_tokens)
+                    .wait()
+                    .unwrap()
+                    .first()
                     .unwrap()
                     .iter()
                     .map(|t| t.id)


### PR DESCRIPTION
* adds `EncodeHandle` return type to pave the way for async
* takes `impl Into<Inputs>` as an input
    * pairs are not properly supported atm, we still need to handle post-processor logic
* some of the benchmarks call encode* in a loop because it used to be single sequence only
  * I didn't dig too much to pass in the full batch and have kept it single-sequence for the moment, we could change that eventually
   