### PR TITLE
chore: first round of cleanup in preparation for 1.0.0rc0

### DIFF
--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -2798,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/tokenizers/atomsplit/src/fsm.rs
+++ b/tokenizers/atomsplit/src/fsm.rs
@@ -8,6 +8,18 @@
 //! regex-shaped ones ([`fsm_cl100k`] / [`fsm_o200k`] / [`fsm_tekken`] / [`fsm_deepseek`] /
 //! [`fsm_byte_level`]) are scalar jump-tables (only the class family's [`class_runs_into`] has a SIMD
 //! path).
+//!
+//! # Safety
+//!
+//! On well-formed UTF-8 input, every fsm emits spans where `start <= end <= text.len()`, and both
+//! offsets fall on a character boundary. Callers slice `text` with those spans, and `tk-encode`'s
+//! pipeline does it without checking, so a new fsm has to follow the same three rules:
+//!
+//! * Scan runs with `run_end`. It folds [`crate::classify::Atom::Cont`] into every mask, so a run
+//!   never stops between the bytes of one character.
+//! * Advance by `char_len` when emitting one character as its own span, never by one byte.
+//! * Walk back over continuation bytes when handing bytes back to the next token, never subtract
+//!   a fixed count. `ws_tail` does this to return the final whitespace character.
 
 pub(crate) use crate::classify::{Atom, char_len, classify, in_mask, mask};
 // Atom-tag aliases, shared with the per-tokenizer FSM submodules (`fsm/*.rs`) via `use super::*`.

--- a/tokenizers/tk-encode/Cargo.toml
+++ b/tokenizers/tk-encode/Cargo.toml
@@ -60,7 +60,7 @@ memchr = "2.8.2"
 unicode-normalization = "0.1.25"
 yada = "0.7.0"
 libc = "0.2"
-wide = "1.6.0"
+wide = "1.6.1"
 
 # Latest released tokenizers, used as the comparison baseline by the CI benchmark
 # (examples gated on `bench-baseline`). Optional so production builds never pull it.

--- a/tokenizers/tk-encode/examples/fixture_bench.rs
+++ b/tokenizers/tk-encode/examples/fixture_bench.rs
@@ -480,7 +480,7 @@ fn bench_throughput(
             .unwrap()
             .iter()
             .flatten()
-            .map(|t| t.id)
+            .map(|t| t.id())
             .collect()
     };
     let ids_match = baseline.map(|b| {
@@ -1039,7 +1039,7 @@ fn memory_child(which: &str, model: &Path) {
                             .first()
                             .unwrap()
                             .iter()
-                            .map(|t| t.id)
+                            .map(|t| t.id())
                             .collect()
                     },
                     &|i| pipeline.decode(i, false).unwrap().len(),

--- a/tokenizers/tk-encode/src/models/bpe/convert.rs
+++ b/tokenizers/tk-encode/src/models/bpe/convert.rs
@@ -1,7 +1,7 @@
 //! Converting a pretoken into internal symbols, in the shape the merge engine that will process
 //! it (`merge_multipass` or `merge_hot_cold_queue`) wants to start from.
 use crate::models::bpe::At;
-use crate::models::bpe::merge_hot_cold_queue::Entry;
+use crate::models::bpe::merge_hot_cold_queue::{Entry, MergeQueue, QueueScratch};
 use crate::models::bpe::model::{Atoms, PipelineBPE};
 use crate::models::bpe::tables::{BpeTables, ID_MASK, RANK_MASK};
 use crate::vocab::bucket_vocab_store::BucketVocabStore;
@@ -73,7 +73,7 @@ impl SinkMode for MultipassSink<'_> {
 /// needs no intermediate array to read back.
 struct QueueSink<'a> {
     entries: &'a mut Vec<Entry>,
-    cold: &'a mut Vec<u64>,
+    queue: &'a mut MergeQueue,
 }
 
 impl SinkMode for QueueSink<'_> {
@@ -82,14 +82,14 @@ impl SinkMode for QueueSink<'_> {
         let index = self.entries.len() as u32;
         self.entries.push(Entry {
             rank: (merge >> 32) as u32,
-            prod: (merge & ID_MASK) as u32,
-            a: previous,
-            b: symbol,
-            l: index.wrapping_sub(1), // u32::MAX at index 0, which is NONE
-            r: index + 1,             // the final entry is patched in `convert_queue`
+            merged_symbol: (merge & ID_MASK) as u32,
+            left_symbol: previous,
+            right_symbol: symbol,
+            left_pair_index: index.wrapping_sub(1), // u32::MAX at index 0, which is NONE
+            right_pair_index: index + 1,            // the final entry is patched in `convert_queue`
         });
         if merge != u64::MAX {
-            self.cold.push((merge & RANK_MASK) | index as u64);
+            self.queue.push_cold((merge & RANK_MASK) | index as u64);
         }
     }
     #[inline(always)]
@@ -152,23 +152,22 @@ impl PipelineBPE {
         &self,
         sequence: &str,
         symbols: &mut Vec<u32>,
-        entries: &mut Vec<Entry>,
-        cold: &mut Vec<u64>,
+        scratch: &mut QueueScratch,
     ) {
+        let QueueScratch { entries, queue } = scratch;
         symbols.clear();
         entries.clear();
-        cold.clear();
         // a word never has more symbols than bytes, so one reserve covers every push
         entries.reserve(sequence.len());
-        cold.reserve(sequence.len());
+        queue.clear(sequence.len());
         let mut sink = SymbolSink {
-            mode: QueueSink { entries, cold },
+            mode: QueueSink { entries, queue },
             previous_symbol: u32::MAX,
         };
         self.convert(sequence, &mut sink);
         let last = sink.previous_symbol;
         match entries.last_mut() {
-            Some(entry) => entry.r = u32::MAX, // NONE: nothing right of the final pair
+            Some(entry) => entry.right_pair_index = u32::MAX, // NONE: nothing right of the final pair
             None if last != u32::MAX => symbols.push(last),
             None => {}
         }

--- a/tokenizers/tk-encode/src/models/bpe/merge_hot_cold_queue.rs
+++ b/tokenizers/tk-encode/src/models/bpe/merge_hot_cold_queue.rs
@@ -15,177 +15,236 @@
 //! which is the order BPE prescribes.
 //!
 //! The word itself is the `entries` arena: one [`Entry`] per adjacent pair, doubly linked through
-//! `l`/`r`. A merge rewrites its neighbour entries in place and pushes their new keys to hot; the
-//! keys already queued for those neighbours go stale, and are recognized and skipped because
-//! their rank half no longer matches the entry's current rank. When the queue runs dry, the
-//! merged word is read back by walking the links from the leftmost live entry.
+//! `left_pair_index`/`right_pair_index`. A merge rewrites its neighbour entries in place and pushes
+//! their new keys to hot; the keys already queued for those neighbours go stale, and are recognized
+//! and skipped because their rank half no longer matches the entry's current rank. When the queue
+//! runs dry, the merged word is read back by walking the links from the leftmost live entry.
 use crate::models::bpe::tables::{BpeTables, ID_MASK, RANK_MASK};
 
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub(crate) struct Entry {
-    /// Rank of the merge (a, b), `DEAD_RANK` when the pair does not merge or was consumed.
-    pub rank: u32,
-    /// Internal id of the token (a, b) merges into.
-    pub prod: u32,
-    /// The pair's symbols, as internal ids.
-    pub a: u32,
-    pub b: u32,
-    /// Arena index of the pair to the left, `NONE` at the word's start.
-    pub l: u32,
-    /// Arena index of the pair to the right, `NONE` at the word's end.
-    pub r: u32,
-}
-
+/// Rank of an [`Entry`] that will not be merged, either because its pair has no merge at all or
+/// because its merge was applied already.
 const DEAD_RANK: u32 = u32::MAX;
+/// No entry, which is what the links of the pairs at both ends of the word hold.
 const NONE: u32 = u32::MAX;
+/// What [`BpeTables::get_value`] returns for a pair that does not merge.
 const NO_MERGE: u64 = u64::MAX;
+/// Stands in for the next key of a drained tier: above every real key, so the other tier wins.
 const EMPTY_KEY: u64 = u64::MAX;
 
-impl Entry {
-    pub fn update(self, tables: &BpeTables, entries: &mut [Entry], hot: &mut Vec<u64>) {
-        if self.l != NONE {
-            // left pair becomes (ent[l].a, prod)
-            let left = &mut entries[self.l as usize];
-            let key = tables.get_value(&left.a, &self.prod);
-            left.b = self.prod;
-            left.rank = (key >> 32) as u32;
-            left.prod = (key & ID_MASK) as u32;
-            left.r = self.r;
-            if key != NO_MERGE {
-                hot_push(hot, (key & RANK_MASK) | self.l as u64)
-            }
-        }
-
-        if self.r != NONE {
-            // right pair becomes (prod, ent[r].b)
-            let right = &mut entries[self.r as usize];
-            let key = tables.get_value(&self.prod, &right.b);
-            right.a = self.prod;
-            right.rank = (key >> 32) as u32;
-            right.prod = (key & ID_MASK) as u32;
-            right.l = self.l;
-            if key != NO_MERGE {
-                hot_push(hot, (key & RANK_MASK) | self.r as u64)
-            }
-        }
-    }
-}
-
-// Binary heap vendored from `std::collections::BinaryHeap`, in min-order over a raw u64 key
-// (rank in the high bits, entry index in the low): std is a max-heap, and wrapping in Reverse
-// would cost us the packed key. Same algorithm as std — sift-up on push, sift-down with early
-// exit on pop (`sift_up` / `sift_down_range`) — and the same "hole" form: the parent/child is
-// shifted into the hole and the key written once at the end, instead of a swap per level.
-#[inline(always)]
-fn hot_push(hot: &mut Vec<u64>, key: u64) {
-    hot.push(key);
-    let mut child = hot.len() - 1;
-    while child > 0 {
-        let parent = (child - 1) / 2;
-        if hot[parent] <= key {
-            break;
-        }
-        hot[child] = hot[parent];
-        child = parent;
-    }
-    hot[child] = key;
-}
-
-#[inline(always)]
-fn hot_pop(hot: &mut Vec<u64>) -> u64 {
-    let top = hot[0];
-    let last = hot.pop().unwrap();
-    let len = hot.len();
-    if len == 0 {
-        return top;
-    }
-    let mut parent = 0usize;
-    loop {
-        let left = 2 * parent + 1;
-        if left >= len {
-            break;
-        }
-        let right = left + 1;
-        let child = if right < len && hot[right] < hot[left] {
-            right
-        } else {
-            left
-        };
-        if hot[child] >= last {
-            break;
-        }
-        hot[parent] = hot[child];
-        parent = child;
-    }
-    hot[parent] = last;
-    top
-}
-
-#[derive(Default)]
-pub struct QueueScratch {
-    /// One [`Entry`] per adjacent pair of the word, linked left/right.
-    pub(crate) entries: Vec<Entry>,
-    /// The initial pairs' keys, sorted once; see the module docs.
-    pub cold: Vec<u64>,
-    /// The merge-created pairs' keys, kept as a binary min-heap.
-    pub hot: Vec<u64>,
-}
-
-/// Merges the word whose pair entries and cold keys `scratch` holds (filled by `convert_queue`),
+/// Merges the word whose pair entries and queue keys `scratch` holds (filled by `convert_queue`),
 /// writing the merged word into `symbols` as internal ids.
-pub fn merge_hot_cold_queue(
-    tables: &BpeTables,
-    symbols: &mut Vec<u32>,
-    scratch: &mut QueueScratch,
-) {
-    let QueueScratch { entries, cold, hot } = scratch;
+pub fn merge_with_queue(tables: &BpeTables, symbols: &mut Vec<u32>, scratch: &mut QueueScratch) {
+    let QueueScratch { entries, queue } = scratch;
     if entries.is_empty() {
         return;
     }
-    // sort the cold only once.
-    cold.sort_unstable();
-    hot.clear();
-    let (mut head, mut single) = (0u32, 0u32);
-    let mut cursor = 0usize;
+    queue.sort_cold();
 
-    loop {
-        let cold_key = cold.get(cursor).copied().unwrap_or(EMPTY_KEY);
-        let hot_key = hot.first().copied().unwrap_or(EMPTY_KEY);
-        let key = if cold_key <= hot_key {
-            if cold_key == EMPTY_KEY {
-                break;
-            }
-            cursor += 1;
-            cold_key
-        } else {
-            hot_pop(hot)
-        };
+    // Entry 0 is the leftmost pair, and only merging the leftmost pair moves it.
+    let mut leftmost = 0u32;
+    // The whole word as one symbol, read back only when `leftmost` ends up `NONE`, which takes the
+    // leftmost pair to have been merged.
+    let mut collapsed_symbol = 0u32;
+
+    while let Some(key) = queue.pop() {
         let index = key as u32 as usize;
         let entry = entries[index];
+        // The entry was rewritten after this key was queued, so the key is stale.
         if entry.rank as u64 != key >> 32 {
             continue;
         }
         entries[index].rank = DEAD_RANK;
-        if entry.l == NONE {
-            head = entry.r;
-            single = entry.prod // pretoken collapsed to one token
+        if entry.left_pair_index == NONE {
+            leftmost = entry.right_pair_index;
+            collapsed_symbol = entry.merged_symbol;
         }
-        entry.update(tables, entries, hot);
+        entry.rewrite_neighbours(tables, entries, queue);
     }
 
     symbols.clear();
-    if head == NONE {
-        symbols.push(single);
+    if leftmost == NONE {
+        symbols.push(collapsed_symbol);
         return;
     }
-    let mut index = head as usize;
-    symbols.push(entries[index].a);
+    let mut index = leftmost as usize;
+    symbols.push(entries[index].left_symbol);
     loop {
-        symbols.push(entries[index].b);
-        match entries[index].r {
+        symbols.push(entries[index].right_symbol);
+        match entries[index].right_pair_index {
             NONE => break,
             next => index = next as usize,
+        }
+    }
+}
+
+/// The buffers one word's merge needs, reused from word to word so that merging allocates nothing.
+#[derive(Default)]
+pub struct QueueScratch {
+    /// One [`Entry`] per adjacent pair of the word, linked left/right.
+    pub(crate) entries: Vec<Entry>,
+    pub(crate) queue: MergeQueue,
+}
+
+/// The two-tier priority queue over pair keys: a sorted vector for the pairs the word starts with,
+/// a binary min-heap for the pairs merges create. The module docs say why.
+#[derive(Default)]
+pub(crate) struct MergeQueue {
+    /// Keys of the pairs the word starts with, in the order [`MergeQueue::sort_cold`] put them.
+    cold: Vec<u64>,
+    /// Keys of the pairs merges create, as a binary min-heap.
+    hot: Vec<u64>,
+    /// How far into `cold` [`MergeQueue::pop`] has walked.
+    cold_cursor: usize,
+}
+
+impl MergeQueue {
+    /// Empties both tiers for a new word, leaving room for `pairs` cold keys.
+    pub(super) fn clear(&mut self, pairs: usize) {
+        self.cold.clear();
+        self.cold.reserve(pairs);
+        self.hot.clear();
+        self.cold_cursor = 0;
+    }
+
+    /// Queues one of the pairs the word starts with. Every cold key is pushed before the first
+    /// [`MergeQueue::pop`], which is what lets one sort replace a heap.
+    #[inline(always)]
+    pub(super) fn push_cold(&mut self, key: u64) {
+        self.cold.push(key);
+    }
+
+    /// Queues a pair a merge created.
+    #[inline(always)]
+    fn push(&mut self, key: u64) {
+        heappush(&mut self.hot, key);
+    }
+
+    /// Sorts the cold tier, so that [`MergeQueue::pop`] can read it front to back. Called once,
+    /// after the conversion has pushed every cold key.
+    fn sort_cold(&mut self) {
+        self.cold.sort_unstable();
+    }
+
+    /// The lowest key of the two tiers, `None` once both are drained.
+    #[inline(always)]
+    fn pop(&mut self) -> Option<u64> {
+        let cold_key = self
+            .cold
+            .get(self.cold_cursor)
+            .copied()
+            .unwrap_or(EMPTY_KEY);
+        let hot_key = self.hot.first().copied().unwrap_or(EMPTY_KEY);
+        if cold_key <= hot_key {
+            if cold_key == EMPTY_KEY {
+                return None;
+            }
+            self.cold_cursor += 1;
+            Some(cold_key)
+        } else {
+            Some(heappop(&mut self.hot))
+        }
+    }
+}
+
+// Binary heap vendored from `std::collections::BinaryHeap`, in min-order over a raw u64 key (rank
+// in the high bits, entry index in the low): std is a max-heap, and wrapping in Reverse would cost
+// us the packed key. Same algorithm as std -- sift-up on push, sift-down with early exit on pop
+// (`sift_up` / `sift_down_range`) -- and the same "hole" form: the parent or child is shifted into
+// the hole and the key written once at the end, instead of a swap per level.
+#[inline(always)]
+fn heappush(heap: &mut Vec<u64>, key: u64) {
+    heap.push(key);
+    let mut hole = heap.len() - 1;
+    while hole > 0 {
+        let parent = (hole - 1) / 2;
+        if heap[parent] <= key {
+            break;
+        }
+        heap[hole] = heap[parent];
+        hole = parent;
+    }
+    heap[hole] = key;
+}
+
+/// Removes and returns the smallest key. The heap must not be empty.
+#[inline(always)]
+fn heappop(heap: &mut Vec<u64>) -> u64 {
+    let top = heap[0];
+    let tail = heap.pop().unwrap();
+    let len = heap.len();
+    if len == 0 {
+        return top;
+    }
+    let mut hole = 0usize;
+    loop {
+        let left_child = 2 * hole + 1;
+        if left_child >= len {
+            break;
+        }
+        let right_child = left_child + 1;
+        let child = if right_child < len && heap[right_child] < heap[left_child] {
+            right_child
+        } else {
+            left_child
+        };
+        if heap[child] >= tail {
+            break;
+        }
+        heap[hole] = heap[child];
+        hole = child;
+    }
+    heap[hole] = tail;
+    top
+}
+
+/// One adjacent pair of the word: the two symbols, the merge the tables have for them, and the
+/// pairs on either side of it.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub(crate) struct Entry {
+    /// Rank (priority) of the merge, `DEAD_RANK` when the pair does not merge or was consumed.
+    pub rank: u32,
+    /// The pair's symbols, as internal ids.
+    pub left_symbol: u32,
+    pub right_symbol: u32,
+    /// The symbol (internal id) of the merged pair. Only meaningful while `rank` is not
+    /// `DEAD_RANK`: a pair that does not merge has no merged symbol.
+    pub merged_symbol: u32,
+    /// Arena index of the pair to the left, `NONE` at the word's start.
+    pub left_pair_index: u32,
+    /// Arena index of the pair to the right, `NONE` at the word's end.
+    pub right_pair_index: u32,
+}
+
+impl Entry {
+    /// Applies this entry's merge to the pairs on either side of it: each takes `merged_symbol` for
+    /// the symbol it shared with this pair, links past this entry, and queues the key of the pair
+    /// it has become.
+    fn rewrite_neighbours(self, tables: &BpeTables, entries: &mut [Entry], queue: &mut MergeQueue) {
+        if self.left_pair_index != NONE {
+            // the pair to the left becomes (its own left symbol, merged_symbol)
+            let left_pair = &mut entries[self.left_pair_index as usize];
+            let merge = tables.get_value(&left_pair.left_symbol, &self.merged_symbol);
+            left_pair.right_symbol = self.merged_symbol;
+            left_pair.rank = (merge >> 32) as u32;
+            left_pair.merged_symbol = (merge & ID_MASK) as u32;
+            left_pair.right_pair_index = self.right_pair_index;
+            if merge != NO_MERGE {
+                queue.push((merge & RANK_MASK) | self.left_pair_index as u64)
+            }
+        }
+
+        if self.right_pair_index != NONE {
+            // the pair to the right becomes (merged_symbol, its own right symbol)
+            let right_pair = &mut entries[self.right_pair_index as usize];
+            let merge = tables.get_value(&self.merged_symbol, &right_pair.right_symbol);
+            right_pair.left_symbol = self.merged_symbol;
+            right_pair.rank = (merge >> 32) as u32;
+            right_pair.merged_symbol = (merge & ID_MASK) as u32;
+            right_pair.left_pair_index = self.left_pair_index;
+            if merge != NO_MERGE {
+                queue.push((merge & RANK_MASK) | self.right_pair_index as u64)
+            }
         }
     }
 }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -8,7 +8,7 @@ use crate::models::bpe::legacy::model::BPE;
 use crate::models::bpe::merge_hot_cold_queue::{QueueScratch, merge_hot_cold_queue};
 use crate::models::bpe::merge_multipass::merge_multipass;
 use crate::models::bpe::tables::BpeTables;
-use crate::pipeline::{self, PipelineToken, Span};
+use crate::pipeline::{self, PipelineToken};
 use crate::tokenizer::Result;
 use crate::utils::byte_level::{self};
 use crate::utils::word_cache::{Lookup, WordCache};
@@ -347,74 +347,6 @@ impl pipeline::Model for PipelineBPE {
             cache.insert(at, output[start..].iter().map(|token| token.id()));
         }
 
-        Ok(())
-    }
-
-    /// Every pre-token of a chunk in one call.
-    ///
-    /// Same work per word as [`Self::tokenize_pipeline`]; what changes is what is *not* repeated.
-    /// The scratch is destructured once instead of once per word, the output is grown once for the
-    /// whole batch instead of being capacity-checked on every push, and the virtual call, the
-    /// slice and the `Result` happen once per chunk rather than once per pre-token.
-    fn tokenize_spans(
-        &self,
-        chunk: &str,
-        spans: &[Span],
-        scratch: &mut Self::Scratch,
-        output: &mut Vec<PipelineToken>,
-    ) -> Result<()> {
-        let BpeScratch {
-            symbols,
-            queue,
-            word_cache,
-        } = scratch;
-
-        // One reservation for the batch. Most pre-tokens are a single token, so the span count is
-        // a close lower bound on what the batch emits; anything past it grows as usual.
-        output.reserve(spans.len());
-
-        for span in spans {
-            // SAFETY: the pre-tokenizer cuts on char boundaries, so a span is always a valid slice
-            // of this chunk. Bounds- and UTF-8-checking it again per word measured worth removing.
-            let sequence = unsafe { chunk.get_unchecked(span.range()) };
-            if sequence.is_empty() {
-                continue;
-            }
-
-            // Same order as `tokenize_pipeline`, and it has to stay that way: the fold answers a
-            // word that is itself a foldable vocabulary entry in one probe, and those words never
-            // reach the cache. Probing the cache first would populate it with words the fold
-            // already serves for free, and the two paths would disagree about what it holds.
-            if let Some(id) = self.fold_id(sequence) {
-                output.push(PipelineToken::from(id));
-                continue;
-            }
-
-            let mut placement = None;
-            if let Some(cache) = word_cache.as_mut() {
-                match cache.lookup(sequence.as_bytes()) {
-                    Lookup::Hit(ids) => {
-                        output.extend(ids.iter().copied().map(PipelineToken::from));
-                        continue;
-                    }
-                    Lookup::Miss(at) => placement = Some(at),
-                }
-            }
-
-            let start = output.len();
-            self.merge_word(sequence, symbols, queue);
-            // the merge engines work in internal ids; `unmap` takes them back to the vocab's own ids
-            output.extend(
-                symbols
-                    .iter()
-                    .map(|&symbol| PipelineToken::from(self.tables.unmap.at(symbol as usize))),
-            );
-            if let Some(cache) = word_cache.as_mut()
-                && let Some(at) = placement
-            {
-                cache.insert(at, output[start..].iter().map(|token| token.id()));
-            }
-        }
         Ok(())
     }
 

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -5,7 +5,7 @@ use crate::models::bpe::At;
 use crate::models::bpe::Error;
 use crate::models::bpe::convert::{AFFIX_BUF, Affixes};
 use crate::models::bpe::legacy::model::BPE;
-use crate::models::bpe::merge_hot_cold_queue::{QueueScratch, merge_hot_cold_queue};
+use crate::models::bpe::merge_hot_cold_queue::{QueueScratch, merge_with_queue};
 use crate::models::bpe::merge_multipass::merge_multipass;
 use crate::models::bpe::tables::BpeTables;
 use crate::pipeline::{self, PipelineToken};
@@ -268,13 +268,8 @@ impl PipelineBPE {
 
         if sequence.len() > gate as usize {
             // conversion writes the entries and cold keys directly: no intermediate symbol array
-            self.convert_queue(
-                sequence,
-                symbols,
-                &mut queue_scratch.entries,
-                &mut queue_scratch.cold,
-            );
-            merge_hot_cold_queue(&self.tables, symbols, queue_scratch);
+            self.convert_queue(sequence, symbols, queue_scratch);
+            merge_with_queue(&self.tables, symbols, queue_scratch);
         } else {
             let first_merge = self.convert_multipass(sequence, symbols);
             merge_multipass(&self.tables, symbols, first_merge);

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -310,7 +310,7 @@ impl pipeline::Model for PipelineBPE {
         }
 
         if let Some(id) = self.fold_id(sequence) {
-            output.push(PipelineToken { id });
+            output.push(PipelineToken::from(id));
             return Ok(());
         }
 
@@ -324,7 +324,7 @@ impl pipeline::Model for PipelineBPE {
         let insert_at = if let Some(cache) = word_cache.as_mut() {
             match cache.lookup(sequence.as_bytes()) {
                 Lookup::Hit(ids) => {
-                    output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                    output.extend(ids.iter().copied().map(PipelineToken::from));
                     return Ok(());
                 }
                 Lookup::Miss(at) => Some(at),
@@ -336,13 +336,15 @@ impl pipeline::Model for PipelineBPE {
         let start = output.len();
         self.merge_word(sequence, symbols, queue);
         // the merge engines work in internal ids; `unmap` takes them back to the vocab's own ids
-        output.extend(symbols.iter().map(|&symbol| PipelineToken {
-            id: self.tables.unmap.at(symbol as usize),
-        }));
+        output.extend(
+            symbols
+                .iter()
+                .map(|&symbol| PipelineToken::from(self.tables.unmap.at(symbol as usize))),
+        );
         if let Some(cache) = word_cache.as_mut()
             && let Some(at) = insert_at
         {
-            cache.insert(at, output[start..].iter().map(|token| token.id));
+            cache.insert(at, output[start..].iter().map(|token| token.id()));
         }
 
         Ok(())
@@ -384,7 +386,7 @@ impl pipeline::Model for PipelineBPE {
             // reach the cache. Probing the cache first would populate it with words the fold
             // already serves for free, and the two paths would disagree about what it holds.
             if let Some(id) = self.fold_id(sequence) {
-                output.push(PipelineToken { id });
+                output.push(PipelineToken::from(id));
                 continue;
             }
 
@@ -392,7 +394,7 @@ impl pipeline::Model for PipelineBPE {
             if let Some(cache) = word_cache.as_mut() {
                 match cache.lookup(sequence.as_bytes()) {
                     Lookup::Hit(ids) => {
-                        output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                        output.extend(ids.iter().copied().map(PipelineToken::from));
                         continue;
                     }
                     Lookup::Miss(at) => placement = Some(at),
@@ -402,13 +404,15 @@ impl pipeline::Model for PipelineBPE {
             let start = output.len();
             self.merge_word(sequence, symbols, queue);
             // the merge engines work in internal ids; `unmap` takes them back to the vocab's own ids
-            output.extend(symbols.iter().map(|&symbol| PipelineToken {
-                id: self.tables.unmap.at(symbol as usize),
-            }));
+            output.extend(
+                symbols
+                    .iter()
+                    .map(|&symbol| PipelineToken::from(self.tables.unmap.at(symbol as usize))),
+            );
             if let Some(cache) = word_cache.as_mut()
                 && let Some(at) = placement
             {
-                cache.insert(at, output[start..].iter().map(|token| token.id));
+                cache.insert(at, output[start..].iter().map(|token| token.id()));
             }
         }
         Ok(())
@@ -462,7 +466,7 @@ mod fold_tests {
                 .unwrap()
                 .remove(0)
                 .iter()
-                .map(|t| t.id)
+                .map(|t| t.id())
                 .collect();
             assert_eq!(want, got, "the fold changed the ids for {text:?}");
         }
@@ -504,7 +508,7 @@ mod fold_tests {
             .unwrap()
             .remove(0)
             .iter()
-            .map(|t| t.id)
+            .map(|t| t.id())
             .collect();
         assert_eq!(want.len(), got.len(), "token count differs");
         assert_eq!(want, got, "the batched path changed the ids");

--- a/tokenizers/tk-encode/src/models/bpe/tests.rs
+++ b/tokenizers/tk-encode/src/models/bpe/tests.rs
@@ -535,7 +535,7 @@ mod pipeline_bpe {
         let mut out = Vec::new();
         let mut scratch = model.init_scratch();
         pipeline::Model::tokenize_pipeline(model, sequence, &mut scratch, &mut out).unwrap();
-        out.iter().map(|t| t.id).collect()
+        out.iter().map(|t| t.id()).collect()
     }
 
     fn reference_ids(model: &BPE, sequence: &str) -> Vec<u32> {
@@ -587,7 +587,7 @@ mod pipeline_bpe {
         for input in ["hello", "hell", "helo", "oleh", "hello", "", "hxe"] {
             let mut out = Vec::new();
             pipeline::Model::tokenize_pipeline(&model, input, &mut scratch, &mut out).unwrap();
-            let got: Vec<u32> = out.iter().map(|t| t.id).collect();
+            let got: Vec<u32> = out.iter().map(|t| t.id()).collect();
             assert_eq!(got, reference_ids(&reference, input), "{input:?}");
         }
     }
@@ -615,7 +615,7 @@ mod pipeline_bpe {
             ] {
                 let mut out = Vec::new();
                 pipeline::Model::tokenize_pipeline(&cached, word, &mut scratch, &mut out).unwrap();
-                let got: Vec<u32> = out.iter().map(|t| t.id).collect();
+                let got: Vec<u32> = out.iter().map(|t| t.id()).collect();
                 assert_eq!(got, pipeline_ids(&uncached, word), "{word:?}");
             }
         }

--- a/tokenizers/tk-encode/src/models/unigram/model.rs
+++ b/tokenizers/tk-encode/src/models/unigram/model.rs
@@ -554,7 +554,7 @@ impl pipeline::Model for Unigram {
         {
             match cache.lookup(sequence.as_bytes()) {
                 Lookup::Hit(ids) => {
-                    output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                    output.extend(ids.iter().copied().map(PipelineToken::from));
                     return Ok(());
                 }
                 Lookup::Miss(at) => placement = Some(at),
@@ -565,7 +565,7 @@ impl pipeline::Model for Unigram {
         for string in self.encode_uncached(sequence)? {
             match self.token_to_ids.token_to_id(&string) {
                 Some(id) => {
-                    output.push(PipelineToken { id });
+                    output.push(PipelineToken::from(id));
                 }
                 None => {
                     if self.byte_fallback {
@@ -577,13 +577,13 @@ impl pipeline::Model for Unigram {
                             })
                             .collect();
                         if let Some(token_ids) = byte_token_ids {
-                            output.extend(token_ids.iter().map(|&id| PipelineToken { id }));
+                            output.extend(token_ids.iter().copied().map(PipelineToken::from));
                             continue;
                         }
                     }
-                    output.push(PipelineToken {
-                        id: self.unk_id.ok_or(UnigramError::MissingUnkId)? as u32,
-                    });
+                    output.push(PipelineToken::from(
+                        self.unk_id.ok_or(UnigramError::MissingUnkId)? as u32,
+                    ));
                 }
             };
         }
@@ -593,7 +593,7 @@ impl pipeline::Model for Unigram {
         if let Some(cache) = scratch.word_cache.as_mut()
             && let Some(at) = placement
         {
-            cache.insert(at, output[start..].iter().map(|token| token.id));
+            cache.insert(at, output[start..].iter().map(|token| token.id()));
         }
         Ok(())
     }
@@ -777,7 +777,7 @@ mod tests {
     fn pipeline_ids(model: &Unigram, sequence: &str, scratch: &mut UnigramScratch) -> Vec<u32> {
         let mut output = vec![];
         pipeline::Model::tokenize_pipeline(model, sequence, scratch, &mut output).unwrap();
-        output.iter().map(|token| token.id).collect()
+        output.iter().map(|token| token.id()).collect()
     }
 
     #[test]
@@ -830,7 +830,7 @@ mod tests {
         pipeline::Model::tokenize_pipeline(&model, "ab", &mut scratch, &mut output).unwrap();
         pipeline::Model::tokenize_pipeline(&model, "cd", &mut scratch, &mut output).unwrap();
 
-        let ids: Vec<u32> = output.iter().map(|token| token.id).collect();
+        let ids: Vec<u32> = output.iter().map(|token| token.id()).collect();
         assert_eq!(ids, [6, 5]);
         let cache = scratch.word_cache.as_mut().unwrap();
         assert_eq!(cache.lookup(b"cd").hit(), Some(&[5u32][..]));

--- a/tokenizers/tk-encode/src/models/wordlevel/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordlevel/mod.rs
@@ -220,9 +220,9 @@ impl pipeline::Model for WordLevel {
         output: &mut Vec<pipeline::PipelineToken>,
     ) -> Result<()> {
         if let Some(&id) = self.vocab.get(sequence) {
-            output.push(PipelineToken { id })
+            output.push(PipelineToken::from(id))
         } else if let Some(&unk_id) = self.vocab.get(&self.unk_token) {
-            output.push(PipelineToken { id: unk_id });
+            output.push(PipelineToken::from(unk_id));
         } else {
             return Err(Box::new(Error::MissingUnkToken));
         }

--- a/tokenizers/tk-encode/src/models/wordpiece/mod.rs
+++ b/tokenizers/tk-encode/src/models/wordpiece/mod.rs
@@ -380,7 +380,7 @@ impl PipelineWordPiece {
         let char_len = sequence.chars().count();
         if char_len > self.max_input_chars_per_word {
             let unk_id = self.unk_token.ok_or(Error::MissingUnkToken)?;
-            output.push(PipelineToken { id: unk_id });
+            output.push(PipelineToken::from(unk_id));
             return Ok(());
         }
 
@@ -407,10 +407,10 @@ impl PipelineWordPiece {
             else {
                 let unk_id = self.unk_token.ok_or(Error::MissingUnkToken)?;
                 output.truncate(checkpoint);
-                output.push(PipelineToken { id: unk_id });
+                output.push(PipelineToken::from(unk_id));
                 return Ok(());
             };
-            output.push(PipelineToken { id: token_id });
+            output.push(PipelineToken::from(token_id));
             start += match_len - prefix_len;
         }
         Ok(())
@@ -449,7 +449,7 @@ impl pipeline::Model for PipelineWordPiece {
 
         let placement = match word_cache.lookup(sequence.as_bytes()) {
             Lookup::Hit(ids) => {
-                output.extend(ids.iter().map(|&id| PipelineToken { id }));
+                output.extend(ids.iter().copied().map(PipelineToken::from));
                 return Ok(());
             }
             Lookup::Miss(at) => at,
@@ -458,7 +458,7 @@ impl pipeline::Model for PipelineWordPiece {
         let start = output.len();
         self.tokenize_word(sequence, candidate_str, output)?;
 
-        word_cache.insert(placement, output[start..].iter().map(|token| token.id));
+        word_cache.insert(placement, output[start..].iter().map(|token| token.id()));
         Ok(())
     }
 }
@@ -501,7 +501,7 @@ mod tests {
     ) -> Vec<u32> {
         let mut output = vec![];
         pipeline::Model::tokenize_pipeline(model, sequence, scratch, &mut output).unwrap();
-        output.iter().map(|token| token.id).collect()
+        output.iter().map(|token| token.id()).collect()
     }
 
     #[test]
@@ -556,7 +556,7 @@ mod tests {
         pipeline::Model::tokenize_pipeline(&model, "hello", &mut scratch, &mut output).unwrap();
         pipeline::Model::tokenize_pipeline(&model, "world", &mut scratch, &mut output).unwrap();
 
-        let ids: Vec<u32> = output.iter().map(|token| token.id).collect();
+        let ids: Vec<u32> = output.iter().map(|token| token.id()).collect();
         assert_eq!(ids, [3, 4]);
         assert_eq!(scratch.word_cache.lookup(b"world").hit(), Some(&[4u32][..]));
     }

--- a/tokenizers/tk-encode/src/normalizers/metaspace.rs
+++ b/tokenizers/tk-encode/src/normalizers/metaspace.rs
@@ -54,7 +54,15 @@ impl pipeline::Normalizer for MetaspaceNormalizer {
             // Whitespace is thrown away, so cut the text where `WhitespaceSplit` would and write the
             // words back one after the other, each with its own delimiter.
             let mut words = Vec::new();
-            pipeline::PreTokenizer::pre_tokenize(&WhitespaceSplit, input, &mut words)?;
+            // A normalizer runs before the pipeline reaches its pre-tokenizer, so there is no
+            // scratch to borrow here and this one is built and thrown away per call.
+            let mut scratch = pipeline::PreTokenizerScratch::default();
+            pipeline::PreTokenizer::pre_tokenize(
+                &WhitespaceSplit,
+                input,
+                &mut scratch,
+                &mut words,
+            )?;
             for span in &words {
                 let word = &input[span.range()];
                 // The text may already hold delimiters of its own — never write a second one.

--- a/tokenizers/tk-encode/src/normalizers/metaspace.rs
+++ b/tokenizers/tk-encode/src/normalizers/metaspace.rs
@@ -15,7 +15,6 @@
 
 use std::borrow::Cow;
 
-use crate::pre_tokenizers::whitespace::WhitespaceSplit;
 use crate::tokenizer::{Result, pipeline};
 
 /// Writes the delimiter where words start (after a space)

--- a/tokenizers/tk-encode/src/normalizers/metaspace.rs
+++ b/tokenizers/tk-encode/src/normalizers/metaspace.rs
@@ -51,20 +51,7 @@ impl pipeline::Normalizer for MetaspaceNormalizer {
         // The delimiter is 3 bytes where a space is 1, so the rewrite grows by 2 bytes per space, hence we allocate a bit more space
         let mut rewritten = String::with_capacity(input.len() + input.len() / 2);
         if self.drop_whitespace {
-            // Whitespace is thrown away, so cut the text where `WhitespaceSplit` would and write the
-            // words back one after the other, each with its own delimiter.
-            let mut words = Vec::new();
-            // A normalizer runs before the pipeline reaches its pre-tokenizer, so there is no
-            // scratch to borrow here and this one is built and thrown away per call.
-            let mut scratch = pipeline::PreTokenizerScratch::default();
-            pipeline::PreTokenizer::pre_tokenize(
-                &WhitespaceSplit,
-                input,
-                &mut scratch,
-                &mut words,
-            )?;
-            for span in &words {
-                let word = &input[span.range()];
+            for word in input.split_whitespace() {
                 // The text may already hold delimiters of its own — never write a second one.
                 if self.prepend && !word.starts_with(self.delimiter) {
                     rewritten.push(self.delimiter);

--- a/tokenizers/tk-encode/src/pre_tokenizers/bert.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/bert.rs
@@ -17,7 +17,9 @@ impl PreTokenizer for BertPreTokenizer {
     }
 }
 
-impl pipeline::PreTokenizer for BertPreTokenizer {
+// SAFETY: the spans come from an `atomsplit` fsm, which splits only at character boundaries of `text`.
+// See `atomsplit::fsm` docs.
+unsafe impl pipeline::PreTokenizer for BertPreTokenizer {
     #[inline(never)]
     fn pre_tokenize(
         &self,

--- a/tokenizers/tk-encode/src/pre_tokenizers/bert.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/bert.rs
@@ -1,8 +1,10 @@
-use crate::pipeline;
+use crate::pipeline::{self, PreTokenizerScratch};
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use crate::utils::macro_rules_attribute;
 
 use super::punctuation::is_punc;
+use atomsplit::classify::mask;
+use atomsplit::fsm::class_runs_into;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
@@ -17,18 +19,20 @@ impl PreTokenizer for BertPreTokenizer {
 
 impl pipeline::PreTokenizer for BertPreTokenizer {
     #[inline(never)]
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        scratch: &mut PreTokenizerScratch,
+        out: &mut Vec<pipeline::Span>,
+    ) -> Result<()> {
         // Bert pre-tokenization = drop whitespace runs, isolate each punctuation char, keep every other
         // run. One `atomsplit` SIMD classify (bytes → atom tags) + the class-runs FSM, byte-exact with
         // the legacy `char::is_whitespace` / `is_punc` split above (see the tests).
-        use atomsplit::classify::{classify, mask};
-        use atomsplit::fsm::class_runs_into;
-        let bytes = text.as_bytes();
-        let mut tags = vec![0u8; bytes.len()];
-        classify(bytes, &mut tags);
-        let mut spans = vec![pipeline::Span::default(); bytes.len() + 1];
-        let n = class_runs_into::<{ mask::WS }, { mask::PUNCT }, 0>(bytes, &tags, &mut spans);
-        out.extend_from_slice(&spans[..n]);
+        scratch.split_on_tags(
+            text.as_bytes(),
+            class_runs_into::<{ mask::WS }, { mask::PUNCT }, 0>,
+            out,
+        );
         Ok(())
     }
 }
@@ -38,10 +42,13 @@ mod tests {
     use super::BertPreTokenizer;
     use crate::{NormalizedString, OffsetReferential, OffsetType, PreTokenizedString};
 
+    use crate::pipeline::PreTokenizerScratch;
     fn pretokenize(text: &str) -> Vec<(&str, (u32, u32))> {
         let pretok = BertPreTokenizer;
+        let mut scratch = PreTokenizerScratch::default();
         let mut splits = Vec::new();
-        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut scratch, &mut splits)
+            .unwrap();
         splits
             .iter()
             .map(|s| (&text[s.range()], (s.start, s.end)))

--- a/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/byte_level.rs
@@ -532,8 +532,10 @@ mod tests {
             crate::PreTokenizerWrapper::ByteLevel(byte_level),
         )
         .unwrap();
+        let mut scratch = crate::pipeline::PreTokenizerScratch::default();
         let mut out = Vec::new();
-        crate::pipeline::PreTokenizer::pre_tokenize(&converted, text, &mut out).unwrap();
+        crate::pipeline::PreTokenizer::pre_tokenize(&converted, text, &mut scratch, &mut out)
+            .unwrap();
         out.iter()
             .map(|s| {
                 let transformed = text[s.range()]

--- a/tokenizers/tk-encode/src/pre_tokenizers/delimiter.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/delimiter.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::pipeline;
+use crate::pipeline::PreTokenizerScratch;
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use crate::utils::macro_rules_attribute;
 
@@ -27,17 +28,26 @@ impl PreTokenizer for CharDelimiterSplit {
 }
 
 impl pipeline::PreTokenizer for CharDelimiterSplit {
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        scratch: &mut PreTokenizerScratch,
+        out: &mut Vec<pipeline::Span>,
+    ) -> Result<()> {
         // native atomsplit FSM (memchr-backed single-byte scan); `Removed` — drops the delimiter,
         // keeps the runs between, no empty spans. Byte-exact with the char-predicate split.
-        let bytes = text.as_bytes();
-        let mut spans = vec![pipeline::Span::default(); bytes.len() + 1];
-        let n = atomsplit::fsm::CharDelimiterSplit(self.delimiter).pre_tokenize(
-            bytes,
-            &mut [],
-            &mut spans,
+        // It keys on the delimiter's own bytes rather than on an atom class, so it needs no tags.
+        scratch.split_on_bytes(
+            text.as_bytes(),
+            |bytes, spans| {
+                atomsplit::fsm::CharDelimiterSplit(self.delimiter).pre_tokenize(
+                    bytes,
+                    &mut [],
+                    spans,
+                )
+            },
+            out,
         );
-        out.extend_from_slice(&spans[..n]);
         Ok(())
     }
 }
@@ -48,8 +58,10 @@ mod tests {
 
     fn pretokenize(delimiter: char, text: &str) -> Vec<(&str, (u32, u32))> {
         let pretok = CharDelimiterSplit::new(delimiter);
+        let mut scratch = pipeline::PreTokenizerScratch::default();
         let mut splits = Vec::new();
-        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut scratch, &mut splits)
+            .unwrap();
         splits
             .iter()
             .map(|s| (&text[s.range()], (s.start, s.end)))

--- a/tokenizers/tk-encode/src/pre_tokenizers/delimiter.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/delimiter.rs
@@ -27,7 +27,10 @@ impl PreTokenizer for CharDelimiterSplit {
     }
 }
 
-impl pipeline::PreTokenizer for CharDelimiterSplit {
+// SAFETY: the spans come from `atomsplit::fsm::CharDelimiterSplit`, which splits only at character
+// boundaries of `text`. It scans for the delimiter's own UTF-8 bytes and confirms the whole encoding
+// before cutting.
+unsafe impl pipeline::PreTokenizer for CharDelimiterSplit {
     fn pre_tokenize(
         &self,
         text: &str,

--- a/tokenizers/tk-encode/src/pre_tokenizers/digits.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/digits.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use crate::pipeline;
+use crate::pipeline::{self, PreTokenizerScratch};
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use crate::utils::macro_rules_attribute;
+use atomsplit::classify::mask;
+use atomsplit::fsm::class_runs_into;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Pre tokenizes the numbers into single tokens. If individual_digits is set
@@ -40,23 +42,29 @@ impl PreTokenizer for Digits {
 }
 
 impl pipeline::PreTokenizer for Digits {
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        scratch: &mut PreTokenizerScratch,
+        out: &mut Vec<pipeline::Span>,
+    ) -> Result<()> {
         // isolate each numeric char (`individual_digits`) or keep numeric runs — atomsplit classify +
         // class-runs FSM. atom `NUMERIC` == `char::is_numeric`, so byte-exact with the scalar path.
-        use atomsplit::classify::{classify, mask};
-        use atomsplit::fsm::class_runs_into;
-        let bytes = text.as_bytes();
-        let mut tags = vec![0u8; bytes.len()];
-        classify(bytes, &mut tags);
-        let mut spans = vec![pipeline::Span::default(); bytes.len() + 1];
-        let n = if self.individual_digits {
-            class_runs_into::<0, { mask::NUMERIC }, 0>(bytes, &tags, &mut spans)
-        // isolate each digit
+        if self.individual_digits {
+            // isolate each digit
+            scratch.split_on_tags(
+                text.as_bytes(),
+                class_runs_into::<0, { mask::NUMERIC }, 0>,
+                out,
+            );
         } else {
-            class_runs_into::<0, 0, { mask::NUMERIC }>(bytes, &tags, &mut spans)
             // keep digit runs
-        };
-        out.extend_from_slice(&spans[..n]);
+            scratch.split_on_tags(
+                text.as_bytes(),
+                class_runs_into::<0, 0, { mask::NUMERIC }>,
+                out,
+            );
+        }
         Ok(())
     }
 }
@@ -69,7 +77,9 @@ mod tests {
     fn pretokenize(individual_digits: bool, text: &str) -> Vec<(&str, (u32, u32))> {
         let pretok = Digits::new(individual_digits);
         let mut splits = Vec::new();
-        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        let mut scratch = PreTokenizerScratch::default();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut scratch, &mut splits)
+            .unwrap();
         splits
             .iter()
             .map(|s| (&text[s.range()], (s.start, s.end)))

--- a/tokenizers/tk-encode/src/pre_tokenizers/digits.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/digits.rs
@@ -41,7 +41,9 @@ impl PreTokenizer for Digits {
     }
 }
 
-impl pipeline::PreTokenizer for Digits {
+// SAFETY: the spans come from an `atomsplit` fsm, which splits only at character boundaries of `text`.
+// See `atomsplit::fsm` docs.
+unsafe impl pipeline::PreTokenizer for Digits {
     fn pre_tokenize(
         &self,
         text: &str,

--- a/tokenizers/tk-encode/src/pre_tokenizers/fixed_length.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/fixed_length.rs
@@ -50,7 +50,9 @@ impl PreTokenizer for FixedLength {
     }
 }
 
-impl pipeline::PreTokenizer for FixedLength {
+// SAFETY: every offset is one `str::char_indices` yielded, or `text.len()`, and they are pushed in
+// increasing order.
+unsafe impl pipeline::PreTokenizer for FixedLength {
     fn pre_tokenize(
         &self,
         text: &str,

--- a/tokenizers/tk-encode/src/pre_tokenizers/fixed_length.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/fixed_length.rs
@@ -51,7 +51,12 @@ impl PreTokenizer for FixedLength {
 }
 
 impl pipeline::PreTokenizer for FixedLength {
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        _scratch: &mut pipeline::PreTokenizerScratch,
+        out: &mut Vec<pipeline::Span>,
+    ) -> Result<()> {
         if text.is_empty() {
             return Ok(());
         }
@@ -91,8 +96,10 @@ mod tests {
 
     fn pretokenize(length: usize, text: &str) -> Vec<(&str, (u32, u32))> {
         let pretok = FixedLength { length };
+        let mut scratch = pipeline::PreTokenizerScratch::default();
         let mut splits = Vec::new();
-        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut scratch, &mut splits)
+            .unwrap();
         splits
             .iter()
             .map(|s| (&text[s.range()], (s.start, s.end)))

--- a/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
@@ -488,8 +488,10 @@ mod tests {
                     .collect();
 
                 let normalized = pipeline::Normalizer::normalize(&normalizer, text).unwrap();
+                let mut scratch = pipeline::PreTokenizerScratch::default();
                 let mut spans = Vec::new();
-                pipeline::PreTokenizer::pre_tokenize(&split, &normalized, &mut spans).unwrap();
+                pipeline::PreTokenizer::pre_tokenize(&split, &normalized, &mut scratch, &mut spans)
+                    .unwrap();
                 let words: Vec<&str> = spans.iter().map(|s| &normalized[s.range()]).collect();
                 assert_eq!(words, expected, "{text:?}");
             }

--- a/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
@@ -461,6 +461,9 @@ mod tests {
             "  both  ",
             "one\ttab\nand a newline",
             "\tleading tab",
+            // A gap that is whitespace to `char::is_whitespace` but not to an ASCII scan:
+            // a no-break space and an ideographic space.
+            "nbsp\u{a0}gap and\u{3000}an ideographic space",
             "▁already marked",
             "a▁b c",
             "▁▁▁a b",

--- a/tokenizers/tk-encode/src/pre_tokenizers/punctuation.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/punctuation.rs
@@ -41,7 +41,10 @@ impl PreTokenizer for Punctuation {
     }
 }
 
-impl pipeline::PreTokenizer for Punctuation {
+// SAFETY: both routes cut only at character boundaries of `text`.
+// The class-runs route is an `atomsplit` fsm.
+// the merge behaviors go through `pipeline::split_delimiter`, which takes its offsets from `str::char_indices`.
+unsafe impl pipeline::PreTokenizer for Punctuation {
     fn pre_tokenize(
         &self,
         text: &str,

--- a/tokenizers/tk-encode/src/pre_tokenizers/punctuation.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/punctuation.rs
@@ -1,8 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use crate::pipeline;
+use crate::pipeline::{self, PreTokenizerScratch};
 use crate::tokenizer::{PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior};
 use crate::utils::macro_rules_attribute;
+use SplitDelimiterBehavior::{Isolated, Removed};
+use atomsplit::classify::mask;
+use atomsplit::fsm::class_runs_into;
 use unicode_categories::UnicodeCategories;
 
 pub(crate) fn is_punc(x: char) -> bool {
@@ -39,22 +42,26 @@ impl PreTokenizer for Punctuation {
 }
 
 impl pipeline::PreTokenizer for Punctuation {
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
-        use SplitDelimiterBehavior::{Isolated, Removed};
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        scratch: &mut PreTokenizerScratch,
+        out: &mut Vec<pipeline::Span>,
+    ) -> Result<()> {
         // atom `PUNCT` == `is_punc` (ASCII-punct ∪ \p{P}), so Isolated/Removed map to the class-runs FSM
         // byte-exactly. The merge/contiguous behaviors aren't a class-runs shape → keep the scalar split.
-        if matches!(self.behavior, Isolated | Removed) {
-            use atomsplit::classify::mask;
-            use atomsplit::fsm::class_runs_into;
-            pipeline::classify_into_spans(
+        if self.behavior == Removed {
+            // drop punct
+            scratch.split_on_tags(
                 text.as_bytes(),
-                |b, t, s| {
-                    if self.behavior == Removed {
-                        class_runs_into::<{ mask::PUNCT }, 0, 0>(b, t, s) // drop punct
-                    } else {
-                        class_runs_into::<0, { mask::PUNCT }, 0>(b, t, s) // isolate each punct
-                    }
-                },
+                class_runs_into::<{ mask::PUNCT }, 0, 0>,
+                out,
+            );
+        } else if self.behavior == Isolated {
+            // isolate each punct
+            scratch.split_on_tags(
+                text.as_bytes(),
+                class_runs_into::<0, { mask::PUNCT }, 0>,
                 out,
             );
         } else {
@@ -94,7 +101,9 @@ mod tests {
     fn pretokenize(behavior: SplitDelimiterBehavior, text: &str) -> Vec<(&str, (u32, u32))> {
         let pretok = Punctuation::new(behavior);
         let mut splits = Vec::new();
-        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        let mut scratch = PreTokenizerScratch::default();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut scratch, &mut splits)
+            .unwrap();
         splits
             .iter()
             .map(|s| (&text[s.range()], (s.start, s.end)))

--- a/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
@@ -99,7 +99,12 @@ impl pipeline::PreTokenizer for PipelineSequence {
     /// so far. A child sees only the text of a span (`&text[span]`) and returns
     /// offsets relative to it, which we rebase to absolute mirroring how the
     /// legacy path worked.
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        scratch: &mut pipeline::PreTokenizerScratch,
+        out: &mut Vec<pipeline::Span>,
+    ) -> Result<()> {
         if text.is_empty() {
             return Ok(());
         }
@@ -107,7 +112,7 @@ impl pipeline::PreTokenizer for PipelineSequence {
         // deepseek's 3-Split composition → one native FSM pass (also lets the Sequence handle the
         // trailing byte-map ByteLevel, which the generic child loop can't range-split).
         if self.is_deepseek() {
-            pipeline::classify_into_spans(text.as_bytes(), atomsplit::fsm::fsm_deepseek, out);
+            scratch.split_on_tags(text.as_bytes(), atomsplit::fsm::fsm_deepseek, out);
             return Ok(());
         }
 
@@ -121,7 +126,7 @@ impl pipeline::PreTokenizer for PipelineSequence {
             .iter()
             .filter(|c| !matches!(c, PipelinePreTokenizer::None));
         if let (Some(only), None) = (work.next(), work.next()) {
-            return pipeline::PreTokenizer::pre_tokenize(only, text, out);
+            return pipeline::PreTokenizer::pre_tokenize(only, text, scratch, out);
         }
 
         let cap = text.len() / 5;
@@ -140,7 +145,12 @@ impl pipeline::PreTokenizer for PipelineSequence {
                 // The child appends span-relative spans straight into `next`;
                 // rebase just those to absolute in place — no scratch buffer.
                 let from = next.len();
-                pipeline::PreTokenizer::pre_tokenize(child, &text[span.range()], &mut next)?;
+                pipeline::PreTokenizer::pre_tokenize(
+                    child,
+                    &text[span.range()],
+                    scratch,
+                    &mut next,
+                )?;
                 // FIXME: do we want to add an `offset` param to `pre_tokenize` so we don't have to
                 // rebase?
                 for s in &mut next[from..] {
@@ -168,8 +178,9 @@ mod tests {
 
     /// Run the pipeline path and return `(piece, (start, end))` for each split.
     fn pipeline_pretokenize(seq: &PipelineSequence, text: &str) -> Vec<(String, (usize, usize))> {
+        let mut scratch = pipeline::PreTokenizerScratch::default();
         let mut out = Vec::new();
-        crate::pipeline::PreTokenizer::pre_tokenize(seq, text, &mut out).unwrap();
+        crate::pipeline::PreTokenizer::pre_tokenize(seq, text, &mut scratch, &mut out).unwrap();
         out.iter()
             .map(|s| {
                 (
@@ -435,8 +446,10 @@ mod tests {
             "中文 text 123, mixed! 🤗",
             "I'm sure it's fine   ",
         ] {
+            let mut scratch = pipeline::PreTokenizerScratch::default();
             let mut out = Vec::new();
-            crate::pipeline::PreTokenizer::pre_tokenize(&pipe_seq, text, &mut out).unwrap();
+            crate::pipeline::PreTokenizer::pre_tokenize(&pipe_seq, text, &mut scratch, &mut out)
+                .unwrap();
             let pipeline: Vec<(String, (usize, usize))> = out
                 .iter()
                 .map(|s| {

--- a/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
@@ -129,14 +129,12 @@ impl pipeline::PreTokenizer for PipelineSequence {
             return pipeline::PreTokenizer::pre_tokenize(only, text, scratch, out);
         }
 
-        let cap = text.len() / 5;
-
-        let mut current: Vec<pipeline::Span> = Vec::with_capacity(cap);
+        let [mut current, mut next] = scratch.take_pair();
+        current.clear();
         current.push(pipeline::Span {
             start: 0,
             end: text.len() as u32,
         });
-        let mut next: Vec<pipeline::Span> = Vec::with_capacity(cap);
 
         for child in &self.pre_tokenizers {
             next.clear();
@@ -161,7 +159,16 @@ impl pipeline::PreTokenizer for PipelineSequence {
             std::mem::swap(&mut current, &mut next);
         }
 
-        out.extend_from_slice(&current);
+        // Every call the pipeline makes arrives with `out` empty, since `encode_sequence` clears
+        // `pre_tokens` before pre-tokenizing: hand it the buffer the loop just filled instead of
+        // copying. `current` takes `out`'s allocation in exchange and goes back to the scratch,
+        // and both are pooled, so which buffer ends up where does not matter.
+        if out.is_empty() {
+            std::mem::swap(out, &mut current);
+        } else {
+            out.extend_from_slice(&current);
+        }
+        scratch.put_pair([current, next]);
         Ok(())
     }
 }

--- a/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/sequence.rs
@@ -94,7 +94,14 @@ impl TryFrom<Sequence> for PipelineSequence {
     }
 }
 
-impl pipeline::PreTokenizer for PipelineSequence {
+// SAFETY: a `Sequence` runs its children in order. A child splits the spans emitted by the previous child.
+// `Sequence` is safe because:
+// - all of its children are safe
+// - offsets added by the sequence are correct and land on character boundaries
+//
+// The deepseek fast path has no children to run: it calls an `atomsplit` fsm, which splits only at
+// character boundaries of `text`. See the `atomsplit::fsm` docs.
+unsafe impl pipeline::PreTokenizer for PipelineSequence {
     /// Runs each child in turn, where every child subdivides the spans produced
     /// so far. A child sees only the text of a span (`&text[span]`) and returns
     /// offsets relative to it, which we rebase to absolute mirroring how the

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -179,7 +179,12 @@ impl PreTokenizer for Split {
 }
 
 impl pipeline::PreTokenizer for Split {
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        scratch: &mut pipeline::PreTokenizerScratch,
+        out: &mut Vec<pipeline::Span>,
+    ) -> Result<()> {
         // A recognized GPT regex (gpt2 / cl100k-Llama-3) in its only real usage — `Isolated`, not
         // inverted — routes straight to the native atomsplit FSM. These regexes cover the whole input,
         // so `Isolated` == the match list, and the FSM is byte-exact with `regex` (see the tests).
@@ -187,7 +192,7 @@ impl pipeline::PreTokenizer for Split {
             .fsm
             .filter(|_| !self.invert && self.behavior == SplitDelimiterBehavior::Isolated)
         {
-            pipeline::classify_into_spans(
+            scratch.split_on_tags(
                 text.as_bytes(),
                 |bytes, tags, spans| match fsm {
                     GptFsm::Cl100k { digit_cap } => {
@@ -316,8 +321,10 @@ mod tests {
         text: &str,
     ) -> Vec<(&str, (u32, u32))> {
         let pretok = Split::new(pattern, behavior, invert).unwrap();
+        let mut scratch = pipeline::PreTokenizerScratch::default();
         let mut splits = Vec::with_capacity(text.len() / 5);
-        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut scratch, &mut splits)
+            .unwrap();
         splits
             .iter()
             .map(|s| (&text[s.range()], (s.start, s.end)))

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -178,7 +178,12 @@ impl PreTokenizer for Split {
     }
 }
 
-impl pipeline::PreTokenizer for Split {
+// SAFETY: both routes cut only at character boundaries of `text`. The native route is an `atomsplit`
+// fsm, see "What the spans guarantee" in its docs. The search route forwards the offsets of
+// `Pattern::find_matches` through `pipeline::split_matches`, and every `Pattern` here reports
+// boundaries: a regex matches on a `&str`, and `Literal` holds the bytes of a `&str` pattern, which
+// well-formed UTF-8 can only contain starting and ending on a boundary.
+unsafe impl pipeline::PreTokenizer for Split {
     fn pre_tokenize(
         &self,
         text: &str,

--- a/tokenizers/tk-encode/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
@@ -83,7 +83,9 @@ static BMP_SCRIPT: LazyLock<[Script; 0x10000]> = LazyLock::new(|| {
     std::array::from_fn(|i| char::from_u32(i as u32).map_or(Script::Common, fixed_script))
 });
 
-impl pipeline::PreTokenizer for UnicodeScripts {
+// SAFETY: every offset is one `str::char_indices` yielded, or `text.len()`, and they are pushed in
+// increasing order.
+unsafe impl pipeline::PreTokenizer for UnicodeScripts {
     fn pre_tokenize(
         &self,
         text: &str,

--- a/tokenizers/tk-encode/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
@@ -84,7 +84,12 @@ static BMP_SCRIPT: LazyLock<[Script; 0x10000]> = LazyLock::new(|| {
 });
 
 impl pipeline::PreTokenizer for UnicodeScripts {
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        _scratch: &mut pipeline::PreTokenizerScratch,
+        out: &mut Vec<pipeline::Span>,
+    ) -> Result<()> {
         let mut start = None;
         let mut last_script = None;
 
@@ -175,8 +180,10 @@ mod tests {
 
     fn pretokenize(text: &str) -> Vec<(&str, (u32, u32))> {
         let pretok = UnicodeScripts;
+        let mut scratch = pipeline::PreTokenizerScratch::default();
         let mut splits = Vec::new();
-        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut scratch, &mut splits)
+            .unwrap();
         splits
             .iter()
             .map(|s| (&text[s.range()], (s.start, s.end)))

--- a/tokenizers/tk-encode/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/whitespace.rs
@@ -43,7 +43,9 @@ impl PreTokenizer for WhitespaceSplit {
     }
 }
 
-impl pipeline::PreTokenizer for WhitespaceSplit {
+// SAFETY: the spans come from an `atomsplit` fsm, which cuts only at character boundaries of `text`.
+// See "What the spans guarantee" in the `atomsplit::fsm` docs.
+unsafe impl pipeline::PreTokenizer for WhitespaceSplit {
     fn pre_tokenize(
         &self,
         text: &str,
@@ -75,7 +77,9 @@ pub fn is_word_char(ch: char) -> bool {
         || ch == '\u{200d}' // Zero-Width Joiner
 }
 
-impl pipeline::PreTokenizer for Whitespace {
+// SAFETY: the spans come from an `atomsplit` fsm, which splits only at character boundaries of `text`.
+// See `atomsplit::fsm` docs.
+unsafe impl pipeline::PreTokenizer for Whitespace {
     #[inline(never)]
     fn pre_tokenize(
         &self,

--- a/tokenizers/tk-encode/src/pre_tokenizers/whitespace.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/whitespace.rs
@@ -2,7 +2,7 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-use crate::pipeline;
+use crate::pipeline::{self, PreTokenizerScratch};
 use crate::tokenizer::{
     PreTokenizedString, PreTokenizer, Result, SplitDelimiterBehavior, pattern::Invert,
 };
@@ -11,6 +11,8 @@ use crate::utils::macro_rules_attribute;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[macro_rules_attribute(impl_serde_type!)]
 pub struct Whitespace;
+
+use atomsplit::classify::mask;
 
 impl Default for Whitespace {
     fn default() -> Self {
@@ -42,11 +44,15 @@ impl PreTokenizer for WhitespaceSplit {
 }
 
 impl pipeline::PreTokenizer for WhitespaceSplit {
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        scratch: &mut PreTokenizerScratch,
+        out: &mut Vec<pipeline::Span>,
+    ) -> Result<()> {
         // drop whitespace runs, keep everything else as runs — atomsplit SIMD classify + class-runs FSM.
         // atom `WS` == `char::is_whitespace`, so byte-exact with the scalar path.
-        use atomsplit::classify::mask;
-        pipeline::classify_into_spans(
+        scratch.split_on_tags(
             text.as_bytes(),
             atomsplit::fsm::class_runs_into::<{ mask::WS }, 0, 0>,
             out,
@@ -71,11 +77,15 @@ pub fn is_word_char(ch: char) -> bool {
 
 impl pipeline::PreTokenizer for Whitespace {
     #[inline(never)]
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<pipeline::Span>) -> Result<()> {
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        scratch: &mut PreTokenizerScratch,
+        out: &mut Vec<pipeline::Span>,
+    ) -> Result<()> {
         // `\w+|[^\w\s]+`: drop whitespace, cut at the word↔symbol boundary, each run one token —
         // atomsplit classify + class-runs FSM (`WORD` = `\w`; keep-A = word, keep-B = symbol).
-        use atomsplit::classify::mask;
-        pipeline::classify_into_spans(
+        scratch.split_on_tags(
             text.as_bytes(),
             atomsplit::fsm::class_runs_into::<{ mask::WS }, 0, { mask::WORD }>,
             out,
@@ -91,8 +101,10 @@ mod tests {
 
     fn pretokenize(text: &str) -> Vec<(&str, (u32, u32))> {
         let pretok = Whitespace;
+        let mut scratch = PreTokenizerScratch::default();
         let mut splits = Vec::new();
-        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut scratch, &mut splits)
+            .unwrap();
         splits
             .iter()
             .map(|s| (&text[s.range()], (s.start, s.end)))
@@ -149,8 +161,10 @@ mod tests {
 
     fn pretokenize_split(text: &str) -> Vec<(&str, (u32, u32))> {
         let pretok = WhitespaceSplit;
+        let mut scratch = PreTokenizerScratch::default();
         let mut splits = Vec::new();
-        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut splits).unwrap();
+        crate::pipeline::PreTokenizer::pre_tokenize(&pretok, text, &mut scratch, &mut splits)
+            .unwrap();
         splits
             .iter()
             .map(|s| (&text[s.range()], (s.start, s.end)))

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -900,7 +900,7 @@ impl PipelineTokenizer {
         let tokens = ids
             .iter()
             .filter_map(|&id| {
-                if id > self.added_id_min {
+                if id >= self.added_id_min {
                     self.added_vocabulary
                         .simple_id_to_token(id)
                         .or_else(|| self.model.id_to_token(id))

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -19,7 +19,7 @@ use crate::vocab::bucket_added_vocabulary::{
     AddedToken as BucketAddedToken, AddedVocabulary as BucketAddedVocabulary,
 };
 use crate::{
-    DecoderWrapper, ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Token, Tokenizer,
+    DecoderWrapper, ModelWrapper, PostProcessorWrapper, PreTokenizerWrapper, Tokenizer,
     normalizers::{NormalizerWrapper, metaspace::MetaspaceNormalizer},
     pre_tokenizers::{
         bert::BertPreTokenizer,
@@ -246,16 +246,16 @@ impl TryFrom<&PostProcessorWrapper> for PipelinePostProcessor {
                 cls: (_, cls_id),
                 sep: (_, sep_id),
             }) => Ok(Self {
-                prefix: vec![PipelineToken { id: *cls_id }].into_boxed_slice(),
-                suffix: vec![PipelineToken { id: *sep_id }].into_boxed_slice(),
+                prefix: vec![PipelineToken::from(*cls_id)].into_boxed_slice(),
+                suffix: vec![PipelineToken::from(*sep_id)].into_boxed_slice(),
             }),
             PostProcessorWrapper::Roberta(RobertaProcessing {
                 cls: (_, cls_id),
                 sep: (_, sep_id),
                 ..
             }) => Ok(Self {
-                prefix: vec![PipelineToken { id: *cls_id }].into_boxed_slice(),
-                suffix: vec![PipelineToken { id: *sep_id }].into_boxed_slice(),
+                prefix: vec![PipelineToken::from(*cls_id)].into_boxed_slice(),
+                suffix: vec![PipelineToken::from(*sep_id)].into_boxed_slice(),
             }),
             PostProcessorWrapper::Template(pp) => {
                 // todo: handle pair template
@@ -281,7 +281,7 @@ impl TryFrom<&PostProcessorWrapper> for PipelinePostProcessor {
                                     "post-processor not supported: Template references unknown special token `{token_string}`"
                                 )
                             })?;
-                            let token_ids = special.ids().iter().map(|&id| PipelineToken { id });
+                            let token_ids = special.ids().iter().copied().map(PipelineToken::from);
                             if seen_sequence {
                                 suffix.extend(token_ids);
                             } else {
@@ -330,14 +330,40 @@ impl TryFrom<&PostProcessorWrapper> for PipelinePostProcessor {
 
 /// An output token. Carries only the vocabulary `id`, since offsets and the token
 /// string are dropped, which is all an encode-only caller needs.
-#[derive(Debug, Clone, Copy)]
-pub struct PipelineToken {
-    pub id: u32,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct PipelineToken(u32);
+
+impl PipelineToken {
+    /// The vocabulary id this token stands for.
+    pub const fn id(self) -> u32 {
+        self.0
+    }
 }
 
-impl From<Token> for PipelineToken {
-    fn from(value: Token) -> Self {
-        Self { id: value.id }
+impl From<u32> for PipelineToken {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PipelineToken> for u32 {
+    fn from(value: PipelineToken) -> Self {
+        value.0
+    }
+}
+
+/// Compares a token against a bare id, so a caller can assert against `[u32]`
+/// without mapping the ids out first.
+impl PartialEq<u32> for PipelineToken {
+    fn eq(&self, id: &u32) -> bool {
+        self.0 == *id
+    }
+}
+
+impl PartialEq<PipelineToken> for u32 {
+    fn eq(&self, token: &PipelineToken) -> bool {
+        *self == token.0
     }
 }
 
@@ -1005,7 +1031,7 @@ impl PipelineTokenizer {
         for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
             match segment {
                 Segment::SpecialToken(token) => {
-                    output.push(PipelineToken { id: token });
+                    output.push(PipelineToken::from(token));
                 }
                 Segment::Text(chunk) => {
                     let normalized: Cow<str> = if STAGE >= Self::STAGE_NORMALIZE {
@@ -1020,7 +1046,7 @@ impl PipelineTokenizer {
                     {
                         match segment {
                             Segment::SpecialToken(token) => {
-                                output.push(PipelineToken { id: token });
+                                output.push(PipelineToken::from(token));
                             }
                             Segment::Text(normalized_chunk) => {
                                 if STAGE >= Self::STAGE_SPLIT {
@@ -1485,18 +1511,13 @@ mod tests {
         tok.with_normalizer(Some(normalizer)).unwrap();
         tok.with_pre_tokenizer(Some(pre_tokenizer));
 
-        let ids: Vec<u32> = PipelineTokenizer::try_from(&tok)
+        let encoded = PipelineTokenizer::try_from(&tok)
             .unwrap()
             .encode("hello world", false)
             .wait()
-            .unwrap()
-            .first()
-            .unwrap()
-            .iter()
-            .map(|t| t.id)
-            .collect();
+            .unwrap();
         // Not the unk id: both the `Replace` and the `Split` really ran on the literal path.
-        assert_eq!(ids, [1, 2]);
+        assert_eq!(*encoded.first().unwrap(), [1, 2]);
         assert_pipeline_matches_reference(&tok, "hello world");
     }
 
@@ -1598,7 +1619,7 @@ mod tests {
                 .first()
                 .unwrap()
                 .iter()
-                .map(|t| t.id)
+                .map(|t| t.id())
                 .collect();
             assert_eq!(expected, got, "add_special_tokens={add_special_tokens}");
         }
@@ -1622,7 +1643,7 @@ mod tests {
             enc.first()
                 .unwrap()
                 .iter()
-                .map(|t| t.id)
+                .map(|t| t.id())
                 .collect::<Vec<_>>()
         };
         assert_eq!(
@@ -1713,7 +1734,7 @@ mod tests {
             .first()
             .unwrap()
             .iter()
-            .map(|t| t.id)
+            .map(|t| t.id())
             .collect();
         assert_eq!(ids, vec![102, 100, 2, 3, 101, 103]);
     }
@@ -1870,7 +1891,7 @@ mod tests {
             .unwrap()
             .remove(0)
             .iter()
-            .map(|t| t.id)
+            .map(|t| t.id())
             .collect();
         assert_eq!(want, vec![7]);
 
@@ -1881,7 +1902,7 @@ mod tests {
                 .unwrap()
                 .remove(0)
                 .iter()
-                .map(|t| t.id)
+                .map(|t| t.id())
                 .collect::<Vec<_>>()
                 == want
         });

--- a/tokenizers/tk-encode/src/tokenizer/pipeline.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline.rs
@@ -838,16 +838,6 @@ thread_local! {
 }
 
 impl PipelineTokenizer {
-    /// Stage gates for [`encode_generic`](Self::encode_generic), in execution order.
-    /// Each level runs every stage up to and including itself; `STAGE_POSTPROCESS` is
-    /// a full encode. `STAGE_FRAME` is the special-token scan + iteration only (the
-    /// "other" slice in the decomposition).
-    pub const STAGE_FRAME: u8 = 0;
-    pub const STAGE_NORMALIZE: u8 = 1;
-    pub const STAGE_SPLIT: u8 = 2;
-    pub const STAGE_MODEL: u8 = 3;
-    pub const STAGE_POSTPROCESS: u8 = 4;
-
     pub fn get_model(&self) -> &PipelineModel {
         &self.model
     }
@@ -865,27 +855,19 @@ impl PipelineTokenizer {
 
         match inputs {
             Inputs::Single(s) => {
-                let output =
-                    self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(&s, add_special_tokens);
+                let output = self.encode_sequence(&s, add_special_tokens);
                 EncodeHandle::blocking(vec![output])
             }
             // TODO: proper post-processor logic, this is temporary
             Inputs::Pair(s1, s2) => {
-                let p1 =
-                    self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(&s1, add_special_tokens);
-                let p2 =
-                    self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(&s2, add_special_tokens);
+                let p1 = self.encode_sequence(&s1, add_special_tokens);
+                let p2 = self.encode_sequence(&s2, add_special_tokens);
                 EncodeHandle::blocking(vec![p1, p2])
             }
             Inputs::Batch(b) => {
                 let mut output = Vec::with_capacity(b.len());
                 for seq in b {
-                    output.push(
-                        self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(
-                            &seq,
-                            add_special_tokens,
-                        ),
-                    );
+                    output.push(self.encode_sequence(&seq, add_special_tokens));
                 }
                 EncodeHandle::blocking(output)
             }
@@ -893,16 +875,71 @@ impl PipelineTokenizer {
             Inputs::PairBatch(pb) => {
                 let mut output = Vec::with_capacity(pb.len() * 2);
                 for (s1, s2) in pb {
-                    output.push(
-                        self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(&s1, add_special_tokens),
-                    );
-                    output.push(
-                        self.encode_generic::<{ Self::STAGE_POSTPROCESS }>(&s2, add_special_tokens),
-                    );
+                    output.push(self.encode_sequence(&s1, add_special_tokens));
+                    output.push(self.encode_sequence(&s2, add_special_tokens));
                 }
                 EncodeHandle::blocking(output)
             }
         }
+    }
+
+    pub fn encode_sequence(
+        &self,
+        input: &str,
+        add_special_tokens: bool,
+    ) -> Result<Vec<PipelineToken>> {
+        let mut output = Vec::with_capacity(input.len() / 4);
+        let mut scratch = self.scratch_pool.get(&self.model);
+        let PipelinePostProcessor { prefix, suffix } = &self.post_processor;
+        // Prepend prefix tokens, if any
+        // todo: handle post-processing when encoding a pair of sequences (currently unsupported by the PipelineTokenizer)
+        if add_special_tokens {
+            output.extend_from_slice(prefix);
+        }
+        // First, we extract all special tokens from the non-normalized input
+        for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
+            match segment {
+                Segment::SpecialToken(token) => {
+                    output.push(PipelineToken::from(token));
+                }
+                Segment::Text(chunk) => {
+                    let normalized = normalize_all(&self.normalizers, chunk)?;
+
+                    // Extract special tokens from the normalized input
+                    for segment in
+                        SpecialSegmentIterator::new(&normalized, &self.added_vocabulary, true)
+                    {
+                        match segment {
+                            Segment::SpecialToken(token) => {
+                                output.push(PipelineToken::from(token));
+                            }
+                            Segment::Text(normalized_chunk) => {
+                                // Pre-tokenize the chunk of normalized text
+                                PRE_TOKENS_SCRATCH.with(|cell| -> Result<()> {
+                                    let mut pre_tokens = cell.borrow_mut();
+                                    pre_tokens.clear();
+                                    self.pre_tokenizer
+                                        .pre_tokenize(normalized_chunk, &mut pre_tokens)?;
+                                    // The whole span list at once; see Model::tokenize_spans.
+                                    self.model.tokenize_spans(
+                                        normalized_chunk,
+                                        &pre_tokens,
+                                        &mut scratch,
+                                        &mut output,
+                                    )?;
+                                    Ok(())
+                                })?;
+                            }
+                        }
+                    }
+                }
+            };
+        }
+        // Append suffix tokens, if any
+        if add_special_tokens {
+            output.extend_from_slice(suffix);
+        }
+        Ok(output)
     }
 
     /// Decode token ids back to a `String`.
@@ -998,87 +1035,6 @@ impl PipelineTokenizer {
             prefix: String::new(),
             prefix_index: 0,
         }
-    }
-
-    /// Single source of truth for the encode pipeline, generic over how many stages
-    /// run. `STAGE` is a **const generic**, so `if STAGE >= …` folds at compile time and
-    /// the disabled stages are compiled out, so the full specialization
-    /// ([`STAGE_POSTPROCESS`], which [`encode`](Self::encode) calls) is branchless and
-    /// identical to a hand-written full pipeline, while the benchmark drives lower
-    /// `STAGE` values to time each stage's marginal cost (the ablation ladder), e.g.
-    /// `model = t(MODEL) − t(SPLIT)`. No runtime gate, no `Instant` in the loop.
-    ///
-    /// [`STAGE_POSTPROCESS`]: Self::STAGE_POSTPROCESS
-    ///
-    /// `output` and the `pre_tokens` scratch are caller-owned so a benchmark can reuse
-    /// them across calls and observe both buffers to anchor the ablation levels. The
-    /// library itself stays free of any `black_box`/timing artifact.
-    #[doc(hidden)] // public only so `examples/fixture_bench.rs` can drive partial stages
-    pub fn encode_generic<const STAGE: u8>(
-        &self,
-        input: &str,
-        add_special_tokens: bool,
-    ) -> Result<Vec<PipelineToken>> {
-        let mut output = Vec::with_capacity(input.len() / 4);
-        let mut scratch = self.scratch_pool.get(&self.model);
-        let PipelinePostProcessor { prefix, suffix } = &self.post_processor;
-        // Prepend prefix tokens, if any
-        // todo: handle post-processing when encoding a pair of sequences (currently unsupported by the PipelineTokenizer)
-        if add_special_tokens && STAGE >= Self::STAGE_POSTPROCESS {
-            output.extend_from_slice(prefix);
-        }
-        // First, we extract all special tokens from the non-normalized input
-        for segment in SpecialSegmentIterator::new(input, &self.added_vocabulary, false) {
-            match segment {
-                Segment::SpecialToken(token) => {
-                    output.push(PipelineToken::from(token));
-                }
-                Segment::Text(chunk) => {
-                    let normalized: Cow<str> = if STAGE >= Self::STAGE_NORMALIZE {
-                        normalize_all(&self.normalizers, chunk)?
-                    } else {
-                        Cow::Borrowed(chunk)
-                    };
-
-                    // Extract special tokens from the normalized input
-                    for segment in
-                        SpecialSegmentIterator::new(&normalized, &self.added_vocabulary, true)
-                    {
-                        match segment {
-                            Segment::SpecialToken(token) => {
-                                output.push(PipelineToken::from(token));
-                            }
-                            Segment::Text(normalized_chunk) => {
-                                if STAGE >= Self::STAGE_SPLIT {
-                                    // Pre-tokenize the chunk of normalized text
-                                    PRE_TOKENS_SCRATCH.with(|cell| -> Result<()> {
-                                        let mut pre_tokens = cell.borrow_mut();
-                                        pre_tokens.clear();
-                                        self.pre_tokenizer
-                                            .pre_tokenize(normalized_chunk, &mut pre_tokens)?;
-                                        if STAGE >= Self::STAGE_MODEL {
-                                            // The whole span list at once; see Model::tokenize_spans.
-                                            self.model.tokenize_spans(
-                                                normalized_chunk,
-                                                &pre_tokens,
-                                                &mut scratch,
-                                                &mut output,
-                                            )?;
-                                        }
-                                        Ok(())
-                                    })?;
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-        }
-        // Append suffix tokens, if any
-        if add_special_tokens && STAGE >= Self::STAGE_POSTPROCESS {
-            output.extend_from_slice(suffix);
-        }
-        Ok(output)
     }
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -1444,6 +1444,54 @@ mod tests {
         tok
     }
 
+    fn pipeline_ids(pipeline: &PipelineTokenizer, input: &str) -> Vec<u32> {
+        pipeline
+            .encode(input, false)
+            .wait()
+            .unwrap()
+            .remove(0)
+            .iter()
+            .map(|t| t.id())
+            .collect()
+    }
+
+    // A single `&self` tokenizer is meant to be shared across rayon workers, and the scratch it
+    // hands each of them carries the pre-token spans of the chunk being encoded. So the workers
+    // must not be able to reach each other's: every thread encodes a different input here, and
+    // has to get back the answer that input produces on its own.
+    //
+    // The inputs disagree on both how many tokens they produce and which, so another input's
+    // spans cannot yield the right ids by luck. This also only compiles if
+    // `PipelineTokenizer: Sync`.
+    #[test]
+    fn concurrent_encodes_of_different_inputs_stay_independent() {
+        use rayon::prelude::*;
+
+        let tok = wordlevel_tokenizer(vec![("<unk>", 0), ("hello", 1), ("world", 2)], None);
+        let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
+
+        let inputs = [
+            "hello".to_string(),
+            "hello world".to_string(),
+            "world hello world".to_string(),
+            "hello world ".repeat(25),
+        ];
+        let want: Vec<Vec<u32>> = inputs
+            .iter()
+            .map(|input| pipeline_ids(&pipeline, input))
+            .collect();
+        assert_eq!(
+            want,
+            vec![vec![1], vec![1, 2], vec![2, 1, 2], [1, 2].repeat(25)]
+        );
+
+        let all_match = (0..10_000usize).into_par_iter().all(|i| {
+            let case = i % inputs.len();
+            pipeline_ids(&pipeline, &inputs[case]) == want[case]
+        });
+        assert!(all_match);
+    }
+
     fn assert_pipeline_matches_reference(tok: &Tokenizer, input: &str) {
         let pipeline = PipelineTokenizer::try_from(tok).unwrap();
         for add_special_tokens in [false, true] {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -104,7 +104,18 @@ impl Normalizer for PipelineNormalizer {
 
 /// Range-based pre-tokenization: yields spans into the input rather than owned
 /// substrings, so the pipeline can pre-tokenize without allocating.
-pub trait PreTokenizer {
+///
+/// # Safety
+///
+/// [`PreTokenizer::pre_tokenize`] produces [`Span`] objects that are later consumed by [`PipelineTokenizer::encode_sequence`].
+/// For performance reasons, [`PipelineTokenizer::encode_sequence`] turns every span into a `&str` with [`str::get_unchecked`].
+/// As a consequence, every implementation of this trait *MUST* ensure the following invariants for each [`Span`]:
+///
+/// * `span.end <= text.len()`: the span is inside the text
+/// * `span.start <= span.end`: the span is not reversed
+/// * `text.is_char_boundary(start)` and `text.is_char_boundary(end)`: the start and end offset must be UTF-8 char boundaries
+/// * The offsets are relative to the `text`.
+pub unsafe trait PreTokenizer {
     /// Split `text` into pre-tokens, appending to `out`. Ranges are into `text`.
     /// `scratch` holds the working buffers, see [`PreTokenizerScratch`].
     fn pre_tokenize(
@@ -200,7 +211,9 @@ pub enum PipelinePreTokenizer {
     None,
 }
 
-impl PreTokenizer for PipelinePreTokenizer {
+// SAFETY: every arm but `None` forwards to another `PreTokenizer`, which upholds the contract itself.
+// `None` emits the single span covering all of `text`, whose ends are `0` and `text.len()`.
+unsafe impl PreTokenizer for PipelinePreTokenizer {
     fn pre_tokenize(
         &self,
         text: &str,
@@ -892,6 +905,18 @@ impl PipelineTokenizer {
                                 output.push(PipelineToken::from(token));
                             }
                             Segment::Text(normalized_chunk) => {
+                                // A [`Span`] holds `u32` offsets, which breaks the `PreTokenizer` contract the
+                                // `str::get_unchecked` below relies on.
+                                // Normalization can grow the text (`Metaspace` widens every space to a 3-byte delimiter),
+                                // which is why this is checked here and not on `input`.
+                                if normalized_chunk.len() > u32::MAX as usize {
+                                    return Err(format!(
+                                        "sequence too long to pre-tokenize: {} bytes after normalization, the limit is {}",
+                                        normalized_chunk.len(),
+                                        u32::MAX
+                                    )
+                                    .into());
+                                }
                                 // Pre-tokenize the chunk of normalized text
                                 let EncodeScratch {
                                     model: model_scratch,
@@ -906,11 +931,16 @@ impl PipelineTokenizer {
                                 )?;
                                 output.reserve(pre_tokens.len());
                                 for pre_token in pre_tokens {
-                                    // The get_unchecked saves us a UTF-8 boundary check
-                                    // SAFETY: the pre-tokenizer must return a range that ends on utf-8 character boundaries
-                                    let sequence = unsafe {
-                                        normalized_chunk.get_unchecked(pre_token.range())
-                                    };
+                                    let range = pre_token.range();
+                                    debug_assert!(
+                                        range.start <= range.end
+                                            && normalized_chunk.is_char_boundary(range.start)
+                                            && normalized_chunk.is_char_boundary(range.end),
+                                        "{:?} broke the PreTokenizer contract: emitted {pre_token:?} for {normalized_chunk:?}",
+                                        self.pre_tokenizer,
+                                    );
+                                    // SAFETY: `PreTokenizer` guarantees every span is a valid range of `normalized_chunk`
+                                    let sequence = unsafe { normalized_chunk.get_unchecked(range) };
                                     self.model.tokenize_pipeline(
                                         sequence,
                                         model_scratch,
@@ -1376,6 +1406,137 @@ mod tests {
     use crate::models::wordpiece::WordPiece;
     use crate::pre_tokenizers::byte_level::ByteLevel;
     use crate::pre_tokenizers::sequence::Sequence;
+    fn variant_name(pre_tokenizer: &PipelinePreTokenizer) -> &'static str {
+        match pre_tokenizer {
+            PipelinePreTokenizer::Bert(_) => "Bert",
+            PipelinePreTokenizer::Delimiter(_) => "Delimiter",
+            PipelinePreTokenizer::Digits(_) => "Digits",
+            PipelinePreTokenizer::FixedLength(_) => "FixedLength",
+            PipelinePreTokenizer::Punctuation(_) => "Punctuation",
+            PipelinePreTokenizer::Sequence(_) => "Sequence",
+            PipelinePreTokenizer::Split(_) => "Split",
+            PipelinePreTokenizer::UnicodeScripts(_) => "UnicodeScripts",
+            PipelinePreTokenizer::Whitespace(_) => "Whitespace",
+            PipelinePreTokenizer::WhitespaceSplit(_) => "WhitespaceSplit",
+            PipelinePreTokenizer::None => "None",
+        }
+    }
+
+    const HOSTILE: &[&str] = &[
+        "",
+        " ",
+        "\r",
+        "\r\n\n",
+        "hello world",
+        "café naïve",
+        "a\u{0301}b\u{0301}\u{0301}c",
+        "中文分词。ひらがな 한글",
+        "😀👍🏽 👨‍👩‍👧‍👦 x",
+        "\u{FEFF}leading bom",
+        "مرحبا\u{200F} العربية",
+        "नरेंद्र मोदी",
+        "hello▁world▁▁",
+        "a1b22c333d4444 42 ½²¼ Ⅷ",
+        "!!!...?! a, b; c",
+        "  \t  trailing   ",
+        "Ⓘ\u{200D}x_y a-b'c",
+    ];
+
+    /// Every variant must produce spans that [`PipelineTokenizer::encode_sequence`] can hand to `str::get_unchecked`
+    #[test]
+    fn every_pre_tokenizer_emits_sliceable_spans() {
+        use crate::pre_tokenizers::digits::Digits;
+        use crate::pre_tokenizers::fixed_length::FixedLength;
+        use crate::pre_tokenizers::punctuation::Punctuation;
+        use crate::pre_tokenizers::split::SplitPattern;
+        use SplitDelimiterBehavior::*;
+
+        let literal_split = |pattern: &str, behavior| {
+            SplitPretok::new(SplitPattern::String(pattern.to_owned()), behavior, false).unwrap()
+        };
+        // The gpt2 regex is recognized, so this routes to `fsm_byte_level` with no regex backend.
+        let gpt2_split = SplitPretok::new(
+            SplitPattern::Regex(GPT2_REGEX_STR.to_owned()),
+            Isolated,
+            false,
+        )
+        .unwrap();
+
+        let cases = vec![
+            PipelinePreTokenizer::Bert(BertPreTokenizer),
+            PipelinePreTokenizer::Delimiter(CharDelimiterSplit::new(' ')),
+            PipelinePreTokenizer::Delimiter(CharDelimiterSplit::new('▁')),
+            PipelinePreTokenizer::Digits(Digits::new(true)),
+            PipelinePreTokenizer::Digits(Digits::new(false)),
+            PipelinePreTokenizer::FixedLength(FixedLength::new(3)),
+            PipelinePreTokenizer::FixedLength(FixedLength::new(0)),
+            PipelinePreTokenizer::Punctuation(Punctuation::new(Removed)),
+            PipelinePreTokenizer::Punctuation(Punctuation::new(Isolated)),
+            PipelinePreTokenizer::Punctuation(Punctuation::new(Contiguous)),
+            PipelinePreTokenizer::Punctuation(Punctuation::new(MergedWithPrevious)),
+            PipelinePreTokenizer::Punctuation(Punctuation::new(MergedWithNext)),
+            PipelinePreTokenizer::Sequence(PipelineSequence::new(vec![
+                PipelinePreTokenizer::WhitespaceSplit(WhitespaceSplit),
+                PipelinePreTokenizer::Punctuation(Punctuation::new(Isolated)),
+            ])),
+            PipelinePreTokenizer::Split(gpt2_split),
+            PipelinePreTokenizer::Split(literal_split("▁", MergedWithPrevious)),
+            PipelinePreTokenizer::Split(literal_split("▁", MergedWithNext)),
+            PipelinePreTokenizer::Split(literal_split(" ", Removed)),
+            PipelinePreTokenizer::UnicodeScripts(UnicodeScripts::new()),
+            PipelinePreTokenizer::Whitespace(Whitespace),
+            PipelinePreTokenizer::WhitespaceSplit(WhitespaceSplit),
+            PipelinePreTokenizer::None,
+        ];
+
+        let mut covered: Vec<&str> = cases.iter().map(variant_name).collect();
+        covered.sort_unstable();
+        covered.dedup();
+        assert_eq!(
+            covered,
+            [
+                "Bert",
+                "Delimiter",
+                "Digits",
+                "FixedLength",
+                "None",
+                "Punctuation",
+                "Sequence",
+                "Split",
+                "UnicodeScripts",
+                "Whitespace",
+                "WhitespaceSplit",
+            ],
+            "every PipelinePreTokenizer variant needs a case above",
+        );
+
+        let mut scratch = PreTokenizerScratch::default();
+        let mut spans = Vec::new();
+        for pre_tokenizer in &cases {
+            for text in HOSTILE {
+                spans.clear();
+                pre_tokenizer
+                    .pre_tokenize(text, &mut scratch, &mut spans)
+                    .unwrap();
+                for span in &spans {
+                    let range = span.range();
+                    assert!(
+                        range.start <= range.end,
+                        "{} reversed {span:?} on {text:?}",
+                        variant_name(pre_tokenizer),
+                    );
+                    assert!(
+                        text.is_char_boundary(range.start) && text.is_char_boundary(range.end),
+                        "{} cut {span:?} off a character boundary of {text:?}",
+                        variant_name(pre_tokenizer),
+                    );
+                    // What the pipeline does with the span. Slicing checked here is the point: it
+                    // panics on exactly the ranges `get_unchecked` would turn into undefined behavior.
+                    assert!(text.get(range).is_some());
+                }
+            }
+        }
+    }
 
     struct FixedMatcher(Vec<((usize, usize), u32)>);
     impl PipelinePatternMatcher for FixedMatcher {

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -1,8 +1,6 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
 use std::iter::Enumerate;
-use std::mem;
-use std::sync::{Mutex, PoisonError};
 use std::vec::IntoIter;
 use std::{borrow::Cow, convert::TryFrom};
 
@@ -12,6 +10,7 @@ use crate::models::bpe::{BpeScratch, PipelineBPE};
 use crate::models::unigram::{Unigram, UnigramScratch};
 use crate::models::wordlevel::WordLevel;
 use crate::models::wordpiece::{PipelineWordPiece, WordPieceScratch};
+use crate::pipeline::scratch_pool::{EncodeScratch, ScratchPool};
 use crate::processors::bert::BertProcessing;
 use crate::processors::roberta::RobertaProcessing;
 use crate::utils::byte_level::GPT2_REGEX_STR;
@@ -40,6 +39,10 @@ use crate::{
 use super::{Result, SplitDelimiterBehavior};
 
 pub use atomsplit::fsm::Span;
+
+mod scratch_pool;
+
+pub use scratch_pool::ModelScratch;
 
 /// We use a thread local scratch for the tags (per byte class) and for the split spans.
 pub(crate) fn classify_into_spans(
@@ -486,77 +489,6 @@ pub struct PipelineTokenizer {
     scratch_pool: ScratchPool,
 }
 
-/// A pool of [`PipelineModelScratch`].
-///
-/// When calling [`PipelineTokenizer::encode`], an instance of [`PipelineModelScratch`] is taken out of this pool
-/// and given to the tokenizer. When the encoding is done, the scratch buffer is returned to the pool and can be
-/// reused by later calls.
-///
-/// The reusability matters because the scratch buffer may hold cache structures which are more useful when reused,
-/// and less importantly it saves an extra allocation for an fresh buffer every time.
-struct ScratchPool(Mutex<Vec<PipelineModelScratch>>);
-
-impl ScratchPool {
-    fn new() -> Self {
-        Self(Mutex::new(Vec::new()))
-    }
-
-    /// Get a scratch buffer from the pool, wrapped in a [`ScratchGuard`].
-    /// When the [`ScratchGuard`] gets dropped, the scratch buffer is pushed back to the pool.
-    fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
-        // The Mutex lock is held just long enough to pop the scratch out of the pool
-        let taken = self.0.lock().unwrap_or_else(PoisonError::into_inner).pop();
-        ScratchGuard {
-            // If there was no scratch buffer available in the pool, we build.a fresh one
-            scratch: taken.unwrap_or_else(|| model.init_scratch()),
-            pool: self,
-        }
-    }
-
-    #[cfg(test)]
-    fn len(&self) -> usize {
-        self.0.lock().unwrap_or_else(PoisonError::into_inner).len()
-    }
-}
-
-/// A wrapper around [`PipelineModelScratch`].
-/// Implements [`Deref`] and [`DerefMut`], so it behaves as [`PipelineModelScratch`].
-///
-/// When it gets dropped, it pushes [`Self::scratch`] back into the shared [`Self::pool`] so it can
-/// get reused by a later call to [`PipelineTokenizer::encode`].
-///
-/// TODO @McPatate : The Mutex can create contention, to be replaced by a better access pattern
-struct ScratchGuard<'a> {
-    scratch: PipelineModelScratch,
-    pool: &'a ScratchPool,
-}
-
-impl Drop for ScratchGuard<'_> {
-    fn drop(&mut self) {
-        // Steals the scratch buffer from self, replaces it with PipelineModelScratch::default()
-        let scratch = mem::take(&mut self.scratch);
-        // Push the scratch back in the pool
-        self.pool
-            .0
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .push(scratch);
-    }
-}
-
-impl std::ops::Deref for ScratchGuard<'_> {
-    type Target = PipelineModelScratch;
-    fn deref(&self) -> &PipelineModelScratch {
-        &self.scratch
-    }
-}
-
-impl std::ops::DerefMut for ScratchGuard<'_> {
-    fn deref_mut(&mut self) -> &mut PipelineModelScratch {
-        &mut self.scratch
-    }
-}
-
 impl TryFrom<&Tokenizer> for PipelineTokenizer {
     type Error = super::Error;
 
@@ -830,13 +762,6 @@ impl IntoIterator for EncodeHandle {
     }
 }
 
-thread_local! {
-    /// Persistent state across encode calls
-    ///
-    /// This avoids having to reallocate pre-tokens buffers, reusing is cheaper
-    static PRE_TOKENS_SCRATCH: RefCell<Vec<Span>> = const { RefCell::new(Vec::new()) };
-}
-
 impl PipelineTokenizer {
     pub fn get_model(&self) -> &PipelineModel {
         &self.model
@@ -915,20 +840,26 @@ impl PipelineTokenizer {
                             }
                             Segment::Text(normalized_chunk) => {
                                 // Pre-tokenize the chunk of normalized text
-                                PRE_TOKENS_SCRATCH.with(|cell| -> Result<()> {
-                                    let mut pre_tokens = cell.borrow_mut();
-                                    pre_tokens.clear();
-                                    self.pre_tokenizer
-                                        .pre_tokenize(normalized_chunk, &mut pre_tokens)?;
-                                    // The whole span list at once; see Model::tokenize_spans.
-                                    self.model.tokenize_spans(
-                                        normalized_chunk,
-                                        &pre_tokens,
-                                        &mut scratch,
+                                let EncodeScratch {
+                                    model: model_scratch,
+                                    pre_tokens,
+                                } = &mut *scratch;
+                                pre_tokens.clear();
+                                self.pre_tokenizer
+                                    .pre_tokenize(normalized_chunk, pre_tokens)?;
+                                output.reserve(pre_tokens.len());
+                                for pre_token in pre_tokens {
+                                    // The get_unchecked saves us a UTF-8 boundary check
+                                    // SAFETY: the pre-tokenizer must return a range that ends on utf-8 character boundaries
+                                    let sequence = unsafe {
+                                        normalized_chunk.get_unchecked(pre_token.range())
+                                    };
+                                    self.model.tokenize_pipeline(
+                                        sequence,
+                                        model_scratch,
                                         &mut output,
                                     )?;
-                                    Ok(())
-                                })?;
+                                }
                             }
                         }
                     }
@@ -1292,8 +1223,6 @@ pub fn split_matches(
     }
 }
 
-pub trait ModelScratch {}
-
 pub trait Model {
     type Scratch: ModelScratch;
 
@@ -1303,27 +1232,6 @@ pub trait Model {
         scratch: &mut Self::Scratch,
         output: &mut Vec<PipelineToken>,
     ) -> Result<()>;
-
-    /// Every pre-token of a chunk in one call.
-    ///
-    /// The pipeline has the whole span list before the model runs, so handing them over one at a
-    /// time bought nothing and cost a virtual call, a slice, a `Result` and an output capacity
-    /// check per pre-token -- on English that is one round trip per ~5 bytes.
-    ///
-    /// The default is the loop it replaces, so a model only overrides this if it has per-chunk
-    /// work to hoist out of the loop.
-    fn tokenize_spans(
-        &self,
-        chunk: &str,
-        spans: &[Span],
-        scratch: &mut Self::Scratch,
-        output: &mut Vec<PipelineToken>,
-    ) -> Result<()> {
-        for span in spans {
-            self.tokenize_pipeline(&chunk[span.range()], scratch, output)?;
-        }
-        Ok(())
-    }
 
     fn init_scratch(&self) -> Self::Scratch;
 }
@@ -1351,6 +1259,23 @@ impl PipelineModel {
     }
 }
 
+/// A set of buffers and other state the model needs to encode efficiently,
+/// reused among calls to [`PipelineTokenizer::encode`].
+///
+/// Each model gets its own variant.
+#[derive(Default)]
+pub enum PipelineModelScratch {
+    BPE(BpeScratch),
+    WordLevel(()),
+    WordPiece(WordPieceScratch),
+    Unigram(UnigramScratch),
+    /// We need a default value to be able to use [`mem::take`] in [`ScratchGuard::drop`]
+    #[default]
+    None,
+}
+
+impl ModelScratch for PipelineModelScratch {}
+
 impl Model for PipelineModel {
     type Scratch = PipelineModelScratch;
 
@@ -1377,30 +1302,6 @@ impl Model for PipelineModel {
         }
     }
 
-    fn tokenize_spans(
-        &self,
-        chunk: &str,
-        spans: &[Span],
-        scratch: &mut Self::Scratch,
-        output: &mut Vec<PipelineToken>,
-    ) -> Result<()> {
-        match (self, scratch) {
-            (Self::BPE(model), PipelineModelScratch::BPE(scratch)) => {
-                model.tokenize_spans(chunk, spans, scratch, output)
-            }
-            (Self::Unigram(model), PipelineModelScratch::Unigram(scratch)) => {
-                model.tokenize_spans(chunk, spans, scratch, output)
-            }
-            (Self::WordLevel(model), PipelineModelScratch::WordLevel(scratch)) => {
-                model.tokenize_spans(chunk, spans, scratch, output)
-            }
-            (Self::WordPiece(model), PipelineModelScratch::WordPiece(scratch)) => {
-                model.tokenize_spans(chunk, spans, scratch, output)
-            }
-            _ => unreachable!(),
-        }
-    }
-
     fn init_scratch(&self) -> Self::Scratch {
         match self {
             Self::BPE(bpe) => PipelineModelScratch::BPE(bpe.init_scratch()),
@@ -1410,23 +1311,6 @@ impl Model for PipelineModel {
         }
     }
 }
-
-/// A set of buffers and other state the model needs to encode efficiently,
-/// reused among calls to [`PipelineTokenizer::encode`].
-///
-/// Each model gets its own variant.
-#[derive(Default)]
-pub enum PipelineModelScratch {
-    BPE(BpeScratch),
-    WordLevel(()),
-    WordPiece(WordPieceScratch),
-    Unigram(UnigramScratch),
-    /// We need a default value to be able to use [`mem::take`] in [`ScratchGuard::drop`]
-    #[default]
-    None,
-}
-
-impl ModelScratch for PipelineModelScratch {}
 
 #[cfg(test)]
 mod tests {
@@ -1798,170 +1682,5 @@ mod tests {
         );
         let err = conversion_error(&tok);
         assert!(err.contains("not supported"), "{}", err);
-    }
-
-    /// A BPE pipeline that merges "hello" into the single id 7.
-    fn hello_pipeline() -> PipelineTokenizer {
-        use crate::models::bpe::{BpeBuilder, Merges, Vocab};
-
-        let vocab: Vocab = [
-            ("h", 0u32),
-            ("e", 1),
-            ("l", 2),
-            ("o", 3),
-            ("he", 4),
-            ("hel", 5),
-            ("hell", 6),
-            ("hello", 7),
-        ]
-        .into_iter()
-        .map(|(s, i)| (s.to_string(), i))
-        .collect();
-        let merges: Merges = vec![
-            ("h".to_string(), "e".to_string()),
-            ("he".to_string(), "l".to_string()),
-            ("hel".to_string(), "l".to_string()),
-            ("hell".to_string(), "o".to_string()),
-        ];
-        let bpe = BpeBuilder::default()
-            .vocab_and_merges(vocab, merges)
-            .build()
-            .unwrap();
-        PipelineTokenizer::try_from(&Tokenizer::new(bpe)).unwrap()
-    }
-
-    // The pool exists so ONE `&self` tokenizer can be shared across rayon workers. Encode
-    // the same input from thousands of threads through a single instance; each must get a
-    // private scratch and produce the sequential result. Two threads sharing a scratch
-    // would corrupt some of them. This only compiles if `PipelineTokenizer: Sync`,
-    // which the pool has to preserve.
-    #[test]
-    fn encode_shared_across_threads() {
-        use rayon::prelude::*;
-
-        let pipeline = hello_pipeline();
-
-        let want: Vec<u32> = pipeline
-            .encode("hello", false)
-            .wait()
-            .unwrap()
-            .remove(0)
-            .iter()
-            .map(|t| t.id())
-            .collect();
-        assert_eq!(want, vec![7]);
-
-        let all_match = (0..10_000u32).into_par_iter().all(|_| {
-            pipeline
-                .encode("hello", false)
-                .wait()
-                .unwrap()
-                .remove(0)
-                .iter()
-                .map(|t| t.id())
-                .collect::<Vec<_>>()
-                == want
-        });
-        assert!(all_match);
-    }
-
-    // Reusing scratches is the whole point of the pool, so it must not build one per call:
-    // one thread encoding in a loop has to keep coming back to the same scratch, and a
-    // burst of N threads must leave at most N behind for later calls to use.
-    #[test]
-    fn scratches_are_reused_rather_than_piling_up() {
-        use std::sync::Barrier;
-
-        let pipeline = hello_pipeline();
-        for _ in 0..1000 {
-            pipeline.encode("hello", false).wait().unwrap();
-        }
-        assert_eq!(pipeline.scratch_pool.len(), 1);
-
-        let threads = 64;
-        let all_holding = Barrier::new(threads);
-        std::thread::scope(|scope| {
-            for _ in 0..threads {
-                scope.spawn(|| {
-                    let scratch = pipeline.scratch_pool.get(&pipeline.model);
-                    all_holding.wait();
-                    drop(scratch);
-                });
-            }
-        });
-
-        let after_burst = pipeline.scratch_pool.len();
-        assert!(
-            after_burst <= threads,
-            "{after_burst} scratches kept for {threads} threads"
-        );
-        for _ in 0..1000 {
-            pipeline.encode("hello", false).wait().unwrap();
-        }
-        assert_eq!(pipeline.scratch_pool.len(), after_burst);
-    }
-
-    // ScratchGuard::drop moves the scratch to the pool with mem::take, which leaves the
-    // default None variant behind in the guard. The pool must end up holding the scratch
-    // the model used: if the None leftover were pushed instead, the pool would still
-    // count one scratch, and the next encode would take it and panic in
-    // PipelineModel::tokenize_pipeline.
-    #[test]
-    fn the_pool_gets_back_the_used_scratch_not_the_none_leftover() {
-        let pipeline = hello_pipeline();
-        pipeline.encode("hello", false).wait().unwrap();
-        assert_eq!(pipeline.scratch_pool.len(), 1);
-        let scratch = pipeline.scratch_pool.get(&pipeline.model);
-        assert!(
-            matches!(*scratch, PipelineModelScratch::BPE(_)),
-            "the pooled scratch is not the BPE scratch the model used"
-        );
-    }
-
-    // Pooling is only worth it if a scratch keeps the state it built up across calls.
-    // A fresh BpeScratch starts with an empty merge arena; encoding a longer sequence
-    // reserves one entry per byte and so grows it. After a second, short encode the
-    // pooled scratch must still be the grown one, not a fresh replacement built
-    // somewhere along the way.
-    #[test]
-    fn a_reused_scratch_keeps_its_grown_buffers() {
-        let pipeline = hello_pipeline();
-        let long_input = "hello".repeat(50);
-        pipeline.encode(&long_input, false).wait().unwrap();
-        assert_eq!(pipeline.scratch_pool.len(), 1);
-
-        pipeline.encode("hello", false).wait().unwrap();
-        assert_eq!(pipeline.scratch_pool.len(), 1);
-
-        let scratch = pipeline.scratch_pool.get(&pipeline.model);
-        let PipelineModelScratch::BPE(bpe_scratch) = &*scratch else {
-            panic!("the pooled scratch is not a BPE scratch");
-        };
-        assert!(
-            bpe_scratch.queue.entries.capacity() >= long_input.len(),
-            "the pooled scratch is not the one grown by the long input: \
-             room for {} merge entries after a {}-byte input",
-            bpe_scratch.queue.entries.capacity(),
-            long_input.len()
-        );
-    }
-
-    // A scratch coming back out of the pool has to still know the words of the last
-    // encode: a cache emptied between calls would never hit.
-    //
-    // "helo" and not "hello": a whole word that is itself a vocabulary entry is answered
-    // by the fold in one probe, before the cache is ever consulted, so it would never be
-    // stored. Only words that reach the merge engines land in the cache.
-    #[test]
-    fn the_word_cache_outlives_the_encode_call() {
-        let pipeline = hello_pipeline();
-        pipeline.encode("helo", false).wait().unwrap();
-
-        let mut scratch = pipeline.scratch_pool.get(&pipeline.model);
-        let PipelineModelScratch::BPE(bpe) = &mut *scratch else {
-            panic!("a BPE pipeline encodes with a BPE scratch");
-        };
-        let cache = bpe.word_cache.as_mut().expect("BPE encodes with a cache");
-        assert_eq!(cache.lookup(b"helo").hit(), Some(&[5u32, 3][..]));
     }
 }

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -123,6 +123,11 @@ pub struct PreTokenizerScratch {
     tags: Vec<u8>,
     /// An intermediate buffer in which the FSM writes the Span before they get appended to the output
     spans: Vec<Span>,
+    /// The two buffers a [`PipelineSequence`] reads and writes as each of its children subdivides
+    /// the spans the child before it produced. Handed out by [`Self::take_pair`] rather than
+    /// borrowed, so the sequence can pass the rest of the scratch to its children while it holds
+    /// them.
+    pair: [Vec<Span>; 2],
 }
 
 impl PreTokenizerScratch {
@@ -135,7 +140,7 @@ impl PreTokenizerScratch {
         out: &mut Vec<Span>,
     ) {
         let n = bytes.len();
-        let Self { tags, spans } = self;
+        let Self { tags, spans, .. } = self;
         if tags.len() < n {
             tags.resize(n, 0);
         }
@@ -165,6 +170,16 @@ impl PreTokenizerScratch {
         }
         let k = fsm(bytes, &mut spans[..n + 1]);
         out.extend_from_slice(&spans[..k]);
+    }
+
+    /// Take the sequence's two buffers, leaving empty ones behind.
+    pub fn take_pair(&mut self) -> [Vec<Span>; 2] {
+        std::mem::take(&mut self.pair)
+    }
+
+    /// Give back what [`Self::take_pair`] handed out, so the next sequence reuses the allocations.
+    pub fn put_pair(&mut self, pair: [Vec<Span>; 2]) {
+        self.pair = pair;
     }
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -1,10 +1,7 @@
-use std::cell::RefCell;
 use std::convert::TryInto;
 use std::iter::Enumerate;
 use std::vec::IntoIter;
 use std::{borrow::Cow, convert::TryFrom};
-
-use atomsplit::classify::classify;
 
 use crate::models::bpe::{BpeScratch, PipelineBPE};
 use crate::models::unigram::{Unigram, UnigramScratch};
@@ -38,35 +35,12 @@ use crate::{
 
 use super::{Result, SplitDelimiterBehavior};
 
+use atomsplit::classify::classify;
 pub use atomsplit::fsm::Span;
 
 mod scratch_pool;
 
 pub use scratch_pool::ModelScratch;
-
-/// We use a thread local scratch for the tags (per byte class) and for the split spans.
-pub(crate) fn classify_into_spans(
-    bytes: &[u8],
-    fsm: impl FnOnce(&[u8], &[u8], &mut [Span]) -> usize,
-    out: &mut Vec<Span>,
-) {
-    thread_local! {
-        static SCRATCH: RefCell<(Vec<u8>, Vec<Span>)> = const { RefCell::new((Vec::new(), Vec::new())) };
-    }
-    let n = bytes.len();
-    SCRATCH.with(|cell| {
-        let (tags, spans) = &mut *cell.borrow_mut();
-        if tags.len() < n {
-            tags.resize(n, 0); // grow-only: after the largest segment, no realloc / no re-zeroing
-        }
-        if spans.len() < n + 1 {
-            spans.resize(n + 1, Span::default());
-        }
-        classify(bytes, &mut tags[..n]);
-        let k = fsm(bytes, &tags[..n], &mut spans[..n + 1]);
-        out.extend_from_slice(&spans[..k]); // same type now: plain memcpy, no per-token conversion
-    });
-}
 
 pub trait Normalizer {
     fn normalize<'a>(&self, input: &'a str) -> Result<Cow<'a, str>>;
@@ -132,7 +106,66 @@ impl Normalizer for PipelineNormalizer {
 /// substrings, so the pipeline can pre-tokenize without allocating.
 pub trait PreTokenizer {
     /// Split `text` into pre-tokens, appending to `out`. Ranges are into `text`.
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<Span>) -> Result<()>;
+    /// `scratch` holds the working buffers, see [`PreTokenizerScratch`].
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        scratch: &mut PreTokenizerScratch,
+        out: &mut Vec<Span>,
+    ) -> Result<()>;
+}
+
+/// The working buffers a [`PreTokenizer`] needs to split a text into pre-tokens.
+#[derive(Default)]
+pub struct PreTokenizerScratch {
+    /// One [`atomsplit`] atom tag per input byte, what [`atomsplit::classify::classify`] writes
+    /// and the FSMs read.
+    tags: Vec<u8>,
+    /// An intermediate buffer in which the FSM writes the Span before they get appended to the output
+    spans: Vec<Span>,
+}
+
+impl PreTokenizerScratch {
+    /// Tag every byte of `bytes` with its [`atomsplit`] atom class, run `fsm` over the tags, and
+    /// append the spans to `out`.
+    pub fn split_on_tags(
+        &mut self,
+        bytes: &[u8],
+        fsm: impl FnOnce(&[u8], &[u8], &mut [Span]) -> usize,
+        out: &mut Vec<Span>,
+    ) {
+        let n = bytes.len();
+        let Self { tags, spans } = self;
+        if tags.len() < n {
+            tags.resize(n, 0);
+        }
+        if spans.len() < n + 1 {
+            spans.resize(n + 1, Span::default());
+        }
+        // Assign a tag to each byte
+        classify(bytes, &mut tags[..n]);
+        // Run the fsm on the tags to determine where to cut
+        let k = fsm(bytes, &tags[..n], &mut spans[..n + 1]);
+        // Copy spans to output
+        out.extend_from_slice(&spans[..k]);
+    }
+
+    /// Run `fsm` over `bytes` and append the spans it cut to `out`, for an FSM that scans the bytes
+    /// itself and so has no use for the atom tags. Skips the [`classify`]
+    pub fn split_on_bytes(
+        &mut self,
+        bytes: &[u8],
+        fsm: impl FnOnce(&[u8], &mut [Span]) -> usize,
+        out: &mut Vec<Span>,
+    ) {
+        let n = bytes.len();
+        let spans = &mut self.spans;
+        if spans.len() < n + 1 {
+            spans.resize(n + 1, Span::default());
+        }
+        let k = fsm(bytes, &mut spans[..n + 1]);
+        out.extend_from_slice(&spans[..k]);
+    }
 }
 
 /// The pre-tokenizers a [`PipelineTokenizer`] can run.
@@ -153,7 +186,12 @@ pub enum PipelinePreTokenizer {
 }
 
 impl PreTokenizer for PipelinePreTokenizer {
-    fn pre_tokenize(&self, text: &str, out: &mut Vec<Span>) -> Result<()> {
+    fn pre_tokenize(
+        &self,
+        text: &str,
+        scratch: &mut PreTokenizerScratch,
+        out: &mut Vec<Span>,
+    ) -> Result<()> {
         match self {
             Self::None => {
                 out.push(Span {
@@ -162,16 +200,16 @@ impl PreTokenizer for PipelinePreTokenizer {
                 });
                 Ok(())
             }
-            Self::Bert(pretok) => pretok.pre_tokenize(text, out),
-            Self::Delimiter(pretok) => pretok.pre_tokenize(text, out),
-            Self::Digits(pretok) => pretok.pre_tokenize(text, out),
-            Self::FixedLength(pretok) => pretok.pre_tokenize(text, out),
-            Self::Punctuation(pretok) => pretok.pre_tokenize(text, out),
-            Self::Sequence(pretok) => pretok.pre_tokenize(text, out),
-            Self::Split(pretok) => pretok.pre_tokenize(text, out),
-            Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, out),
-            Self::Whitespace(pretok) => pretok.pre_tokenize(text, out),
-            Self::WhitespaceSplit(pretok) => pretok.pre_tokenize(text, out),
+            Self::Bert(pretok) => pretok.pre_tokenize(text, scratch, out),
+            Self::Delimiter(pretok) => pretok.pre_tokenize(text, scratch, out),
+            Self::Digits(pretok) => pretok.pre_tokenize(text, scratch, out),
+            Self::FixedLength(pretok) => pretok.pre_tokenize(text, scratch, out),
+            Self::Punctuation(pretok) => pretok.pre_tokenize(text, scratch, out),
+            Self::Sequence(pretok) => pretok.pre_tokenize(text, scratch, out),
+            Self::Split(pretok) => pretok.pre_tokenize(text, scratch, out),
+            Self::UnicodeScripts(pretok) => pretok.pre_tokenize(text, scratch, out),
+            Self::Whitespace(pretok) => pretok.pre_tokenize(text, scratch, out),
+            Self::WhitespaceSplit(pretok) => pretok.pre_tokenize(text, scratch, out),
         }
     }
 }
@@ -843,10 +881,14 @@ impl PipelineTokenizer {
                                 let EncodeScratch {
                                     model: model_scratch,
                                     pre_tokens,
+                                    split: pre_tokenizer_scratch,
                                 } = &mut *scratch;
                                 pre_tokens.clear();
-                                self.pre_tokenizer
-                                    .pre_tokenize(normalized_chunk, pre_tokens)?;
+                                self.pre_tokenizer.pre_tokenize(
+                                    normalized_chunk,
+                                    pre_tokenizer_scratch,
+                                    pre_tokens,
+                                )?;
                                 output.reserve(pre_tokens.len());
                                 for pre_token in pre_tokens {
                                     // The get_unchecked saves us a UTF-8 boundary check

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/scratch_pool.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/scratch_pool.rs
@@ -97,13 +97,14 @@ impl std::ops::DerefMut for ScratchGuard<'_> {
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
+    use std::collections::BTreeSet;
     use std::sync::Barrier;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
-    use crate::Tokenizer;
     use crate::pipeline::PipelineTokenizer;
     use crate::pre_tokenizers::whitespace::Whitespace;
+    use crate::{PreTokenizerWrapper, Tokenizer};
 
     /// A BPE tokenizer that merges "hello" into the single id 7.
     fn hello_tokenizer() -> Tokenizer {
@@ -145,6 +146,22 @@ mod tests {
     fn hello_pipeline_split_on_words() -> PipelineTokenizer {
         let mut tok = hello_tokenizer();
         tok.with_pre_tokenizer(Some(Whitespace));
+        PipelineTokenizer::try_from(&tok).unwrap()
+    }
+
+    /// The same tokenizer, with a `Sequence` of two real children: the shape that runs
+    /// [`PipelineSequence`]'s child loop, where a single child or a recognized deepseek
+    /// composition would take a fast path above it instead.
+    fn hello_pipeline_sequence() -> PipelineTokenizer {
+        use crate::pre_tokenizers::digits::Digits;
+        use crate::pre_tokenizers::sequence::Sequence;
+        use crate::pre_tokenizers::whitespace::WhitespaceSplit;
+
+        let mut tok = hello_tokenizer();
+        tok.with_pre_tokenizer(Some(Sequence::new(vec![
+            PreTokenizerWrapper::WhitespaceSplit(WhitespaceSplit),
+            PreTokenizerWrapper::Digits(Digits::default()),
+        ])));
         PipelineTokenizer::try_from(&tok).unwrap()
     }
 
@@ -296,6 +313,47 @@ mod tests {
             pooled_buffers(&pipeline),
             warm,
             "a warm encode did not write into the buffers the pool handed it"
+        );
+    }
+
+    /// The addresses of the three span buffers a sequence encode rotates between.
+    fn pooled_span_buffers(pipeline: &PipelineTokenizer) -> BTreeSet<usize> {
+        let scratch = pipeline.scratch_pool.get(&pipeline.model);
+        let [first, second] = &scratch.split.pair;
+        [&scratch.pre_tokens, first, second]
+            .map(|spans| spans.as_ptr() as usize)
+            .into_iter()
+            .collect()
+    }
+
+    // `PipelineSequence` swaps its two buffers with `pre_tokens` rather than copying out of them,
+    // so no one buffer keeps the same allocation from call to call and the per-buffer comparison
+    // above would not hold here. What must hold is that the three allocations a warm pipeline
+    // rotates are still the three it uses: a call that allocated a fresh buffer instead of taking
+    // the pooled one would show an address the warm set does not have.
+    #[test]
+    fn a_warm_sequence_reuses_the_same_span_buffers() {
+        let pipeline = hello_pipeline_sequence();
+        let input = "helo ".repeat(50);
+
+        // The buffers rotate, so they take a few encodes to all have been grown once.
+        for _ in 0..4 {
+            pipeline.encode(input.as_str(), false).wait().unwrap();
+        }
+        let warm = pooled_span_buffers(&pipeline);
+        assert_eq!(
+            warm.len(),
+            3,
+            "the encodes left buffers this test cannot compare: a `Vec` that never allocated \
+             reports the same dangling address as every other one, so a set smaller than three \
+             is comparing addresses that prove nothing"
+        );
+
+        pipeline.encode(input.as_str(), false).wait().unwrap();
+        assert_eq!(
+            pooled_span_buffers(&pipeline),
+            warm,
+            "a warm sequence encode allocated a span buffer instead of reusing the pooled ones"
         );
     }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/scratch_pool.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/scratch_pool.rs
@@ -1,0 +1,293 @@
+use std::{
+    mem,
+    sync::{Mutex, PoisonError},
+};
+
+use atomsplit::fsm::Span;
+
+use crate::pipeline::{Model, PipelineModel, PipelineModelScratch};
+
+pub trait ModelScratch {}
+
+#[derive(Default)]
+pub(crate) struct EncodeScratch {
+    pub(crate) model: PipelineModelScratch,
+    pub(crate) pre_tokens: Vec<Span>,
+}
+
+/// A pool of [`PipelineModelScratch`].
+///
+/// When calling [`PipelineTokenizer::encode`], an instance of [`PipelineModelScratch`] is taken out of this pool
+/// and given to the tokenizer. When the encoding is done, the scratch buffer is returned to the pool and can be
+/// reused by later calls.
+///
+/// The reusability matters because the scratch buffer may hold cache structures which are more useful when reused,
+/// and less importantly it saves an extra allocation for an fresh buffer every time.
+pub(super) struct ScratchPool(Mutex<Vec<EncodeScratch>>);
+
+impl ScratchPool {
+    pub(crate) fn new() -> Self {
+        Self(Mutex::new(Vec::new()))
+    }
+
+    /// Get a scratch buffer from the pool, wrapped in a [`ScratchGuard`].
+    /// When the [`ScratchGuard`] gets dropped, the scratch buffer is pushed back to the pool.
+    pub(crate) fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
+        // The Mutex lock is held just long enough to pop the scratch out of the pool
+        let taken = self.0.lock().unwrap_or_else(PoisonError::into_inner).pop();
+        ScratchGuard {
+            // If there was no scratch buffer available in the pool, we build.a fresh one
+            scratch: taken.unwrap_or_else(|| EncodeScratch {
+                model: model.init_scratch(),
+                pre_tokens: Vec::new(),
+            }),
+            pool: self,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.0.lock().unwrap_or_else(PoisonError::into_inner).len()
+    }
+}
+
+/// A wrapper around [`PipelineModelScratch`].
+/// Implements [`Deref`] and [`DerefMut`], so it behaves as [`PipelineModelScratch`].
+///
+/// When it gets dropped, it pushes [`Self::scratch`] back into the shared [`Self::pool`] so it can
+/// get reused by a later call to [`PipelineTokenizer::encode`].
+///
+/// TODO @McPatate : The Mutex can create contention, to be replaced by a better access pattern
+pub(super) struct ScratchGuard<'a> {
+    scratch: EncodeScratch,
+    pool: &'a ScratchPool,
+}
+
+impl Drop for ScratchGuard<'_> {
+    fn drop(&mut self) {
+        // Steals the scratch buffer from self, replaces it with PipelineModelScratch::default()
+        let scratch = mem::take(&mut self.scratch);
+        // Push the scratch back in the pool
+        self.pool
+            .0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(scratch);
+    }
+}
+
+impl std::ops::Deref for ScratchGuard<'_> {
+    type Target = EncodeScratch;
+    fn deref(&self) -> &EncodeScratch {
+        &self.scratch
+    }
+}
+
+impl std::ops::DerefMut for ScratchGuard<'_> {
+    fn deref_mut(&mut self) -> &mut EncodeScratch {
+        &mut self.scratch
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Tokenizer;
+    use crate::pipeline::PipelineTokenizer;
+
+    /// A BPE tokenizer that merges "hello" into the single id 7.
+    fn hello_tokenizer() -> Tokenizer {
+        use crate::models::bpe::{BpeBuilder, Merges, Vocab};
+
+        let vocab: Vocab = [
+            ("h", 0u32),
+            ("e", 1),
+            ("l", 2),
+            ("o", 3),
+            ("he", 4),
+            ("hel", 5),
+            ("hell", 6),
+            ("hello", 7),
+        ]
+        .into_iter()
+        .map(|(s, i)| (s.to_string(), i))
+        .collect();
+        let merges: Merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+            ("hel".to_string(), "l".to_string()),
+            ("hell".to_string(), "o".to_string()),
+        ];
+        let bpe = BpeBuilder::default()
+            .vocab_and_merges(vocab, merges)
+            .build()
+            .unwrap();
+        Tokenizer::new(bpe)
+    }
+
+    fn hello_pipeline() -> PipelineTokenizer {
+        PipelineTokenizer::try_from(&hello_tokenizer()).unwrap()
+    }
+
+    // The pool exists so ONE `&self` tokenizer can be shared across rayon workers. Encode
+    // the same input from thousands of threads through a single instance; each must get a
+    // private scratch and produce the sequential result. Two threads sharing a scratch
+    // would corrupt some of them. This only compiles if `PipelineTokenizer: Sync`,
+    // which the pool has to preserve.
+    #[test]
+    fn encode_shared_across_threads() {
+        use rayon::prelude::*;
+
+        let pipeline = hello_pipeline();
+
+        let want: Vec<u32> = pipeline
+            .encode("hello", false)
+            .wait()
+            .unwrap()
+            .remove(0)
+            .iter()
+            .map(|t| t.id())
+            .collect();
+        assert_eq!(want, vec![7]);
+
+        let all_match = (0..10_000u32).into_par_iter().all(|_| {
+            pipeline
+                .encode("hello", false)
+                .wait()
+                .unwrap()
+                .remove(0)
+                .iter()
+                .map(|t| t.id())
+                .collect::<Vec<_>>()
+                == want
+        });
+        assert!(all_match);
+    }
+
+    // Reusing scratches is the whole point of the pool, so it must not build one per call:
+    // one thread encoding in a loop has to keep coming back to the same scratch, and a
+    // burst of N threads must leave at most N behind for later calls to use.
+    #[test]
+    fn scratches_are_reused_rather_than_piling_up() {
+        use std::sync::Barrier;
+
+        let pipeline = hello_pipeline();
+        for _ in 0..1000 {
+            pipeline.encode("hello", false).wait().unwrap();
+        }
+        assert_eq!(pipeline.scratch_pool.len(), 1);
+
+        let threads = 64;
+        let all_holding = Barrier::new(threads);
+        std::thread::scope(|scope| {
+            for _ in 0..threads {
+                scope.spawn(|| {
+                    let scratch = pipeline.scratch_pool.get(&pipeline.model);
+                    all_holding.wait();
+                    drop(scratch);
+                });
+            }
+        });
+
+        let after_burst = pipeline.scratch_pool.len();
+        assert!(
+            after_burst <= threads,
+            "{after_burst} scratches kept for {threads} threads"
+        );
+        for _ in 0..1000 {
+            pipeline.encode("hello", false).wait().unwrap();
+        }
+        assert_eq!(pipeline.scratch_pool.len(), after_burst);
+    }
+
+    // ScratchGuard::drop moves the scratch to the pool with mem::take, which leaves a default
+    // EncodeScratch, holding the None model variant, behind in the guard. The pool must end up
+    // holding the scratch the model used: if the default leftover were pushed instead, the pool
+    // would still count one scratch, and the next encode would take it and panic in
+    // PipelineModel::tokenize_pipeline.
+    #[test]
+    fn the_pool_gets_back_the_used_scratch_not_the_none_leftover() {
+        let pipeline = hello_pipeline();
+        pipeline.encode("hello", false).wait().unwrap();
+        assert_eq!(pipeline.scratch_pool.len(), 1);
+        let scratch = pipeline.scratch_pool.get(&pipeline.model);
+        assert!(
+            matches!(scratch.model, PipelineModelScratch::BPE(_)),
+            "the pooled scratch is not the BPE scratch the model used"
+        );
+    }
+
+    // Pooling is only worth it if a scratch keeps the state it built up across calls.
+    // A fresh BpeScratch starts with an empty merge arena; encoding a longer sequence
+    // reserves one entry per byte and so grows it. After a second, short encode the
+    // pooled scratch must still be the grown one, not a fresh replacement built
+    // somewhere along the way.
+    #[test]
+    fn a_reused_scratch_keeps_its_grown_buffers() {
+        let pipeline = hello_pipeline();
+        let long_input = "hello".repeat(50);
+        pipeline.encode(&long_input, false).wait().unwrap();
+        assert_eq!(pipeline.scratch_pool.len(), 1);
+
+        pipeline.encode("hello", false).wait().unwrap();
+        assert_eq!(pipeline.scratch_pool.len(), 1);
+
+        let scratch = pipeline.scratch_pool.get(&pipeline.model);
+        let PipelineModelScratch::BPE(bpe_scratch) = &scratch.model else {
+            panic!("the pooled scratch is not a BPE scratch");
+        };
+        assert!(
+            bpe_scratch.queue.entries.capacity() >= long_input.len(),
+            "the pooled scratch is not the one grown by the long input: \
+             room for {} merge entries after a {}-byte input",
+            bpe_scratch.queue.entries.capacity(),
+            long_input.len()
+        );
+    }
+
+    // The pre-token spans travel in the same EncodeScratch as the model state, for the same
+    // reason: the buffer a call grows is the buffer the next call writes into. The tokenizer
+    // gets a Whitespace pre-tokenizer here so the input is cut into many spans, where the
+    // pipelines above leave the whole chunk as one.
+    #[test]
+    fn a_reused_scratch_keeps_its_pre_token_buffer() {
+        use crate::pre_tokenizers::whitespace::Whitespace;
+
+        let mut tok = hello_tokenizer();
+        tok.with_pre_tokenizer(Some(Whitespace));
+        let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
+
+        let words = 50;
+        pipeline
+            .encode("hello ".repeat(words).as_str(), false)
+            .wait()
+            .unwrap();
+
+        let scratch = pipeline.scratch_pool.get(&pipeline.model);
+        assert!(
+            scratch.pre_tokens.capacity() >= words,
+            "the pooled pre-token buffer is not the one grown by the {words} words: \
+             room for {} spans",
+            scratch.pre_tokens.capacity()
+        );
+    }
+
+    // A scratch coming back out of the pool has to still know the words of the last
+    // encode: a cache emptied between calls would never hit.
+    //
+    // "helo" and not "hello": a whole word that is itself a vocabulary entry is answered
+    // by the fold in one probe, before the cache is ever consulted, so it would never be
+    // stored. Only words that reach the merge engines land in the cache.
+    #[test]
+    fn the_word_cache_outlives_the_encode_call() {
+        let pipeline = hello_pipeline();
+        pipeline.encode("helo", false).wait().unwrap();
+
+        let mut scratch = pipeline.scratch_pool.get(&pipeline.model);
+        let PipelineModelScratch::BPE(bpe) = &mut scratch.model else {
+            panic!("a BPE pipeline encodes with a BPE scratch");
+        };
+        let cache = bpe.word_cache.as_mut().expect("BPE encodes with a cache");
+        assert_eq!(cache.lookup(b"helo").hit(), Some(&[5u32, 3][..]));
+    }
+}

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/scratch_pool.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/scratch_pool.rs
@@ -33,14 +33,17 @@ impl ScratchPool {
     /// Get a scratch buffer from the pool, wrapped in a [`ScratchGuard`].
     /// When the [`ScratchGuard`] gets dropped, the scratch buffer is pushed back to the pool.
     pub(crate) fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
+        self.get_with(|| EncodeScratch {
+            model: model.init_scratch(),
+            pre_tokens: Vec::new(),
+        })
+    }
+
+    pub(crate) fn get_with<'a>(&'a self, init: impl FnOnce() -> EncodeScratch) -> ScratchGuard<'a> {
         // The Mutex lock is held just long enough to pop the scratch out of the pool
         let taken = self.0.lock().unwrap_or_else(PoisonError::into_inner).pop();
         ScratchGuard {
-            // If there was no scratch buffer available in the pool, we build.a fresh one
-            scratch: taken.unwrap_or_else(|| EncodeScratch {
-                model: model.init_scratch(),
-                pre_tokens: Vec::new(),
-            }),
+            scratch: taken.unwrap_or_else(init),
             pool: self,
         }
     }
@@ -91,9 +94,14 @@ impl std::ops::DerefMut for ScratchGuard<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+    use std::sync::Barrier;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
     use crate::Tokenizer;
     use crate::pipeline::PipelineTokenizer;
+    use crate::pre_tokenizers::whitespace::Whitespace;
 
     /// A BPE tokenizer that merges "hello" into the single id 7.
     fn hello_tokenizer() -> Tokenizer {
@@ -129,75 +137,93 @@ mod tests {
         PipelineTokenizer::try_from(&hello_tokenizer()).unwrap()
     }
 
-    // The pool exists so ONE `&self` tokenizer can be shared across rayon workers. Encode
-    // the same input from thousands of threads through a single instance; each must get a
-    // private scratch and produce the sequential result. Two threads sharing a scratch
-    // would corrupt some of them. This only compiles if `PipelineTokenizer: Sync`,
-    // which the pool has to preserve.
-    #[test]
-    fn encode_shared_across_threads() {
-        use rayon::prelude::*;
-
-        let pipeline = hello_pipeline();
-
-        let want: Vec<u32> = pipeline
-            .encode("hello", false)
-            .wait()
-            .unwrap()
-            .remove(0)
-            .iter()
-            .map(|t| t.id())
-            .collect();
-        assert_eq!(want, vec![7]);
-
-        let all_match = (0..10_000u32).into_par_iter().all(|_| {
-            pipeline
-                .encode("hello", false)
-                .wait()
-                .unwrap()
-                .remove(0)
-                .iter()
-                .map(|t| t.id())
-                .collect::<Vec<_>>()
-                == want
-        });
-        assert!(all_match);
+    /// The same tokenizer, with a pre-tokenizer that cuts one span per word. A pipeline with no
+    /// pre-tokenizer leaves the whole chunk as a single span, which barely exercises
+    /// [`EncodeScratch::pre_tokens`].
+    fn hello_pipeline_split_on_words() -> PipelineTokenizer {
+        let mut tok = hello_tokenizer();
+        tok.with_pre_tokenizer(Some(Whitespace));
+        PipelineTokenizer::try_from(&tok).unwrap()
     }
 
-    // Reusing scratches is the whole point of the pool, so it must not build one per call:
-    // one thread encoding in a loop has to keep coming back to the same scratch, and a
-    // burst of N threads must leave at most N behind for later calls to use.
-    #[test]
-    fn scratches_are_reused_rather_than_piling_up() {
-        use std::sync::Barrier;
+    /// Builds a default scratch and counts the call, for the tests that assert the pool reuses
+    /// what it has instead of building.
+    fn counting_init(built: &AtomicUsize) -> EncodeScratch {
+        built.fetch_add(1, Ordering::Relaxed);
+        EncodeScratch::default()
+    }
 
-        let pipeline = hello_pipeline();
+    // Reusing scratches is the whole point of the pool, so one caller coming back a thousand
+    // times must keep getting the one scratch the first call built.
+    #[test]
+    fn builds_one_scratch_and_reuses_it() {
+        let pool = ScratchPool::new();
+        let built = Cell::new(0);
+
         for _ in 0..1000 {
-            pipeline.encode("hello", false).wait().unwrap();
+            drop(pool.get_with(|| {
+                built.set(built.get() + 1);
+                EncodeScratch::default()
+            }));
         }
-        assert_eq!(pipeline.scratch_pool.len(), 1);
+
+        assert_eq!(built.get(), 1);
+    }
+
+    // N callers holding at once need N scratches, and the pool must keep no more than that: it is
+    // there to hand scratches back out, not to grow. The barrier makes all N hold before any of
+    // them drops, so all N really are live at the same time.
+    #[test]
+    fn keeps_at_most_one_scratch_per_concurrent_holder() {
+        let pool = ScratchPool::new();
+        let built = AtomicUsize::new(0);
 
         let threads = 64;
         let all_holding = Barrier::new(threads);
         std::thread::scope(|scope| {
             for _ in 0..threads {
                 scope.spawn(|| {
-                    let scratch = pipeline.scratch_pool.get(&pipeline.model);
+                    let scratch = pool.get_with(|| counting_init(&built));
                     all_holding.wait();
                     drop(scratch);
                 });
             }
         });
-
-        let after_burst = pipeline.scratch_pool.len();
+        let after_burst = pool.len();
         assert!(
             after_burst <= threads,
             "{after_burst} scratches kept for {threads} threads"
         );
-        for _ in 0..1000 {
-            pipeline.encode("hello", false).wait().unwrap();
-        }
-        assert_eq!(pipeline.scratch_pool.len(), after_burst);
+
+        drop(pool.get_with(|| counting_init(&built)));
+        assert_eq!(
+            built.load(Ordering::Relaxed),
+            threads,
+            "the pool built a fresh scratch while it had {after_burst} to hand out"
+        );
+    }
+
+    // `Drop` runs while a panic unwinds, so an encode that blows up half way through still hands
+    // its scratch back rather than taking it with it.
+    //
+    // The panic message on stderr during this test is the one raised here on purpose.
+    #[test]
+    fn a_panicking_holder_still_returns_its_scratch() {
+        let pool = ScratchPool::new();
+        let built = AtomicUsize::new(0);
+
+        let holder = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _scratch = pool.get_with(|| counting_init(&built));
+            panic!("encode blew up while holding a scratch");
+        }));
+        assert!(holder.is_err(), "the holder was supposed to panic");
+
+        drop(pool.get_with(|| counting_init(&built)));
+        assert_eq!(
+            built.load(Ordering::Relaxed),
+            1,
+            "the panicking holder's scratch never made it back to the pool"
+        );
     }
 
     // ScratchGuard::drop moves the scratch to the pool with mem::take, which leaves a default
@@ -217,58 +243,57 @@ mod tests {
         );
     }
 
-    // Pooling is only worth it if a scratch keeps the state it built up across calls.
-    // A fresh BpeScratch starts with an empty merge arena; encoding a longer sequence
-    // reserves one entry per byte and so grows it. After a second, short encode the
-    // pooled scratch must still be the grown one, not a fresh replacement built
-    // somewhere along the way.
-    #[test]
-    fn a_reused_scratch_keeps_its_grown_buffers() {
-        let pipeline = hello_pipeline();
-        let long_input = "hello".repeat(50);
-        pipeline.encode(&long_input, false).wait().unwrap();
-        assert_eq!(pipeline.scratch_pool.len(), 1);
-
-        pipeline.encode("hello", false).wait().unwrap();
-        assert_eq!(pipeline.scratch_pool.len(), 1);
-
-        let scratch = pipeline.scratch_pool.get(&pipeline.model);
-        let PipelineModelScratch::BPE(bpe_scratch) = &scratch.model else {
-            panic!("the pooled scratch is not a BPE scratch");
-        };
-        assert!(
-            bpe_scratch.queue.entries.capacity() >= long_input.len(),
-            "the pooled scratch is not the one grown by the long input: \
-             room for {} merge entries after a {}-byte input",
-            bpe_scratch.queue.entries.capacity(),
-            long_input.len()
-        );
+    /// Where the buffers of the pooled scratch live, and how much room each has. The capacities
+    /// are what keep the addresses honest: a `Vec` that never allocated owns no buffer, and every
+    /// one of those reports the same dangling address.
+    #[derive(Debug, PartialEq)]
+    struct Buffers {
+        pre_tokens: (usize, usize),
+        symbols: (usize, usize),
     }
 
-    // The pre-token spans travel in the same EncodeScratch as the model state, for the same
-    // reason: the buffer a call grows is the buffer the next call writes into. The tokenizer
-    // gets a Whitespace pre-tokenizer here so the input is cut into many spans, where the
-    // pipelines above leave the whole chunk as one.
-    #[test]
-    fn a_reused_scratch_keeps_its_pre_token_buffer() {
-        use crate::pre_tokenizers::whitespace::Whitespace;
-
-        let mut tok = hello_tokenizer();
-        tok.with_pre_tokenizer(Some(Whitespace));
-        let pipeline = PipelineTokenizer::try_from(&tok).unwrap();
-
-        let words = 50;
-        pipeline
-            .encode("hello ".repeat(words).as_str(), false)
-            .wait()
-            .unwrap();
-
+    fn pooled_buffers(pipeline: &PipelineTokenizer) -> Buffers {
         let scratch = pipeline.scratch_pool.get(&pipeline.model);
+        let PipelineModelScratch::BPE(bpe) = &scratch.model else {
+            panic!("a BPE pipeline encodes with a BPE scratch");
+        };
+        Buffers {
+            pre_tokens: (
+                scratch.pre_tokens.as_ptr() as usize,
+                scratch.pre_tokens.capacity(),
+            ),
+            symbols: (bpe.symbols.as_ptr() as usize, bpe.symbols.capacity()),
+        }
+    }
+
+    // What pooling buys is the allocation the previous call already made, for the pre-token spans
+    // as much as for the model's own buffers. A warm scratch must therefore come back with the
+    // same buffers, not merely with buffers large enough: an address moves when a `Vec`
+    // reallocates, so this catches a call that replaces or regrows what the last one left.
+    //
+    // "helo " and not "hello ": a word that is itself a vocabulary entry is answered by the fold,
+    // and the merge engines that write the symbols never run.
+    #[test]
+    fn a_warm_scratch_reuses_the_same_allocations() {
+        let pipeline = hello_pipeline_split_on_words();
+        let words = 50;
+        let input = "helo ".repeat(words);
+
+        // The first encode grows the buffers to what this input needs, the second runs inside
+        // them. Anything from there on has nothing left to grow.
+        pipeline.encode(input.as_str(), false).wait().unwrap();
+        pipeline.encode(input.as_str(), false).wait().unwrap();
+        let warm = pooled_buffers(&pipeline);
         assert!(
-            scratch.pre_tokens.capacity() >= words,
-            "the pooled pre-token buffer is not the one grown by the {words} words: \
-             room for {} spans",
-            scratch.pre_tokens.capacity()
+            warm.pre_tokens.1 >= words && warm.symbols.1 > 0,
+            "the encodes left buffers this test cannot compare: {warm:?}"
+        );
+
+        pipeline.encode(input.as_str(), false).wait().unwrap();
+        assert_eq!(
+            pooled_buffers(&pipeline),
+            warm,
+            "a warm encode did not write into the buffers the pool handed it"
         );
     }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/scratch_pool.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/scratch_pool.rs
@@ -5,13 +5,14 @@ use std::{
 
 use atomsplit::fsm::Span;
 
-use crate::pipeline::{Model, PipelineModel, PipelineModelScratch};
+use crate::pipeline::{Model, PipelineModel, PipelineModelScratch, PreTokenizerScratch};
 
 pub trait ModelScratch {}
 
 #[derive(Default)]
 pub(crate) struct EncodeScratch {
     pub(crate) model: PipelineModelScratch,
+    pub(crate) split: PreTokenizerScratch,
     pub(crate) pre_tokens: Vec<Span>,
 }
 
@@ -35,6 +36,7 @@ impl ScratchPool {
     pub(crate) fn get<'a>(&'a self, model: &PipelineModel) -> ScratchGuard<'a> {
         self.get_with(|| EncodeScratch {
             model: model.init_scratch(),
+            split: PreTokenizerScratch::default(),
             pre_tokens: Vec::new(),
         })
     }

--- a/tokenizers/tk-encode/src/utils/word_cache.rs
+++ b/tokenizers/tk-encode/src/utils/word_cache.rs
@@ -104,7 +104,11 @@ impl<'a> WordCache {
     pub fn new(num_slots: usize) -> Self {
         let next_pow2 = num_slots.next_power_of_two();
         if next_pow2 != num_slots {
-            // todo: warn the user the capacity has been rounded up
+            warn!(
+                "WordCache: rounding cache_capacity up from {num_slots} to {next_pow2} slots \
+                 (a power of two is required for slot masking); \
+                 behavior is unchanged, the table just uses slightly more memory"
+            );
         }
         let n: usize = next_pow2 + Self::WINDOW_SIZE;
         let spilled_budget = 16 * n;
@@ -167,7 +171,11 @@ impl<'a> WordCache {
             WordCacheSlot::new_self_contained(key, ids)
         } else {
             if self.spilled_buffer.len() + len > self.spilled_budget {
-                // Spilled buffer budget passed: we clear it
+                debug!(
+                    "WordCache: spilled-ids budget ({} ids) exhausted; evicting {} spilled ids",
+                    self.spilled_budget,
+                    self.spilled_buffer.len()
+                );
                 self.spilled_buffer.clear();
                 // Bump the generation to invalidate previous spilled slots
                 self.spilled_generation = self.spilled_generation.wrapping_add(1);
@@ -198,7 +206,12 @@ impl<'a> WordCache {
     }
 
     fn reset(&mut self) {
-        // todo: log the cache clear
+        info!(
+            "WordCache: eviction generation wrapped past u32::MAX; \
+             cleared all {} cached words to avoid stale hits \
+             (lookups will miss until the cache refills)",
+            self.cached_words.len()
+        );
         self.spilled_buffer.clear();
         self.quick_lookup = vec![0; self.quick_lookup.len()].into_boxed_slice();
         self.cached_words =

--- a/tokenizers/tk-encode/tests/bpe_pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/bpe_pipeline_oracle.rs
@@ -68,7 +68,7 @@ fn check_model(name: &str, path: &str) {
                 .first()
                 .unwrap()
                 .iter()
-                .map(|t| t.id)
+                .map(|t| t.id())
                 .collect();
             assert_eq!(
                 expected.get_ids(),

--- a/tokenizers/tk-encode/tests/pipeline_oracle.rs
+++ b/tokenizers/tk-encode/tests/pipeline_oracle.rs
@@ -84,7 +84,7 @@ fn check_model(tok_file: &str) {
                     .first()
                     .unwrap()
                     .iter()
-                    .map(|t| t.id)
+                    .map(|t| t.id())
                     .collect();
                 if expected != got {
                     let at = expected


### PR DESCRIPTION
<!-- pipeline-bench:start -->
## PipelineTokenizer benchmark

**10 / 10 models supported** — PipelineTokenizer vs `tokenizers` v0.23.1 (latest release) · pipeline: whole corpus · release: ~2 MB/fixture sample · ~10 kB chunks · cold caches · add_special_tokens on · 2/4-thread sweep per group

`f82130ba4 · 2026-08-10 16:03 UTC` · Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · 48 cores

<img alt="Per-model encode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-overview.png" width="860">

<img alt="Per-fixture encode throughput vs latest release, across models" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-fixtures.png" width="860">

**Decode** — the release encodes each fixture's decode sample (`add_special_tokens=true`) and both implementations decode those SAME ids with `skip_special_tokens=false`, so the comparison is decode alone. MB/s counts the input bytes the ids came from, the same denominator as the encode charts.

<img alt="Per-model decode throughput vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-decode-overview.png" width="860">

**vs base branch** (`89c9377f4`) — per-model geomean ×speedup of this PR's PipelineTokenizer against the base branch's; **regressions in red**.

<img alt="Per-model encode throughput vs base branch" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-base-overview.png" width="860">

<sub>base numbers measured in this run's jobs, on the same runners as the PR's</sub>

**Work vs base** (`89c9377f4`, allocation lane):

- encode allocations: ⚠ counts changed on 38 of 150 fixtures: bert-base-uncased/added_normalized_sparse -99.29%, bert-base-uncased/added_special_sparse -86.88%, bert-base-uncased/tam_Taml -28.57%, bert-base-uncased/hin_Deva -28.53%, bert-base-uncased/tha_Thai -28.50%, bert-base-uncased/eng_Latn -28.44%, and 32 more
- decode allocations: ✓ exactly identical on all 150 fixtures

<img alt="Encode allocations vs latest release" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-allocs.png" width="860">

<sub>allocation lane measured on: Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz · glibc 2.39</sub>

<img alt="Per-model memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-memory.png" width="860">

<img alt="Per-model decode memory footprint" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-decode-memory.png" width="860">

<img alt="Minimal encode binary size" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-binsize.png" width="860">

<details><summary><b>bert-base-uncased</b> — normalizer-heavy WordPiece · ×5.04 vs v0.23.1 · ×1.04 vs base · decode ×0.99</summary>

<img alt="bert-base-uncased speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-bert-base-uncased.png" width="860">

<img alt="bert-base-uncased input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-bert-base-uncased-sizes.png" width="860">

<img alt="bert-base-uncased thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-bert-base-uncased-threads-lang.png" width="860">

<img alt="bert-base-uncased thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-bert-base-uncased-threads-modalities.png" width="860">

<img alt="bert-base-uncased decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-bert-base-uncased-decode.png" width="860">

<img alt="bert-base-uncased decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-bert-base-uncased-decode-threads-lang.png" width="860">

<img alt="bert-base-uncased decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-bert-base-uncased-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 7+11+0 (peak 37) · Pipeline 4+4+1 (peak 42)

**Allocations** (encode pass, whole corpus): v0.23.1: 159.5M allocs, 52.04 GB allocated, peak live 37 MB; Pipeline: 37.1k allocs, 0.32 GB allocated, peak live 45 MB

**Allocations** (decode pass, decode sample): v0.23.1: 98.5M allocs, 1.26 GB allocated; Pipeline: 98.5M allocs, 1.26 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Δ base | Ids |
|---|---|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 7.8 | 27.2 | ×3.47 | ×0.98 | 473 (×2,038) | ×0.99 | match |
| arb_Arab | lang | 3.8 | 25.8 | ×6.75 | ×0.99 | 565 (×4,841) | ×1.01 | match |
| cmn_Hani | lang | 3.6 | 18.1 | ×5.09 | ×0.99 | 665 (×5,959) | ×0.92 | match |
| eng_Latn | lang | 4.4 | 19.4 | ×4.46 | ×0.97 | 479 (×4,440) | ×1.02 | match |
| hin_Deva | lang | 6.4 | 28.7 | ×4.49 | ×0.98 | 459 (×3,405) | ×1.01 | match |
| jpn_Jpan | lang | 4.2 | 27.3 | ×6.47 | ×0.99 | 672 (×4,297) | ×1.08 | match |
| rus_Cyrl | lang | 3.5 | 25.0 | ×7.17 | ×0.98 | 564 (×6,302) | ×1.09 | match |
| tam_Taml | lang | 6.9 | 38.8 | ×5.62 | ×0.98 | 460 (×3,035) | ×1.02 | match |
| tha_Thai | lang | 8.4 | 32.8 | ×3.92 | ×0.99 | 445 (×2,162) | ×1.01 | match |
| added_normalized_sparse | modalities | 5.3 | 19.4 | ×3.65 | ×0.99 | 490 (×3,280) | ×1.06 | match |
| added_special_sparse | modalities | 3.9 | 23.1 | ×5.87 | ×0.99 | 11,767 (×296) | ×1.33 | match |
| agentic-traces | modalities | 3.8 | 19.2 | ×5.04 | ×0.99 | 526 (×4,972) | ×1.02 | match |
| agentic_swe | modalities | 3.9 | 19.7 | ×5.10 | ×0.99 | 566 (×4,641) | ×1.02 | match |
| code_mixed | modalities | 3.8 | 19.6 | ×5.21 | ×0.99 | 582 (×4,826) | ×1.01 | match |
| math_latex | modalities | 3.9 | 19.1 | ×4.87 | ×1.00 | 491 (×5,023) | ×1.05 | match |

</details>

<details><summary><b>deepseek-v4</b> — deepseek 3-regex split-heavy byte-level BPE · ×14.95 vs v0.23.1 · ×1.01 vs base · decode ×13.28</summary>

<img alt="deepseek-v4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-deepseek-v4.png" width="860">

<img alt="deepseek-v4 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-deepseek-v4-sizes.png" width="860">

<img alt="deepseek-v4 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-deepseek-v4-threads-lang.png" width="860">

<img alt="deepseek-v4 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-deepseek-v4-threads-modalities.png" width="860">

<img alt="deepseek-v4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-deepseek-v4-decode.png" width="860">

<img alt="deepseek-v4 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-deepseek-v4-decode-threads-lang.png" width="860">

<img alt="deepseek-v4 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-deepseek-v4-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 56+0+0 (peak 75) · Pipeline 16+0+0 (peak 56)

**Allocations** (encode pass, whole corpus): v0.23.1: 153.2M allocs, 38.67 GB allocated, peak live 66 MB; Pipeline: 28.0k allocs, 0.23 GB allocated, peak live 57 MB

**Allocations** (decode pass, decode sample): v0.23.1: 15.3M allocs, 0.77 GB allocated; Pipeline: 7.4k allocs, 0.06 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Δ base | Ids |
|---|---|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 62.9 | ×15.27 | ×21.24 | 570 (×3,582) | ×1.00 | match |
| arb_Arab | lang | 4.1 | 53.3 | ×13.04 | ×12.29 | 378 (×5,022) | ×1.00 | match |
| cmn_Hani | lang | 3.4 | 43.2 | ×12.86 | ×10.65 | 397 (×4,758) | ×1.01 | match |
| eng_Latn | lang | 3.0 | 67.0 | ×21.98 | ×11.90 | 385 (×7,925) | ×1.06 | match |
| hin_Deva | lang | 5.3 | 85.3 | ×16.09 | ×11.68 | 366 (×4,352) | ×1.02 | match |
| jpn_Jpan | lang | 3.8 | 42.6 | ×11.32 | ×11.99 | 418 (×3,717) | ×1.02 | match |
| rus_Cyrl | lang | 4.0 | 41.3 | ×10.44 | ×10.22 | 376 (×4,319) | ×0.96 | match |
| tam_Taml | lang | 5.5 | 50.2 | ×9.12 | ×12.57 | 368 (×2,674) | ×1.03 | match |
| tha_Thai | lang | 5.1 | 23.3 | ×4.55 | ×10.84 | 357 (×1,476) | ×1.02 | match |
| added_normalized_sparse | modalities | 5.3 | 85.3 | ×16.11 | ×18.91 | 490 (×5,070) | ×0.95 | match |
| added_special_sparse | modalities | 3.9 | 58.8 | ×15.06 | ×13.25 | 391 (×8,796) | ×0.99 | match |
| agentic-traces | modalities | 2.6 | 66.3 | ×25.16 | ×14.46 | 430 (×8,982) | ×1.03 | match |
| agentic_swe | modalities | 2.8 | 76.2 | ×27.19 | ×16.49 | 470 (×7,846) | ×1.01 | match |
| code_mixed | modalities | 2.8 | 65.8 | ×23.55 | ×15.09 | 467 (×7,449) | ×1.02 | match |
| math_latex | modalities | 2.5 | 60.9 | ×24.02 | ×12.18 | 387 (×9,256) | ×1.01 | match |

</details>

<details><summary><b>gemma-4</b> — byte-fallback BPE, Metaspace-style split (gemma-4) · ×3.02 vs v0.23.1 · ×1.05 vs base · decode ×1.55</summary>

<img alt="gemma-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gemma-4.png" width="860">

<img alt="gemma-4 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gemma-4-sizes.png" width="860">

<img alt="gemma-4 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gemma-4-threads-lang.png" width="860">

<img alt="gemma-4 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gemma-4-threads-modalities.png" width="860">

<img alt="gemma-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gemma-4-decode.png" width="860">

<img alt="gemma-4 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gemma-4-decode-threads-lang.png" width="860">

<img alt="gemma-4 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gemma-4-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 285+0+0 (peak 365) · Pipeline 0+0+0 (peak 365)

**Allocations** (encode pass, whole corpus): v0.23.1: 29.1M allocs, 23.69 GB allocated, peak live 310 MB; Pipeline: 65.2k allocs, 2.35 GB allocated, peak live 310 MB

**Allocations** (decode pass, decode sample): v0.23.1: 18.9M allocs, 1.79 GB allocated; Pipeline: 18.9M allocs, 1.79 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Δ base | Ids |
|---|---|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 10.7 | 43.9 | ×4.09 | ×1.53 | 780 (×521) | ×0.98 | match |
| arb_Arab | lang | 6.9 | 22.6 | ×3.27 | ×1.50 | 753 (×514) | ×1.02 | match |
| cmn_Hani | lang | 12.2 | 51.0 | ×4.19 | ×1.29 | 831 (×350) | ×1.11 | match |
| eng_Latn | lang | 3.8 | 8.8 | ×2.34 | ×1.61 | 768 (×732) | ×1.05 | match |
| hin_Deva | lang | 9.2 | 27.5 | ×2.99 | ×1.59 | 732 (×375) | ×1.05 | match |
| jpn_Jpan | lang | 13.0 | 43.2 | ×3.34 | ×1.30 | 764 (×303) | ×1.10 | match |
| rus_Cyrl | lang | 7.2 | 19.2 | ×2.67 | ×1.45 | 752 (×414) | ×1.07 | match |
| tam_Taml | lang | 11.0 | 29.7 | ×2.71 | ×1.46 | 736 (×261) | ×1.05 | match |
| tha_Thai | lang | 13.4 | 39.4 | ×2.95 | ×1.37 | 711 (×234) | ×1.12 | match |
| added_normalized_sparse | modalities | 4.5 | 12.4 | ×2.77 | ×1.74 | 881 (×659) | ×1.04 | match |
| added_special_sparse | modalities | 4.2 | 13.5 | ×3.22 | ×1.90 | 156,197 (×9.98) | ×1.01 | match |
| agentic-traces | modalities | 4.3 | 11.6 | ×2.70 | ×1.57 | 788 (×825) | ×1.04 | match |
| agentic_swe | modalities | 4.3 | 14.3 | ×3.33 | ×1.75 | 849 (×1,004) | ×1.04 | match |
| code_mixed | modalities | 4.4 | 13.0 | ×2.97 | ×1.73 | 873 (×797) | ×1.05 | match |
| math_latex | modalities | 4.0 | 9.8 | ×2.43 | ×1.60 | 740 (×792) | ×1.04 | match |

</details>

<details><summary><b>gpt2</b> — gpt2 ByteLevel regex · ×22.35 vs v0.23.1 · ×1.00 vs base · decode ×29.87</summary>

<img alt="gpt2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt2.png" width="860">

<img alt="gpt2 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt2-sizes.png" width="860">

<img alt="gpt2 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt2-threads-lang.png" width="860">

<img alt="gpt2 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt2-threads-modalities.png" width="860">

<img alt="gpt2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt2-decode.png" width="860">

<img alt="gpt2 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt2-decode-threads-lang.png" width="860">

<img alt="gpt2 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt2-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 21+12+0 (peak 82) · Pipeline 2+1+0 (peak 75)

**Allocations** (encode pass, whole corpus): v0.23.1: 243.3M allocs, 38.17 GB allocated, peak live 79 MB; Pipeline: 34.6k allocs, 0.43 GB allocated, peak live 76 MB

**Allocations** (decode pass, decode sample): v0.23.1: 30.9M allocs, 1.36 GB allocated; Pipeline: 6.0k allocs, 0.07 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Δ base | Ids |
|---|---|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 3.9 | 78.0 | ×19.78 | ×41.26 | 570 (×4,658) | ×1.01 | match |
| arb_Arab | lang | 3.8 | 72.4 | ×19.26 | ×22.95 | 564 (×5,616) | ×0.99 | match |
| cmn_Hani | lang | 3.3 | 46.1 | ×13.81 | ×30.06 | 572 (×4,864) | ×0.98 | match |
| eng_Latn | lang | 3.3 | 81.6 | ×25.06 | ×21.43 | 386 (×8,670) | ×1.00 | match |
| hin_Deva | lang | 3.0 | 83.3 | ×27.94 | ×37.20 | 549 (×7,411) | ×0.99 | match |
| jpn_Jpan | lang | 3.7 | 40.2 | ×10.87 | ×24.30 | 504 (×4,683) | ×0.99 | match |
| rus_Cyrl | lang | 3.8 | 70.1 | ×18.45 | ×23.60 | 564 (×5,089) | ×0.99 | match |
| tam_Taml | lang | 2.6 | 85.3 | ×33.04 | ×52.01 | 553 (×10,027) | ×0.98 | match |
| tha_Thai | lang | 3.2 | 72.2 | ×22.60 | ×45.40 | 533 (×6,617) | ×1.00 | match |
| added_normalized_sparse | modalities | 4.5 | 101.8 | ×22.65 | ×30.59 | 490 (×6,465) | ×0.99 | match |
| added_special_sparse | modalities | 3.6 | 72.5 | ×20.19 | ×19.22 | 391 (×8,582) | ×1.02 | match |
| agentic-traces | modalities | 2.8 | 78.3 | ×27.53 | ×26.40 | 441 (×9,456) | ×1.02 | match |
| agentic_swe | modalities | 2.9 | 89.4 | ×31.03 | ×36.53 | 491 (×8,756) | ×1.00 | match |
| code_mixed | modalities | 2.8 | 77.2 | ×27.75 | ×32.06 | 496 (×8,611) | ×1.01 | match |
| math_latex | modalities | 2.5 | 72.6 | ×28.96 | ×24.03 | 406 (×9,294) | ×0.99 | match |

</details>

<details><summary><b>gpt-oss</b> — o200k-regex byte-level BPE (gpt-oss) · ×9.96 vs v0.23.1 · ×0.87 vs base · decode ×14.01</summary>

<img alt="gpt-oss speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt-oss.png" width="860">

<img alt="gpt-oss input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt-oss-sizes.png" width="860">

<img alt="gpt-oss thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt-oss-threads-lang.png" width="860">

<img alt="gpt-oss thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt-oss-threads-modalities.png" width="860">

<img alt="gpt-oss decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt-oss-decode.png" width="860">

<img alt="gpt-oss decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt-oss-decode-threads-lang.png" width="860">

<img alt="gpt-oss decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-gpt-oss-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 236+0+0 (peak 309) · Pipeline 0+0+0 (peak 311)

**Allocations** (encode pass, whole corpus): v0.23.1: 127.8M allocs, 29.89 GB allocated, peak live 272 MB; Pipeline: 28.4k allocs, 0.23 GB allocated, peak live 272 MB

**Allocations** (decode pass, decode sample): v0.23.1: 14.5M allocs, 0.71 GB allocated; Pipeline: 7.4k allocs, 0.05 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Δ base | Ids |
|---|---|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 60.6 | ×14.69 | ×30.33 | 570 (×3,431) | ×0.97 | match |
| arb_Arab | lang | 4.3 | 49.1 | ×11.41 | ×13.27 | 378 (×4,522) | ×1.01 | match |
| cmn_Hani | lang | 3.9 | 21.7 | ×5.60 | ×18.61 | 474 (×2,360) | ×1.03 | match |
| eng_Latn | lang | 3.8 | 58.6 | ×15.57 | ×15.13 | 383 (×7,145) | ×1.00 | match |
| hin_Deva | lang | 5.8 | 71.7 | ×12.30 | ×11.00 | 366 (×3,680) | ×0.95 | match |
| jpn_Jpan | lang | 4.4 | 29.5 | ×6.67 | ×13.01 | 475 (×1,990) | ×1.03 | match |
| rus_Cyrl | lang | 4.4 | 38.4 | ×8.77 | ×9.15 | 376 (×3,878) | ×1.03 | match |
| tam_Taml | lang | 5.7 | 39.1 | ×6.86 | ×11.17 | 368 (×2,372) | ×1.01 | match |
| tha_Thai | lang | 5.4 | 20.0 | ×3.67 | ×10.31 | 358 (×1,345) | ×1.02 | match |
| added_normalized_sparse | modalities | 5.8 | 30.2 | ×5.21 | ×17.40 | 490 (×4,723) | ×0.31 | match |
| added_special_sparse | modalities | 4.7 | 28.7 | ×6.05 | ×11.53 | 391 (×7,345) | ×0.41 | match |
| agentic-traces | modalities | 3.8 | 65.4 | ×17.40 | ×14.40 | 414 (×7,406) | ×0.97 | match |
| agentic_swe | modalities | 3.9 | 79.8 | ×20.41 | ×16.30 | 458 (×6,524) | ×1.00 | match |
| code_mixed | modalities | 3.8 | 74.9 | ×19.81 | ×15.44 | 447 (×6,828) | ×0.98 | match |
| math_latex | modalities | 3.5 | 56.5 | ×16.11 | ×12.64 | 386 (×7,848) | ×1.00 | match |

</details>

<details><summary><b>glm-5.2</b> — cl100k-variant regex byte-level BPE (glm-5.2) · ×14.33 vs v0.23.1 · ×0.95 vs base · decode ×20.96</summary>

<img alt="glm-5.2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-glm-5-2.png" width="860">

<img alt="glm-5.2 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-glm-5-2-sizes.png" width="860">

<img alt="glm-5.2 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-glm-5-2-threads-lang.png" width="860">

<img alt="glm-5.2 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-glm-5-2-threads-modalities.png" width="860">

<img alt="glm-5.2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-glm-5-2-decode.png" width="860">

<img alt="glm-5.2 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-glm-5-2-decode-threads-lang.png" width="860">

<img alt="glm-5.2 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-glm-5-2-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 163+0+0 (peak 225) · Pipeline 0+0+0 (peak 226)

**Allocations** (encode pass, whole corpus): v0.23.1: 154.7M allocs, 33.00 GB allocated, peak live 212 MB; Pipeline: 29.5k allocs, 0.25 GB allocated, peak live 212 MB

**Allocations** (decode pass, decode sample): v0.23.1: 18.3M allocs, 0.90 GB allocated; Pipeline: 6.8k allocs, 0.05 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Δ base | Ids |
|---|---|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.0 | 72.9 | ×18.38 | ×40.36 | 570 (×3,814) | ×1.01 | match |
| arb_Arab | lang | 4.1 | 54.3 | ×13.10 | ×16.16 | 384 (×4,896) | ×0.99 | match |
| cmn_Hani | lang | 4.3 | 21.7 | ×5.05 | ×15.92 | 425 (×2,520) | ×1.06 | match |
| eng_Latn | lang | 3.7 | 68.5 | ×18.35 | ×17.50 | 384 (×7,146) | ×1.06 | match |
| hin_Deva | lang | 3.9 | 88.1 | ×22.76 | ×17.88 | 458 (×6,443) | ×1.00 | match |
| jpn_Jpan | lang | 4.7 | 24.4 | ×5.19 | ×17.51 | 433 (×2,153) | ×0.98 | match |
| rus_Cyrl | lang | 4.2 | 38.3 | ×9.08 | ×12.61 | 376 (×3,881) | ×1.00 | match |
| tam_Taml | lang | 3.8 | 95.0 | ×24.98 | ×27.62 | 464 (×6,456) | ×0.98 | match |
| tha_Thai | lang | 4.5 | 70.7 | ×15.73 | ×28.25 | 445 (×3,747) | ×1.01 | match |
| added_normalized_sparse | modalities | 4.5 | 58.5 | ×12.90 | ×29.26 | 490 (×4,755) | ×0.58 | match |
| added_special_sparse | modalities | 3.8 | 42.0 | ×11.16 | ×18.38 | 391 (×7,379) | ×0.74 | match |
| agentic-traces | modalities | 3.5 | 68.4 | ×19.64 | ×21.62 | 422 (×7,221) | ×1.01 | match |
| agentic_swe | modalities | 3.6 | 80.1 | ×22.02 | ×23.15 | 460 (×6,451) | ×1.00 | match |
| code_mixed | modalities | 3.5 | 70.4 | ×20.07 | ×22.33 | 446 (×6,650) | ×1.01 | match |
| math_latex | modalities | 3.3 | 61.1 | ×18.81 | ×19.63 | 390 (×7,773) | ×0.99 | match |

</details>

<details><summary><b>llama-2</b> — model-bounded BPE, no pre-tokenizer · ×4.95 vs v0.23.1 · ×1.03 vs base · decode ×1.52</summary>

<img alt="llama-2 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-2.png" width="860">

<img alt="llama-2 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-2-sizes.png" width="860">

<img alt="llama-2 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-2-threads-lang.png" width="860">

<img alt="llama-2 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-2-threads-modalities.png" width="860">

<img alt="llama-2 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-2-decode.png" width="860">

<img alt="llama-2 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-2-decode-threads-lang.png" width="860">

<img alt="llama-2 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-2-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 20+6+0 (peak 62) · Pipeline 0+3+1 (peak 63)

**Allocations** (encode pass, whole corpus): v0.23.1: 63.0M allocs, 28.31 GB allocated, peak live 61 MB; Pipeline: 67.7k allocs, 0.56 GB allocated, peak live 68 MB

**Allocations** (decode pass, decode sample): v0.23.1: 35.7M allocs, 3.03 GB allocated; Pipeline: 35.7M allocs, 3.03 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Δ base | Ids |
|---|---|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 5.6 | 87.2 | ×15.48 | ×1.34 | 850 (×3,793) | ×1.02 | match |
| arb_Arab | lang | 12.4 | 76.5 | ×6.16 | ×1.71 | 845 (×844) | ×1.06 | match |
| cmn_Hani | lang | 11.1 | 107.5 | ×9.67 | ×1.30 | 849 (×1,468) | ×1.00 | match |
| eng_Latn | lang | 4.4 | 11.7 | ×2.68 | ×1.65 | 823 (×744) | ×1.08 | match |
| hin_Deva | lang | 14.1 | 108.7 | ×7.69 | ×1.44 | 824 (×847) | ×1.04 | match |
| jpn_Jpan | lang | 15.9 | 126.3 | ×7.94 | ×1.30 | 859 (×828) | ×0.96 | match |
| rus_Cyrl | lang | 8.7 | 30.4 | ×3.48 | ×1.43 | 753 (×505) | ×1.01 | match |
| tam_Taml | lang | 15.1 | 128.5 | ×8.49 | ×1.51 | 829 (×938) | ×1.06 | match |
| tha_Thai | lang | 19.2 | 128.9 | ×6.72 | ×1.35 | 800 (×638) | ×1.12 | match |
| added_normalized_sparse | modalities | 5.1 | 15.7 | ×3.06 | ×1.43 | 881 (×772) | ×1.02 | match |
| added_special_sparse | modalities | 4.5 | 16.1 | ×3.56 | ×1.92 | 145,162 (×11.23) | ×1.01 | match |
| agentic-traces | modalities | 4.6 | 13.7 | ×2.97 | ×1.53 | 791 (×916) | ×1.01 | match |
| agentic_swe | modalities | 4.5 | 13.7 | ×3.04 | ×1.78 | 851 (×1,059) | ×0.98 | match |
| code_mixed | modalities | 4.6 | 14.3 | ×3.10 | ×1.69 | 877 (×1,010) | ×1.02 | match |
| math_latex | modalities | 4.4 | 12.5 | ×2.87 | ×1.57 | 762 (×860) | ×1.00 | match |

</details>

<details><summary><b>llama-3</b> — cl100k-regex byte-level BPE (llama-3), single regex · ×16.24 vs v0.23.1 · ×0.97 vs base · decode ×18.95</summary>

<img alt="llama-3 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-3.png" width="860">

<img alt="llama-3 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-3-sizes.png" width="860">

<img alt="llama-3 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-3-threads-lang.png" width="860">

<img alt="llama-3 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-3-threads-modalities.png" width="860">

<img alt="llama-3 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-3-decode.png" width="860">

<img alt="llama-3 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-3-decode-threads-lang.png" width="860">

<img alt="llama-3 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-llama-3-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 67+2+0 (peak 89) · Pipeline 7+0+0 (peak 90)

**Allocations** (encode pass, whole corpus): v0.23.1: 152.3M allocs, 33.83 GB allocated, peak live 91 MB; Pipeline: 28.7k allocs, 0.24 GB allocated, peak live 92 MB

**Allocations** (decode pass, decode sample): v0.23.1: 17.3M allocs, 0.88 GB allocated; Pipeline: 9.6k allocs, 0.06 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Δ base | Ids |
|---|---|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.2 | 80.1 | ×19.09 | ×29.35 | 570 (×3,818) | ×0.99 | match |
| arb_Arab | lang | 4.3 | 60.2 | ×14.11 | ×13.49 | 379 (×4,900) | ×0.95 | match |
| cmn_Hani | lang | 4.4 | 27.9 | ×6.36 | ×18.36 | 476 (×2,372) | ×1.04 | match |
| eng_Latn | lang | 3.9 | 75.0 | ×19.19 | ×17.60 | 384 (×7,149) | ×1.04 | match |
| hin_Deva | lang | 4.4 | 121.5 | ×27.55 | ×15.92 | 366 (×7,163) | ×1.01 | match |
| jpn_Jpan | lang | 4.8 | 25.8 | ×5.33 | ×17.07 | 433 (×2,151) | ×1.02 | match |
| rus_Cyrl | lang | 4.6 | 43.6 | ×9.40 | ×12.63 | 376 (×3,985) | ×1.04 | match |
| tam_Taml | lang | 3.9 | 101.7 | ×25.82 | ×26.01 | 464 (×6,460) | ×0.99 | match |
| tha_Thai | lang | 4.6 | 60.5 | ×13.16 | ×16.05 | 356 (×4,118) | ×0.97 | match |
| added_normalized_sparse | modalities | 4.6 | 99.3 | ×21.55 | ×28.94 | 490 (×4,760) | ×0.81 | match |
| added_special_sparse | modalities | 3.9 | 69.8 | ×18.11 | ×17.20 | 391 (×7,385) | ×0.87 | match |
| agentic-traces | modalities | 3.3 | 75.8 | ×22.75 | ×20.93 | 414 (×7,327) | ×0.98 | match |
| agentic_swe | modalities | 3.7 | 88.0 | ×24.04 | ×23.48 | 458 (×6,458) | ×0.96 | match |
| code_mixed | modalities | 3.5 | 75.6 | ×21.50 | ×19.29 | 446 (×6,650) | ×0.99 | match |
| math_latex | modalities | 3.2 | 64.8 | ×20.35 | ×16.85 | 388 (×7,791) | ×0.98 | match |

</details>

<details><summary><b>mistral-small-4</b> — tekken byte-level BPE, 1k added specials (mistral-small-4) · ×11.25 vs v0.23.1 · ×0.99 vs base · decode ×14.38</summary>

<img alt="mistral-small-4 speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-mistral-small-4.png" width="860">

<img alt="mistral-small-4 input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-mistral-small-4-sizes.png" width="860">

<img alt="mistral-small-4 thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-mistral-small-4-threads-lang.png" width="860">

<img alt="mistral-small-4 thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-mistral-small-4-threads-modalities.png" width="860">

<img alt="mistral-small-4 decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-mistral-small-4-decode.png" width="860">

<img alt="mistral-small-4 decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-mistral-small-4-decode-threads-lang.png" width="860">

<img alt="mistral-small-4 decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-mistral-small-4-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 151+0+0 (peak 188) · Pipeline 0+0+0 (peak 189)

**Allocations** (encode pass, whole corpus): v0.23.1: 135.2M allocs, 31.26 GB allocated, peak live 185 MB; Pipeline: 28.7k allocs, 0.24 GB allocated, peak live 185 MB

**Allocations** (decode pass, decode sample): v0.23.1: 16.6M allocs, 0.81 GB allocated; Pipeline: 7.1k allocs, 0.05 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Δ base | Ids |
|---|---|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 4.1 | 59.7 | ×14.68 | ×26.41 | 570 (×3,847) | ×0.97 | match |
| arb_Arab | lang | 4.4 | 45.1 | ×10.25 | ×10.36 | 378 (×4,557) | ×0.95 | match |
| cmn_Hani | lang | 4.4 | 27.8 | ×6.38 | ×15.12 | 476 (×2,565) | ×1.02 | match |
| eng_Latn | lang | 3.8 | 54.6 | ×14.27 | ×12.50 | 388 (×7,243) | ×1.01 | match |
| hin_Deva | lang | 5.9 | 69.6 | ×11.80 | ×10.67 | 366 (×3,846) | ×0.99 | match |
| jpn_Jpan | lang | 4.8 | 32.2 | ×6.67 | ×13.54 | 471 (×2,080) | ×1.02 | match |
| rus_Cyrl | lang | 4.4 | 37.3 | ×8.44 | ×10.34 | 376 (×4,023) | ×0.98 | match |
| tam_Taml | lang | 5.9 | 38.6 | ×6.50 | ×11.46 | 368 (×2,471) | ×0.97 | match |
| tha_Thai | lang | 5.9 | 21.9 | ×3.67 | ×12.43 | 358 (×1,515) | ×1.00 | match |
| added_normalized_sparse | modalities | 5.8 | 83.2 | ×14.39 | ×19.35 | 490 (×4,858) | ×0.93 | match |
| added_special_sparse | modalities | 4.7 | 62.4 | ×13.23 | ×15.35 | 391 (×7,459) | ×0.95 | match |
| agentic-traces | modalities | 3.3 | 61.9 | ×18.49 | ×16.17 | 438 (×7,687) | ×1.02 | match |
| agentic_swe | modalities | 3.4 | 72.0 | ×20.90 | ×18.03 | 471 (×6,995) | ×1.01 | match |
| code_mixed | modalities | 3.4 | 71.1 | ×21.11 | ×16.98 | 465 (×6,767) | ×1.01 | match |
| math_latex | modalities | 3.2 | 55.2 | ×17.35 | ×14.32 | 396 (×7,918) | ×1.03 | match |

</details>

<details><summary><b>t5-base</b> — Unigram + Metaspace · ×3.16 vs v0.23.1 · ×1.09 vs base · decode ×0.95</summary>

<img alt="t5-base speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-t5-base.png" width="860">

<img alt="t5-base input-size response" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-t5-base-sizes.png" width="860">

<img alt="t5-base thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-t5-base-threads-lang.png" width="860">

<img alt="t5-base thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-t5-base-threads-modalities.png" width="860">

<img alt="t5-base decode speedup" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-t5-base-decode.png" width="860">

<img alt="t5-base decode thread scaling (lang)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-t5-base-decode-threads-lang.png" width="860">

<img alt="t5-base decode thread scaling (modalities)" src="https://huggingface.co/datasets/hf-internal-testing/tokenizers-bench/resolve/main/charts/pipeline-31406231080-t5-base-decode-threads-modalities.png" width="860">

**Memory** (RSS MB, load+encode+decode): v0.23.1 31+10+0 (peak 56) · Pipeline 19+11+1 (peak 80)

**Allocations** (encode pass, whole corpus): v0.23.1: 260.7M allocs, 35.16 GB allocated, peak live 53 MB; Pipeline: 50.7M allocs, 4.68 GB allocated, peak live 98 MB

**Allocations** (decode pass, decode sample): v0.23.1: 12.0M allocs, 0.64 GB allocated; Pipeline: 12.0M allocs, 0.64 GB allocated

| Fixture | Group | v0.23.1 MB/s | Pipeline MB/s | Speedup | Decode | allocs/MB | Δ base | Ids |
|---|---|---:|---:|---:|---:|---:|---:|:--|
| amh_Ethi | lang | 6.2 | 25.6 | ×4.12 | ×0.93 | 425,717 (×6.45) | ×1.16 | match |
| arb_Arab | lang | 5.0 | 20.1 | ×4.03 | ×0.92 | 562,972 (×7.24) | ×1.11 | match |
| cmn_Hani | lang | 10.1 | 17.5 | ×1.73 | ×0.94 | 933,157 (×1.44) | ×1.11 | match |
| eng_Latn | lang | 2.7 | 9.8 | ×3.57 | ×0.96 | 856,308 (×7.71) | ×1.05 | match |
| hin_Deva | lang | 6.6 | 27.8 | ×4.24 | ×0.93 | 208,681 (×15.21) | ×1.16 | match |
| jpn_Jpan | lang | 10.3 | 16.2 | ×1.58 | ×0.95 | 825,891 (×1.52) | ×0.94 | match |
| rus_Cyrl | lang | 4.2 | 14.1 | ×3.36 | ×0.98 | 962,881 (×4.39) | ×1.11 | match |
| tam_Taml | lang | 8.6 | 26.5 | ×3.07 | ×0.93 | 484,771 (×4.28) | ×1.09 | match |
| tha_Thai | lang | 10.2 | 17.9 | ×1.75 | ×0.94 | 769,749 (×1.71) | ×1.00 | match |
| added_normalized_sparse | modalities | 4.9 | 19.6 | ×4.01 | ×0.98 | 130,242 (×49.37) | ×1.05 | match |
| added_special_sparse | modalities | 5.0 | 21.3 | ×4.23 | ×0.97 | 132,882 (×39.65) | ×1.13 | match |
| agentic-traces | modalities | 3.0 | 10.4 | ×3.51 | ×0.97 | 1,041,900 (×5.73) | ×1.13 | match |
| agentic_swe | modalities | 3.5 | 12.1 | ×3.44 | ×0.96 | 863,676 (×6.10) | ×1.07 | match |
| code_mixed | modalities | 3.2 | 10.9 | ×3.45 | ×0.97 | 994,914 (×5.88) | ×1.09 | match |
| math_latex | modalities | 2.9 | 10.4 | ×3.61 | ×0.97 | 890,581 (×7.35) | ×1.11 | match |

</details>
<!-- pipeline-bench:end -->


