### PR TITLE
fix(bpe): the byte gate classifies the delimiter, not the word

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
@@ -5,7 +5,7 @@ use crate::models::bpe::bpe_build_tables::BpeTables;
 use crate::models::bpe::bpe_scratch::BpeScratch;
 use crate::models::bpe::legacy_model::BPE;
 use crate::models::bpe::merge_hot_cold_queue::{
-    MergeScratch, build_byte_to_gate, two_tier_queue_merge,
+    MergeScratch, build_byte_to_gate, content_start, two_tier_queue_merge,
 };
 use crate::models::bpe::merge_multipass::merge_multipass;
 use crate::models::bpe::{Error, bpe_build_tables::At};
@@ -143,7 +143,8 @@ impl PipelineBPE {
         })
     }
 
-    /// Converts a word to symbols and merges it. The gate, indexed by the word's first byte, says
+    /// Converts a word to symbols and merges it. The gate, indexed by the word's first *content*
+    /// byte (past any delimiter the pre-tokenizer prepended -- see [`content_start`]), says
     /// which engine gets it: short words go to multipass, longer ones to the two-tier queue.
     /// `to_merge` is the caller's reusable symbol buffer -- it lives in the scratch so that a word
     /// costs no allocation. On return it holds the merged word as internal ids, which the caller
@@ -154,7 +155,9 @@ impl PipelineBPE {
         symbols: &mut Vec<u32>,
         merge_scratch: &mut MergeScratch,
     ) {
-        let gate: u16 = self.byte_to_mode[sequence.as_bytes()[0] as usize];
+        let bytes = sequence.as_bytes();
+        // Classify on the first content byte, not on the delimiter the pre-tokenizer prepended.
+        let gate: u16 = self.byte_to_mode[bytes[content_start(bytes)] as usize];
 
         if sequence.len() > gate as usize {
             // conversion writes the entries and cold keys directly: no intermediate rank array

--- a/tokenizers/tk-encode/src/models/bpe/merge_hot_cold_queue.rs
+++ b/tokenizers/tk-encode/src/models/bpe/merge_hot_cold_queue.rs
@@ -5,12 +5,44 @@ const GATE_ASCII: u16 = 24;
 pub fn build_byte_to_gate() -> [u16; 256] {
     let mut b2g = [GATE_MULTI; 256];
     b2g[..0x80].fill(GATE_ASCII);
-    // A ByteLevel pre-tokenizer hands us the leading space (" word"), so the first byte says
-    // nothing about the script of the rest: " <greek>" would read as ASCII and take the long gate.
+    // Kept for a word that is *only* a delimiter (a run of spaces), where there is no content to
+    // classify. Words with content are indexed past their delimiter -- see [`content_start`].
     for ws in *b" \t\n\r" {
         b2g[ws as usize] = GATE_MULTI;
     }
     b2g
+}
+
+/// Byte offset of the first byte that describes a word's script, skipping the delimiter a
+/// pre-tokenizer prepended.
+///
+/// The gate table is indexed by a single byte, so it has to be given one that actually says
+/// something about the word. A pre-tokenizer hands the model its delimiter attached to the front,
+/// and that delimiter says nothing about what follows: ByteLevel produces `" word"` or `"Ġword"`,
+/// Metaspace produces `"▁word"`. Indexing byte 0 classifies the delimiter instead of the content.
+///
+/// The miss is worst for Metaspace. `▁` is U+2581 (`E2 96 81`), so on a SentencePiece-style
+/// tokenizer -- llama-2, or any `Prepend` + `Replace(" " -> "▁")` config -- *every* word begins
+/// `0xE2` and takes `GATE_MULTI`, including the pure-ASCII English words that belong on
+/// `GATE_ASCII`. The whitespace special-case above shows the same hazard was already known for a
+/// literal leading space; `▁` simply never got the same treatment.
+///
+/// A word that is only a delimiter keeps offset 0: there is no content to classify, and the
+/// multibyte gate is the right conservative answer for it.
+///
+/// This cannot change the token stream. The gate only chooses which of two byte-exact merge
+/// engines runs (multipass or the two-tier queue), so it is purely a throughput decision.
+#[inline]
+pub fn content_start(bytes: &[u8]) -> usize {
+    match bytes {
+        // Metaspace `▁` (U+2581).
+        [0xE2, 0x96, 0x81, rest @ ..] if !rest.is_empty() => 3,
+        // ByteLevel `Ġ` (U+0120) -- the byte-level spelling of a leading space.
+        [0xC4, 0xA0, rest @ ..] if !rest.is_empty() => 2,
+        // A literal leading space, which a ByteLevel pre-tokenizer also hands over.
+        [ws, rest @ ..] if ws.is_ascii_whitespace() && !rest.is_empty() => 1,
+        _ => 0,
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/tokenizers/tk-encode/src/models/bpe/merge_hot_cold_queue.rs
+++ b/tokenizers/tk-encode/src/models/bpe/merge_hot_cold_queue.rs
@@ -16,17 +16,6 @@ pub fn build_byte_to_gate() -> [u16; 256] {
 /// ByteLevel produces `" word"` or `"Ġword"`,
 /// Metaspace produces `"▁word"`. Indexing byte 0 classifies the delimiter instead of the content.
 ///
-/// The miss is worst for Metaspace. `▁` is U+2581 (`E2 96 81`), so on a SentencePiece-style
-/// tokenizer -- llama-2, or any `Prepend` + `Replace(" " -> "▁")` config -- *every* word begins
-/// `0xE2` and takes `GATE_MULTI`, including the pure-ASCII English words that belong on
-/// `GATE_ASCII`. The whitespace special-case above shows the same hazard was already known for a
-/// literal leading space; `▁` simply never got the same treatment.
-///
-/// A word that is only a delimiter keeps offset 0: there is no content to classify, and the
-/// multibyte gate is the right conservative answer for it.
-///
-/// This cannot change the token stream. The gate only chooses which of two byte-exact merge
-/// engines runs (multipass or the two-tier queue), so it is purely a throughput decision.
 #[inline]
 pub fn content_start(bytes: &[u8]) -> usize {
     match bytes {

--- a/tokenizers/tk-encode/src/models/bpe/merge_hot_cold_queue.rs
+++ b/tokenizers/tk-encode/src/models/bpe/merge_hot_cold_queue.rs
@@ -13,12 +13,7 @@ pub fn build_byte_to_gate() -> [u16; 256] {
     b2g
 }
 
-/// Byte offset of the first byte that describes a word's script, skipping the delimiter a
-/// pre-tokenizer prepended.
-///
-/// The gate table is indexed by a single byte, so it has to be given one that actually says
-/// something about the word. A pre-tokenizer hands the model its delimiter attached to the front,
-/// and that delimiter says nothing about what follows: ByteLevel produces `" word"` or `"Ġword"`,
+/// ByteLevel produces `" word"` or `"Ġword"`,
 /// Metaspace produces `"▁word"`. Indexing byte 0 classifies the delimiter instead of the content.
 ///
 /// The miss is worst for Metaspace. `▁` is U+2581 (`E2 96 81`), so on a SentencePiece-style


### PR DESCRIPTION
Stacks on #2241 (`perf/bpe-merge`).

## The bug

`merge_word` picks its merge engine from a table indexed by the word's **first byte**:

```rust
let gate: u16 = self.byte_to_mode[sequence.as_bytes()[0] as usize];
if sequence.len() > gate as usize { /* two-tier queue */ } else { /* multipass */ }
```

But a pre-tokenizer hands the model its delimiter attached to the front, so byte 0 describes the *delimiter*, not the word. ByteLevel gives `"Ġword"` (`Ġ` = U+0120 = `C4 A0`); Metaspace gives `"▁word"` (`▁` = U+2581 = `E2 96 81`). Both are ≥ 0x80, so both take `GATE_MULTI` (8) — even when the word behind them is pure ASCII and belongs on `GATE_ASCII` (24).

`build_byte_to_gate` already special-cases a literal leading space down to `GATE_MULTI`, with a comment observing that the first byte "says nothing about the script of the rest". So the hazard was already known for `" word"`; the multibyte spellings of the same delimiter just never got the same treatment — and forcing them to MULTI is the wrong direction anyway. The fix is to classify the content.

## The change

`content_start` skips one leading delimiter (`▁`, `Ġ`, or ASCII whitespace) and `merge_word` indexes the gate there. A delimiter-only word (a run of spaces) keeps offset 0, where MULTI stays the right conservative answer.

## Reach

200 kB of `corpora/english.txt` under the gpt2 pre-tokenizer: **30.6%** of words are both inside the gate's decision band (9..24 bytes) and `Ġ`-prefixed with ASCII content, so they change engine. On `code.txt` only **0.9%** are.

## Measured

gpt2/english, 10 kB chunks, best-of-3 warm, three **interleaved** A/B rounds so machine drift cannot masquerade as the effect:

| | round 1 | round 2 | round 3 |
|---|---|---|---|
| with fix | 97.2 | 98.3 | 98.7 MB/s |
| without | 89.4 | 91.0 | 85.3 MB/s |

Non-overlapping ranges: **+10.7%**. `code`, `dense`, `russian`, `chinese` are flat, consistent with their much smaller affected fraction.

## Byte-exactness

Guaranteed by construction — the gate only chooses between two merge engines that must already produce identical output — and confirmed empirically: identical token counts on every model × corpus probed (llama-2, gpt2, llama-3 × english/code/dense/russian/chinese).

`cargo test -p tk-encode`: 311 passed, 1 failed. The failure (`normalizers::precompiled::tests::pipeline_precompiled_matches_legacy`, a missing data fixture) reproduces **unchanged with this commit stashed**, so it is pre-existing.

## What this is *not*

**Not a fix for llama-2.** Its config has `pre_tokenizer: None`, so a 10 kB chunk arrives as a single word whose length exceeds *both* gates — it always took the two-tier queue and still does. Measured: 31.4 vs 31.3 MB/s, i.e. unchanged. llama-2's cost is the merge over one unbounded span, and closing that needs a derived word split (e.g. proving from the vocab that no piece crosses a `▁` boundary, then splitting there), which is a separate change.