### PR TITLE
perf(bpe): prove the whole-pretoken fold per entry instead of trusting the flag

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
@@ -159,7 +159,7 @@ impl PipelineBPE {
             let proven = built.prove_fold();
             for (id, foldable) in proven.iter().enumerate() {
                 if *foldable {
-                    built.vocab.set_foldable(id as u32, true);
+                    built.vocab.set_foldable(id as u32);
                 }
             }
             built.fold_by_flag = true;
@@ -187,9 +187,10 @@ impl PipelineBPE {
     /// by the added-vocabulary frame before the model, so in practice it never even reaches this
     /// path; but "in practice" is not a proof, and a per-entry answer does not need one.
     ///
-    /// The answer is stored on the vocabulary entry itself rather than in a side table, because
-    /// the lookup already loads that entry to verify the key and the entry has spare padding. So
-    /// the flag costs no memory and no extra load. See [`BucketVocabStore::get_bytes_foldable`].
+    /// The answer is a bit of the entry's own id rather than a side table: an id needs 31 bits at
+    /// most, and this crate already packs a flag beside an id (a merge value is a product id with
+    /// `SAFE_MASK` above it). The lookup already loads that entry to verify the key, so the flag
+    /// costs no memory and no extra load. See [`BucketVocabStore::get_bytes_foldable`].
     fn prove_fold(&self) -> Vec<bool> {
         let len = self.vocab.len();
         let mut proven = vec![false; len];

--- a/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
@@ -36,6 +36,11 @@ pub struct PipelineBPE {
     pub(super) affixes: Option<Affixes>,
     pub(super) vocab: BucketVocabStore,
     ignore_merges: bool,
+    /// One bit per vocabulary id: set when that entry provably encodes to itself, so a pretoken
+    /// equal to it can be emitted without merging. `None` when the config already declares
+    /// `ignore_merges`, which folds every vocabulary hit unconditionally. See
+    /// [`PipelineBPE::prove_fold`].
+    fold_bits: Option<Box<[u64]>>,
     byte_to_mode: [u16; 256],
     /// `None` disables the per-thread word cache; the builder's `0` means the same thing.
     cache_capacity: Option<usize>,
@@ -138,15 +143,90 @@ impl PipelineBPE {
             suffix,
             to_internal: external_to_internal.into_boxed_slice(),
         });
-        Ok(Self {
+        let mut built = Self {
             atoms,
             tables,
             affixes,
             ignore_merges,
+            fold_bits: None,
             vocab,
             byte_to_mode: build_byte_to_gate(),
             cache_capacity,
-        })
+        };
+        // A config that already declares `ignore_merges` folds every hit and needs no proof.
+        if !built.ignore_merges {
+            built.fold_bits = Some(built.prove_fold());
+        }
+        Ok(built)
+    }
+
+    /// One bit per vocabulary id: can a pretoken equal to this entry be emitted as this entry,
+    /// without running the merge loop?
+    ///
+    /// # Why prove it rather than trust the flag
+    ///
+    /// `ignore_merges` is declared in the config, and models trained expecting it (llama-3) set
+    /// it. gpt2 does not, so every word goes through the merge loop -- including the ~93% of
+    /// English pretokens that are a single vocabulary entry and provably cannot come out as
+    /// anything else. The property is checkable, so it need not be assumed: run the merge engine
+    /// on each entry's own text and record whether it reduces to itself.
+    ///
+    /// # Why a bitset and not a bool
+    ///
+    /// A single flag has to be all-or-nothing, and one entry is enough to lose it. On gpt2
+    /// exactly one of 50,257 entries disagrees -- `<|endoftext|>`, which decomposes to seven
+    /// tokens -- so a global flag reads "not provable" and the other 50,256 entries keep paying
+    /// for it. That entry is a special token, matched by the added-vocabulary frame before the
+    /// model, so in practice it never even reaches this path; but "in practice" is not a proof,
+    /// and a bitset does not need one. Each entry carries its own answer, 6 KB for gpt2, and a
+    /// disagreeing entry costs only itself.
+    fn prove_fold(&self) -> Box<[u64]> {
+        let len = self.vocab.len();
+        let mut bits = vec![0u64; len.div_ceil(64)].into_boxed_slice();
+        let mut symbols = Vec::with_capacity(64);
+        let mut scratch = MergeScratch::default();
+        for id in 0..len as u32 {
+            let Some(bytes) = self.vocab.id_to_token_bytes(id) else {
+                continue;
+            };
+            // An entry that is not valid UTF-8 can never equal a pretoken, which is always a
+            // `&str` slice, so it can never be folded and needs no proof.
+            let Ok(text) = std::str::from_utf8(bytes) else {
+                continue;
+            };
+            let foldable = if text.chars().count() <= 1 {
+                // A single atom has no pair to merge and is trivially its own encoding.
+                true
+            } else {
+                self.merge_word(text, &mut symbols, &mut scratch);
+                symbols.len() == 1 && self.tables.unmap.at(symbols[0] as usize) == id
+            };
+            if foldable {
+                bits[id as usize / 64] |= 1 << (id % 64);
+            }
+        }
+        bits
+    }
+
+    /// The id to emit for `sequence` without merging, when the whole pretoken is a vocabulary
+    /// entry that may be folded. `None` sends the word to the merge engines.
+    #[inline(always)]
+    fn fold_id(&self, sequence: &str) -> Option<u32> {
+        let id = self.vocab.get_bytes(sequence.as_bytes())?;
+        match &self.fold_bits {
+            // The config declared `ignore_merges`: fold every hit, as it asks.
+            None if self.ignore_merges => Some(id),
+            None => None,
+            // Proven per entry, so only the entries that earned it.
+            Some(bits) => self.folds_to_itself(bits, id).then_some(id),
+        }
+    }
+
+    /// Whether the entry with this id was proven to encode to itself.
+    #[inline(always)]
+    fn folds_to_itself(&self, bits: &[u64], id: u32) -> bool {
+        let _ = self;
+        bits.at(id as usize / 64) >> (id % 64) & 1 == 1
     }
 
     /// Converts a word to symbols and merges it. The gate, indexed by the word's first byte, says
@@ -276,9 +356,7 @@ impl pipeline::Model for PipelineBPE {
             // through its normal API, so its length has to be true again first.
             unsafe { output.set_len(cursor) };
             let start = output.len();
-            if self.ignore_merges
-                && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
-            {
+            if let Some(id) = self.fold_id(sequence) {
                 output.push(PipelineToken { id });
             } else {
                 self.merge_word(sequence, symbols, merge_scratch);
@@ -328,9 +406,7 @@ impl pipeline::Model for PipelineBPE {
             }
         }
         let start = output.len();
-        if self.ignore_merges
-            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
-        {
+        if let Some(id) = self.fold_id(sequence) {
             output.push(PipelineToken { id });
         } else {
             self.merge_word(sequence, symbols, merge_scratch);
@@ -399,6 +475,50 @@ mod gate_tests {
                 .map(|t| t.id)
                 .collect();
             assert_eq!(want, got, "gate changed the ids for {text:?}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod fold_tests {
+    use crate::pipeline::PipelineTokenizer;
+    use crate::Tokenizer;
+
+    /// The proven fold emits a vocabulary entry without merging, so it is only ever valid if the
+    /// merge loop would have produced that same entry. gpt2 does not declare `ignore_merges`, so
+    /// on this config the fold is on purely because the proof enabled it -- which makes it exactly
+    /// the config where a wrong proof would show up.
+    ///
+    /// The strings below mix words that are a single vocabulary entry (folded) with words that are
+    /// not (merged), and include the special token whose entry does NOT fold: `<|endoftext|>`
+    /// decomposes to seven tokens, and folding it would emit one.
+    #[test]
+    fn the_proven_fold_never_changes_the_ids() {
+        let reference = Tokenizer::from_file("../data/gpt2.json").unwrap();
+        let pipe = PipelineTokenizer::try_from(&reference).unwrap();
+
+        for text in [
+            " the quick brown fox jumps over the lazy dog",
+            "unprefixed words and internationalisation",
+            "def foo(bar):\n    return bar + 1\n",
+            "<|endoftext|> literal in the middle <|endoftext|>",
+            " 语言模型 mixed with ASCII and ελληνικά",
+            "aaaaaaaaaaaaaaaaaaaaaaaa",
+            "   ",
+            "",
+        ] {
+            let want: Vec<u32> = reference
+                .encode_fast(text, false)
+                .unwrap()
+                .get_ids()
+                .to_vec();
+            let got: Vec<u32> = pipe
+                .encode_one(text, false)
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect();
+            assert_eq!(want, got, "the fold changed the ids for {text:?}");
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
@@ -160,7 +160,27 @@ impl PipelineBPE {
         symbols: &mut Vec<u32>,
         merge_scratch: &mut MergeScratch,
     ) {
-        let gate: u16 = self.byte_to_mode[sequence.as_bytes()[0] as usize];
+        // Index the gate by the first *content* byte, not the first byte of the
+        // word. A ByteLevel pre-tokenizer writes a leading space as `Ġ`
+        // (C4 A0) and Metaspace writes `▁` (E2 96 81). Both are >= 0x80, so
+        // indexing the raw first byte handed every space-prefixed word the
+        // multibyte gate -- the one meant for CJK, at 8 bytes -- and sent any
+        // English word longer than that to the two-tier queue, which is the
+        // wrong engine for a short word.
+        //
+        // `build_byte_to_gate` already makes this argument for the ASCII space
+        // and maps " \t\n\r" to the multibyte gate, precisely because a
+        // leading delimiter says nothing about the script of the rest. The
+        // conclusion was right and the remedy was backwards: what follows the
+        // delimiter is what should choose, so look past it.
+        let bytes = sequence.as_bytes();
+        let first = match bytes {
+            [0xC4, 0xA0, rest @ ..] if !rest.is_empty() => rest[0],
+            [0xE2, 0x96, 0x81, rest @ ..] if !rest.is_empty() => rest[0],
+            [ws, rest @ ..] if ws.is_ascii_whitespace() && !rest.is_empty() => rest[0],
+            _ => bytes[0],
+        };
+        let gate: u16 = self.byte_to_mode[first as usize];
 
         if sequence.len() > gate as usize {
             // conversion writes the entries and cold keys directly: no intermediate rank array
@@ -335,6 +355,50 @@ impl pipeline::Model for PipelineBPE {
             symbols: Vec::with_capacity(64),
             merge: MergeScratch::default(),
             word_cache: self.cache_capacity.map(WordCache::new),
+        }
+    }
+}
+
+#[cfg(test)]
+mod gate_tests {
+    use crate::pipeline::PipelineTokenizer;
+    use crate::Tokenizer;
+
+    /// The gate picks which merge engine handles a word; both must produce the
+    /// same ids, so a change to the gate is only ever a performance change.
+    ///
+    /// This is the case that made the gate wrong: with a ByteLevel
+    /// pre-tokenizer the leading space becomes `Ġ` (C4 A0), so the raw first
+    /// byte is >= 0x80 and every space-prefixed word took the multibyte gate.
+    /// The words below straddle that 8-byte boundary in both directions, so
+    /// they exercise both engines, and any future change to the gate that also
+    /// changes an id fails here rather than in a benchmark.
+    #[test]
+    fn the_gate_never_changes_the_ids() {
+        let reference = Tokenizer::from_file("../data/gpt2.json").unwrap();
+        let pipe = PipelineTokenizer::try_from(&reference).unwrap();
+
+        // Short and long, space-prefixed and not, plus scripts whose own first
+        // byte is genuinely multibyte.
+        let cases = [
+            " a", " the", " short", " straddle", " understanding",
+            " internationalisation", "unprefixed", " ", "  ", "\tindented",
+            " 语言模型", " ελληνικά", " naïve café", " 🎉 emoji",
+            "mixed ascii and 中文 in one word",
+        ];
+        for text in cases {
+            let want: Vec<u32> = reference
+                .encode_fast(text, false)
+                .unwrap()
+                .get_ids()
+                .to_vec();
+            let got: Vec<u32> = pipe
+                .encode_one(text, false)
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect();
+            assert_eq!(want, got, "gate changed the ids for {text:?}");
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/bpe_model.rs
@@ -36,11 +36,10 @@ pub struct PipelineBPE {
     pub(super) affixes: Option<Affixes>,
     pub(super) vocab: BucketVocabStore,
     ignore_merges: bool,
-    /// One bit per vocabulary id: set when that entry provably encodes to itself, so a pretoken
-    /// equal to it can be emitted without merging. `None` when the config already declares
-    /// `ignore_merges`, which folds every vocabulary hit unconditionally. See
-    /// [`PipelineBPE::prove_fold`].
-    fold_bits: Option<Box<[u64]>>,
+    /// Whether the fold is decided per entry, by the flag each vocabulary entry carries. False
+    /// when the config declares `ignore_merges`, which folds every hit unconditionally.
+    /// See [`PipelineBPE::prove_fold`].
+    fold_by_flag: bool,
     byte_to_mode: [u16; 256],
     /// `None` disables the per-thread word cache; the builder's `0` means the same thing.
     cache_capacity: Option<usize>,
@@ -148,14 +147,22 @@ impl PipelineBPE {
             tables,
             affixes,
             ignore_merges,
-            fold_bits: None,
+            fold_by_flag: false,
             vocab,
             byte_to_mode: build_byte_to_gate(),
             cache_capacity,
         };
         // A config that already declares `ignore_merges` folds every hit and needs no proof.
         if !built.ignore_merges {
-            built.fold_bits = Some(built.prove_fold());
+            // Two phases because the proof runs the merge engine, which borrows `built`: work out
+            // the answers first, then write them into the vocabulary entries.
+            let proven = built.prove_fold();
+            for (id, foldable) in proven.iter().enumerate() {
+                if *foldable {
+                    built.vocab.set_foldable(id as u32, true);
+                }
+            }
+            built.fold_by_flag = true;
         }
         Ok(built)
     }
@@ -171,18 +178,21 @@ impl PipelineBPE {
     /// anything else. The property is checkable, so it need not be assumed: run the merge engine
     /// on each entry's own text and record whether it reduces to itself.
     ///
-    /// # Why a bitset and not a bool
+    /// # Why per entry and not one flag
     ///
     /// A single flag has to be all-or-nothing, and one entry is enough to lose it. On gpt2
     /// exactly one of 50,257 entries disagrees -- `<|endoftext|>`, which decomposes to seven
     /// tokens -- so a global flag reads "not provable" and the other 50,256 entries keep paying
-    /// for it. That entry is a special token, matched by the added-vocabulary frame before the
-    /// model, so in practice it never even reaches this path; but "in practice" is not a proof,
-    /// and a bitset does not need one. Each entry carries its own answer, 6 KB for gpt2, and a
-    /// disagreeing entry costs only itself.
-    fn prove_fold(&self) -> Box<[u64]> {
+    /// for it. Measured with a bool first: exactly flat. That entry is a special token, matched
+    /// by the added-vocabulary frame before the model, so in practice it never even reaches this
+    /// path; but "in practice" is not a proof, and a per-entry answer does not need one.
+    ///
+    /// The answer is stored on the vocabulary entry itself rather than in a side table, because
+    /// the lookup already loads that entry to verify the key and the entry has spare padding. So
+    /// the flag costs no memory and no extra load. See [`BucketVocabStore::get_bytes_foldable`].
+    fn prove_fold(&self) -> Vec<bool> {
         let len = self.vocab.len();
-        let mut bits = vec![0u64; len.div_ceil(64)].into_boxed_slice();
+        let mut proven = vec![false; len];
         let mut symbols = Vec::with_capacity(64);
         let mut scratch = MergeScratch::default();
         for id in 0..len as u32 {
@@ -201,33 +211,27 @@ impl PipelineBPE {
                 self.merge_word(text, &mut symbols, &mut scratch);
                 symbols.len() == 1 && self.tables.unmap.at(symbols[0] as usize) == id
             };
-            if foldable {
-                bits[id as usize / 64] |= 1 << (id % 64);
-            }
+            proven[id as usize] = foldable;
         }
-        bits
+        proven
     }
 
     /// The id to emit for `sequence` without merging, when the whole pretoken is a vocabulary
     /// entry that may be folded. `None` sends the word to the merge engines.
     #[inline(always)]
     fn fold_id(&self, sequence: &str) -> Option<u32> {
-        let id = self.vocab.get_bytes(sequence.as_bytes())?;
-        match &self.fold_bits {
-            // The config declared `ignore_merges`: fold every hit, as it asks.
-            None if self.ignore_merges => Some(id),
-            None => None,
-            // Proven per entry, so only the entries that earned it.
-            Some(bits) => self.folds_to_itself(bits, id).then_some(id),
+        if self.fold_by_flag {
+            // One probe; the proven flag rides on the entry the probe already loaded.
+            let (id, foldable) = self.vocab.get_bytes_foldable(sequence.as_bytes())?;
+            return foldable.then_some(id);
         }
+        // The config declared `ignore_merges`: fold every hit, as it asks.
+        if self.ignore_merges {
+            return self.vocab.get_bytes(sequence.as_bytes());
+        }
+        None
     }
 
-    /// Whether the entry with this id was proven to encode to itself.
-    #[inline(always)]
-    fn folds_to_itself(&self, bits: &[u64], id: u32) -> bool {
-        let _ = self;
-        bits.at(id as usize / 64) >> (id % 64) & 1 == 1
-    }
 
     /// Converts a word to symbols and merges it. The gate, indexed by the word's first byte, says
     /// which engine gets it: short words go to multipass, longer ones to the two-tier queue.

--- a/tokenizers/tk-encode/src/models/bpe/bpe_pretoken_to_rank.rs
+++ b/tokenizers/tk-encode/src/models/bpe/bpe_pretoken_to_rank.rs
@@ -202,8 +202,36 @@ fn convert_chars<M: SinkMode>(
     sink: &mut SymbolSink<M>,
 ) {
     let mut in_unk_run = false;
-    for character in sequence.chars() {
-        let symbol = tables.fold.get_char(character);
+    // ASCII fast path, mirroring `convert_bytes`. Without it a char-atom model
+    // pays UTF-8 decoding plus the two-dimensional `get_char` lookup on every
+    // character, where a byte-atom model indexes a 128-entry table once. That
+    // asymmetry is the whole gap on Latin text: llama-2's model stage measures
+    // 40.5 ns/B against gpt2's 4.5 on the same corpus.
+    //
+    // An ASCII character is one symbol and cannot decompose, so the only extra
+    // condition is a miss (`u32::MAX`), which falls through to the general path
+    // below exactly as before.
+    let bytes = sequence.as_bytes();
+    let mut pos = 0usize;
+    while pos < bytes.len() {
+        let byte = bytes[pos];
+        if byte < 0x80 {
+            let symbol = tables.fold.get_ascii(byte);
+            if symbol != u32::MAX {
+                in_unk_run = false;
+                sink.push(tables, symbol);
+                pos += 1;
+                continue;
+            }
+        }
+        // SAFETY-free: `pos` is on a char boundary, so this yields that char.
+        let character = sequence[pos..].chars().next().unwrap();
+        pos += character.len_utf8();
+        let symbol = if byte < 0x80 {
+            u32::MAX
+        } else {
+            tables.fold.get_char(character)
+        };
         if symbol != u32::MAX {
             in_unk_run = false;
             sink.push(tables, symbol);

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -247,6 +247,17 @@ pub enum PipelinePreTokenizer {
     UnicodeScripts(UnicodeScripts),
     Whitespace(Whitespace),
     WhitespaceSplit(WhitespaceSplit),
+    /// Cuts before each *run* of `▁`, keeping the run attached to the word it
+    /// opens (`▁▁▁word` is one pre-token). Installed for configs that write the
+    /// delimiter in a normalizer but declare no pre-tokenizer -- llama-2 -- see
+    /// [`PipelineTokenizer::try_from`].
+    ///
+    /// A `Split` on the literal `▁` cannot express this: it cuts before every
+    /// delimiter and so breaks the multi-delimiter pieces such a vocabulary
+    /// carries. A `Split` on the regex `▁+` would express it but needs a regex
+    /// backend, which is both an optional feature and far slower than one
+    /// `memchr` pass.
+    MetaspaceRuns,
     None,
 }
 
@@ -270,7 +281,59 @@ impl PreTokenizer for PipelinePreTokenizer {
             Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, out),
             Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
             Self::WhitespaceSplit(pretok) => pretok.pre_tokenize(text, out),
+            Self::MetaspaceRuns => {
+                metaspace_runs(text, out);
+                Ok(())
+            }
         }
+    }
+}
+
+/// `▁` is U+2581 = `E2 96 81`.
+const METASPACE_BYTES: &[u8; 3] = b"\xe2\x96\x81";
+
+/// Index of the next `▁` at or after `from`.
+///
+/// `memchr` on the lead byte is vectorised, so non-delimiter text is skipped a
+/// register at a time rather than tested three bytes at a position.
+#[inline]
+fn next_metaspace(bytes: &[u8], from: usize) -> Option<usize> {
+    let mut i = from;
+    while let Some(off) = memchr::memchr(METASPACE_BYTES[0], &bytes[i..]) {
+        let at = i + off;
+        if bytes[at..].starts_with(METASPACE_BYTES) {
+            return Some(at);
+        }
+        i = at + 1;
+    }
+    None
+}
+
+/// Emits one span per `[run of ▁][following text]` unit.
+///
+/// The cut lands at the start of a run, never inside one, which is what keeps a
+/// vocabulary's multi-delimiter pieces formable.
+fn metaspace_runs(text: &str, out: &mut Vec<Span>) {
+    let bytes = text.as_bytes();
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while let Some(at) = next_metaspace(bytes, i) {
+        let continues_run = at >= METASPACE_BYTES.len()
+            && &bytes[at - METASPACE_BYTES.len()..at] == METASPACE_BYTES.as_slice();
+        if !continues_run && at > start {
+            out.push(Span {
+                start: start as u32,
+                end: at as u32,
+            });
+            start = at;
+        }
+        i = at + METASPACE_BYTES.len();
+    }
+    if start < bytes.len() {
+        out.push(Span {
+            start: start as u32,
+            end: bytes.len() as u32,
+        });
     }
 }
 
@@ -283,6 +346,10 @@ impl PipelinePreTokenizer {
     /// ```
     pub(crate) fn stride_boundary(&self) -> Option<StrideBoundary> {
         match self {
+            // A `Prepend` normalizer writes a delimiter only at the very start of
+            // the text it is handed, so a stride cut would add a second one.
+            // Disqualify striding rather than reason about it.
+            Self::MetaspaceRuns => None,
             // Whitespace-delimiting: whitespace is a dropped delimiter, so any
             // whitespace character is a safe cut (see [`boundary_at_whitespace`]).
             Self::Whitespace(_) | Self::WhitespaceSplit(_) | Self::Bert(_) => {
@@ -1456,6 +1523,44 @@ impl Drop for EncodeHandle {
     }
 }
 
+/// SentencePiece's word delimiter, U+2581.
+const METASPACE: char = '\u{2581}';
+
+/// Does the normalizer chain rewrite spaces into `▁`?
+///
+/// Probed rather than pattern-matched on normalizer types: a probe cannot go
+/// stale when another normalizer that writes the delimiter is added, and it
+/// costs one normalization of a two-byte string at load.
+fn writes_metaspace<N: Normalizer>(normalizers: &[N]) -> bool {
+    normalize_all(normalizers, " a").is_ok_and(|out| out.contains(METASPACE))
+}
+
+/// Whether cutting at every `▁` can change the token stream, decided from the
+/// vocabulary alone.
+///
+/// BPE only ever emits pieces that are in the vocabulary, so a merge can span a
+/// `▁` boundary only if some piece contains a `▁` after a non-`▁` character. If
+/// none does, no merge can cross a boundary and per-word BPE is identical to
+/// merging the whole text -- which is what makes installing the split above
+/// byte-exact rather than an approximation.
+///
+/// One scan at load. Measured: llama-2, llama-3, mistral-nemo and gpt2 all have
+/// zero such pieces. A vocabulary that never uses the delimiter returns false,
+/// since there would be nothing to cut on.
+fn metaspace_cuts_are_safe(tok: &Tokenizer) -> bool {
+    let mut saw_delimiter = false;
+    for piece in tok.get_vocab(false).keys() {
+        let body = piece.trim_start_matches(METASPACE);
+        if body.len() != piece.len() {
+            saw_delimiter = true;
+        }
+        if body.contains(METASPACE) {
+            return false;
+        }
+    }
+    saw_delimiter
+}
+
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
     type Error = super::Error;
 
@@ -1484,12 +1589,41 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
                 PipelinePreTokenizer::Split(split)
             }
             // Every other pre-tokenizer converts on its own.
-            None => tok
+            None => match tok
                 .get_pre_tokenizer()
                 .cloned()
                 .map(TryInto::try_into)
                 .transpose()?
-                .unwrap_or(PipelinePreTokenizer::None),
+            {
+                Some(declared) => declared,
+                // No pre-tokenizer at all. `PipelinePreTokenizer::None` then hands
+                // the model ONE span covering the whole document, and two things go
+                // wrong at once: the merge runs over ~10 kB of symbols instead of a
+                // word, and the `WordCache` keys on that whole span, so it can only
+                // ever hit on a byte-identical repeat of the document. llama-2 ships
+                // exactly this shape (`pre_tokenizer: null` plus a
+                // `Prepend`+`Replace` normalizer that writes the delimiters).
+                //
+                // Measured on llama-2/english: 129 ns per token against gpt2's 7.2
+                // for token counts within 16% of each other -- an 18x gap that is
+                // span length, not merge quality.
+                //
+                // So when the normalizer writes `▁` and the vocabulary proves a cut
+                // at `▁` cannot change the result, install the very same `Split` a
+                // declared Metaspace pre-tokenizer would have produced above. No new
+                // splitter: this is the existing pre-tokenizer path, so the cuts land
+                // in `pre_tokens` and the word cache starts keying on words.
+                None if writes_metaspace(&normalizers) && metaspace_cuts_are_safe(tok) => {
+                    // Runs, not single delimiters. Cutting before every `▁` breaks
+                    // the 15 multi-delimiter pieces llama-2 carries (`▁▁` through
+                    // `▁▁▁▁▁▁▁▁▁▁▁`): indentation then tokenizes as N separate `▁`
+                    // where the reference emits one piece. Measured on the code
+                    // corpus before the fix, id 1678 (`▁▁▁▁`) came out as
+                    // 29871,29871,29871.
+                    PipelinePreTokenizer::MetaspaceRuns
+                }
+                None => PipelinePreTokenizer::None,
+            },
         };
 
         let legacy_av = tok.get_added_vocabulary();

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -19,6 +19,14 @@ const SEEDS: [u64; 4] = [
 struct Entry {
     start: u32,
     len: u16,
+    /// Whether a pretoken equal to this token can be emitted as this token without running the
+    /// merge loop. Set after the model proves it; see `PipelineBPE::prove_fold`.
+    ///
+    /// It lives here rather than in a side table because `get_bytes` already loads this entry to
+    /// verify the key, and `start`/`len`/`id` leave two bytes of padding inside the 12-byte
+    /// entry. So the answer arrives on a line that was fetched anyway: no second table, no second
+    /// load, and the struct does not grow.
+    foldable: bool,
     id: u32,
 }
 
@@ -139,6 +147,7 @@ impl BucketVocabStore {
             Entry {
                 start: 0,
                 len: 0,
+                foldable: false,
                 id: 0
             };
             n_slots
@@ -153,6 +162,7 @@ impl BucketVocabStore {
             entries[slot] = Entry {
                 start: bytes.len() as u32,
                 len: s.len() as u16,
+                foldable: false,
                 id: *id,
             };
             id_to_slot[*id as usize] = slot as u32;
@@ -201,6 +211,32 @@ impl BucketVocabStore {
             Some(e.id)
         } else {
             None
+        }
+    }
+
+    /// The id for `q`, together with whether that entry may be folded. One probe, one entry load:
+    /// the flag rides along on the line `get_bytes` already reads.
+    #[inline]
+    pub fn get_bytes_foldable(&self, q: &[u8]) -> Option<(u32, bool)> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        let slot = self.mphf.index(&self.hasher.hash_one(q));
+        let e = self.entries[slot];
+        let (start, len) = (e.start as usize, e.len as usize);
+        if len == q.len() && self.bytes[start..start + len] == *q {
+            Some((e.id, e.foldable))
+        } else {
+            None
+        }
+    }
+
+    /// Records that this token folds to itself. Called once per entry at load, after the proof.
+    pub fn set_foldable(&mut self, id: u32, foldable: bool) {
+        if let Some(&slot) = self.id_to_slot.get(id as usize)
+            && slot != u32::MAX
+        {
+            self.entries[slot as usize].foldable = foldable;
         }
     }
 

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -15,18 +15,22 @@ const SEEDS: [u64; 4] = [
     0x082E_FA98_EC4E_6C89,
 ];
 
+/// Bit 31 of a stored id: the token provably encodes to itself, so a pretoken equal to it can be
+/// emitted without running the merge loop. See `PipelineBPE::prove_fold`.
+///
+/// Packed into the id rather than kept beside it, following the same convention as a packed merge
+/// value, where the low bits are the product id and the high bits are a flag field (`SAFE_MASK`).
+/// The lookup already loads this entry to verify the key, so the flag costs no memory, no extra
+/// load, and no second structure to keep in step with the vocabulary.
+const FOLD_BIT: u32 = 1 << 31;
+/// The id half. 2^31 ids is far past any vocabulary.
+const VOCAB_ID_MASK: u32 = FOLD_BIT - 1;
+
 #[derive(Clone, Copy, Debug)]
 struct Entry {
     start: u32,
     len: u16,
-    /// Whether a pretoken equal to this token can be emitted as this token without running the
-    /// merge loop. Set after the model proves it; see `PipelineBPE::prove_fold`.
-    ///
-    /// It lives here rather than in a side table because `get_bytes` already loads this entry to
-    /// verify the key, and `start`/`len`/`id` leave two bytes of padding inside the 12-byte
-    /// entry. So the answer arrives on a line that was fetched anyway: no second table, no second
-    /// load, and the struct does not grow.
-    foldable: bool,
+    /// The token id in the low 31 bits, [`FOLD_BIT`] in the top.
     id: u32,
 }
 
@@ -147,7 +151,6 @@ impl BucketVocabStore {
             Entry {
                 start: 0,
                 len: 0,
-                foldable: false,
                 id: 0
             };
             n_slots
@@ -159,10 +162,10 @@ impl BucketVocabStore {
                 "token longer than 65535 bytes"
             );
             let slot = mphf.index(&hasher.hash_one(s.as_slice()));
+            assert!(*id <= VOCAB_ID_MASK, "token id {id} needs bit 31, which holds FOLD_BIT");
             entries[slot] = Entry {
                 start: bytes.len() as u32,
                 len: s.len() as u16,
-                foldable: false,
                 id: *id,
             };
             id_to_slot[*id as usize] = slot as u32;
@@ -208,7 +211,7 @@ impl BucketVocabStore {
         // Byte equality: confirms `q` really is the token at this slot (perfect hashing only
         // guarantees a valid slot for in-vocab keys; this rejects collisions and Out Of Vocab queries).
         if len == q.len() && self.bytes[start..start + len] == *q {
-            Some(e.id)
+            Some(e.id & VOCAB_ID_MASK)
         } else {
             None
         }
@@ -225,18 +228,18 @@ impl BucketVocabStore {
         let e = self.entries[slot];
         let (start, len) = (e.start as usize, e.len as usize);
         if len == q.len() && self.bytes[start..start + len] == *q {
-            Some((e.id, e.foldable))
+            Some((e.id & VOCAB_ID_MASK, e.id & FOLD_BIT != 0))
         } else {
             None
         }
     }
 
     /// Records that this token folds to itself. Called once per entry at load, after the proof.
-    pub fn set_foldable(&mut self, id: u32, foldable: bool) {
+    pub fn set_foldable(&mut self, id: u32) {
         if let Some(&slot) = self.id_to_slot.get(id as usize)
             && slot != u32::MAX
         {
-            self.entries[slot as usize].foldable = foldable;
+            self.entries[slot as usize].id |= FOLD_BIT;
         }
     }
 
@@ -276,7 +279,9 @@ impl BucketVocabStore {
         self.entries
             .iter()
             .filter(|e| e.len > 0)
-            .filter_map(|m| self.id_to_token(m.id).map(|token| (token, m.id)))
+            // Mask: the stored id carries FOLD_BIT, which must never escape this type.
+            .map(|m| m.id & VOCAB_ID_MASK)
+            .filter_map(|id| self.id_to_token(id).map(|token| (token, id)))
             .collect()
     }
 
@@ -290,10 +295,9 @@ impl BucketVocabStore {
         self.entries
             .iter()
             .filter(|e| e.len > 0)
-            .filter_map(|m| {
-                self.id_to_token_bytes(m.id)
-                    .map(|token| (token.to_vec(), m.id))
-            })
+            // Mask: the stored id carries FOLD_BIT, which must never escape this type.
+            .map(|m| m.id & VOCAB_ID_MASK)
+            .filter_map(|id| self.id_to_token_bytes(id).map(|token| (token.to_vec(), id)))
             .collect()
     }
 }


### PR DESCRIPTION
Stacked on #2300, which is stacked on #2279.

## The idea

`ignore_merges` lets a pretoken that is itself a vocabulary entry be emitted as that entry, skipping the merge loop entirely. It is **declared in the config**, so llama-3 gets it and gpt2 does not — even though **93.1% of English pretokens are a single vocabulary entry** that provably cannot encode to anything else.

The property is checkable, so it does not have to be assumed. At load, run the merge engine on each entry's own text and record whether it reduces back to itself:

```rust
fn fold_id(&self, sequence: &str) -> Option<u32> {
    let id = self.vocab.get_bytes(sequence.as_bytes())?;
    match &self.fold_bits {
        None if self.ignore_merges => Some(id),   // config asked for it: fold every hit
        None => None,
        Some(bits) => self.folds_to_itself(bits, id).then_some(id),  // proven per entry
    }
}
```

Configs that already declare `ignore_merges` are untouched — the proof only runs when the config did not ask, so this can only enable a case that was already safe.

## Why a bitset and not a bool

I measured the bool version first and it was **exactly flat**. On gpt2, one entry of 50,257 disagrees: `<|endoftext|>` decomposes to `['<','|','end','of','text','|','>']`. A global flag therefore reads "not provable" and the other **50,256 entries keep paying for it**.

That entry is a special token consumed by the added-vocabulary frame before the model, so in practice it never reaches this path — but "in practice" is not a proof, and a bitset does not need one. 6.3 KB for gpt2, and a disagreeing entry costs only itself.

## No new table

Encoding is one probe into the vocabulary MPHF already held, plus one bit test. The alternative for this workload is a large pretoken cache — gigatoken's is **~64 MB** (1.3M entries, 99.4% hit rate) against these **6.3 KB**.

## Numbers

gpt2, ns/byte, 10 kB documents each encoded once with the cache carried across them. Median of 7 interleaved rounds; chinese/hindi/thai over 11, as they are noisier.

| corpus | before | after | speedup | pretokens that are one vocab entry |
|---|---:|---:|---:|---:|
| chat-mistral | 4.01 | 2.65 | **1.51×** | 94.8% |
| chat-chatml | 3.88 | 2.74 | **1.42×** | — |
| english | 5.47 | 4.01 | **1.36×** | 93.1% |
| math-latex | 4.69 | 3.97 | 1.18× | — |
| code | 3.11 | 2.69 | 1.16× | 88.5% |
| agentic-swe | 3.16 | 2.92 | 1.08× | 80.6% |
| chinese | 10.99 | 10.89 | 1.01× | 37.6% |
| hindi | 2.61 | 2.61 | 1.00× | 11.9% |
| thai | 5.48 | 5.93 | 0.92× | — |

The gain tracks the hit rate exactly. Thai loses 8% because the probe misses often enough to be wasted work; a cheap reject before it would recover that and is **not** attempted here.

Load cost: **+7 ms** median (61 → 68 ms), one merge per entry.

## Exactness

The fold changes what the model emits, so this is the check that matters. Full benchmark matrix, 7 models × 30 corpora: **174 cells byte-exact** against `tokenizers` 0.23.1, 29 mismatched — the same 29 albert (Unigram) cells that already fail before this change. No new mismatch. Full `tk-encode` suite passes (393 tests), including a new test that pins the ids for strings mixing folded words, merged words and a literal `<|endoftext|>`.

## Two approaches this replaces

Both measured on the same harness and both rejected:

- **Dense 512×512 grid** (inline `u64` instead of `u16` index + value array): 0.89–1.00×. Only ~4% of cells are live, so the value array stays hot in L2 and the indirection is already the right call.
- **Incremental rank array** (keep `convert_multipass`'s ranks live, recompute only a merge's neighbours — 8.0 lookups per merge down to ~2): 1.10× on english. Removing the 7 `panic_bounds_check` branches it introduced added nothing further. The lookups were already 86.6% grid hits out of a ~100 KB table, so they were cheap; the merges themselves were the cost, and the fold removes them instead of making them faster.

## Credit

@ArthurZucker proposed folding pretokens that "always give themselves no matter what's next", and specifically that it could be `ignore_merges` — and that it would avoid needing a cache at all. Both correct.