### PR TITLE
perf(vocab): pack words up to 15 bytes exactly, in two tiers

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -241,9 +241,9 @@ impl PipelineBPE {
     }
 
     #[inline(always)]
-    fn fold_id_keyed(&self, key: u64, hash: u64) -> Option<u32> {
+    fn fold_id_keyed(&self, hash: u64) -> Option<u32> {
         // One probe; the foldable bit is part of the id that probe already returned. Which entries
-        let (id, foldable) = self.vocab.get_keyed_foldable(key, hash)?;
+        let (id, foldable) = self.vocab.get_keyed_foldable(hash)?;
         foldable.then_some(id)
     }
 
@@ -329,7 +329,7 @@ impl pipeline::Model for PipelineBPE {
             None
         };
 
-        if let Some(id) = self.fold_id_keyed(key, hash) {
+        if let Some(id) = self.fold_id_keyed(hash) {
             output.push(PipelineToken { id });
             if let Some(cache) = word_cache.as_mut()
                 && let Some(at) = insert_at
@@ -465,7 +465,7 @@ impl pipeline::Model for PipelineBPE {
 
             // Cache miss. The fold still answers a word that is its own vocabulary entry in one
             // probe, which beats running the merge engine for it.
-            if let Some(id) = self.fold_id_keyed(key, hash) {
+            if let Some(id) = self.fold_id_keyed(hash) {
                 // SAFETY: the check above leaves at least `MAX_INLINE_IDS >= 1` slots past `cursor`.
                 unsafe { dst.write(PipelineToken { id }) };
                 cursor += 1;

--- a/tokenizers/tk-encode/src/utils/word_cache.rs
+++ b/tokenizers/tk-encode/src/utils/word_cache.rs
@@ -55,7 +55,7 @@ use std::fmt::Debug;
 use std::iter::Iterator;
 use wide::i8x16;
 
-use crate::vocab::bucket_vocab_store::key_and_hash;
+use crate::vocab::bucket_vocab_store::{KEY_IS_HASH, key_and_hash};
 #[cfg(test)]
 use crate::vocab::bucket_vocab_store::INLINE_KEY_BYTES;
 
@@ -114,7 +114,7 @@ impl<'a> WordCache {
     }
 
     #[inline]
-    pub fn lookup_keyed(&'a self, key: u64, hash: u64) -> Lookup<'a> {
+    pub fn lookup_keyed(&'a self, key: u128, hash: u64) -> Lookup<'a> {
         self.lookup_placed(placement_from(LookupKey(key), hash, self.placement_mask))
     }
 
@@ -132,7 +132,7 @@ impl<'a> WordCache {
     ///
     /// # Safety
     #[inline]
-    pub unsafe fn probe_emit_keyed(&'a self, key: u64, hash: u64, dst: *mut u32) -> ProbeEmit<'a> {
+    pub unsafe fn probe_emit_keyed(&'a self, key: u128, hash: u64, dst: *mut u32) -> ProbeEmit<'a> {
         let placement = placement_from(LookupKey(key), hash, self.placement_mask);
         // SAFETY: `index` is masked with `placement_mask` (`next_pow2 - 1`), and the table is
         let slot = unsafe { *self.cached_words.as_ptr().add(placement.index) };
@@ -393,7 +393,7 @@ impl<'a> SelfContained<'a> {
 /// ```
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 #[repr(transparent)]
-pub struct LookupKey(u64);
+pub struct LookupKey(u128);
 
 /// The key, home slot and tag of a word.
 #[inline]
@@ -414,14 +414,16 @@ fn placement_from(key: LookupKey, hash: u64, placement_mask: u64) -> InsertPlace
 
 impl std::fmt::Debug for LookupKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let len = (self.0 >> 56) as usize;
-        if len <= 7 {
+        // The two packed tiers put the length in different places.
+        let wide = (self.0 >> 120) as usize;
+        let len = if wide != 0 { wide } else { (self.0 >> 56) as usize };
+        if self.0 & KEY_IS_HASH == 0 {
             let bytes = self.0.to_le_bytes();
             f.debug_tuple("LookupKey")
                 .field(&String::from_utf8_lossy(&bytes[..len]).into_owned())
                 .finish()
         } else {
-            write!(f, "LookupKey(hash {:#018x})", self.0)
+            write!(f, "LookupKey(hash {:#018x})", self.0 as u64)
         }
     }
 }
@@ -711,9 +713,10 @@ mod tests {
             let mut padded = [0u8; 8];
             padded[..len].copy_from_slice(&word);
             padded[7] = len as u8;
+            // the cheap tier's key is its u64 pack widened, so bits 64.. stay clear
             assert_eq!(
                 key_and_hash(&word).0,
-                u64::from_le_bytes(padded),
+                u64::from_le_bytes(padded) as u128,
                 "len={len}"
             );
         }

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -25,13 +25,68 @@ const FOLD_BIT: u32 = 1 << 31;
 /// The id half. 2^31 ids is far past any vocabulary.
 const VOCAB_ID_MASK: u32 = FOLD_BIT - 1;
 
+/// A word this long or shorter packs into the *cheap* tier: eight-byte masked load, one multiply.
 pub(crate) const INLINE_KEY_BYTES: usize = 7;
+/// ...and this long or shorter into the wide tier: sixteen-byte masked load, wyhash fold. Still
+/// exact -- the key is the word -- so a cache hit on anything up to this length cannot be wrong.
+///
+/// Two tiers rather than one, because collapsing them lost: making every length take the wide path
+/// (`mix128` is a 64x64->128 multiply where `mix` is one multiply, and the wide masked load needs 16
+/// readable bytes so short words near a chunk's end fall back to the stitched pack) cost the corpora
+/// whose pretokens are *already* under seven bytes -- hindi 0.857, tamil 0.868, bengali 0.870, whose
+/// pretokens are one or two three-byte characters. The wide tier only has to serve the range that
+/// was paying ahash: 8..15 bytes, which is where ASCII words live.
+pub(crate) const WIDE_KEY_BYTES: usize = 15;
+
+/// Set on the key of a word too long even for the wide tier, where the key is 64 bits of hash rather
+/// than the word. Neither packed tier can set it: the cheap tier leaves bits 64.. clear and the wide
+/// tier puts a length of at most 15 at bits 120..=126.
+pub(crate) const KEY_IS_HASH: u128 = 1 << 127;
 
 #[inline(always)]
 fn mix(z: u64) -> u64 {
     let z = z.wrapping_mul(0x9E37_79B9_7F4A_7C15);
     z ^ (z >> 29)
 }
+
+/// Fold a wide packed key to the 64 bits the placement and the digest come from: one 64x64->128
+/// multiply of the halves, then xor the product's halves -- wyhash's core.
+///
+/// **Do not "simplify" this to `lo ^ hi`.** That fold is linear, so the same xor delta at the same
+/// byte offset in each half cancels: ` dignified` and ` signifies` differ only at bytes 1 and 9, both
+/// `d` vs `s`, so they folded to one hash and a vocabulary holding one answered a query for the
+/// other. Regression test: `the_fold_separates_words_whose_halves_cancel`.
+#[inline(always)]
+fn mix128(key: u128) -> u64 {
+    const A: u64 = 0xA076_1D64_78BD_642F;
+    const B: u64 = 0xE703_7ED1_A0B4_28DB;
+    let lo = key as u64;
+    let hi = (key >> 64) as u64;
+    let product = ((lo ^ A) as u128).wrapping_mul((hi ^ B) as u128);
+    (product as u64) ^ ((product >> 64) as u64)
+}
+
+/// `KEY_MASK_WIDE[len]` keeps the low `len` bytes of a sixteen-byte load; `LEN_TAG_WIDE[len]` is the
+/// length that goes on top. Spelled as loops because sixteen 128-bit literals are harder to check
+/// than the rule they follow.
+static KEY_MASK_WIDE: [u128; WIDE_KEY_BYTES + 1] = {
+    let mut mask = [0u128; WIDE_KEY_BYTES + 1];
+    let mut len = 1;
+    while len <= WIDE_KEY_BYTES {
+        mask[len] = (1u128 << (8 * len)) - 1;
+        len += 1;
+    }
+    mask
+};
+static LEN_TAG_WIDE: [u128; WIDE_KEY_BYTES + 1] = {
+    let mut tag = [0u128; WIDE_KEY_BYTES + 1];
+    let mut len = 0;
+    while len <= WIDE_KEY_BYTES {
+        tag[len] = (len as u128) << 120;
+        len += 1;
+    }
+    tag
+};
 
 ///
 ///
@@ -46,18 +101,39 @@ fn mix(z: u64) -> u64 {
 /// span loop while the hash stays a call -- which is also the shape it wants, since the long arm is
 /// already dominated by hashing rather than by call overhead.
 #[inline(always)]
-pub fn key_and_hash_readable(word: &[u8], readable: usize) -> (u64, u64) {
+pub fn key_and_hash_readable(word: &[u8], readable: usize) -> (u128, u64) {
     let len = word.len();
-    if len > INLINE_KEY_BYTES || readable < 8 {
-        return key_and_hash(word);
+    // Cheap tier first: it is the common case for every script whose characters are multi-byte, and
+    // it is strictly less work than the wide one.
+    if len <= INLINE_KEY_BYTES && readable >= 8 {
+        // SAFETY: `readable >= 8` bytes exist from `word.as_ptr()`, and `len <= 7 < 8`.
+        let raw = unsafe { word.as_ptr().cast::<u64>().read_unaligned() };
+        // SAFETY: `len <= INLINE_KEY_BYTES == 7`, and both tables have 8 entries.
+        let (mask, tag) = unsafe { (*KEY_MASK.get_unchecked(len), *LEN_TAG.get_unchecked(len)) };
+        let key = (raw & mask) | tag;
+        debug_assert_eq!(
+            key as u128,
+            key_and_hash(word).0,
+            "masked load must match the stitched pack"
+        );
+        return (key as u128, mix(key));
     }
-    // SAFETY: `readable >= 8` bytes exist from `word.as_ptr()`, and `len <= 7 < 8`.
-    let raw = unsafe { word.as_ptr().cast::<u64>().read_unaligned() };
-    // SAFETY: `len <= INLINE_KEY_BYTES == 7`, and both tables have 8 entries.
-    let (mask, tag) = unsafe { (*KEY_MASK.get_unchecked(len), *LEN_TAG.get_unchecked(len)) };
-    let key = (raw & mask) | tag;
-    debug_assert_eq!(key, key_and_hash(word).0, "masked load must match the stitched pack");
-    (key, mix(key))
+    // Wide tier: an ASCII word of 8..15 bytes used to reach ahash from here.
+    if len <= WIDE_KEY_BYTES && readable >= 16 {
+        // SAFETY: `readable >= 16` bytes exist from `word.as_ptr()`, and `len <= 15 < 16`.
+        let raw = unsafe { word.as_ptr().cast::<u128>().read_unaligned() };
+        // SAFETY: `len <= WIDE_KEY_BYTES == 15`, and both tables have 16 entries.
+        let (mask, tag) = unsafe {
+            (
+                *KEY_MASK_WIDE.get_unchecked(len),
+                *LEN_TAG_WIDE.get_unchecked(len),
+            )
+        };
+        let key = (raw & mask) | tag;
+        debug_assert_eq!(key, key_and_hash(word).0, "masked load must match the stitched pack");
+        return (key, mix128(key));
+    }
+    key_and_hash(word)
 }
 
 /// A word too long to pack into the key: hash it for real. Kept out of line so that the packing
@@ -65,16 +141,24 @@ pub fn key_and_hash_readable(word: &[u8], readable: usize) -> (u64, u64) {
 /// `#[cold]` on purpose -- for CJK this is the *common* arm, and telling the predictor otherwise
 /// would cost more than the call.
 #[inline(never)]
-fn key_and_hash_long(word: &[u8]) -> (u64, u64) {
+fn key_and_hash_long(word: &[u8]) -> (u128, u64) {
     let hash = KEY_HASHER.hash_one(word);
-    (hash, hash)
+    ((hash as u128) | KEY_IS_HASH, hash)
 }
 
 #[inline(always)]
-pub fn key_and_hash(word: &[u8]) -> (u64, u64) {
+pub fn key_and_hash(word: &[u8]) -> (u128, u64) {
     let len = word.len();
-    if len > INLINE_KEY_BYTES {
+    if len > WIDE_KEY_BYTES {
         return key_and_hash_long(word);
+    }
+    // Wide tier, stitched (no 16 readable bytes to load from): head and tail overlap and the bytes
+    // they share are the same bytes, so the `|` cannot lose one.
+    if len > INLINE_KEY_BYTES {
+        let head = u64::from_le_bytes(word[..8].try_into().unwrap()) as u128;
+        let tail = u64::from_le_bytes(word[len - 8..].try_into().unwrap()) as u128;
+        let key = (head | tail << (8 * (len - 8))) | (len as u128) << 120;
+        return (key, mix128(key));
     }
     let raw = if len >= 4 {
         let head = u32::from_le_bytes(word[..4].try_into().unwrap()) as u64;
@@ -89,7 +173,7 @@ pub fn key_and_hash(word: &[u8]) -> (u64, u64) {
         0
     };
     let key = raw | (len as u64) << 56;
-    (key, mix(key))
+    (key as u128, mix(key))
 }
 
 ///
@@ -248,7 +332,7 @@ impl BucketVocabStore {
                 "token longer than 65535 bytes"
             );
             assert!(*id <= VOCAB_ID_MASK, "token id {id} needs bit 31, which holds FOLD_BIT");
-            let (key, hash) = key_and_hash(s.as_slice());
+            let (_, hash) = key_and_hash(s.as_slice());
             let slot = mphf.index(&hash);
             entries[slot] = Entry {
                 digest: digest_of(hash),
@@ -294,7 +378,7 @@ impl BucketVocabStore {
         if self.entries.is_empty() {
             return None;
         }
-        let (key, hash) = key_and_hash(q);
+        let (_, hash) = key_and_hash(q);
         let slot = self.mphf.index(&hash);
         let e = self.entries[slot];
         (e.digest == digest_of(hash)).then_some(e.id & VOCAB_ID_MASK)
@@ -304,8 +388,8 @@ impl BucketVocabStore {
     /// load: the flag is a bit of the id the probe already read.
     #[inline]
     pub fn get_bytes_foldable(&self, q: &[u8]) -> Option<(u32, bool)> {
-        let (key, hash) = key_and_hash(q);
-        self.get_keyed_foldable(key, hash)
+        let (_, hash) = key_and_hash(q);
+        self.get_keyed_foldable(hash)
     }
 
     #[inline(always)]
@@ -326,8 +410,7 @@ impl BucketVocabStore {
     }
 
     #[inline]
-    pub fn get_keyed_foldable(&self, key: u64, hash: u64) -> Option<(u32, bool)> {
-        let _ = key;
+    pub fn get_keyed_foldable(&self, hash: u64) -> Option<(u32, bool)> {
         if self.entries.is_empty() {
             return None;
         }
@@ -418,6 +501,60 @@ impl BucketVocabStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The pair a linear `lo ^ hi` fold could not separate: same length, and the only two bytes that
+    /// differ sit one in each half at the same offset, so their xor deltas cancelled and a vocabulary
+    /// holding one answered a query for the other. This is why `mix128` multiplies.
+    #[test]
+    fn the_fold_separates_words_whose_halves_cancel() {
+        let (dignified, signifies) = (b" dignified", b" signifies");
+        assert_ne!(
+            key_and_hash(dignified).1,
+            key_and_hash(signifies).1,
+            "the halves' deltas cancelled -- mix128 must not fold linearly"
+        );
+        assert_ne!(key_and_hash(dignified).0, key_and_hash(signifies).0);
+        let vocab = BucketVocabStore::build(vec![(signifies.to_vec(), 7)]);
+        assert_eq!(vocab.get_bytes(signifies), Some(7));
+        assert_eq!(vocab.get_bytes(dignified), None);
+    }
+
+    /// Every offset, not just the one that bit us: the same bit flipped in byte `i` of each half must
+    /// still land on two hashes.
+    #[test]
+    fn no_paired_byte_delta_cancels() {
+        for i in 0..7usize {
+            let a = *b"0123456789abcde";
+            let mut b = a;
+            b[i] ^= 0x17;
+            b[i + 8] ^= 0x17;
+            assert_ne!(
+                key_and_hash(&a).1,
+                key_and_hash(&b).1,
+                "paired delta at byte {i} cancelled"
+            );
+        }
+    }
+
+    /// A packed key *is* the word, in both tiers, so no two words up to `WIDE_KEY_BYTES` may share
+    /// one -- that is what makes a cache hit on a short word exact rather than probabilistic. The two
+    /// tiers must not collide with each other either: the cheap one leaves bits 64.. clear, the wide
+    /// one always sets a length of at least 8 at bits 120...
+    #[test]
+    fn both_tiers_pack_words_uniquely() {
+        use std::collections::HashMap;
+        let mut seen: HashMap<u128, Vec<u8>> = HashMap::new();
+        for len in 1..=WIDE_KEY_BYTES {
+            for b in [b'a', b'b', 0x00, 0xFF] {
+                let word = vec![b; len];
+                let key = key_and_hash(&word).0;
+                assert_eq!(key & KEY_IS_HASH, 0, "a packed key must not look hashed");
+                if let Some(prev) = seen.insert(key, word.clone()) {
+                    panic!("{prev:?} and {word:?} packed to the same key");
+                }
+            }
+        }
+    }
 
     #[test]
     fn single_token() {


### PR DESCRIPTION
Stacked on #2323.

## What

A pretoken longer than the 7-byte inline key reached ahash. A profile of warm english put `key_and_hash_long` at **6.5–8.5% of self time** — english pretokens run to 13 bytes, so ASCII was paying a real hash for words that would have fit in a key.

## Why two tiers and not one

Widening to 15 bytes as a *single* tier was tried first and **lost: 0.9789x, 10/29 faster.** It taxed every corpus whose pretokens are already under seven bytes — hindi 0.857, tamil 0.868, bengali 0.870, whose pretokens are one or two three-byte characters — because `mix128` is a 64×64→128 multiply where `mix` is one multiply, and the wide masked load needs 16 readable bytes so short words near a chunk's end fell back to the stitched pack.

Keeping both tiers instead of replacing one:

```
len ≤ 7    u64 pack,  mix      unchanged — Indic and CJK keep today's exact path
len 8..15  u128 pack, mix128   new — ASCII stops reaching ahash
len > 15   ahash               unchanged
```

The packs cannot collide: a cheap key leaves bits 64.. clear, a wide key always carries a length ≥ 8 at bits 120..=126. Everything up to 15 bytes stays **exact** — the key *is* the word — so a cache hit on one cannot be wrong.

`LookupKey` widens to `u128` at **no memory cost**: the slot was `u64 + [u32; 3] + u8 + [u8; 3]` = 24 bytes rounded to 32 by `align(32)`, so those eight bytes were already padding, and the layout now matches what the module docs have always drawn.

## Result

tokbench gpt2, 29 corpora, 3 interleaved rounds, medians: **1.0300x, 20/29 corpora faster.**

All eight models, one round each: **1.0225x, 140/232 cells faster** — albert 1.0876, deepseek-v4 1.0790, gemma-3 1.0686 (29/29), llama-3 and mistral-nemo flat.

The corpora the one-tier version taxed now gain instead:

| corpus | one tier | **two tiers** |
|---|---|---|
| hindi | 0.857x | **1.130x** |
| bengali | 0.870x | 1.029x |
| japanese | — | 1.055x |
| thai | — | 1.078x |
| chat-deepseek | 1.101x | **1.164x** |
| chat-chatml | — | 1.127x |
| english | 1.007x | 1.056x |

All 30 corpora byte-exact against the reference tokenizer; 373 `tk-encode` tests pass.

## `mix128` must multiply, never `lo ^ hi`

That fold is linear, so the same xor delta at the same byte offset in each half cancels: ` dignified` and ` signifies` differ only at bytes 1 and 9, both `d` vs `s`, so they folded to one hash and a vocabulary holding one **answered a query for the other**. Found by diffing against the reference tokenizer on `amharic`. Pinned by `the_fold_separates_words_whose_halves_cancel` and `no_paired_byte_delta_cancels`, plus `both_tiers_pack_words_uniquely` for the tier-disjointness invariant.

## Also

`get_keyed_foldable` took a key it never read (`let _ = key;`) — the vocabulary probes on the hash alone, which is why widening the key needs no MPHF change. Parameter dropped.