### PR TITLE
perf(bpe): wire the word cache into the pipeline model

### DIFF
--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -1494,7 +1494,6 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "log",
- "rayon",
  "serde",
  "serde_json",
  "thiserror",

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1647,7 +1647,6 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "log",
- "rayon",
  "serde",
  "serde_json",
  "thiserror",

--- a/tokenizers/tk-encode/src/models/bpe/legacy/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/legacy/model.rs
@@ -302,7 +302,7 @@ pub struct BPE {
     /// Contains the mapping between Pairs and their (rank, new_id).
     pub merges: MergeMap,
     /// Contains the cache for optimizing the encoding step.
-    pub(super) cache: Option<BpeCache>,
+    pub(in crate::models::bpe) cache: Option<BpeCache>,
     /// Dropout probability for merges. 0.0 = no dropout is the default. At 1.0, tokenization will
     /// perform no merges, so the result will just be characters.
     pub dropout: Option<f32>,

--- a/tokenizers/tk-encode/src/models/bpe/legacy/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/legacy/model.rs
@@ -302,7 +302,7 @@ pub struct BPE {
     /// Contains the mapping between Pairs and their (rank, new_id).
     pub merges: MergeMap,
     /// Contains the cache for optimizing the encoding step.
-    pub(in crate::models::bpe) cache: Option<BpeCache>,
+    pub(crate) cache: Option<BpeCache>,
     /// Dropout probability for merges. 0.0 = no dropout is the default. At 1.0, tokenization will
     /// perform no merges, so the result will just be characters.
     pub dropout: Option<f32>,

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -11,6 +11,7 @@ use crate::models::bpe::tables::BpeTables;
 use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::Result;
 use crate::utils::byte_level::{self};
+use crate::utils::word_cache::{Lookup, WordCache};
 use crate::vocab::bucket_vocab_store::BucketVocabStore;
 
 const GATE_MULTI: u16 = 8;
@@ -55,6 +56,8 @@ pub struct PipelineBPE {
     /// See [`PipelineBPE::prove_fold`].
     fold_by_flag: bool,
     byte_to_gate: [u16; 256],
+    /// Slots for the per-scratch word cache, from the config. `None` disables it.
+    cache_capacity: Option<usize>,
 }
 
 // A `PipelineBPE` holds exactly one `Atoms`, so `Chars`' 1 KB byte-fallback table costs nothing.
@@ -83,8 +86,11 @@ impl PipelineBPE {
             fuse_unk,
             continuing_subword_prefix,
             end_of_word_suffix,
+            cache,
             ..
         } = model;
+        // A capacity of zero means "no cache"; anything else sizes the per-scratch table.
+        let cache_capacity = cache.map(|cache| cache.capacity).filter(|&c| c > 0);
         let prefix = continuing_subword_prefix.unwrap_or_default();
         let suffix = end_of_word_suffix.unwrap_or_default();
         if prefix.len() + 4 + suffix.len() > AFFIX_BUF {
@@ -158,6 +164,7 @@ impl PipelineBPE {
             affixes,
             ignore_merges,
             fold_by_flag: false,
+            cache_capacity,
             vocab,
             byte_to_gate: build_byte_to_gate(),
         };
@@ -261,6 +268,9 @@ pub struct BpeScratch {
     pub(crate) symbols: Vec<u32>,
     /// Entry arena and the two queue tiers.
     pub(crate) queue: QueueScratch,
+    /// Words already seen, so a repeat costs a probe instead of a merge. It lives in the scratch
+    /// so it outlives the encode call that fills it -- otherwise it would never see a word twice.
+    pub(crate) word_cache: Option<WordCache>,
 }
 
 impl pipeline::ModelScratch for BpeScratch {}
@@ -283,13 +293,35 @@ impl pipeline::Model for PipelineBPE {
             return Ok(());
         }
 
-        let BpeScratch { symbols, queue } = scratch;
+        let BpeScratch {
+            symbols,
+            queue,
+            word_cache,
+        } = scratch;
 
+        // A word seen before costs a probe instead of a merge.
+        let mut placement = None;
+        if let Some(cache) = word_cache.as_mut() {
+            match cache.lookup(sequence.as_bytes()) {
+                Lookup::Hit(ids) => {
+                    output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                    return Ok(());
+                }
+                Lookup::Miss(at) => placement = Some(at),
+            }
+        }
+
+        let start = output.len();
         self.merge_word(sequence, symbols, queue);
         // the merge engines work in internal ids; `unmap` takes them back to the vocab's own ids
         output.extend(symbols.iter().map(|&symbol| PipelineToken {
             id: self.tables.unmap.at(symbol as usize),
         }));
+        if let Some(cache) = word_cache.as_mut()
+            && let Some(at) = placement
+        {
+            cache.insert(at, output[start..].iter().map(|token| token.id));
+        }
 
         Ok(())
     }
@@ -298,6 +330,7 @@ impl pipeline::Model for PipelineBPE {
         Self::Scratch {
             symbols: Vec::with_capacity(64),
             queue: QueueScratch::default(),
+            word_cache: self.cache_capacity.map(WordCache::new),
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -300,16 +300,17 @@ impl pipeline::Model for PipelineBPE {
         } = scratch;
 
         // A word seen before costs a probe instead of a merge.
-        let mut placement = None;
-        if let Some(cache) = word_cache.as_mut() {
+        let insert_at = if let Some(cache) = word_cache.as_mut() {
             match cache.lookup(sequence.as_bytes()) {
                 Lookup::Hit(ids) => {
                     output.extend(ids.iter().map(|&id| PipelineToken { id }));
                     return Ok(());
                 }
-                Lookup::Miss(at) => placement = Some(at),
+                Lookup::Miss(at) => Some(at),
             }
-        }
+        } else {
+            None
+        };
 
         let start = output.len();
         self.merge_word(sequence, symbols, queue);
@@ -318,7 +319,7 @@ impl pipeline::Model for PipelineBPE {
             id: self.tables.unmap.at(symbol as usize),
         }));
         if let Some(cache) = word_cache.as_mut()
-            && let Some(at) = placement
+            && let Some(at) = insert_at
         {
             cache.insert(at, output[start..].iter().map(|token| token.id));
         }

--- a/tokenizers/tk-encode/src/models/bpe/tests.rs
+++ b/tokenizers/tk-encode/src/models/bpe/tests.rs
@@ -592,6 +592,35 @@ mod pipeline_bpe {
         }
     }
 
+    // A cache may forget a word, but it must never change one. Run every word twice
+    // through one scratch, the second time answered from the cache, against a model
+    // built with no cache at all.
+    #[test]
+    fn cached_ids_match_uncached() {
+        let cached = PipelineBPE::from_bpe(hello_builder().build().unwrap(), false).unwrap();
+        let uncached =
+            PipelineBPE::from_bpe(hello_builder().cache_capacity(0).build().unwrap(), false)
+                .unwrap();
+
+        let mut scratch = cached.init_scratch();
+        assert!(scratch.word_cache.is_some(), "nothing is being cached");
+        for _ in 0..2 {
+            for word in [
+                "hello",
+                "hell",
+                "o",
+                "hellohello",
+                "hello-a-word-past-fifteen-bytes",
+                "hxe",
+            ] {
+                let mut out = Vec::new();
+                pipeline::Model::tokenize_pipeline(&cached, word, &mut scratch, &mut out).unwrap();
+                let got: Vec<u32> = out.iter().map(|t| t.id).collect();
+                assert_eq!(got, pipeline_ids(&uncached, word), "{word:?}");
+            }
+        }
+    }
+
     #[test]
     fn unknown_char_without_unk_is_dropped() {
         let bpe = hello_builder().build().unwrap();

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -1841,4 +1841,23 @@ mod tests {
             long_input.len()
         );
     }
+
+    // A scratch coming back out of the pool has to still know the words of the last
+    // encode: a cache emptied between calls would never hit.
+    //
+    // "helo" and not "hello": a whole word that is itself a vocabulary entry is answered
+    // by the fold in one probe, before the cache is ever consulted, so it would never be
+    // stored. Only words that reach the merge engines land in the cache.
+    #[test]
+    fn the_word_cache_outlives_the_encode_call() {
+        let pipeline = hello_pipeline();
+        pipeline.encode("helo", false).wait().unwrap();
+
+        let mut scratch = pipeline.scratch_pool.get(&pipeline.model);
+        let PipelineModelScratch::BPE(bpe) = &mut *scratch else {
+            panic!("a BPE pipeline encodes with a BPE scratch");
+        };
+        let cache = bpe.word_cache.as_mut().expect("BPE encodes with a cache");
+        assert_eq!(cache.lookup(b"helo").hit(), Some(&[5u32, 3][..]));
+    }
 }


### PR DESCRIPTION
Four files, +83/−2.

## The gap

`word_cache.rs` has been on this branch since #2262 — which wired it into the pipeline BPE too. #2241 merged a day later as a squash of a branch that predated it, and its whole-file rewrite of `models/bpe/model.rs` (`@@ -1,694 +1,67 @@`) took the wiring and its tests with it. Nothing was deleted line by line; an older copy of the file simply landed on top. Unigram and WordPiece kept their cache, which is what makes it a clobber rather than a decision.

So today **only the legacy BPE uses it**. The pipeline model's scratch is `{ symbols, queue }` — no cache — so every pre-token is merged from scratch even when the same word appeared moments earlier. On text with any word repetition, that is most of the work.

`BpeScratch` gains `word_cache: Option<WordCache>`, sized from the model's own `cache` descriptor so a config setting capacity `0` still opts out. It lives in the scratch, not the model, because it has to outlive the encode call that fills it — otherwise it never sees a word twice.

One visibility change: `BPE::cache` from `pub(super)` to `pub(in crate::models::bpe)`, so the pipeline model reads the configured capacity rather than assuming the default.

## Numbers

Single thread, 10 kB documents, median of 3 interleaved rounds, MB/s:

| cell | before | after | |
|---|---:|---:|---:|
| gpt2 / hindi | 101 | 137 | **1.35×** |
| llama-3 / russian | 38 | 50 | **1.31×** |
| gpt2 / agentic-swe | 121 | 153 | **1.27×** |
| gpt2 / russian | 85 | 107 | 1.26× |
| llama-3 / xnli | 54 | 68 | 1.26× |
| gpt2 / xnli | 74 | 86 | 1.17× |
| llama-3 / agentic-swe | 110 | 128 | 1.17× |
| llama-3 / hindi | 150 | 174 | 1.16× |
| gpt2 / code | 121 | 139 | 1.15× |
| llama-3 / english | 117 | 122 | 1.04× |
| gpt2 / chinese | 84 | 84 | 1.01× |
| gpt2 / english | 143 | 141 | 0.98× |

**Median 1.16×.** Flat where words rarely repeat (chinese) and largest where they do. gpt2/english is within run-to-run noise on this box — sequential runs here are worth ±10% on some cells, so every figure above is interleaved.

## Why this matters beyond the numbers

Comparing this branch against `poc/target-encode` on the same harness, the pristine branch is roughly **half** poc's throughput on several cells (gpt2/code 121 vs 291, gpt2/hindi 101 vs 337, llama-3/agentic-swe 110 vs 282). This PR closes part of that. The rest is bitsplit and the batched model call, which are separate.

Worth stating plainly: the merge engines on the two branches are **not** algorithmically different — I diffed them. `MergeState` exists on both, `build_byte_to_gate` just lives in `model.rs` here and in `merge_hot_cold_queue.rs` there, and `QueueScratch`/`MergeScratch` is a rename. #2241 upstreamed the same engine with cleaner naming. So the gap is missing *features*, not a worse merge loop.

## Tests

Two of the three tests #2241 dropped come back with the code:

- `cached_ids_match_uncached` — a cache may forget a word, but it must never change one. Every word runs twice through one scratch, the second time answered from the cache, against a model built with `cache_capacity(0)`.
- `the_word_cache_outlives_the_encode_call` — the cache lives in the scratch precisely so it survives the call that filled it. Emptied between calls it would still be correct and never hit, and nothing else catches that.

The second now asks for `"helo"` rather than `"hello"`: a whole word that is itself a vocabulary entry is answered by `fold_id` in one probe, *before* the cache is consulted, so it is never stored. Only words that reach the merge engines land in the cache — worth knowing when reading the hit rate.

The third, `ignore_merges_stores_the_whole_word_id`, stays gone. It asserted the cache holds the whole-word id under `ignore_merges`, which is now the fold's job.

## Exactness

Full benchmark matrix, 8 models × 30 corpora: **203 cells byte-exact** against `tokenizers` 0.23.1, 29 mismatched — the same albert (Unigram) cells that already fail. No new mismatch. 369 tests pass.

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**10 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · ~10 kB inputs · add_special_tokens on · single thread + 1/2/4/8/max-thread sweep

`499afeb56 · 2026-08-06 10:30 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 96 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-overview.png" width="860">

**vs base branch** (`dcbdc457f`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-base-overview.png" width="860">

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-binsize.png" width="860">

### Decode

Round-trip: v0.23.1 `encode_fast` produces the id streams (same fixtures, `add_special_tokens=true`); both implementations decode those SAME ids with `skip_special_tokens=false`. MB/s counts decoded text bytes.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-decode-overview.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-decode-memory.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×5.15 vs v0.23.1 · ×0.99 vs base · decode pending</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-bert-base-uncased-stages.png" width="860">

<img alt="bert-base-uncased thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-bert-base-uncased-threads.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-bert-base-uncased-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 12+0 (peak 11) · Pipeline 8+2 (peak 17)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.9 | 27.2 | ×3.45 | ×1.01 | 3% (1.2) | 76% (27.5) | 13% (4.8) | 8% (2.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.2 | 26.8 | ×6.44 | ×1.00 | 3% (1.2) | 76% (27.4) | 9% (3.3) | 12% (4.5) | 0% (0.0) | match |
| ben_Beng | lang | 6.0 | 36.1 | ×6.05 | ×0.97 | 4% (1.2) | 73% (19.2) | 11% (2.9) | 11% (3.0) | 0% (0.0) | match |
| cmn_Hani | lang | 3.8 | 19.1 | ×4.96 | ×0.99 | 2% (1.2) | 74% (37.6) | 11% (5.8) | 13% (6.4) | 0% (0.0) | match |
| ell_Grek | lang | 3.7 | 26.1 | ×6.97 | ×1.00 | 3% (1.2) | 75% (28.7) | 9% (3.4) | 13% (4.8) | 0% (0.0) | match |
| eng_Latn | lang | 4.5 | 19.1 | ×4.27 | ×0.99 | 5% (2.7) | 75% (39.0) | 9% (4.5) | 11% (5.9) | 1% (0.3) | match |
| heb_Hebr | lang | 4.2 | 20.8 | ×4.97 | ×1.00 | 2% (1.2) | 78% (37.6) | 7% (3.5) | 12% (6.0) | 0% (0.0) | match |
| hin_Deva | lang | 6.4 | 28.3 | ×4.40 | ×0.99 | 3% (1.2) | 78% (26.7) | 9% (3.2) | 10% (3.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.2 | 28.2 | ×6.67 | ×0.99 | 3% (1.2) | 66% (23.3) | 13% (4.5) | 18% (6.2) | 0% (0.1) | match |
| kat_Geor | lang | 6.1 | 29.4 | ×4.80 | ×1.00 | 4% (1.2) | 78% (26.2) | 9% (3.2) | 9% (2.9) | 0% (0.1) | match |
| kor_Hang | lang | 2.4 | 19.3 | ×8.01 | ×0.99 | 2% (1.2) | 65% (35.4) | 13% (7.1) | 19% (10.1) | 1% (0.4) | match |
| rus_Cyrl | lang | 3.6 | 27.1 | ×7.46 | ×1.00 | 3% (1.2) | 73% (27.5) | 9% (3.2) | 16% (5.9) | 0% (0.0) | match |
| tam_Taml | lang | 6.9 | 39.7 | ×5.73 | ×1.00 | 5% (1.2) | 75% (18.7) | 10% (2.5) | 10% (2.5) | 0% (0.1) | match |
| tha_Thai | lang | 8.3 | 33.3 | ×4.02 | ×1.00 | 4% (1.2) | 84% (25.0) | 8% (2.3) | 4% (1.2) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.7 | 19.6 | ×2.94 | ×0.99 | 3% (1.3) | 82% (40.5) | 14% (7.1) | 2% (0.8) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.2 | 18.7 | ×3.56 | ×0.97 | 4% (2.0) | 77% (39.9) | 14% (7.3) | 5% (2.8) | 0% (0.0) | match |
| added_special_dense | modalities | 5.2 | 38.2 | ×7.33 | ×1.01 | 20% (5.1) | 41% (10.2) | 36% (9.0) | 5% (1.2) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 22.3 | ×5.67 | ×1.00 | 8% (3.7) | 64% (28.3) | 20% (9.0) | 8% (3.6) | 0% (0.0) | match |
| agentic-traces | modalities | 3.8 | 18.7 | ×4.86 | ×0.99 | 5% (2.5) | 73% (38.8) | 9% (4.7) | 13% (6.8) | 0% (0.2) | match |
| agentic_swe | modalities | 4.1 | 19.7 | ×4.83 | ×1.00 | 4% (2.0) | 77% (38.6) | 8% (3.9) | 11% (5.7) | 0% (0.2) | match |
| code_mixed | modalities | 3.9 | 19.4 | ×4.98 | ×0.99 | 4% (2.2) | 76% (38.6) | 9% (4.3) | 11% (5.8) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 18.8 | ×4.70 | ×0.99 | 5% (2.6) | 73% (38.6) | 9% (4.8) | 13% (7.1) | 0% (0.0) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×21.90 vs v0.23.1 · ×2.42 vs base · decode pending</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-deepseek-v4.png" width="860">

<img alt="deepseek-v4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-deepseek-v4-stages.png" width="860">

<img alt="deepseek-v4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-deepseek-v4-threads.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-deepseek-v4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 62+0 (peak 67) · Pipeline 93+0 (peak 91)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 80.8 | ×18.37 | ×1.75 | 6% (0.7) | 0% (0.0) | 44% (4.6) | 52% (5.4) | 0% (0.0) | match |
| arb_Arab | lang | 4.4 | 97.9 | ×22.21 | ×3.40 | 6% (0.6) | 0% (0.0) | 37% (3.5) | 60% (5.6) | 0% (0.0) | match |
| ben_Beng | lang | 6.4 | 122.2 | ×19.16 | ×3.69 | 7% (0.6) | 0% (0.0) | 38% (3.1) | 53% (4.3) | 1% (0.1) | match |
| cmn_Hani | lang | 3.7 | 97.9 | ×26.13 | ×2.19 | 6% (0.8) | 0% (0.0) | 26% (3.2) | 68% (8.4) | 0% (0.0) | match |
| ell_Grek | lang | 4.6 | 100.2 | ×21.56 | ×3.35 | 5% (0.6) | 0% (0.0) | 29% (3.4) | 66% (7.8) | 0% (0.0) | match |
| eng_Latn | lang | 3.2 | 70.3 | ×21.74 | ×1.27 | 16% (2.1) | 1% (0.1) | 41% (5.2) | 43% (5.5) | 0% (0.0) | match |
| heb_Hebr | lang | 4.1 | 90.4 | ×22.28 | ×3.99 | 4% (0.6) | 0% (0.0) | 24% (3.5) | 72% (10.8) | 0% (0.0) | match |
| hin_Deva | lang | 5.9 | 115.0 | ×19.58 | ×3.02 | 7% (0.6) | 0% (0.0) | 37% (3.3) | 55% (4.8) | 0% (0.0) | match |
| jpn_Jpan | lang | 4.2 | 113.0 | ×26.99 | ×2.65 | 6% (0.7) | 0% (0.0) | 27% (3.0) | 68% (7.8) | 0% (0.0) | match |
| kat_Geor | lang | 6.0 | 119.7 | ×20.00 | ×4.31 | 6% (0.6) | 0% (0.0) | 26% (2.9) | 68% (7.5) | 0% (0.0) | match |
| kor_Hang | lang | 3.8 | 79.3 | ×21.08 | ×2.70 | 3% (0.6) | 0% (0.0) | 20% (3.6) | 76% (13.6) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.3 | 101.0 | ×23.23 | ×3.87 | 4% (0.6) | 0% (0.0) | 21% (3.3) | 76% (11.7) | 0% (0.0) | match |
| tam_Taml | lang | 6.2 | 131.7 | ×21.29 | ×4.48 | 6% (0.6) | 0% (0.0) | 25% (2.7) | 73% (7.9) | 0% (0.0) | match |
| tha_Thai | lang | 7.0 | 174.5 | ×24.81 | ×7.44 | 6% (0.6) | 0% (0.0) | 21% (2.2) | 75% (7.8) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.6 | 146.4 | ×26.04 | ×3.10 | 12% (0.8) | 0% (0.0) | 41% (2.7) | 47% (3.1) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.1 | 110.4 | ×21.62 | ×1.77 | 15% (1.3) | 0% (0.0) | 43% (3.7) | 41% (3.5) | 1% (0.1) | match |
| added_special_dense | modalities | 3.5 | 59.4 | ×16.91 | ×1.02 | 41% (6.7) | 6% (0.9) | 39% (6.3) | 16% (2.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 3.9 | 65.7 | ×16.97 | ×1.01 | 28% (3.9) | 3% (0.4) | 49% (7.0) | 23% (3.2) | 0% (0.0) | match |
| agentic-traces | modalities | 2.9 | 66.3 | ×22.46 | ×1.45 | 14% (1.9) | 0% (0.0) | 40% (5.6) | 45% (6.3) | 1% (0.1) | match |
| agentic_swe | modalities | 3.0 | 84.8 | ×28.21 | ×1.82 | 13% (1.4) | 0% (0.0) | 36% (3.8) | 49% (5.2) | 1% (0.1) | match |
| code_mixed | modalities | 3.5 | 78.0 | ×22.20 | ×1.52 | 14% (1.7) | 0% (0.0) | 39% (4.6) | 45% (5.3) | 1% (0.2) | match |
| math_latex | modalities | 2.9 | 67.5 | ×23.36 | ×1.23 | 15% (2.0) | 0% (0.0) | 41% (5.4) | 43% (5.6) | 1% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.60 | 3.11 | 4.63 | 5.14 | 43.2 | 20.6 | 9.1 | — | 9.3× / 8.4× | 4.5× / 4.0× | 2.0× / 1.8× | — |
| arb_Arab | 1.01 | 2.74 | 3.46 | 5.19 | 50.6 | 22.6 | 10.1 | — | 14.6× / 9.7× | 6.5× / 4.4× | 2.9× / 1.9× | — |
| ben_Beng | 1.47 | 2.57 | 3.12 | 4.23 | 36.9 | 16.0 | 7.5 | — | 11.8× / 8.7× | 5.1× / 3.8× | 2.4× / 1.8× | — |
| cmn_Hani | 1.13 | 1.98 | 3.24 | 4.09 | 62.4 | 34.0 | 14.1 | — | 19.3× / 15.3× | 10.5× / 8.3× | 4.4× / 3.5× | — |
| ell_Grek | 0.59 | 2.76 | 3.38 | 5.55 | 48.7 | 20.7 | 9.5 | — | 14.4× / 8.8× | 6.1× / 3.7× | 2.8× / 1.7× | — |
| eng_Latn | 0.09 | 0.89 | 5.23 | 6.03 | 67.9 | 38.9 | 16.0 | — | 13.0× / 11.3× | 7.4× / 6.5× | 3.1× / 2.7× | — |
| heb_Hebr | 1.01 | 2.80 | 3.52 | 5.31 | 52.4 | 23.9 | 10.6 | — | 14.9× / 9.9× | 6.8× / 4.5× | 3.0× / 2.0× | — |
| hin_Deva | 1.38 | 2.77 | 3.28 | 4.67 | 39.2 | 18.8 | 8.4 | — | 11.9× / 8.4× | 5.7× / 4.0× | 2.6× / 1.8× | — |
| jpn_Jpan | 1.56 | 3.12 | 3.03 | 4.59 | 54.5 | 27.5 | 11.7 | — | 18.0× / 11.9× | 9.1× / 6.0× | 3.9× / 2.5× | — |
| kat_Geor | 1.38 | 2.34 | 2.92 | 3.87 | 33.6 | 15.0 | 7.1 | — | 11.5× / 8.7× | 5.1× / 3.9× | 2.4× / 1.8× | — |
| kor_Hang | 1.07 | 2.39 | 3.60 | 4.92 | 51.7 | 27.2 | 11.9 | — | 14.3× / 10.5× | 7.5× / 5.5× | 3.3× / 2.4× | — |
| rus_Cyrl | 1.02 | 2.71 | 3.29 | 4.98 | 49.0 | 20.5 | 9.4 | — | 14.9× / 9.9× | 6.2× / 4.1× | 2.9× / 1.9× | — |
| tam_Taml | 0.92 | 2.60 | 2.69 | 4.37 | 32.6 | 13.8 | 6.5 | — | 12.1× / 7.5× | 5.1× / 3.2× | 2.4× / 1.5× | — |
| tha_Thai | 1.36 | 2.23 | 2.16 | 3.03 | 27.9 | 10.1 | 5.2 | — | 12.9× / 9.2× | 4.7× / 3.3× | 2.4× / 1.7× | — |
| added_normalized_dense | 0.06 | 0.88 | 2.69 | 3.52 | 43.8 | 20.6 | 9.0 | — | 16.3× / 12.5× | 7.7× / 5.9× | 3.3× / 2.6× | — |
| added_normalized_sparse | 0.06 | 0.88 | 3.73 | 4.55 | 50.8 | 26.1 | 11.3 | — | 13.6× / 11.2× | 7.0× / 5.7× | 3.0× / 2.5× | — |
| added_special_dense | 0.06 | 0.88 | 6.30 | 7.13 | 181.5 | 96.6 | 38.3 | — | 28.8× / 25.5× | 15.3× / 13.6× | 6.1× / 5.4× | — |
| added_special_sparse | 0.06 | 0.88 | 7.02 | 7.84 | 106.6 | 57.4 | 23.7 | — | 15.2× / 13.6× | 8.2× / 7.3× | 3.4× / 3.0× | — |
| agentic-traces | 0.62 | 0.92 | 5.60 | 5.90 | 82.9 | 52.1 | 19.6 | — | 14.8× / 14.0× | 9.3× / 8.8× | 3.5× / 3.3× | — |
| agentic_swe | 0.51 | 0.87 | 3.81 | 4.17 | 98.9 | 64.6 | 23.5 | — | 25.9× / 23.7× | 16.9× / 15.5× | 6.2× / 5.6× | — |
| code_mixed | 0.07 | 0.87 | 4.64 | 5.44 | 76.1 | 52.7 | 18.3 | — | 16.4× / 14.0× | 11.4× / 9.7× | 3.9× / 3.4× | — |
| math_latex | 0.58 | 0.92 | 5.37 | 5.72 | 81.2 | 46.9 | 19.2 | — | 15.1× / 14.2× | 8.7× / 8.2× | 3.6× / 3.4× | — |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×37.39 vs v0.23.1 · ×12.28 vs base · decode pending</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gemma-4.png" width="860">

<img alt="gemma-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gemma-4-stages.png" width="860">

<img alt="gemma-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gemma-4-threads.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gemma-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 304+0 (peak 371) · Pipeline 274+0 (peak 370)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 11.3 | 398.5 | ×35.34 | ×9.18 | 28% (0.7) | 56% (1.3) | 1% (0.0) | 15% (0.4) | 0% (0.0) | match |
| arb_Arab | lang | 7.6 | 357.1 | ×46.79 | ×15.05 | 24% (0.6) | 62% (1.6) | 1% (0.0) | 14% (0.4) | 0% (0.0) | match |
| ben_Beng | lang | 10.9 | 484.2 | ×44.31 | ×16.97 | 30% (0.6) | 53% (1.0) | 1% (0.0) | 15% (0.3) | 0% (0.0) | match |
| cmn_Hani | lang | 14.2 | 768.0 | ×54.21 | ×14.47 | 53% (0.6) | 17% (0.2) | 1% (0.0) | 30% (0.4) | 0% (0.0) | match |
| ell_Grek | lang | 8.0 | 348.3 | ×43.75 | ×13.48 | 24% (0.6) | 62% (1.6) | 1% (0.0) | 16% (0.4) | 0% (0.0) | match |
| eng_Latn | lang | 4.1 | 171.8 | ×41.42 | ×18.82 | 36% (2.1) | 55% (3.2) | 1% (0.1) | 7% (0.4) | 0% (0.0) | match |
| heb_Hebr | lang | 8.3 | 342.0 | ×41.18 | ×11.40 | 23% (0.6) | 62% (1.6) | 1% (0.0) | 14% (0.4) | 0% (0.0) | match |
| hin_Deva | lang | 9.9 | 373.4 | ×37.75 | ×12.74 | 26% (0.6) | 60% (1.4) | 1% (0.0) | 13% (0.3) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.8 | 797.8 | ×57.74 | ×17.76 | 56% (0.6) | 15% (0.2) | 2% (0.0) | 30% (0.3) | 0% (0.0) | match |
| kat_Geor | lang | 12.3 | 508.0 | ×41.38 | ×12.38 | 33% (0.6) | 48% (0.9) | 1% (0.0) | 17% (0.3) | 0% (0.0) | match |
| kor_Hang | lang | 10.3 | 360.9 | ×35.12 | ×9.35 | 23% (0.6) | 62% (1.7) | 1% (0.0) | 14% (0.4) | 0% (0.0) | match |
| rus_Cyrl | lang | 7.6 | 381.9 | ×50.04 | ×19.79 | 25% (0.6) | 61% (1.5) | 1% (0.0) | 14% (0.3) | 0% (0.0) | match |
| tam_Taml | lang | 11.6 | 527.1 | ×45.59 | ×17.66 | 35% (0.6) | 46% (0.8) | 1% (0.0) | 18% (0.3) | 0% (0.0) | match |
| tha_Thai | lang | 13.7 | 640.5 | ×46.88 | ×16.67 | 44% (0.6) | 33% (0.5) | 2% (0.0) | 22% (0.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.2 | 312.7 | ×60.11 | ×18.99 | 26% (0.8) | 61% (1.8) | 1% (0.0) | 13% (0.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.7 | 204.8 | ×43.19 | ×15.45 | 29% (1.4) | 60% (2.8) | 3% (0.1) | 8% (0.4) | 0% (0.0) | match |
| added_special_dense | modalities | 4.7 | 38.3 | ×8.12 | ×1.56 | 37% (9.6) | 28% (7.1) | 26% (6.6) | 10% (2.7) | 0% (0.0) | match |
| added_special_sparse | modalities | 7.2 | 51.1 | ×7.09 | ×3.52 | 28% (5.2) | 57% (10.6) | 5% (1.0) | 11% (2.0) | 0% (0.0) | match |
| agentic-traces | modalities | 4.5 | 187.1 | ×42.00 | ×16.63 | 37% (1.9) | 54% (2.8) | 1% (0.0) | 9% (0.4) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 161.5 | ×38.57 | ×10.42 | 23% (1.4) | 68% (4.1) | 1% (0.0) | 8% (0.5) | 0% (0.0) | match |
| code_mixed | modalities | 4.2 | 168.4 | ×39.95 | ×12.64 | 30% (1.7) | 61% (3.5) | 0% (0.0) | 9% (0.5) | 0% (0.0) | match |
| math_latex | modalities | 4.3 | 178.6 | ×41.06 | ×17.40 | 36% (2.0) | 53% (2.9) | 1% (0.1) | 11% (0.6) | 0% (0.0) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×26.08 vs v0.23.1 · ×1.70 vs base · decode pending</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gpt2.png" width="860">

<img alt="gpt2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gpt2-stages.png" width="860">

<img alt="gpt2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gpt2-threads.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gpt2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 25+2 (peak 27) · Pipeline 32+0 (peak 32)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 96.5 | ×24.47 | ×1.49 | 8% (0.7) | 0% (0.0) | 41% (3.6) | 51% (4.4) | 0% (0.0) | match |
| arb_Arab | lang | 3.8 | 99.2 | ×25.77 | ×2.28 | 7% (0.6) | 0% (0.0) | 25% (2.3) | 68% (6.1) | 0% (0.0) | match |
| ben_Beng | lang | 2.9 | 71.7 | ×24.91 | ×1.23 | 5% (0.6) | 0% (0.0) | 23% (3.0) | 72% (9.6) | 1% (0.1) | match |
| cmn_Hani | lang | 3.8 | 113.2 | ×29.83 | ×2.32 | 5% (0.6) | 0% (0.0) | 19% (2.3) | 89% (10.8) | 0% (0.0) | match |
| ell_Grek | lang | 4.4 | 109.3 | ×24.91 | ×2.37 | 6% (0.6) | 0% (0.0) | 22% (2.2) | 72% (7.2) | 0% (0.0) | match |
| eng_Latn | lang | 3.6 | 97.2 | ×27.11 | ×1.36 | 20% (2.1) | 0% (0.0) | 29% (3.0) | 49% (5.0) | 1% (0.1) | match |
| heb_Hebr | lang | 4.0 | 106.3 | ×26.59 | ×2.26 | 5% (0.6) | 0% (0.0) | 20% (2.3) | 75% (8.6) | 0% (0.0) | match |
| hin_Deva | lang | 3.1 | 79.9 | ×25.60 | ×1.39 | 5% (0.6) | 0% (0.0) | 25% (3.1) | 69% (8.6) | 1% (0.1) | match |
| jpn_Jpan | lang | 4.5 | 153.7 | ×33.88 | ×3.63 | 5% (0.6) | 0% (0.0) | 18% (2.1) | 80% (9.2) | 0% (0.0) | match |
| kat_Geor | lang | 4.8 | 148.3 | ×31.06 | ×1.69 | 9% (0.6) | 0% (0.0) | 30% (2.0) | 61% (4.2) | 0% (0.0) | match |
| kor_Hang | lang | 3.4 | 93.4 | ×27.45 | ×1.48 | 5% (0.6) | 0% (0.0) | 20% (2.4) | 81% (9.8) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.3 | 115.5 | ×27.04 | ×2.44 | 6% (0.6) | 0% (0.0) | 19% (2.1) | 75% (8.1) | 0% (0.0) | match |
| tam_Taml | lang | 2.7 | 77.8 | ×28.67 | ×0.98 | 5% (0.6) | 0% (0.0) | 22% (2.7) | 72% (8.6) | 1% (0.1) | match |
| tha_Thai | lang | 3.7 | 94.9 | ×25.79 | ×1.63 | 6% (0.6) | 0% (0.0) | 23% (2.5) | 75% (8.0) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.0 | 177.4 | ×29.53 | ×3.52 | 14% (0.8) | 0% (0.0) | 20% (1.1) | 61% (3.2) | 5% (0.2) | match |
| added_normalized_sparse | modalities | 5.2 | 133.8 | ×25.85 | ×2.05 | 18% (1.3) | 0% (0.0) | 28% (2.0) | 53% (3.7) | 1% (0.1) | match |
| added_special_dense | modalities | 4.2 | 79.0 | ×18.86 | ×1.02 | 43% (5.1) | 3% (0.4) | 34% (4.1) | 21% (2.4) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.3 | 82.6 | ×19.14 | ×1.12 | 29% (3.2) | 2% (0.2) | 39% (4.4) | 33% (3.7) | 0% (0.0) | match |
| agentic-traces | modalities | 3.2 | 77.3 | ×24.24 | ×1.43 | 16% (1.9) | 0% (0.0) | 29% (3.5) | 54% (6.6) | 1% (0.1) | match |
| agentic_swe | modalities | 3.4 | 94.5 | ×28.03 | ×1.45 | 14% (1.4) | 0% (0.0) | 24% (2.4) | 60% (6.0) | 2% (0.2) | match |
| code_mixed | modalities | 3.5 | 86.4 | ×24.60 | ×1.51 | 15% (1.6) | 0% (0.0) | 28% (3.0) | 56% (6.2) | 1% (0.1) | match |
| math_latex | modalities | 3.3 | 82.8 | ×25.15 | ×1.36 | 18% (2.0) | 0% (0.0) | 29% (3.3) | 51% (5.8) | 1% (0.1) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.60 | 3.07 | 3.63 | 4.10 | 28.1 | 20.4 | 5.8 | 4.8 | 7.7× / 6.9× | 5.6× / 5.0× | 1.6× / 1.4× | 1.3× / 1.2× |
| arb_Arab | 1.00 | 2.75 | 2.28 | 4.03 | 33.1 | 25.4 | 6.8 | 5.1 | 14.5× / 8.2× | 11.1× / 6.3× | 3.0× / 1.7× | 2.2× / 1.3× |
| ben_Beng | 1.46 | 2.59 | 3.02 | 4.15 | 68.2 | 56.7 | 13.6 | 4.0 | 22.6× / 16.4× | 18.8× / 13.7× | 4.5× / 3.3× | 1.3× / 1.0× |
| cmn_Hani | 1.13 | 1.98 | 2.32 | 3.17 | 26.8 | 21.1 | 6.0 | 2.4 | 11.5× / 8.5× | 9.1× / 6.6× | 2.6× / 1.9× | 1.0× / 0.8× |
| ell_Grek | 0.58 | 2.76 | 2.18 | 4.36 | 29.2 | 21.7 | 6.0 | 4.8 | 13.4× / 6.7× | 10.0× / 5.0× | 2.8× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.09 | 0.90 | 2.99 | 3.79 | 46.0 | 42.4 | 12.0 | 3.8 | 15.4× / 12.1× | 14.2× / 11.2× | 4.0× / 3.2× | 1.3× / 1.0× |
| heb_Hebr | 1.00 | 2.81 | 2.30 | 4.11 | 32.6 | 26.9 | 7.0 | 3.0 | 14.2× / 7.9× | 11.7× / 6.5× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.36 | 2.81 | 3.09 | 4.54 | 64.1 | 52.4 | 13.4 | 4.3 | 20.8× / 14.1× | 17.0× / 11.5× | 4.3× / 3.0× | 1.4× / 1.0× |
| jpn_Jpan | 1.55 | 3.09 | 2.12 | 3.66 | 23.8 | 17.4 | 5.1 | 3.8 | 11.2× / 6.5× | 8.2× / 4.8× | 2.4× / 1.4× | 1.8× / 1.0× |
| kat_Geor | 1.39 | 2.20 | 2.04 | 2.86 | 17.9 | 14.2 | 4.2 | 2.0 | 8.8× / 6.3× | 6.9× / 5.0× | 2.1× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.08 | 2.38 | 2.44 | 3.74 | 32.6 | 27.0 | 7.6 | 3.7 | 13.3× / 8.7× | 11.0× / 7.2× | 3.1× / 2.0× | 1.5× / 1.0× |
| rus_Cyrl | 1.02 | 2.72 | 2.09 | 3.80 | 28.1 | 21.3 | 5.9 | 2.5 | 13.5× / 7.4× | 10.2× / 5.6× | 2.8× / 1.5× | 1.2× / 0.7× |
| tam_Taml | 0.92 | 2.62 | 2.68 | 4.38 | 71.9 | 58.8 | 14.2 | 3.8 | 26.8× / 16.4× | 21.9× / 13.4× | 5.3× / 3.2× | 1.4× / 0.9× |
| tha_Thai | 1.36 | 2.22 | 2.50 | 3.36 | 41.3 | 31.3 | 8.8 | 3.2 | 16.5× / 12.3× | 12.5× / 9.3× | 3.5× / 2.6× | 1.3× / 1.0× |
| added_normalized_dense | 0.06 | 0.88 | 1.07 | 1.89 | 24.3 | 22.7 | 6.4 | 1.9 | 22.8× / 12.8× | 21.3× / 12.0× | 6.0× / 3.4× | 1.8× / 1.0× |
| added_normalized_sparse | 0.06 | 0.88 | 1.97 | 2.80 | 32.4 | 31.0 | 8.6 | 2.7 | 16.4× / 11.6× | 15.7× / 11.1× | 4.4× / 3.1× | 1.4× / 1.0× |
| added_special_dense | 0.06 | 0.88 | 4.06 | 4.89 | 97.4 | 98.0 | 20.3 | 3.1 | 24.0× / 19.9× | 24.1× / 20.0× | 5.0× / 4.1× | 0.8× / 0.6× |
| added_special_sparse | 0.06 | 0.88 | 4.37 | 5.19 | 63.3 | 61.0 | 14.6 | 3.3 | 14.5× / 12.2× | 14.0× / 11.7× | 3.3× / 2.8× | 0.8× / 0.6× |
| agentic-traces | 0.60 | 0.92 | 3.51 | 3.83 | 60.9 | 60.7 | 15.4 | 4.6 | 17.3× / 15.9× | 17.3× / 15.8× | 4.4× / 4.0× | 1.3× / 1.2× |
| agentic_swe | 0.51 | 0.87 | 2.43 | 2.80 | 62.1 | 68.4 | 14.6 | 3.5 | 25.5× / 22.2× | 28.1× / 24.4× | 6.0× / 5.2× | 1.4× / 1.2× |
| code_mixed | 0.07 | 0.86 | 3.02 | 3.81 | 60.3 | 66.0 | 15.2 | 4.0 | 20.0× / 15.8× | 21.9× / 17.3× | 5.0× / 4.0× | 1.3× / 1.1× |
| math_latex | 0.59 | 0.92 | 3.33 | 3.66 | 54.2 | 50.4 | 13.8 | 4.2 | 16.3× / 14.8× | 15.1× / 13.8× | 4.1× / 3.8× | 1.3× / 1.1× |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×21.31 vs v0.23.1 · ×2.82 vs base · decode pending</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gpt-oss.png" width="860">

<img alt="gpt-oss stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gpt-oss-stages.png" width="860">

<img alt="gpt-oss thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gpt-oss-threads.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-gpt-oss-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 241+0 (peak 315) · Pipeline 234+0 (peak 316)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 85.4 | ×20.91 | ×2.01 | 7% (0.7) | 0% (0.0) | 47% (4.8) | 47% (4.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.7 | 110.9 | ×23.49 | ×3.49 | 7% (0.6) | 0% (0.0) | 36% (3.3) | 57% (5.2) | 0% (0.0) | match |
| ben_Beng | lang | 7.2 | 129.1 | ×18.01 | ×4.03 | 7% (0.6) | 0% (0.0) | 42% (3.7) | 51% (4.4) | 0% (0.0) | match |
| cmn_Hani | lang | 4.9 | 125.3 | ×25.78 | ×5.02 | 4% (0.6) | 0% (0.0) | 19% (3.3) | 80% (14.2) | 0% (0.0) | match |
| ell_Grek | lang | 5.2 | 120.4 | ×23.08 | ×3.89 | 5% (0.6) | 0% (0.0) | 27% (3.3) | 67% (8.1) | 1% (0.1) | match |
| eng_Latn | lang | 4.2 | 80.6 | ×19.03 | ×1.56 | 17% (2.1) | 0% (0.0) | 36% (4.6) | 47% (6.0) | 0% (0.0) | match |
| heb_Hebr | lang | 4.8 | 112.0 | ×23.14 | ×3.87 | 5% (0.6) | 0% (0.0) | 25% (3.4) | 71% (9.7) | 0% (0.0) | match |
| hin_Deva | lang | 7.2 | 125.3 | ×17.36 | ×2.76 | 7% (0.6) | 0% (0.0) | 42% (3.8) | 51% (4.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.7 | 151.4 | ×26.70 | ×4.91 | 4% (0.6) | 0% (0.0) | 22% (3.1) | 74% (10.5) | 0% (0.0) | match |
| kat_Geor | lang | 6.9 | 142.8 | ×20.55 | ×5.31 | 5% (0.6) | 0% (0.0) | 25% (2.9) | 70% (8.1) | 0% (0.0) | match |
| kor_Hang | lang | 4.3 | 94.1 | ×22.14 | ×3.57 | 3% (0.6) | 0% (0.0) | 19% (3.7) | 78% (15.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.4 | 126.8 | ×23.46 | ×5.00 | 4% (0.6) | 0% (0.0) | 21% (3.2) | 75% (11.0) | 0% (0.0) | match |
| tam_Taml | lang | 7.1 | 149.5 | ×21.14 | ×6.24 | 5% (0.6) | 0% (0.0) | 26% (3.2) | 69% (8.6) | 0% (0.0) | match |
| tha_Thai | lang | 8.0 | 165.7 | ×20.73 | ×8.20 | 5% (0.6) | 0% (0.0) | 26% (3.2) | 69% (8.5) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.5 | 154.4 | ×28.30 | ×3.44 | 12% (0.8) | 0% (0.0) | 35% (2.2) | 52% (3.3) | 1% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 117.7 | ×21.92 | ×1.87 | 16% (1.3) | 0% (0.0) | 39% (3.2) | 46% (3.7) | 0% (0.0) | match |
| added_special_dense | modalities | 4.3 | 73.8 | ×17.02 | ×0.99 | 39% (5.2) | 2% (0.3) | 42% (5.6) | 18% (2.4) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.5 | 75.5 | ×16.95 | ×1.03 | 26% (3.3) | 1% (0.1) | 49% (6.3) | 24% (3.1) | 0% (0.0) | match |
| agentic-traces | modalities | 3.7 | 73.1 | ×19.64 | ×1.45 | 15% (2.0) | 0% (0.0) | 37% (5.0) | 48% (6.5) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 91.9 | ×22.42 | ×1.86 | 13% (1.4) | 0% (0.0) | 35% (3.7) | 52% (5.5) | 1% (0.1) | match |
| code_mixed | modalities | 4.1 | 88.0 | ×21.71 | ×1.39 | 15% (1.7) | 0% (0.0) | 38% (4.3) | 46% (5.3) | 0% (0.0) | match |
| math_latex | modalities | 3.7 | 72.8 | ×19.78 | ×1.46 | 15% (2.0) | 0% (0.0) | 36% (4.9) | 48% (6.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.60 | 3.08 | 4.80 | 5.28 | 29.7 | 13.8 | 7.0 | 4.8 | 6.2× / 5.6× | 2.9× / 2.6× | 1.5× / 1.3× | 1.0× / 0.9× |
| arb_Arab | 1.00 | 2.76 | 3.33 | 5.09 | 33.9 | 15.7 | 7.6 | 5.1 | 10.2× / 6.7× | 4.7× / 3.1× | 2.3× / 1.5× | 1.5× / 1.0× |
| ben_Beng | 1.46 | 2.56 | 3.69 | 4.79 | 23.7 | 10.6 | 5.4 | 2.8 | 6.4× / 5.0× | 2.9× / 2.2× | 1.5× / 1.1× | 0.8× / 0.6× |
| cmn_Hani | 1.12 | 1.98 | 3.31 | 4.16 | 21.4 | 10.7 | 5.4 | 2.5 | 6.5× / 5.1× | 3.2× / 2.6× | 1.6× / 1.3× | 0.7× / 0.6× |
| ell_Grek | 0.58 | 2.76 | 3.26 | 5.44 | 29.9 | 14.8 | 6.8 | 5.0 | 9.2× / 5.5× | 4.5× / 2.7× | 2.1× / 1.3× | 1.5× / 0.9× |
| eng_Latn | 0.10 | 0.90 | 4.58 | 5.38 | 42.6 | 28.6 | 13.6 | 4.2 | 9.3× / 7.9× | 6.2× / 5.3× | 3.0× / 2.5× | 0.9× / 0.8× |
| heb_Hebr | 1.00 | 2.80 | 3.41 | 5.21 | 33.1 | 16.8 | 8.2 | 2.9 | 9.7× / 6.4× | 4.9× / 3.2× | 2.4× / 1.6× | 0.8× / 0.6× |
| hin_Deva | 1.37 | 2.72 | 3.80 | 5.16 | 25.6 | 12.4 | 6.3 | 3.2 | 6.7× / 5.0× | 3.3× / 2.4× | 1.7× / 1.2× | 0.8× / 0.6× |
| jpn_Jpan | 1.55 | 3.11 | 3.07 | 4.63 | 20.3 | 9.1 | 4.7 | 3.8 | 6.6× / 4.4× | 3.0× / 2.0× | 1.5× / 1.0× | 1.2× / 0.8× |
| kat_Geor | 1.39 | 2.27 | 2.93 | 3.80 | 18.6 | 9.9 | 4.6 | 2.2 | 6.4× / 4.9× | 3.4× / 2.6× | 1.6× / 1.2× | 0.8× / 0.6× |
| kor_Hang | 1.14 | 2.44 | 3.75 | 5.05 | 32.9 | 18.8 | 8.9 | 3.7 | 8.8× / 6.5× | 5.0× / 3.7× | 2.4× / 1.8× | 1.0× / 0.7× |
| rus_Cyrl | 1.02 | 2.72 | 3.16 | 4.86 | 28.6 | 14.6 | 6.7 | 4.8 | 9.1× / 5.9× | 4.6× / 3.0× | 2.1× / 1.4× | 1.5× / 1.0× |
| tam_Taml | 0.92 | 2.60 | 3.22 | 4.89 | 19.0 | 8.5 | 4.2 | 2.8 | 5.9× / 3.9× | 2.6× / 1.7× | 1.3× / 0.9× | 0.9× / 0.6× |
| tha_Thai | 1.36 | 2.30 | 3.20 | 4.13 | 13.1 | 5.6 | 2.7 | 2.3 | 4.1× / 3.2× | 1.8× / 1.4× | 0.9× / 0.7× | 0.7× / 0.6× |
| added_normalized_dense | 0.06 | 0.88 | 2.17 | 3.00 | 33.4 | 17.7 | 11.3 | 2.2 | 15.4× / 11.1× | 8.2× / 5.9× | 5.2× / 3.8× | 1.0× / 0.7× |
| added_normalized_sparse | 0.06 | 0.88 | 3.19 | 4.02 | 35.5 | 21.0 | 11.8 | 2.9 | 11.1× / 8.8× | 6.6× / 5.2× | 3.7× / 2.9× | 0.9× / 0.7× |
| added_special_dense | 0.06 | 0.88 | 5.55 | 6.38 | 85.5 | 67.4 | 23.9 | 3.3 | 15.4× / 13.4× | 12.1× / 10.6× | 4.3× / 3.7× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 0.88 | 6.27 | 7.09 | 59.2 | 41.3 | 16.6 | 3.7 | 9.5× / 8.4× | 6.6× / 5.8× | 2.7× / 2.3× | 0.6× / 0.5× |
| agentic-traces | 0.57 | 0.92 | 4.97 | 5.31 | 51.9 | 40.9 | 17.2 | 4.9 | 10.4× / 9.8× | 8.2× / 7.7× | 3.5× / 3.2× | 1.0× / 0.9× |
| agentic_swe | 0.55 | 0.87 | 3.74 | 4.07 | 52.5 | 47.8 | 17.5 | 3.6 | 14.1× / 12.9× | 12.8× / 11.8× | 4.7× / 4.3× | 1.0× / 0.9× |
| code_mixed | 0.08 | 0.86 | 4.35 | 5.14 | 51.8 | 47.0 | 17.2 | 4.3 | 11.9× / 10.1× | 10.8× / 9.2× | 4.0× / 3.4× | 1.0× / 0.8× |
| math_latex | 0.60 | 0.92 | 4.92 | 5.25 | 49.0 | 35.0 | 16.0 | 4.5 | 10.0× / 9.3× | 7.1× / 6.7× | 3.2× / 3.0× | 0.9× / 0.9× |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×19.54 vs v0.23.1 · ×2.23 vs base · decode pending</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-glm-5-2.png" width="860">

<img alt="glm-5.2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-glm-5-2-stages.png" width="860">

<img alt="glm-5.2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-glm-5-2-threads.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-glm-5-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 169+0 (peak 231) · Pipeline 170+0 (peak 231)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 81.8 | ×19.59 | ×1.45 | 13% (1.2) | 0% (0.0) | 38% (3.7) | 49% (4.8) | 0% (0.0) | match |
| arb_Arab | lang | 4.8 | 101.2 | ×20.88 | ×3.64 | 13% (1.2) | 0% (0.0) | 26% (2.3) | 60% (5.4) | 1% (0.1) | match |
| ben_Beng | lang | 4.2 | 89.8 | ×21.18 | ×2.03 | 14% (1.5) | 0% (0.0) | 30% (3.1) | 58% (6.1) | 1% (0.1) | match |
| cmn_Hani | lang | 5.2 | 104.9 | ×20.00 | ×5.18 | 7% (1.2) | 0% (0.0) | 14% (2.4) | 79% (13.6) | 1% (0.1) | match |
| ell_Grek | lang | 5.5 | 118.2 | ×21.69 | ×4.35 | 10% (1.2) | 0% (0.0) | 19% (2.2) | 71% (8.4) | 0% (0.0) | match |
| eng_Latn | lang | 4.1 | 73.1 | ×17.93 | ×1.39 | 23% (2.7) | 0% (0.0) | 27% (3.1) | 50% (5.8) | 0% (0.0) | match |
| heb_Hebr | lang | 4.5 | 84.6 | ×18.97 | ×2.22 | 9% (1.2) | 0% (0.0) | 17% (2.3) | 76% (10.2) | 0% (0.0) | match |
| hin_Deva | lang | 4.0 | 86.0 | ×21.44 | ×1.85 | 10% (1.2) | 0% (0.0) | 29% (3.2) | 60% (6.8) | 1% (0.1) | match |
| jpn_Jpan | lang | 5.9 | 120.2 | ×20.36 | ×5.17 | 8% (1.2) | 0% (0.0) | 14% (2.2) | 79% (12.4) | 0% (0.0) | match |
| kat_Geor | lang | 6.6 | 120.6 | ×18.19 | ×3.06 | 12% (1.2) | 0% (0.0) | 22% (2.1) | 65% (6.2) | 0% (0.0) | match |
| kor_Hang | lang | 4.2 | 76.7 | ×18.45 | ×3.04 | 6% (1.2) | 0% (0.0) | 13% (2.5) | 81% (15.2) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.5 | 108.8 | ×19.94 | ×4.44 | 8% (1.2) | 0% (0.0) | 15% (2.2) | 76% (10.9) | 0% (0.0) | match |
| tam_Taml | lang | 4.0 | 90.9 | ×22.59 | ×1.84 | 11% (1.2) | 0% (0.0) | 26% (2.7) | 63% (6.6) | 1% (0.1) | match |
| tha_Thai | lang | 5.2 | 94.2 | ×18.14 | ×1.60 | 11% (1.2) | 0% (0.0) | 24% (2.6) | 66% (7.1) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.2 | 167.5 | ×27.12 | ×3.68 | 24% (1.3) | 0% (0.0) | 21% (1.2) | 52% (2.9) | 3% (0.2) | match |
| added_normalized_sparse | modalities | 5.5 | 128.3 | ×23.36 | ×2.03 | 26% (1.9) | 0% (0.0) | 26% (1.9) | 48% (3.5) | 0% (0.0) | match |
| added_special_dense | modalities | 4.2 | 46.1 | ×10.94 | ×1.02 | 60% (12.7) | 2% (0.4) | 26% (5.4) | 12% (2.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 60.8 | ×13.68 | ×1.04 | 45% (7.1) | 0% (0.0) | 34% (5.4) | 21% (3.2) | 0% (0.0) | match |
| agentic-traces | modalities | 3.7 | 70.8 | ×19.18 | ×1.53 | 20% (2.6) | 0% (0.0) | 29% (3.7) | 51% (6.5) | 0% (0.0) | match |
| agentic_swe | modalities | 4.0 | 89.4 | ×22.37 | ×1.87 | 19% (2.0) | 0% (0.0) | 27% (2.8) | 53% (5.5) | 1% (0.1) | match |
| code_mixed | modalities | 4.1 | 86.6 | ×21.08 | ×1.55 | 22% (2.3) | 0% (0.0) | 30% (3.3) | 48% (5.2) | 0% (0.0) | match |
| math_latex | modalities | 4.0 | 76.2 | ×19.21 | ×1.52 | 21% (2.6) | 0% (0.0) | 28% (3.5) | 51% (6.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.62 | 3.07 | 3.69 | 4.14 | 27.5 | 15.8 | 5.9 | 4.8 | 7.4× / 6.6× | 4.3× / 3.8× | 1.6× / 1.4× | 1.3× / 1.2× |
| arb_Arab | 1.01 | 2.75 | 2.32 | 4.06 | 30.9 | 18.9 | 6.8 | 5.2 | 13.3× / 7.6× | 8.1× / 4.6× | 2.9× / 1.7× | 2.2× / 1.3× |
| ben_Beng | 1.47 | 2.58 | 3.11 | 4.22 | 44.6 | 28.3 | 10.4 | 3.7 | 14.3× / 10.6× | 9.1× / 6.7× | 3.3× / 2.5× | 1.2× / 0.9× |
| cmn_Hani | 1.12 | 1.99 | 2.39 | 3.26 | 19.4 | 11.7 | 4.8 | 2.5 | 8.1× / 6.0× | 4.9× / 3.6× | 2.0× / 1.5× | 1.0× / 0.8× |
| ell_Grek | 0.58 | 2.77 | 2.23 | 4.42 | 28.4 | 16.7 | 6.2 | 4.8 | 12.7× / 6.4× | 7.5× / 3.8× | 2.8× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.09 | 0.89 | 3.10 | 3.89 | 43.3 | 33.1 | 12.5 | 3.8 | 14.0× / 11.1× | 10.7× / 8.5× | 4.0× / 3.2× | 1.2× / 1.0× |
| heb_Hebr | 1.00 | 2.82 | 2.33 | 4.15 | 30.9 | 19.3 | 6.9 | 3.0 | 13.3× / 7.4× | 8.3× / 4.6× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 2.73 | 3.23 | 4.59 | 47.4 | 30.1 | 11.2 | 4.0 | 14.7× / 10.3× | 9.3× / 6.6× | 3.5× / 2.4× | 1.2× / 0.9× |
| jpn_Jpan | 1.55 | 3.10 | 2.21 | 3.75 | 18.1 | 9.9 | 4.1 | 3.8 | 8.2× / 4.8× | 4.5× / 2.6× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.39 | 2.26 | 2.11 | 2.99 | 17.1 | 11.3 | 4.3 | 2.0 | 8.1× / 5.7× | 5.3× / 3.8× | 2.0× / 1.4× | 0.9× / 0.7× |
| kor_Hang | 1.07 | 2.39 | 2.51 | 3.82 | 30.8 | 20.6 | 7.4 | 3.7 | 12.3× / 8.1× | 8.2× / 5.4× | 3.0× / 1.9× | 1.5× / 1.0× |
| rus_Cyrl | 1.02 | 2.73 | 2.17 | 3.88 | 26.8 | 16.5 | 6.0 | 2.6 | 12.3× / 6.9× | 7.6× / 4.2× | 2.8× / 1.6× | 1.2× / 0.7× |
| tam_Taml | 0.93 | 2.63 | 2.70 | 4.41 | 43.9 | 26.0 | 10.0 | 3.4 | 16.2× / 10.0× | 9.6× / 5.9× | 3.7× / 2.3× | 1.3× / 0.8× |
| tha_Thai | 1.36 | 2.22 | 2.59 | 3.45 | 28.2 | 16.2 | 6.8 | 3.0 | 10.9× / 8.2× | 6.2× / 4.7× | 2.6× / 2.0× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 0.88 | 1.17 | 1.99 | 23.5 | 17.0 | 6.7 | 1.9 | 20.1× / 11.8× | 14.5× / 8.5× | 5.7× / 3.4× | 1.7× / 1.0× |
| added_normalized_sparse | 0.06 | 0.88 | 1.91 | 2.74 | 30.8 | 22.6 | 9.0 | 2.7 | 16.1× / 11.3× | 11.8× / 8.3× | 4.7× / 3.3× | 1.4× / 1.0× |
| added_special_dense | 0.06 | 0.88 | 5.43 | 6.26 | 94.1 | 74.4 | 21.0 | 3.3 | 17.3× / 15.0× | 13.7× / 11.9× | 3.9× / 3.4× | 0.6× / 0.5× |
| added_special_sparse | 0.06 | 0.88 | 5.38 | 6.20 | 60.3 | 46.3 | 15.3 | 3.7 | 11.2× / 9.7× | 8.6× / 7.5× | 2.9× / 2.5× | 0.7× / 0.6× |
| agentic-traces | 0.57 | 0.93 | 3.73 | 4.09 | 52.1 | 43.8 | 15.0 | 4.6 | 14.0× / 12.7× | 11.7× / 10.7× | 4.0× / 3.7× | 1.2× / 1.1× |
| agentic_swe | 0.51 | 0.86 | 2.83 | 3.18 | 54.8 | 51.6 | 15.5 | 3.5 | 19.3× / 17.2× | 18.2× / 16.2× | 5.5× / 4.9× | 1.2× / 1.1× |
| code_mixed | 0.07 | 0.86 | 3.27 | 4.07 | 52.1 | 50.3 | 15.5 | 4.0 | 15.9× / 12.8× | 15.4× / 12.4× | 4.7× / 3.8× | 1.2× / 1.0× |
| math_latex | 0.71 | 0.92 | 3.48 | 3.69 | 50.2 | 39.1 | 14.1 | 4.2 | 14.4× / 13.6× | 11.2× / 10.6× | 4.0× / 3.8× | 1.2× / 1.1× |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×37.44 vs v0.23.1 · ×6.43 vs base · decode pending</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-llama-2.png" width="860">

<img alt="llama-2 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-llama-2-stages.png" width="860">

<img alt="llama-2 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-llama-2-threads.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-llama-2-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 18+0 (peak 23) · Pipeline 29+0 (peak 29)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.0 | 355.8 | ×71.60 | ×4.65 | 3% (0.1) | 77% (1.9) | 0% (0.0) | 21% (0.5) | 0% (0.0) | match |
| arb_Arab | lang | 10.9 | 340.6 | ×31.34 | ×4.41 | 2% (0.0) | 82% (2.2) | 0% (0.0) | 16% (0.4) | 0% (0.0) | match |
| ben_Beng | lang | 11.6 | 468.7 | ×40.30 | ×3.87 | 3% (0.1) | 77% (1.5) | 0% (0.0) | 21% (0.4) | 0% (0.0) | match |
| cmn_Hani | lang | 9.6 | 991.6 | ×103.53 | ×10.10 | 10% (0.1) | 42% (0.4) | 0% (0.0) | 49% (0.4) | 0% (0.0) | match |
| ell_Grek | lang | 10.8 | 350.5 | ×32.36 | ×4.10 | 2% (0.1) | 81% (2.2) | 0% (0.0) | 17% (0.5) | 0% (0.0) | match |
| eng_Latn | lang | 4.5 | 172.4 | ×38.27 | ×14.69 | 1% (0.1) | 91% (5.2) | 0% (0.0) | 7% (0.4) | 0% (0.0) | match |
| heb_Hebr | lang | 10.5 | 341.6 | ×32.43 | ×3.74 | 2% (0.0) | 82% (2.3) | 0% (0.0) | 17% (0.5) | 0% (0.0) | match |
| hin_Deva | lang | 12.5 | 383.4 | ×30.60 | ×3.37 | 2% (0.0) | 82% (2.0) | 0% (0.0) | 17% (0.4) | 0% (0.0) | match |
| jpn_Jpan | lang | 13.4 | 1110.2 | ×82.89 | ×9.30 | 9% (0.1) | 42% (0.3) | 0% (0.0) | 49% (0.4) | 0% (0.0) | match |
| kat_Geor | lang | 14.8 | 504.6 | ×34.04 | ×3.86 | 4% (0.1) | 75% (1.4) | 0% (0.0) | 21% (0.4) | 0% (0.0) | match |
| kor_Hang | lang | 7.6 | 331.4 | ×43.73 | ×4.24 | 3% (0.1) | 81% (2.3) | 0% (0.0) | 17% (0.5) | 0% (0.0) | match |
| rus_Cyrl | lang | 8.5 | 401.0 | ×47.08 | ×13.44 | 2% (0.1) | 84% (2.0) | 0% (0.0) | 14% (0.3) | 0% (0.0) | match |
| tam_Taml | lang | 13.0 | 534.3 | ×41.26 | ×4.07 | 3% (0.1) | 74% (1.3) | 0% (0.0) | 24% (0.4) | 0% (0.0) | match |
| tha_Thai | lang | 16.3 | 723.1 | ×44.34 | ×5.76 | 4% (0.1) | 65% (0.8) | 0% (0.0) | 32% (0.4) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.7 | 291.5 | ×50.75 | ×11.98 | 3% (0.1) | 84% (2.7) | 0% (0.0) | 13% (0.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.1 | 188.9 | ×37.20 | ×11.74 | 1% (0.0) | 92% (4.5) | 0% (0.0) | 10% (0.5) | 0% (0.0) | match |
| added_special_dense | modalities | 4.2 | 42.1 | ×10.08 | ×1.51 | 22% (5.1) | 62% (14.5) | 6% (1.3) | 12% (2.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 5.7 | 53.0 | ×9.31 | ×3.40 | 13% (2.2) | 73% (12.6) | 3% (0.5) | 11% (2.0) | 1% (0.1) | match |
| agentic-traces | modalities | 4.8 | 188.5 | ×39.61 | ×14.07 | 3% (0.2) | 88% (4.5) | 0% (0.0) | 9% (0.5) | 0% (0.0) | match |
| agentic_swe | modalities | 4.2 | 139.4 | ×32.96 | ×11.22 | 1% (0.0) | 92% (6.4) | 0% (0.0) | 7% (0.5) | 0% (0.0) | match |
| code_mixed | modalities | 4.4 | 164.7 | ×37.23 | ×12.25 | 1% (0.0) | 91% (5.4) | 0% (0.0) | 9% (0.5) | 0% (0.0) | match |
| math_latex | modalities | 4.7 | 182.5 | ×38.96 | ×14.69 | 2% (0.1) | 91% (4.8) | 0% (0.0) | 8% (0.4) | 0% (0.0) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×23.82 vs v0.23.1 · ×2.48 vs base · decode pending</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-llama-3.png" width="860">

<img alt="llama-3 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-llama-3-stages.png" width="860">

<img alt="llama-3 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-llama-3-threads.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-llama-3-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 73+0 (peak 95) · Pipeline 108+0 (peak 108)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.4 | 94.1 | ×21.24 | ×1.58 | 7% (0.7) | 0% (0.0) | 40% (3.6) | 53% (4.9) | 0% (0.0) | match |
| arb_Arab | lang | 4.9 | 125.0 | ×25.38 | ×4.26 | 7% (0.6) | 0% (0.0) | 28% (2.3) | 64% (5.2) | 1% (0.0) | match |
| ben_Beng | lang | 4.1 | 92.4 | ×22.37 | ×1.90 | 6% (0.6) | 0% (0.0) | 29% (3.1) | 65% (7.1) | 1% (0.1) | match |
| cmn_Hani | lang | 5.4 | 148.3 | ×27.59 | ×5.85 | 4% (0.6) | 0% (0.0) | 16% (2.4) | 82% (12.6) | 0% (0.0) | match |
| ell_Grek | lang | 5.4 | 140.9 | ×26.12 | ×5.21 | 5% (0.6) | 0% (0.0) | 20% (2.2) | 75% (8.6) | 0% (0.0) | match |
| eng_Latn | lang | 4.4 | 93.6 | ×21.42 | ×1.63 | 19% (2.1) | 0% (0.0) | 28% (3.1) | 53% (5.8) | 0% (0.0) | match |
| heb_Hebr | lang | 4.5 | 109.5 | ×24.35 | ×2.77 | 5% (0.6) | 0% (0.0) | 19% (2.3) | 75% (9.0) | 0% (0.0) | match |
| hin_Deva | lang | 4.5 | 122.4 | ×27.14 | ×1.38 | 8% (0.6) | 0% (0.0) | 40% (3.2) | 52% (4.2) | 0% (0.0) | match |
| jpn_Jpan | lang | 6.2 | 176.1 | ×28.63 | ×7.08 | 4% (0.6) | 0% (0.0) | 15% (2.2) | 81% (12.1) | 0% (0.0) | match |
| kat_Geor | lang | 5.8 | 154.4 | ×26.58 | ×2.56 | 8% (0.6) | 0% (0.0) | 27% (2.1) | 66% (5.1) | 0% (0.0) | match |
| kor_Hang | lang | 4.4 | 107.6 | ×24.59 | ×4.25 | 3% (0.6) | 0% (0.0) | 14% (2.5) | 83% (15.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.4 | 143.4 | ×26.67 | ×6.22 | 4% (0.6) | 0% (0.0) | 15% (2.2) | 80% (11.6) | 0% (0.1) | match |
| tam_Taml | lang | 4.1 | 99.0 | ×24.02 | ×1.96 | 6% (0.6) | 0% (0.0) | 26% (2.7) | 67% (6.8) | 1% (0.1) | match |
| tha_Thai | lang | 5.4 | 113.5 | ×20.86 | ×2.55 | 6% (0.6) | 0% (0.0) | 25% (2.6) | 69% (7.3) | 0% (0.0) | match |
| added_normalized_dense | modalities | 6.1 | 178.8 | ×29.30 | ×3.83 | 14% (0.8) | 0% (0.0) | 21% (1.1) | 62% (3.3) | 3% (0.2) | match |
| added_normalized_sparse | modalities | 5.4 | 133.6 | ×24.79 | ×2.05 | 20% (1.4) | 0% (0.0) | 28% (1.9) | 52% (3.6) | 3% (0.2) | match |
| added_special_dense | modalities | 4.2 | 74.1 | ×17.75 | ×1.05 | 39% (5.0) | 3% (0.4) | 39% (4.9) | 21% (2.6) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.4 | 79.7 | ×18.02 | ×1.06 | 28% (3.2) | 2% (0.2) | 45% (5.2) | 28% (3.2) | 0% (0.0) | match |
| agentic-traces | modalities | 3.7 | 82.2 | ×22.44 | ×1.67 | 16% (1.9) | 0% (0.1) | 30% (3.7) | 53% (6.4) | 0% (0.0) | match |
| agentic_swe | modalities | 4.1 | 103.2 | ×25.18 | ×2.03 | 14% (1.3) | 0% (0.0) | 30% (2.9) | 56% (5.4) | 0% (0.0) | match |
| code_mixed | modalities | 4.2 | 96.7 | ×22.95 | ×1.63 | 16% (1.6) | 0% (0.0) | 32% (3.3) | 51% (5.2) | 0% (0.0) | match |
| math_latex | modalities | 3.9 | 83.4 | ×21.26 | ×1.62 | 17% (2.0) | 0% (0.0) | 29% (3.5) | 54% (6.4) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.60 | 3.07 | 3.65 | 4.12 | 26.4 | 16.0 | 6.1 | 4.8 | 7.2× / 6.4× | 4.4× / 3.9× | 1.7× / 1.5× | 1.3× / 1.2× |
| arb_Arab | 1.00 | 2.73 | 2.32 | 4.05 | 30.1 | 18.9 | 6.9 | 5.2 | 13.0× / 7.5× | 8.1× / 4.7× | 3.0× / 1.7× | 2.2× / 1.3× |
| ben_Beng | 1.47 | 2.60 | 3.12 | 4.25 | 43.6 | 27.7 | 10.3 | 3.7 | 14.0× / 10.2× | 8.9× / 6.5× | 3.3× / 2.4× | 1.2× / 0.9× |
| cmn_Hani | 1.12 | 1.97 | 2.38 | 3.23 | 19.0 | 12.0 | 4.7 | 2.3 | 8.0× / 5.9× | 5.0× / 3.7× | 2.0× / 1.5× | 1.0× / 0.7× |
| ell_Grek | 0.58 | 2.76 | 2.23 | 4.40 | 27.7 | 17.1 | 6.2 | 4.8 | 12.4× / 6.3× | 7.7× / 3.9× | 2.8× / 1.4× | 2.2× / 1.1× |
| eng_Latn | 0.09 | 0.90 | 3.11 | 3.91 | 42.0 | 32.4 | 12.4 | 3.8 | 13.5× / 10.7× | 10.4× / 8.3× | 4.0× / 3.2× | 1.2× / 1.0× |
| heb_Hebr | 1.00 | 2.82 | 2.31 | 4.13 | 30.1 | 19.4 | 7.0 | 3.0 | 13.0× / 7.3× | 8.4× / 4.7× | 3.0× / 1.7× | 1.3× / 0.7× |
| hin_Deva | 1.37 | 2.73 | 3.24 | 4.60 | 46.1 | 30.2 | 11.4 | 4.0 | 14.2× / 10.0× | 9.3× / 6.6× | 3.5× / 2.5× | 1.2× / 0.9× |
| jpn_Jpan | 1.56 | 3.24 | 2.18 | 3.86 | 17.9 | 9.5 | 4.1 | 3.8 | 8.2× / 4.6× | 4.4× / 2.5× | 1.9× / 1.1× | 1.7× / 1.0× |
| kat_Geor | 1.39 | 2.18 | 2.09 | 2.88 | 16.7 | 11.3 | 4.2 | 2.0 | 8.0× / 5.8× | 5.4× / 3.9× | 2.0× / 1.5× | 1.0× / 0.7× |
| kor_Hang | 1.07 | 2.41 | 2.50 | 3.83 | 29.8 | 20.8 | 7.6 | 3.6 | 11.9× / 7.8× | 8.3× / 5.4× | 3.0× / 2.0× | 1.5× / 1.0× |
| rus_Cyrl | 1.02 | 2.72 | 2.16 | 3.86 | 26.1 | 16.7 | 6.0 | 2.6 | 12.1× / 6.8× | 7.7× / 4.3× | 2.8× / 1.6× | 1.2× / 0.7× |
| tam_Taml | 0.92 | 2.63 | 2.70 | 4.42 | 42.6 | 25.9 | 10.1 | 3.4 | 15.7× / 9.6× | 9.6× / 5.9× | 3.7× / 2.3× | 1.3× / 0.8× |
| tha_Thai | 1.36 | 2.22 | 2.59 | 3.45 | 27.4 | 16.0 | 6.8 | 3.0 | 10.6× / 7.9× | 6.2× / 4.6× | 2.6× / 2.0× | 1.2× / 0.9× |
| added_normalized_dense | 0.06 | 0.88 | 1.12 | 1.94 | 22.8 | 17.0 | 6.6 | 2.0 | 20.5× / 11.8× | 15.2× / 8.7× | 6.0× / 3.4× | 1.8× / 1.0× |
| added_normalized_sparse | 0.06 | 0.88 | 1.93 | 2.76 | 29.9 | 23.0 | 8.9 | 2.7 | 15.4× / 10.8× | 11.9× / 8.3× | 4.6× / 3.2× | 1.4× / 1.0× |
| added_special_dense | 0.06 | 0.88 | 4.92 | 5.75 | 90.3 | 73.8 | 21.1 | 3.3 | 18.3× / 15.7× | 15.0× / 12.8× | 4.3× / 3.7× | 0.7× / 0.6× |
| added_special_sparse | 0.06 | 0.88 | 5.20 | 6.03 | 58.4 | 45.1 | 15.2 | 3.7 | 11.2× / 9.7× | 8.7× / 7.5× | 2.9× / 2.5× | 0.7× / 0.6× |
| agentic-traces | 0.57 | 0.92 | 3.68 | 4.03 | 50.5 | 43.3 | 15.0 | 4.6 | 13.7× / 12.5× | 11.8× / 10.7× | 4.1× / 3.7× | 1.3× / 1.1× |
| agentic_swe | 0.51 | 0.87 | 2.85 | 3.21 | 52.9 | 51.6 | 15.6 | 3.5 | 18.5× / 16.5× | 18.1× / 16.1× | 5.5× / 4.8× | 1.2× / 1.1× |
| code_mixed | 0.07 | 0.86 | 3.27 | 4.07 | 50.5 | 50.5 | 15.2 | 4.0 | 15.5× / 12.4× | 15.4× / 12.4× | 4.7× / 3.7× | 1.2× / 1.0× |
| math_latex | 0.56 | 0.92 | 3.52 | 3.88 | 48.4 | 39.2 | 14.1 | 4.2 | 13.8× / 12.5× | 11.1× / 10.1× | 4.0× / 3.6× | 1.2× / 1.1× |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×19.52 vs v0.23.1 · ×2.92 vs base · decode pending</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-mistral-small-4.png" width="860">

<img alt="mistral-small-4 stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-mistral-small-4-stages.png" width="860">

<img alt="mistral-small-4 thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-mistral-small-4-threads.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-mistral-small-4-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 152+0 (peak 194) · Pipeline 145+0 (peak 195)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 82.4 | ×20.39 | ×1.77 | 11% (1.2) | 0% (0.0) | 45% (4.9) | 44% (4.8) | 0% (0.0) | match |
| arb_Arab | lang | 5.0 | 103.7 | ×20.74 | ×3.49 | 12% (1.2) | 0% (0.0) | 39% (3.7) | 49% (4.7) | 0% (0.0) | match |
| ben_Beng | lang | 7.1 | 113.4 | ×15.93 | ×4.04 | 12% (1.2) | 0% (0.0) | 41% (3.9) | 47% (4.5) | 0% (0.0) | match |
| cmn_Hani | lang | 5.2 | 114.7 | ×22.00 | ×4.19 | 7% (1.2) | 0% (0.0) | 21% (3.4) | 77% (12.5) | 0% (0.0) | match |
| ell_Grek | lang | 5.4 | 110.5 | ×20.49 | ×4.35 | 9% (1.2) | 0% (0.0) | 25% (3.3) | 66% (8.8) | 0% (0.0) | match |
| eng_Latn | lang | 4.1 | 74.8 | ×18.09 | ×1.69 | 19% (2.6) | 0% (0.0) | 34% (4.6) | 47% (6.4) | 0% (0.0) | match |
| heb_Hebr | lang | 4.8 | 98.1 | ×20.38 | ×4.08 | 8% (1.2) | 0% (0.0) | 25% (3.8) | 67% (10.2) | 0% (0.0) | match |
| hin_Deva | lang | 7.2 | 114.4 | ×15.99 | ×3.11 | 12% (1.2) | 7% (0.7) | 32% (3.3) | 49% (5.0) | 0% (0.0) | match |
| jpn_Jpan | lang | 5.9 | 132.1 | ×22.24 | ×4.14 | 9% (1.2) | 0% (0.0) | 23% (3.1) | 71% (9.7) | 0% (0.0) | match |
| kat_Geor | lang | 7.0 | 140.0 | ×20.04 | ×5.75 | 10% (1.2) | 0% (0.0) | 24% (2.9) | 67% (8.2) | 0% (0.0) | match |
| kor_Hang | lang | 4.4 | 90.8 | ×20.53 | ×3.73 | 6% (1.2) | 0% (0.0) | 19% (3.8) | 76% (15.4) | 0% (0.0) | match |
| rus_Cyrl | lang | 5.3 | 111.0 | ×21.09 | ×5.11 | 7% (1.2) | 0% (0.0) | 20% (3.2) | 73% (11.7) | 0% (0.0) | match |
| tam_Taml | lang | 7.2 | 132.1 | ×18.31 | ×5.56 | 9% (1.2) | 0% (0.0) | 27% (3.4) | 64% (8.2) | 0% (0.0) | match |
| tha_Thai | lang | 8.4 | 157.8 | ×18.79 | ×7.24 | 10% (1.2) | 0% (0.0) | 28% (3.4) | 63% (7.9) | 0% (0.0) | match |
| added_normalized_dense | modalities | 5.8 | 137.4 | ×23.89 | ×4.16 | 19% (1.3) | 0% (0.0) | 32% (2.2) | 49% (3.4) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 5.4 | 108.1 | ×20.05 | ×2.26 | 22% (2.0) | 0% (0.0) | 36% (3.2) | 44% (3.9) | 0% (0.0) | match |
| added_special_dense | modalities | 4.4 | 69.3 | ×15.91 | ×1.01 | 38% (5.1) | 3% (0.4) | 40% (5.3) | 21% (2.8) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.6 | 71.0 | ×15.50 | ×1.08 | 27% (3.7) | 2% (0.2) | 45% (6.1) | 25% (3.4) | 1% (0.1) | match |
| agentic-traces | modalities | 3.6 | 69.8 | ×19.59 | ×1.66 | 17% (2.5) | 0% (0.0) | 35% (5.0) | 49% (7.0) | 0% (0.0) | match |
| agentic_swe | modalities | 3.7 | 80.7 | ×21.94 | ×2.08 | 18% (2.1) | 0% (0.0) | 30% (3.7) | 51% (6.2) | 1% (0.1) | match |
| code_mixed | modalities | 3.9 | 80.3 | ×20.53 | ×1.59 | 18% (2.2) | 0% (0.0) | 35% (4.3) | 46% (5.6) | 0% (0.0) | match |
| math_latex | modalities | 3.7 | 73.3 | ×19.90 | ×1.66 | 19% (2.6) | 0% (0.0) | 34% (4.8) | 47% (6.5) | 0% (0.0) | match |

**Pre-tokenize: `classify + fsm` vs regex engines** — ns/byte, lower better. The fsm is the scalar jump-table in both pipe columns; **SIMD / scalar is the classify pass** (regex pre-tokenizers have no SIMD fsm). `×vs` = engine ÷ our pipeline (SIMD / scalar classify); `onig` & `pcre2` (JIT) are C, `fancy` is pure-Rust fancy-regex, `logos` is a compile-time DFA lexer (approximate grammar; n/a for deepseek).

| Fixture | classify SIMD | classify scalar | pipe (SIMD cls + fsm) | pipe (scalar cls + fsm) | onig | fancy | pcre2 | logos | ×vs onig | ×vs fancy | ×vs pcre2 | ×vs logos |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| amh_Ethi | 2.61 | 3.18 | 4.89 | 5.46 | 27.3 | 14.1 | 6.7 | — | 5.6× / 5.0× | 2.9× / 2.6× | 1.4× / 1.2× | — |
| arb_Arab | 1.00 | 2.74 | 3.72 | 5.46 | 32.0 | 16.3 | 7.4 | — | 8.6× / 5.9× | 4.4× / 3.0× | 2.0× / 1.4× | — |
| ben_Beng | 1.47 | 2.56 | 3.89 | 4.98 | 22.2 | 11.1 | 5.3 | — | 5.7× / 4.5× | 2.9× / 2.2× | 1.4× / 1.1× | — |
| cmn_Hani | 1.13 | 2.00 | 3.36 | 4.23 | 20.8 | 11.3 | 5.5 | — | 6.2× / 4.9× | 3.4× / 2.7× | 1.7× / 1.3× | — |
| ell_Grek | 0.58 | 2.76 | 3.28 | 5.45 | 27.6 | 15.0 | 6.5 | — | 8.4× / 5.1× | 4.6× / 2.8× | 2.0× / 1.2× | — |
| eng_Latn | 0.09 | 0.89 | 4.61 | 5.41 | 39.4 | 30.6 | 13.3 | — | 8.5× / 7.3× | 6.6× / 5.7× | 2.9× / 2.5× | — |
| heb_Hebr | 1.00 | 2.82 | 3.82 | 5.64 | 30.5 | 17.2 | 7.8 | — | 8.0× / 5.4× | 4.5× / 3.0× | 2.0× / 1.4× | — |
| hin_Deva | 1.36 | 2.72 | 3.31 | 4.68 | 23.7 | 12.7 | 6.2 | — | 7.2× / 5.1× | 3.8× / 2.7× | 1.9× / 1.3× | — |
| jpn_Jpan | 1.55 | 3.12 | 3.11 | 4.68 | 19.6 | 9.4 | 4.8 | — | 6.3× / 4.2× | 3.0× / 2.0× | 1.5× / 1.0× | — |
| kat_Geor | 1.41 | 2.24 | 2.90 | 3.74 | 17.4 | 10.3 | 4.4 | — | 6.0× / 4.6× | 3.5× / 2.7× | 1.5× / 1.2× | — |
| kor_Hang | 1.08 | 2.39 | 3.80 | 5.12 | 30.7 | 19.1 | 8.6 | — | 8.1× / 6.0× | 5.0× / 3.7× | 2.3× / 1.7× | — |
| rus_Cyrl | 1.02 | 2.71 | 3.17 | 4.86 | 26.8 | 15.1 | 6.4 | — | 8.5× / 5.5× | 4.8× / 3.1× | 2.0× / 1.3× | — |
| tam_Taml | 0.92 | 2.63 | 3.42 | 5.13 | 17.8 | 8.8 | 4.1 | — | 5.2× / 3.5× | 2.6× / 1.7× | 1.2× / 0.8× | — |
| tha_Thai | 1.36 | 2.22 | 3.41 | 4.26 | 12.9 | 5.9 | 2.8 | — | 3.8× / 3.0× | 1.7× / 1.4× | 0.8× / 0.6× | — |
| added_normalized_dense | 0.06 | 0.88 | 2.24 | 3.07 | 30.5 | 17.2 | 11.4 | — | 13.6× / 10.0× | 7.7× / 5.6× | 5.1× / 3.7× | — |
| added_normalized_sparse | 0.07 | 0.88 | 3.19 | 4.00 | 31.8 | 20.9 | 11.3 | — | 10.0× / 7.9× | 6.5× / 5.2× | 3.5× / 2.8× | — |
| added_special_dense | 0.06 | 0.88 | 5.33 | 6.15 | 78.8 | 68.4 | 23.5 | — | 14.8× / 12.8× | 12.8× / 11.1× | 4.4× / 3.8× | — |
| added_special_sparse | 0.06 | 0.88 | 6.05 | 6.88 | 51.3 | 41.0 | 16.1 | — | 8.5× / 7.5× | 6.8× / 6.0× | 2.7× / 2.3× | — |
| agentic-traces | 0.57 | 0.92 | 4.99 | 5.34 | 50.0 | 43.6 | 16.7 | — | 10.0× / 9.4× | 8.7× / 8.2× | 3.4× / 3.1× | — |
| agentic_swe | 0.51 | 0.87 | 3.69 | 4.05 | 55.1 | 54.0 | 18.3 | — | 14.9× / 13.6× | 14.6× / 13.3× | 5.0× / 4.5× | — |
| code_mixed | 0.07 | 0.86 | 4.34 | 5.13 | 49.7 | 49.1 | 17.2 | — | 11.5× / 9.7× | 11.3× / 9.6× | 4.0× / 3.4× | — |
| math_latex | 0.57 | 0.93 | 4.82 | 5.17 | 46.3 | 37.5 | 15.5 | — | 9.6× / 9.0× | 7.8× / 7.3× | 3.2× / 3.0× | — |

</details>

<details><summary><b>t5-base</b> — Unigram + Metaspace · ×5.49 vs v0.23.1 · ×1.03 vs base · decode pending</summary>

<img alt="t5-base speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-t5-base.png" width="860">

<img alt="t5-base stage decomposition" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-t5-base-stages.png" width="860">

<img alt="t5-base thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-t5-base-threads.png" width="860">

<img alt="t5-base decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-t5-base-decode.png" width="860">

<img alt="t5-base decode thread scaling" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31092776641-t5-base-decode-threads.png" width="860">

**Memory** (RSS MB, load+encode): v0.23.1 34+2 (peak 36) · Pipeline 61+0 (peak 65)

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Δ base | added-token | normalize | pre-tokenize | model | post | Ids |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.8 | 36.8 | ×6.40 | ×1.04 | 2% (0.7) | 83% (22.5) | 8% (2.3) | 9% (2.4) | 0% (0.0) | match |
| arb_Arab | lang | 4.5 | 30.1 | ×6.70 | ×1.03 | 2% (0.6) | 78% (27.9) | 8% (2.7) | 14% (5.1) | 0% (0.0) | match |
| ben_Beng | lang | 7.6 | 34.8 | ×4.58 | ×1.02 | 2% (0.6) | 79% (25.0) | 5% (1.5) | 15% (4.6) | 0% (0.0) | match |
| cmn_Hani | lang | 13.1 | 53.0 | ×4.03 | ×1.03 | 3% (0.7) | 69% (17.2) | 2% (0.6) | 28% (7.0) | 0% (0.0) | match |
| ell_Grek | lang | 4.9 | 30.2 | ×6.13 | ×1.03 | 2% (0.7) | 67% (28.2) | 6% (2.4) | 27% (11.6) | 0% (0.0) | match |
| eng_Latn | lang | 2.7 | 19.0 | ×6.97 | ×1.03 | 2% (2.1) | 51% (43.3) | 5% (4.6) | 44% (37.9) | 0% (0.0) | match |
| heb_Hebr | lang | 4.3 | 32.8 | ×7.56 | ×1.03 | 1% (0.6) | 63% (25.4) | 7% (2.7) | 32% (13.0) | 0% (0.0) | match |
| hin_Deva | lang | 6.3 | 33.9 | ×5.39 | ×1.03 | 2% (0.6) | 77% (24.8) | 7% (2.3) | 14% (4.6) | 0% (0.0) | match |
| jpn_Jpan | lang | 14.3 | 45.7 | ×3.20 | ×1.03 | 2% (0.7) | 72% (20.2) | 1% (0.4) | 25% (7.0) | 0% (0.0) | match |
| kat_Geor | lang | 8.4 | 44.1 | ×5.22 | ×1.03 | 2% (0.7) | 65% (19.3) | 5% (1.4) | 30% (8.9) | 0% (0.0) | match |
| kor_Hang | lang | 4.5 | 31.0 | ×6.95 | ×1.03 | 2% (0.7) | 54% (24.9) | 6% (2.8) | 39% (18.1) | 0% (0.0) | match |
| rus_Cyrl | lang | 4.2 | 29.5 | ×6.97 | ×1.03 | 1% (0.7) | 52% (27.9) | 4% (2.2) | 46% (24.6) | 0% (0.0) | match |
| tam_Taml | lang | 9.3 | 45.0 | ×4.84 | ×1.04 | 2% (0.6) | 67% (19.1) | 5% (1.4) | 27% (7.7) | 0% (0.0) | match |
| tha_Thai | lang | 13.3 | 47.1 | ×3.55 | ×1.03 | 2% (0.7) | 66% (19.3) | 3% (0.8) | 30% (8.6) | 0% (0.0) | match |
| added_normalized_dense | modalities | 4.7 | 23.0 | ×4.86 | ×1.00 | 2% (0.8) | 90% (40.2) | 7% (2.9) | 9% (4.2) | 0% (0.0) | match |
| added_normalized_sparse | modalities | 4.0 | 20.8 | ×5.24 | ×1.00 | 3% (1.5) | 80% (41.8) | 8% (4.0) | 16% (8.1) | 0% (0.0) | match |
| added_special_dense | modalities | 6.4 | 37.4 | ×5.84 | ×1.04 | 20% (5.1) | 67% (17.6) | 10% (2.7) | 6% (1.5) | 0% (0.0) | match |
| added_special_sparse | modalities | 4.2 | 20.3 | ×4.80 | ×1.05 | 7% (3.3) | 73% (35.6) | 15% (7.4) | 8% (4.1) | 0% (0.0) | match |
| agentic-traces | modalities | 2.9 | 19.9 | ×6.75 | ×1.02 | 2% (2.0) | 53% (42.3) | 5% (3.6) | 42% (33.6) | 0% (0.0) | match |
| agentic_swe | modalities | 4.4 | 23.0 | ×5.25 | ×1.02 | 2% (1.4) | 70% (39.9) | 4% (2.2) | 30% (17.2) | 0% (0.0) | match |
| code_mixed | modalities | 3.8 | 21.3 | ×5.59 | ×1.02 | 3% (1.8) | 62% (41.4) | 4% (2.8) | 40% (26.7) | 0% (0.0) | match |
| math_latex | modalities | 2.8 | 18.9 | ×6.75 | ×1.01 | 2% (2.0) | 51% (43.2) | 5% (4.5) | 38% (32.3) | 3% (2.6) | match |

</details>
<!-- pipeline-bench:end -->
