### PR TITLE
fix(normalizer): make NormalizedString::prepend work when normalized is empty

### DIFF
--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -509,6 +509,9 @@ impl NormalizedString {
                 .chain(std::iter::once((next, 1)));
 
             self.transform_range(Range::Normalized(0..next.len_utf8()), transformations, 0);
+        } else {
+            let transformations = s.chars().map(|c| (c, 1));
+            self.transform_range(Range::Normalized(..), transformations, 0);
         }
         self
     }
@@ -2307,5 +2310,25 @@ mod tests {
         assert_eq!(n.get_range_original(Range::Normalized(0..6)), Some(""));
 
         assert_eq!(n.get_range(Range::Normalized(0..6)), Some(" World"));
+    }
+
+    #[test]
+    fn test_prepend_after_clear() {
+        let mut n = NormalizedString::from("Hello");
+        assert_eq!(n.get(), "Hello");
+
+        n.clear();
+        assert_eq!(n.get(), "");
+
+        n.prepend("World ");
+        assert_eq!(n.get(), "World ");
+
+        assert_eq!(n.len_original(), 5);
+        assert_eq!(n.len(), 6);
+
+        assert_eq!(n.get_range_original(Range::Original(0..5)), Some("Hello"));
+        assert_eq!(n.get_range_original(Range::Normalized(0..6)), Some(""));
+
+        assert_eq!(n.get_range(Range::Normalized(0..6)), Some("World "));
     }
 }


### PR DESCRIPTION
## Problem

`NormalizedString::prepend` is a silent no-op when `normalized` is empty:

```rust
let mut n = NormalizedString::from("Hello");
n.clear();
n.prepend("World ");
assert_eq!(n.get(), "World "); // fails, n.get() == ""
```

Same through the Python binding:

```python
s = NormalizedString("Hi."); s.clear(); s.prepend("Hello.")  # normalized stays empty
```

This is the unfixed half of #1636. That issue reported it for both `append` and `prepend` ("This is also a problem with `prepend`"); #1717 fixed `append` and added `test_append_after_clear`, but left `prepend` alone.

`prepend` anchors on the first character of `normalized` - it needs it both as the target range for `transform_range` and as the trailing element it re-emits:

```rust
if let Some(next) = self.normalized.chars().next() {
    ...
    self.transform_range(Range::Normalized(0..next.len_utf8()), transformations, 0);
}
// no else -> returns unchanged, no error
```

On an empty `normalized` there is no anchor, the body is skipped, and there is no `else`. `clear()` is exactly the operation that empties `normalized` while leaving `original` intact.

## Fix

Mirror the merged `append` fix: with no anchor character to replace, emit every char of `s` as an insertion over the empty normalized range.

```rust
} else {
    let transformations = s.chars().map(|c| (c, 1));
    self.transform_range(Range::Normalized(..), transformations, 0);
}
```

Insertions with `idx < 1` get alignment `(0, 0)`, a zero-width span at the start of the original - correct, since none of the text originates from `original`. `original` and `len_original()` are untouched.

Blast radius is narrow: `normalizers::prepend::Prepend::normalize` already guards on `!normalized.is_empty()`, so the `Prepend` normalizer is unaffected. Only direct `NormalizedString::prepend` on an empty normalized string changes, and its prior behavior was to drop the input silently. No public API or serialization change, no new dependency.

## Tests

`test_prepend_after_clear`, placed next to the existing `test_append_after_clear` and asserting the same properties. Fails on `main` (`left: "" right: "World "`), passes with the fix.

Full crate suite green: 256 tests, 0 failures (202 lib unit + 33 integration + 21 doc). `cargo fmt -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` both clean.
