### PR TITLE
chore(ci): more faithful numbers for baseline

### DIFF
--- a/.github/scripts/render_pipeline_bench.py
+++ b/.github/scripts/render_pipeline_bench.py
@@ -687,41 +687,6 @@ def alloc_line(model, baseline_label, lane="encode"):
                         (("baseline", baseline_label), ("pipeline", "Pipeline"))))
 
 
-# How far the canary may drift from its cached number before the report warns
-# that the machines no longer match the cached baseline run. Single-number
-# medians on shared runners carry a few percent of noise on their own.
-CANARY_FENCE_PCT = 10.0
-
-
-def canary_lines(data, benched):
-    """The cached-baseline trust note: when the release's numbers were copied
-    from a cached run, each model job re-measured one canary fixture; compare
-    every canary against its cached number and clear or warn in one line.
-    Empty when this run measured the release itself."""
-    if not (data.get("baseline") or {}).get("cached"):
-        return []
-    drifts, fixture = [], None
-    for m in benched:
-        c = m.get("baseline_canary") or {}
-        cur, old = c.get("measured_mbps"), c.get("cached_mbps")
-        if cur and old:
-            drifts.append(((cur / old - 1) * 100, m["model"]))
-            fixture = c.get("fixture", fixture)
-    if not drifts:
-        return ["<sub>release numbers from the cached baseline run (no canary data)</sub>", ""]
-    pct, model = max(drifts, key=lambda t: abs(t[0]))
-    if abs(pct) > CANARY_FENCE_PCT:
-        return [f"> ⚠️ **Release numbers are reused from a cached baseline run, and the "
-                f"canary ({fixture}, re-measured by every model job) drifted {pct:+.1f}% on "
-                f"{model}, beyond ±{CANARY_FENCE_PCT:g}%.** The runners changed since the "
-                f"cache was seeded; read the vs-release throughput comparisons with "
-                f"suspicion (allocation counts are unaffected). Any edit to "
-                f"fixture_bench.rs re-keys the cache and re-measures.", ""]
-    return [f"<sub>release numbers from the cached baseline run · canary ({fixture}) "
-            f"re-measured by {len(drifts)} model job(s): max drift {pct:+.1f}% "
-            f"(fence ±{CANARY_FENCE_PCT:g}%)</sub>", ""]
-
-
 def base_work_lookup(base_data):
     """(model, fixture) -> the base run's pipeline allocation rows, one per pass.
     Feeds `work_verdict`; entries hold whatever the base run measured (older runs
@@ -955,7 +920,8 @@ def sizes_svg(sweep, meta, baseline_label, subtitle_base=""):
 
 
 def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
-                    base_lookup=None, base_ref=None, base_work=None, env=None):
+                    base_lookup=None, base_ref=None, base_work=None, env=None,
+                    base_note=None):
     """Overview charts inline; everything per-model inside one <details> block, so
     the PR description stays a single screen."""
     models = data["models"]
@@ -977,7 +943,6 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
           picture(base, run_id, "overview", "Per-model encode throughput vs latest release", 860), "",
           picture(base, run_id, "fixtures",
                   "Per-fixture encode throughput vs latest release, across models", 860), ""]
-    md += canary_lines(data, benched)
     if has_decode:
         md += ["**Decode** — the release encodes each fixture's decode sample "
                "(`add_special_tokens=true`) and both implementations decode those "
@@ -990,6 +955,10 @@ def render_markdown(data, subtitle_base, meta, base, run_id, sizes,
         md += [f"**vs base branch** (`{escape(base_ref or 'base')}`) — per-model geomean ×speedup of "
                f"this PR's PipelineTokenizer against the base branch's; **regressions in red**.", "",
                picture(base, run_id, "base-overview", "Per-model encode throughput vs base branch", 860), ""]
+        if base_note:
+            md += [f"<sub>{base_note}</sub>", ""]
+    elif base_note:
+        md += [f"> ⚠️ {base_note}", ""]
     if base_work is not None:
         md += work_verdict(benched, base_work, base_ref or "base") + [""]
     if has_allocs:
@@ -1107,16 +1076,20 @@ def main():
     ap.add_argument("results")
     ap.add_argument("--out-dir", default=".")
     ap.add_argument("--subtitle",
-                    default="whole corpus · ~10 kB chunks · cold caches · add_special_tokens on")
+                    default="pipeline: whole corpus · release: ~2 MB/fixture sample · "
+                            "~10 kB chunks · cold caches · add_special_tokens on")
     ap.add_argument("--revision", default="")
     ap.add_argument("--img-base", default="", help="base URL for uploaded PNGs")
     ap.add_argument("--run-id", default="local")
     ap.add_argument("--binary-sizes", default="",
                     help="JSON file {baseline, pipeline} of stripped binary bytes")
     ap.add_argument("--base-bench", default="",
-                    help="base branch's cached fixture_bench JSON — enables the 'vs base branch' chart")
+                    help="base branch's fixture_bench JSON — enables the 'vs base branch' chart")
     ap.add_argument("--base-ref", default="",
                     help="label for the base branch baseline (e.g. short sha)")
+    ap.add_argument("--base-same-run", action="store_true",
+                    help="the base JSON was measured in this run's own jobs, "
+                         "on the same runners as the PR's numbers")
     args = ap.parse_args()
 
     rev = args.revision
@@ -1136,20 +1109,36 @@ def main():
     benched = [m for m in models if m["results"]]
     lo, hi = scale(benched)
 
-    # "vs base branch": join the PR results against the base branch's cached run by
+    # "vs base branch": join the PR results against the base branch's run by
     # (model, fixture). base_lookup[(model, fixture)] = base pipeline MB/s;
     # base_work carries the allocation lane's rows.
     base_lookup, base_speedups_of, blo, bhi, base_work = None, None, lo, hi, None
+    base_note = None
     if args.base_bench and Path(args.base_bench).exists():
         base_data = json.loads(Path(args.base_bench).read_text())
-        base_lookup = {(bm["model"], r["fixture"]): r["mbps"].get("pipeline")
-                       for bm in base_data["models"] for r in bm["results"]}
         base_work = base_work_lookup(base_data)
-        if any(base_lookup.values()):
-            base_speedups_of = lambda m: base_model_speedups(m, base_lookup)  # noqa: E731
-            blo, bhi = scale(benched, base_speedups_of)
+        # Wall time is only diffed between runs that measured under the same
+        # rules: a regime change (chunking, sample size, reps) moves every
+        # number for reasons that are not the PR's doing. Allocation counts
+        # come from full-corpus passes that the regime stamp does not describe,
+        # so the work verdict below survives the skip.
+        if base_data.get("regime") != data.get("regime"):
+            base_note = (f"vs-base throughput is not shown: the base run "
+                         f"(`{escape(args.base_ref or 'base')}`) measured under a different "
+                         f"regime, so its wall-time numbers are not comparable with this "
+                         f"run's. The allocation verdict below still applies.")
         else:
-            base_lookup = None
+            base_lookup = {(bm["model"], r["fixture"]): r["mbps"].get("pipeline")
+                           for bm in base_data["models"] for r in bm["results"]}
+            if any(base_lookup.values()):
+                base_speedups_of = lambda m: base_model_speedups(m, base_lookup)  # noqa: E731
+                blo, bhi = scale(benched, base_speedups_of)
+                base_note = ("base numbers measured in this run's jobs, on the same "
+                             "runners as the PR's" if args.base_same_run else
+                             "base numbers come from an earlier run on other machines; "
+                             "read differences within a few percent with suspicion")
+            else:
+                base_lookup = None
 
     out = Path(args.out_dir)
     (out / "pipeline_bench_overview.svg").write_text(
@@ -1224,7 +1213,8 @@ def main():
     (out / "pipeline_bench.md").write_text(
         render_markdown(data, args.subtitle, meta, args.img_base, args.run_id, sizes,
                         base_lookup=base_lookup, base_ref=args.base_ref,
-                        base_work=base_work, env=data.get("env")))
+                        base_work=base_work, env=data.get("env"),
+                        base_note=base_note))
 
     # per-model geomeans only — a cross-model aggregate would average unrelated modes
     per_model = " · ".join(

--- a/.github/workflows/pipeline-bench.yml
+++ b/.github/workflows/pipeline-bench.yml
@@ -6,7 +6,8 @@ name: Pipeline Benchmark
 # phased out, so it only *builds* the pipeline and is never benched or trusted as
 # an oracle. Runs for every model in tk-encode/examples/bench_models.json across
 # every corpus in data/fixtures/.
-# Measures single-thread throughput (whole corpus, cold instance per pass), an
+# Measures single-thread throughput (cold instance per pass; the pipeline over
+# the whole corpus, the release over a ~2 MB spread sample per fixture), an
 # input-size sweep, a multi-thread sweep (2/4 threads) per fixture group,
 # per-implementation memory footprint (RSS), stripped minimal-binary size, a
 # decode phase over a release-minted id stream (`text_match` is its gate), and a
@@ -16,15 +17,13 @@ name: Pipeline Benchmark
 # base branch with a "work vs base" verdict. The release dep is
 # behind tk-encode's `bench-baseline` feature, so production builds never pull it.
 #
-# The released crate's numbers are CACHED, not re-measured every run: the release
-# is pinned, so they only move when the machine does, yet timing its few-MB/s
-# encodes used to dominate the run. The `plan` job hashes the bench inputs
-# (fixture_bench.rs, the model manifest, the Makefile fixture lists) and looks for
-# baselines/release-<runner group>-<hash>.json on the HF Hub dataset. Hit: the
-# bench jobs run `--baseline-from` that file, skip all baseline timing, and
-# re-measure one canary fixture per model so the report can flag a machine that
-# drifted from the cache. Miss (any bench-input change): this run measures the
-# baseline itself and the report job seeds the cache for the runs after it.
+# The released crate is timed LIVE in every job, over a ~2 MB sample per
+# fixture (see fixture_bench.rs): sampling makes the release cheap enough that
+# nothing is cached across runs, so every vs-release ratio divides two numbers
+# measured seconds apart on the same machine. (Earlier revisions cached the
+# release's numbers on the Hub; jobs in the same runner group differ by tens of
+# percent in raw speed, so every ratio against a cached number moved with
+# whichever host the job landed on.)
 #
 # A `build` job compiles the bench + binsize example binaries ONCE (each with its
 # exact per-example feature set) and uploads them; the work is then fanned out,
@@ -51,12 +50,18 @@ name: Pipeline Benchmark
 # vs base branch: besides the "vs latest release" charts, the report shows a
 # "vs base branch" overview — this run's PipelineTokenizer against the base
 # branch's, per fixture, so a PR's own wins/regressions are visible (regressions
-# in red). The base's numbers are cached: a push to feat/train_encode_split
-# uploads its merged JSON to the HF Hub dataset as baselines/pipeline-<sha>.json
-# and force-moves the lightweight `pipeline-baseline` git tag to that commit
-# ("add the tag if not there"). A PR run resolves that tag, downloads the cached
-# JSON, and diffs against it ("otherwise read the data and plot the diff"). No
-# tag yet (or no cached JSON) → the base overview is skipped, release charts stay.
+# in red). The base's numbers are measured IN THIS RUN, on the same runners: a
+# push to feat/train_encode_split uploads its merged JSON and its fixture_bench
+# binary to the HF Hub dataset (baselines/pipeline-<sha>.json and
+# baselines/fixture_bench-<sha>) and force-moves the lightweight
+# `pipeline-baseline` git tag to that commit. A PR run downloads the base
+# binary, and each bench job runs it with `--pipeline-only` right before the PR
+# binary, so base and PR pipeline numbers come from the same machine and
+# per-host speed differences cancel in the ratio. No base binary yet (the tag
+# predates this workflow) → fall back to the base JSON from the tag, else to
+# the newest successful base-branch bench artifact — cross-run numbers, which
+# the report only wall-time-diffs when both runs measured under the same
+# regime. Neither → the base overview is skipped, release charts stay.
 
 on:
   push:
@@ -93,20 +98,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Reads the model manifest into the bench matrix (one job per model) and
-  # resolves the cached release-baseline numbers. The cache key hashes every
-  # input that shapes the numbers — bench code, model manifest, fixture lists —
-  # so any change to what is measured starts a fresh measuring run; the runner
-  # group is in the file name (keep it in sync with `runs-on` below). On a hit
-  # the JSON is re-published as a run artifact for the bench jobs.
+  # Reads the model manifest into the bench matrix (one job per model) and, on
+  # PR runs, fetches the base branch's prebuilt bench binary so every bench job
+  # can measure the base pipeline on its own runner, beside the PR's numbers.
   plan:
-    name: plan (models + baseline cache)
+    name: plan (models + base binary)
     if: github.event_name != 'pull_request' || github.event.label.name == 'run-pipeline-bench'
     runs-on: ubuntu-latest
     outputs:
       models: ${{ steps.models.outputs.models }}
-      baseline_path: ${{ steps.key.outputs.path }}
-      have_baseline: ${{ steps.fetch.outputs.have }}
+      base_sha: ${{ steps.base.outputs.sha }}
+      have_base_bin: ${{ steps.base.outputs.have }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
@@ -116,36 +118,37 @@ jobs:
           echo "models=$(jq -c '[.[].name]' tokenizers/tk-encode/examples/bench_models.json)" \
             >> "$GITHUB_OUTPUT"
 
-      - name: Compute the baseline cache key
-        id: key
-        run: |
-          hash="${{ hashFiles('tokenizers/tk-encode/examples/fixture_bench.rs', 'tokenizers/tk-encode/examples/bench_models.json', 'tokenizers/Makefile') }}"
-          echo "path=baselines/release-aws-general-8-plus-${hash}.json" >> "$GITHUB_OUTPUT"
-
       - name: Install uv
+        if: github.event_name == 'pull_request'
         uses: astral-sh/setup-uv@v6
 
-      - name: Fetch cached baseline numbers
-        id: fetch
+      # The binary the last base-branch run published (see "Publish base-branch
+      # baseline"). Missing until the first base push after this workflow lands;
+      # the report then falls back to the base bench JSON.
+      - name: Fetch the base-branch bench binary
+        id: base
+        if: github.event_name == 'pull_request'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          if uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-bench \
-               "${{ steps.key.outputs.path }}" --repo-type dataset --local-dir cache_dir; then
-            mv "cache_dir/${{ steps.key.outputs.path }}" baseline_cache.json
+          sha=$(git ls-remote origin refs/tags/pipeline-baseline | awk '{print $1}' | head -1)
+          if [ -n "$sha" ] && uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-bench \
+               "baselines/fixture_bench-$sha" --repo-type dataset --local-dir base_bin; then
+            mv "base_bin/baselines/fixture_bench-$sha" fixture_bench_base
             echo "have=true" >> "$GITHUB_OUTPUT"
-            echo "Baseline cache hit: ${{ steps.key.outputs.path }}"
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
+            echo "Base binary from the pipeline-baseline tag ($sha)."
           else
             echo "have=false" >> "$GITHUB_OUTPUT"
-            echo "No cached baseline for this key — this run measures the release."
+            echo "No base binary — the report falls back to the base bench JSON."
           fi
 
-      - name: Publish the cache to this run's jobs
-        if: steps.fetch.outputs.have == 'true'
+      - name: Publish the base binary to this run's jobs
+        if: steps.base.outputs.have == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: baseline-cache
-          path: baseline_cache.json
+          name: base-binary
+          path: fixture_bench_base
           retention-days: 3
 
   # Compile the bench + binsize example binaries ONCE here, instead of every bench
@@ -246,8 +249,9 @@ jobs:
 
   # Fan-out: one job per manifest model, on its own 8-vCPU runner (isolated +
   # parallel), running the prebuilt binary, uploading a partial JSON. No
-  # toolchain here — these jobs only fetch data + the binary. With a baseline
-  # cache hit the binary skips all release timing (`--baseline-from`).
+  # toolchain here — these jobs only fetch data + the binaries. On PR runs the
+  # job also runs the base branch's binary (`--pipeline-only`) on this same
+  # runner, so the vs-base ratio never mixes machines.
   bench:
     name: bench ${{ matrix.model }}
     needs: [plan, build]
@@ -288,21 +292,42 @@ jobs:
           name: bench-binaries
           path: tokenizers/target/release/examples
 
-      - name: Download cached baseline numbers
-        if: needs.plan.outputs.have_baseline == 'true'
+      - name: Download the base bench binary
+        if: needs.plan.outputs.have_base_bin == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
-          name: baseline-cache
+          name: base-binary
           path: tokenizers
+
+      # The base branch's pipeline, measured on THIS job's runner right before
+      # the PR's numbers. A base binary that predates a manifest or fixture
+      # change may fail on this model; drop its partial and keep the run — the
+      # report skips what is missing.
+      - name: Bench the base-branch pipeline (${{ matrix.model }})
+        if: needs.plan.outputs.have_base_bin == 'true'
+        run: |
+          chmod +x fixture_bench_base
+          if ! ./fixture_bench_base --pipeline-only --model "${{ matrix.model }}" \
+              > "base_bench_${{ matrix.model }}.json"; then
+            rm -f "base_bench_${{ matrix.model }}.json"
+            echo "Base binary failed on this model — vs-base will skip it."
+          fi
 
       - name: Run comparative benchmark (${{ matrix.model }})
         run: |
           chmod +x target/release/examples/fixture_bench
-          args=(--model "${{ matrix.model }}")
-          [ -f baseline_cache.json ] && args+=(--baseline-from baseline_cache.json)
-          ./target/release/examples/fixture_bench "${args[@]}" \
+          ./target/release/examples/fixture_bench --model "${{ matrix.model }}" \
             > "pipeline_bench_${{ matrix.model }}.json"
           cat "pipeline_bench_${{ matrix.model }}.json"
+
+      - name: Upload base partial
+        if: needs.plan.outputs.have_base_bin == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: base-partial-${{ matrix.model }}
+          path: tokenizers/base_bench_${{ matrix.model }}.json
+          retention-days: 3
+          if-no-files-found: ignore
 
       - name: Upload model partial
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -354,44 +379,45 @@ jobs:
           merge-multiple: true
           path: tokenizers/partials
 
+      # Base partials exist only on PR runs where the plan job found a base
+      # binary, and only for the models it could still bench.
+      - name: Download base partials
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          pattern: base-partial-*
+          merge-multiple: true
+          path: tokenizers/base_partials
+
       - name: Merge model partials
         run: |
           python3 - <<'PY'
           import glob, json
           order = [e["name"] for e in
                    json.load(open('tk-encode/examples/bench_models.json'))]
-          model_of = lambda f: f.rsplit('/', 1)[-1][len('pipeline_bench_'):-len('.json')]
-          parts = sorted(glob.glob('partials/**/pipeline_bench_*.json', recursive=True),
-                         key=lambda f: order.index(model_of(f)))
-          merged = None
-          for f in parts:
-              d = json.load(open(f))
-              if merged is None:
-                  # `env` (cpu/glibc stamp) from the first partial: the jobs
-                  # share a runner group, so one stamp stands for the run.
-                  merged = {"baseline": d["baseline"], "env": d.get("env"), "models": []}
-              merged["models"].extend(d["models"])
-          if merged is None:
+          def merge(pattern, prefix, out):
+              model_of = lambda f: f.rsplit('/', 1)[-1][len(prefix):-len('.json')]
+              parts = sorted(glob.glob(pattern, recursive=True),
+                             key=lambda f: order.index(model_of(f)))
+              merged = None
+              for f in parts:
+                  d = json.load(open(f))
+                  if merged is None:
+                      # `env` (cpu/glibc stamp) from the first partial: the jobs
+                      # share a runner group, so one stamp stands for the run.
+                      merged = {"baseline": d["baseline"], "env": d.get("env"),
+                                "regime": d.get("regime"), "models": []}
+                  merged["models"].extend(d["models"])
+              if merged is not None:
+                  json.dump(merged, open(out, 'w'))
+              print(f"{out}: merged {len(parts)} partial(s)")
+              return merged
+          if merge('partials/**/pipeline_bench_*.json', 'pipeline_bench_',
+                   'pipeline_bench.json') is None:
               raise SystemExit("no model partials found")
-          json.dump(merged, open('pipeline_bench.json', 'w'))
-          print(f"merged {len(parts)} partial(s) -> {len(merged['models'])} models")
+          merge('base_partials/**/base_bench_*.json', 'base_bench_', 'base_bench.json')
           PY
           head -c 300 pipeline_bench.json; echo
-
-      # Seed the release-baseline cache: this run had no cached numbers, so it
-      # measured the release itself; publish the merged JSON under the plan
-      # job's key so every following run skips the baseline timing. The full
-      # bench JSON is stored as-is — cached-mode runs read only its baseline
-      # fields.
-      - name: Publish release-baseline cache
-        if: needs.plan.outputs.have_baseline == 'false'
-        continue-on-error: true
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          uvx --from huggingface_hub hf upload hf-internal-testing/tokenizers-bench \
-            pipeline_bench.json "${{ needs.plan.outputs.baseline_path }}" --repo-type dataset \
-            --commit-message "release baseline: ${{ needs.plan.outputs.baseline_path }}"
 
       - name: Download prebuilt binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
@@ -422,21 +448,36 @@ jobs:
           cat binary_sizes.json
 
       # "vs base branch": find the base branch's bench to diff this run against.
-      #   1. Primary — the `pipeline-baseline` tag pins a base commit whose merged
-      #      bench is cached on HF Hub (durable, survives artifact expiry).
+      #   0. Primary — this run's own base partials: the bench jobs ran the base
+      #      binary beside the PR binary, so the numbers share each job's runner.
+      #   1. Fallback — the `pipeline-baseline` tag pins a base commit whose
+      #      merged bench is cached on HF Hub (durable, survives artifact
+      #      expiry). Cross-run numbers: the report wall-time-diffs them only
+      #      when the two runs measured under the same regime.
       #   2. Fallback — before that tag exists (e.g. on this very PR, or any PR
       #      before the feature has merged + a base push), use the newest
       #      successful base-branch bench *artifact*. Always available, so the
       #      comparison shows up without any manual seeding.
-      # Skipped (has_base=false) only when neither exists or both point at this
-      # same commit; the release charts render regardless.
+      # Skipped (has_base=false) only when none exists or the fallbacks point at
+      # this same commit; the release charts render regardless.
       - name: Resolve base-branch baseline
         id: base
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ needs.plan.outputs.base_sha }}
         run: |
+          # 0. base partials measured in this run's own jobs
+          if [ -f base_bench.json ]; then
+            {
+              echo "has_base=true"
+              echo "base_json=base_bench.json"
+              echo "base_ref=${BASE_SHA:0:9}"
+              echo "same_run=true"
+            } >> "$GITHUB_OUTPUT"
+            echo "Base baseline measured in this run (base binary from $BASE_SHA)."; exit 0
+          fi
           # 1. tag -> HF Hub JSON
           base_sha=$(git ls-remote origin refs/tags/pipeline-baseline | awk '{print $1}' | head -1)
           if [ -n "$base_sha" ] && [ "$base_sha" != "$CUR_SHA" ]; then
@@ -480,10 +521,13 @@ jobs:
           base_args=""
           if [ "${{ steps.base.outputs.has_base }}" = "true" ]; then
             base_args="--base-bench ${{ steps.base.outputs.base_json }} --base-ref ${{ steps.base.outputs.base_ref }}"
+            if [ "${{ steps.base.outputs.same_run }}" = "true" ]; then
+              base_args="$base_args --base-same-run"
+            fi
           fi
           python3 ${{ github.workspace }}/.github/scripts/render_pipeline_bench.py \
             pipeline_bench.json \
-            --subtitle "whole corpus · ~10 kB chunks · cold caches · add_special_tokens on · 2/4-thread sweep per group" \
+            --subtitle "pipeline: whole corpus · release: ~2 MB/fixture sample · ~10 kB chunks · cold caches · add_special_tokens on · 2/4-thread sweep per group" \
             --revision "${{ github.event.pull_request.head.sha || github.sha }}" \
             --img-base "$base_url" \
             --run-id "${{ github.run_id }}" \
@@ -568,11 +612,13 @@ jobs:
           "
 
       # Establish/refresh the base-branch baseline: on a push to
-      # feat/train_encode_split, cache this commit's merged bench on HF Hub and
-      # force-move the `pipeline-baseline` tag to it. Runs only after the id check
-      # passes, so a broken base never becomes the baseline. The tag push is a
-      # refs/tags update — it does NOT match the `push: branches` trigger, so no
-      # re-run loop. Uses the checkout's persisted GITHUB_TOKEN (contents: write).
+      # feat/train_encode_split, upload this commit's merged bench JSON and its
+      # fixture_bench binary to HF Hub, and force-move the `pipeline-baseline`
+      # tag to it. PR runs then bench that binary (`--pipeline-only`) beside
+      # their own. Runs only after the id check passes, so a broken base never
+      # becomes the baseline. The tag push is a refs/tags update — it does NOT
+      # match the `push: branches` trigger, so no re-run loop. Uses the
+      # checkout's persisted GITHUB_TOKEN (contents: write).
       - name: Publish base-branch baseline
         if: github.event_name == 'push'
         env:
@@ -581,9 +627,11 @@ jobs:
           sha="${{ github.sha }}"
           uvx --from huggingface_hub hf upload hf-internal-testing/tokenizers-bench \
             pipeline_bench.json "baselines/pipeline-$sha.json" --repo-type dataset
+          uvx --from huggingface_hub hf upload hf-internal-testing/tokenizers-bench \
+            target/release/examples/fixture_bench "baselines/fixture_bench-$sha" --repo-type dataset
           git tag -f pipeline-baseline "$sha"
           git push -f origin "refs/tags/pipeline-baseline"
-          echo "Published baseline for $sha and moved the pipeline-baseline tag."
+          echo "Published baseline JSON + binary for $sha and moved the pipeline-baseline tag."
 
       - name: Upload results artifact
         if: always()

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -6,12 +6,21 @@
 //! because the pipeline's `encode` computes no offsets either; timing the
 //! baseline's offset-tracking `encode` would flatter the pipeline.
 //!
-//! # Measurement regime: whole corpus, cold caches
+//! # Measurement regime: cold caches, the release on a sample
 //!
-//! Every fixture is benched **in full**: the file is cut into ~10 kB chunks at
-//! line boundaries (concatenating the chunks reproduces the file byte for byte)
-//! and one pass encodes every chunk once. ~10 kB is the regime where per-call
-//! overhead is amortized; see `pipeline_benchmark.rs` for the size sweep.
+//! Each corpus is cut into ~10 kB chunks at line boundaries (concatenating the
+//! chunks reproduces the file byte for byte). ~10 kB is the regime where
+//! per-call overhead is amortized; see `pipeline_benchmark.rs` for the size
+//! sweep. The pipeline's timed passes encode the whole corpus. The release's
+//! encode a ~2 MB sample of it, whole chunks spread from the first line to the
+//! last ([`baseline_chunks`]): sampling is what makes timing the release
+//! affordable on every run (it encodes at a few MB/s where the pipeline does
+//! tens to hundreds). The sample keeps the corpus's content mix, but a cold
+//! word cache pays its fill over fewer bytes, so the release's number sits a
+//! little lower than a whole-corpus pass would measure, in the pipeline's
+//! favor; the vs-base comparison times both pipelines on the whole corpus and
+//! does not carry this. The correctness gates and the allocation/memory
+//! children also cover every chunk of every fixture.
 //!
 //! Every timed pass starts **cold**: the pipeline is rebuilt and the baseline
 //! re-cloned before the pass, and thrown away after it. The released BPE and
@@ -27,7 +36,8 @@
 //!
 //! # Four isolated phases per model
 //!
-//! 1. **Throughput**: single-thread MB/s per fixture, the median of `REPS` cold
+//! 1. **Throughput**: single-thread MB/s per fixture (the pipeline over the
+//!    whole corpus, the release over its sample), the median of `REPS` cold
 //!    passes, both implementations alternating so frequency drift hits them
 //!    equally. Both sides encode with `add_special_tokens` on, so the headline
 //!    includes the post-process cost.
@@ -36,7 +46,8 @@
 //!    documents), over one fixed sample mixing every fixture, so the report
 //!    shows how much of the ~10 kB headline speedup survives at either end.
 //! 3. **Scaling & memory**: a multi-thread throughput sweep (2 and 4 threads)
-//!    per fixture group (`lang`, `modalities`), cold instance per pass, and
+//!    per fixture group (the same whole-corpus/sample split as phase 1),
+//!    cold instance per pass, and
 //!    resident-set deltas measured by re-spawning this binary as
 //!    `--memory <impl> <model.json>` children; one implementation per process,
 //!    so allocator page reuse can't blur the attribution. The children also
@@ -75,20 +86,31 @@
 //! the comparison the sweeps exist to draw. Single-thread numbers were unaffected;
 //! uncontended atomics are cheap, it is the cross-core traffic that bites.
 //!
-//! # Cached baseline numbers (`--baseline-from`)
+//! # The release is timed live, in every run
 //!
-//! The released crate is pinned, so its numbers only move when the machine
-//! changes, yet timing it dominates a full run: it encodes at a few MB/s where
-//! the pipeline does tens. `--baseline-from <merged bench JSON>` skips every
-//! baseline timing lane and copies the release's numbers (phase-1 MB/s, size
-//! sweep, thread sweep, memory, decode) from that file, a previous run of this
-//! bench that did measure them; CI caches one per bench-input hash. The release
-//! is still loaded — it is the oracle both gates compare against, and the only
-//! thing that may mint the decode phase's ids — and one **canary**
-//! fixture ([`CANARY_FIXTURE`]) re-measures baseline throughput in the phase-1
-//! regime. Each model's output pairs the canary's measured and cached MB/s so
-//! the report can tell whether the cached numbers still describe this machine.
-//! Allocation counts are exact, so the copied ones need no canary.
+//! Earlier revisions cached the release's numbers on the Hub and copied them
+//! into later runs, because timing the release over whole corpora dominated
+//! the run. Copied numbers turned every ratio into a cross-machine comparison:
+//! two jobs in the same CI runner group can differ by tens of percent in raw
+//! speed, so a fresh pipeline number divided by a cached release number moved
+//! with whichever host each job landed on, and a canary fixture could only
+//! warn about it after the fact. Sampled timing (see above) makes the release
+//! cheap enough to measure in every job, so every ratio in the report divides
+//! two numbers measured seconds apart on the same machine.
+//!
+//! # `--pipeline-only`: the base branch measured beside this run
+//!
+//! The vs-base comparison in the CI report needs the base branch's pipeline
+//! measured on the same machine as this run's, for the same reason. CI
+//! downloads the base commit's prebuilt copy of this binary and runs it with
+//! `--pipeline-only` next to the full run. That mode never loads the release
+//! (so no gates and no decode phase) and skips the input-size and thread
+//! sweeps; it emits the same JSON shape with the pipeline's throughput rows
+//! and its memory child, which is everything the report's vs-base lanes read.
+//!
+//! The output carries a `regime` object naming the chunking and sampling
+//! constants, so the report can refuse to diff wall time between two runs
+//! that measured under different rules.
 //!
 //! `--model <name>` benches a single manifest entry; CI fans out one job per
 //! model and concatenates the partial JSONs in manifest order.
@@ -96,10 +118,10 @@
 //! # The decode sample ([`DECODE_SAMPLE_BYTES`])
 //!
 //! Decode replays a capped prefix of each fixture, not the whole corpus.
-//! Minting the ids runs at *release encode* speed — the slowest thing in the
-//! bench, and exactly what `--baseline-from` exists to skip — while decoding
-//! them is two orders of magnitude faster, so a full-corpus stream would cost
-//! far more to prepare than to measure. Throughput is reported over the *input*
+//! Minting the ids runs at *release encode* speed, the slowest thing in the
+//! bench, while decoding them is two orders of magnitude faster, so a
+//! full-corpus stream would cost far more to prepare than to measure.
+//! Throughput is reported over the *input*
 //! bytes those ids came from: the same denominator the encode phases use, so
 //! decode and encode MB/s are directly comparable, and it costs no extra pass
 //! to obtain (measuring the decoded bytes instead would need a whole released
@@ -123,11 +145,10 @@
 //! cards. Each manifest entry carries a `desc`: a one-line label of the workload
 //! archetype the model exercises, passed through to the report.
 //!
-//! Emits one JSON object (`{baseline, env, models}`) on stdout, consumed by
-//! `.github/scripts/render_pipeline_bench.py` in CI.
+//! Emits one JSON object (`{baseline, env, regime, models}`) on stdout,
+//! consumed by `.github/scripts/render_pipeline_bench.py` in CI.
 
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::hint::black_box;
 use std::path::{Path, PathBuf};
@@ -158,9 +179,12 @@ const GROUPS: [&str; 2] = ["lang", "modalities"];
 // phase 1 already anchors single-thread, and every extra count costs `REPS`
 // cold passes over a whole fixture group per implementation.
 const THREAD_COUNTS: [usize; 2] = [2, 4];
-// The fixture the cached-baseline canary re-measures (see the module docs).
-// Present in every fixture set and representative of the headline workload.
-const CANARY_FIXTURE: &str = "eng_Latn";
+// How much of each fixture the released crate's timed passes encode (see the
+// module docs); the pipeline's encode the whole fixture. Two MB is most of a
+// second of release encode per pass, enough that scheduler noise stays well
+// under the medians it feeds, and small enough that the release lanes cost a
+// model job a couple of minutes, not tens.
+const BASELINE_SAMPLE_BYTES: usize = 2 * 1024 * 1024;
 // Chunk sizes for the input-size sweep: ~256 B chat messages up to ~256 kB
 // documents. The ~10 kB headline regime sits inside the range, so the curve
 // shows how much of the headline speedup survives at either end.
@@ -379,6 +403,19 @@ fn load_fixtures() -> Vec<Fixture> {
         .collect()
 }
 
+/// The chunks the released crate's timed passes encode: every `step`-th chunk
+/// of `f`, with the step chosen so the sample totals about
+/// [`BASELINE_SAMPLE_BYTES`] while still spanning the fixture from its first
+/// line to its last (a prefix would overweight one region's content). A
+/// fixture smaller than the target is taken in full. Returns the chunks and
+/// their byte total, the throughput denominator.
+fn baseline_chunks(f: &Fixture) -> (Vec<&String>, usize) {
+    let step = f.bytes.div_ceil(BASELINE_SAMPLE_BYTES).max(1);
+    let chunks: Vec<&String> = f.chunks.iter().step_by(step).collect();
+    let bytes = chunks.iter().map(|c| c.len()).sum();
+    (chunks, bytes)
+}
+
 /// The prefix of `f`'s chunks the decode phase replays — whole chunks totalling
 /// at most [`DECODE_SAMPLE_BYTES`]. A single chunk over the cap (one very long
 /// line) is still taken, so the sample is never empty for a non-empty fixture.
@@ -417,19 +454,19 @@ fn time_pass<S: AsRef<str>>(encode: &dyn Fn(&str) -> usize, chunks: &[S]) -> f64
 /// Cold single-thread throughput + the id gate for one fixture.
 ///
 /// Each of the `REPS` timed passes runs on an instance that has never seen the
-/// corpus: the baseline is re-cloned (the released models' `Clone` starts with an
-/// empty cache) and the pipeline rebuilt from `oracle`, both outside the timed
-/// region. The two implementations alternate so frequency and thermal drift hit
-/// them equally. The id gate runs first, on instances of its own, so its encodes
-/// cannot warm anything a timed pass sees.
-///
-/// With `time_baseline` false (cached-baseline mode) the id gate still runs but
-/// the baseline is never timed; `main` copies its MB/s from the cache.
+/// text: the baseline is re-cloned (the released models' `Clone` starts with
+/// an empty cache) and the pipeline rebuilt from `oracle`, both outside the
+/// timed region. The pipeline encodes the whole fixture; the baseline encodes
+/// the fixture's sample (`base_chunks`/`base_bytes`, from [`baseline_chunks`]).
+/// The two implementations alternate so frequency and thermal
+/// drift hit them equally. The id gate runs first, on instances of its own, so
+/// its encodes cannot warm anything a timed pass sees.
 fn bench_throughput(
     baseline: Option<&BaselineTokenizer>,
     oracle: &Tokenizer,
     f: &Fixture,
-    time_baseline: bool,
+    base_chunks: &[&String],
+    base_bytes: usize,
 ) -> Value {
     // The correctness gate CI fails on: pipeline ids == the released crate's ids,
     // for both `add_special_tokens` values (`true` exercises the post-process
@@ -459,11 +496,11 @@ fn bench_throughput(
 
     let (mut base_s, mut pipe_s) = (Vec::new(), Vec::new());
     for _ in 0..REPS {
-        if let Some(b) = baseline.filter(|_| time_baseline) {
+        if let Some(b) = baseline {
             let cold = b.clone();
             base_s.push(time_pass(
                 &|s| cold.encode_fast(s, true).unwrap().len(),
-                &f.chunks,
+                base_chunks,
             ));
         }
         let cold = PipelineTokenizer::try_from(oracle).expect("probed at model load");
@@ -472,9 +509,8 @@ fn bench_throughput(
             &f.chunks,
         ));
     }
-    let mbps = |secs: f64| f.bytes as f64 / secs / 1e6;
-    let base_mbps = (!base_s.is_empty()).then(|| mbps(median_secs(base_s)));
-    let pipe_mbps = mbps(median_secs(pipe_s));
+    let base_mbps = (!base_s.is_empty()).then(|| base_bytes as f64 / median_secs(base_s) / 1e6);
+    let pipe_mbps = f.bytes as f64 / median_secs(pipe_s) / 1e6;
 
     eprintln!(
         "  {}: baseline {} MB/s, pipeline {pipe_mbps:.1} MB/s",
@@ -547,21 +583,14 @@ fn size_label(bytes: usize) -> String {
 /// Throughput of both implementations at every `SIZE_SWEEP` chunk size, over the
 /// same `sample`, single thread. Cold instance per pass and interleaved reps,
 /// exactly like phase 1; only the chunk size varies, so the curve isolates how
-/// per-call overhead and amortization move the headline comparison. With
-/// `time_baseline` false the baseline series is left empty for `main` to fill
-/// from the cache.
-fn bench_sizes(
-    baseline: Option<&BaselineTokenizer>,
-    oracle: &Tokenizer,
-    sample: &str,
-    time_baseline: bool,
-) -> Value {
+/// per-call overhead and amortization move the headline comparison.
+fn bench_sizes(baseline: Option<&BaselineTokenizer>, oracle: &Tokenizer, sample: &str) -> Value {
     let (mut pipe, mut base) = (Vec::new(), Vec::new());
     for &size in SIZE_SWEEP {
         let chunks = sized_chunks(sample, size);
         let (mut base_s, mut pipe_s) = (Vec::new(), Vec::new());
         for _ in 0..REPS {
-            if let Some(b) = baseline.filter(|_| time_baseline) {
+            if let Some(b) = baseline {
                 let cold = b.clone();
                 base_s.push(time_pass(
                     &|s| cold.encode_fast(s, true).unwrap().len(),
@@ -617,31 +646,33 @@ fn par_mbps<T: Sync, E: Fn(&T) -> usize + Sync>(
     bytes as f64 / median_secs(samples) / 1e6
 }
 
-/// Multi-thread throughput sweep over one fixture group's corpus: pipeline vs the
-/// released crate at each `THREAD_COUNTS` entry. Every timed pass gets a cold
-/// instance, same as the single-thread phase; within a pass the per-thread caches
-/// fill from the mixed stream, which is what a parallel `.encode()` run over fresh
-/// text reaches. The two implementations alternate per thread count so thermal
-/// drift hits them equally. With `time_baseline` false the baseline series is
-/// left empty for `main` to fill from the cache.
+/// Multi-thread throughput sweep over one fixture group: pipeline vs the
+/// released crate at each `THREAD_COUNTS` entry. The pipeline works through
+/// the group's whole corpus (`chunks`), the baseline through the group's
+/// per-fixture samples (`base_chunks`), the same split phase 1 makes. Every
+/// timed pass gets a cold instance, same as the single-thread phase; within a
+/// pass the per-thread caches fill from the mixed stream, which is what a
+/// parallel `.encode()` run over fresh text reaches. The two implementations
+/// alternate per thread count so thermal drift hits them equally.
 fn bench_threads(
     baseline: Option<&BaselineTokenizer>,
     oracle: &Tokenizer,
     chunks: &[&String],
-    time_baseline: bool,
+    base_chunks: &[&String],
 ) -> Value {
     let bytes: usize = chunks.iter().map(|c| c.len()).sum();
+    let base_bytes: usize = base_chunks.iter().map(|c| c.len()).sum();
     let counts = THREAD_COUNTS;
     let (mut pipe, mut base) = (Vec::new(), Vec::new());
     for &n in &counts {
-        let b = baseline.filter(|_| time_baseline).map(|b| {
+        let b = baseline.map(|b| {
             par_mbps(
                 || {
                     let cold = b.clone();
                     move |s: &&String| cold.encode_fast(s.as_str(), true).unwrap().len()
                 },
-                chunks,
-                bytes,
+                base_chunks,
+                base_bytes,
                 n,
             )
         });
@@ -712,15 +743,13 @@ fn decode_samples(baseline: &BaselineTokenizer, fixtures: &[Fixture]) -> Vec<Dec
 /// `text_match` = pipeline decode == released decode over the sample's first
 /// chunks: the gate CI fails on. It is `null` while `pipeline_ok` is false (the
 /// pipeline can't decode this model at all), which is also when the pipeline
-/// series stays `null` and renders as "pending". With `time_baseline` false the
-/// baseline is never timed; `main` copies its MB/s from the cache.
+/// series stays `null` and renders as "pending".
 fn bench_decode(
     baseline: &BaselineTokenizer,
     pipeline: &PipelineTokenizer,
     f: &Fixture,
     sample: &DecodeSample,
     pipeline_ok: bool,
-    time_baseline: bool,
 ) -> Value {
     let text_match = pipeline_ok.then(|| {
         sample
@@ -744,17 +773,13 @@ fn bench_decode(
 
     // One throwaway pass each, then the reps alternate, so thermal drift hits
     // both equally — the same interleaving phase 1 uses.
-    if time_baseline {
-        one_pass(&base_pass);
-    }
+    one_pass(&base_pass);
     if pipeline_ok {
         one_pass(&pipe_pass);
     }
     let (mut base_s, mut pipe_s) = (Vec::new(), Vec::new());
     for _ in 0..REPS {
-        if time_baseline {
-            base_s.push(one_pass(&base_pass));
-        }
+        base_s.push(one_pass(&base_pass));
         if pipeline_ok {
             pipe_s.push(one_pass(&pipe_pass));
         }
@@ -795,19 +820,16 @@ fn bench_decode_threads(
     ids: &[&Vec<u32>],
     bytes: usize,
     pipeline_ok: bool,
-    time_baseline: bool,
 ) -> Value {
     let counts = THREAD_COUNTS;
     let (mut pipe, mut base) = (Vec::new(), Vec::new());
     for &n in &counts {
-        let b = time_baseline.then(|| {
-            par_mbps(
-                || |i: &&Vec<u32>| baseline.decode(i, false).unwrap().len(),
-                ids,
-                bytes,
-                n,
-            )
-        });
+        let b = Some(par_mbps(
+            || |i: &&Vec<u32>| baseline.decode(i, false).unwrap().len(),
+            ids,
+            bytes,
+            n,
+        ));
         let p = pipeline_ok.then(|| {
             par_mbps(
                 || |i: &&Vec<u32>| pipeline.decode(i, false).unwrap().len(),
@@ -1115,55 +1137,6 @@ fn measure_memory(model: &Path, baseline_ok: bool) -> Value {
     Value::Object(out)
 }
 
-// ── cached baseline numbers ─────────────────────────────────────────────────
-
-/// A previous merged bench JSON, one that measured the release, indexed by model
-/// name. `--baseline-from` mode copies the release's numbers out of it instead
-/// of re-timing them; see the module docs.
-struct BaselineCache {
-    models: HashMap<String, Value>,
-}
-
-impl BaselineCache {
-    fn load(path: &Path) -> Self {
-        let data: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
-        // The CI cache key covers the pinned version, but numbers from another
-        // release would silently corrupt every chart; check it outright.
-        assert_eq!(
-            data["baseline"]["version"].as_str(),
-            Some(BASELINE_VERSION),
-            "cached baseline numbers are for another release"
-        );
-        let models = data["models"]
-            .as_array()
-            .expect("no models in the cached bench JSON")
-            .iter()
-            .map(|m| (m["model"].as_str().unwrap().to_string(), m.clone()))
-            .collect();
-        Self { models }
-    }
-
-    /// The cached entry for one model. A missing model means the cache key
-    /// failed to cover a manifest change; refuse rather than bench without a
-    /// baseline.
-    fn model(&self, name: &str) -> &Value {
-        self.models
-            .get(name)
-            .unwrap_or_else(|| panic!("model {name:?} is not in the cached baseline"))
-    }
-
-    /// The cached baseline MB/s for one fixture, from the phase-1 (`mbps`) or the
-    /// decode (`decode_mbps`) lane; `Null` when the release could not bench it.
-    fn fixture_mbps(&self, model: &str, fixture: &str, lane: &str) -> Value {
-        self.model(model)["results"]
-            .as_array()
-            .into_iter()
-            .flatten()
-            .find(|r| r["fixture"] == fixture)
-            .map_or(Value::Null, |r| r[lane]["baseline"].clone())
-    }
-}
-
 // ── model manifest helpers ──────────────────────────────────────────────────
 
 /// Local path to a manifest entry's config: `data/<file>`, else `data/<name>.json`.
@@ -1219,21 +1192,22 @@ fn main() {
         return;
     }
     // `--model <name>` benches one manifest entry (CI runs one job per model);
-    // `--baseline-from <json>` copies the release's numbers from a cached run
-    // instead of re-timing them (see the module docs). No flags = the whole
-    // manifest, everything measured.
+    // `--pipeline-only` skips the release and the sweeps, for the base-branch
+    // twin run (see the module docs). No flags = the whole manifest, everything
+    // measured.
     let mut model_filter: Option<String> = None;
-    let mut baseline_from: Option<PathBuf> = None;
+    let mut pipeline_only = false;
     let mut rest = args[1..].iter();
     while let Some(arg) = rest.next() {
-        let mut value = || rest.next().unwrap_or_else(|| panic!("{arg} needs a value"));
         match arg.as_str() {
-            "--model" => model_filter = Some(value().clone()),
-            "--baseline-from" => baseline_from = Some(PathBuf::from(value())),
+            "--model" => {
+                let value = rest.next().unwrap_or_else(|| panic!("{arg} needs a value"));
+                model_filter = Some(value.clone());
+            }
+            "--pipeline-only" => pipeline_only = true,
             other => panic!("unknown argument {other:?}"),
         }
     }
-    let cache = baseline_from.as_deref().map(BaselineCache::load);
 
     let full: Vec<Value> =
         serde_json::from_str(&std::fs::read_to_string(MANIFEST).unwrap()).unwrap();
@@ -1249,13 +1223,12 @@ fn main() {
         "benching {} of {} model(s){}",
         manifest.len(),
         full.len(),
-        if cache.is_some() {
-            ", baseline numbers from cache"
-        } else {
-            ""
-        }
+        if pipeline_only { ", pipeline only" } else { "" }
     );
     let fixtures = load_fixtures();
+    // The release's per-fixture samples; the pipeline is timed on the whole
+    // corpus (see the module docs).
+    let base_samples: Vec<(Vec<&String>, usize)> = fixtures.iter().map(baseline_chunks).collect();
     // The corpus per fixture group, flattened once: the multi-thread sweeps run
     // over a whole group so thread-spawn/scheduling overhead is amortized and the
     // scaling curve is stable, and per group so the report can show how scaling
@@ -1267,6 +1240,20 @@ fn main() {
                 .iter()
                 .filter(|f| f.group == *g)
                 .flat_map(|f| f.chunks.iter())
+                .collect();
+            (*g, chunks)
+        })
+        .collect();
+    // The baseline's side of the thread sweeps: the same groups, reduced to
+    // the per-fixture samples.
+    let group_base_chunks: Vec<(&str, Vec<&String>)> = GROUPS
+        .iter()
+        .map(|g| {
+            let chunks = fixtures
+                .iter()
+                .zip(&base_samples)
+                .filter(|(f, _)| f.group == *g)
+                .flat_map(|(_, (chunks, _))| chunks.iter().copied())
                 .collect();
             (*g, chunks)
         })
@@ -1327,70 +1314,62 @@ fn main() {
 
         // The released crate may not load (or encode) a config that needs
         // features newer than the release — bench without it rather than fail.
-        let baseline = match BaselineTokenizer::from_file(&path) {
-            Ok(mut b) => {
-                inject_added_tokens_baseline(&mut b);
-                match b.encode_fast(PROBE, false) {
-                    Ok(_) => Some(b),
-                    Err(e) => {
-                        eprintln!("  baseline v{BASELINE_VERSION} loads but can't encode: {e}");
-                        None
+        // The `--pipeline-only` twin run never loads it: the report reads only
+        // its pipeline rows, and the full run next to it owns the gates.
+        let baseline = if pipeline_only {
+            None
+        } else {
+            match BaselineTokenizer::from_file(&path) {
+                Ok(mut b) => {
+                    inject_added_tokens_baseline(&mut b);
+                    match b.encode_fast(PROBE, false) {
+                        Ok(_) => Some(b),
+                        Err(e) => {
+                            eprintln!("  baseline v{BASELINE_VERSION} loads but can't encode: {e}");
+                            None
+                        }
                     }
                 }
-            }
-            Err(e) => {
-                eprintln!("  baseline v{BASELINE_VERSION} can't load this config: {e}");
-                None
+                Err(e) => {
+                    eprintln!("  baseline v{BASELINE_VERSION} can't load this config: {e}");
+                    None
+                }
             }
         };
 
-        // The canary, before any timed phase: re-measure the baseline on one
-        // fixture in the phase-1 regime and pair it with the cached number, so
-        // the report can tell whether the cache still describes this machine.
-        let canary = cache.as_ref().zip(baseline.as_ref()).map(|(cache, b)| {
-            let f = fixtures
-                .iter()
-                .find(|f| f.name == CANARY_FIXTURE)
-                .expect("canary fixture missing from data/fixtures");
-            let mut samples = Vec::with_capacity(REPS);
-            for _ in 0..REPS {
-                let cold = b.clone();
-                samples.push(time_pass(
-                    &|s| cold.encode_fast(s, true).unwrap().len(),
-                    &f.chunks,
-                ));
-            }
-            let measured = f.bytes as f64 / median_secs(samples) / 1e6;
-            let cached = cache.fixture_mbps(&name, &f.name, "mbps");
-            eprintln!(
-                "  canary {}: baseline measured {measured:.1} MB/s, cached {cached} MB/s",
-                f.name
-            );
-            json!({ "fixture": f.name, "measured_mbps": measured, "cached_mbps": cached })
-        });
-
-        let time_baseline = cache.is_none();
         let mut rows: Vec<Value> = fixtures
             .iter()
-            .map(|f| bench_throughput(baseline.as_ref(), &tok, f, time_baseline))
+            .zip(&base_samples)
+            .map(|(f, (chunks, bytes))| {
+                bench_throughput(baseline.as_ref(), &tok, f, chunks, *bytes)
+            })
             .collect();
 
-        eprintln!("  input-size sweep:");
-        let mut input_sizes = bench_sizes(baseline.as_ref(), &tok, &sample, time_baseline);
+        let input_sizes = if pipeline_only {
+            Value::Null
+        } else {
+            eprintln!("  input-size sweep:");
+            bench_sizes(baseline.as_ref(), &tok, &sample)
+        };
 
-        let mut memory = measure_memory(&path, baseline.is_some() && time_baseline);
-        let mut threads = Value::Object(
-            group_chunks
-                .iter()
-                .map(|(g, chunks)| {
-                    eprintln!("  encode thread sweep ({g}):");
-                    (
-                        g.to_string(),
-                        bench_threads(baseline.as_ref(), &tok, chunks, time_baseline),
-                    )
-                })
-                .collect(),
-        );
+        let memory = measure_memory(&path, baseline.is_some());
+        let threads = if pipeline_only {
+            Value::Null
+        } else {
+            Value::Object(
+                group_chunks
+                    .iter()
+                    .zip(&group_base_chunks)
+                    .map(|((g, chunks), (_, base_chunks))| {
+                        eprintln!("  encode thread sweep ({g}):");
+                        (
+                            g.to_string(),
+                            bench_threads(baseline.as_ref(), &tok, chunks, base_chunks),
+                        )
+                    })
+                    .collect(),
+            )
+        };
 
         // Phase 4. The id stream is minted by the release, so a model it can't
         // load gets no decode phase either. One pipeline instance serves the whole
@@ -1407,14 +1386,14 @@ fn main() {
         let decode_input = baseline.as_ref().zip(samples.as_ref());
         for (i, (row, f)) in rows.iter_mut().zip(&fixtures).enumerate() {
             let dec = decode_input.map_or_else(decode_null, |(b, s)| {
-                bench_decode(b, &decode_pipeline, f, &s[i], decode_ok, time_baseline)
+                bench_decode(b, &decode_pipeline, f, &s[i], decode_ok)
             });
             let row = row.as_object_mut().unwrap();
             for (k, v) in dec.as_object().unwrap() {
                 row.insert(k.clone(), v.clone());
             }
         }
-        let mut decode_threads = decode_input.map_or(Value::Null, |(b, samples)| {
+        let decode_threads = decode_input.map_or(Value::Null, |(b, samples)| {
             Value::Object(
                 GROUPS
                     .iter()
@@ -1428,55 +1407,33 @@ fn main() {
                             .collect();
                         let ids: Vec<&Vec<u32>> = group.iter().flat_map(|s| s.ids.iter()).collect();
                         let bytes = group.iter().map(|s| s.bytes).sum();
-                        let sweep = bench_decode_threads(
-                            b,
-                            &decode_pipeline,
-                            &ids,
-                            bytes,
-                            decode_ok,
-                            time_baseline,
-                        );
+                        let sweep =
+                            bench_decode_threads(b, &decode_pipeline, &ids, bytes, decode_ok);
                         (g.to_string(), sweep)
                     })
                     .collect(),
             )
         });
 
-        // Stitch the cached baseline numbers into the shapes the measuring run
-        // would have produced, so the merged JSON and the report never care
-        // where they came from.
-        if let Some(cache) = &cache {
-            let cached = cache.model(&name);
-            for (row, f) in rows.iter_mut().zip(&fixtures) {
-                row["mbps"]["baseline"] = cache.fixture_mbps(&name, &f.name, "mbps");
-                row["decode_mbps"]["baseline"] = cache.fixture_mbps(&name, &f.name, "decode_mbps");
-            }
-            input_sizes["baseline_mbps"] = cached["input_sizes"]["baseline_mbps"].clone();
-            for (g, _) in &group_chunks {
-                threads[*g]["baseline_mbps"] = cached["threads"][*g]["baseline_mbps"].clone();
-                if decode_threads.is_object() {
-                    decode_threads[*g]["baseline_mbps"] =
-                        cached["decode_threads"][*g]["baseline_mbps"].clone();
-                }
-            }
-            memory["baseline"] = cached["memory"]["baseline"].clone();
-        }
-
         models.push(json!({
             "model": name, "desc": desc, "shape": shape,
             "results": rows, "memory": memory, "threads": threads,
-            "input_sizes": input_sizes, "baseline_canary": canary,
+            "input_sizes": input_sizes,
             "decode_threads": decode_threads, "decode_reason": decode_reason,
         }));
     }
 
     let out = json!({
-        "baseline": {
-            "crate": "tokenizers",
-            "version": BASELINE_VERSION,
-            "cached": cache.is_some(),
-        },
+        "baseline": { "crate": "tokenizers", "version": BASELINE_VERSION },
         "env": env_stamp(),
+        // The measurement rules behind every wall-time number in this file.
+        // The CI report refuses to diff throughput between two runs whose
+        // stamps differ; see the module docs.
+        "regime": {
+            "chunk_bytes": CHUNK_BYTES,
+            "baseline_sample_bytes": BASELINE_SAMPLE_BYTES,
+            "reps": REPS,
+        },
         "models": models,
     });
     println!("{}", serde_json::to_string_pretty(&out).unwrap());


### PR DESCRIPTION
Two cross-machine comparisons hid in the CI bench, and both made its ratios move with whichever host a job landed on. Canary data from recent runs measured jobs in the same runner group at **-30.8% / +24.5%** against a fleet that had not changed; any ratio dividing numbers from two machines carries that.

### The release is timed live, in every job

The release's timed passes now encode a **~2 MB spread sample per fixture** (whole ~10 kB chunks, first line to last) instead of the whole corpus, which makes it cheap enough to measure in every job. The pipeline keeps the whole corpus. The baseline cache on the Hub, its key, the seeding step, and the canary are all deleted: every vs-release ratio now divides two numbers measured seconds apart on the same machine. Correctness gates and the allocation/memory children still cover the full corpus.

Known trade-off, documented in the module docs: the sampled release pays its cache-cold ramp over fewer bytes, so vs-release speedups read slightly high. The vs-base lane times both pipelines on the whole corpus and does not carry this.

### The base branch is measured in the same job

Base pushes publish their `fixture_bench` binary next to the baseline JSON on the Hub. PR bench jobs download it and run it with the new `--pipeline-only` flag (pipeline throughput rows + memory child only) right before the PR binary, so the vs-base ratio compares whole-corpus numbers born on the same runner. Until the first base push publishes a binary, the report falls back to the cross-run JSON as before.

### Regime guard

The bench output carries a `regime` stamp (chunking, sample size, reps). The report refuses to wall-time-diff two runs whose stamps differ and says so, keeping the allocation verdict — no more phantom regressions after a methodology change.

### Verified

Smoke-tested locally on gpt2: both modes run, gates pass, regimes match, and the paired same-machine vs-base on an unchanged binary reads **×1.006** with an exactly-identical allocation verdict — that is the noise floor the pairing buys, against the ±25-30% host lottery of cross-run numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**10 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · pipeline: whole corpus · release: ~2 MB/fixture sample · ~10 kB chunks · cold caches · add_special_tokens on · 2/4-thread sweep per group

`52941546b · 2026-08-07 10:24 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-overview.png" width="860">

<img alt="Per-fixture encode throughput vs latest release, across models" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-fixtures.png" width="860">

**Decode** — the release encodes each fixture's decode sample (`add_special_tokens=true`) and both implementations decode those SAME ids with `skip_special_tokens=false`, so the comparison is decode alone. MB/s counts the input bytes the ids came from, the same denominator as the encode charts.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-decode-overview.png" width="860">

> ⚠️ vs-base throughput is not shown: the base run (`d64ad20b7`) measured under a different regime, so its wall-time numbers are not comparable with this run's. The allocation verdict below still applies.

**Work vs base** (`d64ad20b7`, allocation lane):

- encode allocations: ✓ exactly identical on all 150 fixtures
- decode allocations: ✓ exactly identical on all 150 fixtures

<img alt="Encode allocations vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-allocs.png" width="860">

<sub>allocation lane measured on: Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · glibc 2.39</sub>

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-memory.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-decode-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-binsize.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×4.82 vs v0.23.1 · decode ×1.09</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-bert-base-uncased-sizes.png" width="860">

<img alt="bert-base-uncased thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-bert-base-uncased-threads-lang.png" width="860">

<img alt="bert-base-uncased thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-bert-base-uncased-threads-modalities.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-bert-base-uncased-decode-threads-lang.png" width="860">

<img alt="bert-base-uncased decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-bert-base-uncased-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 7+11+0 (peak 38) · Pipeline 4+4+0 (peak 42)

**Allocations** (encode pass, whole corpus): v0.23.1: 159.5M allocs, 52.04 GB allocated, peak live 37 MB; Pipeline: 61.6k allocs, 0.94 GB allocated, peak live 44 MB

**Allocations** (decode pass, decode sample): v0.23.1: 98.5M allocs, 1.26 GB allocated; Pipeline: 98.5M allocs, 1.26 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Ids |
|---|---|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 8.1 | 27.2 | ×3.34 | ×1.07 | 660 (×1,461) | match |
| arb_Arab | lang | 4.2 | 25.5 | ×6.00 | ×1.09 | 752 (×3,636) | match |
| cmn_Hani | lang | 3.9 | 19.6 | ×5.03 | ×1.08 | 855 (×4,638) | match |
| eng_Latn | lang | 4.4 | 18.9 | ×4.27 | ×1.12 | 670 (×3,178) | match |
| hin_Deva | lang | 6.4 | 27.9 | ×4.34 | ×1.10 | 642 (×2,434) | match |
| jpn_Jpan | lang | 4.3 | 26.8 | ×6.26 | ×1.09 | 864 (×3,342) | match |
| rus_Cyrl | lang | 3.6 | 25.2 | ×6.91 | ×1.10 | 752 (×4,727) | match |
| tam_Taml | lang | 7.0 | 37.7 | ×5.41 | ×1.09 | 644 (×2,168) | match |
| tha_Thai | lang | 8.4 | 32.3 | ×3.86 | ×1.07 | 622 (×1,546) | match |
| added_normalized_sparse | modalities | 5.3 | 18.2 | ×3.42 | ×1.09 | 68,958 (×23.29) | match |
| added_special_sparse | modalities | 4.0 | 21.3 | ×5.37 | ×1.10 | 89,671 (×38.89) | match |
| agentic-traces | modalities | 3.8 | 18.8 | ×4.89 | ×1.10 | 702 (×3,726) | match |
| agentic_swe | modalities | 3.9 | 19.5 | ×5.01 | ×1.09 | 755 (×3,476) | match |
| code_mixed | modalities | 3.8 | 19.4 | ×5.10 | ×1.10 | 776 (×3,615) | match |
| math_latex | modalities | 4.1 | 18.7 | ×4.61 | ×1.11 | 661 (×3,725) | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×15.04 vs v0.23.1 · decode ×12.19</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-deepseek-v4.png" width="860">

<img alt="deepseek-v4 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-deepseek-v4-sizes.png" width="860">

<img alt="deepseek-v4 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-deepseek-v4-threads-lang.png" width="860">

<img alt="deepseek-v4 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-deepseek-v4-threads-modalities.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-deepseek-v4-decode-threads-lang.png" width="860">

<img alt="deepseek-v4 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-deepseek-v4-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 57+0+0 (peak 74) · Pipeline 42+0+0 (peak 88)

**Allocations** (encode pass, whole corpus): v0.23.1: 153.2M allocs, 38.67 GB allocated, peak live 66 MB; Pipeline: 28.0k allocs, 0.23 GB allocated, peak live 74 MB

**Allocations** (decode pass, decode sample): v0.23.1: 15.3M allocs, 0.77 GB allocated; Pipeline: 7.4k allocs, 0.06 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Ids |
|---|---|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 64.0 | ×15.08 | ×17.18 | 570 (×3,582) | match |
| arb_Arab | lang | 4.1 | 52.9 | ×12.97 | ×11.27 | 378 (×5,022) | match |
| cmn_Hani | lang | 3.3 | 42.2 | ×12.86 | ×11.00 | 397 (×4,758) | match |
| eng_Latn | lang | 3.0 | 63.2 | ×21.08 | ×12.38 | 385 (×7,925) | match |
| hin_Deva | lang | 5.2 | 86.3 | ×16.70 | ×11.33 | 366 (×4,352) | match |
| jpn_Jpan | lang | 3.8 | 42.6 | ×11.32 | ×12.76 | 418 (×3,717) | match |
| rus_Cyrl | lang | 4.0 | 43.0 | ×10.88 | ×9.61 | 376 (×4,319) | match |
| tam_Taml | lang | 5.4 | 49.8 | ×9.15 | ×11.14 | 368 (×2,674) | match |
| tha_Thai | lang | 5.4 | 23.7 | ×4.36 | ×10.08 | 357 (×1,476) | match |
| added_normalized_sparse | modalities | 5.1 | 88.1 | ×17.14 | ×17.63 | 490 (×5,070) | match |
| added_special_sparse | modalities | 3.8 | 59.8 | ×15.61 | ×11.97 | 391 (×8,796) | match |
| agentic-traces | modalities | 2.7 | 65.8 | ×24.69 | ×12.72 | 430 (×8,982) | match |
| agentic_swe | modalities | 2.7 | 74.4 | ×27.08 | ×12.47 | 470 (×7,846) | match |
| code_mixed | modalities | 2.7 | 64.5 | ×23.91 | ×12.52 | 467 (×7,449) | match |
| math_latex | modalities | 2.5 | 61.2 | ×24.58 | ×11.37 | 387 (×9,256) | match |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×3.06 vs v0.23.1 · decode ×1.57</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gemma-4.png" width="860">

<img alt="gemma-4 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gemma-4-sizes.png" width="860">

<img alt="gemma-4 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gemma-4-threads-lang.png" width="860">

<img alt="gemma-4 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gemma-4-threads-modalities.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gemma-4-decode-threads-lang.png" width="860">

<img alt="gemma-4 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gemma-4-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 286+0+0 (peak 366) · Pipeline 1+0+0 (peak 365)

**Allocations** (encode pass, whole corpus): v0.23.1: 29.1M allocs, 23.69 GB allocated, peak live 310 MB; Pipeline: 65.2k allocs, 2.35 GB allocated, peak live 310 MB

**Allocations** (decode pass, decode sample): v0.23.1: 18.9M allocs, 1.79 GB allocated; Pipeline: 18.9M allocs, 1.79 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Ids |
|---|---|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 10.1 | 42.0 | ×4.15 | ×1.56 | 780 (×521) | match |
| arb_Arab | lang | 6.4 | 21.4 | ×3.34 | ×1.46 | 753 (×514) | match |
| cmn_Hani | lang | 10.4 | 41.3 | ×3.95 | ×1.22 | 831 (×350) | match |
| eng_Latn | lang | 3.4 | 8.2 | ×2.39 | ×1.70 | 768 (×732) | match |
| hin_Deva | lang | 8.2 | 25.9 | ×3.17 | ×1.65 | 732 (×375) | match |
| jpn_Jpan | lang | 11.2 | 38.2 | ×3.40 | ×1.20 | 764 (×303) | match |
| rus_Cyrl | lang | 6.1 | 17.2 | ×2.80 | ×1.42 | 752 (×414) | match |
| tam_Taml | lang | 10.1 | 27.9 | ×2.76 | ×1.46 | 736 (×261) | match |
| tha_Thai | lang | 12.2 | 34.2 | ×2.80 | ×1.34 | 711 (×234) | match |
| added_normalized_sparse | modalities | 4.3 | 11.5 | ×2.69 | ×1.85 | 881 (×659) | match |
| added_special_sparse | modalities | 4.1 | 12.7 | ×3.10 | ×2.06 | 156,197 (×9.98) | match |
| agentic-traces | modalities | 4.0 | 10.9 | ×2.76 | ×1.59 | 788 (×825) | match |
| agentic_swe | modalities | 3.9 | 13.8 | ×3.51 | ×1.88 | 849 (×1,004) | match |
| code_mixed | modalities | 4.0 | 12.3 | ×3.04 | ×1.81 | 873 (×797) | match |
| math_latex | modalities | 3.6 | 9.1 | ×2.51 | ×1.60 | 740 (×792) | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×16.57 vs v0.23.1 · decode ×23.44</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt2.png" width="860">

<img alt="gpt2 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt2-sizes.png" width="860">

<img alt="gpt2 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt2-threads-lang.png" width="860">

<img alt="gpt2 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt2-threads-modalities.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt2-decode-threads-lang.png" width="860">

<img alt="gpt2 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt2-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 21+12+0 (peak 82) · Pipeline 6+4+0 (peak 83)

**Allocations** (encode pass, whole corpus): v0.23.1: 243.3M allocs, 38.17 GB allocated, peak live 79 MB; Pipeline: 34.6k allocs, 0.43 GB allocated, peak live 80 MB

**Allocations** (decode pass, decode sample): v0.23.1: 30.9M allocs, 1.36 GB allocated; Pipeline: 6.0k allocs, 0.07 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Ids |
|---|---|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 79.1 | ×20.11 | ×36.67 | 570 (×4,658) | match |
| arb_Arab | lang | 3.7 | 75.0 | ×20.22 | ×20.08 | 564 (×5,616) | match |
| cmn_Hani | lang | 3.4 | 46.6 | ×13.79 | ×24.54 | 572 (×4,864) | match |
| eng_Latn | lang | 3.3 | 79.8 | ×24.42 | ×17.69 | 386 (×8,670) | match |
| hin_Deva | lang | 2.9 | 79.6 | ×27.49 | ×28.30 | 549 (×7,411) | match |
| jpn_Jpan | lang | 3.7 | 40.0 | ×10.75 | ×19.66 | 504 (×4,683) | match |
| rus_Cyrl | lang | 3.8 | 67.5 | ×17.76 | ×19.05 | 564 (×5,089) | match |
| tam_Taml | lang | 2.5 | 79.7 | ×32.02 | ×46.21 | 553 (×10,027) | match |
| tha_Thai | lang | 3.2 | 66.2 | ×20.73 | ×36.93 | 533 (×6,617) | match |
| added_normalized_sparse | modalities | 4.2 | 10.5 | ×2.48 | ×20.92 | 490 (×6,465) | match |
| added_special_sparse | modalities | 3.5 | 13.0 | ×3.66 | ×14.63 | 391 (×8,582) | match |
| agentic-traces | modalities | 2.8 | 66.2 | ×23.99 | ×18.27 | 441 (×9,456) | match |
| agentic_swe | modalities | 2.8 | 75.7 | ×27.20 | ×25.97 | 491 (×8,756) | match |
| code_mixed | modalities | 2.7 | 69.4 | ×26.03 | ×22.48 | 496 (×8,611) | match |
| math_latex | modalities | 2.5 | 66.9 | ×26.47 | ×18.75 | 406 (×9,294) | match |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×8.57 vs v0.23.1 · decode ×15.24</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt-oss.png" width="860">

<img alt="gpt-oss input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt-oss-sizes.png" width="860">

<img alt="gpt-oss thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt-oss-threads-lang.png" width="860">

<img alt="gpt-oss thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt-oss-threads-modalities.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt-oss-decode-threads-lang.png" width="860">

<img alt="gpt-oss decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-gpt-oss-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 236+0+0 (peak 310) · Pipeline 1+0+0 (peak 311)

**Allocations** (encode pass, whole corpus): v0.23.1: 127.8M allocs, 29.89 GB allocated, peak live 272 MB; Pipeline: 28.4k allocs, 0.23 GB allocated, peak live 272 MB

**Allocations** (decode pass, decode sample): v0.23.1: 14.5M allocs, 0.71 GB allocated; Pipeline: 7.4k allocs, 0.05 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Ids |
|---|---|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 62.9 | ×15.54 | ×22.43 | 570 (×3,431) | match |
| arb_Arab | lang | 4.2 | 51.4 | ×12.14 | ×10.65 | 378 (×4,522) | match |
| cmn_Hani | lang | 4.0 | 23.3 | ×5.88 | ×13.62 | 474 (×2,360) | match |
| eng_Latn | lang | 3.6 | 58.3 | ×15.97 | ×13.98 | 383 (×7,145) | match |
| hin_Deva | lang | 6.0 | 70.9 | ×11.86 | ×10.99 | 366 (×3,680) | match |
| jpn_Jpan | lang | 4.5 | 29.3 | ×6.46 | ×14.39 | 475 (×1,990) | match |
| rus_Cyrl | lang | 4.5 | 37.6 | ×8.29 | ×10.96 | 376 (×3,878) | match |
| tam_Taml | lang | 5.6 | 37.6 | ×6.70 | ×12.65 | 368 (×2,372) | match |
| tha_Thai | lang | 5.5 | 19.9 | ×3.65 | ×13.59 | 358 (×1,345) | match |
| added_normalized_sparse | modalities | 5.6 | 10.7 | ×1.92 | ×24.33 | 490 (×4,723) | match |
| added_special_sparse | modalities | 4.6 | 9.5 | ×2.05 | ×16.39 | 391 (×7,345) | match |
| agentic-traces | modalities | 3.5 | 55.4 | ×15.64 | ×18.19 | 414 (×7,406) | match |
| agentic_swe | modalities | 3.8 | 72.3 | ×19.21 | ×20.07 | 458 (×6,524) | match |
| code_mixed | modalities | 3.7 | 72.0 | ×19.70 | ×18.10 | 447 (×6,828) | match |
| math_latex | modalities | 3.5 | 53.6 | ×15.41 | ×15.61 | 386 (×7,848) | match |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×12.31 vs v0.23.1 · decode ×20.89</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-glm-5-2.png" width="860">

<img alt="glm-5.2 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-glm-5-2-sizes.png" width="860">

<img alt="glm-5.2 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-glm-5-2-threads-lang.png" width="860">

<img alt="glm-5.2 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-glm-5-2-threads-modalities.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-glm-5-2-decode-threads-lang.png" width="860">

<img alt="glm-5.2 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-glm-5-2-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 164+0+0 (peak 225) · Pipeline 1+0+0 (peak 226)

**Allocations** (encode pass, whole corpus): v0.23.1: 154.7M allocs, 33.00 GB allocated, peak live 212 MB; Pipeline: 29.5k allocs, 0.25 GB allocated, peak live 212 MB

**Allocations** (decode pass, decode sample): v0.23.1: 18.3M allocs, 0.90 GB allocated; Pipeline: 6.8k allocs, 0.05 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Ids |
|---|---|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 2.9 | 56.0 | ×19.01 | ×38.42 | 570 (×3,814) | match |
| arb_Arab | lang | 3.1 | 45.1 | ×14.38 | ×16.24 | 384 (×4,896) | match |
| cmn_Hani | lang | 3.2 | 16.0 | ×5.05 | ×16.44 | 425 (×2,520) | match |
| eng_Latn | lang | 2.6 | 53.8 | ×20.90 | ×18.69 | 384 (×7,146) | match |
| hin_Deva | lang | 2.8 | 68.5 | ×24.39 | ×21.27 | 458 (×6,443) | match |
| jpn_Jpan | lang | 3.6 | 20.1 | ×5.64 | ×18.16 | 433 (×2,153) | match |
| rus_Cyrl | lang | 3.3 | 32.4 | ×9.83 | ×14.16 | 376 (×3,881) | match |
| tam_Taml | lang | 2.7 | 68.1 | ×24.98 | ×26.77 | 464 (×6,456) | match |
| tha_Thai | lang | 3.3 | 52.6 | ×15.71 | ×25.39 | 445 (×3,747) | match |
| added_normalized_sparse | modalities | 3.1 | 8.2 | ×2.69 | ×29.31 | 490 (×4,755) | match |
| added_special_sparse | modalities | 2.6 | 7.8 | ×3.05 | ×17.35 | 391 (×7,379) | match |
| agentic-traces | modalities | 2.4 | 46.0 | ×19.45 | ×18.55 | 422 (×7,221) | match |
| agentic_swe | modalities | 2.5 | 57.0 | ×22.93 | ×22.30 | 460 (×6,451) | match |
| code_mixed | modalities | 2.4 | 50.0 | ×20.68 | ×22.38 | 446 (×6,650) | match |
| math_latex | modalities | 2.3 | 45.2 | ×19.40 | ×18.77 | 390 (×7,773) | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×4.95 vs v0.23.1 · decode ×1.57</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-2.png" width="860">

<img alt="llama-2 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-2-sizes.png" width="860">

<img alt="llama-2 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-2-threads-lang.png" width="860">

<img alt="llama-2 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-2-threads-modalities.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-2-decode-threads-lang.png" width="860">

<img alt="llama-2 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-2-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 20+6+0 (peak 63) · Pipeline 7+3+1 (peak 71)

**Allocations** (encode pass, whole corpus): v0.23.1: 63.0M allocs, 28.31 GB allocated, peak live 61 MB; Pipeline: 67.7k allocs, 0.56 GB allocated, peak live 72 MB

**Allocations** (decode pass, decode sample): v0.23.1: 35.7M allocs, 3.03 GB allocated; Pipeline: 35.7M allocs, 3.03 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Ids |
|---|---|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.7 | 89.9 | ×15.89 | ×1.39 | 850 (×3,793) | match |
| arb_Arab | lang | 12.3 | 76.8 | ×6.26 | ×1.46 | 845 (×844) | match |
| cmn_Hani | lang | 10.8 | 109.8 | ×10.12 | ×1.38 | 849 (×1,468) | match |
| eng_Latn | lang | 4.6 | 11.9 | ×2.58 | ×1.68 | 823 (×744) | match |
| hin_Deva | lang | 14.1 | 110.7 | ×7.83 | ×1.54 | 824 (×847) | match |
| jpn_Jpan | lang | 15.6 | 131.8 | ×8.44 | ×1.39 | 859 (×828) | match |
| rus_Cyrl | lang | 9.1 | 30.7 | ×3.35 | ×1.49 | 753 (×505) | match |
| tam_Taml | lang | 15.2 | 130.0 | ×8.52 | ×1.46 | 829 (×938) | match |
| tha_Thai | lang | 19.8 | 132.2 | ×6.67 | ×1.42 | 800 (×638) | match |
| added_normalized_sparse | modalities | 5.2 | 16.0 | ×3.05 | ×1.66 | 881 (×772) | match |
| added_special_sparse | modalities | 4.6 | 16.6 | ×3.60 | ×1.98 | 145,162 (×11.23) | match |
| agentic-traces | modalities | 5.0 | 14.1 | ×2.84 | ×1.58 | 791 (×916) | match |
| agentic_swe | modalities | 4.7 | 14.5 | ×3.10 | ×1.85 | 851 (×1,059) | match |
| code_mixed | modalities | 4.8 | 14.5 | ×3.05 | ×1.75 | 877 (×1,010) | match |
| math_latex | modalities | 4.7 | 12.9 | ×2.71 | ×1.61 | 762 (×860) | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×16.53 vs v0.23.1 · decode ×20.42</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-3.png" width="860">

<img alt="llama-3 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-3-sizes.png" width="860">

<img alt="llama-3 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-3-threads-lang.png" width="860">

<img alt="llama-3 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-3-threads-modalities.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-3-decode-threads-lang.png" width="860">

<img alt="llama-3 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-llama-3-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 67+2+0 (peak 89) · Pipeline 36+0+0 (peak 103)

**Allocations** (encode pass, whole corpus): v0.23.1: 152.3M allocs, 33.83 GB allocated, peak live 91 MB; Pipeline: 28.7k allocs, 0.24 GB allocated, peak live 92 MB

**Allocations** (decode pass, decode sample): v0.23.1: 17.3M allocs, 0.88 GB allocated; Pipeline: 9.6k allocs, 0.06 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Ids |
|---|---|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.8 | 76.0 | ×20.05 | ×39.32 | 570 (×3,818) | match |
| arb_Arab | lang | 4.2 | 58.4 | ×13.86 | ×16.07 | 379 (×4,900) | match |
| cmn_Hani | lang | 4.2 | 26.7 | ×6.33 | ×20.82 | 476 (×2,372) | match |
| eng_Latn | lang | 3.8 | 70.9 | ×18.75 | ×18.66 | 384 (×7,149) | match |
| hin_Deva | lang | 4.2 | 122.0 | ×29.12 | ×16.74 | 366 (×7,163) | match |
| jpn_Jpan | lang | 4.7 | 26.8 | ×5.69 | ×18.65 | 433 (×2,151) | match |
| rus_Cyrl | lang | 4.4 | 42.1 | ×9.55 | ×13.24 | 376 (×3,985) | match |
| tam_Taml | lang | 3.8 | 102.3 | ×26.89 | ×27.57 | 464 (×6,460) | match |
| tha_Thai | lang | 4.6 | 60.9 | ×13.14 | ×16.13 | 356 (×4,118) | match |
| added_normalized_sparse | modalities | 4.4 | 103.8 | ×23.52 | ×28.29 | 490 (×4,760) | match |
| added_special_sparse | modalities | 3.6 | 73.8 | ×20.24 | ×17.39 | 391 (×7,385) | match |
| agentic-traces | modalities | 3.5 | 74.2 | ×21.22 | ×20.90 | 414 (×7,327) | match |
| agentic_swe | modalities | 3.6 | 90.1 | ×24.85 | ×23.86 | 458 (×6,458) | match |
| code_mixed | modalities | 3.4 | 73.8 | ×21.39 | ×21.73 | 446 (×6,650) | match |
| math_latex | modalities | 3.1 | 59.4 | ×19.09 | ×18.66 | 388 (×7,791) | match |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×9.75 vs v0.23.1 · decode ×14.64</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-mistral-small-4.png" width="860">

<img alt="mistral-small-4 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-mistral-small-4-sizes.png" width="860">

<img alt="mistral-small-4 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-mistral-small-4-threads-lang.png" width="860">

<img alt="mistral-small-4 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-mistral-small-4-threads-modalities.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-mistral-small-4-decode-threads-lang.png" width="860">

<img alt="mistral-small-4 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-mistral-small-4-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 151+0+0 (peak 187) · Pipeline 9+0+0 (peak 189)

**Allocations** (encode pass, whole corpus): v0.23.1: 135.2M allocs, 31.26 GB allocated, peak live 185 MB; Pipeline: 28.7k allocs, 0.24 GB allocated, peak live 185 MB

**Allocations** (decode pass, decode sample): v0.23.1: 16.6M allocs, 0.81 GB allocated; Pipeline: 7.1k allocs, 0.05 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Ids |
|---|---|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 62.5 | ×15.92 | ×27.16 | 570 (×3,847) | match |
| arb_Arab | lang | 4.5 | 47.3 | ×10.58 | ×10.73 | 378 (×4,557) | match |
| cmn_Hani | lang | 4.4 | 28.5 | ×6.53 | ×15.84 | 476 (×2,565) | match |
| eng_Latn | lang | 3.6 | 56.1 | ×15.44 | ×13.35 | 388 (×7,243) | match |
| hin_Deva | lang | 6.1 | 67.3 | ×11.12 | ×11.10 | 366 (×3,846) | match |
| jpn_Jpan | lang | 4.9 | 32.8 | ×6.74 | ×14.28 | 471 (×2,080) | match |
| rus_Cyrl | lang | 4.5 | 36.4 | ×8.14 | ×10.34 | 376 (×4,023) | match |
| tam_Taml | lang | 6.0 | 40.8 | ×6.84 | ×11.56 | 368 (×2,471) | match |
| tha_Thai | lang | 6.2 | 22.3 | ×3.63 | ×12.96 | 358 (×1,515) | match |
| added_normalized_sparse | modalities | 5.5 | 26.7 | ×4.84 | ×20.50 | 490 (×4,858) | match |
| added_special_sparse | modalities | 4.6 | 23.9 | ×5.23 | ×15.11 | 391 (×7,459) | match |
| agentic-traces | modalities | 3.4 | 60.1 | ×17.73 | ×16.41 | 438 (×7,687) | match |
| agentic_swe | modalities | 3.4 | 67.3 | ×19.58 | ×18.00 | 471 (×6,995) | match |
| code_mixed | modalities | 3.3 | 63.7 | ×19.32 | ×16.03 | 465 (×6,767) | match |
| math_latex | modalities | 3.2 | 49.3 | ×15.63 | ×13.79 | 396 (×7,918) | match |

</details>

<details><summary><b>t5-base</b> — Unigram + Metaspace · ×2.94 vs v0.23.1 · decode ×0.95</summary>

<img alt="t5-base speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-t5-base.png" width="860">

<img alt="t5-base input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-t5-base-sizes.png" width="860">

<img alt="t5-base thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-t5-base-threads-lang.png" width="860">

<img alt="t5-base thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-t5-base-threads-modalities.png" width="860">

<img alt="t5-base decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-t5-base-decode.png" width="860">

<img alt="t5-base decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-t5-base-decode-threads-lang.png" width="860">

<img alt="t5-base decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31169435276-t5-base-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 31+10+0 (peak 56) · Pipeline 26+14+1 (peak 94)

**Allocations** (encode pass, whole corpus): v0.23.1: 260.7M allocs, 35.16 GB allocated, peak live 53 MB; Pipeline: 50.7M allocs, 4.73 GB allocated, peak live 107 MB

**Allocations** (decode pass, decode sample): v0.23.1: 12.0M allocs, 0.64 GB allocated; Pipeline: 12.0M allocs, 0.64 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Ids |
|---|---|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 6.1 | 21.9 | ×3.60 | ×0.93 | 425,812 (×6.45) | match |
| arb_Arab | lang | 4.8 | 18.4 | ×3.81 | ×0.92 | 563,067 (×7.24) | match |
| cmn_Hani | lang | 9.8 | 16.2 | ×1.65 | ×0.94 | 933,252 (×1.44) | match |
| eng_Latn | lang | 2.5 | 8.2 | ×3.26 | ×0.97 | 856,403 (×7.71) | match |
| hin_Deva | lang | 6.3 | 24.9 | ×3.94 | ×0.93 | 208,773 (×15.20) | match |
| jpn_Jpan | lang | 9.8 | 16.5 | ×1.68 | ×0.95 | 825,987 (×1.52) | match |
| rus_Cyrl | lang | 4.1 | 11.8 | ×2.89 | ×0.97 | 962,975 (×4.39) | match |
| tam_Taml | lang | 8.4 | 24.4 | ×2.90 | ×0.93 | 484,863 (×4.28) | match |
| tha_Thai | lang | 10.0 | 17.8 | ×1.77 | ×0.94 | 769,838 (×1.71) | match |
| added_normalized_sparse | modalities | 4.9 | 18.2 | ×3.76 | ×0.97 | 130,340 (×49.33) | match |
| added_special_sparse | modalities | 5.0 | 18.9 | ×3.79 | ×0.98 | 162,215 (×32.48) | match |
| agentic-traces | modalities | 2.8 | 9.1 | ×3.28 | ×0.96 | 1,041,988 (×5.73) | match |
| agentic_swe | modalities | 3.4 | 10.3 | ×3.03 | ×0.96 | 863,771 (×6.10) | match |
| code_mixed | modalities | 3.0 | 9.2 | ×3.12 | ×0.97 | 995,011 (×5.88) | match |
| math_latex | modalities | 2.6 | 8.5 | ×3.28 | ×0.97 | 890,667 (×7.35) | match |

</details>
<!-- pipeline-bench:end -->
