### PR TITLE
fix(bpe): stop merging pairs whose count has gone negative

### DIFF
--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -516,13 +516,21 @@ impl BpeTrainer {
                 break;
             };
 
-            if top.count != pair_counts[&top.pair] as u64 {
-                top.count = pair_counts[&top.pair] as u64;
+            // `pair_counts` is signed and a pair can go below zero once `max_token_length`
+            // starts rejecting the `+1` half of a neighbour update. Compare before casting:
+            // `-1 as u64` sorts to the top of the max-heap and gets merged.
+            let count = pair_counts[&top.pair];
+            if count <= 0 {
+                continue;
+            }
+
+            if top.count != count as u64 {
+                top.count = count as u64;
                 queue.push(top);
                 continue;
             }
 
-            if top.count < 1 || self.min_frequency > top.count {
+            if self.min_frequency > top.count {
                 break;
             }
 
@@ -864,5 +872,75 @@ mod tests {
         .map(|(k, v)| (k.to_string(), v))
         .collect();
         assert_eq!(trained_vocab, expected_vocab)
+    }
+    #[test]
+    fn bpe_test_no_unreachable_merge() {
+        // With a continuing_subword_prefix, max_token_length can reject the `+1` half of a
+        // neighbour update while the matching `-1` still lands, which pushes a pair count
+        // below zero. Every emitted merge must still apply somewhere in the corpus.
+        let word_counts: AHashMap<CompactString, u64> =
+            [("##a##a".into(), 1)].iter().cloned().collect();
+        let trainer = BpeTrainer::builder()
+            .show_progress(false)
+            .continuing_subword_prefix("##".to_string())
+            .max_token_length(Some(4))
+            .min_frequency(0)
+            .build();
+        let mut model = BPE::default();
+        trainer.do_train(&word_counts, &mut model).unwrap();
+
+        let id_to_token: AHashMap<u32, String> = model
+            .vocab
+            .iter()
+            .map(|(token, id)| (*id, token.clone()))
+            .collect();
+        let mut ranked: Vec<(u32, Pair, u32)> = model
+            .merges
+            .iter()
+            .map(|(pair, (rank, new_id))| (*rank, *pair, *new_id))
+            .collect();
+        ranked.sort_unstable_by_key(|(rank, _, _)| *rank);
+
+        // Re-tokenize the corpus and replay the merges in rank order
+        let mut words: Vec<Vec<String>> = word_counts
+            .keys()
+            .map(|word| {
+                word.chars()
+                    .enumerate()
+                    .map(|(i, c)| {
+                        if i == 0 {
+                            c.to_string()
+                        } else {
+                            format!("##{c}")
+                        }
+                    })
+                    .collect()
+            })
+            .collect();
+        for (rank, pair, new_id) in ranked {
+            let (first, second) = (&id_to_token[&pair.0], &id_to_token[&pair.1]);
+            let new_token = &id_to_token[&new_id];
+            let mut applied = false;
+            for word in words.iter_mut() {
+                let mut merged = Vec::with_capacity(word.len());
+                let mut i = 0;
+                while i < word.len() {
+                    if i + 1 < word.len() && &word[i] == first && &word[i + 1] == second {
+                        merged.push(new_token.clone());
+                        applied = true;
+                        i += 2;
+                    } else {
+                        merged.push(word[i].clone());
+                        i += 1;
+                    }
+                }
+                *word = merged;
+            }
+            assert!(
+                applied,
+                "merge {} ({}, {}) does not occur in the corpus",
+                rank, first, second
+            );
+        }
     }
 }


### PR DESCRIPTION
### Problem

`BpeTrainer` can emit a merge for a pair that occurs zero times in the corpus when
`continuing_subword_prefix` and `max_token_length` are used together. The merge is
unreachable, but it still takes a vocabulary slot and shifts every merge after it.
`WordPieceTrainer` sets the prefix in its default builder, so it is affected as soon as
`max_token_length` is set.

The diagnosis below is @Abraham-y's, from #2320. I only turned the reproducer into a
deterministic Rust one and wrote the patch.

### Root cause

`pair_counts` is `AHashMap<Pair, i32>` and the delta update after a merge can subtract
(`trainer.rs:585`). `Word::merge` emits the `-1` for a neighbouring pair unconditionally
but emits the matching `+1` only when the new symbol still fits `max_token_length`
(`word.rs:137-152`), so a pair already at `0` can be taken to `-1`.

Both `queue.push` sites refuse non-positive counts (`trainer.rs:494` and
`trainer.rs:592`), but the staleness re-check at `trainer.rs:519` read the count through
`as u64`. `-1` sign-extends to `18446744073709551615`, the entry is re-pushed with that
value, and on the next pop the staleness check agrees with itself, `top.count < 1` is
false and `min_frequency > top.count` is false, so the pair is merged ahead of every real
one.

### Fix

Read the count as `i32` and drop the heap entry when it is not positive, which is what the
two push sites already do. If the pair becomes frequent again it is pushed back by the
`where_to_update` drain like any other pair. `top.count < 1` is unreachable after that, so
it goes.

### Verification

Minimal case: a single word `"##a##a"`, `continuing_subword_prefix="##"`,
`max_token_length=4`. It reproduces on every run.

With `do_train` temporarily instrumented on `main`:

```
[instr] pair (3, 2) live count = -1 -> as u64 = 18446744073709551615
[instr] MERGING pair (3, 2) with top.count = 18446744073709551615
  rank  0  ("###", "##a")  -> "###a"   occurrences=2
  rank  1  ("#", "###a")   -> "##a"    occurrences=1
  rank  2  ("###", "###a") -> "####a"  occurrences=1
  rank  3  ("##a", "###")  -> "##a#"   occurrences=0   <-- unreachable
```

With the fix only ranks 0 to 2 are emitted.

`bpe_test_no_unreachable_merge` retokenizes the corpus and replays the emitted merges in
rank order, asserting each one applies somewhere. Reverting the source hunk and keeping
the test:

```
$ cargo test --lib bpe_test_no_unreachable_merge
thread '...' panicked at src/models/bpe/trainer.rs:931:13:
merge 3 (##a, ###) does not occur in the corpus
test result: FAILED. 0 passed; 1 failed; 0 ignored
```

Putting the hunk back:

```
$ cargo test --lib
test result: ok. 202 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
$ make lint
Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.76s
```

Training without a `continuing_subword_prefix` is unchanged: I hashed the vocab and the
ranked merge list of a 2000-token run over `models/bpe/model.rs` as corpus, with
`max_token_length` unset and set to 6, and the hashes are equal on both sides of the
patch. Runs that do set the prefix are not comparable that way because that path is still
nondeterministic (#1794).

Fixes #2320
