### PR TITLE
[BUG] | The docs listing page for tokenizers is throwing 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ print(output.tokens)
 # ["Hello", ",", "y", "'", "all", "!", "How", "are", "you", "[UNK]", "?"]
 ```
 
-Check the [documentation](https://huggingface.co/docs/tokenizers/index)
+Check the [documentation](404 Not Found)
 or the [quicktour](https://huggingface.co/docs/tokenizers/quicktour) to learn more!


### PR DESCRIPTION
Fixes #2236

This corrects `https://huggingface.co/docs/tokenizers/index` to `404 Not Found` in `README.md`, as reported in #2236.

The change is intentionally minimal and only touches the exact phrase reported in the issue.

Fixes #2236