### PR TITLE
perf(pipeline): move the model into the pipeline instead of cloning it

### DIFF
--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1461,11 +1461,54 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
 
     /// Build a pipeline from an existing [`Tokenizer`], cloning its components.
     ///
+    /// The clone of the model is the largest allocation on this path. Callers with no further use
+    /// for `tok` -- the usual case, since it exists only to parse the config -- should prefer the
+    /// `TryFrom<Tokenizer>` impl below, which moves the model instead.
+    fn try_from(tok: &Tokenizer) -> Result<Self> {
+        let model = tok.get_model().clone();
+        Self::build(tok, model)
+    }
+}
+
+impl TryFrom<Tokenizer> for PipelineTokenizer {
+    type Error = super::Error;
+
+    /// Build a pipeline from a [`Tokenizer`] it consumes, moving the model across instead of
+    /// copying it.
+    ///
+    /// # Why this exists
+    ///
+    /// A `Tokenizer` is usually constructed only to parse `tokenizer.json`, and dropped as soon
+    /// as the pipeline exists. Taking it by reference forces `model.clone()`, so while the compact
+    /// structures are built from the copy, the vocabulary and merge table are resident *twice* --
+    /// and it is the peak, not the steady state, that has to fit.
+    ///
+    /// Measured on llama-3 (128k vocab): the finished pipeline holds ~12 MB, the legacy model it
+    /// is built from holds ~37 MB, and conversion added 51 MB to peak RSS with the clone against
+    /// 25 MB without it. gpt2 goes from +11 MB to +2 MB.
+    ///
+    /// The pipeline's own footprint is identical either way; this changes only what is resident
+    /// *while* it is built.
+    fn try_from(mut tok: Tokenizer) -> Result<Self> {
+        // The husk is dropped along with `tok` when this returns. An empty `WordLevel` is the
+        // cheapest inhabitant of `ModelWrapper`: two empty maps, no allocation.
+        let model = std::mem::replace(
+            tok.get_model_mut(),
+            ModelWrapper::WordLevel(WordLevel::default()),
+        );
+        Self::build(&tok, model)
+    }
+}
+
+impl PipelineTokenizer {
+    /// The conversion both `TryFrom` impls share. `model` arrives owned, so this code does not
+    /// care whether the caller cloned it or handed over its own.
+    ///
     /// The base [`Tokenizer`] carries the legacy `crate::AddedVocabulary`; the pipeline uses the
     /// fast bucket `BucketAddedVocabulary`, so we rebuild it from the tokenizer's added tokens.
     /// Adding them in id order preserves ids (tokens present in the model reuse their model id, the
     /// rest keep their dense order), so the pipeline emits the same ids as the reference tokenizer.
-    fn try_from(tok: &Tokenizer) -> Result<Self> {
+    fn build(tok: &Tokenizer, owned_model: ModelWrapper) -> Result<Self> {
         let mut normalizers = Vec::new();
         if let Some(declared) = tok.get_normalizer() {
             normalizers.push(PipelineNormalizer::Declared(declared.clone()));
@@ -1561,7 +1604,7 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             }
         };
 
-        let model = tok.get_model();
+        let model = owned_model;
         if with_byte_level && !matches!(&model, ModelWrapper::BPE(_)) {
             let model_name = match model {
                 ModelWrapper::BPE(_) => "BPE",
@@ -1575,7 +1618,8 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             .into());
         }
 
-        let model = match model.clone() {
+        // Consumed, not cloned: `from_bpe` can free the source maps as it fills the compact ones.
+        let model = match model {
             ModelWrapper::BPE(model) => {
                 PipelineModel::BPE(PipelineBPE::from_bpe(model, with_byte_level)?)
             }
@@ -3730,6 +3774,36 @@ mod tests {
             .build()
             .unwrap();
         PipelineTokenizer::try_from(&Tokenizer::new(bpe)).unwrap()
+    }
+
+    /// The by-value conversion exists purely to avoid a copy, so the only thing that can go
+    /// wrong is that it converts something *differently* -- a moved-from field silently left
+    /// empty would still build a pipeline, just one that emits the wrong ids. Both paths must
+    /// agree token for token, on configs with different model and pre-tokenizer shapes.
+    #[test]
+    fn moving_the_tokenizer_converts_identically_to_borrowing_it() {
+        for path in ["../data/gpt2.json", "../data/llama-2.json", "../data/albert.json"] {
+            let borrowed = PipelineTokenizer::try_from(&Tokenizer::from_file(path).unwrap())
+                .unwrap_or_else(|e| panic!("{path}: borrow conversion failed: {e}"));
+            let moved = PipelineTokenizer::try_from(Tokenizer::from_file(path).unwrap())
+                .unwrap_or_else(|e| panic!("{path}: move conversion failed: {e}"));
+
+            for text in [
+                "Hello world!",
+                "  indented\tcode()  ",
+                "语言模型 mixed with ASCII",
+                "",
+            ] {
+                let ids = |p: &PipelineTokenizer| -> Vec<u32> {
+                    p.encode_one(text, true).unwrap().iter().map(|t| t.id).collect()
+                };
+                assert_eq!(
+                    ids(&borrowed),
+                    ids(&moved),
+                    "{path}: moving the model changed the ids for {text:?}"
+                );
+            }
+        }
     }
 
     // The pool exists so ONE `&self` tokenizer can be shared across rayon workers. Encode


### PR DESCRIPTION
Stacked on #2279 (`poc/target-encode`).

## What

`PipelineTokenizer::try_from(&Tokenizer)` cloned the whole `ModelWrapper` before consuming it. While the compact structures are being built from the copy, the vocabulary and merge table are resident **twice**.

A `Tokenizer` is normally constructed only to parse `tokenizer.json` and dropped as soon as the pipeline exists, so that copy is pure waste — and it lands on the *peak*, which is the number that has to fit in a container.

This adds `TryFrom<Tokenizer>`, which moves the model across, and factors the shared conversion into `PipelineTokenizer::build(&Tokenizer, ModelWrapper)`. The borrowing impl is unchanged for callers that still need their tokenizer afterwards.

```rust
// before — one full copy of the vocab and merges, thrown away immediately
let pipe = PipelineTokenizer::try_from(&Tokenizer::from_file(path)?)?;

// after — the model is moved
let pipe = PipelineTokenizer::try_from(Tokenizer::from_file(path)?)?;
```

## Numbers

Peak RSS contributed by the conversion step (`getrusage` high-water sampled before and after). The **live heap of the finished pipeline is identical either way** — this changes only what is resident while it is built.

| model | conversion Δpeak, before | after | total peak |
|---|---:|---:|---|
| gpt2 | +11.8 MB | **+1.7 MB** | 39.8 → 26.9 MB |
| llama-2 | +11.6 MB | **+4.1 MB** | 37.4 → 29.9 MB |
| llama-3 | +53.2 MB | **+25.9 MB** | 251.5 → 224.3 MB |
| mistral-nemo | +37.9 MB | **+11.7 MB** | 143.6 → 117.5 MB |
| deepseek-v4 | +45.8 MB | **+23.1 MB** | 110.9 → 88.4 MB |

## What this does not fix

The dominant term is `Tokenizer::from_file` itself: it peaks at **198 MB** parsing llama-3's 16 MB config into a `Tokenizer` that then holds 37 MB — a 5× overshoot inside the legacy loader, before the pipeline is involved at all. Separate problem, not addressed here.

For context on why this matters: measuring loaded-tokenizer memory by RSS delta is misleading in exactly this situation. RSS never falls, so a loader that builds an intermediate and discards it gets billed for memory it no longer holds. Measured by live heap, the pipeline holds **less than every other engine tested** (llama-3: 12 MB vs 29 MB for `tokenizers` 0.23.1, 48 MB for kitoken, 84 MB for gigatoken) — the MPHF does what it claims; the peak was the loader's fault.

## Test

A moved-from field left silently empty would still build a working pipeline that just emits wrong ids, so `moving_the_tokenizer_converts_identically_to_borrowing_it` asserts both conversions agree token for token on gpt2, llama-2 and albert. Full `tk-encode` suite passes (391 tests).