### PR TITLE
ci: pin every action to one SHA, drop stale audit suppressions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,18 +47,18 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.x
       - name: Build wheels
-        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-linux-${{ matrix.platform.arch }}
           path: dist
@@ -78,18 +78,18 @@ jobs:
             target: armv7
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.x
       - name: Build wheels
-        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: 'true'
           manylinux: musllinux_1_2
       - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: dist
@@ -110,18 +110,18 @@ jobs:
             architecture: arm64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.x
           architecture: ${{ matrix.platform.architecture }}
       - name: Build wheels
-        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: dist
@@ -137,11 +137,11 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.x
       - name: Build wheels
-        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
@@ -152,7 +152,7 @@ jobs:
           # doesn't pass this flag automatically on macOS.
           RUSTFLAGS: "-C link-arg=-undefined -C link-arg=dynamic_lookup"
       - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
@@ -162,12 +162,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Build sdist
-        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
         with:
           command: sdist
           args: --out dist --manifest-path bindings/python/Cargo.toml
       - name: Upload sdist
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-sdist
           path: dist
@@ -185,14 +185,14 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018  # v1
         with:
           subject-path: 'wheels-*/*'
       - name: Publish to PyPI
         if: "startsWith(github.ref, 'refs/tags/')"
-        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN_DIST}}
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -44,7 +44,7 @@ jobs:
       run:
         working-directory: tokenizers
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Mark check run in progress
         if: inputs.check_run_id != ''
@@ -58,13 +58,13 @@ jobs:
             -f "output[summary]=Compiling and running benchmarks..."
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
 
       # cairosvg (chart rendering) dlopens the system libcairo, which the
       # aws-general-8-plus runner image doesn't ship (ubuntu-latest did)
@@ -239,16 +239,16 @@ jobs:
     runs-on:
       group: aws-general-8-plus
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
 
       # cairosvg (chart rendering) dlopens the system libcairo, which the
       # aws-general-8-plus runner image doesn't ship (ubuntu-latest did)

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.12
 
@@ -33,7 +33,7 @@ jobs:
         run: make clean && make html_all O="-W --keep-going"
 
       - name: Upload built doc
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: documentation
           path: ./docs/build/*

--- a/.github/workflows/docs_backfill.yml
+++ b/.github/workflows/docs_backfill.yml
@@ -18,7 +18,7 @@ jobs:
       max-parallel: 1
       matrix:
         version: ${{ fromJson(github.event.inputs.versions) }}
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@e60a538eea9817ab312196d0d233604b01697265
     with:
       commit_sha: ${{ matrix.version }}
       package: tokenizers

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -122,7 +122,7 @@ jobs:
             ${{ matrix.settings.build }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: bindings-${{ matrix.settings.target }}
           path: bindings/node/*.node
@@ -164,7 +164,7 @@ jobs:
             artifacts/${{ env.APP_NAME }}.darwin-x64.node \
             artifacts/${{ env.APP_NAME }}.darwin-arm64.node
       - name: Upload universal artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: bindings-universal-apple-darwin
           path: bindings/node/${{ env.APP_NAME }}.*.node

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -26,13 +26,13 @@ jobs:
       - run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
 
       - name: Cache Cargo Registry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: latest
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
       # Test fixtures are immutable — cache them so CI doesn't re-download
       # from the Hub (and get rate-limited) on every run.
       - name: Cache HF test data
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: bindings/node/data
           key: hf-test-data-node-${{ hashFiles('bindings/node/Makefile') }}
@@ -71,7 +71,7 @@ jobs:
       # Provides `uvx`, used to run the huggingface_hub CLI that downloads
       # test fixtures (see the Makefile) without a separate install step.
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
 
       - name: Run JS tests
         working-directory: ./bindings/node

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -142,7 +142,7 @@ jobs:
       - run: pip install -U twine
 
       - name: build wheels
-        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38  # v1.51.0
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
         with:
           target: ${{ matrix.target }}
           working-directory: ./bindings/python
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38  # v1.51.0
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
         with:
           working-directory: ./bindings/python
           command: sdist

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -108,7 +108,7 @@ jobs:
       # datasets cache used by the test suite at runtime) so CI doesn't
       # re-download from the Hub (and get rate-limited) on every run.
       - name: Cache HF test data
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             bindings/python/data
@@ -168,4 +168,4 @@ jobs:
         run: cargo generate-lockfile --manifest-path ./bindings/python/Cargo.toml
 
       - name: Run Audit
-        run: cargo audit -D warnings -f ./bindings/python/Cargo.lock --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0014 --ignore RUSTSEC-2025-0119
+        run: cargo audit -D warnings -f ./bindings/python/Cargo.lock --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
       # from the Hub (and get rate-limited) on every run.
       - name: Cache HF test data
         if: matrix.os != 'windows-latest'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: tokenizers/data
           key: hf-test-data-${{ hashFiles('tokenizers/Makefile') }}
@@ -80,7 +80,7 @@ jobs:
       # test fixtures (see the Makefile) without a separate install step.
       - name: Install uv
         if: matrix.os != 'windows-latest'
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
 
       - name: Run Tests
         if: matrix.os != 'windows-latest'
@@ -100,7 +100,7 @@ jobs:
         run: cargo test --verbose --manifest-path ./tokenizers/Cargo.toml --doc
 
       - name: Run Audit
-        run: cargo audit -D warnings -f ./tokenizers/Cargo.lock --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0014 --ignore RUSTSEC-2025-0119
+        run: cargo audit -D warnings -f ./tokenizers/Cargo.lock --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119
 
       # Verify that Readme.md is up to date.
       - name: Make sure, Readme generated from lib.rs matches actual Readme

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           days-before-stale: 30


### PR DESCRIPTION
Independent of the node dependency stack (#2286→#2290) — this one targets `main` directly.

## A broken pin

`PyO3/maturin-action@3e2bdf6ba645...` is used twice in `python-release.yml`, commented `# v1.51.0`. That commit does not exist:

```
$ gh api repos/PyO3/maturin-action/commits/3e2bdf6ba6453a61e649744019b8a2d906c7eb38
No commit found for SHA (HTTP 422)
```

The real v1.51.0 is `e83996d1`. All maturin-action uses now point there.

## Pin consolidation

Nine actions carried more than one pin — `checkout` ×3, `upload-artifact` ×3, `cache` ×3, plus `setup-python`, `setup-node`, `download-artifact`, `maturin-action`. Every distinct pin is a separate update to review, for no benefit.

Each is now a single SHA, chosen as the **newest of the SHAs already in use in this repo** (verified via commit dates through the API, so nothing untrusted is introduced):

| action | SHA | tag |
|---|---|---|
| `actions/checkout` | `de0fac2e` | v6.0.2 |
| `actions/cache` | `27d5ce7f` | v5.0.5 |
| `actions/download-artifact` | `3e5f45b2` | v8.0.1 |
| `actions/setup-node` | `53b83947` | v6.3.0 |
| `actions/setup-python` | `a309ff8b` | v6.2.0 |
| `actions/upload-artifact` | `043fb46d` | v7.0.1 |
| `PyO3/maturin-action` | `e83996d1` | v1.51.0 |

## Moving refs now pinned

Six uses tracked mutable refs. Most notable: **`huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main`** — a third-party reusable workflow following a branch, in a repo that otherwise SHA-pins carefully.

Also `dtolnay/rust-toolchain@stable`, `actions/stale@v9`, `astral-sh/setup-uv@v6`, `mozilla-actions/sccache-action@v0.0.9`.

`rust-toolchain` follows the convention already proven in `node.yml`, `docs-check.yml` and `rust-release.yml`: SHA plus a `# stable` comment, no `toolchain:` input needed.

## Stale audit suppressions

`cargo audit` suppressed five advisories. Auditing main's actual resolved graph, only **two** still fire — `RUSTSEC-2024-0436` (paste) and `RUSTSEC-2025-0119` (number_prefix), both unmaintained-crate warnings with no fix available. Those stay.

The three removed:
- **`RUSTSEC-2025-0014`** — clearest case: that humantime advisory was **withdrawn upstream on 2025-03-12**. It cannot fire at all.
- **`RUSTSEC-2025-0057`** (fxhash) and **`RUSTSEC-2026-0204`** (crossbeam-epoch) — neither fires on main, which resolves `crossbeam-epoch` to the patched 0.9.20.

A suppression matching nothing isn't harmless: it silently hides a *future* recurrence of that same advisory.

⚠️ **Heads-up for branches carrying committed lockfiles.** `main` commits no `Cargo.lock`, so CI resolves fresh each run. Long-running branches that *do* commit locks (e.g. `bitsplit`) pin `crossbeam-epoch` **0.9.18**, which is exactly `RUSTSEC-2026-0204`. With that ignore gone, audit will correctly flag it on merge — the fix is a `cargo update -p crossbeam-epoch`, not restoring the suppression.

## Verification

- all **24** actions single-SHA pinned across **102** uses, zero moving refs remaining
- every workflow still parses as valid YAML
- both surviving `cargo audit` invocations verified against a real audit run

## Not included

I had also flagged `pytest-asyncio` as an unused test extra. **That was wrong** — it's used via `@pytest.mark.asyncio` on the async tests in `tests/bindings/test_tokenizer.py`, which my import-only grep missed. It stays.