### PR TITLE
fix: reject invalid sequence IDs in encoding mappings

### DIFF
--- a/bindings/python/tests/bindings/test_encoding.py
+++ b/bindings/python/tests/bindings/test_encoding.py
@@ -1,8 +1,21 @@
 import pytest
 
-from tokenizers import BertWordPieceTokenizer
+from tokenizers import BertWordPieceTokenizer, Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
 
 from ..utils import bert_files, data_dir
+
+
+def test_sequence_ids_support_non_dense_ids():
+    tokenizer = Tokenizer(WordLevel({"[UNK]": 0, "a": 1, "b": 2}, unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = Whitespace()
+    encoding = tokenizer.encode("a b")
+    encoding.set_sequence_id(5)
+
+    assert encoding.token_to_sequence(0) == 5
+    assert encoding.word_to_tokens(0, 5) == (0, 1)
+    assert encoding.sequence_ids == [5, 5]
 
 
 @pytest.mark.network

--- a/bindings/python/tests/bindings/test_encoding.py
+++ b/bindings/python/tests/bindings/test_encoding.py
@@ -47,6 +47,7 @@ class TestEncoding:
         assert pair.word_to_tokens(0, 0) == (1, 2)
         assert pair.word_to_tokens(6, 0) == None
         assert pair.word_to_tokens(0, 1) == (6, 7)
+        assert single.word_to_tokens(0, 1) == None
 
     def test_word_to_chars(self, encodings):
         single, pair = encodings
@@ -55,6 +56,7 @@ class TestEncoding:
         assert pair.word_to_chars(2) == (7, 18)
         assert pair.word_to_chars(2, 0) == (7, 18)
         assert pair.word_to_chars(2, 1) == (6, 7)
+        assert single.word_to_chars(2, 1) == None
 
     def test_token_to_sequence(self, encodings):
         single, pair = encodings
@@ -98,6 +100,7 @@ class TestEncoding:
         assert pair.char_to_token(1, 0) == None
         assert pair.char_to_token(0, 1) == 6
         assert pair.char_to_token(2, 1) == None
+        assert single.char_to_token(0, 1) == None
 
     def test_char_to_word(self, encodings):
         single, pair = encodings
@@ -108,6 +111,7 @@ class TestEncoding:
         assert pair.char_to_word(2, 0) == 1
         assert pair.char_to_word(2, 1) == None
         assert pair.char_to_word(3, 1) == 1
+        assert single.char_to_word(0, 1) == None
 
     def test_truncation(self, encodings):
         single, _ = encodings

--- a/bindings/python/tests/bindings/test_encoding.py
+++ b/bindings/python/tests/bindings/test_encoding.py
@@ -7,15 +7,18 @@ from tokenizers.pre_tokenizers import Whitespace
 from ..utils import bert_files, data_dir
 
 
-def test_sequence_ids_support_non_dense_ids():
+def test_set_sequence_id_replaces_previous_id():
     tokenizer = Tokenizer(WordLevel({"[UNK]": 0, "a": 1, "b": 2}, unk_token="[UNK]"))
     tokenizer.pre_tokenizer = Whitespace()
     encoding = tokenizer.encode("a b")
     encoding.set_sequence_id(5)
+    encoding.set_sequence_id(6)
 
-    assert encoding.token_to_sequence(0) == 5
-    assert encoding.word_to_tokens(0, 5) == (0, 1)
-    assert encoding.sequence_ids == [5, 5]
+    assert encoding.n_sequences == 1
+    assert encoding.token_to_sequence(0) == 6
+    assert encoding.word_to_tokens(0, 5) is None
+    assert encoding.word_to_tokens(0, 6) == (0, 1)
+    assert encoding.sequence_ids == [6, 6]
 
 
 @pytest.mark.network

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -137,9 +137,10 @@ impl Encoding {
     pub fn get_sequence_ids(&self) -> Vec<Option<usize>> {
         let mut sequences = vec![None; self.len()];
         for seq_id in 0..self.n_sequences() {
-            let range = self.sequence_range(seq_id);
-            let seq_len = range.len();
-            sequences.splice(range, std::iter::repeat_n(Some(seq_id), seq_len));
+            if let Some(range) = self.sequence_range(seq_id) {
+                let seq_len = range.len();
+                sequences.splice(range, std::iter::repeat_n(Some(seq_id), seq_len));
+            }
         }
         sequences
     }
@@ -201,11 +202,12 @@ impl Encoding {
 
     /// Returns the range to target to retrieve something (word_id, offsets, ..) related to the
     /// given sequence id
-    fn sequence_range(&self, sequence_id: usize) -> Range<usize> {
-        self.sequence_ranges
-            .get(&sequence_id)
-            .cloned()
-            .unwrap_or(0..self.len())
+    fn sequence_range(&self, sequence_id: usize) -> Option<Range<usize>> {
+        if self.sequence_ranges.is_empty() {
+            (sequence_id == 0).then(|| 0..self.len())
+        } else {
+            self.sequence_ranges.get(&sequence_id).cloned()
+        }
     }
 
     /// Returns the index of the sequence containing the given token
@@ -229,7 +231,7 @@ impl Encoding {
     /// with the form (start_token, end_token + 1)
     pub fn word_to_tokens(&self, word: u32, sequence_id: usize) -> Option<(usize, usize)> {
         let (mut start, mut end) = (None, None);
-        let sequence_range = self.sequence_range(sequence_id);
+        let sequence_range = self.sequence_range(sequence_id)?;
 
         self.words
             .get(sequence_range.clone())?
@@ -283,7 +285,7 @@ impl Encoding {
 
     /// Get the token that contains the given char.
     pub fn char_to_token(&self, pos: usize, sequence_id: usize) -> Option<usize> {
-        let sequence_range = self.sequence_range(sequence_id);
+        let sequence_range = self.sequence_range(sequence_id)?;
 
         self.offsets
             .get(sequence_range.clone())?
@@ -603,6 +605,27 @@ mod tests {
                 ..Default::default()
             }
         );
+    }
+
+    #[test]
+    fn mapping_rejects_invalid_sequence_ids() {
+        let encoding = Encoding {
+            ids: vec![1],
+            tokens: vec![String::from("Hello")],
+            words: vec![Some(0)],
+            offsets: vec![(0, 5)],
+            ..Default::default()
+        };
+
+        assert_eq!(encoding.word_to_tokens(0, 0), Some((0, 1)));
+        assert_eq!(encoding.word_to_chars(0, 0), Some((0, 5)));
+        assert_eq!(encoding.char_to_token(0, 0), Some(0));
+        assert_eq!(encoding.char_to_word(0, 0), Some(0));
+
+        assert_eq!(encoding.word_to_tokens(0, 1), None);
+        assert_eq!(encoding.word_to_chars(0, 1), None);
+        assert_eq!(encoding.char_to_token(0, 1), None);
+        assert_eq!(encoding.char_to_word(0, 1), None);
     }
 
     #[test]

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -135,12 +135,13 @@ impl Encoding {
     }
 
     pub fn get_sequence_ids(&self) -> Vec<Option<usize>> {
+        if self.sequence_ranges.is_empty() {
+            return vec![Some(0); self.len()];
+        }
+
         let mut sequences = vec![None; self.len()];
-        for seq_id in 0..self.n_sequences() {
-            if let Some(range) = self.sequence_range(seq_id) {
-                let seq_len = range.len();
-                sequences.splice(range, std::iter::repeat_n(Some(seq_id), seq_len));
-            }
+        for (seq_id, range) in &self.sequence_ranges {
+            sequences[range.clone()].fill(Some(*seq_id));
         }
         sequences
     }
@@ -626,6 +627,17 @@ mod tests {
         assert_eq!(encoding.word_to_chars(0, 1), None);
         assert_eq!(encoding.char_to_token(0, 1), None);
         assert_eq!(encoding.char_to_word(0, 1), None);
+    }
+
+    #[test]
+    fn sequence_ids_support_non_dense_ids() {
+        let mut encoding = Encoding {
+            ids: vec![1, 2],
+            ..Default::default()
+        };
+        encoding.set_sequence_id(5);
+
+        assert_eq!(encoding.get_sequence_ids(), vec![Some(5), Some(5)]);
     }
 
     #[test]

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -119,6 +119,7 @@ impl Encoding {
 
     /// Set the given sequence id for the whole range of tokens contained in this Encoding
     pub fn set_sequence_id(&mut self, sequence_id: usize) {
+        self.sequence_ranges.clear();
         self.sequence_ranges.insert(sequence_id, 0..self.len());
     }
 
@@ -630,14 +631,19 @@ mod tests {
     }
 
     #[test]
-    fn sequence_ids_support_non_dense_ids() {
+    fn set_sequence_id_replaces_previous_id() {
         let mut encoding = Encoding {
             ids: vec![1, 2],
             ..Default::default()
         };
         encoding.set_sequence_id(5);
+        encoding.set_sequence_id(6);
 
-        assert_eq!(encoding.get_sequence_ids(), vec![Some(5), Some(5)]);
+        assert_eq!(encoding.n_sequences(), 1);
+        assert_eq!(encoding.sequence_range(5), None);
+        assert_eq!(encoding.sequence_range(6), Some(0..2));
+        assert_eq!(encoding.token_to_sequence(0), Some(6));
+        assert_eq!(encoding.get_sequence_ids(), vec![Some(6), Some(6)]);
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

Keep sequence-ID mapping behavior consistent after the Tokenizers v1 reorganization.

For an encoding with no explicit `sequence_ranges`, only sequence ID 0 denotes the implicit full-length sequence. When ranges are present, mapping APIs now require an exact stored ID instead of silently falling back to sequence 0. `get_sequence_ids()` iterates the IDs actually stored in the map, including sparse IDs such as 5. Assigning an ID to the whole encoding also clears previous ranges, so repeated `set_sequence_id(5); set_sequence_id(6)` calls cannot leave overlapping ranges and make public Rust mapping methods disagree.

The original PR included Python-binding regressions. Upstream's Tokenizers v1 merge removed the old Python `Encoding` sequence-mapping API and moved the Rust implementation into `tk-encode`; the obsolete Python tests were therefore not carried forward. The current diff and regression tests are confined to the Rust encoding module. This does not claim that the removed Python API is covered on v1.

## Tests

- `cargo test -p tk-encode --lib --quiet` in `tokenizers/`: 191 passed, 1 ignored.
- `cargo fmt -p tk-encode --check` in `tokenizers/`: passed.
