### PR TITLE
fix(bpe): stop build() panicking on a merge longer than any vocab token

### DIFF
--- a/tokenizers/src/models/bpe/model.rs
+++ b/tokenizers/src/models/bpe/model.rs
@@ -248,7 +248,10 @@ impl BpeBuilder {
         } else {
             0
         };
-        let mut buffer: Vec<u8> = vec![0; max_len];
+        // A merge concatenates two vocabulary entries, and both are looked up in
+        // the vocab before anything is written here, so the result never exceeds
+        // twice the longest single entry.
+        let mut buffer: Vec<u8> = vec![0; max_len * 2];
         let merge_map: MergeMap = self
             .config
             .merges
@@ -261,11 +264,13 @@ impl BpeBuilder {
                 let b_id = vocab
                     .get(&b)
                     .ok_or_else(|| Error::MergeTokenOutOfVocabulary(b.to_owned()))?;
+                let b_suffix = b
+                    .get(prefix_len..)
+                    .ok_or_else(|| Error::MergeTokenOutOfVocabulary(b.to_owned()))?;
                 buffer[0..a.len()].copy_from_slice(a.as_bytes());
-                let b_len = b.len() - prefix_len;
-                let merge_len = a.len() + b_len;
-                buffer[a.len()..merge_len].copy_from_slice(&b.as_bytes()[prefix_len..]);
-                // SAFETY: buffer contains a concatenation of two valid UTF-8 strings, so it is itself valid UTF-8, even considering prefix_len
+                let merge_len = a.len() + b_suffix.len();
+                buffer[a.len()..merge_len].copy_from_slice(b_suffix.as_bytes());
+                // SAFETY: buffer contains a concatenation of two valid UTF-8 strings, so it is itself valid UTF-8: `str::get` rejects a prefix_len that is not a char boundary of b
                 let new_token = unsafe { from_utf8_unchecked(&buffer[..merge_len]) };
                 let new_id = vocab
                     .get(new_token)
@@ -975,6 +980,57 @@ mod tests {
                 offsets: (0, 3)
             }]
         );
+    }
+
+    #[test]
+    // A merge whose concatenation is longer than the longest single vocab entry
+    // must be reported as out of vocabulary, not panic while building the
+    // merge map.
+    fn test_bpe_merge_longer_than_longest_vocab_token() {
+        let vocab: Vocab = [("aa".into(), 0), ("bb".into(), 1)]
+            .iter()
+            .cloned()
+            .collect();
+        let merges = vec![("aa".to_string(), "bb".to_string())];
+
+        match BpeBuilder::default()
+            .vocab_and_merges(vocab, merges)
+            .build()
+        {
+            Ok(_) => unreachable!(),
+            Err(err) => match err.downcast_ref::<Error>() {
+                Some(Error::MergeTokenOutOfVocabulary(token)) => {
+                    assert_eq!(*token, String::from("aabb"))
+                }
+                _ => unreachable!(),
+            },
+        }
+    }
+
+    #[test]
+    // A merge whose right token is shorter than the continuing subword prefix
+    // must be reported as out of vocabulary, not underflow the length
+    // computation.
+    fn test_bpe_merge_shorter_than_continuing_subword_prefix() {
+        let vocab: Vocab = [("a".into(), 0), ("b".into(), 1), ("ab".into(), 2)]
+            .iter()
+            .cloned()
+            .collect();
+        let merges = vec![("a".to_string(), "b".to_string())];
+
+        match BpeBuilder::default()
+            .vocab_and_merges(vocab, merges)
+            .continuing_subword_prefix("##".to_string())
+            .build()
+        {
+            Ok(_) => unreachable!(),
+            Err(err) => match err.downcast_ref::<Error>() {
+                Some(Error::MergeTokenOutOfVocabulary(token)) => {
+                    assert_eq!(*token, String::from("b"))
+                }
+                _ => unreachable!(),
+            },
+        }
     }
 
     #[test]

--- a/tokenizers/src/models/bpe/serialization.rs
+++ b/tokenizers/src/models/bpe/serialization.rs
@@ -235,4 +235,13 @@ mod test {
         let bpe_string = r#"{"type":"BPE","dropout":null,"unk_token":"<unk>","continuing_subword_prefix":null,"end_of_word_suffix":null,"fuse_unk":false,"byte_fallback":false,"vocab":{"<unk>":0,"a":1,"b":2},"merges":[]}"#;
         assert_eq!(serde_json::from_str::<BPE>(bpe_string).unwrap(), bpe);
     }
+
+    #[test]
+    // A file whose merges concatenate to a token longer than any vocab entry
+    // must deserialize to an error, not panic.
+    fn test_deserialization_merge_longer_than_vocab() {
+        let bpe_string = r#"{"type":"BPE","dropout":null,"unk_token":null,"continuing_subword_prefix":null,"end_of_word_suffix":null,"fuse_unk":false,"byte_fallback":false,"vocab":{"aa":0,"bb":1},"merges":[["aa","bb"]]}"#;
+        let err = serde_json::from_str::<BPE>(bpe_string).unwrap_err();
+        assert!(err.to_string().contains("aabb"), "{}", err);
+    }
 }


### PR DESCRIPTION
### Summary

`BpeBuilder::build()` sizes its merge-map scratch buffer to the longest single vocab entry, but each merge writes the concatenation of two entries into it. When that concatenation is not itself in the vocab, the copy runs past the end of the buffer and panics instead of returning `MergeTokenOutOfVocabulary`. A `tokenizer.json` with `vocab: {"aa":0,"bb":1}` and `merges: [["aa","bb"]]` is enough:

```
range end index 4 out of range for slice of length 2
```

The same loop computed `b.len() - prefix_len` unchecked. A right-hand merge token shorter than `continuing_subword_prefix` underflows it: `attempt to subtract with overflow` in debug, a wrap then a slice panic in release.

Both are reachable from `Tokenizer::from_file` / `from_str`, before any tokenization runs: the deserializer funnels through `builder.build()` in `serialization.rs`.

Fixes #2198.

### Changes

- Size the buffer to twice the longest vocab entry. Both merge halves are looked up in the vocab and error out before anything is written, so that is the bound, and it is exact: `{"a":0}` with merge `("a","a")` needs 2.
- Take the right-hand suffix with `str::get(prefix_len..)` instead of an unchecked subtraction and byte slice. Out of range, or off a char boundary, now returns an error. This also makes the `SAFETY` claim on the `from_utf8_unchecked` below it true rather than assumed, since `str::get` will not hand back a non-boundary split.
- Three regression tests: two on the builder, one deserializing a crafted model JSON.

### Behavior

No change on input that worked before. `str::get` returns `Some` for every `prefix_len <= b.len()` on a char boundary, which is every case the old code completed. The existing blind-strip behavior when `b` does not actually start with the prefix is preserved on purpose; `strip_prefix` would have changed it.

One thing worth a maintainer opinion: the prefix-underflow case reports `MergeTokenOutOfVocabulary(b)`, and `b` is in the vocab, so the variant name is a slight stretch. I reused it rather than adding a variant to the public `Error` enum right before 1.0.0rc0. Happy to add a dedicated variant if you prefer.

### Evidence

The three new tests fail before the change and pass after. Verified by reverting only the two source hunks, keeping the tests, and re-running: 3 failed, 20 existing bpe tests passed, with the panic above. Restored: 23 passed. They also pass under `--release`, where the underflow manifests differently.

- `cargo test --lib`: 204 passed, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt -- --check`: clean.

Not run: the Python and Node binding suites (this is a core-crate change with no API surface change), and `tokenizers/tests/`, which needs the `make test` data download.

### Risk

Low. Two hunks in one function, both on paths that panic today. The buffer grows by at most the length of the longest vocab token, allocated once per `build()`.

### Note on the in-flight 1.0 work

This loop survives unchanged on the `feat/train_encode_split` stack at `tokenizers/tk-encode/src/models/bpe/legacy/model.rs:186-220`, so #2293 and #2332 do not obsolete this fix, but it will need carrying across the directory move when that stack lands. Otherwise the bug ships in 1.0.
