### PR TITLE
fix(python): pin the ruff rule set so a ruff release can't redden main

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -50,6 +50,12 @@ features = ["pyo3/extension-module", "abi3"]
 [tool.ruff]
 line-length = 119
 target-version = "py311"
+# This is ruff's historical default rule set, which we relied on implicitly
+# until ruff started shipping a much larger one by default (0.14 enabled 53
+# rules here, 0.16 enables 411). CI installs ruff unpinned, so leaving the
+# selection implicit means a ruff release can turn hundreds of new rules on
+# and redden main without a line of our code changing. Opt in explicitly.
+lint.select = ["E4", "E7", "E9", "F"]
 lint.ignore = [
   # a == None in tests vs is None.
   "E711",


### PR DESCRIPTION
## Problem

`make check-style` fails on `main` with **615 ruff errors**. No Python source changed — ruff did.

`[tool.ruff]` in `bindings/python/pyproject.toml` sets `lint.ignore` but never `lint.select`, so the rule set was implicitly "whatever ruff ships as default today". CI installs ruff unpinned (`testing = [..., "ruff", ...]`), so it picks up whichever ruff released most recently.

On the same tree with the same config:

| ruff | rules enabled | `ruff check py_src/tokenizers tests` |
|---|---|---|
| 0.14.10 | 53 | `All checks passed!` |
| 0.16.1 | 411 | `Found 621 errors.` |

So the findings are ~358 rule families we never opted into — docstring style (`D419`), PEP 585/604 annotation rewrites (`UP006`/`UP007`/`UP045`), stub conventions (`PYI*`), `PIE790`, `BLE001`, `TRY002` — not debt we accumulated.

## Fix

Select ruff's historical default explicitly:

```toml
lint.select = ["E4", "E7", "E9", "F"]
```

That is exactly the 53 rules (41 `F` + 12 `E`) we were already being held to, so **no source change is needed**, and a future ruff release can no longer switch hundreds of rules on for us.

## Verification

With ruff 0.16.1 (what CI resolves to today):

- rules enabled: **53** — identical to 0.14.10
- `ruff check py_src/tokenizers tests` → `All checks passed!`
- `ruff format --check py_src/tokenizers tests` → `49 files already formatted`
- `ruff format --check py_src/tokenizers/*.pyi` → `8 files already formatted`
- `ty check py_src --exclude ...` → `All checks passed!`

The alternative was running `make style` and committing ~381 autofixes, which would adopt those 358 new rules across the binding in a PR that is nominally about unbreaking CI. Happy to do that separately if you'd rather take the new rules on purpose.

## Note

This is the same class of bug as the `cargo-readme` break fixed in #2287: an unpinned tool in CI changing behaviour under us. `ty` is unpinned in the same extra and passes today, but is exposed the same way.