### PR TITLE
perf(bpe): prove the whole-pretoken fold per entry instead of trusting the flag (onto #2241)

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -179,23 +179,7 @@ impl PipelineBPE {
     /// One bit per vocabulary id: can a pretoken equal to this entry be emitted as this entry,
     /// without running the merge loop?
     ///
-    /// # Why prove it rather than trust the flag
-    ///
-    /// `ignore_merges` is declared in the config, and models trained expecting it (llama-3) set
-    /// it. gpt2 does not, so every word goes through the merge loop -- including the ~93% of
-    /// English pretokens that are a single vocabulary entry and provably cannot come out as
-    /// anything else. The property is checkable, so it need not be assumed: run the merge engine
-    /// on each entry's own text and record whether it reduces to itself.
-    ///
-    /// # Why per entry and not one flag
-    ///
-    /// A single flag has to be all-or-nothing, and one entry is enough to lose it. On gpt2
-    /// exactly one of 50,257 entries disagrees -- `<|endoftext|>`, which decomposes to seven
-    /// tokens -- so a global flag reads "not provable" and the other 50,256 entries keep paying
-    /// for it. That entry is a special token, matched by the added-vocabulary frame before the
-    /// model, so in practice it never even reaches this path; but "in practice" is not a proof,
-    /// and a per-entry answer does not need one. The answer is a bit of the entry's own id, so it
-    /// costs no memory and no extra load, and a disagreeing entry costs only itself.
+    /// We replace the old "ignore_merges" with something that actually ignores whether or not the flag was set.
     fn prove_fold(&self) -> Vec<bool> {
         let len = self.vocab.len();
         let mut proven = vec![false; len];

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -50,6 +50,11 @@ pub struct PipelineBPE {
     pub(super) affixes: Option<Affixes>,
     pub(super) vocab: BucketVocabStore,
     ignore_merges: bool,
+    /// One bit per vocabulary id: set when that entry provably encodes to itself, so a pretoken
+    /// equal to it can be emitted without merging. `None` when the config already declares
+    /// `ignore_merges`, which folds every vocabulary hit unconditionally. See
+    /// [`PipelineBPE::prove_fold`].
+    fold_bits: Option<Box<[u64]>>,
     byte_to_gate: [u16; 256],
 }
 
@@ -148,14 +153,82 @@ impl PipelineBPE {
             suffix,
             to_internal: external_to_internal.into_boxed_slice(),
         });
-        Ok(Self {
+        let mut built = Self {
             atoms,
             tables,
             affixes,
             ignore_merges,
+            fold_bits: None,
             vocab,
             byte_to_gate: build_byte_to_gate(),
-        })
+        };
+        // A config that already declares `ignore_merges` folds every hit and needs no proof.
+        if !built.ignore_merges {
+            built.fold_bits = Some(built.prove_fold());
+        }
+        Ok(built)
+    }
+
+    /// One bit per vocabulary id: can a pretoken equal to this entry be emitted as this entry,
+    /// without running the merge loop?
+    ///
+    /// # Why prove it rather than trust the flag
+    ///
+    /// `ignore_merges` is declared in the config, and models trained expecting it (llama-3) set
+    /// it. gpt2 does not, so every word goes through the merge loop -- including the ~93% of
+    /// English pretokens that are a single vocabulary entry and provably cannot come out as
+    /// anything else. The property is checkable, so it need not be assumed: run the merge engine
+    /// on each entry's own text and record whether it reduces to itself.
+    ///
+    /// # Why a bitset and not a bool
+    ///
+    /// A single flag has to be all-or-nothing, and one entry is enough to lose it. On gpt2
+    /// exactly one of 50,257 entries disagrees -- `<|endoftext|>`, which decomposes to seven
+    /// tokens -- so a global flag reads "not provable" and the other 50,256 entries keep paying
+    /// for it. That entry is a special token, matched by the added-vocabulary frame before the
+    /// model, so in practice it never even reaches this path; but "in practice" is not a proof,
+    /// and a bitset does not need one. Each entry carries its own answer, 6.3 KB for gpt2, and a
+    /// disagreeing entry costs only itself.
+    fn prove_fold(&self) -> Box<[u64]> {
+        let len = self.vocab.len();
+        let mut bits = vec![0u64; len.div_ceil(64)].into_boxed_slice();
+        let mut symbols = Vec::with_capacity(64);
+        let mut scratch = QueueScratch::default();
+        for id in 0..len as u32 {
+            let Some(bytes) = self.vocab.id_to_token_bytes(id) else {
+                continue;
+            };
+            // An entry that is not valid UTF-8 can never equal a pretoken, which is always a
+            // `&str` slice, so it can never be folded and needs no proof.
+            let Ok(text) = std::str::from_utf8(bytes) else {
+                continue;
+            };
+            let foldable = if text.chars().count() <= 1 {
+                // A single atom has no pair to merge and is trivially its own encoding.
+                true
+            } else {
+                self.merge_word(text, &mut symbols, &mut scratch);
+                symbols.len() == 1 && self.tables.unmap.at(symbols[0] as usize) == id
+            };
+            if foldable {
+                bits[id as usize / 64] |= 1 << (id % 64);
+            }
+        }
+        bits
+    }
+
+    /// The id to emit for `sequence` without merging, when the whole pretoken is a vocabulary
+    /// entry that may be folded. `None` sends the word to the merge engines.
+    #[inline(always)]
+    fn fold_id(&self, sequence: &str) -> Option<u32> {
+        let id = self.vocab.get_bytes(sequence.as_bytes())?;
+        match &self.fold_bits {
+            // The config declared `ignore_merges`: fold every hit, as it asks.
+            None if self.ignore_merges => Some(id),
+            None => None,
+            // Proven per entry, so only the entries that earned it.
+            Some(bits) => (bits.at(id as usize / 64) >> (id % 64) & 1 == 1).then_some(id),
+        }
     }
 
     /// Converts a word to symbols and merges it. The gate, indexed by the word's first *content*
@@ -214,9 +287,7 @@ impl pipeline::Model for PipelineBPE {
             return Ok(());
         }
 
-        if self.ignore_merges
-            && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
-        {
+        if let Some(id) = self.fold_id(sequence) {
             output.push(PipelineToken { id });
             return Ok(());
         }
@@ -236,6 +307,52 @@ impl pipeline::Model for PipelineBPE {
         Self::Scratch {
             symbols: Vec::with_capacity(64),
             queue: QueueScratch::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod fold_tests {
+    use crate::pipeline::PipelineTokenizer;
+    use crate::Tokenizer;
+
+    /// The proven fold emits a vocabulary entry without merging, so it is only valid if the merge
+    /// loop would have produced that same entry. gpt2 does not declare `ignore_merges`, so here
+    /// the fold is on purely because the proof enabled it -- which makes it the config where a
+    /// wrong proof would show up.
+    ///
+    /// These strings mix words that are a single vocabulary entry (folded) with words that are
+    /// not (merged), and include the special token whose entry does NOT fold: `<|endoftext|>`
+    /// decomposes to seven tokens, and folding it would emit one.
+    #[test]
+    fn the_proven_fold_never_changes_the_ids() {
+        let reference = Tokenizer::from_file("../data/gpt2.json").unwrap();
+        let pipe = PipelineTokenizer::try_from(&reference).unwrap();
+
+        for text in [
+            " the quick brown fox jumps over the lazy dog",
+            "unprefixed words and internationalisation",
+            "def foo(bar):\n    return bar + 1\n",
+            "<|endoftext|> literal in the middle <|endoftext|>",
+            " 语言模型 mixed with ASCII and ελληνικά",
+            "aaaaaaaaaaaaaaaaaaaaaaaa",
+            "   ",
+            "",
+        ] {
+            let want: Vec<u32> = reference
+                .encode_fast(text, false)
+                .unwrap()
+                .get_ids()
+                .to_vec();
+            let got: Vec<u32> = pipe
+                .encode(text, false)
+                .wait()
+                .unwrap()
+                .remove(0)
+                .iter()
+                .map(|t| t.id)
+                .collect();
+            assert_eq!(want, got, "the fold changed the ids for {text:?}");
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -50,11 +50,10 @@ pub struct PipelineBPE {
     pub(super) affixes: Option<Affixes>,
     pub(super) vocab: BucketVocabStore,
     ignore_merges: bool,
-    /// One bit per vocabulary id: set when that entry provably encodes to itself, so a pretoken
-    /// equal to it can be emitted without merging. `None` when the config already declares
-    /// `ignore_merges`, which folds every vocabulary hit unconditionally. See
-    /// [`PipelineBPE::prove_fold`].
-    fold_bits: Option<Box<[u64]>>,
+    /// Whether the fold is decided per entry, by the bit each vocabulary entry carries in its id.
+    /// False when the config declares `ignore_merges`, which folds every hit unconditionally.
+    /// See [`PipelineBPE::prove_fold`].
+    fold_by_flag: bool,
     byte_to_gate: [u16; 256],
 }
 
@@ -158,13 +157,21 @@ impl PipelineBPE {
             tables,
             affixes,
             ignore_merges,
-            fold_bits: None,
+            fold_by_flag: false,
             vocab,
             byte_to_gate: build_byte_to_gate(),
         };
         // A config that already declares `ignore_merges` folds every hit and needs no proof.
         if !built.ignore_merges {
-            built.fold_bits = Some(built.prove_fold());
+            // Two phases because the proof runs the merge engine, which borrows `built`: work out
+            // the answers first, then set the bit on each entry that earned it.
+            let proven = built.prove_fold();
+            for (id, foldable) in proven.iter().enumerate() {
+                if *foldable {
+                    built.vocab.set_foldable(id as u32);
+                }
+            }
+            built.fold_by_flag = true;
         }
         Ok(built)
     }
@@ -180,18 +187,18 @@ impl PipelineBPE {
     /// anything else. The property is checkable, so it need not be assumed: run the merge engine
     /// on each entry's own text and record whether it reduces to itself.
     ///
-    /// # Why a bitset and not a bool
+    /// # Why per entry and not one flag
     ///
     /// A single flag has to be all-or-nothing, and one entry is enough to lose it. On gpt2
     /// exactly one of 50,257 entries disagrees -- `<|endoftext|>`, which decomposes to seven
     /// tokens -- so a global flag reads "not provable" and the other 50,256 entries keep paying
     /// for it. That entry is a special token, matched by the added-vocabulary frame before the
     /// model, so in practice it never even reaches this path; but "in practice" is not a proof,
-    /// and a bitset does not need one. Each entry carries its own answer, 6.3 KB for gpt2, and a
-    /// disagreeing entry costs only itself.
-    fn prove_fold(&self) -> Box<[u64]> {
+    /// and a per-entry answer does not need one. The answer is a bit of the entry's own id, so it
+    /// costs no memory and no extra load, and a disagreeing entry costs only itself.
+    fn prove_fold(&self) -> Vec<bool> {
         let len = self.vocab.len();
-        let mut bits = vec![0u64; len.div_ceil(64)].into_boxed_slice();
+        let mut proven = vec![false; len];
         let mut symbols = Vec::with_capacity(64);
         let mut scratch = QueueScratch::default();
         for id in 0..len as u32 {
@@ -210,25 +217,25 @@ impl PipelineBPE {
                 self.merge_word(text, &mut symbols, &mut scratch);
                 symbols.len() == 1 && self.tables.unmap.at(symbols[0] as usize) == id
             };
-            if foldable {
-                bits[id as usize / 64] |= 1 << (id % 64);
-            }
+            proven[id as usize] = foldable;
         }
-        bits
+        proven
     }
 
     /// The id to emit for `sequence` without merging, when the whole pretoken is a vocabulary
     /// entry that may be folded. `None` sends the word to the merge engines.
     #[inline(always)]
     fn fold_id(&self, sequence: &str) -> Option<u32> {
-        let id = self.vocab.get_bytes(sequence.as_bytes())?;
-        match &self.fold_bits {
-            // The config declared `ignore_merges`: fold every hit, as it asks.
-            None if self.ignore_merges => Some(id),
-            None => None,
-            // Proven per entry, so only the entries that earned it.
-            Some(bits) => (bits.at(id as usize / 64) >> (id % 64) & 1 == 1).then_some(id),
+        if self.fold_by_flag {
+            // One probe; the proven bit is part of the id that probe already returned.
+            let (id, foldable) = self.vocab.get_bytes_foldable(sequence.as_bytes())?;
+            return foldable.then_some(id);
         }
+        // The config declared `ignore_merges`: fold every hit, as it asks.
+        if self.ignore_merges {
+            return self.vocab.get_bytes(sequence.as_bytes());
+        }
+        None
     }
 
     /// Converts a word to symbols and merges it. The gate, indexed by the word's first *content*

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -15,10 +15,22 @@ const SEEDS: [u64; 4] = [
     0x082E_FA98_EC4E_6C89,
 ];
 
+/// Bit 31 of a stored id: the token provably encodes to itself, so a pretoken equal to it can be
+/// emitted without running the merge loop. See `PipelineBPE::prove_fold`.
+///
+/// Packed into the id rather than kept beside it, following the same convention as a packed merge
+/// value, where the low bits are the product id and the high bits are a flag field (`SAFE_MASK`).
+/// The lookup already loads this entry to verify the key, so the flag costs no memory, no extra
+/// load, and no second structure to keep in step with the vocabulary.
+const FOLD_BIT: u32 = 1 << 31;
+/// The id half. 2^31 ids is far past any vocabulary.
+const VOCAB_ID_MASK: u32 = FOLD_BIT - 1;
+
 #[derive(Clone, Copy, Debug)]
 struct Entry {
     start: u32,
     len: u16,
+    /// The token id in the low 31 bits, [`FOLD_BIT`] in the top.
     id: u32,
 }
 
@@ -144,6 +156,7 @@ impl BucketVocabStore {
                 s.len() <= u16::MAX as usize,
                 "token longer than 65535 bytes"
             );
+            assert!(*id <= VOCAB_ID_MASK, "token id {id} needs bit 31, which holds FOLD_BIT");
             let slot = mphf.index(&hasher.hash_one(s.as_slice()));
             entries[slot] = Entry {
                 start: bytes.len() as u32,
@@ -193,9 +206,35 @@ impl BucketVocabStore {
         // Byte equality: confirms `q` really is the token at this slot (perfect hashing only
         // guarantees a valid slot for in-vocab keys; this rejects collisions and Out Of Vocab queries).
         if len == q.len() && self.bytes[start..start + len] == *q {
-            Some(e.id)
+            Some(e.id & VOCAB_ID_MASK)
         } else {
             None
+        }
+    }
+
+    /// The id for `q`, together with whether that entry may be folded. One probe and one entry
+    /// load: the flag is a bit of the id the probe already read.
+    #[inline]
+    pub fn get_bytes_foldable(&self, q: &[u8]) -> Option<(u32, bool)> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        let slot = self.mphf.index(&self.hasher.hash_one(q));
+        let e = self.entries[slot];
+        let (start, len) = (e.start as usize, e.len as usize);
+        if len == q.len() && self.bytes[start..start + len] == *q {
+            Some((e.id & VOCAB_ID_MASK, e.id & FOLD_BIT != 0))
+        } else {
+            None
+        }
+    }
+
+    /// Records that this token folds to itself. Called once per entry at load, after the proof.
+    pub fn set_foldable(&mut self, id: u32) {
+        if let Some(&slot) = self.id_to_slot.get(id as usize)
+            && slot != u32::MAX
+        {
+            self.entries[slot as usize].id |= FOLD_BIT;
         }
     }
 
@@ -235,7 +274,9 @@ impl BucketVocabStore {
         self.entries
             .iter()
             .filter(|e| e.len > 0)
-            .filter_map(|m| self.id_to_token(m.id).map(|token| (token, m.id)))
+            // Mask: the stored id carries FOLD_BIT, which must never escape this type.
+            .map(|m| m.id & VOCAB_ID_MASK)
+            .filter_map(|id| self.id_to_token(id).map(|token| (token, id)))
             .collect()
     }
 
@@ -249,10 +290,9 @@ impl BucketVocabStore {
         self.entries
             .iter()
             .filter(|e| e.len > 0)
-            .filter_map(|m| {
-                self.id_to_token_bytes(m.id)
-                    .map(|token| (token.to_vec(), m.id))
-            })
+            // Mask: the stored id carries FOLD_BIT, which must never escape this type.
+            .map(|m| m.id & VOCAB_ID_MASK)
+            .filter_map(|id| self.id_to_token_bytes(id).map(|token| (token.to_vec(), id)))
             .collect()
     }
 }


### PR DESCRIPTION
Same change as #2301, ported onto `perf/bpe-merge` (#2241) so it lands on the branch that already carries the content-byte gate from #2294.

## The idea

`ignore_merges` lets a pretoken that is itself a vocabulary entry be emitted as that entry, skipping the merge loop. It is **declared in the config**, so llama-3 gets it and gpt2 does not — even though **93.1% of English pretokens are a single vocabulary entry** that provably cannot encode to anything else.

The property is checkable, so it need not be assumed. At load, run the merge engine on each entry's own text and record whether it reduces back to itself.

```rust
fn fold_id(&self, sequence: &str) -> Option<u32> {
    let id = self.vocab.get_bytes(sequence.as_bytes())?;
    match &self.fold_bits {
        None if self.ignore_merges => Some(id),   // config asked for it: fold every hit
        None => None,
        Some(bits) => (bits.at(id as usize / 64) >> (id % 64) & 1 == 1).then_some(id),
    }
}
```

Configs that already declare `ignore_merges` are untouched — the proof only runs when the config did not ask, so this can only enable a case that was already safe.

## Why a bitset and not a bool

The bool version measured **exactly flat**. On gpt2 one entry of 50,257 disagrees: `<|endoftext|>` decomposes to `['<','|','end','of','text','|','>']`. A global flag therefore reads "not provable" and the other **50,256 entries keep paying for it**. That entry is a special token consumed by the added-vocabulary frame before the model, so in practice it never reaches this path — but "in practice" is not a proof, and a bitset does not need one. 6.3 KB for gpt2; a disagreeing entry costs only itself.

## No new table

One probe into the vocabulary MPHF already held, plus one bit test. The alternative for this workload is a large pretoken cache — gigatoken's is **~64 MB** (1.3M entries, 99.4% hit rate) against these **6.3 KB**.

## Numbers

Measured on the #2279 encode path (identical change), gpt2, ns/byte, 10 kB documents each encoded once with the cache carried. Median of 7 interleaved rounds; chinese/hindi/thai over 11.

| corpus | before | after | speedup | pretokens that are one vocab entry |
|---|---:|---:|---:|---:|
| chat-mistral | 4.01 | 2.65 | **1.51×** | 94.8% |
| chat-chatml | 3.88 | 2.74 | **1.42×** | — |
| english | 5.47 | 4.01 | **1.36×** | 93.1% |
| math-latex | 4.69 | 3.97 | 1.18× | — |
| code | 3.11 | 2.69 | 1.16× | 88.5% |
| agentic-swe | 3.16 | 2.92 | 1.08× | 80.6% |
| chinese | 10.99 | 10.89 | 1.01× | 37.6% |
| hindi | 2.61 | 2.61 | 1.00× | 11.9% |
| thai | 5.48 | 5.93 | 0.92× | — |

Load cost: **+7 ms** median (61 → 68 ms), one merge per entry.

Thai loses 8% to probes that miss. Gating the probe on the content-byte gate was tried and is **a wash** (0.96× against the ungated fold): the miss path then computes the gate twice, once in `fold_id` and once in `merge_word`, which costs about what the skipped probe saved. A cheaper reject is still open.

## Exactness

Full benchmark matrix on the #2279 path, 7 models × 30 corpora: **174 cells byte-exact** against `tokenizers` 0.23.1, 29 mismatched — the same 29 albert (Unigram) cells that already fail before the change. No new mismatch. `tk-encode` suite passes here (338 tests) with a new test pinning ids for strings that mix folded words, merged words and a literal `<|endoftext|>`.

## Two approaches this replaces

Both measured and rejected:

- **Dense 512×512 grid** (inline `u64` instead of `u16` index + values): 0.89–1.00×. Only ~4% of cells are live, so the value array stays hot in L2 and the indirection is already right.
- **Incremental rank array** (8.0 lookups per merge → ~2): 1.10× on english; removing the 7 `panic_bounds_check` branches it introduced added nothing. 86.6% of lookups were already grid hits from a ~100 KB table, so they were cheap. The merges were the cost, and the fold removes them rather than speeding them up.