### PR TITLE
perf(normalizers): fast-path BertNormalizer for non-CJK input

### DIFF
--- a/tokenizers/src/normalizers/bert.rs
+++ b/tokenizers/src/normalizers/bert.rs
@@ -96,6 +96,10 @@ impl BertNormalizer {
     }
 
     fn do_handle_chinese_chars(&self, normalized: &mut NormalizedString) {
+        if !normalized.get().chars().any(is_chinese_char) {
+            return;
+        }
+
         let mut new_chars: Vec<(char, isize)> = vec![];
         normalized.for_each(|c| {
             if is_chinese_char(c) {


### PR DESCRIPTION
## Problem

`do_handle_chinese_chars` unconditionally allocates a `Vec<(char, isize)>`, iterates every character, and calls `transform()` to rebuild alignments — even when the input contains no Chinese characters. This is wasted work for the common English/Latin case.

## Change

```rust
fn do_handle_chinese_chars(&self, normalized: &mut NormalizedString) {
    if !normalized.get().chars().any(is_chinese_char) {
        return;
    }
    // ... existing logic unchanged
}
```

One early-return guard. No API changes, no new dependencies, no behavior change.

## What it skips (for non-CJK input)

- `Vec` allocation
- `for_each()` closure dispatch
- `transform()` + alignment reconstruction

## Trade-off

CJK input pays for one extra `chars().any()` scan that short-circuits on the first match. For inputs that are mostly CJK this is negligible relative to the `transform()` cost that follows.