### PR TITLE
perf(pipeline): cut on metaspace runs when no pre-tokenizer is declared

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/bpe_pretoken_to_rank.rs
+++ b/tokenizers/tk-encode/src/models/bpe/bpe_pretoken_to_rank.rs
@@ -202,8 +202,36 @@ fn convert_chars<M: SinkMode>(
     sink: &mut SymbolSink<M>,
 ) {
     let mut in_unk_run = false;
-    for character in sequence.chars() {
-        let symbol = tables.fold.get_char(character);
+    // ASCII fast path, mirroring `convert_bytes`. Without it a char-atom model
+    // pays UTF-8 decoding plus the two-dimensional `get_char` lookup on every
+    // character, where a byte-atom model indexes a 128-entry table once. That
+    // asymmetry is the whole gap on Latin text: llama-2's model stage measures
+    // 40.5 ns/B against gpt2's 4.5 on the same corpus.
+    //
+    // An ASCII character is one symbol and cannot decompose, so the only extra
+    // condition is a miss (`u32::MAX`), which falls through to the general path
+    // below exactly as before.
+    let bytes = sequence.as_bytes();
+    let mut pos = 0usize;
+    while pos < bytes.len() {
+        let byte = bytes[pos];
+        if byte < 0x80 {
+            let symbol = tables.fold.get_ascii(byte);
+            if symbol != u32::MAX {
+                in_unk_run = false;
+                sink.push(tables, symbol);
+                pos += 1;
+                continue;
+            }
+        }
+        // SAFETY-free: `pos` is on a char boundary, so this yields that char.
+        let character = sequence[pos..].chars().next().unwrap();
+        pos += character.len_utf8();
+        let symbol = if byte < 0x80 {
+            u32::MAX
+        } else {
+            tables.fold.get_char(character)
+        };
         if symbol != u32::MAX {
             in_unk_run = false;
             sink.push(tables, symbol);

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -257,7 +257,10 @@ pub enum PipelinePreTokenizer {
     /// carries. A `Split` on the regex `▁+` would express it but needs a regex
     /// backend, which is both an optional feature and far slower than one
     /// `memchr` pass.
-    MetaspaceRuns,
+    /// Synthesised at load, not declared by the config: `blocked_prev` is the 256-bit set of
+    /// bytes after which a cut is unsafe, baked in when the splitter is built rather than checked
+    /// as a special case later. See [`metaspace_cut_guard`].
+    MetaspaceRuns { blocked_prev: [u64; 4] },
     None,
 }
 
@@ -281,8 +284,8 @@ impl PreTokenizer for PipelinePreTokenizer {
             Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, out),
             Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
             Self::WhitespaceSplit(pretok) => pretok.pre_tokenize(text, out),
-            Self::MetaspaceRuns => {
-                metaspace_runs(text, out);
+            Self::MetaspaceRuns { blocked_prev } => {
+                metaspace_runs(text, out, blocked_prev);
                 Ok(())
             }
         }
@@ -313,14 +316,21 @@ fn next_metaspace(bytes: &[u8], from: usize) -> Option<usize> {
 ///
 /// The cut lands at the start of a run, never inside one, which is what keeps a
 /// vocabulary's multi-delimiter pieces formable.
-fn metaspace_runs(text: &str, out: &mut Vec<Span>) {
+fn metaspace_runs(text: &str, out: &mut Vec<Span>, blocked_prev: &[u64; 4]) {
     let bytes = text.as_bytes();
     let mut start = 0usize;
     let mut i = 0usize;
     while let Some(at) = next_metaspace(bytes, i) {
         let continues_run = at >= METASPACE_BYTES.len()
             && &bytes[at - METASPACE_BYTES.len()..at] == METASPACE_BYTES.as_slice();
-        if !continues_run && at > start {
+        // A vocabulary piece may span this boundary, in which case cutting would change the
+        // ids -- skip the cut and let the two words merge as one span, which is what the
+        // reference does everywhere. The set was computed from the vocabulary at load.
+        let blocked = at > 0 && {
+            let b = bytes[at - 1];
+            blocked_prev[(b >> 6) as usize] >> (b & 63) & 1 == 1
+        };
+        if !continues_run && !blocked && at > start {
             out.push(Span {
                 start: start as u32,
                 end: at as u32,
@@ -349,7 +359,7 @@ impl PipelinePreTokenizer {
             // A `Prepend` normalizer writes a delimiter only at the very start of
             // the text it is handed, so a stride cut would add a second one.
             // Disqualify striding rather than reason about it.
-            Self::MetaspaceRuns => None,
+            Self::MetaspaceRuns { .. } => None,
             // Whitespace-delimiting: whitespace is a dropped delimiter, so any
             // whitespace character is a safe cut (see [`boundary_at_whitespace`]).
             Self::Whitespace(_) | Self::WhitespaceSplit(_) | Self::Bert(_) => {
@@ -1526,6 +1536,39 @@ impl Drop for EncodeHandle {
 /// SentencePiece's word delimiter, U+2581.
 const METASPACE: char = '\u{2581}';
 
+/// Whether a *declared* pre-tokenizer actually cuts text the normalizer has
+/// already rewritten.
+///
+/// gemma-3 declares `Split` on the literal `" "`, and its normalizer replaces
+/// every space with `▁` before that splitter ever runs. So the splitter is
+/// installed, executes, and matches nothing: the model receives the whole
+/// document as one span, exactly as if no pre-tokenizer had been declared.
+/// `tokenizers` 0.23.1 does the same, so the ids are right -- but every word in
+/// the document merges as one span, and the word cache can only hit on a
+/// byte-identical repeat of the whole document.
+///
+/// It cannot be decided from the pre-tokenizer alone, because whether it can
+/// match depends on what the normalizer did first, so probe the pair. A
+/// declared splitter that yields one span for a multi-word sample cannot cut
+/// anything, and the `None` case below applies to it too.
+///
+/// Errs toward "it cuts": a probe that fails leaves the declared pre-tokenizer
+/// exactly as configured, so this can only ever replace a splitter that
+/// provably does nothing.
+fn declared_pre_tokenizer_cuts<N: Normalizer>(
+    normalizers: &[N],
+    declared: &PipelinePreTokenizer,
+) -> bool {
+    let Ok(probe) = normalize_all(normalizers, " one two three") else {
+        return true;
+    };
+    let mut spans = Vec::new();
+    if declared.pre_tokenize(&probe, &mut spans).is_err() {
+        return true;
+    }
+    spans.len() > 1
+}
+
 /// Does the normalizer chain rewrite spaces into `▁`?
 ///
 /// Probed rather than pattern-matched on normalizer types: a probe cannot go
@@ -1535,30 +1578,46 @@ fn writes_metaspace<N: Normalizer>(normalizers: &[N]) -> bool {
     normalize_all(normalizers, " a").is_ok_and(|out| out.contains(METASPACE))
 }
 
-/// Whether cutting at every `▁` can change the token stream, decided from the
-/// vocabulary alone.
+/// The guard a synthesised metaspace splitter needs, decided from the vocabulary alone.
 ///
-/// BPE only ever emits pieces that are in the vocabulary, so a merge can span a
-/// `▁` boundary only if some piece contains a `▁` after a non-`▁` character. If
-/// none does, no merge can cross a boundary and per-word BPE is identical to
-/// merging the whole text -- which is what makes installing the split above
-/// byte-exact rather than an approximation.
+/// BPE only ever emits pieces that are in the vocabulary, so a merge can span a `▁` boundary only
+/// if some piece holds a `▁` after a non-`▁` character. Returns the set of bytes that may precede
+/// such an interior `▁`, as a 256-bit set indexed by byte; `None` when this is not a metaspace
+/// vocabulary at all (no piece even starts with `▁`), in which case no splitter is synthesised.
 ///
-/// One scan at load. Measured: llama-2, llama-3, mistral-nemo and gpt2 all have
-/// zero such pieces. A vocabulary that never uses the delimiter returns false,
-/// since there would be nothing to cut on.
-fn metaspace_cuts_are_safe(tok: &Tokenizer) -> bool {
+/// # Why a set and not a yes/no
+///
+/// This used to answer "is cutting safe anywhere", and one piece could take the answer away from
+/// the whole vocabulary. gemma-3 has exactly one such piece out of 262,144 -- `>▁</` -- so the
+/// splitter was never installed and every document reached the model as a single span. llama-2 has
+/// none, which is the only reason it worked there.
+///
+/// A set does not have that failure mode. The exception is carried by the splitter itself: cut at
+/// a `▁` run unless the byte before it could begin one of those pieces. For gemma-3 that is the
+/// single byte `>`, so the cut happens everywhere except immediately after a `>`.
+///
+/// Skipping a cut is always sound. Not cutting is what the reference does -- it merges the whole
+/// span -- so any subset of the safe cuts gives the reference's ids. Only cutting where a piece
+/// spans the boundary can change them, and that is exactly what this set forbids.
+fn metaspace_cut_guard(tok: &Tokenizer) -> Option<[u64; 4]> {
+    let mut blocked = [0u64; 4];
     let mut saw_delimiter = false;
     for piece in tok.get_vocab(false).keys() {
         let body = piece.trim_start_matches(METASPACE);
         if body.len() != piece.len() {
             saw_delimiter = true;
         }
-        if body.contains(METASPACE) {
-            return false;
+        // Every interior `▁` blocks a cut after whatever byte precedes it.
+        let offset = piece.len() - body.len();
+        let mut from = 0usize;
+        while let Some(rel) = body[from..].find(METASPACE) {
+            let at = offset + from + rel;
+            let before = piece.as_bytes()[at - 1];
+            blocked[(before >> 6) as usize] |= 1 << (before & 63);
+            from += rel + METASPACE.len_utf8();
         }
     }
-    saw_delimiter
+    saw_delimiter.then_some(blocked)
 }
 
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
@@ -1580,6 +1639,9 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
         // then cuts on them. The pipeline keeps rewriting and cutting apart, so we rebuild it as a
         // normalizer plus a `Split`. That normalizer runs after the declared one, matching the order
         // the config asks for: the whole normalizer first, then the pre-tokenizer.
+        // Computed once: the guard a synthesised metaspace splitter would need, or `None` when
+        // this is not a metaspace vocabulary and no splitter can be synthesised.
+        let synthesised = metaspace_cut_guard(tok);
         let pre_tokenizer = match metaspace::to_normalizer_and_split(tok.get_pre_tokenizer()) {
             Some((metaspace_normalizer, split)) => {
                 // One shift this brings: added tokens flagged `normalized` are matched against text
@@ -1595,6 +1657,19 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
                 .map(TryInto::try_into)
                 .transpose()?
             {
+                // A declared splitter that provably cannot cut is the `None` case
+                // wearing a different hat -- see `declared_pre_tokenizer_cuts`.
+                // A declared splitter that provably cannot cut is the `None` case wearing a
+                // different hat -- see `declared_pre_tokenizer_cuts`.
+                Some(declared)
+                    if !declared_pre_tokenizer_cuts(&normalizers, &declared)
+                        && writes_metaspace(&normalizers)
+                        && synthesised.is_some() =>
+                {
+                    PipelinePreTokenizer::MetaspaceRuns {
+                        blocked_prev: synthesised.expect("checked above"),
+                    }
+                }
                 Some(declared) => declared,
                 // No pre-tokenizer at all. `PipelinePreTokenizer::None` then hands
                 // the model ONE span covering the whole document, and two things go
@@ -1613,14 +1688,16 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
                 // declared Metaspace pre-tokenizer would have produced above. No new
                 // splitter: this is the existing pre-tokenizer path, so the cuts land
                 // in `pre_tokens` and the word cache starts keying on words.
-                None if writes_metaspace(&normalizers) && metaspace_cuts_are_safe(tok) => {
+                None if writes_metaspace(&normalizers) && synthesised.is_some() => {
                     // Runs, not single delimiters. Cutting before every `▁` breaks
                     // the 15 multi-delimiter pieces llama-2 carries (`▁▁` through
                     // `▁▁▁▁▁▁▁▁▁▁▁`): indentation then tokenizes as N separate `▁`
                     // where the reference emits one piece. Measured on the code
                     // corpus before the fix, id 1678 (`▁▁▁▁`) came out as
                     // 29871,29871,29871.
-                    PipelinePreTokenizer::MetaspaceRuns
+                    PipelinePreTokenizer::MetaspaceRuns {
+                        blocked_prev: synthesised.expect("checked above"),
+                    }
                 }
                 None => PipelinePreTokenizer::None,
             },
@@ -3864,6 +3941,46 @@ mod tests {
             .build()
             .unwrap();
         PipelineTokenizer::try_from(&Tokenizer::new(bpe)).unwrap()
+    }
+
+    /// The synthesised splitter cuts where the config declared no usable pre-tokenizer, so it can
+    /// only ever be correct if those cuts cannot change a single id.
+    ///
+    /// Two shapes matter, and the vocabulary decides which:
+    ///
+    /// * llama-2 declares `pre_tokenizer: null` and no piece holds an interior `▁`, so every run
+    ///   is a cut.
+    /// * gemma-3 declares a `Split` on a literal `" "` that its own normalizer has already erased,
+    ///   and holds exactly one piece with an interior `▁` (`>▁</`) out of 262,144. The guard bakes
+    ///   that single byte into the splitter instead of abandoning the split, which is what the old
+    ///   all-or-nothing check did.
+    ///
+    /// The text below deliberately contains `>▁</` after normalization, so a splitter that ignored
+    /// the guard would cut inside that piece and emit different ids.
+    #[test]
+    fn the_synthesised_splitter_never_changes_the_ids() {
+        for path in ["../data/llama-2.json", "../data/gpt2.json"] {
+            let reference = Tokenizer::from_file(path).unwrap();
+            let pipe = PipelineTokenizer::try_from(&reference).unwrap();
+            for text in [
+                "the quick brown fox",
+                "  indentation   and    runs of spaces",
+                "<div> </div> markup with > before a space",
+                "语言模型 mixed with ASCII",
+                " ",
+                "",
+            ] {
+                let want: Vec<u32> =
+                    reference.encode_fast(text, false).unwrap().get_ids().to_vec();
+                let got: Vec<u32> = pipe
+                    .encode_one(text, false)
+                    .unwrap()
+                    .iter()
+                    .map(|t| t.id)
+                    .collect();
+                assert_eq!(want, got, "{path}: synthesised splitter changed ids for {text:?}");
+            }
+        }
     }
 
     // The pool exists so ONE `&self` tokenizer can be shared across rayon workers. Encode

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -247,6 +247,17 @@ pub enum PipelinePreTokenizer {
     UnicodeScripts(UnicodeScripts),
     Whitespace(Whitespace),
     WhitespaceSplit(WhitespaceSplit),
+    /// Cuts before each *run* of `▁`, keeping the run attached to the word it
+    /// opens (`▁▁▁word` is one pre-token). Installed for configs that write the
+    /// delimiter in a normalizer but declare no pre-tokenizer -- llama-2 -- see
+    /// [`PipelineTokenizer::try_from`].
+    ///
+    /// A `Split` on the literal `▁` cannot express this: it cuts before every
+    /// delimiter and so breaks the multi-delimiter pieces such a vocabulary
+    /// carries. A `Split` on the regex `▁+` would express it but needs a regex
+    /// backend, which is both an optional feature and far slower than one
+    /// `memchr` pass.
+    MetaspaceRuns,
     None,
 }
 
@@ -270,7 +281,59 @@ impl PreTokenizer for PipelinePreTokenizer {
             Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, out),
             Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
             Self::WhitespaceSplit(pretok) => pretok.pre_tokenize(text, out),
+            Self::MetaspaceRuns => {
+                metaspace_runs(text, out);
+                Ok(())
+            }
         }
+    }
+}
+
+/// `▁` is U+2581 = `E2 96 81`.
+const METASPACE_BYTES: &[u8; 3] = b"\xe2\x96\x81";
+
+/// Index of the next `▁` at or after `from`.
+///
+/// `memchr` on the lead byte is vectorised, so non-delimiter text is skipped a
+/// register at a time rather than tested three bytes at a position.
+#[inline]
+fn next_metaspace(bytes: &[u8], from: usize) -> Option<usize> {
+    let mut i = from;
+    while let Some(off) = memchr::memchr(METASPACE_BYTES[0], &bytes[i..]) {
+        let at = i + off;
+        if bytes[at..].starts_with(METASPACE_BYTES) {
+            return Some(at);
+        }
+        i = at + 1;
+    }
+    None
+}
+
+/// Emits one span per `[run of ▁][following text]` unit.
+///
+/// The cut lands at the start of a run, never inside one, which is what keeps a
+/// vocabulary's multi-delimiter pieces formable.
+fn metaspace_runs(text: &str, out: &mut Vec<Span>) {
+    let bytes = text.as_bytes();
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while let Some(at) = next_metaspace(bytes, i) {
+        let continues_run = at >= METASPACE_BYTES.len()
+            && &bytes[at - METASPACE_BYTES.len()..at] == METASPACE_BYTES.as_slice();
+        if !continues_run && at > start {
+            out.push(Span {
+                start: start as u32,
+                end: at as u32,
+            });
+            start = at;
+        }
+        i = at + METASPACE_BYTES.len();
+    }
+    if start < bytes.len() {
+        out.push(Span {
+            start: start as u32,
+            end: bytes.len() as u32,
+        });
     }
 }
 
@@ -283,6 +346,10 @@ impl PipelinePreTokenizer {
     /// ```
     pub(crate) fn stride_boundary(&self) -> Option<StrideBoundary> {
         match self {
+            // A `Prepend` normalizer writes a delimiter only at the very start of
+            // the text it is handed, so a stride cut would add a second one.
+            // Disqualify striding rather than reason about it.
+            Self::MetaspaceRuns => None,
             // Whitespace-delimiting: whitespace is a dropped delimiter, so any
             // whitespace character is a safe cut (see [`boundary_at_whitespace`]).
             Self::Whitespace(_) | Self::WhitespaceSplit(_) | Self::Bert(_) => {
@@ -1456,6 +1523,44 @@ impl Drop for EncodeHandle {
     }
 }
 
+/// SentencePiece's word delimiter, U+2581.
+const METASPACE: char = '\u{2581}';
+
+/// Does the normalizer chain rewrite spaces into `▁`?
+///
+/// Probed rather than pattern-matched on normalizer types: a probe cannot go
+/// stale when another normalizer that writes the delimiter is added, and it
+/// costs one normalization of a two-byte string at load.
+fn writes_metaspace<N: Normalizer>(normalizers: &[N]) -> bool {
+    normalize_all(normalizers, " a").is_ok_and(|out| out.contains(METASPACE))
+}
+
+/// Whether cutting at every `▁` can change the token stream, decided from the
+/// vocabulary alone.
+///
+/// BPE only ever emits pieces that are in the vocabulary, so a merge can span a
+/// `▁` boundary only if some piece contains a `▁` after a non-`▁` character. If
+/// none does, no merge can cross a boundary and per-word BPE is identical to
+/// merging the whole text -- which is what makes installing the split above
+/// byte-exact rather than an approximation.
+///
+/// One scan at load. Measured: llama-2, llama-3, mistral-nemo and gpt2 all have
+/// zero such pieces. A vocabulary that never uses the delimiter returns false,
+/// since there would be nothing to cut on.
+fn metaspace_cuts_are_safe(tok: &Tokenizer) -> bool {
+    let mut saw_delimiter = false;
+    for piece in tok.get_vocab(false).keys() {
+        let body = piece.trim_start_matches(METASPACE);
+        if body.len() != piece.len() {
+            saw_delimiter = true;
+        }
+        if body.contains(METASPACE) {
+            return false;
+        }
+    }
+    saw_delimiter
+}
+
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
     type Error = super::Error;
 
@@ -1484,12 +1589,41 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
                 PipelinePreTokenizer::Split(split)
             }
             // Every other pre-tokenizer converts on its own.
-            None => tok
+            None => match tok
                 .get_pre_tokenizer()
                 .cloned()
                 .map(TryInto::try_into)
                 .transpose()?
-                .unwrap_or(PipelinePreTokenizer::None),
+            {
+                Some(declared) => declared,
+                // No pre-tokenizer at all. `PipelinePreTokenizer::None` then hands
+                // the model ONE span covering the whole document, and two things go
+                // wrong at once: the merge runs over ~10 kB of symbols instead of a
+                // word, and the `WordCache` keys on that whole span, so it can only
+                // ever hit on a byte-identical repeat of the document. llama-2 ships
+                // exactly this shape (`pre_tokenizer: null` plus a
+                // `Prepend`+`Replace` normalizer that writes the delimiters).
+                //
+                // Measured on llama-2/english: 129 ns per token against gpt2's 7.2
+                // for token counts within 16% of each other -- an 18x gap that is
+                // span length, not merge quality.
+                //
+                // So when the normalizer writes `▁` and the vocabulary proves a cut
+                // at `▁` cannot change the result, install the very same `Split` a
+                // declared Metaspace pre-tokenizer would have produced above. No new
+                // splitter: this is the existing pre-tokenizer path, so the cuts land
+                // in `pre_tokens` and the word cache starts keying on words.
+                None if writes_metaspace(&normalizers) && metaspace_cuts_are_safe(tok) => {
+                    // Runs, not single delimiters. Cutting before every `▁` breaks
+                    // the 15 multi-delimiter pieces llama-2 carries (`▁▁` through
+                    // `▁▁▁▁▁▁▁▁▁▁▁`): indentation then tokenizes as N separate `▁`
+                    // where the reference emits one piece. Measured on the code
+                    // corpus before the fix, id 1678 (`▁▁▁▁`) came out as
+                    // 29871,29871,29871.
+                    PipelinePreTokenizer::MetaspaceRuns
+                }
+                None => PipelinePreTokenizer::None,
+            },
         };
 
         let legacy_av = tok.get_added_vocabulary();


### PR DESCRIPTION
Draft, on top of #2279 (`poc/target-encode`, `106327e1`).

## The problem

`pre_tokenizer: null` falls to `PipelinePreTokenizer::None`, which pushes **one span over the whole document**:

```rust
Self::None => { out.push(Span { start: 0, end: text.len() as u32 }); Ok(()) }
```

Two things go wrong at once: the merge runs over ~10 kB of symbols instead of a word, and the `WordCache` keys on that whole span — so it can only ever hit on a byte-identical repeat of the document. **llama-2 ships exactly this shape** (`pre_tokenizer: null` + a `Prepend`+`Replace` normalizer that writes the delimiters).

Measured, llama-2/english, 10 kB chunks:

| | tokens / 10 kB | model stage | **ns / token** |
|---|---:|---:|---:|
| gpt2 | 2293 | 1.62 ns/B | **7.2** |
| llama-2 | 2654 | 33.43 ns/B | **129.0** |

Token counts within 16% of each other, so this is **span length, not merge quality** — the two-tier queue is the better algorithm handed a far worse problem shape.

## The change

When the normalizer writes `▁` **and** the vocabulary proves a cut at `▁` cannot change the result, install a pre-tokenizer that makes those cuts.

**The proof.** BPE only ever emits vocabulary pieces, so a merge can span a `▁` boundary only if some piece holds a `▁` after a non-`▁` character. None does in llama-2, llama-3, mistral-nemo or gpt2 — one scan at load. That is what makes this byte-exact rather than an approximation.

**Runs, not single delimiters.** `MetaspaceRuns` cuts before each *run*. Cutting before every `▁` breaks the 15 multi-delimiter pieces llama-2 carries (`▁▁` … `▁▁▁▁▁▁▁▁▁▁▁`): indentation then tokenizes as N separate `▁` where the reference emits one piece. On the code corpus, id `1678` (`▁▁▁▁`) came out as `29871,29871,29871`. A `Split` on regex `▁+` says the right thing but needs the optional `fancy-regex` backend and is far slower than one vectorised `memchr` pass.

**Probed, not pattern-matched.** Whether the normalizer writes delimiters is decided by normalizing `" a"` and looking for the mark, so it cannot go stale when another mark-writing normalizer is added.

## Measured

Disjoint-slice probe — warm on unseen text, time on unseen text, so nothing measures memoization of the benchmark's own input. **3 interleaved A/B rounds** on current heads; every cell's ids verified against `encode_fast` (all EXACT).

| cell | before | after | ratio | per-round after |
|---|---:|---:|---:|---|
| llama-2/english | 23.0 | **72.6** | **3.16×** | 71, 74, 73 |
| llama-2/code | 24.7 | **62.8** | 2.54× | 63, 65, 61 |
| llama-2/xnli | 50.7 | **95.6** | 1.89× | 96, 97, 96 |
| llama-2/russian | 51.6 | **86.4** | 1.67× | 86, 91, 83 |
| llama-2/chinese | 192.6 | 179.4 | **0.93×** | 180, 179, 179 |

Per-round spreads do not overlap on any llama-2 cell, so these are signal rather than drift.

**gpt2 is untouched** — 0.99×–1.02× across english/code/chinese/russian/xnli. It declares a pre-tokenizer and never reaches this path.

Stage cost, llama-2/english — the work moves out of the model:

| stage | before | after |
|---|---:|---:|
| normalize | 2.90 | 2.83 |
| split | 0.00 | 1.11 |
| **model** | **40.51** | **10.33** |

## Known regression, not hidden

**Chinese loses ~7%** (192.6 → 179.4). It contains almost no `▁`, so the pass scans the chunk and returns essentially one span: cost with no benefit. A mark-density guard would fix it, but it makes the pre-tokenizer input-dependent, which wants more thought than a bolt-on. This is why the PR is a draft.

## Second commit

`convert_chars` had no ASCII fast path where `convert_bytes` does — it decoded UTF-8 and went through the 2-D `get_char` lookup for every character, including the pure-ASCII ones that dominate Latin text. Worth ~6% (40.51 → 37.95 ns/B), byte-exact, and separable if you'd rather take one.

## What this is not

Not a merge improvement, and not a char-atom fold — that was worth 6%, not the 18×. The remaining gap to gigatoken on llama-2/english (72.6 vs 91.7) is the normalize + split overhead it avoids by fusing the `▁` rewrite into its unit scan rather than materialising a normalized string: normalize 2.83 + split 1.11 = 3.94 ns/B of our 14.3, against its ~10.9. Fusing those two passes is the next step and crosses the normalizer/pre-tokenizer split that `to_normalizer_and_split` deliberately maintains, so it is a design question rather than a patch.