### PR TITLE
chore(ci): oracle test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,18 +62,19 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make test HF="uvx --from huggingface_hub hf"
 
-      # The only gate that checks the slim reader against an *independent* implementation: both
-      # oracles encode/decode through `tk_serialize::from_json` and compare against the released
-      # `tokenizers` crate. They sit behind `bench-baseline` because that pulls the released crate in
-      # as a dependency, which means `cargo test --workspace` skips them -- so they need their own
-      # step or the guarantee is not actually being checked. 16 tests.
-      - name: Run the release-crate id oracles
+      # The only gate that checks the slim reader against an *independent* implementation: one test
+      # per model encodes/decodes through `tk_serialize::from_json` and compares against the
+      # released `tokenizers` crate. It sits behind `bench-baseline` because that pulls the released
+      # crate in as a dependency, which means `cargo test --workspace` skips it -- so it needs its
+      # own step or the guarantee is not actually being checked. `make oracle` fetches its fixtures
+      # first; the raw `cargo test` this used to run skipped that and only worked because those
+      # fixtures came from a live Hub fetch at the time.
+      - name: Run the release-crate oracle
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          cargo test -p tk-convert --features bench-baseline --test oracle
+        run: make oracle HF="uvx --from huggingface_hub hf"
 
       # Windows skips the integration tests and the full fixture set, but the
       # tk-encode lib tests load these two tokenizer files and fail without

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,7 +85,7 @@ jobs:
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-test-data gpt2.json albert-base-v1-tokenizer.json --repo-type dataset --revision e20ac5914f5ada06874e4f9d45e49b31a049904e --local-dir data
+        run: uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-test-data gpt2.json albert-base-v1-tokenizer.json --repo-type dataset --revision 54d012f11a4911b797aa6ef2dffc0fb67cbc7619 --local-dir data
 
       # Windows runs lib + doc tests only. bash so the step fails on the first
       # failing command. The default pwsh only propagates the last command's
@@ -274,7 +274,7 @@ jobs:
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-test-data gpt2.json albert-base-v1-tokenizer.json --repo-type dataset --revision e20ac5914f5ada06874e4f9d45e49b31a049904e --local-dir data
+        run: uvx --from huggingface_hub hf download hf-internal-testing/tokenizers-test-data gpt2.json albert-base-v1-tokenizer.json --repo-type dataset --revision 54d012f11a4911b797aa6ef2dffc0fb67cbc7619 --local-dir data
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,8 +184,8 @@ rather than the in-tree `Tokenizer` object model, which this rc doesn't ship
 
 Those checks link the released crate, so they live behind the `bench-baseline`
 feature and a plain `cargo test` skips them. One test per model (`gpt2`,
-`bert_base_uncased`, `t5_base`, `albert_base_v1`); `make oracle` fetches each
-model's fixture, then runs them all:
+`bert_base_uncased`, `t5_base`, `albert_base_v1`, `llama_3_2_1b`); `make oracle`
+fetches each model's fixture, then runs them all:
 
 ```bash
 cd tokenizers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,20 +177,25 @@ samply record python my_script.py
 
 ### PipelineTokenizer oracle tests
 
-`PipelineTokenizer` (in `tk-encode`) is an experimental reimplementation of the
-encode/decode pipeline. It is checked for parity against the latest *released*
-`tokenizers` crate — same token ids on encode, same decoded string — rather than
-the in-tree `Tokenizer`, which is being retired.
+`PipelineTokenizer` (in `tk-encode`) is checked for parity against the latest
+*released* `tokenizers` crate: same token ids on encode, same decoded string,
+rather than the in-tree `Tokenizer` object model, which this rc doesn't ship
+(see `REQUIRED_FOR_V1.md`).
 
 Those checks link the released crate, so they live behind the `bench-baseline`
-feature and a plain `cargo test` skips them. Fetch the corpora and model
-tokenizers, then run with the feature:
+feature and a plain `cargo test` skips them. One test per model (`gpt2`,
+`bert_base_uncased`, `t5_base`, `albert_base_v1`); `make oracle` fetches each
+model's fixture, then runs them all:
 
 ```bash
 cd tokenizers
-make fixtures   # needs HF_TOKEN
+make oracle   # needs HF_TOKEN
+```
 
-cargo test -p tk-convert --features bench-baseline --test oracle
+Run one model directly once its fixture is there:
+
+```bash
+cargo test -p tk-convert --features bench-baseline --test oracle gpt2
 ```
 
 CI runs it in the **rust** workflow (`.github/workflows/rust.yml`).

--- a/tokenizers/Cargo.lock
+++ b/tokenizers/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,19 +505,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
@@ -990,16 +971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,25 +1245,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "hf-hub"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
-dependencies = [
- "dirs",
- "http",
- "indicatif 0.17.11",
- "libc",
- "log",
- "rand 0.9.5",
- "serde",
- "serde_json",
- "thiserror",
- "ureq",
- "windows-sys 0.60.2",
-]
 
 [[package]]
 name = "hf-hub"
@@ -1615,24 +1567,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console 0.15.11",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
- "web-time",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
- "console 0.16.4",
+ "console",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -1937,16 +1876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,12 +1962,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc2-core-foundation"
@@ -2669,9 +2592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2923,12 +2844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
-
-[[package]]
 name = "simd_cesu8"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,17 +2879,6 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3245,7 +3149,6 @@ version = "1.0.0-rc.0"
 dependencies = [
  "bitsplit",
  "criterion 0.8.2",
- "hf-hub 0.4.3",
  "rayon",
  "serde_json",
  "thiserror",
@@ -3264,8 +3167,8 @@ dependencies = [
  "daachorse 5.0.0",
  "dary_heap",
  "fancy-regex",
- "hf-hub 1.0.0",
- "indicatif 0.18.6",
+ "hf-hub",
+ "indicatif",
  "itertools 0.15.0",
  "libc",
  "log",
@@ -3316,7 +3219,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "indicatif 0.18.6",
+ "indicatif",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
@@ -3660,25 +3563,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "socks",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,24 +3768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "whoami"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4073,25 +3939,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4109,31 +3957,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4152,22 +3983,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4176,22 +3995,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4200,22 +4007,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4224,22 +4019,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -25,34 +25,14 @@ SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2.json $(DATA_DIR)
 # Exactly what tk-serialize/benches/{encode,decode}.rs read: big.txt and llama-3 come from
 # SHARED_RESOURCES, plus the Japanese corpus decode uses and the config encode profiles.
 BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/deepseek-v4.json
-TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/fixtures/modalities/agentic-traces.txt
+TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json
 # tk-convert/tests/oracle.rs's four MODELS, named directly rather than built from
 # SHARED_RESOURCES: `make oracle` should fetch only what oracle.rs reads.
 ORACLE_RESOURCES = $(DATA_DIR)/gpt2.json $(DATA_DIR)/bert-base-uncased.json $(DATA_DIR)/t5-base.json $(DATA_DIR)/albert-base-v1-tokenizer.json
 
-# One language per encode regime (script structure × vocab coverage), not one per
-# script: eng is the vocab-native anchor, rus the 2-byte European alphabet, arb the
-# 2-byte RTL abjad, hin mainstream Indic, tam the extreme-fertility stress probe,
-# amh the poorly-covered 3-byte script, cmn the Han inventory, jpn script mixing,
-# tha spaceless text. Structural near-twins (ell/heb/ben/kat/kor) were cut: they
-# tracked their representative on every model and only diluted the aggregates.
-FIXTURE_LANGS = amh_Ethi arb_Arab cmn_Hani eng_Latn hin_Deva jpn_Jpan rus_Cyrl tam_Taml tha_Thai
-# Only the sparse added-token corpora: realistic marker density (text sprinkled with
-# specials, like chat-template traffic), covering both the raw-special and the
-# normalized-added scan paths. The dense variants were marker soup that skewed every
-# aggregate while measuring nothing the sparse ones don't.
-FIXTURE_MODALITIES = agentic_swe agentic-traces code_mixed math_latex added_special_sparse added_normalized_sparse
-FIXTURES_RESOURCES = $(FIXTURE_LANGS:%=$(DATA_DIR)/fixtures/lang/%.txt) $(FIXTURE_MODALITIES:%=$(DATA_DIR)/fixtures/modalities/%.txt)
-
-# Every file the tests and benches read (corpora, vocabs, tokenizer configs),
-# plus the fixture corpora.
+# Every file the tests and benches read: corpora, vocabs, tokenizer configs.
 .PHONY : data
-data : $(TESTS_RESOURCES) $(BENCHMARK_RESOURCES) $(FIXTURES_RESOURCES)
-
-# Multilingual + modality corpora for cross-language benchmarks; see
-# fixtures/FIXTURES.md in $(HF_TEST_REPO) for provenance.
-.PHONY : fixtures
-fixtures : $(FIXTURES_RESOURCES)
+data : $(TESTS_RESOURCES) $(BENCHMARK_RESOURCES)
 
 # ---- dev loop ----
 

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -7,6 +7,8 @@ SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2-merges.txt $(DAT
 # SHARED_RESOURCES, plus the Japanese corpus decode uses and the config encode profiles.
 BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/deepseek-v4.json
 TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/fixtures/modalities/agentic-traces.txt
+# tk-convert/tests/oracle.rs's models: gpt2 and albert-base-v1 are already in SHARED_RESOURCES.
+ORACLE_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/bert-base-uncased.json $(DATA_DIR)/t5-base.json
 
 # One language per encode regime (script structure × vocab coverage), not one per
 # script: eng is the vocab-native anchor, rus the 2-byte European alphabet, arb the
@@ -43,6 +45,12 @@ lint :
 test : $(TESTS_RESOURCES)
 	cargo test --workspace
 
+# Checks the pipeline against the latest released `tokenizers` crate, on fixtures pinned to
+# HF_REVISION rather than each model's live `main` (see the pin note on HF_REVISION below).
+.PHONY : oracle
+oracle : $(ORACLE_RESOURCES)
+	cargo test -p tk-convert --features bench-baseline --test oracle
+
 .PHONY : doc
 doc :
 	cargo doc --workspace
@@ -55,7 +63,7 @@ publish :
 MODEL_FEATURES = bpe,unigram,wordpiece,wordlevel,normalizers
 
 .PHONY : all-checks
-all-checks : lint test doc feature-matrix
+all-checks : lint test doc feature-matrix oracle
 
 # Compile, lint and test tk-encode under each meaningful feature combination.
 #

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -1,14 +1,34 @@
-DATA_DIR = data
+# ---- fixtures ----
+# Every test/bench/oracle target below declares its data/ files as prerequisites; this section is
+# how those files get there.
 
+DATA_DIR = data
 dir_guard=@mkdir -p $(@D)
 
-SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2-merges.txt $(DATA_DIR)/gpt2.json $(DATA_DIR)/bert-base-uncased-vocab.txt $(DATA_DIR)/big.txt $(DATA_DIR)/small.txt $(DATA_DIR)/albert-base-v1-tokenizer.json  $(DATA_DIR)/llama-3-tokenizer.json
+HF_TEST_REPO = hf-internal-testing/tokenizers-test-data
+# Fetch fixtures through the huggingface_hub CLI: it handles auth (HF_TOKEN),
+# retry/backoff on rate limits, and caching for us. CI overrides HF with
+# `uvx --from huggingface_hub hf` to avoid a separate install step.
+HF ?= hf
+# Pinned, not `main`. `json_oracle`'s recorded digests are only meaningful against a fixed fixture
+# set, and the `$(DATA_DIR)/%` rule below is existence-based -- it never re-downloads a file you
+# already have. Together those two facts silently pinned one developer's digests to a stale
+# `llama-2.json` and produced four spurious drifts on any fresh checkout. Bump this deliberately,
+# and re-record the digests in the same commit.
+HF_REVISION ?= e20ac5914f5ada06874e4f9d45e49b31a049904e
+
+$(DATA_DIR)/% :
+	$(dir_guard)
+	$(HF) download $(HF_TEST_REPO) $* --repo-type dataset --revision $(HF_REVISION) --local-dir $(DATA_DIR)
+
+SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2.json $(DATA_DIR)/big.txt $(DATA_DIR)/albert-base-v1-tokenizer.json $(DATA_DIR)/llama-3-tokenizer.json
 # Exactly what tk-serialize/benches/{encode,decode}.rs read: big.txt and llama-3 come from
 # SHARED_RESOURCES, plus the Japanese corpus decode uses and the config encode profiles.
 BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/deepseek-v4.json
 TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json $(DATA_DIR)/fixtures/modalities/agentic-traces.txt
-# tk-convert/tests/oracle.rs's models: gpt2 and albert-base-v1 are already in SHARED_RESOURCES.
-ORACLE_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/bert-base-uncased.json $(DATA_DIR)/t5-base.json
+# tk-convert/tests/oracle.rs's four MODELS, named directly rather than built from
+# SHARED_RESOURCES: `make oracle` should fetch only what oracle.rs reads.
+ORACLE_RESOURCES = $(DATA_DIR)/gpt2.json $(DATA_DIR)/bert-base-uncased.json $(DATA_DIR)/t5-base.json $(DATA_DIR)/albert-base-v1-tokenizer.json
 
 # One language per encode regime (script structure × vocab coverage), not one per
 # script: eng is the vocab-native anchor, rus the 2-byte European alphabet, arb the
@@ -23,6 +43,18 @@ FIXTURE_LANGS = amh_Ethi arb_Arab cmn_Hani eng_Latn hin_Deva jpn_Jpan rus_Cyrl t
 # aggregate while measuring nothing the sparse ones don't.
 FIXTURE_MODALITIES = agentic_swe agentic-traces code_mixed math_latex added_special_sparse added_normalized_sparse
 FIXTURES_RESOURCES = $(FIXTURE_LANGS:%=$(DATA_DIR)/fixtures/lang/%.txt) $(FIXTURE_MODALITIES:%=$(DATA_DIR)/fixtures/modalities/%.txt)
+
+# Every file the tests and benches read (corpora, vocabs, tokenizer configs),
+# plus the fixture corpora.
+.PHONY : data
+data : $(TESTS_RESOURCES) $(BENCHMARK_RESOURCES) $(FIXTURES_RESOURCES)
+
+# Multilingual + modality corpora for cross-language benchmarks; see
+# fixtures/FIXTURES.md in $(HF_TEST_REPO) for provenance.
+.PHONY : fixtures
+fixtures : $(FIXTURES_RESOURCES)
+
+# ---- dev loop ----
 
 .PHONY : build
 build :
@@ -46,7 +78,7 @@ test : $(TESTS_RESOURCES)
 	cargo test --workspace
 
 # Checks the pipeline against the latest released `tokenizers` crate, on fixtures pinned to
-# HF_REVISION rather than each model's live `main` (see the pin note on HF_REVISION below).
+# HF_REVISION rather than each model's live `main` (see the pin note on HF_REVISION above).
 .PHONY : oracle
 oracle : $(ORACLE_RESOURCES)
 	cargo test -p tk-convert --features bench-baseline --test oracle
@@ -58,6 +90,8 @@ doc :
 .PHONY : publish
 publish :
 	cargo publish
+
+# ---- aggregate checks ----
 
 # The features that are `cfg` gates on enum variants, so a combination of them can break on its own.
 MODEL_FEATURES = bpe,unigram,wordpiece,wordlevel,normalizers
@@ -78,6 +112,8 @@ feature-matrix : $(SHARED_RESOURCES)
 	  --include-features $(MODEL_FEATURES) clippy --all-targets -- -D warnings
 	cargo hack --package tk-encode --each-feature \
 	  --include-features $(MODEL_FEATURES) test --lib
+
+# ---- size profiling (opt-in, not part of all-checks) ----
 
 # tk-encode's stripped and gzipped size per feature configuration, under
 # `--profile minsize`.
@@ -144,34 +180,10 @@ slimest-size : slimest
 	@b=target/$(HOST_TRIPLE)/slimest/examples/binsize_pipeline; \
 	  gzip -9 -c $$b | wc -c | tr -d ' ' | xargs printf 'slimest tk-encode: %s bytes gzipped\n'
 
+# ---- bench ----
+
 # The two benches live in tk-serialize, which is the only crate that can build a
 # `PipelineTokenizer`. The big cross-engine benchmarks live in huggingface/tokbench.
 .PHONY : bench
 bench : $(BENCHMARK_RESOURCES)
 	cargo bench -p tk-serialize
-
-# Every file the tests and benches read (corpora, vocabs, tokenizer configs),
-# plus the fixture corpora.
-.PHONY : data
-data : $(TESTS_RESOURCES) $(BENCHMARK_RESOURCES) $(FIXTURES_RESOURCES)
-
-# Multilingual + modality corpora for cross-language benchmarks; see
-# fixtures/FIXTURES.md in $(HF_TEST_REPO) for provenance.
-.PHONY : fixtures
-fixtures : $(FIXTURES_RESOURCES)
-
-HF_TEST_REPO = hf-internal-testing/tokenizers-test-data
-# Fetch fixtures through the huggingface_hub CLI: it handles auth (HF_TOKEN),
-# retry/backoff on rate limits, and caching for us. CI overrides HF with
-# `uvx --from huggingface_hub hf` to avoid a separate install step.
-HF ?= hf
-# Pinned, not `main`. `json_oracle`'s recorded digests are only meaningful against a fixed fixture
-# set, and the `$(DATA_DIR)/%` rule below is existence-based -- it never re-downloads a file you
-# already have. Together those two facts silently pinned one developer's digests to a stale
-# `llama-2.json` and produced four spurious drifts on any fresh checkout. Bump this deliberately,
-# and re-record the digests in the same commit.
-HF_REVISION ?= e20ac5914f5ada06874e4f9d45e49b31a049904e
-
-$(DATA_DIR)/% :
-	$(dir_guard)
-	$(HF) download $(HF_TEST_REPO) $* --repo-type dataset --revision $(HF_REVISION) --local-dir $(DATA_DIR)

--- a/tokenizers/Makefile
+++ b/tokenizers/Makefile
@@ -15,7 +15,10 @@ HF ?= hf
 # already have. Together those two facts silently pinned one developer's digests to a stale
 # `llama-2.json` and produced four spurious drifts on any fresh checkout. Bump this deliberately,
 # and re-record the digests in the same commit.
-HF_REVISION ?= e20ac5914f5ada06874e4f9d45e49b31a049904e
+#
+# Bumped for fixtures/models/llama-3.2-1b.json (hf-internal-testing/tokenizers-test-data#10):
+# meta-llama/Llama-3.2-1B is gated, so its tokenizer.json is mirrored there instead of fetched live.
+HF_REVISION ?= 54d012f11a4911b797aa6ef2dffc0fb67cbc7619
 
 $(DATA_DIR)/% :
 	$(dir_guard)
@@ -26,9 +29,9 @@ SHARED_RESOURCES = $(DATA_DIR)/gpt2-vocab.json $(DATA_DIR)/gpt2.json $(DATA_DIR)
 # SHARED_RESOURCES, plus the Japanese corpus decode uses and the config encode profiles.
 BENCHMARK_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/deepseek-v4.json
 TESTS_RESOURCES = $(SHARED_RESOURCES) $(DATA_DIR)/unigram.json $(DATA_DIR)/unigram_wagahaiwa_nekodearu.txt $(DATA_DIR)/roberta.json $(DATA_DIR)/tokenizer-wiki.json $(DATA_DIR)/bert-wiki.json
-# tk-convert/tests/oracle.rs's four MODELS, named directly rather than built from
+# tk-convert/tests/oracle.rs's five models, named directly rather than built from
 # SHARED_RESOURCES: `make oracle` should fetch only what oracle.rs reads.
-ORACLE_RESOURCES = $(DATA_DIR)/gpt2.json $(DATA_DIR)/bert-base-uncased.json $(DATA_DIR)/t5-base.json $(DATA_DIR)/albert-base-v1-tokenizer.json
+ORACLE_RESOURCES = $(DATA_DIR)/gpt2.json $(DATA_DIR)/bert-base-uncased.json $(DATA_DIR)/t5-base.json $(DATA_DIR)/albert-base-v1-tokenizer.json $(DATA_DIR)/fixtures/models/llama-3.2-1b.json
 
 # Every file the tests and benches read: corpora, vocabs, tokenizer configs.
 .PHONY : data

--- a/tokenizers/tk-convert/Cargo.toml
+++ b/tokenizers/tk-convert/Cargo.toml
@@ -33,8 +33,7 @@ thiserror = "2"
 # the FSM fast path without changing any test.
 bitsplit = { path = "../bitsplit" }
 
-# Latest released tokenizers, used as the comparison baseline by the fixture bench and as the
-# independent id/decode oracle by `tests/pipeline_oracle.rs` and `tests/pipeline_decode_oracle.rs`.
+# Latest released tokenizers, the independent id/decode oracle `tests/oracle.rs` compares against.
 tokenizers-release = { package = "tokenizers", version = "=0.23.1", optional = true }
 
 [features]
@@ -56,8 +55,5 @@ tk-serialize = { path = "../tk-serialize", features = [
 tk-encode = { path = "../tk-encode", default-features = false, features = [
   "fancy-regex",
 ] }
-# The oracles fetch their tokenizer.json from the Hub instead of relying on `make models`, so each
-# one is self-contained. `hf-hub` caches under ~/.cache/huggingface, so only the first run is online.
-hf-hub = { version = "0.4.1", features = ["ureq"], default-features = false }
 criterion = "0.8"
 rayon = "1.12"

--- a/tokenizers/tk-convert/tests/oracle.rs
+++ b/tokenizers/tk-convert/tests/oracle.rs
@@ -5,6 +5,9 @@
 //! the pairing tk-convert exists to make work. The release is the oracle, so nothing in this tree
 //! grades its own homework.
 //!
+//! One test per model, covering the three shapes the conversion has to handle: byte-level BPE
+//! (gpt2), WordPiece (bert-base-uncased), and SentencePiece Unigram (t5-base, albert-base-v1).
+//!
 //! Decode is fed the release's *own* ids, so it is judged on decode alone even where encode
 //! legitimately diverges.
 //!
@@ -12,18 +15,10 @@
 
 #![cfg(feature = "bench-baseline")]
 
+use tk_convert::ConvertError;
 use tokenizers_release::Tokenizer as Released;
 
 const DATA: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
-
-/// (Hub repo, its `tokenizer.json` fixture) pairs, covering the three shapes the conversion has
-/// to handle: byte-level BPE, WordPiece, and SentencePiece Unigram.
-const MODELS: &[(&str, &str)] = &[
-    ("gpt2", "gpt2.json"),
-    ("bert-base-uncased", "bert-base-uncased.json"),
-    ("t5-base", "t5-base.json"),
-    ("albert-base-v1", "albert-base-v1-tokenizer.json"),
-];
 
 /// One line per script the old fixture corpora covered, plus the two modalities that stress the
 /// byte and delimiter paths hardest. Short on purpose -- these exercise the encoders' branches, not
@@ -43,46 +38,69 @@ const TEXTS: &[&str] = &[
     r"\frac{1}{2} \sum_{i=0}^{n}",       // math
 ];
 
-#[test]
-fn matches_the_released_crate() {
-    let mut diverged = Vec::new();
-    for &(repo, file) in MODELS {
-        let path = format!("{DATA}/{file}");
-        let canonical = tk_convert::canonicalize_file(&path)
-            .unwrap_or_else(|e| panic!("{repo}: this pass refuses it: {e}"));
+fn assert_matches_released(repo: &str, file: &str) {
+    let path = format!("{DATA}/{file}");
+    let canonical = match tk_convert::canonicalize_file(&path) {
+        Ok(c) => c,
+        Err(ConvertError::Io { .. }) => panic!(
+            "{repo}: no fixture at {path}. Run `make oracle` to fetch it, or add it to \
+             hf-internal-testing/tokenizers-test-data if it isn't there yet."
+        ),
         // A refusal here is the regression this oracle exists to catch, so it fails, not skips.
-        let pipeline = tk_serialize::from_json(&canonical)
-            .unwrap_or_else(|e| panic!("{repo}: the canonical reader refuses the conversion: {e}"));
-        let released = Released::from_file(&path).expect("the released crate reads it");
+        Err(e) => panic!("{repo}: this pass refuses it: {e}"),
+    };
+    let pipeline = tk_serialize::from_json(&canonical)
+        .unwrap_or_else(|e| panic!("{repo}: the canonical reader refuses the conversion: {e}"));
+    let released = Released::from_file(&path).expect("the released crate reads it");
 
-        for text in TEXTS {
-            for special in [false, true] {
-                let ids = released
-                    .encode_fast(*text, special)
-                    .unwrap()
-                    .get_ids()
-                    .to_vec();
-                let got: Vec<u32> = pipeline.encode(*text, special).wait().unwrap()[0]
-                    .ids()
-                    .iter()
-                    .map(|t| t.id())
-                    .collect();
-                if ids != got {
-                    diverged.push(format!("{repo} encode special={special} {text:?}"));
-                    continue; // decoding ids we already disagree about says nothing
-                }
-                for skip in [false, true] {
-                    let want = released.decode(&ids, skip).unwrap();
-                    if pipeline.decode(&ids, skip).unwrap_or_default() != want {
-                        diverged.push(format!("{repo} decode skip={skip} {text:?}"));
-                    }
+    let mut diverged = Vec::new();
+    for text in TEXTS {
+        for special in [false, true] {
+            let ids = released
+                .encode_fast(*text, special)
+                .unwrap()
+                .get_ids()
+                .to_vec();
+            let got: Vec<u32> = pipeline.encode(*text, special).wait().unwrap()[0]
+                .ids()
+                .iter()
+                .map(|t| t.id())
+                .collect();
+            if ids != got {
+                diverged.push(format!("encode special={special} {text:?}"));
+                continue; // decoding ids we already disagree about says nothing
+            }
+            for skip in [false, true] {
+                let want = released.decode(&ids, skip).unwrap();
+                if pipeline.decode(&ids, skip).unwrap_or_default() != want {
+                    diverged.push(format!("decode skip={skip} {text:?}"));
                 }
             }
         }
     }
     assert!(
         diverged.is_empty(),
-        "diverges from the released crate:\n{}",
+        "{repo} diverges from the released crate:\n{}",
         diverged.join("\n")
     );
+}
+
+#[test]
+fn gpt2() {
+    assert_matches_released("gpt2", "gpt2.json");
+}
+
+#[test]
+fn bert_base_uncased() {
+    assert_matches_released("bert-base-uncased", "bert-base-uncased.json");
+}
+
+#[test]
+fn t5_base() {
+    assert_matches_released("t5-base", "t5-base.json");
+}
+
+#[test]
+fn albert_base_v1() {
+    assert_matches_released("albert-base-v1", "albert-base-v1-tokenizer.json");
 }

--- a/tokenizers/tk-convert/tests/oracle.rs
+++ b/tokenizers/tk-convert/tests/oracle.rs
@@ -1,26 +1,28 @@
 //! The pipeline must encode and decode exactly like the latest *released* `tokenizers`.
 //!
-//! Each model is fetched from the Hub, converted by this crate, and read back by the canonical
-//! reader -- the pairing tk-convert exists to make work. The release is the oracle, so nothing in
-//! this tree grades its own homework. `hf-hub` caches, so only the first run is online.
+//! Each model's `tokenizer.json` is a fixture pinned in `hf-internal-testing/tokenizers-test-data`
+//! (`make oracle` fetches them), converted by this crate, and read back by the canonical reader --
+//! the pairing tk-convert exists to make work. The release is the oracle, so nothing in this tree
+//! grades its own homework.
 //!
 //! Decode is fed the release's *own* ids, so it is judged on decode alone even where encode
 //! legitimately diverges.
 //!
-//!   cargo test -p tk-convert --features bench-baseline --test oracle
+//!   make oracle
 
 #![cfg(feature = "bench-baseline")]
 
 use tokenizers_release::Tokenizer as Released;
 
-/// Byte-level BPE, WordPiece, and SentencePiece Unigram -- the three shapes the conversion has to
-/// handle.
-const MODELS: &[&str] = &[
-    "gpt2",
-    "bert-base-uncased",
-    "t5-base",
-    "albert-base-v1",
-    "meta-llama/Llama-3.2-1B",
+const DATA: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../data");
+
+/// (Hub repo, its `tokenizer.json` fixture) pairs, covering the three shapes the conversion has
+/// to handle: byte-level BPE, WordPiece, and SentencePiece Unigram.
+const MODELS: &[(&str, &str)] = &[
+    ("gpt2", "gpt2.json"),
+    ("bert-base-uncased", "bert-base-uncased.json"),
+    ("t5-base", "t5-base.json"),
+    ("albert-base-v1", "albert-base-v1-tokenizer.json"),
 ];
 
 /// One line per script the old fixture corpora covered, plus the two modalities that stress the
@@ -44,16 +46,8 @@ const TEXTS: &[&str] = &[
 #[test]
 fn matches_the_released_crate() {
     let mut diverged = Vec::new();
-    for &repo in MODELS {
-        let path = match hf_hub::api::sync::Api::new()
-            .and_then(|api| api.model(repo.to_string()).get("tokenizer.json"))
-        {
-            Ok(p) => p,
-            Err(e) => {
-                eprintln!("skip {repo}: cannot fetch tokenizer.json ({e})");
-                continue;
-            }
-        };
+    for &(repo, file) in MODELS {
+        let path = format!("{DATA}/{file}");
         let canonical = tk_convert::canonicalize_file(&path)
             .unwrap_or_else(|e| panic!("{repo}: this pass refuses it: {e}"));
         // A refusal here is the regression this oracle exists to catch, so it fails, not skips.

--- a/tokenizers/tk-convert/tests/oracle.rs
+++ b/tokenizers/tk-convert/tests/oracle.rs
@@ -6,7 +6,9 @@
 //! grades its own homework.
 //!
 //! One test per model, covering the three shapes the conversion has to handle: byte-level BPE
-//! (gpt2), WordPiece (bert-base-uncased), and SentencePiece Unigram (t5-base, albert-base-v1).
+//! (gpt2, llama-3.2-1b), WordPiece (bert-base-uncased), and SentencePiece Unigram (t5-base,
+//! albert-base-v1). `meta-llama/Llama-3.2-1B` is gated, so its fixture is a mirrored copy
+//! (hf-internal-testing/tokenizers-test-data#10) rather than the Hub repo itself.
 //!
 //! Decode is fed the release's *own* ids, so it is judged on decode alone even where encode
 //! legitimately diverges.
@@ -103,4 +105,12 @@ fn t5_base() {
 #[test]
 fn albert_base_v1() {
     assert_matches_released("albert-base-v1", "albert-base-v1-tokenizer.json");
+}
+
+#[test]
+fn llama_3_2_1b() {
+    assert_matches_released(
+        "meta-llama/Llama-3.2-1B",
+        "fixtures/models/llama-3.2-1b.json",
+    );
 }


### PR DESCRIPTION
# TL;DR

Make Oracle test more reliable. The CI now goes red when the Oracle test fails.

- Fixtures now come from the pinned test-data repo via make oracle, no live fetch in the test.
- Missing fixture = hard failure with a fix-it message, not a silent skip.
- One test per model instead of one big loop.
- Makefile cleanup
- Fixed CI step
- updated CONTRIBUTING.md.