### PR TITLE
docs: note that WordPiece training uses BPE

### DIFF
--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -432,9 +432,10 @@ impl PyBpeTrainer {
 ///
 /// Note:
 ///     This trainer builds the vocabulary with BPE, because a faithful
-///     WordPiece trainer is not implemented. Encode/decode still uses
-///     greedy WordPiece with the ``##`` continuing-subword prefix. The
-///     resulting vocab will not match Google WordPiece on the same corpus.
+///     WordPiece trainer is not implemented. Tokenization still uses greedy
+///     WordPiece with the configured continuing-subword prefix (``##`` by
+///     default). The resulting vocab will not match Google WordPiece on the
+///     same corpus.
 ///
 /// Args:
 ///     vocab_size (:obj:`int`, `optional`):

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -430,6 +430,12 @@ impl PyBpeTrainer {
 
 /// Trainer capable of training a WordPiece model
 ///
+/// Note:
+///     This trainer builds the vocabulary with BPE, because a faithful
+///     WordPiece trainer is not implemented. Encode/decode still uses
+///     greedy WordPiece with the ``##`` continuing-subword prefix. The
+///     resulting vocab will not match Google WordPiece on the same corpus.
+///
 /// Args:
 ///     vocab_size (:obj:`int`, `optional`):
 ///         The size of the final vocabulary, including all tokens and alphabet.

--- a/docs/source-doc-builder/components.mdx
+++ b/docs/source-doc-builder/components.mdx
@@ -130,7 +130,7 @@ they are the only mandatory component of a Tokenizer.
 
 <Tip>
 
-Encode/decode is greedy WordPiece with the `##` continuing-subword prefix.
+Tokenization uses greedy WordPiece with the configured continuing-subword prefix (`##` by default).
 `WordPieceTrainer`, `Tokenizer.train`, and `train_from_iterator` (and transformers' `train_new_from_iterator` on a WordPiece fast tokenizer) build the vocabulary with BPE, because a faithful WordPiece trainer is not implemented. The resulting vocab will not match Google WordPiece on the same corpus. This is expected.
 
 </Tip>

--- a/docs/source-doc-builder/components.mdx
+++ b/docs/source-doc-builder/components.mdx
@@ -128,6 +128,13 @@ they are the only mandatory component of a Tokenizer.
 | WordPiece | This is a subword tokenization algorithm quite similar to BPE, used mainly by Google in models like BERT. It uses a greedy algorithm, that tries to build long words first, splitting in multiple tokens when entire words don’t exist in the vocabulary. This is different from BPE that starts from characters, building bigger tokens as possible. It uses the famous `##` prefix to identify tokens that are part of a word (ie not starting a word).  |
 | Unigram | Unigram is also a subword tokenization algorithm, and works by trying to identify the best set of subword tokens to maximize the probability for a given sentence. This is different from BPE in the way that this is not deterministic based on a set of rules applied sequentially. Instead Unigram will be able to compute multiple ways of tokenizing, while choosing the most probable one. |
 
+<Tip>
+
+Encode/decode is greedy WordPiece with the `##` continuing-subword prefix.
+`WordPieceTrainer`, `Tokenizer.train`, and `train_from_iterator` (and transformers' `train_new_from_iterator` on a WordPiece fast tokenizer) build the vocabulary with BPE, because a faithful WordPiece trainer is not implemented. The resulting vocab will not match Google WordPiece on the same corpus. This is expected.
+
+</Tip>
+
 ## Post-Processors
 
 After the whole pipeline, we sometimes want to insert some special


### PR DESCRIPTION
## Summary
Closes #1777.

`WordPiece` tokenization in this library uses greedy longest-match lookup, but `WordPieceTrainer` / `Tokenizer.train` / `train_from_iterator` (and transformers' `train_new_from_iterator` on a WordPiece fast tokenizer) build the vocabulary with BPE (`WordPiece::from_bpe`). The Hugging Face LLM course already says this; the library docs did not.

@ArthurZucker asked for a PR on #1777. Prior attempt #2065 was self-closed unmerged.

## Test plan
- [x] Docs-only: confirmed the Models → WordPiece tip in `docs/source-doc-builder/components.mdx` matches current trainer behavior
- [x] Confirmed the `WordPieceTrainer` Python docstring note against `WordPieceTrainer::train()` and configurable prefix handling
- [x] No Rust/Python behavior changes

## AI assistance and human-in-the-loop

The initial documentation commits were prepared by Cursor Agent; its underlying model version was not recorded in the commit metadata. During the current re-review, Cad on Hermes Agent with GPT-5.6 Sol traced `WordPieceTrainer::train()` through `BPE` and `WordPiece::from_bpe()`, found that `##` is a configurable default rather than an invariant and that greedy longest-match describes tokenization rather than decoding, and authored follow-up commit `52e86480c3797a90365f9e2e3696520305f6bbcd` to correct both new documentation locations. The branch was then rebased onto current `main`; the full stable patch ID remained `93e23d58354071d3cd798642092858a4b645dcba`.

Luis Felipe Abarca personally reviews Arca's public contributions and verification evidence, directs the workflow, authorizes publication and public follow-up, and remains accountable for what is submitted. Agents may research, draft, inspect source, and run checks, but they do not independently decide what is published or merged. Upstream maintainers retain review and merge authority.

Verification for the follow-up was limited to source tracing and `git diff --check`; this control-plane host does not have a Rust toolchain installed, and GitHub currently reports no CI checks for this PR.

[Arca](https://arca.computer) · [Luis Felipe](https://felirami.com) · [X](https://x.com/felirami) · [GitHub](https://github.com/felirami)
