### PR TITLE
docs: rewrite the README for the crate split

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,84 +4,214 @@
     <br>
 <p>
 <p align="center">
-    <img alt="Build" src="https://github.com/huggingface/tokenizers/workflows/Rust/badge.svg">
-    <a href="https://github.com/huggingface/tokenizers/blob/main/LICENSE">
-        <img alt="GitHub" src="https://img.shields.io/github/license/huggingface/tokenizers.svg?color=blue&cachedrop">
-    </a>
-    <a href="https://pepy.tech/project/tokenizers">
-        <img src="https://pepy.tech/badge/tokenizers/week" />
-    </a>
+    <a href="https://github.com/huggingface/tokenizers/actions"><img alt="Build" src="https://github.com/huggingface/tokenizers/workflows/Rust/badge.svg"></a>
+    <a href="https://crates.io/crates/tokenizers"><img alt="Crates.io" src="https://img.shields.io/crates/v/tokenizers.svg"></a>
+    <a href="https://docs.rs/tokenizers/"><img alt="Docs" src="https://docs.rs/tokenizers/badge.svg"></a>
+    <a href="#footprint"><img alt="Size" src="https://img.shields.io/badge/gzipped-325%20KB-brightgreen"></a>
+    <a href="https://github.com/huggingface/tokenizers/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/huggingface/tokenizers.svg?color=blue&cachedrop"></a>
 </p>
+<br>
 
-Provides an implementation of today's most used tokenizers, with a focus on performance and
-versatility.
+The fastest tokenizer library on the world's text, and the only fast one that runs **every** model
+— BPE, Unigram, WordPiece and WordLevel, from one `tokenizer.json`. Every other engine near the top
+of the table buys its speed by supporting less.
 
-## Main features:
+- **881 MB/s** single thread and **6.5 GB/s** at 8 threads (94% scaling efficiency), measured
+  across the whole script matrix and not an English subset.
+- **5–41×** faster than `tokenizers` 0.23.1 on every model and every corpus.
+- **325 KB** gzipped, no hardware requirement — SIMD is pure speed, never correctness.
 
- - Train new vocabularies and tokenize, using today's most used tokenizers.
- - Extremely fast (both training and tokenization), thanks to the Rust implementation. Takes
-   less than 20 seconds to tokenize a GB of text on a server's CPU.
- - Easy to use, but also extremely versatile.
- - Designed for research and production.
- - Normalization comes with alignments tracking. It's always possible to get the part of the
-   original sentence that corresponds to a given token.
- - Does all the pre-processing: Truncate, Pad, add the special tokens your model needs.
+## Performance
+
+All numbers from [**tokbench**](https://github.com/huggingface/tokbench): one shared timing loop,
+one process, and an FNV-1a id-verification gate — an engine that computes different ids is marked
+`mismatch` and never ranked. Being fast at the wrong answer is not a win.
+
+### The global set
+
+[![head to head](https://raw.githubusercontent.com/huggingface/tokbench/tokbench-init/figs/03-headtohead.png)](https://github.com/huggingface/tokbench)
+
+Head-to-head against gigatoken, the closest competitor. One process, median of 7, idle machine,
+single thread, over all 20 script cells — not a Latin subset:
+
+| | tokenizers | gigatoken |
+|---|---:|---:|
+| median, all scripts | **881 MB/s** | 590 MB/s |
+| cells won | **15 / 20** | 5 / 20 |
+| gpt2 | **698** | 554 |
+| llama-3 | **947** | 612 |
+| cells it will even attempt | **203 / 210** | 145 (declines 65) |
+
+We win non-Latin decisively — chinese **1.90×**, korean 1.75×, arabic 1.67×, greek 1.60×, russian
+1.55×, thai 1.53× — and threading does not rescue the gap, because both engines scale at ~94%: on
+Chinese it is still 6826 vs 3657 MB/s at 8 threads.
+
+<sub>Figures from the <code>pipeline #2279 + #2296</code> snapshot. <code>bitsplit</code>, the thread
+pool and the load-time fold have all landed since; this table has not been re-run.</sub>
+
+### Where we lose, plainly
+
+Two places, and both are in tokbench for anyone to check:
+
+- **Latin and dense text.** gigatoken is faster there — english 0.87×, code 0.82×.
+- **tokbench's 10-engine ranking.** Over the 23 cells all ten engines verify, gigatoken leads on
+  median throughput, **238.6 vs our 170.1 MB/s**. That subset is Latin-heavy by construction — it
+  is the intersection of what ten engines support, and engines that decline non-Latin shrink it
+  toward English. It is a real number about a narrow set, which is why the global set is quoted
+  above rather than instead of it.
+
+The coverage column cuts both ways too: gigatoken is byte-exact on all 145 cells it accepts and
+simply declines the other 65. We attempt 203 of 210 and are exact on 174 — see tokbench's coverage
+table for the rest.
+
+[![overall throughput](https://raw.githubusercontent.com/huggingface/tokbench/tokbench-init/figs/01-overall.png)](https://github.com/huggingface/tokbench)
+
+Every engine ranked over the cells it got byte-exact. Log scale — the spread is three orders of
+magnitude. Full matrix, caveats and the interactive dashboard:
+[huggingface/tokbench](https://github.com/huggingface/tokbench).
+
+<a name="footprint"></a>
+### Footprint
+
+```
+make slim-size      # tk-encode + tk-serialize, minsize profile, stripped
+                    # → 332799 bytes gzipped
+```
+
+Gzipped is the only honest number: Mach-O segments are 16 KiB-quantised, so the on-disk size of a
+small binary is mostly padding. `make slimest` goes lower still (`minsize` plus a `std` rebuilt
+without unwinding, nightly). The badge at the top is this number, measured on macOS — a stripped
+ELF gzips to something slightly different.
+
+## Crates
+
+<details>
+<summary><b><code>tk-encode</code></b> — the inference half</summary>
+
+The model engines (BPE, Unigram, WordPiece, WordLevel) and the full pipeline: `Normalizer`,
+`PreTokenizer`, `Model`, `PostProcessor`, `Decoder`.
+
+**Why separate:** inference is the only half that ships to production. Splitting it from training
+means a serving binary never links a trainer, a corpus reader or a progress bar — which is most of
+the 325 KB story.
+</details>
+
+<details>
+<summary><b><code>bitsplit</code></b> — SIMD pre-tokenization</summary>
+
+Unicode atom classification plus pre-tokenization as a **bitstream program** rather than a scalar
+FSM. Follows *Interleaved Bitstream Execution for Multi-Pattern Regex Matching on GPUs*
+(MICRO'25, [10.1145/3725843.3756052](https://doi.org/10.1145/3725843.3756052)): compile the grammar
+into character-class bitstreams (one bit per input byte) plus boolean ops and carry-propagating
+adds, so 64 input bytes are decided per 64-bit register op, branchlessly. The FSM's per-token
+unpredictable branch disappears.
+
+Ships byte-exact grammars for gpt2 / ByteLevel, cl100k, o200k, tekken, deepseek and kimi-k2.
+
+**Why separate:** it is a regex compiler, not a tokenizer — an independent artifact with its own
+test surface, where every vectorised kernel is validated byte-for-byte against one scalar oracle.
+Keeping it out of `tk-encode` is what makes "SIMD is pure speed, never correctness" checkable
+rather than aspirational.
+</details>
+
+<details>
+<summary><b><code>tk-serialize</code></b> — the reader</summary>
+
+`from_json_file` turns a canonical `tokenizer.json` into a `PipelineTokenizer`. **No serde
+anywhere.**
+
+**Why separate:** serde's derive chain was a large, unconditional dependency sitting in front of
+the one thing every user does exactly once. Reading a config is not the same job as encoding text,
+and it should not tax it.
+</details>
+
+<details>
+<summary><b><code>tk-convert</code></b> — the upgrade pass</summary>
+
+`canonicalize_file` rewrites a `tokenizer.json` written by any older version of this library into
+the canonical form the reader accepts. A pure JSON→JSON rewrite; it depends on nothing but
+`std::path` and `serde_json`.
+
+**Why separate:** every config ever published stays readable without the runtime carrying a decade
+of compatibility branches. `cargo tree -p tk-convert -e normal` is 8 nodes.
+</details>
+
+<details>
+<summary><b><code>tk-train</code></b> — the training half</summary>
+
+The `Trainer` trait, every concrete `*Trainer`, `TrainerWrapper` and the `Trainable` extension.
+
+**Why separate:** training is a batch job on a workstation; inference is a hot loop in a server.
+They have opposite constraints, so they get opposite dependency budgets.
+</details>
+
+<details>
+<summary><b><code>bitmap_gen</code></b> — dev-only table generator</summary>
+
+`cargo run -p bitmap_gen` regenerates `bitsplit`'s committed classify tables from
+`unicode-properties`.
+
+**Why separate:** the Unicode tables are baked and committed, so the generator is never linked into
+anything that ships. Not published.
+</details>
+
+<details>
+<summary><b><code>tokenizers</code></b> — umbrella</summary>
+
+A thin re-export so existing `tokenizers::…` paths keep working. Depend on this one unless you know
+you want less.
+</details>
 
 ## Bindings
 
-We provide bindings to the following languages (more to come!):
-  - [Rust](https://github.com/huggingface/tokenizers/tree/main/tokenizers) (Original implementation)
-  - [Python](https://github.com/huggingface/tokenizers/tree/main/bindings/python)
-  - [Node.js](https://github.com/huggingface/tokenizers/tree/main/bindings/node)
-  - [Ruby](https://github.com/ankane/tokenizers-ruby) (Contributed by @ankane, external repo)
+| | status |
+|---|---|
+| [Rust](tokenizers) | ✅ reference implementation |
+| [Python](bindings/python) | ✅ |
+| [Node.js](bindings/node) | ✅ |
+| C / C++ | 🚧 planned |
+| [Ruby](https://github.com/ankane/tokenizers-ruby) | community, external repo |
 
-## Installation
+## Hardware
 
-You can install from source using:
-```bash
-pip install git+https://github.com/huggingface/tokenizers.git#subdirectory=bindings/python
-```
+**No SIMD is required.** Every kernel has a portable path that is always compiled and is the
+byte-exact test oracle for its vectorised siblings, so correctness never depends on a kernel being
+present — only throughput does.
 
-or install the released versions with
+<details>
+<summary>Which ops are hardware-adapted</summary>
+
+| op | aarch64 | x86_64 | wasm32 | portable fallback |
+|---|---|---|---|---|
+| Unicode atom classify | NEON (baseline) | AVX-512 VBMI → SSE4.1/SSSE3, runtime-detected | SIMD128 | `classify_scalar` |
+| bitstream block build | NEON | SSE/AVX | — | `build_block_scalar` |
+| literal & added-token scan | NEON | x86_64 | — | scalar |
+| vocab bucket nibble match | NEON | — | — | scalar |
+
+aarch64 selects at compile time (NEON is baseline). x86_64 dispatches at runtime via
+`is_x86_feature_detected!`, so one binary covers every x86_64 CPU since 2008. wasm32 needs the
+`simd128` target feature; without it, the scalar walk.
+</details>
+
+## Quick start
 
 ```bash
 pip install tokenizers
 ```
- 
-## Quick example using Python:
-
-Choose your model between Byte-Pair Encoding, WordPiece or Unigram and instantiate a tokenizer:
 
 ```python
 from tokenizers import Tokenizer
-from tokenizers.models import BPE
 
-tokenizer = Tokenizer(BPE())
-```
-
-You can customize how pre-tokenization (e.g., splitting into words) is done:
-
-```python
-from tokenizers.pre_tokenizers import Whitespace
-
-tokenizer.pre_tokenizer = Whitespace()
-```
-
-Then training your tokenizer on a set of files just takes two lines of codes:
-
-```python
-from tokenizers.trainers import BpeTrainer
-
-trainer = BpeTrainer(special_tokens=["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"])
-tokenizer.train(files=["wiki.train.raw", "wiki.valid.raw", "wiki.test.raw"], trainer=trainer)
-```
-
-Once your tokenizer is trained, encode any text with just one line:
-```python
+tokenizer = Tokenizer.from_pretrained("meta-llama/Llama-3.1-8B")
 output = tokenizer.encode("Hello, y'all! How are you 😁 ?")
 print(output.tokens)
-# ["Hello", ",", "y", "'", "all", "!", "How", "are", "you", "[UNK]", "?"]
 ```
 
-Check the [documentation](https://huggingface.co/docs/tokenizers/index)
-or the [quicktour](https://huggingface.co/docs/tokenizers/quicktour) to learn more!
+```toml
+[dependencies]
+tokenizers = "1.0.0-rc.0"
+```
+
+Docs: [guide](https://huggingface.co/docs/tokenizers/index) ·
+[quicktour](https://huggingface.co/docs/tokenizers/quicktour) ·
+[docs.rs](https://docs.rs/tokenizers/)


### PR DESCRIPTION
The README still described the pre-split library. This rewrites it.

## What's in it

- **Headline on the global set.** "Fastest on the world's text, and the only fast one that runs every model." The perf section opens with the 20-cell all-scripts head-to-head against gigatoken (881 vs 590 MB/s, 15/20 cells won) rather than a Latin subset.
- **A section that names where we lose.** english 0.87×, code 0.82×, and gigatoken leading tokbench's 10-engine ranking at 238.6 vs our 170.1 MB/s — with the explanation that this subset is the intersection of what ten engines support, so engines declining non-Latin shrink it toward English. The coverage asymmetry is stated in gigatoken's favour too: they are byte-exact on all 145 cells they accept, we attempt 203 of 210 and are exact on 174.
- **Subcrate map**, seven `<details>` blocks, each answering *why is this its own crate* rather than just what it contains.
- **Bindings matrix** — Rust / Python / Node shipping, C & C++ planned, Ruby community.
- **Hardware section.** The claim is that no SIMD is required: every kernel has an always-compiled portable path that doubles as its byte-exact test oracle. A `<details>` table lists the four hardware-adapted ops and their fallbacks.
- **Footprint**, 332799 bytes gzipped, reproducible with `make slim-size`.

Two figures hotlink from [tokbench](https://github.com/huggingface/tokbench) (`figs/03-headtohead.png`, `figs/01-overall.png`).

## Caveats, deliberately on the page

Perf figures are the `pipeline #2279 + #2296` snapshot and are labelled as such in a `<sub>` under the table. `bitsplit`, the thread pool and the load-time fold have all landed since, so these numbers understate the branch — re-running the matrix is follow-up work, not a blocker for replacing a README that describes a library we no longer ship.

## Three things found while writing, not fixed here

1. `bitsplit`'s `Cargo.toml` description advertises Whitespace and Bert grammars that have no modules in `models/mod.rs`. The README says six (gpt2, cl100k, o200k, tekken, deepseek, kimi); the crate metadata still says eight.
2. tokbench's GitHub Pages site is not deployed, so its own README's `huggingface.github.io/tokbench/dashboard.html` link 404s. This README links the repo instead. Enabling Pages would be worth it — that dashboard is the best artifact there.
3. The size badge is a static shields URL, so the number needs a manual bump. A CI job to auto-update it was built and then dropped as not worth the machinery for a number that moves a few KB a year.

The branch name mentions a size badge for that reason; the badge automation is not in this PR.
