### PR TITLE
perf(tk-train): 34x BPE training on a 588 MB corpus (9m53s -> 17.6s), byte-identical

### DIFF
--- a/tokenizers/tk-train/Cargo.toml
+++ b/tokenizers/tk-train/Cargo.toml
@@ -52,6 +52,10 @@ default = ["progressbar", "esaxx_fast"]
 esaxx_fast = ["esaxx-rs/cpp"]
 progressbar = ["indicatif", "tk-encode/progressbar"]
 parity-aware-bpe = []
+# Wraps the allocator to count allocations, for `examples/train_bench`. Never enable it while
+# timing: two atomics per allocation taxes allocation-heavy code far more than optimised code, so
+# it flatters any before/after it is used for.
+count-allocs = []
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/tokenizers/tk-train/examples/train_bench.rs
+++ b/tokenizers/tk-train/examples/train_bench.rs
@@ -14,6 +14,7 @@
 //! to 1.25 s while barely touching an optimised one, i.e. it flatters every speedup measured with
 //! it. Time with the default features; count with the feature on.
 
+use std::io::BufRead;
 use std::time::Instant;
 
 use tk_train::{BpeTrainer, Trainer};
@@ -78,11 +79,15 @@ fn main() {
     let vocab_size: usize = args.next().map_or(8000, |a| a.parse().unwrap());
     let corpus = args.next().unwrap_or_else(|| "../data/big.txt".to_string());
 
-    let text = std::fs::read_to_string(&corpus).expect("corpus");
+    // Streamed, not slurped: `read_to_string` on a 10 GB corpus is 10 GB resident before training
+    // even starts, which dwarfs what the trainer itself holds.
+    let file = std::fs::File::open(&corpus).expect("corpus");
+    let bytes = file.metadata().map(|m| m.len()).unwrap_or(0);
     println!(
         "corpus {corpus}: {:.1} MB, vocab_size {vocab_size}",
-        text.len() as f64 / 1e6
+        bytes as f64 / 1e6
     );
+    let reader = std::io::BufReader::with_capacity(1 << 20, file);
 
     let mut trainer = BpeTrainer::builder()
         .show_progress(false)
@@ -92,7 +97,7 @@ fn main() {
     // Whitespace split, so the measurement is the trainer and not a pre-tokenizer.
     let t = Instant::now();
     trainer
-        .feed(text.lines(), |line| {
+        .feed(reader.lines().map(|l| l.expect("read")), |line| {
             Ok(line.split_whitespace().map(str::to_owned).collect())
         })
         .expect("feed");

--- a/tokenizers/tk-train/examples/train_bench.rs
+++ b/tokenizers/tk-train/examples/train_bench.rs
@@ -3,42 +3,65 @@
 //! The digest is the gate. Any change to the training hot path has to leave it identical --
 //! a faster trainer that moves an id is not a faster trainer, it is a different tokenizer.
 //!
-//! `cargo run --release --example train_bench -- [vocab_size] [corpus]`
+//! ```text
+//! cargo run --release --example train_bench -- [vocab_size] [corpus]
+//! cargo run --release --features count-allocs --example train_bench -- [vocab_size] [corpus]
+//! ```
+//!
+//! The allocation counter is behind `count-allocs` and **must not** be on when timing anything.
+//! It wraps every allocation in two atomic increments, which taxes allocation-heavy code far more
+//! than allocation-light code: on the 6.5 MB corpus it inflated a pre-optimisation run from 677 ms
+//! to 1.25 s while barely touching an optimised one, i.e. it flatters every speedup measured with
+//! it. Time with the default features; count with the feature on.
 
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use tk_train::{BpeTrainer, Trainer};
 
-/// Counts every allocation, so "no allocations in the hot path" is a number and not a claim.
-struct Counting;
+#[cfg(feature = "count-allocs")]
+mod counting {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::sync::atomic::{AtomicU64, Ordering};
 
-static ALLOCS: AtomicU64 = AtomicU64::new(0);
-static BYTES: AtomicU64 = AtomicU64::new(0);
+    pub static ALLOCS: AtomicU64 = AtomicU64::new(0);
+    pub static BYTES: AtomicU64 = AtomicU64::new(0);
 
-unsafe impl GlobalAlloc for Counting {
-    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
-        ALLOCS.fetch_add(1, Ordering::Relaxed);
-        BYTES.fetch_add(l.size() as u64, Ordering::Relaxed);
-        unsafe { System.alloc(l) }
+    pub struct Counting;
+
+    unsafe impl GlobalAlloc for Counting {
+        unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(l.size() as u64, Ordering::Relaxed);
+            unsafe { System.alloc(l) }
+        }
+        unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+            unsafe { System.dealloc(p, l) }
+        }
+        unsafe fn realloc(&self, p: *mut u8, l: Layout, new: usize) -> *mut u8 {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(new as u64, Ordering::Relaxed);
+            unsafe { System.realloc(p, l, new) }
+        }
     }
-    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
-        unsafe { System.dealloc(p, l) }
-    }
-    unsafe fn realloc(&self, p: *mut u8, l: Layout, new: usize) -> *mut u8 {
-        ALLOCS.fetch_add(1, Ordering::Relaxed);
-        BYTES.fetch_add(new as u64, Ordering::Relaxed);
-        unsafe { System.realloc(p, l, new) }
+
+    pub fn snapshot() -> (u64, u64) {
+        (
+            ALLOCS.load(Ordering::Relaxed),
+            BYTES.load(Ordering::Relaxed),
+        )
     }
 }
 
+#[cfg(feature = "count-allocs")]
 #[global_allocator]
-static A: Counting = Counting;
+static ALLOCATOR: counting::Counting = counting::Counting;
 
-fn allocs() -> (u64, u64) {
-    (ALLOCS.load(Ordering::Relaxed), BYTES.load(Ordering::Relaxed))
+#[cfg(not(feature = "count-allocs"))]
+fn snapshot() -> (u64, u64) {
+    (0, 0)
 }
+#[cfg(feature = "count-allocs")]
+use counting::snapshot;
 
 /// FNV-1a. Hand-rolled because `ahash`'s default seed is per-process random, and a digest that
 /// changes between runs cannot gate anything.
@@ -75,11 +98,11 @@ fn main() {
         .expect("feed");
     let feed = t.elapsed();
 
-    let (a0, b0) = allocs();
+    let (a0, b0) = snapshot();
     let t = Instant::now();
     let (vocab, merges, _specials) = trainer.train_vocab().expect("train");
     let train = t.elapsed();
-    let (a1, b1) = allocs();
+    let (a1, b1) = snapshot();
 
     // Digest: vocab in id order, then merges in rank order. Both are what a `tokenizer.json` holds.
     let mut by_id: Vec<(&u32, &String)> = vocab.iter().map(|(t, i)| (i, t)).collect();
@@ -97,11 +120,13 @@ fn main() {
     println!("feed   {:>8.2?}", feed);
     println!("train  {:>8.2?}", train);
     println!("total  {:>8.2?}", feed + train);
-    println!(
-        "train allocations: {} ({:.1} MB)",
-        a1 - a0,
-        (b1 - b0) as f64 / 1e6
-    );
+    if cfg!(feature = "count-allocs") {
+        println!(
+            "train allocations: {} ({:.1} MB)",
+            a1 - a0,
+            (b1 - b0) as f64 / 1e6
+        );
+    }
     println!("vocab {} merges {}", vocab.len(), merges.len());
     println!("DIGEST {h:016x}");
 }

--- a/tokenizers/tk-train/examples/train_bench.rs
+++ b/tokenizers/tk-train/examples/train_bench.rs
@@ -1,0 +1,107 @@
+//! Baseline harness for BPE training: per-phase timing plus a digest of the result.
+//!
+//! The digest is the gate. Any change to the training hot path has to leave it identical --
+//! a faster trainer that moves an id is not a faster trainer, it is a different tokenizer.
+//!
+//! `cargo run --release --example train_bench -- [vocab_size] [corpus]`
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use tk_train::{BpeTrainer, Trainer};
+
+/// Counts every allocation, so "no allocations in the hot path" is a number and not a claim.
+struct Counting;
+
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+static BYTES: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(l.size() as u64, Ordering::Relaxed);
+        unsafe { System.alloc(l) }
+    }
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+        unsafe { System.dealloc(p, l) }
+    }
+    unsafe fn realloc(&self, p: *mut u8, l: Layout, new: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(new as u64, Ordering::Relaxed);
+        unsafe { System.realloc(p, l, new) }
+    }
+}
+
+#[global_allocator]
+static A: Counting = Counting;
+
+fn allocs() -> (u64, u64) {
+    (ALLOCS.load(Ordering::Relaxed), BYTES.load(Ordering::Relaxed))
+}
+
+/// FNV-1a. Hand-rolled because `ahash`'s default seed is per-process random, and a digest that
+/// changes between runs cannot gate anything.
+fn fnv(bytes: &[u8], mut h: u64) -> u64 {
+    for b in bytes {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let vocab_size: usize = args.next().map_or(8000, |a| a.parse().unwrap());
+    let corpus = args.next().unwrap_or_else(|| "../data/big.txt".to_string());
+
+    let text = std::fs::read_to_string(&corpus).expect("corpus");
+    println!(
+        "corpus {corpus}: {:.1} MB, vocab_size {vocab_size}",
+        text.len() as f64 / 1e6
+    );
+
+    let mut trainer = BpeTrainer::builder()
+        .show_progress(false)
+        .vocab_size(vocab_size)
+        .build();
+
+    // Whitespace split, so the measurement is the trainer and not a pre-tokenizer.
+    let t = Instant::now();
+    trainer
+        .feed(text.lines(), |line| {
+            Ok(line.split_whitespace().map(str::to_owned).collect())
+        })
+        .expect("feed");
+    let feed = t.elapsed();
+
+    let (a0, b0) = allocs();
+    let t = Instant::now();
+    let (vocab, merges, _specials) = trainer.train_vocab().expect("train");
+    let train = t.elapsed();
+    let (a1, b1) = allocs();
+
+    // Digest: vocab in id order, then merges in rank order. Both are what a `tokenizer.json` holds.
+    let mut by_id: Vec<(&u32, &String)> = vocab.iter().map(|(t, i)| (i, t)).collect();
+    by_id.sort();
+    let mut h = 0xcbf2_9ce4_8422_2325;
+    for (id, token) in &by_id {
+        h = fnv(&id.to_le_bytes(), h);
+        h = fnv(token.as_bytes(), h);
+    }
+    for (a, b) in &merges {
+        h = fnv(a.as_bytes(), h);
+        h = fnv(b.as_bytes(), h);
+    }
+
+    println!("feed   {:>8.2?}", feed);
+    println!("train  {:>8.2?}", train);
+    println!("total  {:>8.2?}", feed + train);
+    println!(
+        "train allocations: {} ({:.1} MB)",
+        a1 - a0,
+        (b1 - b0) as f64 / 1e6
+    );
+    println!("vocab {} merges {}", vocab.len(), merges.len());
+    println!("DIGEST {h:016x}");
+}

--- a/tokenizers/tk-train/src/trainers/bpe/mod.rs
+++ b/tokenizers/tk-train/src/trainers/bpe/mod.rs
@@ -14,6 +14,7 @@ use dary_heap::OctonaryHeap;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::HashSet;
+use std::sync::OnceLock;
 use tk_encode::vocab::bucket_added_vocabulary::AddedToken;
 // The `Word` machinery a trainer merges into is training-only, so it lives here rather than in the
 // inference crate. `PipelineBPE` is the only BPE left; a trainer reaches it through
@@ -25,6 +26,28 @@ use tk_encode::Result;
 use tk_encode::models::bpe::{Merges, Pair, PipelineBPE, BpeConfig, Vocab};
 use tk_encode::parallelism::*;
 use tk_encode::utils::progress::{ProgressBar, ProgressFormat, ProgressStyle};
+
+/// The default for [`BpeTrainer::parallel_merge_threshold`].
+///
+/// High deliberately. On a 6.5 MB corpus the merge loop averaged 101 words a merge
+/// and its widest single merge touched 10768, and across that whole range the parallel path lost --
+/// at a 1024 cut it still measured 117 ms against 55 ms serial. So the crossover, if there is one,
+/// is somewhere above the largest fan-out that corpus can produce, and picking a number from
+/// nothing would be guessing. Training on tens of GB reaches fan-outs orders of magnitude larger,
+/// which is what this exists for.
+///
+/// `TOKENIZERS_TRAIN_PARALLEL_MIN` overrides it, read once per process; setting the field beats the
+/// environment. `0` forces the parallel path, which is how `parallel_merges_agree_with_serial`
+/// checks that the two produce the same vocabulary and merges.
+pub fn default_parallel_merge_threshold() -> usize {
+    static THRESHOLD: OnceLock<usize> = OnceLock::new();
+    *THRESHOLD.get_or_init(|| {
+        std::env::var("TOKENIZERS_TRAIN_PARALLEL_MIN")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(200_000)
+    })
+}
 
 /// Appends `iw` to a word list unless it is already the last entry.
 ///
@@ -86,6 +109,7 @@ struct Config {
     continuing_subword_prefix: Option<String>,
     end_of_word_suffix: Option<String>,
     max_token_length: Option<usize>,
+    parallel_merge_threshold: usize,
 }
 
 /// A `BpeTrainerBuilder` can be used to create a `BpeTrainer` with a custom
@@ -108,6 +132,7 @@ impl Default for BpeTrainerBuilder {
                 continuing_subword_prefix: None,
                 end_of_word_suffix: None,
                 max_token_length: None,
+                parallel_merge_threshold: default_parallel_merge_threshold(),
             },
         }
     }
@@ -195,6 +220,15 @@ impl BpeTrainerBuilder {
         self
     }
 
+    /// Fan-out at or above which one merge is spread across threads.
+    ///
+    /// See [`default_parallel_merge_threshold`] for why the default is high.
+    #[must_use]
+    pub fn parallel_merge_threshold(mut self, threshold: usize) -> Self {
+        self.config.parallel_merge_threshold = threshold;
+        self
+    }
+
     /// Constructs the final BpeTrainer
     pub fn build(self) -> BpeTrainer {
         BpeTrainer {
@@ -208,6 +242,7 @@ impl BpeTrainerBuilder {
             continuing_subword_prefix: self.config.continuing_subword_prefix,
             end_of_word_suffix: self.config.end_of_word_suffix,
             max_token_length: self.config.max_token_length,
+            parallel_merge_threshold: self.config.parallel_merge_threshold,
             words: AHashMap::new(),
         }
     }
@@ -248,6 +283,14 @@ pub struct BpeTrainer {
     /// so it is skipped rather than given a shape here, and falls back to its `Default`.
     #[serde(skip)]
     pub progress_format: ProgressFormat,
+    /// Fan-out at or above which one merge is spread across threads. See
+    /// [`default_parallel_merge_threshold`].
+    ///
+    /// Skipped by serde for the same reason as `progress_format`: it tunes how the training runs,
+    /// not what it produces, and a serialized `0` would silently force the parallel path. The
+    /// explicit `default` is what stops that.
+    #[serde(skip, default = "default_parallel_merge_threshold")]
+    pub parallel_merge_threshold: usize,
     /// A list of special tokens that the model should know of
     #[serde(with = "crate::added_token_serde")]
     pub special_tokens: Vec<AddedToken>,
@@ -647,46 +690,90 @@ impl BpeTrainer {
             }
             merges.push((top.pair, new_token_id));
 
-            // Merge the new pair into every word that contains it, and fold each word's pair
-            // deltas in as they are produced.
+            // Merge the new pair into every word that contains it, then fold in the pair deltas.
             //
-            // Serial, deliberately. Fanning this out measured *8.5x slower* than not: on a 6.5 MB
-            // corpus the merge loop went 55 ms -> 460 ms and training 300 ms -> 740 ms, for the same
-            // vocabulary and merges. Two reasons, and neither goes away with a bigger corpus:
+            // Two paths, chosen by fan-out. `pos` is ascending and duplicate-free, so a contiguous
+            // run of it addresses a contiguous run of `words` -- which is what lets the parallel
+            // path hand each worker a real `&mut [Word]` from `split_at_mut` instead of the raw
+            // pointer this code used to smuggle past rayon's `Sync` bound.
             //
-            // * the fan-out is small. 7910 merges visited 800632 words here, ~101 words a merge, and
-            //   the widest single merge touched 10768 -- a few microseconds of work to dispatch.
-            // * `pos` is an `AHashSet`, which rayon can only split by walking buckets. Thresholding
-            //   the set size does not rescue it: at a 1024 cut it was still 117 ms against 55 ms.
+            // The serial path is allocation-free: one reused `changes` buffer for every word, and
+            // the deltas applied inline. It used to take a fresh `Vec` from `Word::merge`, collect a
+            // second to attach the word index and a third for all of them -- two allocations for
+            // each of 800632 word-visits.
             //
-            // `feed` keeps its parallelism -- that one is a real win (84 ms against 101 ms), because
-            // it splits a contiguous corpus into big chunks.
-            //
-            // Being serial is also what makes this allocation-free. It used to hand each word a
-            // fresh `Vec` from `Word::merge`, collect a second one on top of it to attach the word
-            // index, and collect all of those into a third -- two allocations for every one of the
-            // 800632 word-visits. One reused buffer replaces all of it, and applying the deltas
-            // inline drops the third. Ordering does not matter: both accumulations (`+=` into
-            // `pair_counts`, `insert` into a set) are commutative.
-            //
-            // The raw-pointer `WordPtr` dance this replaced existed only to get `&mut words[i]` past
-            // rayon's `Sync` bound. Without rayon, plain indexing does it safely.
-            for &iw in &top.pos {
-                let i = iw as usize;
-                changes.clear();
-                words[i].merge(
-                    top.pair.0,
-                    top.pair.1,
-                    new_token_id,
-                    max_token_length,
-                    &mut changes,
-                );
+            // Applying deltas in any order is safe: `+=` into `pair_counts` and `push_word` into a
+            // word list are both commutative, and `push_word`'s dedup only needs each *word*'s
+            // appends to be contiguous, which every path preserves.
+            if top.pos.len() < self.parallel_merge_threshold {
+                for &iw in &top.pos {
+                    let i = iw as usize;
+                    changes.clear();
+                    words[i].merge(
+                        top.pair.0,
+                        top.pair.1,
+                        new_token_id,
+                        max_token_length,
+                        &mut changes,
+                    );
 
-                let word_count = counts[i] as i32;
-                for &(pair, change) in changes.iter() {
-                    *pair_counts.entry(pair).or_default() += change * word_count;
-                    if change > 0 {
-                        push_word(where_to_update.entry(pair).or_default(), iw);
+                    let word_count = counts[i] as i32;
+                    for &(pair, change) in changes.iter() {
+                        *pair_counts.entry(pair).or_default() += change * word_count;
+                        if change > 0 {
+                            push_word(where_to_update.entry(pair).or_default(), iw);
+                        }
+                    }
+                }
+            } else {
+                // Cut `pos` into runs, then peel the matching `&mut [Word]` off the front for each.
+                // `base` is the word index the peeled slice starts at, so a worker indexes with
+                // `iw - base`.
+                let run = top.pos.len().div_ceil(current_num_threads().max(1));
+                let mut tasks: Vec<(&mut [Word], u32, &[u32])> = Vec::new();
+                let mut rest: &mut [Word] = &mut words[..];
+                let mut base: u32 = 0;
+                for chunk in top.pos.chunks(run) {
+                    // +1 because the run has to include the last word it names.
+                    let take = (chunk[chunk.len() - 1] + 1 - base) as usize;
+                    let (head, tail) = rest.split_at_mut(take);
+                    tasks.push((head, base, chunk));
+                    rest = tail;
+                    base += take as u32;
+                }
+
+                // Each worker keeps its own delta list: per chunk, not per word, so this is a
+                // handful of allocations for the whole merge rather than one per word.
+                let per_chunk: Vec<Vec<(Pair, i32, u32)>> = tasks
+                    .into_maybe_par_iter()
+                    .map(|(slice, base, chunk)| {
+                        let mut local = Vec::new();
+                        let mut scratch = Vec::new();
+                        for &iw in chunk {
+                            scratch.clear();
+                            slice[(iw - base) as usize].merge(
+                                top.pair.0,
+                                top.pair.1,
+                                new_token_id,
+                                max_token_length,
+                                &mut scratch,
+                            );
+                            for &(pair, change) in scratch.iter() {
+                                local.push((pair, change, iw));
+                            }
+                        }
+                        local
+                    })
+                    .collect();
+
+                // Folded back in chunk order, which is `pos` order, so each word's appends stay
+                // contiguous and `push_word` stays exact.
+                for local in &per_chunk {
+                    for &(pair, change, iw) in local {
+                        *pair_counts.entry(pair).or_default() += change * counts[iw as usize] as i32;
+                        if change > 0 {
+                            push_word(where_to_update.entry(pair).or_default(), iw);
+                        }
                     }
                 }
             }
@@ -854,6 +941,44 @@ mod tests {
         ];
         assert_eq!(merges, expected_merges);
     }
+    /// The parallel merge path has to produce the same vocabulary and the same merge list, in the
+    /// same order, as the serial one. It splits `words` with `split_at_mut` over runs of an
+    /// ascending `pos` and folds each run's deltas back in run order, so `push_word`'s
+    /// "duplicates can only be adjacent" invariant has to survive the split -- this is what checks
+    /// that it does.
+    #[test]
+    fn parallel_merges_agree_with_serial() {
+        let word_counts: AHashMap<CompactString, u64> = [
+            ("roses", 3), ("are", 5), ("red", 2), ("violets", 3), ("blue", 4),
+            ("bert", 6), ("is", 7), ("big", 2), ("and", 4), ("so", 3),
+            ("rosier", 2), ("reddish", 2), ("bluer", 2), ("bigger", 3), ("blurred", 2),
+            ("aaaa", 4), ("aaab", 3), ("abab", 3), ("baba", 2), ("bbbb", 2),
+        ]
+        .iter()
+        .map(|(w, c)| (CompactString::from(*w), *c as u64))
+        .collect();
+
+        let train_with = |threshold: usize| {
+            BpeTrainer::builder()
+                .show_progress(false)
+                .min_frequency(0)
+                .vocab_size(120)
+                .parallel_merge_threshold(threshold)
+                .build()
+                .do_train(&word_counts)
+                .unwrap()
+        };
+
+        // `0` forces every merge through the parallel path; `usize::MAX` forces every one serial.
+        let (par_vocab, par_merges, _) = train_with(0);
+        let (ser_vocab, ser_merges, _) = train_with(usize::MAX);
+
+        assert_eq!(par_vocab, ser_vocab, "vocabularies differ");
+        assert_eq!(par_merges, ser_merges, "merge lists differ");
+        // Guard against the test passing because nothing was learned.
+        assert!(!ser_merges.is_empty(), "no merges were produced");
+    }
+
     #[test]
     fn bpe_test_max_token_length_16() {
         /* bpe_test_max_token_length series of tests test the max_token_length flag of bpetrainer

--- a/tokenizers/tk-train/src/trainers/bpe/mod.rs
+++ b/tokenizers/tk-train/src/trainers/bpe/mod.rs
@@ -9,6 +9,7 @@ pub use parity_trainer::{ParityBpeTrainer, ParityBpeTrainerBuilder, ParityVarian
 use crate::Trainer;
 use ahash::{AHashMap, AHashSet};
 use compact_str::CompactString;
+use itertools::Itertools;
 use dary_heap::OctonaryHeap;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -24,7 +25,6 @@ use tk_encode::Result;
 use tk_encode::models::bpe::{Merges, Pair, PipelineBPE, BpeConfig, Vocab};
 use tk_encode::parallelism::*;
 use tk_encode::utils::progress::{ProgressBar, ProgressFormat, ProgressStyle};
-use tk_encode::vocab::bucket_vocab_store::BucketVocabStore;
 
 #[derive(Debug, Eq)]
 struct Merge {
@@ -393,33 +393,69 @@ impl BpeTrainer {
         p: &Option<ProgressBar>,
     ) -> (Vec<Word>, Vec<u64>) {
         let mut words: Vec<Word> = Vec::with_capacity(wc.len());
+        // Reused whenever a character needs a prefix/suffix; see the note below.
+        let mut decorated = String::new();
         let mut counts: Vec<u64> = Vec::with_capacity(wc.len());
 
         for (word, count) in wc {
-            let mut current_word = Word::new();
+            // Sized up front: the symbol count starts at one per character and only shrinks as
+            // merges apply, so the character count is an exact upper bound and the `Vec` never
+            // grows. Starting empty cost one allocation per doubling, per unique word.
+            let mut current_word = Word::with_capacity(word.chars().count());
             counts.push(*count);
 
             for (is_first, is_last, c) in word.chars().with_first_and_last() {
-                let mut s = c.to_string();
-                if w2id.contains_key(&CompactString::from(&s)) {
-                    // Found the initial char in the authorized alphabet
+                // The character as a `&str` in a stack buffer. This used to be `c.to_string()` --
+                // one heap allocation per character of every unique word, which was the single
+                // largest source of allocation in a training run (~925k of 1.08M) even though it
+                // was only 5% of the time. The four `CompactString::from(&s)` rebuilds that
+                // followed it are gone the same way: `AHashMap<CompactString, _>` is `Borrow<str>`,
+                // so it can be probed with the `&str` directly, once.
+                let mut buf = [0u8; 4];
+                let plain: &str = c.encode_utf8(&mut buf);
 
-                    // Add the `continuing_subword_prefix` if relevant
-                    if !is_first && let Some(prefix) = &self.continuing_subword_prefix {
-                        s.insert_str(0, prefix);
-                    }
-                    // Add the `end_of_word_suffix` if relevant
-                    if is_last && let Some(suffix) = &self.end_of_word_suffix {
-                        s.push_str(suffix);
-                    }
-
-                    // Insert the new formed string if necessary
-                    if !w2id.contains_key(&CompactString::from(&s)) {
-                        id2w.push(CompactString::from(&s));
-                        w2id.insert(CompactString::from(&s), (id2w.len() - 1) as u32);
-                    }
-                    current_word.add(w2id[&CompactString::from(&s)], 1); // We do not care about the len here
+                // Found the initial char in the authorized alphabet
+                if !w2id.contains_key(plain) {
+                    continue;
                 }
+
+                // Add the `continuing_subword_prefix` / `end_of_word_suffix` if relevant
+                let prefix = if is_first {
+                    None
+                } else {
+                    self.continuing_subword_prefix.as_deref()
+                };
+                let suffix = if is_last {
+                    self.end_of_word_suffix.as_deref()
+                } else {
+                    None
+                };
+
+                let key: &str = if prefix.is_some() || suffix.is_some() {
+                    decorated.clear();
+                    if let Some(prefix) = prefix {
+                        decorated.push_str(prefix);
+                    }
+                    decorated.push_str(plain);
+                    if let Some(suffix) = suffix {
+                        decorated.push_str(suffix);
+                    }
+                    &decorated
+                } else {
+                    plain
+                };
+
+                // Insert the new formed string if necessary
+                let id = match w2id.get(key) {
+                    Some(&id) => id,
+                    None => {
+                        let id = id2w.len() as u32;
+                        id2w.push(CompactString::from(key));
+                        w2id.insert(CompactString::from(key), id);
+                        id
+                    }
+                };
+                current_word.add(id, 1); // We do not care about the len here
             }
             words.push(current_word);
 
@@ -437,40 +473,29 @@ impl BpeTrainer {
         counts: &[u64],
         p: &Option<ProgressBar>,
     ) -> (AHashMap<Pair, i32>, AHashMap<Pair, AHashSet<usize>>) {
-        words
-            .maybe_par_iter()
-            .enumerate()
-            .map(|(i, word)| {
-                let mut pair_counts = AHashMap::new();
-                let mut where_to_update: AHashMap<Pair, AHashSet<usize>> = AHashMap::new();
+        // Counted straight into one pair of maps, serially.
+        //
+        // It used to build a `Pair -> count` map and a `Pair -> {word}` map *per word* and reduce
+        // them in parallel, which meant the combine step merged hash maps all the way up the
+        // reduction tree -- more work than the counting it was spreading out. Measured on a 6.5 MB
+        // corpus, the parallel version cost 48 ms of a 244 ms training run. Accumulating in place
+        // also drops one map pair, and one `get_chars` `Vec`, per word.
+        let mut pair_counts: AHashMap<Pair, i32> = AHashMap::new();
+        let mut where_to_update: AHashMap<Pair, AHashSet<usize>> = AHashMap::new();
 
-                for window in word.get_chars().windows(2) {
-                    let cur_pair: Pair = (window[0], window[1]);
+        for (i, word) in words.iter().enumerate() {
+            let count = counts[i] as i32;
+            for pair in word.get_chars_iter().tuple_windows::<(u32, u32)>() {
+                *pair_counts.entry(pair).or_default() += count;
+                where_to_update.entry(pair).or_default().insert(i);
+            }
 
-                    // Initialize pair_counts and where_to_update for this pair if we just saw it
-                    // Then update counts
-                    *pair_counts.entry(cur_pair).or_default() += counts[i] as i32;
-                    where_to_update.entry(cur_pair).or_default().insert(i);
-                }
+            if let Some(p) = &p {
+                p.inc(1);
+            }
+        }
 
-                if let Some(p) = &p {
-                    p.inc(1);
-                }
-
-                (pair_counts, where_to_update)
-            })
-            .reduce(
-                || (AHashMap::new(), AHashMap::new()),
-                |(mut pair_counts, mut where_to_update), (pc, wtu)| {
-                    for (k, v) in pc {
-                        *pair_counts.entry(k).or_default() += v;
-                    }
-                    for (k, v) in wtu {
-                        where_to_update.entry(k).or_default().extend(v);
-                    }
-                    (pair_counts, where_to_update)
-                },
-            )
+        (pair_counts, where_to_update)
     }
 
     /// Train and hand back the raw parts, for a caller that wants them rather than a built model.
@@ -554,6 +579,8 @@ impl BpeTrainer {
         //
         self.update_progress(&progress, self.vocab_size, "Compute merges");
         let mut merges: Vec<(Pair, u32)> = vec![];
+        // Reused by every `Word::merge` below; see the note in the loop.
+        let mut changes: Vec<(Pair, i32)> = Vec::new();
         loop {
             // Stop as soon as we have a big enough vocabulary
             if word_to_id.len() >= self.vocab_size {
@@ -596,49 +623,49 @@ impl BpeTrainer {
             }
             merges.push((top.pair, new_token_id));
 
-            // Merge the new pair in every words
-            // Safety: This is just a type assertion, the code below may no longer be safe
-            // if the type of `pos` changes
-            let pos: &AHashSet<usize> = &top.pos;
+            // Merge the new pair into every word that contains it, and fold each word's pair
+            // deltas in as they are produced.
+            //
+            // Serial, deliberately. Fanning this out measured *8.5x slower* than not: on a 6.5 MB
+            // corpus the merge loop went 55 ms -> 460 ms and training 300 ms -> 740 ms, for the same
+            // vocabulary and merges. Two reasons, and neither goes away with a bigger corpus:
+            //
+            // * the fan-out is small. 7910 merges visited 800632 words here, ~101 words a merge, and
+            //   the widest single merge touched 10768 -- a few microseconds of work to dispatch.
+            // * `pos` is an `AHashSet`, which rayon can only split by walking buckets. Thresholding
+            //   the set size does not rescue it: at a 1024 cut it was still 117 ms against 55 ms.
+            //
+            // `feed` keeps its parallelism -- that one is a real win (84 ms against 101 ms), because
+            // it splits a contiguous corpus into big chunks.
+            //
+            // Being serial is also what makes this allocation-free. It used to hand each word a
+            // fresh `Vec` from `Word::merge`, collect a second one on top of it to attach the word
+            // index, and collect all of those into a third -- two allocations for every one of the
+            // 800632 word-visits. One reused buffer replaces all of it, and applying the deltas
+            // inline drops the third. Ordering does not matter: both accumulations (`+=` into
+            // `pair_counts`, `insert` into a set) are commutative.
+            //
+            // The raw-pointer `WordPtr` dance this replaced existed only to get `&mut words[i]` past
+            // rayon's `Sync` bound. Without rayon, plain indexing does it safely.
+            for &i in &top.pos {
+                changes.clear();
+                words[i].merge(
+                    top.pair.0,
+                    top.pair.1,
+                    new_token_id,
+                    max_token_length,
+                    &mut changes,
+                );
 
-            let words_len = words.len();
-            // FIXME: doesn't look great
-            struct WordPtr(*mut Word);
-            // Safety: We do not actually use this for concurrent access to the same memory,
-            // only to different chunks within the same allocation.
-            unsafe impl Sync for WordPtr {}
-            let word_start = WordPtr(words.as_mut_ptr());
-
-            let changes = pos
-                .maybe_par_iter()
-                .flat_map(|&i| {
-                    // We can merge each of these words in parallel here because each position
-                    // can be there only once (AHashSet). So this is safe.
-                    unsafe {
-                        // Edition ≥2021 closures capture the `.0` field (a non-Sync raw
-                        // pointer) unless we force whole-struct capture of the Sync wrapper.
-                        let word_start = &word_start;
-                        assert!(i < words_len);
-                        // This is words[i], but avoids needing to go through &T (which triggers UB)
-                        let word = word_start.0.add(i);
-                        // let word: &mut Word = &mut (*word);
-                        (*word)
-                            .merge(top.pair.0, top.pair.1, new_token_id, max_token_length)
-                            .into_iter()
-                            .map(|c| (c, i))
-                            .collect::<Vec<_>>()
+                let word_count = counts[i] as i32;
+                for &(pair, change) in changes.iter() {
+                    *pair_counts.entry(pair).or_default() += change * word_count;
+                    if change > 0 {
+                        where_to_update.entry(pair).or_default().insert(i);
                     }
-                })
-                .collect::<Vec<_>>();
-
-            // Introduce new formed pairs
-            for ((pair, change), iw) in changes {
-                let count = change * counts[iw] as i32;
-                *pair_counts.entry(pair).or_default() += count;
-                if change > 0 {
-                    where_to_update.entry(pair).or_default().insert(iw);
                 }
             }
+
             where_to_update.drain().for_each(|(pair, pos)| {
                 let count = pair_counts[&pair];
                 if count > 0 {

--- a/tokenizers/tk-train/src/trainers/bpe/mod.rs
+++ b/tokenizers/tk-train/src/trainers/bpe/mod.rs
@@ -29,25 +29,48 @@ use tk_encode::utils::progress::{ProgressBar, ProgressFormat, ProgressStyle};
 
 /// The default for [`BpeTrainer::parallel_merge_threshold`].
 ///
-/// High deliberately. On a 6.5 MB corpus the merge loop averaged 101 words a merge
-/// and its widest single merge touched 10768, and across that whole range the parallel path lost --
-/// at a 1024 cut it still measured 117 ms against 55 ms serial. So the crossover, if there is one,
-/// is somewhere above the largest fan-out that corpus can produce, and picking a number from
-/// nothing would be guessing. Training on tens of GB reaches fan-outs orders of magnitude larger,
-/// which is what this exists for.
+/// 1000, chosen from measurements at two scales rather than from a guess. Training a 32 k vocabulary
+/// over a 588 MB corpus of code and prose:
 ///
-/// `TOKENIZERS_TRAIN_PARALLEL_MIN` overrides it, read once per process; setting the field beats the
-/// environment. `0` forces the parallel path, which is how `parallel_merges_agree_with_serial`
-/// checks that the two produce the same vocabulary and merges.
+/// | threshold | 588 MB corpus | 6.5 MB corpus |
+/// |-----------|---------------|---------------|
+/// | serial    | 29.10 s       | 72 ms         |
+/// | 10000     | 21.94 s       | --            |
+/// | 4000      | 20.17 s       | 83 ms         |
+/// | 1000      | 18.90 s       | 98 ms         |
+/// | 0         | 18.92 s       | 280 ms        |
+///
+/// The two want opposite things -- a big corpus wants to fan out sooner, a small one later -- but
+/// the asymmetry settles it: 1000 costs the small corpus 26 ms and saves the large one 10.2 s.
+///
+/// Fan-out is a proxy for the work a merge represents, and an imperfect one: it counts words, not
+/// their lengths, which is why the two corpora disagree at all -- the large one's words are longer,
+/// so the same fan-out is more work. Weighting by symbol count would discriminate better; it is not
+/// worth the bookkeeping until a corpus is found that this number handles badly.
+///
 pub fn default_parallel_merge_threshold() -> usize {
     static THRESHOLD: OnceLock<usize> = OnceLock::new();
     *THRESHOLD.get_or_init(|| {
         std::env::var("TOKENIZERS_TRAIN_PARALLEL_MIN")
             .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(200_000)
+            .unwrap_or(1_000)
     })
 }
+
+/// The two scratch buffers one worker reuses across every merge it handles.
+///
+/// `scratch` takes a single word's pair deltas from `Word::merge`; `deltas` accumulates the whole
+/// chunk's, tagged with the word they came from, to be folded in once the workers are done.
+#[derive(Default)]
+struct ChunkBuffers {
+    scratch: Vec<(Pair, i32)>,
+    deltas: Vec<(Pair, i32, u32)>,
+}
+
+/// One worker's share: its words, the index that slice starts at, the word indices to merge, and
+/// its buffers.
+type Task<'a> = (&'a mut [Word], u32, &'a [u32], &'a mut ChunkBuffers);
 
 /// Appends `iw` to a word list unless it is already the last entry.
 ///
@@ -648,6 +671,10 @@ impl BpeTrainer {
         let mut merges: Vec<(Pair, u32)> = vec![];
         // Reused by every `Word::merge` below; see the note in the loop.
         let mut changes: Vec<(Pair, i32)> = Vec::new();
+        // One set of buffers per worker, reused for every merge that takes the parallel path.
+        let threads = current_num_threads().max(1);
+        let mut chunk_buffers: Vec<ChunkBuffers> =
+            (0..threads).map(|_| ChunkBuffers::default()).collect();
         loop {
             // Stop as soon as we have a big enough vocabulary
             if word_to_id.len() >= self.vocab_size {
@@ -729,47 +756,59 @@ impl BpeTrainer {
                 // Cut `pos` into runs, then peel the matching `&mut [Word]` off the front for each.
                 // `base` is the word index the peeled slice starts at, so a worker indexes with
                 // `iw - base`.
-                let run = top.pos.len().div_ceil(current_num_threads().max(1));
-                let mut tasks: Vec<(&mut [Word], u32, &[u32])> = Vec::new();
+                let run = top.pos.len().div_ceil(threads);
+
+                // Each worker gets a real `&mut [Word]`, peeled off the front, plus the two buffers
+                // it reuses. `base` is the word index its slice starts at, so it indexes with
+                // `iw - base`.
+                //
+                // The buffers live outside the merge loop. Allocating them per merge cost 38.4 GB of
+                // churn against the serial path's 7.2 GB on a 588 MB corpus -- the per-chunk lists
+                // are short-lived but there are two of them per chunk per merge.
+                // Every buffer, not just the ones this merge hands out: a merge with fewer chunks
+                // than threads would otherwise leave the tail holding the previous merge's deltas,
+                // and the fold below walks all of them.
+                for buf in chunk_buffers.iter_mut() {
+                    buf.deltas.clear();
+                }
+
+                let mut tasks: Vec<Task<'_>> = Vec::with_capacity(threads);
                 let mut rest: &mut [Word] = &mut words[..];
+                let mut buffers: &mut [ChunkBuffers] = &mut chunk_buffers[..];
                 let mut base: u32 = 0;
                 for chunk in top.pos.chunks(run) {
                     // +1 because the run has to include the last word it names.
                     let take = (chunk[chunk.len() - 1] + 1 - base) as usize;
-                    let (head, tail) = rest.split_at_mut(take);
-                    tasks.push((head, base, chunk));
-                    rest = tail;
+                    let (words_head, words_tail) = rest.split_at_mut(take);
+                    let (buf_head, buf_tail) = buffers.split_at_mut(1);
+                    tasks.push((words_head, base, chunk, &mut buf_head[0]));
+                    rest = words_tail;
+                    buffers = buf_tail;
                     base += take as u32;
                 }
 
-                // Each worker keeps its own delta list: per chunk, not per word, so this is a
-                // handful of allocations for the whole merge rather than one per word.
-                let per_chunk: Vec<Vec<(Pair, i32, u32)>> = tasks
+                tasks
                     .into_maybe_par_iter()
-                    .map(|(slice, base, chunk)| {
-                        let mut local = Vec::new();
-                        let mut scratch = Vec::new();
+                    .for_each(|(slice, base, chunk, buf)| {
                         for &iw in chunk {
-                            scratch.clear();
+                            buf.scratch.clear();
                             slice[(iw - base) as usize].merge(
                                 top.pair.0,
                                 top.pair.1,
                                 new_token_id,
                                 max_token_length,
-                                &mut scratch,
+                                &mut buf.scratch,
                             );
-                            for &(pair, change) in scratch.iter() {
-                                local.push((pair, change, iw));
+                            for &(pair, change) in buf.scratch.iter() {
+                                buf.deltas.push((pair, change, iw));
                             }
                         }
-                        local
-                    })
-                    .collect();
+                    });
 
                 // Folded back in chunk order, which is `pos` order, so each word's appends stay
                 // contiguous and `push_word` stays exact.
-                for local in &per_chunk {
-                    for &(pair, change, iw) in local {
+                for buf in chunk_buffers.iter() {
+                    for &(pair, change, iw) in buf.deltas.iter() {
                         *pair_counts.entry(pair).or_default() += change * counts[iw as usize] as i32;
                         if change > 0 {
                             push_word(where_to_update.entry(pair).or_default(), iw);

--- a/tokenizers/tk-train/src/trainers/bpe/mod.rs
+++ b/tokenizers/tk-train/src/trainers/bpe/mod.rs
@@ -20,7 +20,7 @@ use tk_encode::vocab::bucket_added_vocabulary::AddedToken;
 // inference crate. `PipelineBPE` is the only BPE left; a trainer reaches it through
 // `from_vocab_and_merges`, the same serde-free door a reader walks through, because its fields are
 // private to `tk-encode`.
-use word::{WithFirstLastIterator, Word};
+use word::{Symbol, WithFirstLastIterator, WordArena, merge_run};
 
 use tk_encode::Result;
 use tk_encode::models::bpe::{Merges, Pair, PipelineBPE, BpeConfig, Vocab};
@@ -68,9 +68,19 @@ struct ChunkBuffers {
     deltas: Vec<(Pair, i32, u32)>,
 }
 
-/// One worker's share: its words, the index that slice starts at, the word indices to merge, and
-/// its buffers.
-type Task<'a> = (&'a mut [Word], u32, &'a [u32], &'a mut ChunkBuffers);
+/// One worker's share of a merge.
+///
+/// `syms` and `lives` are disjoint slices peeled off the arena, so no two workers can touch the same
+/// word. The two bases translate a global word index into this slice: word `iw` has its length at
+/// `lives[iw - word_base]` and its run starting at `start[iw] - sym_base` within `syms`.
+struct Task<'a> {
+    syms: &'a mut [Symbol],
+    lives: &'a mut [u32],
+    word_base: u32,
+    sym_base: usize,
+    chunk: &'a [u32],
+    buf: &'a mut ChunkBuffers,
+}
 
 /// Appends `iw` to a word list unless it is already the last entry.
 ///
@@ -479,17 +489,18 @@ impl BpeTrainer {
         w2id: &mut AHashMap<CompactString, u32>,
         id2w: &mut Vec<CompactString>,
         p: &Option<ProgressBar>,
-    ) -> (Vec<Word>, Vec<u64>) {
-        let mut words: Vec<Word> = Vec::with_capacity(wc.len());
+    ) -> (WordArena, Vec<u64>) {
+        // One buffer for every word's symbols instead of a `Vec` each. `wc` keys are `CompactString`
+        // so their byte length bounds their character count, which bounds the symbols a word can
+        // ever hold -- runs only shrink from there, so neither `Vec` grows while filling.
+        let symbol_upper_bound = wc.keys().map(|w| w.len()).sum();
+        let mut words = WordArena::with_capacity(wc.len(), symbol_upper_bound);
         // Reused whenever a character needs a prefix/suffix; see the note below.
         let mut decorated = String::new();
         let mut counts: Vec<u64> = Vec::with_capacity(wc.len());
 
         for (word, count) in wc {
-            // Sized up front: the symbol count starts at one per character and only shrinks as
-            // merges apply, so the character count is an exact upper bound and the `Vec` never
-            // grows. Starting empty cost one allocation per doubling, per unique word.
-            let mut current_word = Word::with_capacity(word.chars().count());
+            words.open_word();
             counts.push(*count);
 
             for (is_first, is_last, c) in word.chars().with_first_and_last() {
@@ -543,9 +554,9 @@ impl BpeTrainer {
                         id
                     }
                 };
-                current_word.add(id, 1); // We do not care about the len here
+                words.push_symbol(id, 1); // We do not care about the len here
             }
-            words.push(current_word);
+            words.close_word();
 
             if let Some(p) = p {
                 p.inc(1);
@@ -557,7 +568,7 @@ impl BpeTrainer {
 
     fn count_pairs(
         &self,
-        words: &[Word],
+        words: &WordArena,
         counts: &[u64],
         p: &Option<ProgressBar>,
     ) -> (AHashMap<Pair, i32>, AHashMap<Pair, Vec<u32>>) {
@@ -571,10 +582,10 @@ impl BpeTrainer {
         let mut pair_counts: AHashMap<Pair, i32> = AHashMap::new();
         let mut where_to_update: AHashMap<Pair, Vec<u32>> = AHashMap::new();
 
-        for (i, word) in words.iter().enumerate() {
+        for i in 0..words.len() {
             let count = counts[i] as i32;
             let iw = i as u32;
-            for pair in word.get_chars_iter().tuple_windows::<(u32, u32)>() {
+            for pair in words.chars(i).tuple_windows::<(u32, u32)>() {
                 *pair_counts.entry(pair).or_default() += count;
                 // `push_word` keeps `pos` duplicate-free; a pair can repeat inside one word.
                 push_word(where_to_update.entry(pair).or_default(), iw);
@@ -736,7 +747,8 @@ impl BpeTrainer {
                 for &iw in &top.pos {
                     let i = iw as usize;
                     changes.clear();
-                    words[i].merge(
+                    words.merge(
+                        i,
                         top.pair.0,
                         top.pair.1,
                         new_token_id,
@@ -772,38 +784,77 @@ impl BpeTrainer {
                     buf.deltas.clear();
                 }
 
+                // Destructured so the layout stays readable while the storage is carved up: three
+                // separate field borrows, not one borrow of the arena.
+                let WordArena {
+                    symbols,
+                    start,
+                    live,
+                } = &mut words;
+                let starts: &[u32] = start;
+
                 let mut tasks: Vec<Task<'_>> = Vec::with_capacity(threads);
-                let mut rest: &mut [Word] = &mut words[..];
+                let mut sym_rest: &mut [Symbol] = symbols;
+                let mut live_rest: &mut [u32] = live;
                 let mut buffers: &mut [ChunkBuffers] = &mut chunk_buffers[..];
-                let mut base: u32 = 0;
+                let mut word_base: u32 = 0;
+                let mut sym_base: usize = 0;
                 for chunk in top.pos.chunks(run) {
-                    // +1 because the run has to include the last word it names.
-                    let take = (chunk[chunk.len() - 1] + 1 - base) as usize;
-                    let (words_head, words_tail) = rest.split_at_mut(take);
+                    // +1 because the run has to reach past the last word it names. `start` is
+                    // indexed one past that, which is why it carries a sentinel.
+                    let upto = chunk[chunk.len() - 1] + 1;
+                    let take_words = (upto - word_base) as usize;
+                    let take_syms = starts[upto as usize] as usize - sym_base;
+
+                    let (sym_head, sym_tail) = sym_rest.split_at_mut(take_syms);
+                    let (live_head, live_tail) = live_rest.split_at_mut(take_words);
                     let (buf_head, buf_tail) = buffers.split_at_mut(1);
-                    tasks.push((words_head, base, chunk, &mut buf_head[0]));
-                    rest = words_tail;
+                    tasks.push(Task {
+                        syms: sym_head,
+                        lives: live_head,
+                        word_base,
+                        sym_base,
+                        chunk,
+                        buf: &mut buf_head[0],
+                    });
+
+                    sym_rest = sym_tail;
+                    live_rest = live_tail;
                     buffers = buf_tail;
-                    base += take as u32;
+                    sym_base += take_syms;
+                    word_base = upto;
                 }
 
-                tasks
-                    .into_maybe_par_iter()
-                    .for_each(|(slice, base, chunk, buf)| {
-                        for &iw in chunk {
-                            buf.scratch.clear();
-                            slice[(iw - base) as usize].merge(
-                                top.pair.0,
-                                top.pair.1,
-                                new_token_id,
-                                max_token_length,
-                                &mut buf.scratch,
-                            );
-                            for &(pair, change) in buf.scratch.iter() {
-                                buf.deltas.push((pair, change, iw));
-                            }
+                tasks.into_maybe_par_iter().for_each(|task| {
+                    let Task {
+                        syms,
+                        lives,
+                        word_base,
+                        sym_base,
+                        chunk,
+                        buf,
+                    } = task;
+                    for &iw in chunk {
+                        let local = (iw - word_base) as usize;
+                        let begin = starts[iw as usize] as usize - sym_base;
+                        let live = &mut lives[local];
+                        let run = &mut syms[begin..begin + *live as usize];
+
+                        buf.scratch.clear();
+                        merge_run(
+                            run,
+                            live,
+                            top.pair.0,
+                            top.pair.1,
+                            new_token_id,
+                            max_token_length,
+                            &mut buf.scratch,
+                        );
+                        for &(pair, change) in buf.scratch.iter() {
+                            buf.deltas.push((pair, change, iw));
                         }
-                    });
+                    }
+                });
 
                 // Folded back in chunk order, which is `pos` order, so each word's appends stay
                 // contiguous and `push_word` stays exact.

--- a/tokenizers/tk-train/src/trainers/bpe/mod.rs
+++ b/tokenizers/tk-train/src/trainers/bpe/mod.rs
@@ -26,11 +26,33 @@ use tk_encode::models::bpe::{Merges, Pair, PipelineBPE, BpeConfig, Vocab};
 use tk_encode::parallelism::*;
 use tk_encode::utils::progress::{ProgressBar, ProgressFormat, ProgressStyle};
 
+/// Appends `iw` to a word list unless it is already the last entry.
+///
+/// Both callers append every index for one word before moving to the next, so an index can only
+/// repeat as the immediately preceding entry -- which makes this exactly as strong as the set
+/// membership test it replaces, at one comparison instead of a hash and an allocation.
+#[inline]
+fn push_word(pos: &mut Vec<u32>, iw: u32) {
+    if pos.last() != Some(&iw) {
+        pos.push(iw);
+    }
+}
+
 #[derive(Debug, Eq)]
 struct Merge {
     pair: Pair,
     count: u64,
-    pos: AHashSet<usize>,
+    /// Indices of the words containing `pair`, ascending and without duplicates.
+    ///
+    /// A `Vec<u32>` rather than an `AHashSet<usize>`: the set cost one allocation per pair per
+    /// merge, and rayon can only split a hash set by walking its buckets, which is why fanning the
+    /// merge loop out measured slower at every threshold. A slice splits in constant time.
+    ///
+    /// Ascending comes free -- both producers visit words in index order -- and duplicates cannot
+    /// appear because every append for one word is contiguous, so comparing against the last entry
+    /// is exact. Neither `Ord` nor `PartialEq` for `Merge` looks at this field, so the change cannot
+    /// move an id.
+    pos: Vec<u32>,
 }
 impl PartialEq for Merge {
     fn eq(&self, other: &Self) -> bool {
@@ -472,7 +494,7 @@ impl BpeTrainer {
         words: &[Word],
         counts: &[u64],
         p: &Option<ProgressBar>,
-    ) -> (AHashMap<Pair, i32>, AHashMap<Pair, AHashSet<usize>>) {
+    ) -> (AHashMap<Pair, i32>, AHashMap<Pair, Vec<u32>>) {
         // Counted straight into one pair of maps, serially.
         //
         // It used to build a `Pair -> count` map and a `Pair -> {word}` map *per word* and reduce
@@ -481,13 +503,15 @@ impl BpeTrainer {
         // corpus, the parallel version cost 48 ms of a 244 ms training run. Accumulating in place
         // also drops one map pair, and one `get_chars` `Vec`, per word.
         let mut pair_counts: AHashMap<Pair, i32> = AHashMap::new();
-        let mut where_to_update: AHashMap<Pair, AHashSet<usize>> = AHashMap::new();
+        let mut where_to_update: AHashMap<Pair, Vec<u32>> = AHashMap::new();
 
         for (i, word) in words.iter().enumerate() {
             let count = counts[i] as i32;
+            let iw = i as u32;
             for pair in word.get_chars_iter().tuple_windows::<(u32, u32)>() {
                 *pair_counts.entry(pair).or_default() += count;
-                where_to_update.entry(pair).or_default().insert(i);
+                // `push_word` keeps `pos` duplicate-free; a pair can repeat inside one word.
+                push_word(where_to_update.entry(pair).or_default(), iw);
             }
 
             if let Some(p) = &p {
@@ -647,7 +671,8 @@ impl BpeTrainer {
             //
             // The raw-pointer `WordPtr` dance this replaced existed only to get `&mut words[i]` past
             // rayon's `Sync` bound. Without rayon, plain indexing does it safely.
-            for &i in &top.pos {
+            for &iw in &top.pos {
+                let i = iw as usize;
                 changes.clear();
                 words[i].merge(
                     top.pair.0,
@@ -661,7 +686,7 @@ impl BpeTrainer {
                 for &(pair, change) in changes.iter() {
                     *pair_counts.entry(pair).or_default() += change * word_count;
                     if change > 0 {
-                        where_to_update.entry(pair).or_default().insert(i);
+                        push_word(where_to_update.entry(pair).or_default(), iw);
                     }
                 }
             }

--- a/tokenizers/tk-train/src/trainers/bpe/word.rs
+++ b/tokenizers/tk-train/src/trainers/bpe/word.rs
@@ -1,4 +1,3 @@
-use ahash::AHashMap;
 use std::{iter, mem};
 use tk_encode::models::bpe::Pair;
 
@@ -43,22 +42,17 @@ where
     }
 }
 
+/// 8 bytes, and every one of them is read.
+///
+/// It used to carry `prev`/`next` as well, an intrusive doubly-linked list that only the
+/// dropout-aware `merge_all` ever walked. With that gone the two fields were written on every `add`
+/// and every `merge` and read by nobody, at 4x the width: the merge loop sweeps these symbols once
+/// per affected word per merge, so their size is the loop's memory traffic.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Symbol {
     c: u32,
-    prev: isize,
-    next: isize,
-    len: usize,
-}
-impl Symbol {
-    /// Merges the current Symbol with the other one.
-    /// In order to update prev/next, we consider Self to be the Symbol on the left,
-    /// and other to be the next one on the right.
-    pub fn merge_with(&mut self, other: &Self, new_c: u32) {
-        self.c = new_c;
-        self.len += other.len;
-        self.next = other.next;
-    }
+    /// How many of the original characters this symbol stands for, for `max_token_length`.
+    len: u32,
 }
 
 #[derive(Clone, Default)]
@@ -84,6 +78,9 @@ impl std::fmt::Debug for Word {
 }
 
 impl Word {
+    // `new` and `get_chars` are used by the `parity-aware-bpe` trainer and by the tests below, so a
+    // default build sees no caller for them.
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Word { symbols: vec![] }
     }
@@ -94,89 +91,82 @@ impl Word {
         }
     }
 
-    pub fn clear(&mut self) {
-        self.symbols.clear();
-    }
-
-    pub fn len_symbols(&self) -> usize {
-        self.symbols.len()
-    }
-
     pub fn add(&mut self, c: u32, byte_len: usize) {
-        let (prev, next) = {
-            let len = self.symbols.len() as isize;
-            if let Some(last) = self.symbols.last_mut() {
-                // Update `next` on the previous one
-                last.next = len;
-                (len - 1, -1)
-            } else {
-                (-1, -1)
-            }
-        };
         self.symbols.push(Symbol {
             c,
-            prev,
-            next,
-            len: byte_len,
+            len: byte_len as u32,
         });
     }
 
     // this is a training only function, should potentially be feature gated.
+    ///
+    /// Rewrites the symbols in one forward pass, reading at `i` and writing at `write`.
+    ///
+    /// It used to `insert` the merged symbol then `remove` the two it replaced -- three `Vec`
+    /// memmoves of the whole tail per occurrence, to turn two symbols into one. Since `write` never
+    /// runs ahead of `i`, everything at or after `i` is still untouched when it is read, so the
+    /// compaction needs no shifting at all.
+    ///
+    /// The reported changes are identical to the shifting version's: the left neighbour is the last
+    /// symbol *written* (which may itself be a symbol merged earlier in this same pass, exactly as
+    /// `symbols[i - 1]` was after the removals), and the right neighbour is the first symbol past
+    /// the pair.
+    ///
+    /// Changes are *appended* to `changes` rather than returned in a fresh `Vec`: the caller visits
+    /// hundreds of thousands of words per training run and reuses one buffer for all of them.
     pub fn merge(
         &mut self,
         c1: u32,
         c2: u32,
         replacement: u32,
         max_length: usize,
-    ) -> Vec<(Pair, i32)> {
-        let mut changes: Vec<(Pair, i32)> = vec![];
+        changes: &mut Vec<(Pair, i32)>,
+    ) {
+        let mut write = 0;
         let mut i = 0;
-        loop {
-            if i >= self.symbols.len() {
-                break;
-            }
-
-            // Found a pair
-            if self.symbols[i].c == c1 && i + 1 < self.symbols.len() && self.symbols[i + 1].c == c2
+        while i < self.symbols.len() {
+            if self.symbols[i].c == c1
+                && i + 1 < self.symbols.len()
+                && self.symbols[i + 1].c == c2
             {
-                let first = self.symbols[i];
-                let second = self.symbols[i + 1];
-
-                // Remove in place
-                let new_s = Symbol {
-                    c: replacement,
-                    prev: first.prev,
-                    next: second.next,
-                    len: first.len + second.len,
-                };
+                let merged_len = self.symbols[i].len + self.symbols[i + 1].len;
 
                 // If there are other characters before the pair
-                if i > 0 {
-                    changes.push(((self.symbols[i - 1].c, first.c), -1));
-                    if self.symbols[i - 1].len + new_s.len < max_length {
-                        changes.push(((self.symbols[i - 1].c, replacement), 1));
+                if write > 0 {
+                    let left = self.symbols[write - 1];
+                    changes.push(((left.c, c1), -1));
+                    if ((left.len + merged_len) as usize) < max_length {
+                        changes.push(((left.c, replacement), 1));
                     }
                 }
-
-                self.symbols.insert(i, new_s); // Insert replacement before first char of pair
-                self.symbols.remove(i + 1); // Remove first char of pair
-                self.symbols.remove(i + 1); // And then the second
 
                 // If there are other characters after the pair
-                if i < self.symbols.len() - 1 {
-                    changes.push(((second.c, self.symbols[i + 1].c), -1));
-                    if self.symbols[i + 1].len + new_s.len < max_length {
-                        changes.push(((replacement, self.symbols[i + 1].c), 1));
+                if i + 2 < self.symbols.len() {
+                    let right = self.symbols[i + 2];
+                    changes.push(((c2, right.c), -1));
+                    if ((right.len + merged_len) as usize) < max_length {
+                        changes.push(((replacement, right.c), 1));
                     }
                 }
+
+                self.symbols[write] = Symbol {
+                    c: replacement,
+                    len: merged_len,
+                };
+                write += 1;
+                // Both consumed. The merged symbol is not offered to a second merge in this pass,
+                // which is what advancing past it did before.
+                i += 2;
+            } else {
+                self.symbols[write] = self.symbols[i];
+                write += 1;
+                i += 1;
             }
-
-            i += 1;
         }
-
-        changes
+        self.symbols.truncate(write);
     }
 
+    #[allow(dead_code)]
     pub fn get_chars(&self) -> Vec<u32> {
         self.get_chars_iter().collect()
     }
@@ -185,15 +175,6 @@ impl Word {
         self.symbols.iter().map(|s| s.c)
     }
 
-    pub fn get_offsets_iter(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
-        let mut pos = 0;
-        self.symbols.iter().map(move |symbol| {
-            let new_pos = pos + symbol.len;
-            let offset = (pos, new_pos);
-            pos = new_pos;
-            offset
-        })
-    }
 }
 
 #[cfg(test)]
@@ -213,7 +194,8 @@ mod tests {
 
         // We're going to perform a merge on the pair ('l', 'l') ~= (2, 2). Let's
         // say that 'll' has the ID of 4 in the updated word-to-id vocab.
-        let changes = word.merge(2, 2, 4, usize::MAX);
+        let mut changes = Vec::new();
+        word.merge(2, 2, 4, usize::MAX, &mut changes);
 
         // So the word should now look like this:
         assert_eq!(
@@ -257,7 +239,8 @@ mod tests {
 
         // We're going to perform a merge on the pair ('l', 'l') ~= (2, 2). Let's
         // say that 'll' has the ID of 4 in the updated word-to-id vocab.
-        let changes = word.merge(2, 2, 4, 2);
+        let mut changes = Vec::new();
+        word.merge(2, 2, 4, 2, &mut changes);
         assert_eq!(
             word.get_chars(),
             &[

--- a/tokenizers/tk-train/src/trainers/bpe/word.rs
+++ b/tokenizers/tk-train/src/trainers/bpe/word.rs
@@ -1,15 +1,185 @@
-use std::{iter, mem};
+//! The words a BPE trainer merges into, all in one buffer.
+//!
+//! Every word used to own a `Vec<Symbol>`. For a 588 MB corpus that is one allocation per unique
+//! word -- millions of them -- and, worse, millions of separate heap blocks that the merge loop then
+//! chases a pointer into. The loop visits a word once per merge that touches it, so that pointer
+//! chase is the access pattern of the whole training run.
+//!
+//! Here the symbols live in a single `Vec`, one contiguous run per word. A run is allocated once,
+//! at its full width, and only ever shrinks: merging replaces two symbols with one, so `live[i]`
+//! falls and `start[i]` never moves. That is what keeps the layout static enough to hand out
+//! disjoint `&mut` slices, which is what the parallel merge path needs.
+//!
+//! Because the runs are laid out in word order, a contiguous range of word indices is a contiguous
+//! range of symbols -- so `split_at_mut` carves the arena up for workers with no `unsafe`.
+
 use tk_encode::models::bpe::Pair;
 
-/// Provides access to the `FirstLastIterator` to any Iterator
+/// One symbol of a word: which vocabulary entry it is, and how many of the original characters it
+/// stands for.
+///
+/// 8 bytes, and both halves are read. It used to carry `prev`/`next` as well, an intrusive linked
+/// list that only the dropout-aware `merge_all` walked; with that gone the two fields were written
+/// on every append and every merge and read by nobody, at 4x the width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Symbol {
+    pub c: u32,
+    pub len: u32,
+}
+
+/// Every word's symbols, in one buffer.
+///
+/// The fields are `pub(super)` so the merge loop can peel disjoint slices off them directly; the
+/// split has to stay where the chunking logic already lives.
+#[derive(Default)]
+pub struct WordArena {
+    /// All runs, back to back in word order.
+    pub(super) symbols: Vec<Symbol>,
+    /// `start[i]` is where word `i`'s run begins. `n + 1` entries: the last is `symbols.len()`, so
+    /// `start[i]..start[i + 1]` is word `i`'s run at full width.
+    pub(super) start: Vec<u32>,
+    /// `live[i]` is how much of word `i`'s run is still in use. Only ever shrinks.
+    pub(super) live: Vec<u32>,
+}
+
+impl WordArena {
+    /// `words` runs totalling at most `symbols` entries, so neither `Vec` grows while filling.
+    pub fn with_capacity(words: usize, symbols: usize) -> Self {
+        let mut start = Vec::with_capacity(words + 1);
+        start.push(0);
+        Self {
+            symbols: Vec::with_capacity(symbols),
+            start,
+            live: Vec::with_capacity(words),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.live.len()
+    }
+
+    /// Appends one symbol to the word currently being built.
+    ///
+    /// Call between [`Self::open_word`] and [`Self::close_word`].
+    #[inline]
+    pub fn push_symbol(&mut self, c: u32, len: u32) {
+        self.symbols.push(Symbol { c, len });
+    }
+
+    /// Starts a new word. Its run begins where the previous one ended.
+    #[inline]
+    pub fn open_word(&mut self) {}
+
+    /// Ends the word being built, recording its run.
+    #[inline]
+    pub fn close_word(&mut self) {
+        let begin = *self.start.last().expect("start always holds a sentinel");
+        let end = self.symbols.len() as u32;
+        self.start.push(end);
+        self.live.push(end - begin);
+    }
+
+    /// Word `i`'s live symbols.
+    #[inline]
+    pub fn symbols(&self, i: usize) -> &[Symbol] {
+        let begin = self.start[i] as usize;
+        &self.symbols[begin..begin + self.live[i] as usize]
+    }
+
+    /// Word `i`'s live symbol ids.
+    #[inline]
+    pub fn chars(&self, i: usize) -> impl ExactSizeIterator<Item = u32> + '_ {
+        self.symbols(i).iter().map(|s| s.c)
+    }
+
+    /// Merges every occurrence of `(c1, c2)` in word `i`, appending the pair deltas to `changes`.
+    #[inline]
+    pub fn merge(
+        &mut self,
+        i: usize,
+        c1: u32,
+        c2: u32,
+        replacement: u32,
+        max_length: usize,
+        changes: &mut Vec<(Pair, i32)>,
+    ) {
+        let begin = self.start[i] as usize;
+        let live = &mut self.live[i];
+        let run = &mut self.symbols[begin..begin + *live as usize];
+        merge_run(run, live, c1, c2, replacement, max_length, changes);
+    }
+}
+
+/// Merges every occurrence of `(c1, c2)` in one word's run, rewriting it in place.
+///
+/// One forward pass, reading at `read` and writing at `write`. It used to `insert` the merged symbol
+/// and then `remove` the two it replaced -- three `Vec` memmoves of the whole tail per occurrence,
+/// to turn two symbols into one. Because `write` never runs ahead of `read`, everything at or after
+/// `read` is still untouched when it is read, so nothing needs shifting.
+///
+/// The deltas match what the shifting version reported: the left neighbour is the last symbol
+/// *written* (possibly one merged earlier in this same pass, exactly as `symbols[i - 1]` was after
+/// the removals), and the right neighbour is the first symbol past the pair. They are appended
+/// rather than returned in a fresh `Vec`: a training run visits hundreds of thousands of words and
+/// reuses one buffer for all of them.
+#[inline]
+pub fn merge_run(
+    run: &mut [Symbol],
+    live: &mut u32,
+    c1: u32,
+    c2: u32,
+    replacement: u32,
+    max_length: usize,
+    changes: &mut Vec<(Pair, i32)>,
+) {
+    let n = run.len();
+    let mut write = 0;
+    let mut read = 0;
+    while read < n {
+        if run[read].c == c1 && read + 1 < n && run[read + 1].c == c2 {
+            let merged_len = run[read].len + run[read + 1].len;
+
+            // If there are other characters before the pair
+            if write > 0 {
+                let left = run[write - 1];
+                changes.push(((left.c, c1), -1));
+                if ((left.len + merged_len) as usize) < max_length {
+                    changes.push(((left.c, replacement), 1));
+                }
+            }
+
+            // If there are other characters after the pair
+            if read + 2 < n {
+                let right = run[read + 2];
+                changes.push(((c2, right.c), -1));
+                if ((right.len + merged_len) as usize) < max_length {
+                    changes.push(((replacement, right.c), 1));
+                }
+            }
+
+            run[write] = Symbol {
+                c: replacement,
+                len: merged_len,
+            };
+            write += 1;
+            // Both consumed. The merged symbol is not offered to a second merge in this pass, which
+            // is what advancing past it did before.
+            read += 2;
+        } else {
+            run[write] = run[read];
+            write += 1;
+            read += 1;
+        }
+    }
+    *live = write as u32;
+}
+
+/// Yields each item with whether it is the first and whether it is the last.
 pub trait WithFirstLastIterator: Iterator + Sized {
     fn with_first_and_last(self) -> FirstLastIterator<Self>;
 }
 
-impl<I> WithFirstLastIterator for I
-where
-    I: Iterator,
-{
+impl<I: Iterator> WithFirstLastIterator for I {
     fn with_first_and_last(self) -> FirstLastIterator<Self> {
         FirstLastIterator {
             first: true,
@@ -18,188 +188,53 @@ where
     }
 }
 
-/// Provides information about whether an item is the first and/or the last of the iterator
-pub struct FirstLastIterator<I>
-where
-    I: Iterator,
-{
+pub struct FirstLastIterator<I: Iterator> {
     first: bool,
-    iter: iter::Peekable<I>,
+    iter: std::iter::Peekable<I>,
 }
 
-impl<I> Iterator for FirstLastIterator<I>
-where
-    I: Iterator,
-{
+impl<I: Iterator> Iterator for FirstLastIterator<I> {
     /// (is_first, is_last, item)
     type Item = (bool, bool, I::Item);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let first = mem::replace(&mut self.first, false);
+        let first = self.first;
+        self.first = false;
         self.iter
             .next()
             .map(|e| (first, self.iter.peek().is_none(), e))
     }
 }
 
-/// 8 bytes, and every one of them is read.
-///
-/// It used to carry `prev`/`next` as well, an intrusive doubly-linked list that only the
-/// dropout-aware `merge_all` ever walked. With that gone the two fields were written on every `add`
-/// and every `merge` and read by nobody, at 4x the width: the merge loop sweeps these symbols once
-/// per affected word per merge, so their size is the loop's memory traffic.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct Symbol {
-    c: u32,
-    /// How many of the original characters this symbol stands for, for `max_token_length`.
-    len: u32,
-}
-
-#[derive(Clone, Default)]
-pub struct Word {
-    symbols: Vec<Symbol>,
-}
-
-impl std::fmt::Debug for Word {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        fmt.debug_struct("Word")
-            .field(
-                "chars",
-                &self
-                    .symbols
-                    .iter()
-                    .map(|s| s.c.to_string())
-                    .collect::<Vec<_>>()
-                    .join(" "),
-            )
-            .field("symbols", &self.symbols)
-            .finish()
-    }
-}
-
-impl Word {
-    // `new` and `get_chars` are used by the `parity-aware-bpe` trainer and by the tests below, so a
-    // default build sees no caller for them.
-    #[allow(dead_code)]
-    pub fn new() -> Self {
-        Word { symbols: vec![] }
-    }
-
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            symbols: Vec::with_capacity(capacity),
-        }
-    }
-
-    pub fn add(&mut self, c: u32, byte_len: usize) {
-        self.symbols.push(Symbol {
-            c,
-            len: byte_len as u32,
-        });
-    }
-
-    // this is a training only function, should potentially be feature gated.
-    ///
-    /// Rewrites the symbols in one forward pass, reading at `i` and writing at `write`.
-    ///
-    /// It used to `insert` the merged symbol then `remove` the two it replaced -- three `Vec`
-    /// memmoves of the whole tail per occurrence, to turn two symbols into one. Since `write` never
-    /// runs ahead of `i`, everything at or after `i` is still untouched when it is read, so the
-    /// compaction needs no shifting at all.
-    ///
-    /// The reported changes are identical to the shifting version's: the left neighbour is the last
-    /// symbol *written* (which may itself be a symbol merged earlier in this same pass, exactly as
-    /// `symbols[i - 1]` was after the removals), and the right neighbour is the first symbol past
-    /// the pair.
-    ///
-    /// Changes are *appended* to `changes` rather than returned in a fresh `Vec`: the caller visits
-    /// hundreds of thousands of words per training run and reuses one buffer for all of them.
-    pub fn merge(
-        &mut self,
-        c1: u32,
-        c2: u32,
-        replacement: u32,
-        max_length: usize,
-        changes: &mut Vec<(Pair, i32)>,
-    ) {
-        let mut write = 0;
-        let mut i = 0;
-        while i < self.symbols.len() {
-            if self.symbols[i].c == c1
-                && i + 1 < self.symbols.len()
-                && self.symbols[i + 1].c == c2
-            {
-                let merged_len = self.symbols[i].len + self.symbols[i + 1].len;
-
-                // If there are other characters before the pair
-                if write > 0 {
-                    let left = self.symbols[write - 1];
-                    changes.push(((left.c, c1), -1));
-                    if ((left.len + merged_len) as usize) < max_length {
-                        changes.push(((left.c, replacement), 1));
-                    }
-                }
-
-                // If there are other characters after the pair
-                if i + 2 < self.symbols.len() {
-                    let right = self.symbols[i + 2];
-                    changes.push(((c2, right.c), -1));
-                    if ((right.len + merged_len) as usize) < max_length {
-                        changes.push(((replacement, right.c), 1));
-                    }
-                }
-
-                self.symbols[write] = Symbol {
-                    c: replacement,
-                    len: merged_len,
-                };
-                write += 1;
-                // Both consumed. The merged symbol is not offered to a second merge in this pass,
-                // which is what advancing past it did before.
-                i += 2;
-            } else {
-                self.symbols[write] = self.symbols[i];
-                write += 1;
-                i += 1;
-            }
-        }
-        self.symbols.truncate(write);
-    }
-
-    #[allow(dead_code)]
-    pub fn get_chars(&self) -> Vec<u32> {
-        self.get_chars_iter().collect()
-    }
-
-    pub fn get_chars_iter(&self) -> impl ExactSizeIterator<Item = u32> + '_ {
-        self.symbols.iter().map(|s| s.c)
-    }
-
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Builds a one-word arena from symbol ids, each standing for one character.
+    fn one_word(chars: &[u32]) -> WordArena {
+        let mut arena = WordArena::with_capacity(1, chars.len());
+        arena.open_word();
+        for &c in chars {
+            arena.push_symbol(c, 1);
+        }
+        arena.close_word();
+        arena
+    }
+
     #[test]
     fn test_merge() {
-        // Let's say we have the word 'hello' and a word-to-id vocab that looks
-        // like this: {'h': 0, 'e': 1, 'l': 2, 'o': 3}.
-        let mut word = Word::new();
-        word.add(0, 1); // 'h'
-        word.add(1, 1); // 'e'
-        word.add(2, 1); // 'l'
-        word.add(2, 1); // 'l'
-        word.add(3, 1); // 'o'
+        // Let's say we have the word 'hello' and know the following merges:
+        //   h = 0, e = 1, l = 2, o = 3, ll = 4
+        let mut arena = one_word(&[0, 1, 2, 2, 3]);
 
         // We're going to perform a merge on the pair ('l', 'l') ~= (2, 2). Let's
         // say that 'll' has the ID of 4 in the updated word-to-id vocab.
         let mut changes = Vec::new();
-        word.merge(2, 2, 4, usize::MAX, &mut changes);
+        arena.merge(0, 2, 2, 4, usize::MAX, &mut changes);
 
         // So the word should now look like this:
         assert_eq!(
-            word.get_chars(),
+            arena.chars(0).collect::<Vec<_>>(),
             &[
                 0u32, // 'h'
                 1u32, // 'e'
@@ -228,21 +263,17 @@ mod tests {
 
     #[test]
     fn test_merge_max_length() {
-        // Let's say we have the word 'hello' and a word-to-id vocab that looks
-        // like this: {'h': 0, 'e': 1, 'l': 2, 'o': 3}.
-        let mut word = Word::new();
-        word.add(0, 1); // 'h'
-        word.add(1, 1); // 'e'
-        word.add(2, 1); // 'l'
-        word.add(2, 1); // 'l'
-        word.add(3, 1); // 'o'
+        // Let's say we have the word 'hello' and know the following merges:
+        //   h = 0, e = 1, l = 2, o = 3, ll = 4
+        let mut arena = one_word(&[0, 1, 2, 2, 3]);
 
         // We're going to perform a merge on the pair ('l', 'l') ~= (2, 2). Let's
         // say that 'll' has the ID of 4 in the updated word-to-id vocab.
         let mut changes = Vec::new();
-        word.merge(2, 2, 4, 2, &mut changes);
+        arena.merge(0, 2, 2, 4, 2, &mut changes);
+
         assert_eq!(
-            word.get_chars(),
+            arena.chars(0).collect::<Vec<_>>(),
             &[
                 0u32, // 'h'
                 1u32, // 'e'
@@ -251,14 +282,40 @@ mod tests {
             ]
         );
 
+        // `max_length` of 2 blocks the pairs that would grow past it, so only the
+        // decrements survive.
         assert_eq!(
             changes,
             &[
                 ((1u32, 2u32), -1i32), // count for ('e', 'l') should be decreased by 1.
-                // ((1u32, 4u32), 1i32),  Missing since this would be larger than 2
                 ((2u32, 3u32), -1i32), // count for ('l', 'o') should be decreased by 1.
-                                       // ((4u32, 3u32), 1i32), Missing since this would be larger than 2
             ]
         );
+    }
+
+    /// A run only ever shrinks, so `start` stays put and the arena keeps its layout.
+    #[test]
+    fn runs_shrink_in_place() {
+        let mut arena = WordArena::with_capacity(2, 8);
+        arena.open_word();
+        for &c in &[2u32, 2, 2, 2] {
+            arena.push_symbol(c, 1);
+        }
+        arena.close_word();
+        arena.open_word();
+        for &c in &[7u32, 8] {
+            arena.push_symbol(c, 1);
+        }
+        arena.close_word();
+
+        let second_start = arena.start[1];
+        let mut changes = Vec::new();
+        arena.merge(0, 2, 2, 9, usize::MAX, &mut changes);
+
+        // "2222" -> "99", one pass, both occurrences.
+        assert_eq!(arena.chars(0).collect::<Vec<_>>(), &[9u32, 9u32]);
+        // The neighbour is untouched and did not move.
+        assert_eq!(arena.start[1], second_start);
+        assert_eq!(arena.chars(1).collect::<Vec<_>>(), &[7u32, 8u32]);
     }
 }


### PR DESCRIPTION
Rebased onto `feat/train_encode_split`, which is also a **base change**: this was stacked on
`feat/slim-tk-encode` (#2345), and that PR is closed and never merged, so the old base was dead
and unformatted — 39 files failing `cargo fmt --check` before this PR touches anything, which is
where all 25 red checks came from. All 7 commits replay onto the live branch with no conflicts,
nothing here depends on that base's 56 commits, and the digest is unchanged.

BPE training on the 6.5 MB corpus, re-measured on the rebase with the base's trainer paired to
this PR's harness so both sides run the same benchmark on the same machine:

| | before | after |
|---|---|---|
| `do_train` wall clock | 677.0 ms | **88.7 ms** — 7.6× |
| digest | `e45dda345b8cc7c6` | `e45dda345b8cc7c6` |

The 677 ms reproduces the number this PR was originally filed with. The 588 MB figures from the
original run (592.6 s → 17.6 s, 33.8×; digest `14bf2a711204d211`) are unchanged in kind — both
things fixed here, rayon in the wrong place and an allocation per word per merge, get worse as the
corpus grows — but that corpus is not on this machine, so treat those as carried over rather than
re-verified.

| | 6.5 MB | 588 MB | what it measures |
|---|---|---|---|
| fewer allocations | 33× | 148× | count of `alloc`/`realloc` calls (850,314,822 → 5,728,985) |
| less allocator traffic | 19× | 37× | cumulative bytes requested, not held (163.7 GB → 4.42 GB) |
| smaller peak RSS | 2.05× | 3.14× | memory actually held (21.9 GB → 6.99 GB) |

Byte-identical throughout. `examples/train_bench` digests `(vocab, merges)` — what a
`tokenizer.json` holds — and every commit prints the same value on both the serial and the
parallel path.

### Verification on the rebase

- `tk-train`: **15 tests pass**, clippy clean. Worth stating explicitly because `tk-train` is
  `exclude`d from the workspace, so a `cargo test --workspace` run does *not* cover it — the crate
  has to be tested from its own directory.
- Workspace `cargo fmt --all -- --check`: **clean** on this base (it was 39 files on the old one).
- `tk-train` itself has 6 files that predate this PR and fail rustfmt, unchanged by it and not
  checked by CI: the Format job runs `cargo fmt --all` from `tokenizers/`, which excludes the
  crate. Worth fixing, but not by burying it in a perf PR.
