### PR TITLE
Add missing return type hints to ByteLevelBPETokenizer.from_file, train, train_from_iterator

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
@@ -72,7 +72,7 @@ class ByteLevelBPETokenizer(BaseTokenizer):
         super().__init__(tokenizer, parameters)
 
     @staticmethod
-    def from_file(vocab_filename: str, merges_filename: str, **kwargs):
+    def from_file(vocab_filename: str, merges_filename: str, **kwargs) -> "ByteLevelBPETokenizer":
         vocab, merges = BPE.read_file(vocab_filename, merges_filename)
         return ByteLevelBPETokenizer(vocab, merges, **kwargs)
 
@@ -83,7 +83,7 @@ class ByteLevelBPETokenizer(BaseTokenizer):
         min_frequency: int = 2,
         show_progress: bool = True,
         special_tokens: List[Union[str, AddedToken]] = [],
-    ):
+    ) -> None:
         """Train the model using the given files"""
 
         trainer = trainers.BpeTrainer(
@@ -105,7 +105,7 @@ class ByteLevelBPETokenizer(BaseTokenizer):
         show_progress: bool = True,
         special_tokens: List[Union[str, AddedToken]] = [],
         length: Optional[int] = None,
-    ):
+    ) -> None:
         """Train the model using the given iterator"""
 
         trainer = trainers.BpeTrainer(


### PR DESCRIPTION
## What this PR does

Adds missing return type hints to three methods in
`bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py`:

- `from_file(vocab_filename: str, merges_filename: str, **kwargs) -> "ByteLevelBPETokenizer"`
- `train(...) -> None`
- `train_from_iterator(...) -> None`

This follows the same typing-consistency pattern as #2211, which added
the equivalent missing return hints to `BaseTokenizer.save`,
`save_model`, and `to_str`. `ByteLevelBPETokenizer` (a `BaseTokenizer`
subclass) has the identical gap: every argument was already annotated,
but the return type was never added to these three methods.

## Why these types are correct

- `from_file` is a `@staticmethod` that returns
  `ByteLevelBPETokenizer(vocab, merges, **kwargs)`, i.e. a new instance
  of the class — hence `-> "ByteLevelBPETokenizer"`, using the quoted
  self-referential forward-reference convention (the file has no
  `from __future__ import annotations`, and the class name is not yet
  bound in scope while its own body is being defined). This mirrors the
  identical convention already used on the sibling
  `CharBPETokenizer.from_file -> "CharBPETokenizer"` pattern for the same
  situation elsewhere in `implementations/`.
- `train` and `train_from_iterator` both call `self._tokenizer.train(...)` /
  `self._tokenizer.train_from_iterator(...)` without a `return` statement,
  so they implicitly return `None` — hence `-> None`.

## Scope note

Ran `gh pr list --repo huggingface/tokenizers --search "byte_level_bpe"` and
`--search "ByteLevelBPETokenizer"` before starting; no open or closed PR
currently touches this file. Re-checked immediately before opening this PR.

## No behaviour change

Type-hint-only change on method signatures. No logic, docstrings, or other
files were modified.

## Testing

- `ruff check bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py` — all checks passed.
- `ruff format --check bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py` — passes, file already formatted.
- `python3 -c "import ast; ast.parse(...)"` on the modified file — passes.

> **Note:** Claude Code was used to assist in drafting this change. All changes were reviewed by the submitter.
