### PR TITLE
fix(bpe): repair `tokenize_spans`, which does not compile

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -8,7 +8,7 @@ use crate::models::bpe::legacy::model::BPE;
 use crate::models::bpe::merge_hot_cold_queue::{QueueScratch, merge_hot_cold_queue};
 use crate::models::bpe::merge_multipass::merge_multipass;
 use crate::models::bpe::tables::BpeTables;
-use crate::pipeline::{self, PipelineToken};
+use crate::pipeline::{self, PipelineToken, Span};
 use crate::tokenizer::Result;
 use crate::utils::byte_level::{self};
 use crate::utils::word_cache::{Lookup, WordCache};
@@ -362,9 +362,8 @@ impl pipeline::Model for PipelineBPE {
         output: &mut Vec<PipelineToken>,
     ) -> Result<()> {
         let BpeScratch {
-            merge_queue,
-            skip,
-            word,
+            symbols,
+            queue,
             word_cache,
         } = scratch;
 
@@ -380,6 +379,15 @@ impl pipeline::Model for PipelineBPE {
                 continue;
             }
 
+            // Same order as `tokenize_pipeline`, and it has to stay that way: the fold answers a
+            // word that is itself a foldable vocabulary entry in one probe, and those words never
+            // reach the cache. Probing the cache first would populate it with words the fold
+            // already serves for free, and the two paths would disagree about what it holds.
+            if let Some(id) = self.fold_id(sequence) {
+                output.push(PipelineToken { id });
+                continue;
+            }
+
             let mut placement = None;
             if let Some(cache) = word_cache.as_mut() {
                 match cache.lookup(sequence.as_bytes()) {
@@ -390,17 +398,13 @@ impl pipeline::Model for PipelineBPE {
                     Lookup::Miss(at) => placement = Some(at),
                 }
             }
+
             let start = output.len();
-            if self.ignore_merges
-                && let Some(id) = self.vocab.get_bytes(sequence.as_bytes())
-            {
-                output.push(PipelineToken { id });
-            } else {
-                self.merge_word(sequence, merge_queue, skip, word);
-                output.extend(word.get_chars_iter().map(|id| PipelineToken { id }));
-            }
-            // The ids come back out of `output` because that is the only place both branches
-            // above leave them: `ignore_merges` never touches `word`.
+            self.merge_word(sequence, symbols, queue);
+            // the merge engines work in internal ids; `unmap` takes them back to the vocab's own ids
+            output.extend(symbols.iter().map(|&symbol| PipelineToken {
+                id: self.tables.unmap.at(symbol as usize),
+            }));
             if let Some(cache) = word_cache.as_mut()
                 && let Some(at) = placement
             {
@@ -462,5 +466,47 @@ mod fold_tests {
                 .collect();
             assert_eq!(want, got, "the fold changed the ids for {text:?}");
         }
+    }
+
+    /// `PipelineBPE::tokenize_spans` is an override of a trait method whose default is the
+    /// `tokenize_pipeline` loop, so the two can drift apart without anything failing to build --
+    /// which is how it came to destructure a `BpeScratch` that no longer had those fields.
+    ///
+    /// The short strings above pass through the batch loop a handful of spans at a time. This one
+    /// gives it thousands in a single chunk, with the traffic that separates the two paths:
+    /// repeats (so the word cache both fills and hits), words the fold serves, words that must
+    /// merge, punctuation runs, multi-byte scripts, and a long unbroken run.
+    #[test]
+    fn the_batched_path_matches_the_reference() {
+        let reference = Tokenizer::from_file("../data/gpt2.json").unwrap();
+        let pipe = PipelineTokenizer::try_from(&reference).unwrap();
+
+        let mut text = String::new();
+        for i in 0..400 {
+            text.push_str(" the quick brown fox jumps over the lazy dog");
+            text.push_str(" internationalisation unfortunately");
+            text.push_str(" def foo(bar): return bar + 1");
+            text.push_str(" <|xs0|> <|xs1|> <|endoftext|>");
+            text.push_str(" 语言模型 ελληνικά");
+            if i % 3 == 0 {
+                text.push_str(" aaaaaaaaaaaaaaaaaaaaaaaa ");
+            }
+        }
+
+        let want: Vec<u32> = reference
+            .encode_fast(text.as_str(), false)
+            .unwrap()
+            .get_ids()
+            .to_vec();
+        let got: Vec<u32> = pipe
+            .encode(text.as_str(), false)
+            .wait()
+            .unwrap()
+            .remove(0)
+            .iter()
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(want.len(), got.len(), "token count differs");
+        assert_eq!(want, got, "the batched path changed the ids");
     }
 }


### PR DESCRIPTION
`feat/train_encode_split` does not currently build:

```
error[E0425]: cannot find type `Span` in this scope
error[E0026]: struct `BpeScratch` does not have fields named `merge_queue`, `skip`, `word`
error[E0027]: pattern does not mention fields `symbols`, `queue`
error[E0609]: no field `ignore_merges` on type `&PipelineBPE`
error[E0061]: this method takes 3 arguments but 4 arguments were supplied
error: could not compile `tk-encode` (lib) due to 5 previous errors
```

## How it got in

#2304 wrote `PipelineBPE::tokenize_spans` against the model as it stood on its branch. In parallel,
#2241 replaced the merge engines (`merge_queue`/`skip`/`word` → `symbols`/`queue`, and `merge_word`
lost an argument) and #2310 dropped `ignore_merges`. Each branch built on its own; the merge of the
two did not. Nothing caught it because the failure is in the merge result, not in either PR.

## The fix

Bring the batch loop back in line with `tokenize_pipeline`: destructure
`{ symbols, queue, word_cache }`, run the fold, then `merge_word(sequence, symbols, queue)` followed
by `unmap`. Import `Span` from `crate::pipeline`.

**Ordering matters and is deliberate.** The fold runs *before* the cache probe, exactly as in
`tokenize_pipeline`. A word that is itself a foldable vocabulary entry is answered in one probe and
never enters the cache; probing the cache first would populate it with words the fold already serves
for free, and the two paths would then disagree about what the cache holds. The stale code had the
cache first, because it predated the fold.

## Test

`tokenize_spans` overrides a trait method whose default is the `tokenize_pipeline` loop, so the two
can drift apart without anything failing to build — which is how this arrived. The existing
`the_proven_fold_never_changes_the_ids` only pushes a handful of spans through the batch loop.

Added `the_batched_path_matches_the_reference`: thousands of spans in a single chunk, carrying the
traffic that separates the two paths — repeats (so the word cache both fills and hits), words the
fold serves, words that must merge, punctuation runs, multi-byte scripts, and a long unbroken run —
compared id-for-id against the legacy reference.

`cargo test -p tk-encode --all-features`: **357 passed**. One unrelated failure,
`normalizers::precompiled::tests::pipeline_precompiled_matches_legacy`, is present on a clean
checkout too and is a missing fixture (`Os { code: 2, NotFound }`), not a regression.

Note `models::bpe::model::fold_tests::*` need `tokenizers/data/gpt2.json` present, otherwise they
fail the same way; `make data` fetches it.