### PR TITLE
Add missing return type hints to CharBPETokenizer.from_file, train, train_from_iterator

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/char_level_bpe.py
@@ -90,7 +90,7 @@ class CharBPETokenizer(BaseTokenizer):
         super().__init__(tokenizer, parameters)
 
     @staticmethod
-    def from_file(vocab_filename: str, merges_filename: str, **kwargs):
+    def from_file(vocab_filename: str, merges_filename: str, **kwargs) -> "CharBPETokenizer":
         vocab, merges = BPE.read_file(vocab_filename, merges_filename)
         return CharBPETokenizer(vocab, merges, **kwargs)
 
@@ -104,7 +104,7 @@ class CharBPETokenizer(BaseTokenizer):
         initial_alphabet: List[str] = [],
         suffix: Optional[str] = "</w>",
         show_progress: bool = True,
-    ):
+    ) -> None:
         """Train the model using the given files"""
 
         trainer = trainers.BpeTrainer(
@@ -131,7 +131,7 @@ class CharBPETokenizer(BaseTokenizer):
         suffix: Optional[str] = "</w>",
         show_progress: bool = True,
         length: Optional[int] = None,
-    ):
+    ) -> None:
         """Train the model using the given iterator"""
 
         trainer = trainers.BpeTrainer(


### PR DESCRIPTION
## What this PR does

Adds missing return type hints to three methods in
`bindings/python/py_src/tokenizers/implementations/char_level_bpe.py`:

- `from_file(vocab_filename: str, merges_filename: str, **kwargs) -> "CharBPETokenizer"`
- `train(...) -> None`
- `train_from_iterator(...) -> None`

This follows the same typing-consistency pattern as #2211, which added
the equivalent missing return hints to `BaseTokenizer.save`,
`save_model`, and `to_str`. `CharBPETokenizer` (a `BaseTokenizer`
subclass) had the identical gap in its own methods: every argument was
already annotated, but the return type was never added.

## Why these types are correct

- `from_file` is a `@staticmethod` that returns `CharBPETokenizer(vocab, merges, **kwargs)`,
  i.e. a new instance of the class — hence `-> "CharBPETokenizer"`, matching the quoted
  self-referential forward-reference convention already used elsewhere in this codebase
  (e.g. `Tokenizer.from_file -> "Tokenizer"` and `BPE.from_file -> "BPE"` in the generated
  `.pyi` stubs).
- `train` and `train_from_iterator` both call `self._tokenizer.train(...)` /
  `self._tokenizer.train_from_iterator(...)` without a `return` statement, so they implicitly
  return `None` — hence `-> None`.

## Scope note

Checked `gh pr list --repo huggingface/tokenizers --search "char_level_bpe"` before starting;
no open or closed PR currently touches this file.

## No behaviour change

Type-hint-only change on method signatures. No logic, docstrings, or other files were modified.

## Testing

- `ruff check bindings/python/py_src/tokenizers/implementations/char_level_bpe.py` — all checks passed.
- `ruff format --check bindings/python/py_src/tokenizers/implementations/char_level_bpe.py` — passes, file already formatted.
- `python3 -c "import ast; ast.parse(...)"` on the modified file — passes.

> **Note:** Claude Code was used to assist in drafting this change. All changes were reviewed by the submitter.
