### PR TITLE
fix: correctly decode numpy UCS-4 arrays instead of treating as UTF-8

### DIFF
--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -329,21 +329,19 @@ impl<'a, 'py> FromPyObject<'a, 'py> for PyArrayUnicode {
             let n_elem = *(*arr).dimensions as usize;
             let all_bytes = std::slice::from_raw_parts(data as *const u8, elsize * n_elem);
 
+            // numpy dtype='U' stores UCS-4 (UTF-32LE on little-endian).
+            // Each element is `elsize` bytes = `elsize/4` code points, null-padded.
             let seq = (0..n_elem)
                 .map(|i| {
                     let bytes = &all_bytes[i * elsize..(i + 1) * elsize];
-                    Ok(std::str::from_utf8(bytes)
-                        .map_err(|e| exceptions::PyValueError::new_err(e.to_string()))?
-                        .to_owned())
-                    // let unicode = pyo3::ffi::PyUnicode_FromKindAndData(
-                    //     pyo3::ffi::PyUnicode_4BYTE_KIND as _,
-                    //     bytes.as_ptr() as *const _,
-                    //     elsize as isize / alignment as isize,
-                    // );
-                    // let py = ob.py();
-                    // let obj = Py<PyAny>::from_owned_ptr(py, unicode);
-                    // let s = obj.downcast_bound::<PyString>(py)?;
-                    // Ok(s.to_string_lossy().trim_matches(char::from(0)).to_owned())
+                    let s: String = bytes
+                        .chunks_exact(4)
+                        .filter_map(|chunk| {
+                            let code = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                            if code == 0 { None } else { char::from_u32(code) }
+                        })
+                        .collect();
+                    Ok(s)
                 })
                 .collect::<PyResult<Vec<_>>>()?;
 

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -344,6 +344,21 @@ class TestTokenizer:
         output_without_specials = tokenizer.encode("My name is John", add_special_tokens=False)
         assert output_without_specials.tokens == ["ĠMy", "Ġname", "Ġis", "ĠJohn"]
 
+    def test_numpy_unicode_ucs4(self):
+        """Numpy dtype='U' arrays store UCS-4, not UTF-8. Verify non-ASCII survives."""
+        tokenizer = Tokenizer(BPE())
+        tokenizer.add_tokens(["hello", "café", "日本語", "😁"])
+
+        # ASCII
+        output = tokenizer.encode_batch(np.array(["hello", "café"], dtype="U"))
+        assert output[0].tokens == ["hello"]
+        assert output[1].tokens == ["café"]
+
+        # Non-ASCII / multibyte
+        output = tokenizer.encode_batch(np.array(["日本語", "😁"], dtype="U"))
+        assert output[0].tokens == ["日本語"]
+        assert output[1].tokens == ["😁"]
+
     def test_truncation(self):
         tokenizer = Tokenizer(BPE())
         tokenizer.add_tokens(["my", "name", "is", "john", "pair"])


### PR DESCRIPTION
`PyArrayUnicode` in the Python bindings passes raw numpy `dtype='U'` array bytes directly to `std::str::from_utf8()`. But numpy stores Unicode strings as UCS-4 (UTF-32LE on little-endian), not UTF-8. This causes:

- **ASCII strings**: silent data corruption -- embedded null bytes between every character (e.g. `"hello"` becomes `"h\0\0\0e\0\0\0l\0\0\0l\0\0\0o\0\0\0"`)
- **Non-ASCII strings**: `ValueError('invalid utf-8 sequence')` for any input containing accented characters, CJK, emoji, etc.

The commented-out code directly below the broken path (using `PyUnicode_FromKindAndData` with `PyUnicode_4BYTE_KIND`) was the correct approach but was replaced with the `from_utf8` call.

## Fix

Decode 4-byte chunks as UTF-32LE code points (`u32::from_le_bytes`), filter null padding, convert via `char::from_u32`, and collect to `String`. This correctly handles numpy's UCS-4 encoding for all Unicode inputs.

## Test

Added `test_numpy_unicode_ucs4` in `bindings/python/tests/bindings/test_tokenizer.py` covering ASCII, CJK, and emoji inputs through numpy `dtype='U'` arrays.