### PR TITLE
fix: port the backend-independent fixes out of #2293

### DIFF
--- a/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/metaspace.rs
@@ -18,7 +18,14 @@ pub enum PrependScheme {
 
 impl std::fmt::Display for PrependScheme {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.serialize(f)
+        // Spelled out rather than handed to the serializer, so the name survives a build with no
+        // serde. These must stay identical to the `rename_all = "snake_case"` spelling above;
+        // `display_matches_serde` pins that.
+        f.write_str(match self {
+            Self::First => "first",
+            Self::Never => "never",
+            Self::Always => "always",
+        })
     }
 }
 
@@ -240,6 +247,20 @@ fn normalizer_and_split(
 
 #[cfg(test)]
 mod tests {
+    /// `Display` is spelled out by hand now; keep it identical to what serde emits (`snake_case`),
+    /// so the two cannot drift while both exist.
+    #[test]
+    fn display_matches_serde() {
+        for scheme in [
+            PrependScheme::First,
+            PrependScheme::Never,
+            PrependScheme::Always,
+        ] {
+            let via_serde = serde_json::to_string(&scheme).unwrap();
+            assert_eq!(format!("\"{scheme}\""), via_serde);
+        }
+    }
+
     use regex::Regex;
 
     use super::*;

--- a/tokenizers/tk-encode/src/pre_tokenizers/split.rs
+++ b/tokenizers/tk-encode/src/pre_tokenizers/split.rs
@@ -126,6 +126,40 @@ impl Split {
         })
     }
 
+    /// A `Split` that is known to be driven natively, so no regex backend is compiled.
+    ///
+    /// [`Split::new`] asks the system regex to compile every regex pattern, which a build without
+    /// `fancy-regex` has no engine for. Two cases do not need one: a pattern [`gpt_fsm`] recognises,
+    /// and a member of a composition the pipeline runs as a single native pass -- deepseek's three
+    /// regexes are individually unrecognised but never individually run, so `Split::new` would
+    /// reject them. A literal pattern is searched for directly and never needed an engine either.
+    pub fn native(
+        pattern: SplitPattern,
+        behavior: SplitDelimiterBehavior,
+        invert: bool,
+    ) -> Result<Self> {
+        let fsm = match &pattern {
+            SplitPattern::String(_) => None,
+            SplitPattern::Regex(r) => gpt_fsm(r),
+        };
+        let search = match &pattern {
+            SplitPattern::String(s) => Search::Literal(Literal::new(s.as_bytes())?),
+            SplitPattern::Regex(_) => Search::Unavailable,
+        };
+        Ok(Self {
+            pattern,
+            search,
+            behavior,
+            invert,
+            fsm,
+        })
+    }
+
+    /// The native FSM family this pattern was recognised as, if any.
+    pub fn gpt_fsm(&self) -> Option<GptFsm> {
+        self.fsm
+    }
+
     /// Pipeline canonicalization. A recognized whole-covering GPT regex shipped
     /// as `(invert=true, behavior=Removed)` — the tiktoken-conversion convention
     /// used by cl100k/o200k — is byte-exactly equivalent to `(invert=false,
@@ -232,6 +266,52 @@ unsafe impl pipeline::PreTokenizer for Split {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `Split::new` compiles every regex through the system backend, so a build without
+    /// `fancy-regex` cannot construct deepseek's three patterns -- they are individually
+    /// unrecognised by `gpt_fsm` (the pipeline runs them as one native pass). `Split::native`
+    /// never asks for an engine.
+    #[test]
+    fn native_accepts_patterns_new_would_need_an_engine_for() {
+        use crate::utils::DEEPSEEK_PATTERNS;
+
+        for pattern in DEEPSEEK_PATTERNS {
+            let split = Split::native(
+                SplitPattern::Regex(pattern.to_string()),
+                SplitDelimiterBehavior::Isolated,
+                false,
+            )
+            .expect("native must not need a regex backend");
+            assert!(
+                split.gpt_fsm().is_none(),
+                "deepseek's patterns are not individually FSM-recognised"
+            );
+        }
+
+        // The premise: with no backend compiled, `Split::new` rejects exactly these.
+        #[cfg(not(feature = "fancy-regex"))]
+        for pattern in DEEPSEEK_PATTERNS {
+            assert!(
+                Split::new(
+                    SplitPattern::Regex(pattern.to_string()),
+                    SplitDelimiterBehavior::Isolated,
+                    false,
+                )
+                .is_err(),
+                "without a backend `Split::new` must fail here -- that is why `native` exists"
+            );
+        }
+
+        // A recognised pattern still reports its family, so a caller can route it natively.
+        let gpt2 = Split::native(
+            SplitPattern::Regex(atomsplit::regexes::GPT2.to_string()),
+            SplitDelimiterBehavior::Isolated,
+            false,
+        )
+        .unwrap();
+        assert_eq!(gpt2.gpt_fsm(), Some(GptFsm::Gpt2));
+    }
+
     use crate::{OffsetReferential, OffsetType, PreTokenizer};
     use SplitDelimiterBehavior::*;
 

--- a/tokenizers/tk-encode/src/tokenizer/normalizer.rs
+++ b/tokenizers/tk-encode/src/tokenizer/normalizer.rs
@@ -89,7 +89,17 @@ pub enum SplitDelimiterBehavior {
 
 impl std::fmt::Display for SplitDelimiterBehavior {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.serialize(f)
+        // Spelled out rather than handed to the serializer, so the name survives a build with no
+        // serde -- and it is a `match` instead of abusing a `Formatter` as a `Serializer`. No
+        // `rename_all` on this enum, so the serialized name is the variant name verbatim;
+        // `display_matches_serde` pins that.
+        f.write_str(match self {
+            Self::Removed => "Removed",
+            Self::Isolated => "Isolated",
+            Self::MergedWithPrevious => "MergedWithPrevious",
+            Self::MergedWithNext => "MergedWithNext",
+            Self::Contiguous => "Contiguous",
+        })
     }
 }
 
@@ -1021,6 +1031,23 @@ impl From<&str> for NormalizedString {
 
 #[cfg(test)]
 mod tests {
+    /// `Display` is spelled out by hand now; keep it identical to what serde emits, so the two
+    /// cannot drift while both exist.
+    #[test]
+    fn display_matches_serde() {
+        use crate::tokenizer::normalizer::SplitDelimiterBehavior::*;
+        for behavior in [
+            Removed,
+            Isolated,
+            MergedWithPrevious,
+            MergedWithNext,
+            Contiguous,
+        ] {
+            let via_serde = serde_json::to_string(&behavior).unwrap();
+            assert_eq!(format!("\"{behavior}\""), via_serde);
+        }
+    }
+
     use super::*;
     use atomsplit::literal::Literal;
     use regex::Regex;

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -768,7 +768,12 @@ impl TryFrom<&Tokenizer> for PipelineTokenizer {
     /// rest keep their dense order), so the pipeline emits the same ids as the reference tokenizer.
     fn try_from(tok: &Tokenizer) -> Result<Self> {
         let mut normalizers = Vec::new();
-        if let Some(declared) = tok.get_normalizer() {
+        // An empty `Sequence` is how a config spells "no normalization" (deepseek ships one), so drop
+        // it here instead of calling into a no-op for every segment.
+        let declared = tok.get_normalizer().filter(|declared| {
+            !matches!(declared, NormalizerWrapper::Sequence(seq) if seq.as_ref().is_empty())
+        });
+        if let Some(declared) = declared {
             normalizers.push(PipelineNormalizer::Declared(declared.clone()));
         }
 
@@ -1124,6 +1129,20 @@ impl IntoIterator for EncodeHandle {
 impl PipelineTokenizer {
     pub fn get_model(&self) -> &PipelineModel {
         &self.inner.model
+    }
+
+    /// Whether any normalization step runs before the pre-tokenizer. An empty normalizer
+    /// `Sequence` in the config counts as none, since it is elided on the way in.
+    pub fn has_normalizer(&self) -> bool {
+        !self.inner.normalizers.is_empty()
+    }
+
+    pub fn get_pre_tokenizer(&self) -> &PipelinePreTokenizer {
+        &self.inner.pre_tokenizer
+    }
+
+    pub fn get_post_processor(&self) -> &PipelinePostProcessor {
+        &self.inner.post_processor
     }
 
     /// Encode `input` into token ids.
@@ -1739,6 +1758,32 @@ impl Model for PipelineModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An empty normalizer `Sequence` means "no normalization" (deepseek ships one). It must be
+    /// dropped on the way in, not carried as a no-op call per segment. A non-empty one is kept.
+    #[test]
+    fn empty_normalizer_sequence_is_elided() {
+        use crate::normalizers::utils::{Lowercase, Sequence as NormSequence};
+
+        let vocab = vec![("[UNK]", 0u32), ("hello", 1)];
+
+        let mut tok = wordlevel_tokenizer(vocab.clone(), None);
+        tok.with_normalizer(Some(NormSequence::new(vec![])))
+            .unwrap();
+        assert!(
+            !PipelineTokenizer::try_from(&tok).unwrap().has_normalizer(),
+            "an empty normalizer Sequence should not survive into the pipeline"
+        );
+
+        let mut tok = wordlevel_tokenizer(vocab, None);
+        tok.with_normalizer(Some(NormSequence::new(vec![Lowercase.into()])))
+            .unwrap();
+        assert!(
+            PipelineTokenizer::try_from(&tok).unwrap().has_normalizer(),
+            "a non-empty normalizer Sequence must still be applied"
+        );
+    }
+
     use crate::models::bpe::BPE;
     use crate::models::wordpiece::WordPiece;
     use crate::pre_tokenizers::byte_level::ByteLevel;

--- a/tokenizers/tk-encode/src/utils/mod.rs
+++ b/tokenizers/tk-encode/src/utils/mod.rs
@@ -18,7 +18,7 @@ pub use no_regex::SysRegex;
 
 // Recognize known GPT pre-tokenization regexes and route them to atomsplit's native (unrolled) FSM.
 mod unrolled_regex;
-pub use unrolled_regex::{GptFsm, GptFsmPattern, gpt_fsm, is_deepseek};
+pub use unrolled_regex::{DEEPSEEK_PATTERNS, GptFsm, GptFsmPattern, gpt_fsm, is_deepseek};
 
 pub mod byte_level;
 pub mod iter;

--- a/tokenizers/tk-encode/src/utils/unrolled_regex.rs
+++ b/tokenizers/tk-encode/src/utils/unrolled_regex.rs
@@ -106,6 +106,12 @@ const DS_BIG: &str = concat!(
     r##"]+|\s+(?!\S)|\s+"##,
 );
 
+/// deepseek's three patterns, in order, exactly as the shipped config spells them. The copies in
+/// `atomsplit::regexes` escape CR/LF instead of embedding it, so the two are **not**
+/// interchangeable and [`is_deepseek`] rejects the escaped form -- anything rebuilding these
+/// patterns must use this constant or it silently falls off the native FSM onto the regex fallback.
+pub const DEEPSEEK_PATTERNS: [&str; 3] = [DS_NUM, DS_CJK, DS_BIG];
+
 /// True iff three `Split` patterns are exactly deepseek's `[\p{N}{1,3}, CJK-range, big-regex]` prefix →
 /// `atomsplit::fsm::fsm_deepseek` reproduces the whole composed Isolated split in one pass.
 pub fn is_deepseek(p0: &str, p1: &str, p2: &str) -> bool {
@@ -115,6 +121,26 @@ pub fn is_deepseek(p0: &str, p1: &str, p2: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The trap [`DEEPSEEK_PATTERNS`] exists to close: `atomsplit::regexes::DEEPSEEK_BIG` spells
+    /// CR/LF as the two-character escape `\r\n` inside a raw string, while the shipped configs (and
+    /// so `DS_BIG`) embed real control characters. They are not interchangeable, and rebuilding from
+    /// the wrong one silently drops off the native FSM onto the regex fallback.
+    #[test]
+    fn deepseek_patterns_are_the_only_recognised_spelling() {
+        let [num, cjk, big] = DEEPSEEK_PATTERNS;
+        assert!(is_deepseek(num, cjk, big));
+
+        let escaped = atomsplit::regexes::DEEPSEEK;
+        assert!(
+            !is_deepseek(escaped[0], escaped[1], escaped[2]),
+            "atomsplit's escaped copies must NOT be mistaken for the shipped spelling"
+        );
+        // Only the big one differs; the first two are identical in both.
+        assert_eq!(num, escaped[0]);
+        assert_eq!(cjk, escaped[1]);
+        assert_ne!(big, escaped[2]);
+    }
 
     #[test]
     fn gpt_fsm_recognizes_family_and_extracts_digit_cap() {


### PR DESCRIPTION
Four fixes from #2293 that have nothing to do with the `.tok` container, split out so they can land on their own. No API change, no feature churn, ~200 lines.

Prep for the slim `tk-encode` work; the last two are hard blockers for a build without serde or a regex backend.

### 1. Empty normalizer `Sequence` is elided

`{"type":"Sequence","normalizers":[]}` is how a config spells "no normalization" — deepseek ships one. It was carried into the pipeline and invoked as a no-op for every segment. Now dropped at conversion time. A non-empty `Sequence` is still applied; both directions are tested.

### 2. Both `Display` impls spelled out

`Display for SplitDelimiterBehavior` and `Display for PrependScheme` were `self.serialize(f)` — abusing a `Formatter` as a `Serializer`. Now a `match`: O(1) instead of routing through serde, and it still compiles once serde becomes optional (a `Display` that calls `Serialize` cannot).

`display_matches_serde` in each file asserts the hand-written names equal what serde emits (verbatim variant names for one, `rename_all = "snake_case"` for the other), so the two cannot drift while both exist.

### 3. `Split::native`

`Split::new` compiles every regex through `SysRegex`, which without `fancy-regex` is a stub whose `new` always errors. So with no backend it **rejects deepseek's three patterns**: they are individually unrecognised by `gpt_fsm` even though the pipeline runs them as a single native pass, so the `Err(_) if fsm.is_some()` escape hatch does not catch them.

`Split::native` never asks for an engine. The test asserts the premise under `cfg(not(feature = "fancy-regex"))` — i.e. that `Split::new` really does fail there — so the reason this exists is checked rather than described. Also adds a `Split::gpt_fsm()` accessor.

### 4. `DEEPSEEK_PATTERNS` as the single source

`atomsplit::regexes::DEEPSEEK_BIG` spells CR/LF as the two-character escape `\r\n` inside a raw string; the shipped configs (and so `DS_BIG`) embed real control characters. They are **not** interchangeable, and `is_deepseek` rejects the escaped form — so anything rebuilding these patterns from `atomsplit` silently falls off the native FSM onto the regex fallback. Pinned by a test that asserts the escaped copies are rejected and that only the third pattern differs.

### Also

`PipelineTokenizer::{has_normalizer, get_pre_tokenizer, get_post_processor}`. `has_normalizer` is what makes the elision in (1) testable.

## Deliberately not ported from #2293

- `cl100k_pattern()` and the `CL100K_PRE`/`CL100K_SUF` hoist — they invert FSM-name → regex-source, which only a `.tok` reader needs. JSON carries the source, so the existing `&str → GptFsm` direction is enough.
- `PipelinePostProcessor::from_ids` and the `repr(C) PipelineToken` → `&[u32]` view — no caller until the slim JSON reader lands.

Two of #2293's four listed bug fixes are **already fixed** on this base: `Split::new`'s `Search::Unavailable` escape hatch, and `is_deepseek` single-sourcing its patterns via `concat!`.

## Tests

362 default / 351 `--no-default-features` / 374 `--all-features`, all pass. `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.