### PR TITLE
Pass dropout through in ByteLevelBPETokenizer

### DIFF
--- a/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
+++ b/bindings/python/py_src/tokenizers/implementations/byte_level_bpe.py
@@ -36,7 +36,7 @@ class ByteLevelBPETokenizer(BaseTokenizer):
                 )
             )
         else:
-            tokenizer = Tokenizer(BPE())
+            tokenizer = Tokenizer(BPE(dropout=dropout))
 
         # Check for Unicode normalization first (before everything else)
         normalizers = []

--- a/bindings/python/tests/implementations/test_byte_level_bpe.py
+++ b/bindings/python/tests/implementations/test_byte_level_bpe.py
@@ -101,3 +101,12 @@ class TestByteLevelBPE:
 
         output = tokenizer.encode("A sentence")
         assert output.tokens == ["A", "Ġsentence"]
+
+    def test_dropout_is_used_without_vocab(self):
+        # Without vocab/merges the tokenizer builds its own BPE, and `dropout`
+        # has to reach it the same way it does for the other BPE tokenizers.
+        tokenizer = ByteLevelBPETokenizer(dropout=0.1)
+        assert tokenizer._tokenizer.model.dropout == pytest.approx(0.1)
+
+    def test_dropout_defaults_to_none(self):
+        assert ByteLevelBPETokenizer()._tokenizer.model.dropout is None


### PR DESCRIPTION
`ByteLevelBPETokenizer.__init__` forwards `dropout` to `BPE(...)` only when both `vocab` and `merges` are supplied. The other branch — the train-from-scratch path — builds a bare `BPE()`:

```python
if vocab is not None and merges is not None:
    tokenizer = Tokenizer(
        BPE(
            vocab,
            merges,
            dropout=dropout,
            ...
        )
    )
else:
    tokenizer = Tokenizer(BPE())
```

so `dropout` is silently discarded, and the object ends up disagreeing with itself:

```python
t = ByteLevelBPETokenizer(dropout=0.1)
t._parameters["dropout"]     # 0.1
t._tokenizer.model.dropout   # None
```

The two sibling classes both pass it in the equivalent branch — `char_level_bpe.py` and `sentencepiece_bpe.py`. #1136 made exactly this change to `char_level_bpe.py` in 2022 and did not touch this file.

The value survives training, so BPE-dropout goes from inert to working. Encoding one sentence 300 times after `train_from_iterator`:

```
before: 1 distinct tokenization
after: 36 distinct tokenizations
```

Anyone not passing `dropout` is unaffected: `BPE(dropout=None)` serializes identically to `BPE()`, which I checked for the default, `add_prefix_space`, `lowercase` and `trim_offsets` configurations.

I kept this to `dropout` alone. `continuing_subword_prefix` and `end_of_word_suffix` are dropped in the same branch, but mirroring the `if`-branch's `or ""` there would change the serialized `tokenizer.json` for every default user from `null` to `""`, and passing them through as `None` raises `TypeError`. That one seems worth handling separately, if at all.

Added two tests next to the existing ones: `dropout` reaching the model, and the default still being `None`.
