### PR TITLE
perf(bpe): gate the merge engine on the first content byte, not the delimiter

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
@@ -160,7 +160,27 @@ impl PipelineBPE {
         symbols: &mut Vec<u32>,
         merge_scratch: &mut MergeScratch,
     ) {
-        let gate: u16 = self.byte_to_mode[sequence.as_bytes()[0] as usize];
+        // Index the gate by the first *content* byte, not the first byte of the
+        // word. A ByteLevel pre-tokenizer writes a leading space as `Ġ`
+        // (C4 A0) and Metaspace writes `▁` (E2 96 81). Both are >= 0x80, so
+        // indexing the raw first byte handed every space-prefixed word the
+        // multibyte gate -- the one meant for CJK, at 8 bytes -- and sent any
+        // English word longer than that to the two-tier queue, which is the
+        // wrong engine for a short word.
+        //
+        // `build_byte_to_gate` already makes this argument for the ASCII space
+        // and maps " \t\n\r" to the multibyte gate, precisely because a
+        // leading delimiter says nothing about the script of the rest. The
+        // conclusion was right and the remedy was backwards: what follows the
+        // delimiter is what should choose, so look past it.
+        let bytes = sequence.as_bytes();
+        let first = match bytes {
+            [0xC4, 0xA0, rest @ ..] if !rest.is_empty() => rest[0],
+            [0xE2, 0x96, 0x81, rest @ ..] if !rest.is_empty() => rest[0],
+            [ws, rest @ ..] if ws.is_ascii_whitespace() && !rest.is_empty() => rest[0],
+            _ => bytes[0],
+        };
+        let gate: u16 = self.byte_to_mode[first as usize];
 
         if sequence.len() > gate as usize {
             // conversion writes the entries and cold keys directly: no intermediate rank array
@@ -335,6 +355,50 @@ impl pipeline::Model for PipelineBPE {
             symbols: Vec::with_capacity(64),
             merge: MergeScratch::default(),
             word_cache: self.cache_capacity.map(WordCache::new),
+        }
+    }
+}
+
+#[cfg(test)]
+mod gate_tests {
+    use crate::pipeline::PipelineTokenizer;
+    use crate::Tokenizer;
+
+    /// The gate picks which merge engine handles a word; both must produce the
+    /// same ids, so a change to the gate is only ever a performance change.
+    ///
+    /// This is the case that made the gate wrong: with a ByteLevel
+    /// pre-tokenizer the leading space becomes `Ġ` (C4 A0), so the raw first
+    /// byte is >= 0x80 and every space-prefixed word took the multibyte gate.
+    /// The words below straddle that 8-byte boundary in both directions, so
+    /// they exercise both engines, and any future change to the gate that also
+    /// changes an id fails here rather than in a benchmark.
+    #[test]
+    fn the_gate_never_changes_the_ids() {
+        let reference = Tokenizer::from_file("../data/gpt2.json").unwrap();
+        let pipe = PipelineTokenizer::try_from(&reference).unwrap();
+
+        // Short and long, space-prefixed and not, plus scripts whose own first
+        // byte is genuinely multibyte.
+        let cases = [
+            " a", " the", " short", " straddle", " understanding",
+            " internationalisation", "unprefixed", " ", "  ", "\tindented",
+            " 语言模型", " ελληνικά", " naïve café", " 🎉 emoji",
+            "mixed ascii and 中文 in one word",
+        ];
+        for text in cases {
+            let want: Vec<u32> = reference
+                .encode_fast(text, false)
+                .unwrap()
+                .get_ids()
+                .to_vec();
+            let got: Vec<u32> = pipe
+                .encode_one(text, false)
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect();
+            assert_eq!(want, got, "gate changed the ids for {text:?}");
         }
     }
 }


### PR DESCRIPTION
Stacked on #2279 (`poc/target-encode`).

## The bug

`merge_word` chooses between multipass and the two-tier queue using a per-byte gate indexed by the word's **first byte**:

```rust
let gate: u16 = self.byte_to_mode[sequence.as_bytes()[0] as usize];
if sequence.len() > gate as usize { /* queue */ } else { /* multipass */ }
```

With a ByteLevel pre-tokenizer the leading space arrives as `Ġ` = `C4 A0`; with Metaspace as `▁` = `E2 96 81`. Both are `>= 0x80`, so **every space-prefixed word was read as multibyte** and given `GATE_MULTI = 8` — the gate meant for CJK. Any English word longer than eight bytes went to the queue, which is the wrong engine for a short word.

`build_byte_to_gate` already makes exactly this argument for the ASCII space:

```rust
// A ByteLevel pre-tokenizer hands us the leading space (" word"), so the first byte says
// nothing about the script of the rest: " <greek>" would read as ASCII and take the long gate.
for ws in *b" \t\n\r" { b2g[ws as usize] = GATE_MULTI; }
```

The conclusion was right and the remedy was backwards. What follows the delimiter is what should choose, so look past it rather than pinning the delimiter to the conservative gate.

## Numbers

gpt2, ns/byte, 10 kB documents each encoded **once** with the cache carried across them — the streaming regime, not a replay. Median of 3 interleaved rounds.

| corpus | before | after | speedup | merges/byte |
|---|---:|---:|---:|---:|
| english | 9.02 | 7.13 | **1.27×** | 0.78 |
| chat-mistral | 6.28 | 5.04 | **1.25×** | 0.79 |
| chat-chatml | 6.07 | 4.95 | **1.23×** | 0.77 |
| math-latex | 7.04 | 5.76 | **1.22×** | 0.72 |
| code | 4.03 | 3.54 | 1.14× | 0.66 |
| agentic-swe | 4.27 | 3.92 | 1.09× | 0.45 |
| thai | 7.12 | 6.65 | 1.07× | 0.34 |
| chinese | 13.75 | 13.19 | 1.04× | 0.28 |
| hindi | 2.97 | 2.86 | 1.04× | 0.41 |

No corpus regresses. The gain tracks **merges per byte**: English prose, chat templates and LaTeX run 0.72–0.79 merges/byte against Chinese's 0.28, and that is where picking the wrong merge engine is paid most often.

Cross-check that this is really the gate and not something else — forcing every word through one engine:

| corpus | always queue | gate (before) | gate (after) | always multipass |
|---|---:|---:|---:|---:|
| english | 7.48 | 6.44 | **5.52** | 5.45 |
| chinese | 10.86 | 10.97 | **11.27** | 28.18 |

After the fix English sits essentially at the always-multipass optimum while Chinese stays on the queue, which is what the gate is supposed to do.

## Exactness

The gate only decides which engine runs, so this must not move a single id. Verified across the full benchmark matrix, 7 models × 30 corpora: **174 cells byte-exact** against `tokenizers` 0.23.1, 29 mismatched — the same 29 albert (Unigram) cells that already fail on `poc/target-encode` before this change. No new mismatch.

`the_gate_never_changes_the_ids` pins the case that was wrong, with words straddling the 8-byte boundary in both directions plus scripts whose first byte is genuinely multibyte. Full `tk-encode` suite passes (392 tests).

## Credit

Found because @ArthurZucker pointed out that multipass had benched well on exactly the corpora where this path was losing, and asked why it wasn't winning. It wasn't being selected.