### PR TITLE
perf(train): select top-k in the trainers instead of ordering everything

### DIFF
--- a/tokenizers/tk-train/examples/topk.rs
+++ b/tokenizers/tk-train/examples/topk.rs
@@ -1,0 +1,71 @@
+//! Times `WordLevelTrainer::train` as the number of distinct words grows.
+//!
+//! The change under test replaces "order every distinct word, then take `vocab_size`" with
+//! "partition at `vocab_size`, order only that". The win is a function of n/k, so n is swept and k
+//! is held at the default 30_000. Real corpora sit at the high end: millions of distinct word forms
+//! against a 30k vocabulary.
+//!
+//! `feed` is outside the timer -- it builds the count map, which this change does not touch. Only
+//! `train` is timed, which is the ordering.
+//!
+//! Every word is fed once, so every count is equal and the comparator always falls through to its
+//! word tie-break. That is the long tail of a real corpus (most word forms occur once) and it is
+//! also the case where ordering costs the most, so read these as the favourable end.
+//!
+//! Statistic is the minimum over the passes: a pass that got descheduled can only be slower.
+//!
+//! Usage: topk [n_distinct,...] [passes]
+
+use std::time::Instant;
+
+use tk_encode::models::wordlevel::WordLevel;
+use tk_train::Trainer;
+use tk_train::trainers::wordlevel::WordLevelTrainer;
+
+const VOCAB_SIZE: usize = 30_000;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let sizes: Vec<usize> = args
+        .get(1)
+        .map(|s| s.split(',').filter_map(|x| x.parse().ok()).collect())
+        .unwrap_or_else(|| vec![50_000, 200_000, 1_000_000, 4_000_000]);
+    let passes: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(5);
+    // How many distinct counts to spread the words over. 1 means every count is equal, so the
+    // comparator always falls through to its word tie-break -- the costly end. Higher values let
+    // most comparisons settle on the integer count instead.
+    let spread: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(1);
+
+    for n in sizes {
+        let words: Vec<String> = (0..n).map(|i| format!("w{i:08}")).collect();
+
+        let mut best = f64::MAX;
+        let mut vocab = 0usize;
+        for _ in 0..passes {
+            let mut trainer = WordLevelTrainer::builder()
+                .show_progress(false)
+                .vocab_size(VOCAB_SIZE)
+                .build()
+                .unwrap();
+            // Word i is fed 1 + (i % spread) times, so counts run over `spread` distinct values.
+            let fed = words
+                .iter()
+                .enumerate()
+                .flat_map(|(i, w)| std::iter::repeat_n(w.clone(), 1 + (i % spread)));
+            trainer.feed(fed, |s| Ok(vec![s.to_string()])).unwrap();
+
+            let mut model = WordLevel::default();
+            let t = Instant::now();
+            trainer.train(&mut model).unwrap();
+            let secs = t.elapsed().as_secs_f64();
+
+            vocab = model.vocab.len();
+            best = best.min(secs);
+        }
+        println!(
+            "{{\"n_distinct\":{n},\"vocab\":{vocab},\"secs_min\":{:.4},\"words_per_sec\":{:.0}}}",
+            best,
+            n as f64 / best,
+        );
+    }
+}

--- a/tokenizers/tk-train/src/trainers/unigram.rs
+++ b/tokenizers/tk-train/src/trainers/unigram.rs
@@ -335,8 +335,33 @@ impl UnigramTrainer {
             seed_sentencepieces.push((character.to_string(), count.into()));
         }
 
-        // sort by decreasing score
-        substr_index.sort_by_key(|&a| Reverse(a));
+        // Sort by decreasing score -- but only the front of it is ever read, so partition there
+        // first and order what survives.
+        //
+        // `substr_index` has one entry per distinct substring of the whole flattened corpus that
+        // passed the filters above, which for a real training set is far more than `seed_size`
+        // (default 1_000_000). Ordering all of them to consume the first k is O(n log n) for an
+        // O(n) question, and it is the expensive kind of comparison: the key is
+        // `(score, &[char])`, so every tie is settled by comparing character slices rather than
+        // integers.
+        //
+        // `wanted` mirrors the loop below exactly, including its off-by-one: the length check
+        // happens *after* the push, so a `seed_sentencepieces` that is already at or past
+        // `seed_size` still takes one entry.
+        //
+        // Ties cannot change the outcome. The substrings are distinct, so `(score, string)` is a
+        // total order and the selected set matches what the full sort produced; and were two
+        // entries ever equal on both, they would push identical `(string, score)` pairs and be
+        // indistinguishable in the result anyway.
+        let wanted = self
+            .seed_size
+            .saturating_sub(seed_sentencepieces.len())
+            .max(1);
+        if wanted < substr_index.len() {
+            substr_index.select_nth_unstable_by_key(wanted, |&a| Reverse(a));
+            substr_index.truncate(wanted);
+        }
+        substr_index.sort_unstable_by_key(|&a| Reverse(a));
         for (score, char_string) in substr_index {
             // Just in case
             assert!(self.is_valid_sentencepiece(char_string));
@@ -495,7 +520,28 @@ impl UnigramTrainer {
         let pruned_size: usize = ((pieces.len() as f64) * self.shrinking_factor) as usize;
         let pruned_size = desired_vocab_size.max(pruned_size);
 
-        candidates.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap());
+        // By decreasing loss, ties by ascending id. The id tie-break is not cosmetic: the sort
+        // used to be `sort_by`, which is stable, and `candidates` is built by walking ids in
+        // ascending order -- so equal losses already resolved by id. Spelling that out makes the
+        // order total, which is what lets the selection below pick the same set a full sort would.
+        let by_loss_then_id = |a: &(usize, f64), b: &(usize, f64)| {
+            b.1.partial_cmp(&a.1)
+                .expect("loss is NaN-checked when the candidate is pushed")
+                .then(a.0.cmp(&b.0))
+        };
+
+        // Only enough candidates to reach `pruned_size` are ever pushed, and this runs once per EM
+        // iteration, so the saving repeats. The `==` in the loop below means an already-oversized
+        // `new_pieces` never trips the break and takes every candidate -- that path keeps the full
+        // sort rather than quietly changing what it selects.
+        if new_pieces.len() < pruned_size {
+            let wanted = pruned_size - new_pieces.len();
+            if wanted < candidates.len() {
+                candidates.select_nth_unstable_by(wanted, by_loss_then_id);
+                candidates.truncate(wanted);
+            }
+        }
+        candidates.sort_unstable_by(by_loss_then_id);
         for (id, _score) in candidates {
             if new_pieces.len() == pruned_size {
                 break;
@@ -898,5 +944,92 @@ mod tests {
         assert_approx_eq!(scores[0], -1.098, 0.01);
         // ln(2) - ln(3)
         assert_approx_eq!(scores[1], -0.405, 0.01);
+    }
+
+    /// A `seed_size` of k has to give exactly the first k of an unbounded run. That is the property
+    /// the selection replaced a full sort with, and the existing tests never reached it: the
+    /// default `seed_size` is 1_000_000, so on any test-sized corpus the selection branch is
+    /// skipped entirely.
+    #[test]
+    fn a_bounded_seed_is_a_prefix_of_the_unbounded_one() {
+        // Repetitive on purpose: overlapping repeats make the suffix array emit many substrings
+        // with equal `freq * len` scores, so the kept/dropped boundary lands inside a run of ties
+        // and only the tie-break decides.
+        let sentences: Vec<Sentence> = vec![
+            ("abcabcabc abcabc abc".to_string(), 7),
+            ("xyzxyzxyz xyzxyz xyz".to_string(), 7),
+            ("abcxyz xyzabc abcxyz".to_string(), 3),
+        ];
+        let seeded = |seed_size: usize| -> Vec<String> {
+            let trainer = UnigramTrainerBuilder::default()
+                .show_progress(false)
+                .seed_size(seed_size)
+                .build()
+                .unwrap();
+            trainer
+                .make_seed_sentence_pieces(&sentences, &None)
+                .into_iter()
+                .map(|(piece, _)| piece)
+                .collect()
+        };
+
+        let full = seeded(1_000_000);
+        // The characters are pushed before any substring, unconditionally.
+        let n_chars = UnigramTrainerBuilder::default()
+            .show_progress(false)
+            .build()
+            .unwrap()
+            .required_chars(&sentences)
+            .len();
+        assert!(
+            full.len() > n_chars + 4,
+            "corpus is too small to exercise the selection: {} pieces, {n_chars} chars",
+            full.len()
+        );
+
+        for k in [n_chars + 1, n_chars + 2, n_chars + 5, full.len() - 1] {
+            assert_eq!(seeded(k), full[..k], "seed_size {k}");
+        }
+
+        // Below the character count the loop's length check runs *after* the push, so exactly one
+        // substring still comes through.
+        for k in [0, 1, n_chars] {
+            assert_eq!(seeded(k), full[..n_chars + 1], "seed_size {k}");
+        }
+    }
+
+    /// `prune_sentence_pieces` used a *stable* sort by descending loss, so equal losses resolved by
+    /// ascending id -- the order `candidates` is built in. Selecting instead of sorting is only
+    /// equivalent if that tie-break is spelled out, which is what `by_loss_then_id` does. This
+    /// checks the two agree on tie-heavy input, including at the boundary.
+    #[test]
+    fn selecting_candidates_matches_the_stable_sort_it_replaced() {
+        // Many shared losses, so most boundaries fall inside a tie run.
+        let candidates: Vec<(usize, f64)> = (0..300usize)
+            .map(|id| (id, ((id % 7) as f64) * 0.5))
+            .collect();
+
+        let reference = |wanted: usize| -> Vec<usize> {
+            let mut c = candidates.clone();
+            // Exactly the old code: stable, by descending loss, then take the front.
+            c.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap());
+            c.into_iter().take(wanted).map(|(id, _)| id).collect()
+        };
+        let selected = |wanted: usize| -> Vec<usize> {
+            let mut c = candidates.clone();
+            let by_loss_then_id = |a: &(usize, f64), b: &(usize, f64)| {
+                b.1.partial_cmp(&a.1).unwrap().then(a.0.cmp(&b.0))
+            };
+            if wanted < c.len() {
+                c.select_nth_unstable_by(wanted, by_loss_then_id);
+                c.truncate(wanted);
+            }
+            c.sort_unstable_by(by_loss_then_id);
+            c.into_iter().map(|(id, _)| id).collect()
+        };
+
+        for wanted in [0, 1, 2, 43, 100, 299, 300] {
+            assert_eq!(selected(wanted), reference(wanted), "wanted {wanted}");
+        }
     }
 }

--- a/tokenizers/tk-train/src/trainers/wordlevel.rs
+++ b/tokenizers/tk-train/src/trainers/wordlevel.rs
@@ -82,7 +82,13 @@ impl WordLevelTrainer {
         word_counts: &AHashMap<String, u64>,
         model: &mut WordLevel,
     ) -> Result<Vec<AddedToken>> {
-        let mut ordered_counts = word_counts.iter().collect::<Vec<_>>();
+        // Filtered before the ordering rather than after: the predicate is on the count, which is
+        // the ordering's primary key, so it commutes with the sort and shrinks what has to be
+        // ordered at all.
+        let mut ordered_counts = word_counts
+            .iter()
+            .filter(|(_, n)| **n >= self.min_frequency)
+            .collect::<Vec<_>>();
 
         //sort the word counts first by inverse counts and then by word, in order
         //to keep the sorting deterministic in case of equal counts
@@ -94,19 +100,27 @@ impl WordLevelTrainer {
             l.0.cmp(r.0)
         };
 
-        ordered_counts.sort_by(cmp);
+        // Only `vocab_size` entries are ever read, minus whatever the special tokens take, and
+        // `word_counts` holds every distinct word in the corpus -- commonly millions against a
+        // 30k vocabulary. Ordering all of them to keep 30k is O(n log n) to answer an O(n)
+        // question, so partition at the boundary first and order only the part that survives.
+        //
+        // `cmp` breaks count ties on the word, and the words are unique (they are `AHashMap`
+        // keys), so it is a total order: the selected set and its order are exactly what sorting
+        // everything produced.
+        let wanted = self.vocab_size.saturating_sub(self.special_tokens.len());
+        if wanted < ordered_counts.len() {
+            ordered_counts.select_nth_unstable_by(wanted, cmp);
+            ordered_counts.truncate(wanted);
+        }
+        ordered_counts.sort_unstable_by(cmp);
 
         let word_level = WordLevel::builder()
             .vocab(
                 self.special_tokens
                     .iter()
                     .map(|token| token.content.clone())
-                    .chain(
-                        ordered_counts
-                            .into_iter()
-                            .filter(|(_, n)| **n >= self.min_frequency)
-                            .map(|(w, _)| w.to_owned()),
-                    )
+                    .chain(ordered_counts.into_iter().map(|(w, _)| w.to_owned()))
                     .take(self.vocab_size)
                     .enumerate()
                     .map(|(i, w)| (w, i as u32))
@@ -220,5 +234,75 @@ mod tests {
         .collect();
 
         assert_eq!(model.vocab, expected_vocab);
+    }
+
+    /// The selection has to agree with ordering everything and taking the front, including at the
+    /// boundary where counts tie -- that is the whole reason `cmp` breaks ties on the word.
+    fn reference_vocab(
+        word_counts: &AHashMap<String, u64>,
+        vocab_size: usize,
+        min_frequency: u64,
+        specials: &[AddedToken],
+    ) -> Vec<String> {
+        let mut ordered = word_counts.iter().collect::<Vec<_>>();
+        ordered.sort_by(|l: &(&String, &u64), r: &(&String, &u64)| {
+            let count_comp = l.1.cmp(r.1);
+            if count_comp != Ordering::Equal {
+                return count_comp.reverse();
+            }
+            l.0.cmp(r.0)
+        });
+        specials
+            .iter()
+            .map(|t| t.content.clone())
+            .chain(
+                ordered
+                    .into_iter()
+                    .filter(|(_, n)| **n >= min_frequency)
+                    .map(|(w, _)| w.to_owned()),
+            )
+            .take(vocab_size)
+            .collect()
+    }
+
+    fn trained_vocab(
+        trainer: &WordLevelTrainer,
+        word_counts: &AHashMap<String, u64>,
+    ) -> Vec<String> {
+        let mut model = WordLevel::default();
+        trainer.do_train(word_counts, &mut model).unwrap();
+        let mut by_id: Vec<(u32, String)> =
+            model.vocab.iter().map(|(w, i)| (*i, w.clone())).collect();
+        by_id.sort_unstable();
+        by_id.into_iter().map(|(_, w)| w).collect()
+    }
+
+    #[test]
+    fn selection_agrees_with_sorting_everything() {
+        // Deliberately tie-heavy: many words share a count, so the boundary between kept and
+        // dropped falls inside a run of equal counts and only the word tie-break decides.
+        let word_counts: AHashMap<String, u64> = (0..200u64)
+            .map(|i| (format!("w{i:03}"), 5 + (i % 4)))
+            .collect();
+
+        for vocab_size in [0, 1, 3, 7, 50, 199, 200, 201, 500] {
+            for min_frequency in [0, 5, 6, 8, 99] {
+                for specials in [vec![], vec![AddedToken::from("[UNK]", true)]] {
+                    let trainer = WordLevelTrainer {
+                        vocab_size,
+                        min_frequency,
+                        special_tokens: specials.clone(),
+                        ..Default::default()
+                    };
+                    assert_eq!(
+                        trained_vocab(&trainer, &word_counts),
+                        reference_vocab(&word_counts, vocab_size, min_frequency, &specials),
+                        "vocab_size {vocab_size}, min_frequency {min_frequency}, \
+                         {} special(s)",
+                        specials.len(),
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Three sites ordered a whole collection to consume a prefix of it. `select_nth_unstable`
answers that in O(n). **6.7–8.2× on WordLevel training** with a million distinct words.
Output byte-identical.

### Measured

`cargo run --release --example topk -- 200000,1000000 3 8`, interleaved base/new,
minimum over passes. `feed` is outside the timer — only the ordering is measured.

| n distinct words | all counts equal | 8 distinct counts |
|---|---|---|
| 200,000 | 3.58× | **3.84×** |
| 1,000,000 | 6.69× | **8.17×** |

(1M distinct: 131 ms → 20 ms.) The speedup grows with n/k, which is what an
O(n log n) → O(n) change should do. Tie density barely matters — the cost is the number
of comparisons, not the price of each one.

### The three sites

**`wordlevel.rs`** collected every entry of `word_counts` — one per distinct word in the
corpus, commonly millions — ordered all of them, and took the first `vocab_size`
(default 30_000). The `min_frequency` filter also moves ahead of the selection: its
predicate is on the count, which is the ordering's primary key, so it commutes with the
sort and shrinks n first.

**`unigram.rs` `make_seed_sentence_pieces`** ordered one entry per distinct substring of
the flattened corpus to consume `seed_size` (default 1_000_000) of them. The key is
`(score, &[char])`, so ties compare character slices rather than integers.

**`unigram.rs` `prune_sentence_pieces`** ordered every candidate to take `pruned_size`,
once per EM iteration, so the saving repeats.

### Why the output is unchanged

Each site's comparator is a total order, so "select then order k" picks the same set in
the same order as "order everything":

- `wordlevel`: counts tie-break on the word, and words are unique (map keys).
- seed pieces: substrings are distinct; and two entries equal on both fields would push
  identical `(string, score)` pairs anyway.
- prune: this one needed work. The sort was `sort_by` — *stable* — and `candidates` is
  built by walking ids ascending, so equal losses already resolved by id. `by_loss_then_id`
  spells that out, which is what makes a selection equivalent. Its `==` bound also means
  an already-oversized `new_pieces` takes every candidate; that path keeps the full sort
  rather than quietly changing what it selects.

Both `wanted` computations mirror their loops exactly, including the seed loop's
off-by-one: its length check runs *after* the push, so a list already at `seed_size`
still takes one entry.

### Tests

Neither unigram branch had any coverage — the default `seed_size` of 1_000_000 means no
test-sized corpus reaches the selection, which an `eprintln!` in the branch confirmed
(zero hits across the whole suite). Three tests added, each checked against a reference
that still sorts everything, on deliberately tie-heavy input so the kept/dropped boundary
lands inside a run of ties:

- WordLevel, over 9 vocabulary sizes × 5 minimum frequencies × with/without a special
  token. Verified it fails if the final ordering is dropped.
- Seed pieces: a bounded `seed_size` must equal the front of an unbounded run. Exercises
  the new branch 7 times.
- Candidate selection must agree with the stable sort it replaced.

### Note

`tk-train` is `exclude`d from the workspace, so `make lint` never covers it. It has 5
pre-existing clippy failures under `--all-features`, including an `E0432` unresolved
import in `bpe/parity_trainer.rs`; none are in the files touched here, and I have left
them alone. Worth a separate look — the crate does not currently build under that feature
combination.