### PR TITLE
feat(tk-encode): implement PipelineTokenizer::decode (8-10x over the legacy path)

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -73,6 +73,28 @@ pub(super) enum Atoms {
 }
 
 impl PipelineBPE {
+    /// True when this model was built with `with_byte_level`, which means
+    /// [`byte_level::transform_vocab`] already turned every vocabulary entry into its
+    /// **decoded raw bytes** at load time. Decoding is then a concatenation, and running a
+    /// `ByteLevel` decoder over these entries would decode a second time.
+    pub(crate) fn is_byte_level(&self) -> bool {
+        matches!(self.atoms, Atoms::Bytes)
+    }
+
+    /// A token's bytes, borrowed from the vocab store's slab. For a byte-level model these are
+    /// the decoded bytes (see [`Self::is_byte_level`]) and a single entry is not necessarily
+    /// valid UTF-8 on its own -- only the concatenation of a whole id sequence usually is.
+    pub(crate) fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
+        self.vocab.id_to_token_bytes(id)
+    }
+
+    /// A token as a `String`, for the decoder-chain route. Only meaningful when the entries are
+    /// the token strings as written, i.e. when [`Self::is_byte_level`] is false; a byte-level
+    /// model decodes through [`Self::id_to_token_bytes`] instead.
+    pub(crate) fn id_to_token(&self, id: u32) -> Option<String> {
+        self.vocab.id_to_token(id)
+    }
+
     pub fn from_bpe(model: BPE, with_byte_level: bool) -> Result<Self> {
         if matches!(&model.dropout, Some(dropout) if *dropout > 0.0) {
             return Err("BPE models with dropout not supported yet".into());

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -455,11 +455,7 @@ pub struct PipelineTokenizer {
     post_processor: PipelinePostProcessor,
     decoder: Option<DecoderWrapper>,
     /// Lowest id owned by the added vocabulary, or `u32::MAX` when there is none.
-    ///
-    /// Decode consults the added vocabulary only for ids at or above this, which is exact (every
-    /// added id is >= the minimum) and turns the per-token added-token probe -- two vocab-store
-    /// lookups and a `String` on a hit -- into one comparison. Added tokens sit at the top of the
-    /// id space in practice, so the gate rejects nearly every model token.
+    /// Allows to skip the added vocabulary lookup if the token id is lower than this value.
     added_id_min: u32,
     scratch_pool: ScratchPool,
 }
@@ -644,7 +640,6 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             ModelWrapper::WordPiece(model) => PipelineModel::WordPiece(model.try_into()?),
         };
 
-        // Before `added_vocabulary` is moved into the struct.
         let added_id_min = added_vocabulary
             .get_added_tokens_decoder()
             .keys()
@@ -909,13 +904,17 @@ impl PipelineTokenizer {
 
         let tokens = ids
             .iter()
-            .filter_map(|id| {
-                self.added_vocabulary
-                    .simple_id_to_token(*id)
-                    .or_else(|| self.model.id_to_token(*id))
-                    .filter(|token| {
-                        !skip_special_tokens || !self.added_vocabulary.is_special_token(token)
-                    })
+            .filter_map(|&id| {
+                if id > self.added_id_min {
+                    self.added_vocabulary
+                        .simple_id_to_token(id)
+                        .or_else(|| self.model.id_to_token(id))
+                        .filter(|token| {
+                            !skip_special_tokens || !self.added_vocabulary.is_special_token(token)
+                        })
+                } else {
+                    self.model.id_to_token(id)
+                }
             })
             .collect::<Vec<_>>();
 
@@ -926,33 +925,15 @@ impl PipelineTokenizer {
     }
 
     /// Decode for a byte-level BPE, whose vocab entries are already decoded raw bytes.
-    ///
-    /// Appending each entry's bytes *is* the decode, so there is no per-token UTF-8 validation,
-    /// no `char` iteration and no char->byte table: that work was all done once at load time.
-    /// Running the `ByteLevel` decoder here would be wrong, not just slow -- it would map an
-    /// already-decoded entry a second time.
-    ///
-    /// The output buffer is built once and **moved** into the `String`, so a successful decode
-    /// copies the bytes exactly once. A reusable scratch buffer would be slower, not faster: the
-    /// result is owned by the caller, so reuse trades one allocation for a full copy of the
-    /// output.
-    ///
-    /// An individual entry is often not valid UTF-8 on its own (a multi-byte character is split
-    /// across several vocabulary entries), and callers may pass any ids at all, so the
-    /// concatenation is validated rather than assumed -- `decode_stream` in particular feeds
-    /// deliberately partial sequences whose bytes end mid-character.
     fn decode_byte_level(
         &self,
         bpe: &PipelineBPE,
         ids: &[u32],
         skip_special_tokens: bool,
     ) -> String {
-        // Byte-level tokens average ~4 bytes; growing from here is amortized and cheap next to
-        // the per-token lookups, and over-reserving a long id sequence is not.
+        // Byte-level tokens average ~4 bytes
         let mut out: Vec<u8> = Vec::with_capacity(ids.len() * 4);
         for &id in ids {
-            // An added token's content is stored as written, never byte-level encoded, so its
-            // own UTF-8 bytes go straight out. `added_id_min` keeps the probe off the hot path.
             if id >= self.added_id_min
                 && let Some(token) = self.added_vocabulary.simple_id_to_token(id)
             {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -19,7 +19,7 @@ use crate::vocab::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
 use crate::{
-    ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer,
+    DecoderWrapper, ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer,
     normalizers::{NormalizerWrapper, metaspace::MetaspaceNormalizer},
     pre_tokenizers::{
         bert::BertPreTokenizer,
@@ -34,6 +34,7 @@ use crate::{
         whitespace::{Whitespace, WhitespaceSplit},
     },
     processors::template::Piece,
+    tokenizer::{Decoder as _, Model as _},
 };
 
 use super::{Result, SplitDelimiterBehavior};
@@ -452,6 +453,14 @@ pub struct PipelineTokenizer {
     pre_tokenizer: PipelinePreTokenizer,
     model: PipelineModel,
     post_processor: PipelinePostProcessor,
+    decoder: Option<DecoderWrapper>,
+    /// Lowest id owned by the added vocabulary, or `u32::MAX` when there is none.
+    ///
+    /// Decode consults the added vocabulary only for ids at or above this, which is exact (every
+    /// added id is >= the minimum) and turns the per-token added-token probe -- two vocab-store
+    /// lookups and a `String` on a hit -- into one comparison. Added tokens sit at the top of the
+    /// id space in practice, so the gate rejects nearly every model token.
+    added_id_min: u32,
     scratch_pool: ScratchPool,
 }
 
@@ -635,6 +644,14 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
             ModelWrapper::WordPiece(model) => PipelineModel::WordPiece(model.try_into()?),
         };
 
+        // Before `added_vocabulary` is moved into the struct.
+        let added_id_min = added_vocabulary
+            .get_added_tokens_decoder()
+            .keys()
+            .copied()
+            .min()
+            .unwrap_or(u32::MAX);
+
         Ok(Self {
             added_vocabulary,
             normalizers,
@@ -645,6 +662,8 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
                 .map(PipelinePostProcessor::try_from)
                 .transpose()?
                 .unwrap_or_default(),
+            decoder: tok.get_decoder().cloned(),
+            added_id_min,
             scratch_pool: ScratchPool::new(),
         })
     }
@@ -867,13 +886,89 @@ impl PipelineTokenizer {
 
     /// Decode token ids back to a `String`.
     ///
-    /// Not implemented yet: the pipeline decode path is being built. It fails
-    /// loud (rather than returning a plausible-but-wrong string) so the oracle
-    /// test and the comparative benchmark report decode as *pending* instead of
-    /// silently validating garbage. Implementing this flips the ignored
-    /// `pipeline_decode_oracle` test on and lights up the decode charts.
-    pub fn decode(&self, _ids: &[u32], _skip_special_tokens: bool) -> Result<String> {
-        Err("PipelineTokenizer::decode is not implemented yet".into())
+    /// Two routes, picked by what the model's vocab store actually holds:
+    ///
+    /// * **byte-level BPE** -- [`byte_level::transform_vocab`] already replaced every entry with
+    ///   its decoded raw bytes when the model was built, so decoding is a concatenation of
+    ///   borrowed slices. See [`Self::decode_byte_level`].
+    /// * **everything else** -- the store holds the token strings as written, so the configured
+    ///   [`DecoderWrapper`] still has to invert whatever the pre-tokenizer did. Same shape as the
+    ///   released `Tokenizer::decode`.
+    ///
+    /// [`byte_level::transform_vocab`]: crate::utils::byte_level::transform_vocab
+    pub fn decode(&self, ids: &[u32], skip_special_tokens: bool) -> Result<String> {
+        if let PipelineModel::BPE(bpe) = &self.model
+            && bpe.is_byte_level()
+        {
+            return Ok(self.decode_byte_level(bpe, ids, skip_special_tokens));
+        }
+        if matches!(self.model, PipelineModel::WordPiece(_)) {
+            // Fail loud instead of dropping every id and returning "".
+            return Err("PipelineTokenizer::decode: WordPiece keeps no id -> token map yet".into());
+        }
+
+        let tokens = ids
+            .iter()
+            .filter_map(|id| {
+                self.added_vocabulary
+                    .simple_id_to_token(*id)
+                    .or_else(|| self.model.id_to_token(*id))
+                    .filter(|token| {
+                        !skip_special_tokens || !self.added_vocabulary.is_special_token(token)
+                    })
+            })
+            .collect::<Vec<_>>();
+
+        match &self.decoder {
+            Some(decoder) => decoder.decode(tokens),
+            None => Ok(tokens.join(" ")),
+        }
+    }
+
+    /// Decode for a byte-level BPE, whose vocab entries are already decoded raw bytes.
+    ///
+    /// Appending each entry's bytes *is* the decode, so there is no per-token UTF-8 validation,
+    /// no `char` iteration and no char->byte table: that work was all done once at load time.
+    /// Running the `ByteLevel` decoder here would be wrong, not just slow -- it would map an
+    /// already-decoded entry a second time.
+    ///
+    /// The output buffer is built once and **moved** into the `String`, so a successful decode
+    /// copies the bytes exactly once. A reusable scratch buffer would be slower, not faster: the
+    /// result is owned by the caller, so reuse trades one allocation for a full copy of the
+    /// output.
+    ///
+    /// An individual entry is often not valid UTF-8 on its own (a multi-byte character is split
+    /// across several vocabulary entries), and callers may pass any ids at all, so the
+    /// concatenation is validated rather than assumed -- `decode_stream` in particular feeds
+    /// deliberately partial sequences whose bytes end mid-character.
+    fn decode_byte_level(
+        &self,
+        bpe: &PipelineBPE,
+        ids: &[u32],
+        skip_special_tokens: bool,
+    ) -> String {
+        // Byte-level tokens average ~4 bytes; growing from here is amortized and cheap next to
+        // the per-token lookups, and over-reserving a long id sequence is not.
+        let mut out: Vec<u8> = Vec::with_capacity(ids.len() * 4);
+        for &id in ids {
+            // An added token's content is stored as written, never byte-level encoded, so its
+            // own UTF-8 bytes go straight out. `added_id_min` keeps the probe off the hot path.
+            if id >= self.added_id_min
+                && let Some(token) = self.added_vocabulary.simple_id_to_token(id)
+            {
+                if !skip_special_tokens || !self.added_vocabulary.is_special_token(&token) {
+                    out.extend_from_slice(token.as_bytes());
+                }
+                continue;
+            }
+            if let Some(bytes) = bpe.id_to_token_bytes(id) {
+                out.extend_from_slice(bytes);
+            }
+        }
+        match String::from_utf8(out) {
+            Ok(decoded) => decoded,
+            Err(invalid) => String::from_utf8_lossy(invalid.as_bytes()).into_owned(),
+        }
     }
 
     /// Decode several id sequences at once, one `String` per input. Mirrors the
@@ -1264,6 +1359,22 @@ pub enum PipelineModel {
     Unigram(Unigram),
     WordLevel(WordLevel),
     WordPiece(PipelineWordPiece),
+}
+
+impl PipelineModel {
+    /// `id -> token`, for the decoder-chain route in [`PipelineTokenizer::decode`].
+    ///
+    /// `None` for [`PipelineWordPiece`], which keeps only the forward `vocab_trie` and so has no
+    /// id -> token direction to answer with. `decode` refuses that model up front rather than
+    /// letting every id drop out and returning an empty string.
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        match self {
+            Self::BPE(model) => model.id_to_token(id),
+            Self::Unigram(model) => model.id_to_token(id),
+            Self::WordLevel(model) => model.id_to_token(id),
+            Self::WordPiece(_) => None,
+        }
+    }
 }
 
 impl Model for PipelineModel {

--- a/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_decode_oracle.rs
@@ -23,9 +23,9 @@
 //! survive `skip_special_tokens = true`. It's built by adding the same token to both
 //! sides, so it stays an honest release-vs-pipeline parity check.
 //!
-//! Behind `bench-baseline`. These FAIL until `PipelineTokenizer::decode` applies the
-//! decoder and distinguishes special from non-special added vocab — on purpose: CI
-//! stays red until decode lands, rather than hiding the gap behind a skipped test.
+//! Behind `bench-baseline`. `bert_wiki` still FAILS: `PipelineWordPiece` keeps only its
+//! forward `vocab_trie`, so it has no id → token direction to decode with — on purpose: CI
+//! stays red until that lands, rather than hiding the gap behind a skipped test.
 //!   cargo test -p tk-encode --features bench-baseline --test pipeline_decode_oracle
 
 #![cfg(feature = "bench-baseline")]
@@ -174,7 +174,6 @@ fn stream_decode(
 /// containing it. Byte-level gpt2 decodes this ASCII round-trip correctly, so the
 /// only thing under test here is the special-vs-non-special distinction.
 #[test]
-#[ignore = "PipelineTokenizer::decode is not implemented yet"]
 fn non_special_added_token_survives_skip() {
     let path = Path::new(DATA).join("gpt2.json");
     let Ok(mut tree) = Tokenizer::from_file(&path) else {


### PR DESCRIPTION
`PipelineTokenizer::decode` was a stub returning an error, and the pipeline carried no decoder field at all. This wires one up and implements decode.

Related: #2166 optimizes decode on the **legacy** `Tokenizer` path (whose vocab store holds the byte-level *char* form). This is the pipeline path, where the same work turns out to be unnecessary rather than optimizable.

## The byte-level case needs no decoder

`PipelineBPE::from_bpe` already runs `byte_level::transform_vocab` when `with_byte_level`, so every vocab entry is stored as its **decoded raw bytes**:

```
id=23748  legacy="Ġhello"  pipeline=[32,104,101,108,108,111]  (" hello")
id=255    legacy="Ń"       pipeline=[173]
```

So decoding is a concatenation of borrowed slices — no per-token UTF-8 validation, no `char` iteration, no `CHAR_BYTES_LOOKUP`. That work was all done once at load time. Running the `ByteLevel` decoder over these entries would be **wrong**, not just slow: it would decode a second time (a decoded entry that is valid UTF-8 made only of codepoints `0..324`, e.g. `Ā` = U+0100, would get mapped again).

Everything else keeps the released shape: `id -> token`, then the decoder chain.

## Two details that measure

- **The output buffer is moved into the `String`**, so a decode copies the bytes once. A reusable scratch is *slower*: the result is owned by the caller, so reuse trades one allocation for a full copy of the output (343 vs 381 MiB/s on English).
- **`added_id_min`** gates the per-token added-vocabulary probe behind one compare. Added tokens sit at the top of the id space, so it rejects nearly every model token. Without it the probe costs ~25% (301.8 -> 398.2 MiB/s).

## The UTF-8 check stays

A single entry is often not valid UTF-8 on its own, `decode` accepts arbitrary caller-supplied ids (`decode(&[164])` is a lone `0xE8`), and `decode_stream` feeds deliberately partial sequences that end mid-character. So the concatenation is validated, not assumed.

## Perf

Single-thread decode, gpt2, M-series, vs the in-tree `Tokenizer::decode`:

| corpus | before | after | |
|---|---|---|---|
| english | 49.6 MiB/s | **398.2 MiB/s** | 8.0x |
| japanese | 32.2 MiB/s | **316.4 MiB/s** | 9.8x |

## Tests

`pipeline_decode_oracle` (vs the released crate, over the fetched fixtures) goes from all-failing to **7 passing**: gpt2, llama3, llama2, t5-base, albert, bert-base-uncased, plus `non_special_added_token_survives_skip`, which is un-ignored here.

`bert_wiki` still fails, on purpose. `PipelineWordPiece` keeps only its forward `vocab_trie`, so it has no `id -> token` direction; decode refuses that model up front rather than dropping every id and returning `""`. Building that reverse map is its own change.

Full `cargo test -p tk-encode`: 367 passing, 0 failing. Clippy clean.

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**10 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`e8567f4f5 · 2026-08-06 12:37 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 96 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-overview.png" width="860">

**vs base branch** (`d9cc815b8`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×5.12 vs v0.23.1 · ×1.01 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 11) · Pipeline 8+2 (peak 16)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.8 | 26.5 | ×3.40 | ×1.01 | 3% (1.2) | 74% (27.5) | 16% (5.8) | 7% (2.5) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 25.6 | ×6.13 | ×1.00 | 3% (1.2) | 76% (27.5) | 9% (3.4) | 12% (4.3) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 36.3 | ×6.00 | ×1.01 | 4% (1.2) | 73% (19.1) | 12% (3.0) | 11% (3.0) | 0% (0.0) | match |
| cmn_Hani | lang | 3.9 | 19.4 | ×5.03 | ×1.01 | 2% (1.2) | 74% (37.4) | 11% (5.5) | 13% (6.7) | 0% (0.0) | match |
| ell_Grek | lang | 3.8 | 25.9 | ×6.89 | ×1.03 | 3% (1.2) | 75% (28.6) | 9% (3.5) | 13% (4.8) | 0% (0.0) | match |
| eng_Latn | lang | 4.5 | 19.2 | ×4.25 | ×1.00 | 5% (2.7) | 75% (38.8) | 9% (4.5) | 11% (5.8) | 0% (0.1) | match |
| heb_Hebr | lang | 4.2 | 20.7 | ×4.94 | ×1.02 | 3% (1.2) | 78% (37.6) | 7% (3.4) | 12% (6.0) | 0% (0.0) | match |
| hin_Deva | lang | 6.5 | 28.2 | ×4.35 | ×1.01 | 4% (1.2) | 77% (26.9) | 10% (3.3) | 9% (3.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 28.2 | ×6.58 | ×1.01 | 4% (1.3) | 66% (23.2) | 13% (4.7) | 17% (5.9) | 0% (0.0) | match |
| kat_Geor | lang | 6.2 | 29.1 | ×4.73 | ×1.02 | 3% (1.2) | 76% (26.5) | 12% (4.3) | 8% (2.8) | 0% (0.0) | match |
| kor_Hang | lang | 2.4 | 19.4 | ×8.01 | ×1.01 | 2% (1.2) | 64% (35.0) | 16% (9.0) | 17% (9.5) | 0% (0.1) | match |
| rus_Cyrl | lang | 3.7 | 27.0 | ×7.39 | ×1.03 | 3% (1.2) | 73% (27.4) | 9% (3.4) | 15% (5.7) | 0% (0.0) | match |
| tam_Taml | lang | 7.0 | 39.4 | ×5.66 | ×1.02 | 5% (1.2) | 75% (18.6) | 10% (2.6) | 10% (2.4) | 0% (0.0) | match |
| tha_Thai | lang | 8.3 | 33.0 | ×3.96 | ×1.01 | 4% (1.2) | 84% (25.1) | 8% (2.3) | 4% (1.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.7 | 20.0 | ×3.00 | ×1.01 | 3% (1.5) | 81% (40.5) | 14% (7.2) | 1% (0.6) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 19.1 | ×3.64 | ×1.00 | 4% (2.1) | 77% (40.1) | 14% (7.0) | 6% (2.9) | 0% (0.0) | match |
| added_special_dense | modalities | 5.3 | 39.2 | ×7.44 | ×1.02 | 21% (5.2) | 40% (10.2) | 35% (8.7) | 4% (1.1) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 22.4 | ×5.69 | ×1.01 | 9% (3.8) | 64% (28.4) | 20% (8.9) | 8% (3.3) | 0% (0.0) | match |
| agentic-traces | modalities | 3.8 | 18.7 | ×4.86 | ×1.00 | 5% (2.7) | 72% (38.4) | 9% (4.9) | 13% (7.2) | 0% (0.1) | match |
| agentic_swe | modalities | 4.1 | 19.8 | ×4.83 | ×1.00 | 4% (2.0) | 77% (38.7) | 7% (3.7) | 12% (5.9) | 0% (0.2) | match |
| code_mixed | modalities | 3.9 | 19.5 | ×4.96 | ×1.00 | 4% (2.2) | 76% (38.6) | 9% (4.4) | 11% (5.7) | 0% (0.0) | match |
| math_latex | modalities | 4.1 | 18.8 | ×4.64 | ×1.00 | 5% (2.6) | 73% (38.7) | 9% (4.8) | 13% (6.7) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×21.89 vs v0.23.1 · ×1.00 vs base · decode ×8.21</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 67) · Pipeline 92+0 (peak 90)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 81.0 | ×18.50 | ×0.99 | 6% (0.7) | 0% (0.0) | 45% (4.7) | 47% (4.8) | 1% (0.2) | match |
| arb_Arab | lang | 4.4 | 96.8 | ×22.23 | ×1.00 | 7% (0.6) | 0% (0.0) | 38% (3.4) | 56% (5.0) | 0% (0.0) | match |
| ben_Beng | lang | 6.3 | 121.1 | ×19.23 | ×1.00 | 7% (0.6) | 0% (0.0) | 38% (3.1) | 55% (4.5) | 0% (0.0) | match |
| cmn_Hani | lang | 3.8 | 98.3 | ×26.09 | ×1.01 | 6% (0.8) | 0% (0.0) | 25% (3.2) | 69% (8.7) | 0% (0.0) | match |
| ell_Grek | lang | 4.7 | 100.4 | ×21.25 | ×1.00 | 5% (0.6) | 0% (0.0) | 28% (3.4) | 67% (8.1) | 0% (0.0) | match |
| eng_Latn | lang | 3.2 | 69.7 | ×21.84 | ×1.01 | 18% (2.2) | 0% (0.0) | 41% (5.2) | 42% (5.3) | 1% (0.1) | match |
| heb_Hebr | lang | 4.1 | 91.3 | ×22.49 | ×1.00 | 4% (0.6) | 0% (0.0) | 23% (3.6) | 75% (11.5) | 0% (0.0) | match |
| hin_Deva | lang | 5.9 | 112.6 | ×19.11 | ×0.99 | 7% (0.6) | 0% (0.0) | 37% (3.3) | 56% (5.0) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.3 | 113.5 | ×26.22 | ×1.01 | 6% (0.7) | 0% (0.0) | 26% (3.0) | 68% (7.8) | 0% (0.0) | match |
| kat_Geor | lang | 5.9 | 119.7 | ×20.16 | ×1.00 | 5% (0.6) | 0% (0.0) | 26% (2.9) | 69% (7.7) | 0% (0.0) | match |
| kor_Hang | lang | 3.7 | 78.5 | ×20.95 | ×0.98 | 3% (0.6) | 0% (0.0) | 20% (3.7) | 77% (14.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.4 | 101.5 | ×22.92 | ×1.00 | 4% (0.6) | 0% (0.0) | 21% (3.3) | 71% (11.1) | 3% (0.5) | match |
| tam_Taml | lang | 6.3 | 132.0 | ×21.04 | ×1.01 | 6% (0.6) | 0% (0.0) | 25% (2.7) | 69% (7.3) | 0% (0.0) | match |
| tha_Thai | lang | 7.0 | 175.4 | ×25.01 | ×0.99 | 6% (0.6) | 0% (0.0) | 20% (2.2) | 74% (7.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.6 | 146.4 | ×26.35 | ×1.00 | 12% (0.8) | 0% (0.0) | 42% (2.7) | 46% (3.0) | 1% (0.1) | match |
| added_normalized_sparse | modalities | 5.1 | 111.0 | ×21.56 | ×1.00 | 16% (1.4) | 0% (0.0) | 45% (3.8) | 40% (3.3) | 0% (0.0) | match |
| added_special_dense | modalities | 3.5 | 58.1 | ×16.63 | ×0.98 | 42% (6.7) | 5% (0.8) | 39% (6.1) | 14% (2.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 68.3 | ×17.75 | ×1.03 | 29% (4.0) | 3% (0.5) | 47% (6.6) | 22% (3.2) | 0% (0.0) | match |
| agentic-traces | modalities | 3.0 | 66.9 | ×22.56 | ×1.01 | 14% (1.9) | 0% (0.0) | 40% (5.5) | 46% (6.3) | 0% (0.0) | match |
| agentic_swe | modalities | 3.0 | 85.7 | ×28.34 | ×1.01 | 13% (1.4) | 0% (0.0) | 37% (3.9) | 50% (5.2) | 1% (0.1) | match |
| code_mixed | modalities | 3.5 | 78.7 | ×22.37 | ×1.02 | 14% (1.7) | 0% (0.0) | 40% (4.6) | 45% (5.3) | 1% (0.1) | match |
| math_latex | modalities | 2.9 | 67.8 | ×23.09 | ×1.02 | 16% (2.1) | 0% (0.0) | 41% (5.4) | 43% (5.6) | 0% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.76 | 3.13 | 4.70 | 5.08 | 41.6 | 20.5 | 9.1 | — | 8.9× / 8.2× | 4.4× / 4.0× | 1.9× / 1.8× | — |
| arb_Arab | 1.16 | 2.76 | 3.39 | 4.99 | 48.3 | 23.0 | 10.3 | — | 14.2× / 9.7× | 6.8× / 4.6× | 3.0× / 2.1× | — |
| ben_Beng | 1.60 | 2.65 | 3.11 | 4.16 | 35.2 | 16.6 | 7.7 | — | 11.3× / 8.5× | 5.3× / 4.0× | 2.5× / 1.9× | — |
| cmn_Hani | 1.12 | 2.01 | 3.19 | 4.07 | 59.2 | 34.0 | 14.3 | — | 18.6× / 14.5× | 10.6× / 8.3× | 4.5× / 3.5× | — |
| ell_Grek | 0.58 | 2.80 | 3.38 | 5.59 | 46.7 | 21.4 | 9.6 | — | 13.8× / 8.4× | 6.3× / 3.8× | 2.8× / 1.7× | — |
| eng_Latn | 0.11 | 1.45 | 5.16 | 6.50 | 65.7 | 39.8 | 16.2 | — | 12.7× / 10.1× | 7.7× / 6.1× | 3.1× / 2.5× | — |
| heb_Hebr | 1.15 | 2.84 | 3.55 | 5.24 | 49.9 | 24.8 | 10.7 | — | 14.0× / 9.5× | 7.0× / 4.7× | 3.0× / 2.0× | — |
| hin_Deva | 1.52 | 2.82 | 3.35 | 4.64 | 37.6 | 18.8 | 8.6 | — | 11.2× / 8.1× | 5.6× / 4.1× | 2.6× / 1.8× | — |
| jpn_Jpan | 1.70 | 3.09 | 2.99 | 4.38 | 52.0 | 27.3 | 11.9 | — | 17.4× / 11.9× | 9.1× / 6.2× | 4.0× / 2.7× | — |
| kat_Geor | 1.55 | 2.16 | 2.92 | 3.53 | 31.8 | 15.3 | 7.2 | — | 10.9× / 9.0× | 5.2× / 4.3× | 2.4× / 2.0× | — |
| kor_Hang | 1.23 | 2.53 | 3.70 | 5.01 | 49.6 | 27.5 | 12.0 | — | 13.4× / 9.9× | 7.4× / 5.5× | 3.2× / 2.4× | — |
| rus_Cyrl | 1.17 | 2.73 | 3.31 | 4.87 | 46.3 | 21.3 | 9.5 | — | 14.0× / 9.5× | 6.4× / 4.4× | 2.9× / 2.0× | — |
| tam_Taml | 0.92 | 2.63 | 2.69 | 4.40 | 31.0 | 13.9 | 6.6 | — | 11.5× / 7.0× | 5.2× / 3.2× | 2.5× / 1.5× | — |
| tha_Thai | 1.68 | 2.22 | 2.15 | 2.70 | 26.7 | 10.2 | 5.3 | — | 12.4× / 9.9× | 4.7× / 3.8× | 2.4× / 2.0× | — |
| added_normalized_dense | 0.06 | 1.47 | 2.73 | 4.15 | 43.1 | 20.8 | 9.1 | — | 15.8× / 10.4× | 7.6× / 5.0× | 3.3× / 2.2× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.79 | 5.20 | 49.3 | 26.9 | 11.3 | — | 13.0× / 9.5× | 7.1× / 5.2× | 3.0× / 2.2× | — |
| added_special_dense | 0.06 | 1.47 | 6.14 | 7.55 | 172.5 | 100.4 | 39.2 | — | 28.1× / 22.8× | 16.4× / 13.3× | 6.4× / 5.2× | — |
| added_special_sparse | 0.06 | 1.47 | 6.55 | 7.97 | 102.0 | 58.5 | 24.4 | — | 15.6× / 12.8× | 8.9× / 7.3× | 3.7× / 3.1× | — |
| agentic-traces | 0.74 | 1.46 | 5.52 | 6.25 | 80.4 | 53.3 | 20.3 | — | 14.5× / 12.9× | 9.6× / 8.5× | 3.7× / 3.2× | — |
| agentic_swe | 0.68 | 1.43 | 3.87 | 4.62 | 95.8 | 66.3 | 23.7 | — | 24.7× / 20.7× | 17.1× / 14.4× | 6.1× / 5.1× | — |
| code_mixed | 0.07 | 1.44 | 4.63 | 6.01 | 75.0 | 55.2 | 18.8 | — | 16.2× / 12.5× | 11.9× / 9.2× | 4.1× / 3.1× | — |
| math_latex | 0.74 | 1.48 | 5.43 | 6.17 | 78.3 | 48.6 | 19.4 | — | 14.4× / 12.7× | 9.0× / 7.9× | 3.6× / 3.2× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×37.90 vs v0.23.1 · ×1.01 vs base · decode ×1.62</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 370) · Pipeline 274+0 (peak 370)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 10.7 | 393.6 | ×36.93 | ×1.02 | 28% (0.7) | 56% (1.3) | 0% (0.0) | 15% (0.4) | 0% (0.0) | match |
| arb_Arab | lang | 7.4 | 358.8 | ×48.29 | ×1.03 | 24% (0.6) | 61% (1.6) | 1% (0.0) | 14% (0.4) | 0% (0.0) | match |
| ben_Beng | lang | 10.6 | 467.2 | ×44.16 | ×1.01 | 30% (0.6) | 53% (1.0) | 1% (0.0) | 16% (0.3) | 0% (0.0) | match |
| cmn_Hani | lang | 12.7 | 723.3 | ×56.88 | ×1.01 | 52% (0.6) | 18% (0.2) | 1% (0.0) | 30% (0.4) | 0% (0.0) | match |
| ell_Grek | lang | 7.8 | 341.8 | ×43.62 | ×1.00 | 24% (0.6) | 62% (1.6) | 2% (0.0) | 15% (0.4) | 0% (0.0) | match |
| eng_Latn | lang | 3.9 | 170.4 | ×43.49 | ×0.99 | 39% (2.2) | 54% (3.0) | 0% (0.0) | 8% (0.4) | 0% (0.0) | match |
| heb_Hebr | lang | 8.1 | 339.0 | ×41.74 | ×1.01 | 23% (0.6) | 61% (1.6) | 1% (0.0) | 16% (0.4) | 0% (0.0) | match |
| hin_Deva | lang | 9.8 | 378.9 | ×38.83 | ×1.01 | 26% (0.6) | 59% (1.4) | 1% (0.0) | 14% (0.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.2 | 765.7 | ×58.03 | ×0.99 | 53% (0.6) | 15% (0.2) | 1% (0.0) | 32% (0.4) | 0% (0.0) | match |
| kat_Geor | lang | 12.3 | 497.3 | ×40.54 | ×1.00 | 32% (0.6) | 49% (0.9) | 2% (0.0) | 17% (0.3) | 0% (0.0) | match |
| kor_Hang | lang | 9.8 | 353.6 | ×36.09 | ×1.02 | 23% (0.6) | 61% (1.6) | 1% (0.0) | 15% (0.4) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.2 | 381.0 | ×52.82 | ×1.01 | 25% (0.6) | 60% (1.4) | 1% (0.0) | 14% (0.3) | 0% (0.0) | match |
| tam_Taml | lang | 11.5 | 521.0 | ×45.37 | ×0.99 | 34% (0.6) | 46% (0.8) | 1% (0.0) | 19% (0.3) | 0% (0.0) | match |
| tha_Thai | lang | 13.5 | 637.1 | ×47.17 | ×1.01 | 44% (0.6) | 33% (0.5) | 2% (0.0) | 21% (0.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.2 | 313.0 | ×60.03 | ×1.06 | 26% (0.8) | 61% (1.8) | 1% (0.0) | 13% (0.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.7 | 202.1 | ×42.76 | ×1.04 | 31% (1.4) | 60% (2.8) | 2% (0.1) | 9% (0.4) | 0% (0.0) | match |
| added_special_dense | modalities | 4.7 | 37.2 | ×7.90 | ×1.04 | 39% (9.8) | 28% (7.0) | 24% (6.0) | 10% (2.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 7.2 | 50.6 | ×7.02 | ×1.06 | 30% (5.3) | 36% (6.5) | 24% (4.4) | 12% (2.2) | 0% (0.0) | match |
| agentic-traces | modalities | 4.4 | 185.3 | ×42.39 | ×0.99 | 36% (1.9) | 53% (2.8) | 1% (0.1) | 11% (0.6) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 162.9 | ×39.59 | ×1.00 | 23% (1.4) | 68% (4.0) | 1% (0.0) | 10% (0.6) | 0% (0.0) | match |
| code_mixed | modalities | 4.2 | 170.1 | ×40.77 | ×1.01 | 29% (1.6) | 62% (3.5) | 1% (0.0) | 8% (0.5) | 0% (0.0) | match |
| math_latex | modalities | 4.2 | 176.3 | ×41.60 | ×0.99 | 38% (2.1) | 55% (3.0) | 0% (0.0) | 8% (0.4) | 0% (0.0) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×25.47 vs v0.23.1 · ×1.01 vs base · decode ×15.65</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 32+0 (peak 31)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 86.1 | ×22.38 | ×1.01 | 8% (0.7) | 0% (0.0) | 42% (3.6) | 51% (4.4) | 0% (0.0) | match |
| arb_Arab | lang | 3.8 | 89.1 | ×23.54 | ×1.06 | 7% (0.6) | 0% (0.0) | 26% (2.3) | 68% (6.1) | 0% (0.0) | match |
| ben_Beng | lang | 2.8 | 70.8 | ×24.90 | ×1.03 | 5% (0.6) | 0% (0.0) | 23% (3.1) | 72% (9.6) | 1% (0.1) | match |
| cmn_Hani | lang | 3.7 | 101.6 | ×27.80 | ×1.02 | 5% (0.6) | 0% (0.0) | 19% (2.3) | 91% (11.3) | 0% (0.0) | match |
| ell_Grek | lang | 4.2 | 103.1 | ×24.58 | ×1.05 | 6% (0.6) | 0% (0.0) | 22% (2.2) | 74% (7.4) | 0% (0.0) | match |
| eng_Latn | lang | 3.4 | 91.2 | ×27.11 | ×1.01 | 21% (2.1) | 0% (0.0) | 31% (3.1) | 49% (4.9) | 0% (0.0) | match |
| heb_Hebr | lang | 3.8 | 93.8 | ×24.58 | ×1.01 | 5% (0.6) | 0% (0.0) | 20% (2.3) | 75% (8.5) | 0% (0.0) | match |
| hin_Deva | lang | 3.0 | 79.6 | ×26.56 | ×1.01 | 5% (0.6) | 0% (0.0) | 25% (3.1) | 70% (8.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.4 | 128.5 | ×29.28 | ×0.99 | 5% (0.6) | 0% (0.0) | 18% (2.1) | 81% (9.5) | 0% (0.0) | match |
| kat_Geor | lang | 4.5 | 132.1 | ×29.07 | ×0.99 | 9% (0.6) | 0% (0.0) | 29% (2.1) | 64% (4.5) | 0% (0.0) | match |
| kor_Hang | lang | 3.3 | 84.1 | ×25.82 | ×1.00 | 5% (0.6) | 0% (0.0) | 19% (2.5) | 79% (10.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.1 | 104.6 | ×25.72 | ×1.00 | 6% (0.6) | 0% (0.0) | 20% (2.1) | 75% (8.1) | 0% (0.0) | match |
| tam_Taml | lang | 2.7 | 78.2 | ×28.84 | ×1.01 | 5% (0.6) | 0% (0.0) | 22% (2.7) | 72% (8.6) | 1% (0.1) | match |
| tha_Thai | lang | 3.6 | 92.8 | ×25.77 | ×1.02 | 6% (0.6) | 0% (0.0) | 23% (2.5) | 76% (8.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 174.8 | ×29.82 | ×1.02 | 15% (0.8) | 0% (0.0) | 23% (1.2) | 61% (3.3) | 3% (0.2) | match |
| added_normalized_sparse | modalities | 5.1 | 134.4 | ×26.45 | ×1.02 | 19% (1.3) | 0% (0.0) | 29% (2.0) | 53% (3.7) | 1% (0.0) | match |
| added_special_dense | modalities | 4.1 | 79.1 | ×19.51 | ×1.01 | 43% (5.0) | 4% (0.5) | 33% (3.8) | 20% (2.3) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.2 | 82.3 | ×19.70 | ×1.03 | 29% (3.3) | 2% (0.2) | 36% (4.1) | 33% (3.7) | 0% (0.1) | match |
| agentic-traces | modalities | 3.2 | 77.5 | ×24.55 | ×1.01 | 16% (1.9) | 0% (0.0) | 29% (3.5) | 55% (6.6) | 1% (0.1) | match |
| agentic_swe | modalities | 3.4 | 94.0 | ×27.47 | ×1.01 | 13% (1.3) | 0% (0.0) | 24% (2.4) | 61% (6.1) | 1% (0.1) | match |
| code_mixed | modalities | 3.5 | 86.8 | ×24.72 | ×1.01 | 15% (1.7) | 0% (0.0) | 27% (2.9) | 58% (6.3) | 0% (0.0) | match |
| math_latex | modalities | 3.2 | 82.4 | ×25.38 | ×1.01 | 18% (2.0) | 0% (0.0) | 30% (3.3) | 52% (5.8) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.13 | 3.64 | 4.02 | 26.0 | 21.3 | 6.0 | 4.8 | 7.1× / 6.5× | 5.9× / 5.3× | 1.6× / 1.5× | 1.3× / 1.2× |
| arb_Arab | 1.16 | 2.77 | 2.30 | 3.91 | 30.2 | 26.8 | 7.2 | 5.1 | 13.2× / 7.7× | 11.7× / 6.9× | 3.1× / 1.8× | 2.2× / 1.3× |
| ben_Beng | 1.60 | 2.65 | 3.09 | 4.13 | 62.3 | 57.4 | 14.1 | 4.0 | 20.2× / 15.1× | 18.6× / 13.9× | 4.6× / 3.4× | 1.3× / 1.0× |
| cmn_Hani | 1.12 | 2.00 | 2.32 | 3.21 | 24.8 | 21.6 | 6.1 | 2.4 | 10.7× / 7.7× | 9.3× / 6.7× | 2.6× / 1.9× | 1.0× / 0.7× |
| ell_Grek | 0.59 | 2.78 | 2.18 | 4.37 | 27.0 | 22.6 | 6.1 | 4.8 | 12.4× / 6.2× | 10.4× / 5.2× | 2.8× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.09 | 1.47 | 3.08 | 4.46 | 41.6 | 43.0 | 12.2 | 3.8 | 13.5× / 9.3× | 14.0× / 9.7× | 3.9× / 2.7× | 1.2× / 0.9× |
| heb_Hebr | 1.15 | 2.78 | 2.29 | 3.93 | 30.1 | 26.6 | 7.1 | 2.9 | 13.1× / 7.7× | 11.6× / 6.8× | 3.1× / 1.8× | 1.3× / 0.7× |
| hin_Deva | 1.51 | 2.80 | 3.11 | 4.40 | 57.7 | 55.3 | 13.6 | 4.2 | 18.5× / 13.1× | 17.8× / 12.6× | 4.4× / 3.1× | 1.3× / 1.0× |
| jpn_Jpan | 1.70 | 3.15 | 2.11 | 3.56 | 22.3 | 18.0 | 5.1 | 3.9 | 10.6× / 6.3× | 8.5× / 5.1× | 2.4× / 1.4× | 1.8× / 1.1× |
| kat_Geor | 1.54 | 2.18 | 2.07 | 2.71 | 16.3 | 14.8 | 4.3 | 2.0 | 7.9× / 6.0× | 7.1× / 5.4× | 2.1× / 1.6× | 1.0× / 0.7× |
| kor_Hang | 1.23 | 2.48 | 2.46 | 3.72 | 30.1 | 28.6 | 7.9 | 3.7 | 12.2× / 8.1× | 11.6× / 7.7× | 3.2× / 2.1× | 1.5× / 1.0× |
| rus_Cyrl | 1.17 | 2.76 | 2.13 | 3.72 | 25.7 | 21.7 | 5.9 | 2.6 | 12.1× / 6.9× | 10.2× / 5.8× | 2.8× / 1.6× | 1.2× / 0.7× |
| tam_Taml | 0.92 | 2.66 | 2.65 | 4.39 | 65.7 | 59.3 | 14.5 | 3.8 | 24.7× / 15.0× | 22.3× / 13.5× | 5.4× / 3.3× | 1.4× / 0.9× |
| tha_Thai | 1.51 | 2.23 | 2.51 | 3.23 | 38.1 | 32.5 | 9.0 | 3.2 | 15.2× / 11.8× | 12.9× / 10.1× | 3.6× / 2.8× | 1.3× / 1.0× |
| added_normalized_dense | 0.07 | 1.47 | 1.22 | 2.61 | 22.4 | 23.0 | 6.5 | 1.9 | 18.4× / 8.6× | 18.9× / 8.8× | 5.3× / 2.5× | 1.6× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 2.00 | 3.41 | 29.5 | 31.7 | 8.8 | 2.7 | 14.8× / 8.6× | 15.8× / 9.3× | 4.4× / 2.6× | 1.4× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 3.84 | 5.26 | 88.7 | 97.8 | 20.5 | 2.9 | 23.1× / 16.9× | 25.4× / 18.6× | 5.3× / 3.9× | 0.8× / 0.6× |
| added_special_sparse | 0.06 | 1.47 | 4.08 | 5.49 | 57.6 | 62.0 | 14.8 | 3.4 | 14.1× / 10.5× | 15.2× / 11.3× | 3.6× / 2.7× | 0.8× / 0.6× |
| agentic-traces | 0.75 | 1.48 | 3.48 | 4.22 | 55.3 | 61.2 | 15.9 | 4.7 | 15.9× / 13.1× | 17.6× / 14.5× | 4.6× / 3.8× | 1.4× / 1.1× |
| agentic_swe | 0.65 | 1.46 | 2.42 | 3.23 | 56.3 | 71.8 | 14.9 | 3.5 | 23.3× / 17.5× | 29.7× / 22.3× | 6.2× / 4.6× | 1.4× / 1.1× |
| code_mixed | 0.07 | 1.46 | 2.94 | 4.33 | 55.2 | 67.9 | 15.5 | 4.1 | 18.8× / 12.7× | 23.1× / 15.7× | 5.3× / 3.6× | 1.4× / 0.9× |
| math_latex | 0.72 | 1.49 | 3.34 | 4.11 | 49.3 | 51.9 | 14.1 | 4.2 | 14.7× / 12.0× | 15.5× / 12.6× | 4.2× / 3.4× | 1.3× / 1.0× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×18.93 vs v0.23.1 · ×1.01 vs base · decode ×10.04</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 314) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 77.8 | ×19.45 | ×1.02 | 7% (0.7) | 0% (0.0) | 46% (4.6) | 49% (4.9) | 0% (0.0) | match |
| arb_Arab | lang | 4.6 | 92.0 | ×19.88 | ×1.02 | 7% (0.6) | 0% (0.0) | 36% (3.2) | 57% (5.1) | 0% (0.0) | match |
| ben_Beng | lang | 6.8 | 110.3 | ×16.14 | ×1.00 | 7% (0.6) | 0% (0.0) | 42% (3.7) | 52% (4.5) | 0% (0.0) | match |
| cmn_Hani | lang | 4.6 | 97.2 | ×21.09 | ×0.99 | 3% (0.6) | 0% (0.0) | 18% (3.4) | 82% (15.8) | 0% (0.0) | match |
| ell_Grek | lang | 5.1 | 98.9 | ×19.44 | ×1.01 | 5% (0.6) | 0% (0.0) | 26% (3.2) | 69% (8.5) | 0% (0.0) | match |
| eng_Latn | lang | 4.0 | 66.7 | ×16.79 | ×1.00 | 18% (2.2) | 0% (0.0) | 37% (4.7) | 46% (5.8) | 0% (0.0) | match |
| heb_Hebr | lang | 4.7 | 91.4 | ×19.47 | ×1.01 | 4% (0.6) | 0% (0.0) | 24% (3.3) | 75% (10.3) | 0% (0.0) | match |
| hin_Deva | lang | 7.0 | 110.4 | ×15.76 | ×1.02 | 7% (0.6) | 0% (0.0) | 42% (3.7) | 52% (4.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.6 | 114.5 | ×20.51 | ×1.03 | 4% (0.6) | 0% (0.0) | 21% (3.1) | 77% (11.2) | 0% (0.0) | match |
| kat_Geor | lang | 6.8 | 120.9 | ×17.81 | ×1.05 | 5% (0.6) | 0% (0.0) | 25% (3.0) | 71% (8.5) | 0% (0.0) | match |
| kor_Hang | lang | 4.1 | 74.9 | ×18.18 | ×1.05 | 3% (0.6) | 0% (0.0) | 18% (3.6) | 82% (17.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.2 | 98.9 | ×18.91 | ×1.01 | 4% (0.6) | 0% (0.0) | 20% (3.1) | 77% (12.1) | 0% (0.0) | match |
| tam_Taml | lang | 7.0 | 122.7 | ×17.42 | ×1.02 | 5% (0.6) | 0% (0.0) | 25% (3.2) | 71% (9.0) | 0% (0.0) | match |
| tha_Thai | lang | 8.0 | 144.5 | ×17.98 | ×1.03 | 5% (0.6) | 0% (0.0) | 25% (3.2) | 72% (9.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.4 | 155.4 | ×28.91 | ×1.04 | 12% (0.8) | 0% (0.0) | 35% (2.1) | 54% (3.3) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.3 | 116.1 | ×21.73 | ×1.01 | 17% (1.4) | 0% (0.0) | 39% (3.2) | 46% (3.7) | 0% (0.0) | match |
| added_special_dense | modalities | 4.2 | 72.9 | ×17.25 | ×1.02 | 39% (5.0) | 3% (0.4) | 36% (4.7) | 20% (2.6) | 1% (0.1) | match |
| added_special_sparse | modalities | 4.4 | 75.6 | ×17.19 | ×1.02 | 26% (3.3) | 2% (0.2) | 45% (5.6) | 28% (3.4) | 0% (0.0) | match |
| agentic-traces | modalities | 3.8 | 65.3 | ×17.28 | ×1.00 | 14% (1.9) | 0% (0.0) | 37% (5.0) | 49% (6.7) | 0% (0.0) | match |
| agentic_swe | modalities | 3.8 | 81.3 | ×21.25 | ×0.99 | 13% (1.3) | 0% (0.0) | 36% (3.8) | 52% (5.5) | 0% (0.0) | match |
| code_mixed | modalities | 4.0 | 78.7 | ×19.75 | ×1.01 | 15% (1.6) | 0% (0.0) | 39% (4.4) | 47% (5.3) | 0% (0.0) | match |
| math_latex | modalities | 3.6 | 63.8 | ×17.91 | ×0.99 | 16% (2.1) | 0% (0.0) | 36% (4.9) | 48% (6.5) | 1% (0.2) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.77 | 3.13 | 4.64 | 5.01 | 29.5 | 15.1 | 7.0 | 4.8 | 6.3× / 5.9× | 3.2× / 3.0× | 1.5× / 1.4× | 1.0× / 1.0× |
| arb_Arab | 1.16 | 2.77 | 3.21 | 4.82 | 33.5 | 16.4 | 7.6 | 5.2 | 10.4× / 7.0× | 5.1× / 3.4× | 2.4× / 1.6× | 1.6× / 1.1× |
| ben_Beng | 1.61 | 2.66 | 3.68 | 4.73 | 23.4 | 11.5 | 5.5 | 2.8 | 6.4× / 5.0× | 3.1× / 2.4× | 1.5× / 1.2× | 0.8× / 0.6× |
| cmn_Hani | 1.13 | 2.01 | 3.39 | 4.27 | 21.2 | 11.2 | 5.5 | 2.5 | 6.3× / 5.0× | 3.3× / 2.6× | 1.6× / 1.3× | 0.7× / 0.6× |
| ell_Grek | 0.58 | 2.80 | 3.23 | 5.45 | 29.6 | 15.4 | 7.0 | 5.0 | 9.2× / 5.4× | 4.8× / 2.8× | 2.2× / 1.3× | 1.6× / 0.9× |
| eng_Latn | 0.11 | 1.47 | 4.71 | 6.07 | 43.0 | 29.6 | 13.8 | 4.2 | 9.1× / 7.1× | 6.3× / 4.9× | 2.9× / 2.3× | 0.9× / 0.7× |
| heb_Hebr | 1.14 | 2.77 | 3.29 | 4.91 | 33.0 | 17.6 | 8.1 | 2.9 | 10.0× / 6.7× | 5.4× / 3.6× | 2.5× / 1.7× | 0.9× / 0.6× |
| hin_Deva | 1.52 | 2.88 | 3.74 | 5.10 | 26.5 | 12.9 | 6.4 | 3.1 | 7.1× / 5.2× | 3.4× / 2.5× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.70 | 3.13 | 3.11 | 4.54 | 19.9 | 9.5 | 4.7 | 3.8 | 6.4× / 4.4× | 3.1× / 2.1× | 1.5× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.54 | 2.21 | 3.01 | 3.68 | 18.2 | 10.3 | 4.6 | 2.2 | 6.0× / 4.9× | 3.4× / 2.8× | 1.5× / 1.3× | 0.7× / 0.6× |
| kor_Hang | 1.23 | 2.51 | 3.63 | 4.91 | 32.4 | 19.1 | 8.8 | 3.6 | 8.9× / 6.6× | 5.3× / 3.9× | 2.4× / 1.8× | 1.0× / 0.7× |
| rus_Cyrl | 1.18 | 2.74 | 3.14 | 4.69 | 28.2 | 15.6 | 6.7 | 4.9 | 9.0× / 6.0× | 5.0× / 3.3× | 2.1× / 1.4× | 1.6× / 1.0× |
| tam_Taml | 0.92 | 2.65 | 3.18 | 4.91 | 18.9 | 9.0 | 4.2 | 2.9 | 5.9× / 3.8× | 2.8× / 1.8× | 1.3× / 0.9× | 0.9× / 0.6× |
| tha_Thai | 1.51 | 2.24 | 3.17 | 3.91 | 13.0 | 5.8 | 2.8 | 2.2 | 4.1× / 3.3× | 1.8× / 1.5× | 0.9× / 0.7× | 0.7× / 0.6× |
| added_normalized_dense | 0.06 | 1.47 | 2.13 | 3.54 | 33.6 | 17.8 | 11.8 | 2.2 | 15.8× / 9.5× | 8.4× / 5.0× | 5.5× / 3.3× | 1.0× / 0.6× |
| added_normalized_sparse | 0.06 | 1.47 | 3.17 | 4.59 | 35.6 | 21.3 | 11.6 | 2.9 | 11.2× / 7.8× | 6.7× / 4.6× | 3.7× / 2.5× | 0.9× / 0.6× |
| added_special_dense | 0.06 | 1.47 | 4.74 | 6.16 | 83.3 | 71.0 | 24.0 | 3.1 | 17.6× / 13.5× | 15.0× / 11.5× | 5.1× / 3.9× | 0.7× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 5.60 | 7.02 | 55.6 | 42.5 | 16.8 | 3.5 | 9.9× / 7.9× | 7.6× / 6.1× | 3.0× / 2.4× | 0.6× / 0.5× |
| agentic-traces | 0.73 | 1.46 | 5.02 | 5.75 | 52.1 | 42.3 | 17.1 | 4.9 | 10.4× / 9.1× | 8.4× / 7.4× | 3.4× / 3.0× | 1.0× / 0.9× |
| agentic_swe | 0.67 | 1.44 | 3.82 | 4.59 | 53.0 | 50.4 | 17.8 | 3.6 | 13.9× / 11.5× | 13.2× / 11.0× | 4.6× / 3.9× | 0.9× / 0.8× |
| code_mixed | 0.06 | 1.44 | 4.38 | 5.76 | 52.2 | 47.9 | 17.3 | 4.2 | 11.9× / 9.1× | 10.9× / 8.3× | 4.0× / 3.0× | 1.0× / 0.7× |
| math_latex | 0.76 | 1.49 | 4.95 | 5.68 | 49.3 | 35.8 | 16.0 | 4.5 | 10.0× / 8.7× | 7.2× / 6.3× | 3.2× / 2.8× | 0.9× / 0.8× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×19.43 vs v0.23.1 · ×1.01 vs base · decode ×11.75</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 230) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 78.9 | ×19.31 | ×1.01 | 13% (1.2) | 0% (0.0) | 38% (3.7) | 52% (5.0) | 0% (0.0) | match |
| arb_Arab | lang | 4.7 | 93.5 | ×19.86 | ×1.00 | 13% (1.2) | 0% (0.0) | 26% (2.3) | 62% (5.5) | 0% (0.0) | match |
| ben_Beng | lang | 4.2 | 89.0 | ×21.21 | ×0.98 | 11% (1.2) | 0% (0.0) | 30% (3.2) | 60% (6.4) | 0% (0.0) | match |
| cmn_Hani | lang | 5.0 | 102.9 | ×20.59 | ×1.02 | 7% (1.2) | 0% (0.0) | 13% (2.4) | 84% (15.3) | 0% (0.0) | match |
| ell_Grek | lang | 5.4 | 103.4 | ×19.11 | ×1.02 | 10% (1.2) | 0% (0.0) | 19% (2.2) | 72% (8.7) | 0% (0.0) | match |
| eng_Latn | lang | 4.0 | 72.1 | ×18.19 | ×1.04 | 24% (2.8) | 0% (0.0) | 26% (3.0) | 50% (5.9) | 0% (0.0) | match |
| heb_Hebr | lang | 4.4 | 84.3 | ×19.00 | ×1.02 | 9% (1.2) | 0% (0.0) | 19% (2.4) | 75% (9.5) | 0% (0.0) | match |
| hin_Deva | lang | 4.1 | 84.1 | ×20.75 | ×1.00 | 10% (1.2) | 0% (0.0) | 29% (3.3) | 64% (7.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.8 | 119.3 | ×20.70 | ×0.99 | 7% (1.2) | 0% (0.0) | 13% (2.2) | 89% (15.4) | 0% (0.0) | match |
| kat_Geor | lang | 6.5 | 119.5 | ×18.44 | ×0.99 | 12% (1.2) | 0% (0.0) | 22% (2.1) | 72% (6.9) | 0% (0.0) | match |
| kor_Hang | lang | 4.0 | 73.6 | ×18.51 | ×0.98 | 6% (1.2) | 0% (0.0) | 12% (2.5) | 85% (18.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.0 | 101.8 | ×20.37 | ×1.00 | 7% (1.2) | 0% (0.0) | 14% (2.2) | 81% (13.0) | 0% (0.0) | match |
| tam_Taml | lang | 3.8 | 88.2 | ×23.27 | ×0.98 | 11% (1.2) | 0% (0.0) | 26% (2.8) | 64% (6.8) | 0% (0.0) | match |
| tha_Thai | lang | 5.0 | 92.1 | ×18.37 | ×0.99 | 11% (1.2) | 0% (0.0) | 24% (2.6) | 71% (7.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.0 | 166.9 | ×27.82 | ×1.00 | 24% (1.3) | 0% (0.0) | 19% (1.0) | 58% (3.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 122.8 | ×22.91 | ×0.96 | 26% (1.9) | 0% (0.0) | 26% (1.9) | 48% (3.6) | 1% (0.0) | match |
| added_special_dense | modalities | 4.2 | 46.0 | ×11.05 | ×1.01 | 58% (12.5) | 3% (0.6) | 29% (6.3) | 11% (2.4) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 61.4 | ×14.29 | ×1.03 | 46% (7.2) | 0% (0.0) | 34% (5.3) | 21% (3.4) | 0% (0.1) | match |
| agentic-traces | modalities | 3.5 | 68.9 | ×19.71 | ×1.01 | 20% (2.6) | 0% (0.0) | 29% (3.8) | 53% (6.9) | 0% (0.0) | match |
| agentic_swe | modalities | 3.8 | 84.1 | ×21.96 | ×1.03 | 18% (2.0) | 0% (0.0) | 27% (2.9) | 53% (5.7) | 2% (0.2) | match |
| code_mixed | modalities | 4.0 | 81.5 | ×20.17 | ×1.00 | 21% (2.3) | 0% (0.0) | 30% (3.3) | 49% (5.2) | 0% (0.0) | match |
| math_latex | modalities | 3.9 | 69.4 | ×17.89 | ×1.05 | 20% (2.6) | 0% (0.0) | 27% (3.5) | 55% (7.1) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.11 | 3.69 | 4.05 | 31.3 | 16.3 | 6.1 | 4.8 | 8.5× / 7.7× | 4.4× / 4.0× | 1.6× / 1.5× | 1.3× / 1.2× |
| arb_Arab | 1.15 | 2.76 | 2.35 | 3.96 | 36.2 | 19.5 | 7.0 | 5.1 | 15.4× / 9.1× | 8.3× / 4.9× | 3.0× / 1.8× | 2.2× / 1.3× |
| ben_Beng | 1.60 | 2.65 | 3.16 | 4.21 | 52.9 | 28.8 | 10.4 | 3.7 | 16.7× / 12.6× | 9.1× / 6.8× | 3.3× / 2.5× | 1.2× / 0.9× |
| cmn_Hani | 1.12 | 2.02 | 2.41 | 3.31 | 21.9 | 11.8 | 4.7 | 2.3 | 9.1× / 6.6× | 4.9× / 3.6× | 2.0× / 1.4× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.79 | 2.24 | 4.44 | 32.7 | 17.3 | 6.5 | 4.7 | 14.6× / 7.4× | 7.7× / 3.9× | 2.9× / 1.5× | 2.1× / 1.1× |
| eng_Latn | 0.10 | 1.45 | 3.01 | 4.37 | 53.2 | 33.8 | 12.8 | 3.7 | 17.7× / 12.2× | 11.2× / 7.7× | 4.2× / 2.9× | 1.2× / 0.8× |
| heb_Hebr | 1.14 | 2.79 | 2.36 | 4.01 | 36.2 | 20.5 | 7.1 | 2.9 | 15.3× / 9.0× | 8.7× / 5.1× | 3.0× / 1.8× | 1.2× / 0.7× |
| hin_Deva | 1.51 | 2.80 | 3.28 | 4.57 | 56.7 | 31.5 | 11.6 | 4.0 | 17.3× / 12.4× | 9.6× / 6.9× | 3.5× / 2.5× | 1.2× / 0.9× |
| jpn_Jpan | 1.70 | 3.13 | 2.20 | 3.63 | 20.1 | 10.1 | 4.2 | 3.7 | 9.1× / 5.5× | 4.6× / 2.8× | 1.9× / 1.2× | 1.7× / 1.0× |
| kat_Geor | 1.54 | 2.18 | 2.12 | 2.76 | 19.6 | 11.4 | 4.3 | 2.0 | 9.2× / 7.1× | 5.4× / 4.1× | 2.0× / 1.6× | 0.9× / 0.7× |
| kor_Hang | 1.23 | 2.48 | 2.52 | 3.78 | 36.7 | 22.4 | 7.8 | 3.6 | 14.6× / 9.7× | 8.9× / 5.9× | 3.1× / 2.1× | 1.4× / 1.0× |
| rus_Cyrl | 1.18 | 2.74 | 2.20 | 3.77 | 31.0 | 16.8 | 6.1 | 2.5 | 14.1× / 8.2× | 7.6× / 4.5× | 2.8× / 1.6× | 1.1× / 0.7× |
| tam_Taml | 0.92 | 2.65 | 2.76 | 4.48 | 52.1 | 27.2 | 10.2 | 3.4 | 18.9× / 11.6× | 9.9× / 6.1× | 3.7× / 2.3× | 1.2× / 0.8× |
| tha_Thai | 1.53 | 2.28 | 2.62 | 3.37 | 32.4 | 17.2 | 6.9 | 3.0 | 12.4× / 9.6× | 6.6× / 5.1× | 2.6× / 2.0× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.05 | 2.46 | 28.2 | 17.5 | 6.8 | 1.8 | 27.0× / 11.5× | 16.7× / 7.1× | 6.5× / 2.8× | 1.8× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 1.92 | 3.33 | 37.6 | 22.8 | 9.2 | 2.6 | 19.6× / 11.3× | 11.9× / 6.8× | 4.8× / 2.8× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 6.26 | 7.67 | 114.1 | 75.2 | 21.7 | 3.1 | 18.2× / 14.9× | 12.0× / 9.8× | 3.5× / 2.8× | 0.5× / 0.4× |
| added_special_sparse | 0.06 | 1.47 | 5.26 | 6.67 | 73.2 | 47.2 | 15.5 | 3.5 | 13.9× / 11.0× | 9.0× / 7.1× | 2.9× / 2.3× | 0.7× / 0.5× |
| agentic-traces | 0.75 | 1.45 | 3.77 | 4.48 | 63.6 | 46.5 | 15.7 | 4.6 | 16.9× / 14.2× | 12.3× / 10.4× | 4.2× / 3.5× | 1.2× / 1.0× |
| agentic_swe | 0.67 | 1.44 | 2.90 | 3.68 | 66.1 | 53.5 | 16.1 | 3.4 | 22.8× / 18.0× | 18.4× / 14.6× | 5.5× / 4.4× | 1.2× / 0.9× |
| code_mixed | 0.07 | 1.44 | 3.29 | 4.66 | 63.0 | 51.1 | 15.6 | 3.9 | 19.2× / 13.5× | 15.6× / 11.0× | 4.7× / 3.3× | 1.2× / 0.8× |
| math_latex | 0.74 | 1.46 | 3.48 | 4.21 | 61.7 | 40.7 | 14.8 | 4.1 | 17.7× / 14.6× | 11.7× / 9.7× | 4.2× / 3.5× | 1.2× / 1.0× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×36.09 vs v0.23.1 · ×1.00 vs base · decode ×1.53</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 19+0 (peak 22) · Pipeline 29+0 (peak 29)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.8 | 342.5 | ×71.80 | ×1.00 | 3% (0.1) | 77% (1.9) | 0% (0.0) | 21% (0.5) | 0% (0.0) | match |
| arb_Arab | lang | 10.6 | 340.4 | ×31.99 | ×1.01 | 2% (0.0) | 83% (2.2) | 0% (0.0) | 16% (0.4) | 0% (0.0) | match |
| ben_Beng | lang | 11.5 | 438.9 | ×38.33 | ×1.01 | 3% (0.1) | 77% (1.5) | 0% (0.0) | 21% (0.4) | 0% (0.0) | match |
| cmn_Hani | lang | 9.4 | 882.4 | ×93.74 | ×0.99 | 8% (0.1) | 45% (0.4) | 0% (0.0) | 46% (0.4) | 0% (0.0) | match |
| ell_Grek | lang | 10.7 | 337.4 | ×31.52 | ×1.01 | 2% (0.1) | 82% (2.2) | 0% (0.0) | 18% (0.5) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 171.4 | ×38.72 | ×1.00 | 1% (0.1) | 92% (5.2) | 0% (0.0) | 7% (0.4) | 0% (0.0) | match |
| heb_Hebr | lang | 10.7 | 335.7 | ×31.33 | ×1.02 | 2% (0.0) | 83% (2.2) | 0% (0.0) | 17% (0.5) | 0% (0.0) | match |
| hin_Deva | lang | 12.8 | 371.8 | ×28.98 | ×1.01 | 2% (0.0) | 82% (2.0) | 0% (0.0) | 17% (0.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.7 | 1022.2 | ×74.72 | ×0.99 | 9% (0.1) | 42% (0.3) | 0% (0.0) | 52% (0.4) | 0% (0.0) | match |
| kat_Geor | lang | 15.1 | 477.2 | ×31.54 | ×0.99 | 4% (0.1) | 76% (1.4) | 1% (0.0) | 22% (0.4) | 0% (0.0) | match |
| kor_Hang | lang | 7.7 | 330.4 | ×42.88 | ×1.02 | 3% (0.1) | 82% (2.2) | 0% (0.0) | 17% (0.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 8.6 | 364.8 | ×42.38 | ×0.94 | 2% (0.1) | 84% (2.0) | 0% (0.0) | 14% (0.3) | 0% (0.0) | match |
| tam_Taml | lang | 13.4 | 503.7 | ×37.66 | ×1.00 | 3% (0.0) | 75% (1.3) | 0% (0.0) | 24% (0.4) | 0% (0.0) | match |
| tha_Thai | lang | 16.5 | 681.9 | ×41.27 | ×0.99 | 4% (0.1) | 65% (0.8) | 0% (0.0) | 32% (0.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.9 | 270.6 | ×46.13 | ×0.99 | 3% (0.1) | 85% (2.6) | 0% (0.0) | 13% (0.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.1 | 187.8 | ×36.95 | ×1.00 | 1% (0.0) | 92% (4.5) | 0% (0.0) | 8% (0.4) | 0% (0.0) | match |
| added_special_dense | modalities | 4.2 | 41.3 | ×9.93 | ×1.00 | 21% (5.0) | 64% (15.1) | 4% (0.9) | 11% (2.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 6.0 | 54.3 | ×9.12 | ×1.00 | 13% (2.3) | 74% (12.7) | 1% (0.3) | 12% (2.0) | 0% (0.0) | match |
| agentic-traces | modalities | 4.7 | 186.3 | ×39.85 | ×1.00 | 3% (0.1) | 89% (4.5) | 0% (0.0) | 9% (0.4) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 140.8 | ×33.41 | ×1.01 | 1% (0.0) | 92% (6.3) | 0% (0.0) | 8% (0.5) | 0% (0.0) | match |
| code_mixed | modalities | 4.4 | 163.4 | ×37.33 | ×1.00 | 1% (0.0) | 91% (5.4) | 0% (0.0) | 8% (0.5) | 0% (0.0) | match |
| math_latex | modalities | 4.6 | 181.1 | ×39.20 | ×1.00 | 2% (0.1) | 91% (4.8) | 0% (0.0) | 8% (0.4) | 0% (0.0) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×21.08 vs v0.23.1 · ×1.01 vs base · decode ×11.97</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 108+0 (peak 107)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.5 | 87.4 | ×19.26 | ×1.04 | 7% (0.7) | 0% (0.0) | 40% (3.7) | 53% (4.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.9 | 104.4 | ×21.27 | ×1.02 | 7% (0.6) | 0% (0.0) | 29% (2.3) | 64% (5.2) | 0% (0.0) | match |
| ben_Beng | lang | 4.2 | 89.2 | ×21.33 | ×1.01 | 6% (0.6) | 0% (0.0) | 29% (3.2) | 65% (7.0) | 0% (0.0) | match |
| cmn_Hani | lang | 5.5 | 115.0 | ×21.04 | ×1.03 | 4% (0.6) | 0% (0.0) | 15% (2.4) | 83% (12.8) | 0% (0.0) | match |
| ell_Grek | lang | 5.5 | 116.2 | ×21.15 | ×1.05 | 5% (0.6) | 0% (0.0) | 19% (2.2) | 76% (8.8) | 0% (0.0) | match |
| eng_Latn | lang | 4.3 | 78.9 | ×18.16 | ×1.01 | 20% (2.2) | 0% (0.0) | 28% (3.1) | 55% (6.1) | 0% (0.0) | match |
| heb_Hebr | lang | 4.5 | 91.1 | ×20.08 | ×1.01 | 5% (0.6) | 0% (0.0) | 19% (2.3) | 77% (9.4) | 0% (0.0) | match |
| hin_Deva | lang | 4.5 | 114.0 | ×25.09 | ×1.01 | 8% (0.6) | 0% (0.0) | 41% (3.3) | 52% (4.1) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.2 | 133.2 | ×21.65 | ×1.02 | 4% (0.6) | 0% (0.0) | 15% (2.2) | 82% (12.3) | 0% (0.0) | match |
| kat_Geor | lang | 5.9 | 130.0 | ×22.16 | ×1.02 | 8% (0.6) | 0% (0.0) | 27% (2.1) | 66% (5.1) | 0% (0.0) | match |
| kor_Hang | lang | 4.4 | 85.6 | ×19.62 | ×1.02 | 3% (0.6) | 0% (0.0) | 14% (2.5) | 83% (15.3) | 0% (0.1) | match |
| rus_Cyrl | lang | 5.3 | 113.0 | ×21.17 | ×1.02 | 4% (0.6) | 0% (0.0) | 15% (2.2) | 81% (12.1) | 0% (0.0) | match |
| tam_Taml | lang | 4.2 | 94.7 | ×22.80 | ×0.98 | 6% (0.6) | 0% (0.0) | 27% (2.7) | 67% (6.8) | 0% (0.0) | match |
| tha_Thai | lang | 5.5 | 112.9 | ×20.35 | ×1.01 | 6% (0.6) | 0% (0.0) | 25% (2.6) | 70% (7.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.2 | 175.9 | ×28.51 | ×1.00 | 15% (0.8) | 0% (0.0) | 21% (1.1) | 65% (3.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.5 | 133.9 | ×24.36 | ×0.99 | 20% (1.4) | 0% (0.0) | 29% (2.0) | 52% (3.6) | 0% (0.0) | match |
| added_special_dense | modalities | 4.2 | 72.2 | ×17.07 | ×0.98 | 39% (5.0) | 3% (0.4) | 38% (5.0) | 20% (2.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 80.5 | ×18.54 | ×1.03 | 28% (3.3) | 2% (0.2) | 40% (4.7) | 30% (3.5) | 0% (0.0) | match |
| agentic-traces | modalities | 3.7 | 74.8 | ×20.43 | ×1.01 | 16% (1.9) | 0% (0.0) | 31% (3.8) | 53% (6.3) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 91.4 | ×22.53 | ×1.02 | 14% (1.3) | 0% (0.0) | 30% (2.9) | 56% (5.4) | 0% (0.0) | match |
| code_mixed | modalities | 4.2 | 87.5 | ×20.82 | ×1.00 | 16% (1.6) | 0% (0.0) | 33% (3.3) | 51% (5.2) | 0% (0.0) | match |
| math_latex | modalities | 3.9 | 75.0 | ×19.18 | ×1.02 | 17% (2.0) | 0% (0.0) | 29% (3.5) | 54% (6.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.74 | 3.12 | 3.68 | 4.06 | 27.3 | 16.7 | 6.0 | 4.7 | 7.4× / 6.7× | 4.5× / 4.1× | 1.6× / 1.5× | 1.3× / 1.2× |
| arb_Arab | 1.15 | 2.76 | 2.34 | 3.95 | 30.9 | 19.7 | 6.9 | 5.1 | 13.2× / 7.8× | 8.4× / 5.0× | 3.0× / 1.8× | 2.2× / 1.3× |
| ben_Beng | 1.61 | 2.66 | 3.16 | 4.21 | 45.7 | 28.7 | 10.4 | 3.7 | 14.5× / 10.9× | 9.1× / 6.8× | 3.3× / 2.5× | 1.2× / 0.9× |
| cmn_Hani | 1.12 | 2.01 | 2.40 | 3.29 | 19.4 | 11.8 | 4.8 | 2.3 | 8.1× / 5.9× | 4.9× / 3.6× | 2.0× / 1.5× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.77 | 2.21 | 4.39 | 28.6 | 17.7 | 6.3 | 4.8 | 12.9× / 6.5× | 8.0× / 4.0× | 2.9× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.11 | 1.46 | 3.06 | 4.41 | 44.5 | 34.5 | 12.8 | 3.7 | 14.6× / 10.1× | 11.3× / 7.8× | 4.2× / 2.9× | 1.2× / 0.8× |
| heb_Hebr | 1.16 | 2.82 | 2.33 | 4.00 | 30.8 | 20.0 | 7.1 | 3.0 | 13.2× / 7.7× | 8.6× / 5.0× | 3.0× / 1.8× | 1.3× / 0.7× |
| hin_Deva | 1.52 | 2.79 | 3.25 | 4.53 | 47.7 | 31.2 | 11.6 | 4.0 | 14.7× / 10.5× | 9.6× / 6.9× | 3.6× / 2.6× | 1.2× / 0.9× |
| jpn_Jpan | 1.71 | 3.09 | 2.19 | 3.58 | 18.0 | 10.0 | 4.1 | 3.7 | 8.2× / 5.0× | 4.6× / 2.8× | 1.9× / 1.2× | 1.7× / 1.0× |
| kat_Geor | 1.54 | 2.16 | 2.11 | 2.74 | 17.2 | 11.4 | 4.3 | 2.0 | 8.1× / 6.3× | 5.4× / 4.2× | 2.0× / 1.6× | 0.9× / 0.7× |
| kor_Hang | 1.23 | 2.49 | 2.53 | 3.79 | 31.4 | 21.5 | 7.6 | 3.6 | 12.4× / 8.3× | 8.5× / 5.7× | 3.0× / 2.0× | 1.4× / 0.9× |
| rus_Cyrl | 1.17 | 2.73 | 2.18 | 3.74 | 27.2 | 16.9 | 6.1 | 2.5 | 12.5× / 7.3× | 7.7× / 4.5× | 2.8× / 1.6× | 1.2× / 0.7× |
| tam_Taml | 0.92 | 2.63 | 2.72 | 4.42 | 43.8 | 27.3 | 10.0 | 3.4 | 16.1× / 9.9× | 10.1× / 6.2× | 3.7× / 2.3× | 1.3× / 0.8× |
| tha_Thai | 1.51 | 2.27 | 2.61 | 3.38 | 27.9 | 17.0 | 6.9 | 3.0 | 10.7× / 8.3× | 6.5× / 5.0× | 2.6× / 2.0× | 1.1× / 0.9× |
| added_normalized_dense | 0.06 | 1.47 | 1.09 | 2.50 | 23.7 | 17.1 | 6.7 | 1.9 | 21.7× / 9.5× | 15.7× / 6.8× | 6.1× / 2.7× | 1.7× / 0.7× |
| added_normalized_sparse | 0.06 | 1.47 | 2.01 | 3.42 | 31.7 | 23.4 | 9.1 | 2.6 | 15.8× / 9.3× | 11.6× / 6.8× | 4.5× / 2.6× | 1.3× / 0.8× |
| added_special_dense | 0.06 | 1.47 | 4.96 | 6.38 | 96.1 | 75.5 | 21.2 | 3.1 | 19.4× / 15.1× | 15.2× / 11.8× | 4.3× / 3.3× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 1.47 | 4.69 | 6.10 | 61.5 | 46.9 | 15.4 | 3.6 | 13.1× / 10.1× | 10.0× / 7.7× | 3.3× / 2.5× | 0.8× / 0.6× |
| agentic-traces | 0.77 | 1.46 | 3.76 | 4.45 | 52.5 | 45.1 | 15.4 | 4.6 | 14.0× / 11.8× | 12.0× / 10.1× | 4.1× / 3.5× | 1.2× / 1.0× |
| agentic_swe | 0.66 | 1.45 | 2.91 | 3.70 | 55.1 | 52.8 | 16.0 | 3.4 | 18.9× / 14.9× | 18.1× / 14.3× | 5.5× / 4.3× | 1.2× / 0.9× |
| code_mixed | 0.10 | 1.43 | 3.31 | 4.64 | 52.6 | 50.8 | 15.5 | 3.9 | 15.9× / 11.3× | 15.4× / 10.9× | 4.7× / 3.3× | 1.2× / 0.9× |
| math_latex | 0.73 | 1.46 | 3.49 | 4.22 | 51.3 | 40.0 | 14.6 | 4.1 | 14.7× / 12.2× | 11.5× / 9.5× | 4.2× / 3.5× | 1.2× / 1.0× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×18.44 vs v0.23.1 · ×1.01 vs base · decode ×8.30</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 193) · Pipeline 145+0 (peak 194)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.6 | 71.4 | ×19.96 | ×0.98 | 12% (1.3) | 0% (0.0) | 43% (4.6) | 46% (5.0) | 0% (0.0) | match |
| arb_Arab | lang | 4.6 | 88.3 | ×19.19 | ×1.02 | 13% (1.2) | 0% (0.0) | 34% (3.2) | 53% (5.0) | 0% (0.0) | match |
| ben_Beng | lang | 6.6 | 103.6 | ×15.73 | ×1.01 | 12% (1.2) | 0% (0.0) | 38% (3.6) | 49% (4.6) | 0% (0.0) | match |
| cmn_Hani | lang | 4.9 | 94.0 | ×19.18 | ×0.99 | 7% (1.2) | 0% (0.0) | 20% (3.3) | 80% (13.3) | 0% (0.0) | match |
| ell_Grek | lang | 5.2 | 96.6 | ×18.49 | ×1.02 | 9% (1.2) | 0% (0.0) | 23% (3.2) | 68% (9.3) | 0% (0.0) | match |
| eng_Latn | lang | 3.7 | 65.4 | ×17.47 | ×1.00 | 19% (2.6) | 0% (0.0) | 34% (4.7) | 46% (6.4) | 0% (0.0) | match |
| heb_Hebr | lang | 4.6 | 86.1 | ×18.74 | ×1.03 | 8% (1.2) | 0% (0.0) | 22% (3.3) | 72% (10.9) | 0% (0.0) | match |
| hin_Deva | lang | 6.6 | 102.1 | ×15.39 | ×1.02 | 12% (1.2) | 0% (0.0) | 37% (3.7) | 53% (5.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.6 | 108.1 | ×19.20 | ×0.98 | 8% (1.2) | 0% (0.0) | 22% (3.1) | 74% (10.3) | 0% (0.0) | match |
| kat_Geor | lang | 6.6 | 114.6 | ×17.24 | ×1.00 | 9% (1.2) | 0% (0.0) | 23% (2.8) | 68% (8.4) | 0% (0.0) | match |
| kor_Hang | lang | 4.1 | 74.2 | ×18.00 | ×1.00 | 6% (1.2) | 0% (0.0) | 17% (3.6) | 77% (16.0) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.0 | 95.5 | ×19.29 | ×0.99 | 7% (1.2) | 0% (0.0) | 19% (3.1) | 76% (12.6) | 0% (0.0) | match |
| tam_Taml | lang | 7.0 | 116.5 | ×16.65 | ×1.03 | 9% (1.2) | 0% (0.0) | 25% (3.2) | 66% (8.5) | 0% (0.0) | match |
| tha_Thai | lang | 8.1 | 137.3 | ×16.95 | ×1.03 | 10% (1.2) | 0% (0.0) | 26% (3.2) | 65% (8.1) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.5 | 139.3 | ×25.33 | ×1.01 | 19% (1.3) | 0% (0.0) | 31% (2.1) | 50% (3.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 107.0 | ×20.61 | ×1.00 | 23% (2.0) | 0% (0.0) | 36% (3.1) | 44% (3.8) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 70.9 | ×16.66 | ×1.01 | 38% (5.2) | 3% (0.3) | 37% (5.1) | 22% (2.9) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.5 | 71.3 | ×15.95 | ×1.01 | 27% (3.7) | 1% (0.2) | 40% (5.4) | 31% (4.1) | 1% (0.1) | match |
| agentic-traces | modalities | 3.4 | 63.4 | ×18.54 | ×1.00 | 17% (2.5) | 0% (0.0) | 35% (5.1) | 48% (6.9) | 0% (0.0) | match |
| agentic_swe | modalities | 3.5 | 76.2 | ×21.72 | ×1.01 | 16% (2.0) | 0% (0.0) | 31% (3.8) | 54% (6.6) | 0% (0.0) | match |
| code_mixed | modalities | 3.7 | 74.1 | ×20.11 | ×1.00 | 18% (2.2) | 0% (0.0) | 35% (4.4) | 46% (5.6) | 1% (0.1) | match |
| math_latex | modalities | 3.6 | 63.8 | ×17.82 | ×1.00 | 19% (2.6) | 0% (0.0) | 35% (4.9) | 47% (6.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.75 | 3.20 | 4.62 | 5.07 | 26.7 | 14.8 | 6.6 | — | 5.8× / 5.3× | 3.2× / 2.9× | 1.4× / 1.3× | — |
| arb_Arab | 1.15 | 2.76 | 3.22 | 4.84 | 31.1 | 16.7 | 7.3 | — | 9.6× / 6.4× | 5.2× / 3.5× | 2.3× / 1.5× | — |
| ben_Beng | 1.60 | 2.62 | 3.62 | 4.63 | 21.8 | 11.1 | 5.2 | — | 6.0× / 4.7× | 3.1× / 2.4× | 1.4× / 1.1× | — |
| cmn_Hani | 1.12 | 2.04 | 3.33 | 4.25 | 20.3 | 11.8 | 5.5 | — | 6.1× / 4.8× | 3.6× / 2.8× | 1.7× / 1.3× | — |
| ell_Grek | 0.59 | 2.79 | 3.17 | 5.37 | 27.1 | 15.6 | 6.7 | — | 8.5× / 5.0× | 4.9× / 2.9× | 2.1× / 1.3× | — |
| eng_Latn | 0.10 | 1.47 | 4.66 | 6.02 | 38.9 | 31.1 | 13.4 | — | 8.4× / 6.5× | 6.7× / 5.2× | 2.9× / 2.2× | — |
| heb_Hebr | 1.15 | 2.81 | 3.30 | 4.96 | 30.0 | 17.8 | 7.7 | — | 9.1× / 6.0× | 5.4× / 3.6× | 2.3× / 1.6× | — |
| hin_Deva | 1.52 | 2.77 | 3.72 | 4.98 | 23.2 | 13.1 | 6.1 | — | 6.2× / 4.7× | 3.5× / 2.6× | 1.6× / 1.2× | — |
| jpn_Jpan | 1.70 | 3.14 | 3.11 | 4.55 | 19.2 | 9.9 | 4.8 | — | 6.2× / 4.2× | 3.2× / 2.2× | 1.5× / 1.0× | — |
| kat_Geor | 1.54 | 2.18 | 2.81 | 3.45 | 17.0 | 10.4 | 4.5 | — | 6.1× / 4.9× | 3.7× / 3.0× | 1.6× / 1.3× | — |
| kor_Hang | 1.23 | 2.49 | 3.62 | 4.88 | 30.0 | 19.8 | 8.7 | — | 8.3× / 6.2× | 5.5× / 4.1× | 2.4× / 1.8× | — |
| rus_Cyrl | 1.17 | 2.74 | 3.11 | 4.67 | 26.3 | 15.4 | 6.5 | — | 8.5× / 5.6× | 5.0× / 3.3× | 2.1× / 1.4× | — |
| tam_Taml | 0.93 | 2.63 | 3.19 | 4.88 | 17.7 | 9.1 | 4.1 | — | 5.6× / 3.6× | 2.8× / 1.9× | 1.3× / 0.8× | — |
| tha_Thai | 1.52 | 2.27 | 3.20 | 3.96 | 12.6 | 5.9 | 2.8 | — | 3.9× / 3.2× | 1.8× / 1.5× | 0.9× / 0.7× | — |
| added_normalized_dense | 0.07 | 1.47 | 2.12 | 3.51 | 31.0 | 17.7 | 11.4 | — | 14.6× / 8.8× | 8.3× / 5.0× | 5.4× / 3.3× | — |
| added_normalized_sparse | 0.06 | 1.47 | 3.10 | 4.52 | 31.8 | 20.9 | 11.2 | — | 10.2× / 7.0× | 6.7× / 4.6× | 3.6× / 2.5× | — |
| added_special_dense | 0.06 | 1.47 | 5.07 | 6.48 | 76.8 | 69.0 | 23.5 | — | 15.2× / 11.9× | 13.6× / 10.6× | 4.6× / 3.6× | — |
| added_special_sparse | 0.06 | 1.47 | 5.39 | 6.80 | 50.1 | 42.2 | 16.1 | — | 9.3× / 7.4× | 7.8× / 6.2× | 3.0× / 2.4× | — |
| agentic-traces | 0.74 | 1.46 | 5.06 | 5.79 | 49.1 | 45.0 | 17.3 | — | 9.7× / 8.5× | 8.9× / 7.8× | 3.4× / 3.0× | — |
| agentic_swe | 0.65 | 1.44 | 3.82 | 4.61 | 54.4 | 55.9 | 18.2 | — | 14.2× / 11.8× | 14.6× / 12.1× | 4.8× / 4.0× | — |
| code_mixed | 0.08 | 1.44 | 4.39 | 5.75 | 49.4 | 50.1 | 17.4 | — | 11.3× / 8.6× | 11.4× / 8.7× | 4.0× / 3.0× | — |
| math_latex | 0.71 | 1.47 | 4.88 | 5.63 | 46.0 | 38.5 | 15.5 | — | 9.4× / 8.2× | 7.9× / 6.8× | 3.2× / 2.7× | — |

</details>

<details><summary><b>t5-base</b> — Unigram + Metaspace · ×5.59 vs v0.23.1 · ×1.01 vs base · decode ×0.96</summary>

<img alt="t5-base speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-t5-base.png" width="860">

<img alt="t5-base stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-t5-base-stages.png" width="860">

<img alt="t5-base thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-t5-base-threads.png" width="860">

<img alt="t5-base decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-t5-base-decode.png" width="860">

<img alt="t5-base decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31101422113-t5-base-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 34+2 (peak 34) · Pipeline 61+0 (peak 65)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.4 | 35.7 | ×6.59 | ×1.01 | 2% (0.7) | 77% (21.4) | 10% (2.6) | 9% (2.4) | 2% (0.6) | match |
| arb_Arab | lang | 4.2 | 29.5 | ×6.99 | ×1.01 | 2% (0.6) | 74% (26.6) | 9% (3.1) | 15% (5.4) | 1% (0.3) | match |
| ben_Beng | lang | 7.3 | 34.2 | ×4.69 | ×1.01 | 2% (0.6) | 84% (26.3) | 6% (2.0) | 8% (2.4) | 0% (0.0) | match |
| cmn_Hani | lang | 12.6 | 52.0 | ×4.13 | ×1.01 | 2% (0.6) | 66% (16.6) | 4% (0.9) | 30% (7.5) | 0% (0.0) | match |
| ell_Grek | lang | 4.6 | 29.8 | ×6.50 | ×1.03 | 1% (0.6) | 62% (26.8) | 7% (2.9) | 28% (12.2) | 1% (0.4) | match |
| eng_Latn | lang | 2.6 | 18.5 | ×7.19 | ×1.00 | 2% (2.1) | 44% (40.4) | 7% (6.2) | 46% (41.9) | 1% (0.5) | match |
| heb_Hebr | lang | 4.3 | 32.3 | ×7.60 | ×1.01 | 1% (0.6) | 56% (23.6) | 9% (3.8) | 32% (13.3) | 2% (0.8) | match |
| hin_Deva | lang | 6.1 | 33.6 | ×5.51 | ×1.01 | 2% (0.6) | 75% (24.1) | 8% (2.7) | 18% (5.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.6 | 45.3 | ×3.34 | ×1.02 | 2% (0.6) | 70% (19.6) | 2% (0.6) | 25% (7.0) | 0% (0.1) | match |
| kat_Geor | lang | 8.2 | 43.2 | ×5.24 | ×1.01 | 2% (0.6) | 61% (18.6) | 5% (1.6) | 29% (8.8) | 3% (0.9) | match |
| kor_Hang | lang | 4.4 | 30.9 | ×6.97 | ×1.02 | 2% (0.8) | 52% (23.9) | 6% (3.0) | 39% (18.1) | 0% (0.2) | match |
| rus_Cyrl | lang | 4.2 | 29.0 | ×6.93 | ×1.01 | 1% (0.6) | 48% (26.6) | 5% (2.5) | 48% (26.5) | 0% (0.0) | match |
| tam_Taml | lang | 9.0 | 43.9 | ×4.86 | ×1.02 | 2% (0.6) | 64% (18.6) | 5% (1.5) | 28% (8.0) | 1% (0.3) | match |
| tha_Thai | lang | 12.9 | 46.7 | ×3.63 | ×1.02 | 2% (0.6) | 63% (18.6) | 3% (0.9) | 32% (9.6) | 0% (0.1) | match |
| added_normalized_dense | modalities | 4.6 | 23.0 | ×4.98 | ×1.00 | 2% (0.8) | 76% (36.7) | 10% (4.6) | 9% (4.3) | 4% (2.1) | match |
| added_normalized_sparse | modalities | 4.0 | 20.7 | ×5.20 | ×1.00 | 3% (1.4) | 69% (38.9) | 9% (5.2) | 15% (8.5) | 3% (1.9) | match |
| added_special_dense | modalities | 6.2 | 37.1 | ×5.95 | ×0.99 | 18% (5.0) | 65% (17.6) | 12% (3.2) | 4% (1.1) | 1% (0.3) | match |
| added_special_sparse | modalities | 4.2 | 20.3 | ×4.81 | ×1.00 | 6% (3.2) | 67% (33.9) | 21% (10.5) | 4% (1.9) | 2% (1.1) | match |
| agentic-traces | modalities | 2.8 | 19.5 | ×6.88 | ×1.00 | 2% (1.9) | 46% (39.7) | 6% (5.1) | 42% (36.4) | 3% (2.9) | match |
| agentic_swe | modalities | 4.2 | 22.6 | ×5.38 | ×1.00 | 2% (1.3) | 58% (36.9) | 7% (4.2) | 30% (19.2) | 3% (1.8) | match |
| code_mixed | modalities | 3.7 | 20.9 | ×5.64 | ×1.00 | 2% (1.6) | 54% (38.6) | 6% (4.3) | 36% (25.6) | 2% (1.7) | match |
| math_latex | modalities | 2.7 | 18.7 | ×6.96 | ×1.01 | 2% (2.0) | 47% (40.4) | 7% (6.2) | 41% (35.4) | 3% (2.9) | match |

</details>
<!-- pipeline-bench:end -->
