### PR TITLE
Fix UnicodeScripts pre-tokenizer dropping leading spaces

### DIFF
--- a/tokenizers/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
+++ b/tokenizers/src/pre_tokenizers/unicode_scripts/pre_tokenizer.rs
@@ -51,7 +51,9 @@ impl PreTokenizer for UnicodeScripts {
                         && last_script != Some(Script::Any)
                         && last_script != script
                     {
-                        Some(offset)
+                        // A leading run of `Script::Any` emits no boundary of its own,
+                        // so anchor the first split at 0 instead of skipping past it.
+                        Some(if last_script.is_none() { 0 } else { offset })
                     } else {
                         None
                     };
@@ -63,6 +65,10 @@ impl PreTokenizer for UnicodeScripts {
                     result
                 })
                 .collect();
+            if ranges.is_empty() {
+                // Every char was `Script::Any`, so no boundary was emitted at all.
+                ranges.push(0);
+            }
             ranges.push(normalized.get().len());
             Ok(ranges
                 .windows(2)
@@ -125,6 +131,33 @@ mod tests {
                 .map(|(s, o, _)| (s, o))
                 .collect::<Vec<_>>(),
             vec![("Apples are ", (0, 11)), ("りんご 林檎", (11, 27))]
+        );
+    }
+
+    #[test]
+    fn leading_spaces_are_kept() {
+        let pretok = UnicodeScripts {};
+        for input in [" Yes", "  hello", " どこ", " ", "   "] {
+            let mut pretokenized = PreTokenizedString::from(input);
+            pretok.pre_tokenize(&mut pretokenized).unwrap();
+            let splits: Vec<_> = pretokenized
+                .get_splits(OffsetReferential::Original, OffsetType::Byte)
+                .into_iter()
+                .map(|(s, o, _)| (s, o))
+                .collect();
+            let rebuilt: String = splits.iter().map(|(s, _)| *s).collect();
+            assert_eq!(rebuilt, input, "{input:?} produced {splits:?}");
+        }
+
+        let mut pretokenized = PreTokenizedString::from(" Yes");
+        pretok.pre_tokenize(&mut pretokenized).unwrap();
+        assert_eq!(
+            pretokenized
+                .get_splits(OffsetReferential::Original, OffsetType::Byte)
+                .into_iter()
+                .map(|(s, o, _)| (s, o))
+                .collect::<Vec<_>>(),
+            vec![(" Yes", (0, 4))]
         );
     }
 


### PR DESCRIPTION
`UnicodeScripts` silently drops a leading run of spaces. `fixed_script(' ')` returns `Script::Any`, and the boundary `filter_map` only emits an offset when the script is not `Any`, so `ranges` starts past the spaces. `PreTokenizedString::split` does not check that splits tile the input, so those bytes just vanish.

On main today:

```
" Yes"  -> [("Yes", (1, 4))]     " 1 " -> [("1 ", (1, 3))]
"1 "    -> [("1 ", (0, 2))]      "   " -> []
```

The pre-tokenizer contradicts itself on the same character: a trailing space is absorbed, a leading one is destroyed, and its own test is named `spaces_are_included_in_every_script`.

Through a real `Tokenizer` (WordLevel vocab holding both `"Yes"` and `" Yes"`), `" Yes"` and `"Yes"` encode identically, so the `" Yes"` entry is unreachable and offsets cover 3 of 4 bytes.

Fix anchors the first boundary at 0, which merges the leading spaces into the following run rather than emitting a bare space token. `cargo test --lib`: 201 pass + 1 fail before, 202 pass after. `cargo fmt --check` and `cargo clippy --all-targets -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
