### PR TITLE
perf(bpe): hand the splitter's spans to the model in tiles

### DIFF
--- a/tokenizers/bitsplit/src/lib.rs
+++ b/tokenizers/bitsplit/src/lib.rs
@@ -34,7 +34,7 @@ mod simd;
 
 pub use models::deepseek::bitsplit_deepseek;
 pub use models::cl100k::{bitsplit_cl100k, bitsplit_qwen};
-pub use models::gpt2::bitsplit_byte_level;
+pub use models::gpt2::{bitsplit_byte_level, bitsplit_byte_level_tiled};
 pub use models::kimi::bitsplit_kimi;
 pub use models::o200k::bitsplit_o200k;
 pub use models::tekken::bitsplit_tekken;
@@ -428,6 +428,81 @@ pub(crate) fn letter_match(tags: &[u8], p: usize, re: usize) -> usize {
 }
 
 
+/// Where the emit loop puts the spans it finds.
+///
+/// Two implementations, and the reason this is a trait at all: the whole-chunk sink writes into one
+/// array sized for the worst case, which for a 1 MB input is ~230k spans = 1.8 MB written and then
+/// read back by the consumer -- 3.5 bytes of span traffic per input byte, none of which stays in
+/// cache. The tiled sink hands each small batch straight to the consumer instead, so the array never
+/// grows past L1 and nothing materialises per document. Both share one emit implementation, because
+/// the emit's control flow (contractions especially) is the last thing worth duplicating.
+pub trait SpanSink {
+    fn push(&mut self, span: Span);
+}
+
+/// The whole-chunk sink: `out` must hold the worst case of one span per byte, plus one.
+pub struct SliceSink<'a> {
+    out: &'a mut [Span],
+    written: usize,
+}
+
+impl<'a> SliceSink<'a> {
+    #[inline(always)]
+    pub fn new(out: &'a mut [Span]) -> Self {
+        Self { out, written: 0 }
+    }
+    #[inline(always)]
+    pub fn written(&self) -> usize {
+        self.written
+    }
+}
+
+impl SpanSink for SliceSink<'_> {
+    #[inline(always)]
+    fn push(&mut self, span: Span) {
+        self.out[self.written] = span;
+        self.written += 1;
+    }
+}
+
+/// A fixed tile handed to `consume` whenever it fills. Flushing from inside the emit's own control
+/// flow is what makes this need no resumable state: a contraction chain (`y'all'd've`) can emit an
+/// unbounded run of spans from a single block, so a caller-driven "emit N then return" API would
+/// have to be resumable *mid-chain*, and getting that wrong changes tokenization.
+pub struct TileSink<'a, F: FnMut(&[Span])> {
+    tile: &'a mut [Span],
+    len: usize,
+    consume: F,
+}
+
+impl<'a, F: FnMut(&[Span])> TileSink<'a, F> {
+    #[inline(always)]
+    pub fn new(tile: &'a mut [Span], consume: F) -> Self {
+        assert!(!tile.is_empty(), "a tile needs room for at least one span");
+        Self { tile, len: 0, consume }
+    }
+
+    /// Hand over whatever is buffered. Must be called once the emit returns, for the tail.
+    #[inline]
+    pub fn flush(&mut self) {
+        if self.len > 0 {
+            (self.consume)(&self.tile[..self.len]);
+            self.len = 0;
+        }
+    }
+}
+
+impl<F: FnMut(&[Span])> SpanSink for TileSink<'_, F> {
+    #[inline(always)]
+    fn push(&mut self, span: Span) {
+        self.tile[self.len] = span;
+        self.len += 1;
+        if self.len == self.tile.len() {
+            self.flush();
+        }
+    }
+}
+
 // ── emit ────────────────────────────────────────────────────────────────────────────────────────
 
 /// `starts` bitmap → spans. Each set bit closes the previous token and opens the next; `tzcnt`
@@ -460,16 +535,16 @@ pub(crate) fn emit(starts: &[u64], nblk: usize, n: usize, out: &mut [Span]) -> u
 ///
 /// A matched contraction overrides the algebra outright: it emits its own span and skips every
 /// start bit inside it, which is how the letter alternative loses the tie (`'sx` → `'s`, `x`).
-pub(crate) fn emit_contr(
+pub(crate) fn emit_contr<S: SpanSink>(
     text: &[u8],
     starts: &[u64],
     flag: &[u64],
     nblk: usize,
     n: usize,
     ci: bool,
-    out: &mut [Span],
-) -> usize {
-    let (mut w, mut open, mut skip) = (0usize, u32::MAX, 0usize);
+    sink: &mut S,
+) {
+    let (mut open, mut skip) = (u32::MAX, 0usize);
     for bi in 0..nblk {
         let mut m = starts[bi];
         let f = flag[bi];
@@ -477,8 +552,7 @@ pub(crate) fn emit_contr(
             while m != 0 {
                 let pos = (bi * 64 + m.trailing_zeros() as usize) as u32;
                 if open != u32::MAX {
-                    out[w] = Span::new(open, pos);
-                    w += 1;
+                    sink.push(Span::new(open, pos));
                 }
                 open = pos;
                 m &= m - 1;
@@ -493,8 +567,7 @@ pub(crate) fn emit_contr(
                 continue;
             }
             if open != u32::MAX {
-                out[w] = Span::new(open, pos as u32);
-                w += 1;
+                sink.push(Span::new(open, pos as u32));
             }
             open = pos as u32;
             if f >> j & 1 != 0 {
@@ -507,8 +580,7 @@ pub(crate) fn emit_contr(
                     if l == 0 {
                         break;
                     }
-                    out[w] = Span::new(p as u32, (p + l) as u32);
-                    w += 1;
+                    sink.push(Span::new(p as u32, (p + l) as u32));
                     p += l;
                 }
                 if p > pos {
@@ -522,10 +594,8 @@ pub(crate) fn emit_contr(
         }
     }
     if open != u32::MAX {
-        out[w] = Span::new(open, n as u32);
-        w += 1;
+        sink.push(Span::new(open, n as u32));
     }
-    w
 }
 
 

--- a/tokenizers/bitsplit/src/models/cl100k.rs
+++ b/tokenizers/bitsplit/src/models/cl100k.rs
@@ -265,5 +265,7 @@ fn cl100k(
         code = last_code;
         prev_cont = b.cont;
     }
-    emit_contr(text, starts, flag, nblk, ntext, true, out)
+    let mut sink = crate::SliceSink::new(out);
+    emit_contr(text, starts, flag, nblk, ntext, true, &mut sink);
+    sink.written()
 }

--- a/tokenizers/bitsplit/src/models/gpt2.rs
+++ b/tokenizers/bitsplit/src/models/gpt2.rs
@@ -6,7 +6,7 @@
 //! literal alternation that outranks every other arm is miserable in bit algebra and trivial there.
 
 use crate::{
-    AUX_NONE, CODE_CONT, CONT, Span, build_block, emit_contr, to_lead,
+    AUX_NONE, CODE_CONT, CONT, SliceSink, Span, SpanSink, TileSink, build_block, emit_contr, to_lead,
 };
 
 /// Atom tag → dense 3-bit code, shared by both grammars. Unlike deepseek's table, `Mark` is NOT a
@@ -86,14 +86,42 @@ pub fn bitsplit_byte_level(
     flag: &mut [u64],
     out: &mut [Span],
 ) -> usize {
+    let mut sink = SliceSink::new(out);
+    bitsplit_byte_level_sink(text, tags, starts, flag, &mut sink);
+    sink.written()
+}
+
+/// GPT-2 / byte-level pre-tokenization into a [`TileSink`]: the spans go to the consumer in small
+/// batches instead of one per-document array. See [`SpanSink`] for why that is worth a function.
+///
+/// The mask build is unchanged and still one pass over the chunk -- only where the spans *go*
+/// differs, so the grammar (contractions, the `\s+(?!\S)` steal, block-edge carry) is untouched.
+pub fn bitsplit_byte_level_tiled<F: FnMut(&[Span])>(
+    text: &[u8],
+    tags: &[u8],
+    starts: &mut [u64],
+    flag: &mut [u64],
+    tile: &mut [Span],
+    consume: F,
+) {
+    let mut sink = TileSink::new(tile, consume);
+    bitsplit_byte_level_sink(text, tags, starts, flag, &mut sink);
+    sink.flush();
+}
+
+fn bitsplit_byte_level_sink<S: SpanSink>(
+    text: &[u8],
+    tags: &[u8],
+    starts: &mut [u64],
+    flag: &mut [u64],
+    sink: &mut S,
+) {
     let ntext = text.len();
     if ntext == 0 {
-        return 0;
+        return;
     }
     let nblk = ntext.div_ceil(64);
-    assert!(
-        tags.len() >= ntext && starts.len() >= nblk && flag.len() >= nblk && out.len() >= ntext
-    );
+    assert!(tags.len() >= ntext && starts.len() >= nblk && flag.len() >= nblk);
     let (mut code, mut prev_cont) = (CODE_CONT, 0u64);
 
     for bi in 0..nblk {
@@ -157,6 +185,6 @@ pub fn bitsplit_byte_level(
         code = last_code;
         prev_cont = b.cont;
     }
-    emit_contr(text, starts, flag, nblk, ntext, false, out)
+    emit_contr(text, starts, flag, nblk, ntext, false, sink);
 }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -373,7 +373,18 @@ impl pipeline::Model for PipelineBPE {
             word_cache,
         } = scratch;
 
-        output.reserve(spans.len() + MAX_INLINE_IDS);
+        // Reserve what the *fast* path could write, so the emit loop's capacity test almost never
+        // fires: a cache hit writes at most `MAX_INLINE_IDS` lanes, so `spans.len() *
+        // MAX_INLINE_IDS` covers every one of them. Only for a batch small enough to be a tile,
+        // though -- applying it to a whole chunk reserves three tokens per span where english
+        // produces about one (2.7 MB of buffer for 0.94 MB of tokens), and that over-allocation cost
+        // 3-5% on the models with no tiled emit, which are exactly the ones that see whole chunks.
+        const TILE_LIKE: usize = 8192;
+        output.reserve(if spans.len() <= TILE_LIKE {
+            spans.len() * MAX_INLINE_IDS + MAX_INLINE_IDS
+        } else {
+            spans.len() + MAX_INLINE_IDS
+        });
         let mut capacity = output.capacity();
         let mut cursor = output.len();
         // A raw write cursor held across the whole chunk. `output.as_mut_ptr()` inside the loop had

--- a/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
@@ -94,6 +94,25 @@ impl TryFrom<Sequence> for PipelineSequence {
     }
 }
 
+impl PipelineSequence {
+    /// The single real child, when the `Sequence[Split(regex), ByteLevel]` shape has collapsed to
+    /// one (a byte-map `ByteLevel` converts to `PipelinePreTokenizer::None`, a pure identity pass).
+    /// Same test `pre_tokenize` makes before delegating.
+    pub(crate) fn lone_child(&self) -> Option<&pipeline::PipelinePreTokenizer> {
+        if self.is_deepseek() {
+            return None;
+        }
+        let mut work = self
+            .pre_tokenizers
+            .iter()
+            .filter(|c| !matches!(c, pipeline::PipelinePreTokenizer::None));
+        match (work.next(), work.next()) {
+            (Some(only), None) => Some(only),
+            _ => None,
+        }
+    }
+}
+
 impl pipeline::PreTokenizer for PipelineSequence {
     /// Runs each child in turn, where every child subdivides the spans produced
     /// so far. A child sees only the text of a span (`&text[span]`) and returns

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -178,6 +178,15 @@ impl PreTokenizer for Split {
     }
 }
 
+impl Split {
+    /// The native grammar this `Split` would route to, if any. Same condition `pre_tokenize` uses,
+    /// named so the pipeline can ask before choosing between the tiled and whole-chunk paths.
+    pub(crate) fn native_grammar(&self) -> Option<crate::utils::Grammar> {
+        self.fsm
+            .filter(|_| !self.invert && self.behavior == SplitDelimiterBehavior::Isolated)
+    }
+}
+
 impl pipeline::PreTokenizer for Split {
     fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
         // A recognized GPT regex in its only real usage — `Isolated`, not inverted — routes

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -110,6 +110,69 @@ pub(crate) fn classify_into_spans_bits(
     });
 }
 
+/// How many spans a tile holds. 256 spans is 2 KB, so the tile and the cache slots it probes both
+/// stay in L1; the whole-chunk array it replaces is ~1.8 MB for a 1 MB input, written and then read
+/// back. Big enough that the per-tile call is amortised over hundreds of pretokens.
+const SPAN_TILE_DEFAULT: usize = 1024;
+const SPAN_TILE_MAX: usize = 1 << 16;
+
+/// `TK_SPAN_TILE=<n>` sweeps it without a rebuild. The tradeoff has two sides and they pull opposite
+/// ways: a smaller tile keeps the spans in L1, a larger one amortises the per-tile call -- and that
+/// call is not free, because handing tiles through a closure pushed `tokenize_spans` out of line, so
+/// each tile now re-pays the model enum dispatch, `output.reserve`, and the cursor setup.
+fn span_tile() -> usize {
+    static N: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *N.get_or_init(|| {
+        std::env::var("TK_SPAN_TILE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(SPAN_TILE_DEFAULT)
+            .clamp(1, SPAN_TILE_MAX)
+    })
+}
+
+/// Pre-tokenize and consume in tiles: the spans go straight from the emit to `consume` in small
+/// batches, so no per-document span array is ever built. `false` if this grammar has no tiled emit,
+/// in which case the caller should use [`classify_into_spans_bits`] instead.
+pub(crate) fn classify_into_spans_bits_tiled(
+    bytes: &[u8],
+    grammar: crate::utils::Grammar,
+    consume: impl FnMut(&[Span]),
+) -> bool {
+    thread_local! {
+        static SCRATCH: RefCell<(Vec<u8>, Vec<u64>, Vec<u64>, Vec<Span>)> =
+            const { RefCell::new((Vec::new(), Vec::new(), Vec::new(), Vec::new())) };
+    }
+    let n = bytes.len();
+    if n == 0 {
+        return true;
+    }
+    SCRATCH.with(|cell| {
+        let (tags, starts, flags, tile) = &mut *cell.borrow_mut();
+        if tags.len() < n {
+            tags.resize(n, 0);
+        }
+        let words = n.div_ceil(64) + 1;
+        if starts.len() < words {
+            starts.resize(words, 0);
+            flags.resize(words, 0);
+        }
+        let tile_len = span_tile();
+        if tile.len() < tile_len {
+            tile.resize(tile_len, Span { start: 0, end: 0 });
+        }
+        classify(bytes, &mut tags[..n]);
+        grammar.split_tiled(
+            bytes,
+            &tags[..n],
+            &mut starts[..words],
+            &mut flags[..words],
+            &mut tile[..tile_len],
+            consume,
+        )
+    })
+}
+
 pub trait Normalizer {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>>;
 }
@@ -192,6 +255,19 @@ pub enum PipelinePreTokenizer {
     Whitespace(Whitespace),
     WhitespaceSplit(WhitespaceSplit),
     None,
+}
+
+impl PipelinePreTokenizer {
+    /// The native grammar behind this pre-tokenizer, if the pipeline can drive it in tiles.
+    /// A `Sequence` is included because the dominant `Sequence[Split(regex), ByteLevel]` shape
+    /// collapses to a single real child (see `PipelineSequence::pre_tokenize`).
+    pub(crate) fn native_grammar(&self) -> Option<crate::utils::Grammar> {
+        match self {
+            Self::Split(split) => split.native_grammar(),
+            Self::Sequence(seq) => seq.lone_child()?.native_grammar(),
+            _ => None,
+        }
+    }
 }
 
 impl PreTokenizer for PipelinePreTokenizer {
@@ -1086,6 +1162,47 @@ impl PipelineTokenizer {
                                 output.push(PipelineToken { id: token });
                             }
                             Segment::Text(normalized_chunk) => {
+                                // Fused: hand each tile of spans straight to the model, so the
+                                // ~1.8 MB span array a 1 MB chunk would otherwise write and read
+                                // back never exists. Only for a natively-routed grammar with a
+                                // tiled emit; anything else takes the two-phase path below.
+                                // The model is resolved to its concrete type ONCE, outside the tile
+                                // loop. Handing tiles to `PipelineModel::tokenize_spans` instead put
+                                // the enum dispatch on the per-tile path and, worse, kept the probe
+                                // loop from inlining into the consumer: a profile showed
+                                // `<PipelineModel as Model>::tokenize_spans` newly *outlined* at 58%
+                                // of self time, called once per tile rather than once per chunk.
+                                // gigatoken's equivalent consumer is monomorphic for the same reason.
+                                if STAGE >= Self::STAGE_MODEL
+                                    && let Some(grammar) = self.pre_tokenizer.native_grammar()
+                                    && grammar.supports_tiled()
+                                    && let PipelineModel::BPE(bpe) = &self.model
+                                    && let PipelineModelScratch::BPE(bpe_scratch) = &mut *scratch
+                                {
+                                    let mut err = None;
+                                    let fused = classify_into_spans_bits_tiled(
+                                        normalized_chunk.as_bytes(),
+                                        grammar,
+                                        |spans| {
+                                            if err.is_none() {
+                                                if let Err(e) = bpe.tokenize_spans(
+                                                    normalized_chunk,
+                                                    spans,
+                                                    bpe_scratch,
+                                                    output,
+                                                ) {
+                                                    err = Some(e);
+                                                }
+                                            }
+                                        },
+                                    );
+                                    if let Some(e) = err {
+                                        return Err(e);
+                                    }
+                                    if fused {
+                                        continue;
+                                    }
+                                }
                                 if STAGE >= Self::STAGE_SPLIT {
                                     // Pre-tokenize the chunk of normalized text
                                     PRE_TOKENS_SCRATCH.with(|cell| -> Result<()> {

--- a/tokenizers/tk-encode/src/utils/unrolled_regex.rs
+++ b/tokenizers/tk-encode/src/utils/unrolled_regex.rs
@@ -49,6 +49,34 @@ impl Grammar {
             Grammar::Kimi => bitsplit::bitsplit_kimi(text, tags, starts, flag, out),
         }
     }
+
+    /// Whether [`Self::split_tiled`] can drive this grammar. Ask *before* classifying: the tiled
+    /// driver classifies first and would otherwise leave the fallback to classify the same bytes a
+    /// second time, which is a straight regression for every grammar without a tiled emit.
+    pub fn supports_tiled(self) -> bool {
+        matches!(self, Grammar::Gpt2)
+    }
+
+    /// Emit into small tiles handed to `consume`, instead of one span array per document. Returns
+    /// `false` for a grammar that has no tiled emit yet, so the caller keeps the whole-chunk path
+    /// rather than silently taking a slower or different route.
+    pub fn split_tiled<F: FnMut(&[Span])>(
+        self,
+        text: &[u8],
+        tags: &[u8],
+        starts: &mut [u64],
+        flag: &mut [u64],
+        tile: &mut [Span],
+        consume: F,
+    ) -> bool {
+        match self {
+            Grammar::Gpt2 => {
+                bitsplit::bitsplit_byte_level_tiled(text, tags, starts, flag, tile, consume);
+                true
+            }
+            _ => false,
+        }
+    }
 }
 
 /// The cl100k-family template is fixed except rule 3's digit rule. If `pattern` is that template,


### PR DESCRIPTION
## What

The pre-tokenizer wrote every span of a chunk into one array and the model read it back. For a 1 MB chunk of english that is **~229k spans × 8 B = 1.8 MB written and 1.8 MB read — 3.5 bytes of span traffic per input byte**, none of which stays in cache. The emit now hands the model small tiles (1024 spans, 8 KB) as it finds them, and no per-document span array exists.

## Result

tokbench, gpt2, 29 corpora, 3 interleaved rounds, medians:

| | geomean vs gigatoken |
|---|---|
| base (`poc/target-encode-clean`) | 0.9914x |
| **this PR** | **1.0165x** |

**1.0241x ours-vs-ours, 22/29 corpora faster.** All 30 corpora byte-exact against the reference tokenizer; 370 `tk-encode` tests and `bitsplit`'s parity suite pass.

## How

In `bitsplit`, a `SpanSink` trait with two implementations — `SliceSink` for the existing whole-chunk API and `TileSink`, which flushes to a consumer when it fills — over **one** generic `emit_contr`.

Flushing from inside the emit's own control flow is what lets this need no resumable state: a contraction chain (`y'all'd've`) can emit an unbounded run of spans from a single block, so a caller-driven "emit N spans then return" API would have to resume *mid-chain*, and getting that wrong changes tokenization. The mask build is untouched and still one pass, so the grammar — contractions, the `\s+(?!\S)` steal, the block-edge carry — is exactly as before. `Grammar::supports_tiled` is asked *before* classifying, so a grammar without a tiled emit does not classify twice.

Two details are load-bearing, both found by profiling rather than reasoning:

- **The consumer is resolved to `&PipelineBPE` once, outside the tile loop.** Handing tiles to `PipelineModel::tokenize_spans` put the enum dispatch on the per-tile path and kept the probe loop from inlining — a profile showed that symbol newly *outlined* at 58% of self time, called once per tile instead of once per chunk. That alone made the first version **4% slower** than the array it replaced.
- **`tokenize_spans` reserves the fast path's worst case up front**, so its capacity test almost never fires — but sized by batch shape. `spans.len() * MAX_INLINE_IDS` is right for an 8 KB tile and a 3× over-allocation for a whole chunk (2.7 MB of buffer for 0.94 MB of tokens), which cost 3–5% on the models that have no tiled emit and so still see whole chunks.

## Measured and deliberately *not* included

- **`#[cold] #[inline(never)]` fallback**, in gigatoken's `probe_emit_slow` shape: −4% on gpt2 and **llama-3 0.4157x with chinese 14× slower**. Their slow path takes 3.8% of pretokens and calls out to merge; every cache miss reaches ours and `merge_word` inlines into it, so `#[cold]` has LLVM optimise the merge engine for size.
- **One-deep probe prefetch** (`prfm pldl1keep` on the next span's home line): 0.9363x, and 0.9015x on ASCII cells alone. The table is L1-resident at inference sizes, so there is no latency to hide and the duplicated hash costs real cycles. gigatoken affords `D = 16` only because its span batch already holds every key.

## Review notes

- The tile size is `TK_SPAN_TILE`-overridable; a sweep from 64 to 65536 spans could not distinguish sizes above noise, so 1024 (8 KB) is a comfortable-in-L1 default rather than a tuned optimum.
- `bitsplit`'s `emit_contr` is now generic over the sink. `cl100k` goes through `SliceSink` and is unchanged in behaviour.
- Only the gpt2/byte-level grammar has a tiled emit so far; every other grammar takes the existing path untouched.