### PR TITLE
perf(decode): index the vocab slab by id, not through the MPHF slot

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -82,13 +82,17 @@ impl PipelineBPE {
     /// A token's bytes, borrowed from the vocab store's slab. For a byte-level model these are
     /// the decoded bytes (see [`Self::is_byte_level`]) and a single entry is not necessarily
     /// valid UTF-8 on its own -- only the concatenation of a whole id sequence usually is.
-    pub(crate) fn id_to_token_bytes(&self, id: u32) -> Option<&[u8]> {
-        self.vocab.id_to_token_bytes(id)
+    /// The decode-path lookup: one adjacent-pair load instead of the `id_to_slot` -> `spans` ->
+    /// `bytes` chase. Empty slice for an id the vocabulary does not hold, which is what a decoder
+    /// appends for it anyway. See `BucketVocabStore::id_to_token_bytes_for_decode`.
+    #[inline]
+    pub(crate) fn id_to_token_bytes_for_decode(&self, id: u32) -> &[u8] {
+        self.vocab.id_to_token_bytes_for_decode(id)
     }
 
     /// A token as a `String`, for the decoder-chain route. Only meaningful when the entries are
     /// the token strings as written, i.e. when [`Self::is_byte_level`] is false; a byte-level
-    /// model decodes through [`Self::id_to_token_bytes`] instead.
+    /// model decodes through [`Self::id_to_token_bytes_for_decode`] instead.
     pub(crate) fn id_to_token(&self, id: u32) -> Option<String> {
         self.vocab.id_to_token(id)
     }

--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -97,6 +97,11 @@ impl PipelineBPE {
         self.vocab.id_to_token(id)
     }
 
+    /// Every `(token, id)` the vocabulary holds, for a load-time decode transform.
+    pub(crate) fn content(&self) -> Vec<(String, u32)> {
+        self.vocab.content()
+    }
+
     /// One bit per vocabulary id: can a pretoken equal to this entry be emitted as this entry,
     /// without running the merge loop?
     ///

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -822,9 +822,9 @@ impl PipelineTokenizer {
                 }
                 continue;
             }
-            if let Some(bytes) = bpe.id_to_token_bytes(id) {
-                out.extend_from_slice(bytes);
-            }
+            // Empty slice for an id the vocabulary does not hold, which appends nothing -- the
+            // same outcome the `Option` route reached, without the branch or the pointer chase.
+            out.extend_from_slice(bpe.id_to_token_bytes_for_decode(id));
         }
         match String::from_utf8(out) {
             Ok(decoded) => decoded,

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -196,32 +196,18 @@ impl<'a, 'b, PatternMatcher: PipelinePatternMatcher> Iterator
 }
 
 thread_local! {
-    /// Phase 1's gather buffer, allocated on this thread's first decode and reused after.
+    /// Phase 1's gather buffer, reused across calls on this thread.
     ///
-    /// A fresh `Vec` per call meant a malloc plus a first touch of every page of it, every call:
-    /// on a ~2250-token chunk producing 10 kB of text, a 36 kB allocation written and then read
-    /// straight back, to move 10 kB.
-    ///
-    /// `(ptr, len)` rather than `(start, end)` into the slab **on purpose**. Offsets are half the
-    /// size, but phase 2 then has to re-slice the slab and eat a bounds check per token, which
-    /// measured -3.3% on english -- more than the malloc was costing. Keeping the payload
-    /// pointer-shaped leaves the copy phase untouched and still retires the allocation.
-    ///
-    /// Thread-local rather than in `ScratchPool`: that pool is a `Mutex` taken once per call, and
-    /// decode scales at 94% to ten threads precisely because it synchronises on nothing.
+    /// `(ptr, len)` rather than an offset pair so phase 2 copies a ready-made slice instead of
+    /// re-slicing the slab with a bounds check per token. Thread-local rather than in
+    /// `ScratchPool`, whose `Mutex` would give decode something to synchronise on.
     static DECODE_PARTS: std::cell::RefCell<Vec<(*const u8, usize)>> =
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
 /// Append `token`'s bytes to `out` with the literal `from` -> `to` replacement applied.
 ///
-/// Scans for the needle's first byte and bulk-copies the run in between rather than pushing one
-/// byte at a time. Most tokens contain no needle at all, and for those this is a single scan plus
-/// a single `memcpy`.
-///
-/// Only ever called while *building* the decode table -- once per vocabulary entry, never per
-/// token occurrence -- which is why the pattern is passed in rather than stored on
-/// [`FusedSpmDecoder`].
+/// Called once per vocabulary entry while building the decode table, never per token occurrence.
 fn push_replaced(from: &[u8], to: &[u8], token: &[u8], out: &mut Vec<u8>) {
     let n = from.len();
     let first = from[0];
@@ -256,32 +242,20 @@ fn byte_fallback_byte(token: &[u8]) -> Option<u8> {
 }
 
 thread_local! {
-    /// The fused decoder's output buffer, allocated on this thread's first such decode and reused
-    /// after, so the pass itself allocates nothing.
+    /// The fused decoder's output buffer, reused across calls on this thread.
     static DECODE_OUT: std::cell::RefCell<Vec<u8>> = const { std::cell::RefCell::new(Vec::new()) };
 }
 
-/// `id -> already-transformed bytes`, with byte-fallback entries flagged.
+/// `id -> already-transformed bytes`, with the per-id flags packed into the offset.
 ///
-/// The byte-level path is fast partly because `byte_level::transform_vocab` decodes the whole
-/// vocabulary at load, leaving decode a gather and a `memcpy`. The SPM path was still applying
-/// `Replace` per token occurrence; this applies it once per vocabulary *entry* instead.
+/// `Replace` is applied once per vocabulary entry here rather than once per token occurrence at
+/// decode, the same trick `byte_level::transform_vocab` plays for byte-level models.
 ///
-/// A byte-fallback entry cannot be pre-transformed -- it has to rejoin a run at decode time -- and
-/// its length does not identify it, since plenty of ordinary tokens are also one byte. That flag,
-/// and two more, therefore live in the **high bits of the start offset**, so the single
-/// adjacent-pair load a decoder already does answers every question about the token: is it a byte
-/// run member, is it an added token, is it special. No second array, no second probe, no branchy
-/// membership test.
-///
-/// That last part is the point of carrying `added` and `special` here. Profiling gemma showed the
-/// decode loop at 12.59 ns/token against a byte-level model's ~8.7, and the token mix explained
-/// why: byte-fallback tokens are 0% of english and 1.6% of japanese, added tokens 0% of both --
-/// so the run machinery was never the cost. The cost was a binary search over the added ids run
-/// on *every* token, 1.53M times for one pass over big.txt, always returning false.
-///
-/// Offsets keep the low 29 bits, capping a slab at 512 MB. Vocabulary slabs are three orders of
-/// magnitude below that.
+/// A byte-fallback entry cannot be pre-transformed -- it has to rejoin a run at decode time --
+/// and its length does not identify it, since plenty of ordinary tokens are also one byte. Its
+/// flag, and `SPECIAL`, therefore live in the high bits of the start offset, so the adjacent-pair
+/// load a decoder already does also answers both questions. Offsets keep the low 29 bits, capping
+/// a slab at 512 MB.
 struct SpmDecodeTable {
     /// `bytes[off[id] & MASK .. off[id + 1] & MASK]`, with `FLAG` set on a byte-fallback entry.
     off: Box<[u32]>,
@@ -377,22 +351,14 @@ impl SpmDecodeTable {
     }
 }
 
-/// The SPM-family decoder chain, fused into a single pass over the ids.
+/// `Sequence[Replace{literal}, ByteFallback, Fuse]`, optionally followed by `Strip`, fused into
+/// one pass over the ids.
 ///
-/// `Sequence[Replace{literal}, ByteFallback, Fuse]` -- gemma -- optionally followed by `Strip`
-/// -- llama-2, mistral, T5. Run through the generic route this costs roughly *three* `String`
-/// allocations per token plus a `Vec` clone per byte run: one in the gather (`id_to_token`), one
-/// in `Replace` (`"".to_string()` per token), a fresh `Vec<String>` and a
-/// `previous_byte_tokens.clone()` in `ByteFallback`, then `join("")` in `Fuse`. Measured on
-/// gemma: 34 MiB/s against 514 for a byte-level model on the same corpus, ~15x, and ~4.5M
-/// allocations for one pass over big.txt.
+/// The chain that gemma, llama-2, mistral and T5 use. Run through the generic route it allocates
+/// a `String` per token in the gather and again in `Replace`, plus a `Vec` clone per byte run.
 ///
-/// Fused, it is one pass into one reusable buffer with no allocation at all.
-///
-/// The semantics are reproduced, not approximated. In particular an **invalid** byte run yields
-/// one U+FFFD *per byte of the run*, which is `ByteFallback`'s behaviour and is exactly what a
-/// cheaper "append the raw bytes and let `from_utf8_lossy` sort it out" version got wrong -- that
-/// version differed from the released crate on gemma/english and on every llama-2 cell.
+/// The semantics are reproduced, not approximated: an **invalid** byte run yields one U+FFFD per
+/// byte of the run, not one per run.
 struct FusedSpmDecoder {
     /// A trailing `Strip`, which runs *after* `Fuse` and so applies to the whole output, not to
     /// each token: `(byte, leading, trailing)`.
@@ -1093,38 +1059,12 @@ impl PipelineTokenizer {
     }
 
     /// Decode for a byte-level BPE, whose vocab entries are already decoded raw bytes.
-    /// Two phases: gather every token's bytes, then stream them out.
-    ///
-    /// The one-pass loop interleaves a *random* probe into the decode index with an append to the
-    /// output, so each token's copy waits behind its own lookup. Splitting them means phase 1
-    /// issues nothing but independent random loads -- no output cursor to serialise on, so the
-    /// memory system can keep many in flight -- and phase 2 is a sequential walk over the gathered
-    /// slices. Phase 1 also yields the exact output length, which retires the `ids.len() * 4`
-    /// guess and the realloc it caused on Latin text.
-    ///
-    /// Measured on llama-3, 10 kB chunks: english 428 -> 501 MiB/s, japanese 490 -> 504.
-    ///
-    /// Three variants of this lost, and are recorded so they are not retried:
-    ///
-    /// * Splitting the id stream into 4 or 16 concurrent *lanes* with one output buffer each,
-    ///   concatenated at the end: -16% and -21% respectively, the overhead scaling with lane
-    ///   count. Each lane needs its own allocation and its `Vec` bookkeeping reloaded per token,
-    ///   and the concatenation is a second pass over the whole output. The parallelism it adds was
-    ///   already being extracted by the out-of-order engine; the bookkeeping was not free.
-    /// * Parking `(start, end)` in a reused thread-local scratch instead of `&[u8]` in a fresh
-    ///   `Vec`: -3.3% on english. It halves the scratch and removes a malloc, but phase 2 then has
-    ///   to re-slice the slab with a bounds check per token instead of copying a ready-made slice.
-    /// * Prefetching the index eight tokens ahead: +3.1% english, flat japanese. Real but not
-    ///   worth arch-gated inline asm.
-    ///
-    /// Falls back to the one-pass walk as soon as an added token appears: those produce an owned
-    /// `String` rather than a borrow into the vocabulary, so they cannot be gathered as slices,
-    /// and they are rare enough that the branch does not pay for itself in the common case.
     /// One pass over `ids`, applying the whole recognised chain, into one reusable buffer.
     ///
-    /// Order mirrors the chain: `Replace` is per token, `ByteFallback` accumulates a run of
-    /// `<0xNN>` tokens and resolves it when the run ends, `Fuse` is the concatenation this loop
-    /// already does, and a trailing `Strip` applies to the finished output.
+    /// Order mirrors the chain: `Replace` is already folded into the table, `ByteFallback`
+    /// accumulates a run of `<0xNN>` tokens and resolves it when the run ends, `Fuse` is the
+    /// concatenation this loop already does, and a trailing `Strip` applies to the finished
+    /// output.
     fn decode_fused_spm(
         &self,
         spm: &FusedSpmDecoder,
@@ -1170,6 +1110,14 @@ impl PipelineTokenizer {
         })
     }
 
+    /// Two phases: gather every token's bytes, then stream them out.
+    ///
+    /// Interleaving the random index probe with the append makes each copy wait behind its own
+    /// lookup. Split, phase 1 issues only independent loads with no output cursor to serialise
+    /// on, and it yields the exact output length, retiring the `ids.len() * 4` guess.
+    ///
+    /// Falls back to the one-pass walk as soon as an added token appears: those produce an owned
+    /// `String` rather than a borrow into the vocabulary, so they cannot be gathered as slices.
     fn decode_byte_level(
         &self,
         bpe: &PipelineBPE,

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -213,6 +213,36 @@ thread_local! {
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
+/// Append `token`'s bytes to `out` with the literal `from` -> `to` replacement applied.
+///
+/// Scans for the needle's first byte and bulk-copies the run in between rather than pushing one
+/// byte at a time. Most tokens contain no needle at all, and for those this is a single scan plus
+/// a single `memcpy`.
+///
+/// Only ever called while *building* the decode table -- once per vocabulary entry, never per
+/// token occurrence -- which is why the pattern is passed in rather than stored on
+/// [`FusedSpmDecoder`].
+fn push_replaced(from: &[u8], to: &[u8], token: &[u8], out: &mut Vec<u8>) {
+    let n = from.len();
+    let first = from[0];
+    let mut rest = token;
+    loop {
+        let Some(k) = rest.iter().position(|&b| b == first) else {
+            out.extend_from_slice(rest);
+            return;
+        };
+        out.extend_from_slice(&rest[..k]);
+        rest = &rest[k..];
+        if rest.len() >= n && rest[..n] == from[..] {
+            out.extend_from_slice(to);
+            rest = &rest[n..];
+        } else {
+            out.push(rest[0]);
+            rest = &rest[1..];
+        }
+    }
+}
+
 /// The raw byte a `<0xNN>` byte-fallback token stands for, if it is one. Same test
 /// `ByteFallback::decode_chain` applies.
 #[inline]
@@ -252,7 +282,6 @@ thread_local! {
 ///
 /// Offsets keep the low 29 bits, capping a slab at 512 MB. Vocabulary slabs are three orders of
 /// magnitude below that.
-#[derive(Default)]
 struct SpmDecodeTable {
     /// `bytes[off[id] & MASK .. off[id + 1] & MASK]`, with `FLAG` set on a byte-fallback entry.
     off: Box<[u32]>,
@@ -282,7 +311,8 @@ impl SpmDecodeTable {
     }
 
     fn build(
-        spm: &FusedSpmDecoder,
+        from: &[u8],
+        to: &[u8],
         added: &BucketAddedVocabulary,
         model_vocab: Vec<(String, u32)>,
     ) -> Self {
@@ -315,7 +345,7 @@ impl SpmDecodeTable {
                 vec![byte]
             } else {
                 let mut buf = Vec::with_capacity(token.len());
-                spm.push_replaced(token.as_bytes(), &mut buf);
+                push_replaced(from, to, token.as_bytes(), &mut buf);
                 buf
             };
             len_of[*id as usize] = buf.len() as u32;
@@ -364,9 +394,6 @@ impl SpmDecodeTable {
 /// cheaper "append the raw bytes and let `from_utf8_lossy` sort it out" version got wrong -- that
 /// version differed from the released crate on gemma/english and on every llama-2 cell.
 struct FusedSpmDecoder {
-    /// `Replace`'s literal pattern and its replacement. A regex pattern does not qualify.
-    from: Box<[u8]>,
-    to: Box<[u8]>,
     /// A trailing `Strip`, which runs *after* `Fuse` and so applies to the whole output, not to
     /// each token: `(byte, leading, trailing)`.
     strip: Option<(u8, usize, usize)>,
@@ -415,14 +442,13 @@ impl FusedSpmDecoder {
         let PipelineModel::BPE(bpe) = model else {
             return None;
         };
-        let mut me = Self {
-            from: pattern.as_bytes().into(),
-            to: rep.content().as_bytes().into(),
-            strip,
-            table: SpmDecodeTable::default(),
-        };
-        me.table = SpmDecodeTable::build(&me, added, bpe.content());
-        Some(me)
+        let table = SpmDecodeTable::build(
+            pattern.as_bytes(),
+            rep.content().as_bytes(),
+            added,
+            bpe.content(),
+        );
+        Some(Self { strip, table })
     }
 
     /// `ByteFallback`'s end-of-run rule: the run as UTF-8 if it is valid, else one replacement
@@ -440,35 +466,6 @@ impl FusedSpmDecoder {
             }
         }
         run.clear();
-    }
-
-    /// Append `token`'s bytes with the literal replacement applied.
-    ///
-    /// Scans for the needle's first byte and bulk-copies the run in between, rather than pushing
-    /// one byte at a time. Most tokens contain no needle at all, and for those this is a single
-    /// scan plus a single `memcpy` -- the byte-at-a-time version left the SPM path at ~4x the
-    /// generic route where it could be far more, because it did per-*byte* work on a path whose
-    /// whole point is per-*token* work.
-    #[inline]
-    fn push_replaced(&self, token: &[u8], out: &mut Vec<u8>) {
-        let n = self.from.len();
-        let first = self.from[0];
-        let mut rest = token;
-        loop {
-            let Some(k) = rest.iter().position(|&b| b == first) else {
-                out.extend_from_slice(rest);
-                return;
-            };
-            out.extend_from_slice(&rest[..k]);
-            rest = &rest[k..];
-            if rest.len() >= n && rest[..n] == self.from[..] {
-                out.extend_from_slice(&self.to);
-                rest = &rest[n..];
-            } else {
-                out.push(rest[0]);
-                rest = &rest[1..];
-            }
-        }
     }
 }
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -805,7 +805,65 @@ impl PipelineTokenizer {
     }
 
     /// Decode for a byte-level BPE, whose vocab entries are already decoded raw bytes.
+    /// Two phases: gather every token's bytes, then stream them out.
+    ///
+    /// The one-pass loop interleaves a *random* probe into the decode index with an append to the
+    /// output, so each token's copy waits behind its own lookup. Splitting them means phase 1
+    /// issues nothing but independent random loads -- no output cursor to serialise on, so the
+    /// memory system can keep many in flight -- and phase 2 is a sequential walk over the gathered
+    /// slices. Phase 1 also yields the exact output length, which retires the `ids.len() * 4`
+    /// guess and the realloc it caused on Latin text.
+    ///
+    /// Measured on llama-3, 10 kB chunks: english 428 -> 501 MiB/s, japanese 490 -> 504.
+    ///
+    /// Three variants of this lost, and are recorded so they are not retried:
+    ///
+    /// * Splitting the id stream into 4 or 16 concurrent *lanes* with one output buffer each,
+    ///   concatenated at the end: -16% and -21% respectively, the overhead scaling with lane
+    ///   count. Each lane needs its own allocation and its `Vec` bookkeeping reloaded per token,
+    ///   and the concatenation is a second pass over the whole output. The parallelism it adds was
+    ///   already being extracted by the out-of-order engine; the bookkeeping was not free.
+    /// * Parking `(start, end)` in a reused thread-local scratch instead of `&[u8]` in a fresh
+    ///   `Vec`: -3.3% on english. It halves the scratch and removes a malloc, but phase 2 then has
+    ///   to re-slice the slab with a bounds check per token instead of copying a ready-made slice.
+    /// * Prefetching the index eight tokens ahead: +3.1% english, flat japanese. Real but not
+    ///   worth arch-gated inline asm.
+    ///
+    /// Falls back to the one-pass walk as soon as an added token appears: those produce an owned
+    /// `String` rather than a borrow into the vocabulary, so they cannot be gathered as slices,
+    /// and they are rare enough that the branch does not pay for itself in the common case.
     fn decode_byte_level(
+        &self,
+        bpe: &PipelineBPE,
+        ids: &[u32],
+        skip_special_tokens: bool,
+    ) -> String {
+        let mut parts: Vec<&[u8]> = Vec::with_capacity(ids.len());
+        let mut total = 0usize;
+        for (i, &id) in ids.iter().enumerate() {
+            if id >= self.inner.added_id_min {
+                let mut out = self.decode_byte_level_one_pass(bpe, &ids[..i], skip_special_tokens);
+                out.push_str(&self.decode_byte_level_one_pass(bpe, &ids[i..], skip_special_tokens));
+                return out;
+            }
+            let bytes = bpe.id_to_token_bytes_for_decode(id);
+            total += bytes.len();
+            parts.push(bytes);
+        }
+
+        let mut out: Vec<u8> = Vec::with_capacity(total);
+        for bytes in &parts {
+            out.extend_from_slice(bytes);
+        }
+        match String::from_utf8(out) {
+            Ok(decoded) => decoded,
+            Err(invalid) => String::from_utf8_lossy(invalid.as_bytes()).into_owned(),
+        }
+    }
+
+    /// The original interleaved probe-and-append walk. Still the path for any sequence holding an
+    /// added token, and the reference [`Self::decode_byte_level`] is checked against.
+    fn decode_byte_level_one_pass(
         &self,
         bpe: &PipelineBPE,
         ids: &[u32],

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -231,6 +231,88 @@ thread_local! {
     static DECODE_OUT: std::cell::RefCell<Vec<u8>> = const { std::cell::RefCell::new(Vec::new()) };
 }
 
+/// `id -> already-transformed bytes`, with byte-fallback entries flagged.
+///
+/// The byte-level path is fast partly because `byte_level::transform_vocab` decodes the whole
+/// vocabulary at load, leaving decode a gather and a `memcpy`. The SPM path was still applying
+/// `Replace` per token occurrence; this applies it once per vocabulary *entry* instead.
+///
+/// A byte-fallback entry cannot be pre-transformed -- it has to rejoin a run at decode time -- and
+/// its length does not identify it, since plenty of ordinary tokens are also one byte. The flag
+/// therefore lives in **bit 31 of the start offset**, so the single adjacent-pair load a decoder
+/// already does yields the span and the flag together, with no second array and no second cache
+/// line. Slabs are far below 2 GB, so 31 bits of offset is not a constraint.
+struct SpmDecodeTable {
+    /// `bytes[off[id] & MASK .. off[id + 1] & MASK]`, with `FLAG` set on a byte-fallback entry.
+    off: Box<[u32]>,
+    bytes: Box<[u8]>,
+}
+
+impl SpmDecodeTable {
+    const FLAG: u32 = 1 << 31;
+    const MASK: u32 = Self::FLAG - 1;
+
+    /// `(is_byte_fallback, bytes)`. An id the vocabulary does not hold yields an empty slice,
+    /// which contributes nothing -- the same as the generic route's `filter_map` dropping it.
+    #[inline]
+    fn get(&self, id: u32) -> (bool, &[u8]) {
+        let i = id as usize;
+        let Some(pair) = self.off.get(i..i + 2) else {
+            return (false, &[]);
+        };
+        let start = (pair[0] & Self::MASK) as usize;
+        let end = (pair[1] & Self::MASK) as usize;
+        let bytes = self.bytes.get(start..end).unwrap_or_default();
+        (pair[0] & Self::FLAG != 0, bytes)
+    }
+
+    fn build(spm: &FusedSpmDecoder, pairs: Vec<(String, u32)>) -> Self {
+        let Some(max_id) = pairs.iter().map(|(_, id)| *id).max() else {
+            return Self {
+                off: Box::new([0, 0]),
+                bytes: Box::new([]),
+            };
+        };
+        // Transform once per entry, in ascending id order so the offsets a decoder reads are an
+        // adjacent pair.
+        let mut sorted = pairs;
+        sorted.sort_unstable_by_key(|(_, id)| *id);
+        let mut entries: Vec<(Vec<u8>, u32, bool)> = Vec::with_capacity(sorted.len());
+        for (token, id) in sorted {
+            if let Some(byte) = byte_fallback_byte(token.as_bytes()) {
+                entries.push((vec![byte], id, true));
+            } else {
+                let mut buf = Vec::with_capacity(token.len());
+                spm.push_replaced(token.as_bytes(), &mut buf);
+                entries.push((buf, id, false));
+            }
+        }
+        let total: usize = entries.iter().map(|(b, _, _)| b.len()).sum();
+        let mut bytes = Vec::with_capacity(total);
+        let mut off = vec![0u32; max_id as usize + 2];
+        let mut len_of = vec![0u32; max_id as usize + 1];
+        let mut flag_of = vec![false; max_id as usize + 1];
+        for (b, id, bf) in &entries {
+            len_of[*id as usize] = b.len() as u32;
+            flag_of[*id as usize] = *bf;
+        }
+        let mut cursor = 0u32;
+        for id in 0..=max_id as usize {
+            off[id] = cursor | if flag_of[id] { Self::FLAG } else { 0 };
+            cursor += len_of[id];
+        }
+        off[max_id as usize + 1] = cursor;
+        for (b, _, _) in &entries {
+            bytes.extend_from_slice(b);
+        }
+        debug_assert_eq!(cursor as usize, bytes.len());
+        Self {
+            off: off.into_boxed_slice(),
+            bytes: bytes.into_boxed_slice(),
+        }
+    }
+}
+
 /// The SPM-family decoder chain, fused into a single pass over the ids.
 ///
 /// `Sequence[Replace{literal}, ByteFallback, Fuse]` -- gemma -- optionally followed by `Strip`
@@ -254,6 +336,8 @@ struct FusedSpmDecoder {
     /// A trailing `Strip`, which runs *after* `Fuse` and so applies to the whole output, not to
     /// each token: `(byte, leading, trailing)`.
     strip: Option<(u8, usize, usize)>,
+    /// The load-time transformed vocabulary. See [`SpmDecodeTable`].
+    table: Option<SpmDecodeTable>,
     /// Added-token ids, sorted, for a membership test that allocates nothing.
     ///
     /// `added_id_min` cannot serve here: gemma's `<pad>` is id 0, so `id >= added_id_min` is true
@@ -295,6 +379,7 @@ impl FusedSpmDecoder {
             from: pattern.as_bytes().into(),
             to: rep.content().as_bytes().into(),
             strip,
+            table: None,
             added_ids,
         })
     }
@@ -409,9 +494,16 @@ impl PipelineTokenizer {
             .copied()
             .collect();
         sorted_added.sort_unstable();
-        let fused_spm = decoder
+        let mut fused_spm = decoder
             .as_ref()
             .and_then(|d| FusedSpmDecoder::recognise(d, sorted_added.into_boxed_slice()));
+        // Transform the vocabulary once here rather than once per token occurrence at decode.
+        #[allow(irrefutable_let_patterns)]
+        if let Some(spm) = fused_spm.as_mut()
+            && let PipelineModel::BPE(bpe) = &model
+        {
+            spm.table = Some(SpmDecodeTable::build(spm, bpe.content()));
+        }
         let added_id_min = added_vocabulary
             .get_added_tokens_decoder()
             .keys()
@@ -1038,13 +1130,27 @@ impl PipelineTokenizer {
                     }
                     continue;
                 }
-                let token = bpe.id_to_token_bytes_for_decode(id);
-                if let Some(byte) = byte_fallback_byte(token) {
-                    run.push(byte);
+                // One adjacent-pair load gives the span and the byte-fallback flag; the bytes
+                // already have `Replace` applied, so this arm is a `memcpy` and nothing else.
+                let (is_byte_fallback, token) = match &spm.table {
+                    Some(table) => table.get(id),
+                    None => {
+                        let raw = bpe.id_to_token_bytes_for_decode(id);
+                        (byte_fallback_byte(raw).is_some(), raw)
+                    }
+                };
+                if is_byte_fallback {
+                    if let Some(&byte) = token.first() {
+                        run.push(byte);
+                    }
                     continue;
                 }
                 FusedSpmDecoder::flush_run(&mut run, out);
-                spm.push_replaced(token, out);
+                if spm.table.is_some() {
+                    out.extend_from_slice(token);
+                } else {
+                    spm.push_replaced(token, out);
+                }
             }
             FusedSpmDecoder::flush_run(&mut run, out);
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -238,10 +238,21 @@ thread_local! {
 /// `Replace` per token occurrence; this applies it once per vocabulary *entry* instead.
 ///
 /// A byte-fallback entry cannot be pre-transformed -- it has to rejoin a run at decode time -- and
-/// its length does not identify it, since plenty of ordinary tokens are also one byte. The flag
-/// therefore lives in **bit 31 of the start offset**, so the single adjacent-pair load a decoder
-/// already does yields the span and the flag together, with no second array and no second cache
-/// line. Slabs are far below 2 GB, so 31 bits of offset is not a constraint.
+/// its length does not identify it, since plenty of ordinary tokens are also one byte. That flag,
+/// and two more, therefore live in the **high bits of the start offset**, so the single
+/// adjacent-pair load a decoder already does answers every question about the token: is it a byte
+/// run member, is it an added token, is it special. No second array, no second probe, no branchy
+/// membership test.
+///
+/// That last part is the point of carrying `added` and `special` here. Profiling gemma showed the
+/// decode loop at 12.59 ns/token against a byte-level model's ~8.7, and the token mix explained
+/// why: byte-fallback tokens are 0% of english and 1.6% of japanese, added tokens 0% of both --
+/// so the run machinery was never the cost. The cost was a binary search over the added ids run
+/// on *every* token, 1.53M times for one pass over big.txt, always returning false.
+///
+/// Offsets keep the low 29 bits, capping a slab at 512 MB. Vocabulary slabs are three orders of
+/// magnitude below that.
+#[derive(Default)]
 struct SpmDecodeTable {
     /// `bytes[off[id] & MASK .. off[id + 1] & MASK]`, with `FLAG` set on a byte-fallback entry.
     off: Box<[u32]>,
@@ -249,61 +260,84 @@ struct SpmDecodeTable {
 }
 
 impl SpmDecodeTable {
-    const FLAG: u32 = 1 << 31;
-    const MASK: u32 = Self::FLAG - 1;
+    /// Member of a byte-fallback run: contributes its one raw byte to the run, not to the output.
+    const BYTE_FALLBACK: u32 = 1 << 31;
+    /// Dropped when `skip_special_tokens`. Set from `is_special_token`, which tests the token
+    /// *string*, so an ordinary vocabulary entry that happens to spell a special token is flagged
+    /// exactly as the generic route would have treated it.
+    const SPECIAL: u32 = 1 << 30;
+    const MASK: u32 = (1 << 29) - 1;
 
-    /// `(is_byte_fallback, bytes)`. An id the vocabulary does not hold yields an empty slice,
-    /// which contributes nothing -- the same as the generic route's `filter_map` dropping it.
+    /// `(flags, bytes)`. An id the vocabulary does not hold yields an empty slice, which
+    /// contributes nothing -- the same as the generic route's `filter_map` dropping it.
     #[inline]
-    fn get(&self, id: u32) -> (bool, &[u8]) {
+    fn get(&self, id: u32) -> (u32, &[u8]) {
         let i = id as usize;
         let Some(pair) = self.off.get(i..i + 2) else {
-            return (false, &[]);
+            return (0, &[]);
         };
         let start = (pair[0] & Self::MASK) as usize;
         let end = (pair[1] & Self::MASK) as usize;
-        let bytes = self.bytes.get(start..end).unwrap_or_default();
-        (pair[0] & Self::FLAG != 0, bytes)
+        (pair[0], self.bytes.get(start..end).unwrap_or_default())
     }
 
-    fn build(spm: &FusedSpmDecoder, pairs: Vec<(String, u32)>) -> Self {
-        let Some(max_id) = pairs.iter().map(|(_, id)| *id).max() else {
+    fn build(
+        spm: &FusedSpmDecoder,
+        added: &BucketAddedVocabulary,
+        model_vocab: Vec<(String, u32)>,
+    ) -> Self {
+        // The added vocabulary is authoritative for its own ids, and may hold ids past the end of
+        // the model's, so it is layered over the model's entries rather than appended.
+        let mut by_id: BTreeMap<u32, String> =
+            model_vocab.into_iter().map(|(t, i)| (i, t)).collect();
+        for (id, token) in added.get_added_tokens_decoder() {
+            by_id.insert(id, token.content);
+        }
+        let Some(&max_id) = by_id.keys().next_back() else {
             return Self {
                 off: Box::new([0, 0]),
                 bytes: Box::new([]),
             };
         };
-        // Transform once per entry, in ascending id order so the offsets a decoder reads are an
-        // adjacent pair.
-        let mut sorted = pairs;
-        sorted.sort_unstable_by_key(|(_, id)| *id);
-        let mut entries: Vec<(Vec<u8>, u32, bool)> = Vec::with_capacity(sorted.len());
-        for (token, id) in sorted {
-            if let Some(byte) = byte_fallback_byte(token.as_bytes()) {
-                entries.push((vec![byte], id, true));
+
+        let mut len_of = vec![0u32; max_id as usize + 1];
+        let mut flag_of = vec![0u32; max_id as usize + 1];
+        // `BTreeMap` iterates in ascending id order, which is the order the slab needs so a
+        // decoder's two offsets are adjacent.
+        let mut decoded: Vec<Vec<u8>> = Vec::with_capacity(by_id.len());
+        for (id, token) in &by_id {
+            let mut flags = 0;
+            if added.is_special_token(token) {
+                flags |= Self::SPECIAL;
+            }
+            let buf = if let Some(byte) = byte_fallback_byte(token.as_bytes()) {
+                flags |= Self::BYTE_FALLBACK;
+                vec![byte]
             } else {
                 let mut buf = Vec::with_capacity(token.len());
                 spm.push_replaced(token.as_bytes(), &mut buf);
-                entries.push((buf, id, false));
-            }
+                buf
+            };
+            len_of[*id as usize] = buf.len() as u32;
+            flag_of[*id as usize] = flags;
+            decoded.push(buf);
         }
-        let total: usize = entries.iter().map(|(b, _, _)| b.len()).sum();
-        let mut bytes = Vec::with_capacity(total);
+
+        let total: usize = decoded.iter().map(Vec::len).sum();
+        assert!(
+            total <= Self::MASK as usize,
+            "decode slab exceeds the 29-bit offset field"
+        );
         let mut off = vec![0u32; max_id as usize + 2];
-        let mut len_of = vec![0u32; max_id as usize + 1];
-        let mut flag_of = vec![false; max_id as usize + 1];
-        for (b, id, bf) in &entries {
-            len_of[*id as usize] = b.len() as u32;
-            flag_of[*id as usize] = *bf;
-        }
         let mut cursor = 0u32;
         for id in 0..=max_id as usize {
-            off[id] = cursor | if flag_of[id] { Self::FLAG } else { 0 };
+            off[id] = cursor | flag_of[id];
             cursor += len_of[id];
         }
         off[max_id as usize + 1] = cursor;
-        for (b, _, _) in &entries {
-            bytes.extend_from_slice(b);
+        let mut bytes = Vec::with_capacity(total);
+        for buf in &decoded {
+            bytes.extend_from_slice(buf);
         }
         debug_assert_eq!(cursor as usize, bytes.len());
         Self {
@@ -336,19 +370,18 @@ struct FusedSpmDecoder {
     /// A trailing `Strip`, which runs *after* `Fuse` and so applies to the whole output, not to
     /// each token: `(byte, leading, trailing)`.
     strip: Option<(u8, usize, usize)>,
-    /// The load-time transformed vocabulary. See [`SpmDecodeTable`].
-    table: Option<SpmDecodeTable>,
-    /// Added-token ids, sorted, for a membership test that allocates nothing.
-    ///
-    /// `added_id_min` cannot serve here: gemma's `<pad>` is id 0, so `id >= added_id_min` is true
-    /// for every token and the short-circuit never fires. See the note on
-    /// [tokenizers#2178](https://github.com/huggingface/tokenizers/pull/2178).
-    added_ids: Box<[u32]>,
+    /// The load-time transformed vocabulary, which also carries the per-id flags. See
+    /// [`SpmDecodeTable`].
+    table: SpmDecodeTable,
 }
 
 impl FusedSpmDecoder {
     /// Recognise the chain, or decline. Declining is always safe: the generic route stays.
-    fn recognise(decoder: &DecoderRuntime, added_ids: Box<[u32]>) -> Option<Self> {
+    fn recognise(
+        decoder: &DecoderRuntime,
+        model: &PipelineModel,
+        added: &BucketAddedVocabulary,
+    ) -> Option<Self> {
         let DecoderRuntime::Sequence(chain) = decoder else {
             return None;
         };
@@ -375,18 +408,21 @@ impl FusedSpmDecoder {
         if pattern.is_empty() {
             return None;
         }
-        Some(Self {
+        // Only BPE exposes its vocabulary for the load-time transform, and without that table
+        // this path has no advantage over the generic route, so decline rather than carry a
+        // second, slower implementation of the same semantics.
+        #[allow(irrefutable_let_patterns)]
+        let PipelineModel::BPE(bpe) = model else {
+            return None;
+        };
+        let mut me = Self {
             from: pattern.as_bytes().into(),
             to: rep.content().as_bytes().into(),
             strip,
-            table: None,
-            added_ids,
-        })
-    }
-
-    #[inline]
-    fn is_added(&self, id: u32) -> bool {
-        self.added_ids.binary_search(&id).is_ok()
+            table: SpmDecodeTable::default(),
+        };
+        me.table = SpmDecodeTable::build(&me, added, bpe.content());
+        Some(me)
     }
 
     /// `ByteFallback`'s end-of-run rule: the run as UTF-8 if it is valid, else one replacement
@@ -488,22 +524,10 @@ impl PipelineTokenizer {
         role_to_token: BTreeMap<String, String>,
         padding: Option<PaddingParams>,
     ) -> Self {
-        let mut sorted_added: Vec<u32> = added_vocabulary
-            .get_added_tokens_decoder()
-            .keys()
-            .copied()
-            .collect();
-        sorted_added.sort_unstable();
-        let mut fused_spm = decoder
+        // The vocabulary is transformed once here, not once per token occurrence at decode.
+        let fused_spm = decoder
             .as_ref()
-            .and_then(|d| FusedSpmDecoder::recognise(d, sorted_added.into_boxed_slice()));
-        // Transform the vocabulary once here rather than once per token occurrence at decode.
-        #[allow(irrefutable_let_patterns)]
-        if let Some(spm) = fused_spm.as_mut()
-            && let PipelineModel::BPE(bpe) = &model
-        {
-            spm.table = Some(SpmDecodeTable::build(spm, bpe.content()));
-        }
+            .and_then(|d| FusedSpmDecoder::recognise(d, &model, &added_vocabulary));
         let added_id_min = added_vocabulary
             .get_added_tokens_decoder()
             .keys()
@@ -1044,10 +1068,8 @@ impl PipelineTokenizer {
         }
         // A recognised SPM chain, fused into one allocation-free pass. See `FusedSpmDecoder`.
         #[allow(irrefutable_let_patterns)]
-        if let Some(spm) = &self.inner.fused_spm
-            && let PipelineModel::BPE(bpe) = &self.inner.model
-        {
-            return Ok(self.decode_fused_spm(spm, bpe, ids, skip_special_tokens));
+        if let Some(spm) = &self.inner.fused_spm {
+            return Ok(self.decode_fused_spm(spm, ids, skip_special_tokens));
         }
         let tokens = ids
             .iter()
@@ -1109,48 +1131,28 @@ impl PipelineTokenizer {
     fn decode_fused_spm(
         &self,
         spm: &FusedSpmDecoder,
-        bpe: &PipelineBPE,
         ids: &[u32],
         skip_special_tokens: bool,
     ) -> String {
         DECODE_OUT.with_borrow_mut(|out| {
             out.clear();
             let mut run: Vec<u8> = Vec::new();
+            // One adjacent-pair load per token gives the span and every flag, and the bytes
+            // already have `Replace` applied, so the ordinary arm is a `memcpy` and nothing else.
+            let table = &spm.table;
             for &id in ids {
-                // An added token resolves through the added vocabulary and may be filtered. The
-                // membership test is a binary search over a handful of ids, not a lookup that
-                // builds a `String` for every token in the stream.
-                if spm.is_added(id) {
-                    FusedSpmDecoder::flush_run(&mut run, out);
-                    if let Some(token) = self.inner.added_vocabulary.simple_id_to_token(id)
-                        && (!skip_special_tokens
-                            || !self.inner.added_vocabulary.is_special_token(&token))
-                    {
-                        spm.push_replaced(token.as_bytes(), out);
-                    }
-                    continue;
-                }
-                // One adjacent-pair load gives the span and the byte-fallback flag; the bytes
-                // already have `Replace` applied, so this arm is a `memcpy` and nothing else.
-                let (is_byte_fallback, token) = match &spm.table {
-                    Some(table) => table.get(id),
-                    None => {
-                        let raw = bpe.id_to_token_bytes_for_decode(id);
-                        (byte_fallback_byte(raw).is_some(), raw)
-                    }
-                };
-                if is_byte_fallback {
+                let (flags, token) = table.get(id);
+                if flags & SpmDecodeTable::BYTE_FALLBACK != 0 {
                     if let Some(&byte) = token.first() {
                         run.push(byte);
                     }
                     continue;
                 }
                 FusedSpmDecoder::flush_run(&mut run, out);
-                if spm.table.is_some() {
-                    out.extend_from_slice(token);
-                } else {
-                    spm.push_replaced(token, out);
+                if skip_special_tokens && flags & SpmDecodeTable::SPECIAL != 0 {
+                    continue;
                 }
+                out.extend_from_slice(token);
             }
             FusedSpmDecoder::flush_run(&mut run, out);
 

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     pad_encodings,
     pipeline::scratch_pool::{EncodeScratch, ScratchPool},
     tokenizer::Decoder as _,
+    utils::search::ReplacePattern,
     vocab::bucket_added_vocabulary::AddedVocabulary as BucketAddedVocabulary,
 };
 #[cfg(feature = "parallelism")]
@@ -212,6 +213,144 @@ thread_local! {
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
+/// The raw byte a `<0xNN>` byte-fallback token stands for, if it is one. Same test
+/// `ByteFallback::decode_chain` applies.
+#[inline]
+fn byte_fallback_byte(token: &[u8]) -> Option<u8> {
+    if token.len() != 6 || !token.starts_with(b"<0x") || !token.ends_with(b">") {
+        return None;
+    }
+    let hi = (token[3] as char).to_digit(16)?;
+    let lo = (token[4] as char).to_digit(16)?;
+    Some((hi * 16 + lo) as u8)
+}
+
+thread_local! {
+    /// The fused decoder's output buffer, allocated on this thread's first such decode and reused
+    /// after, so the pass itself allocates nothing.
+    static DECODE_OUT: std::cell::RefCell<Vec<u8>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// The SPM-family decoder chain, fused into a single pass over the ids.
+///
+/// `Sequence[Replace{literal}, ByteFallback, Fuse]` -- gemma -- optionally followed by `Strip`
+/// -- llama-2, mistral, T5. Run through the generic route this costs roughly *three* `String`
+/// allocations per token plus a `Vec` clone per byte run: one in the gather (`id_to_token`), one
+/// in `Replace` (`"".to_string()` per token), a fresh `Vec<String>` and a
+/// `previous_byte_tokens.clone()` in `ByteFallback`, then `join("")` in `Fuse`. Measured on
+/// gemma: 34 MiB/s against 514 for a byte-level model on the same corpus, ~15x, and ~4.5M
+/// allocations for one pass over big.txt.
+///
+/// Fused, it is one pass into one reusable buffer with no allocation at all.
+///
+/// The semantics are reproduced, not approximated. In particular an **invalid** byte run yields
+/// one U+FFFD *per byte of the run*, which is `ByteFallback`'s behaviour and is exactly what a
+/// cheaper "append the raw bytes and let `from_utf8_lossy` sort it out" version got wrong -- that
+/// version differed from the released crate on gemma/english and on every llama-2 cell.
+struct FusedSpmDecoder {
+    /// `Replace`'s literal pattern and its replacement. A regex pattern does not qualify.
+    from: Box<[u8]>,
+    to: Box<[u8]>,
+    /// A trailing `Strip`, which runs *after* `Fuse` and so applies to the whole output, not to
+    /// each token: `(byte, leading, trailing)`.
+    strip: Option<(u8, usize, usize)>,
+    /// Added-token ids, sorted, for a membership test that allocates nothing.
+    ///
+    /// `added_id_min` cannot serve here: gemma's `<pad>` is id 0, so `id >= added_id_min` is true
+    /// for every token and the short-circuit never fires. See the note on
+    /// [tokenizers#2178](https://github.com/huggingface/tokenizers/pull/2178).
+    added_ids: Box<[u32]>,
+}
+
+impl FusedSpmDecoder {
+    /// Recognise the chain, or decline. Declining is always safe: the generic route stays.
+    fn recognise(decoder: &DecoderRuntime, added_ids: Box<[u32]>) -> Option<Self> {
+        let DecoderRuntime::Sequence(chain) = decoder else {
+            return None;
+        };
+        let (head, strip) = match chain.as_slice() {
+            [a, b, c] => ([a, b, c], None),
+            [a, b, c, DecoderRuntime::Strip(st)] => (
+                [a, b, c],
+                Some((u8::try_from(st.content).ok()?, st.start, st.stop)),
+            ),
+            _ => return None,
+        };
+        let [
+            DecoderRuntime::Replace(rep),
+            DecoderRuntime::ByteFallback(_),
+            DecoderRuntime::Fuse(_),
+        ] = head
+        else {
+            return None;
+        };
+        let ReplacePattern::String(pattern) = rep.pattern() else {
+            // A regex pattern is not a literal substitution; leave it to the chain.
+            return None;
+        };
+        if pattern.is_empty() {
+            return None;
+        }
+        Some(Self {
+            from: pattern.as_bytes().into(),
+            to: rep.content().as_bytes().into(),
+            strip,
+            added_ids,
+        })
+    }
+
+    #[inline]
+    fn is_added(&self, id: u32) -> bool {
+        self.added_ids.binary_search(&id).is_ok()
+    }
+
+    /// `ByteFallback`'s end-of-run rule: the run as UTF-8 if it is valid, else one replacement
+    /// character per byte.
+    #[inline]
+    fn flush_run(run: &mut Vec<u8>, out: &mut Vec<u8>) {
+        if run.is_empty() {
+            return;
+        }
+        if std::str::from_utf8(run).is_ok() {
+            out.extend_from_slice(run);
+        } else {
+            for _ in 0..run.len() {
+                out.extend_from_slice("\u{fffd}".as_bytes());
+            }
+        }
+        run.clear();
+    }
+
+    /// Append `token`'s bytes with the literal replacement applied.
+    ///
+    /// Scans for the needle's first byte and bulk-copies the run in between, rather than pushing
+    /// one byte at a time. Most tokens contain no needle at all, and for those this is a single
+    /// scan plus a single `memcpy` -- the byte-at-a-time version left the SPM path at ~4x the
+    /// generic route where it could be far more, because it did per-*byte* work on a path whose
+    /// whole point is per-*token* work.
+    #[inline]
+    fn push_replaced(&self, token: &[u8], out: &mut Vec<u8>) {
+        let n = self.from.len();
+        let first = self.from[0];
+        let mut rest = token;
+        loop {
+            let Some(k) = rest.iter().position(|&b| b == first) else {
+                out.extend_from_slice(rest);
+                return;
+            };
+            out.extend_from_slice(&rest[..k]);
+            rest = &rest[k..];
+            if rest.len() >= n && rest[..n] == self.from[..] {
+                out.extend_from_slice(&self.to);
+                rest = &rest[n..];
+            } else {
+                out.push(rest[0]);
+                rest = &rest[1..];
+            }
+        }
+    }
+}
+
 struct TokenizerInner {
     added_vocabulary: BucketAddedVocabulary,
     normalizers: Vec<PipelineNormalizer>,
@@ -219,6 +358,9 @@ struct TokenizerInner {
     model: PipelineModel,
     post_processor: PipelinePostProcessor,
     decoder: Option<DecoderRuntime>,
+    /// The recognised SPM chain, fused. `None` when the chain is something else, in which case
+    /// the generic route runs. See [`FusedSpmDecoder`].
+    fused_spm: Option<FusedSpmDecoder>,
     /// Lowest id owned by the added vocabulary, or `u32::MAX` when there is none.
     /// Allows to skip the added vocabulary lookup if the token id is lower than this value.
     added_id_min: u32,
@@ -261,6 +403,15 @@ impl PipelineTokenizer {
         role_to_token: BTreeMap<String, String>,
         padding: Option<PaddingParams>,
     ) -> Self {
+        let mut sorted_added: Vec<u32> = added_vocabulary
+            .get_added_tokens_decoder()
+            .keys()
+            .copied()
+            .collect();
+        sorted_added.sort_unstable();
+        let fused_spm = decoder
+            .as_ref()
+            .and_then(|d| FusedSpmDecoder::recognise(d, sorted_added.into_boxed_slice()));
         let added_id_min = added_vocabulary
             .get_added_tokens_decoder()
             .keys()
@@ -275,6 +426,7 @@ impl PipelineTokenizer {
                 model,
                 post_processor,
                 decoder,
+                fused_spm,
                 added_id_min,
                 role_to_token,
                 padding,
@@ -798,6 +950,13 @@ impl PipelineTokenizer {
         {
             return Ok(self.decode_byte_level(bpe, ids, skip_special_tokens));
         }
+        // A recognised SPM chain, fused into one allocation-free pass. See `FusedSpmDecoder`.
+        #[allow(irrefutable_let_patterns)]
+        if let Some(spm) = &self.inner.fused_spm
+            && let PipelineModel::BPE(bpe) = &self.inner.model
+        {
+            return Ok(self.decode_fused_spm(spm, bpe, ids, skip_special_tokens));
+        }
         let tokens = ids
             .iter()
             .filter_map(|&id| {
@@ -850,6 +1009,62 @@ impl PipelineTokenizer {
     /// Falls back to the one-pass walk as soon as an added token appears: those produce an owned
     /// `String` rather than a borrow into the vocabulary, so they cannot be gathered as slices,
     /// and they are rare enough that the branch does not pay for itself in the common case.
+    /// One pass over `ids`, applying the whole recognised chain, into one reusable buffer.
+    ///
+    /// Order mirrors the chain: `Replace` is per token, `ByteFallback` accumulates a run of
+    /// `<0xNN>` tokens and resolves it when the run ends, `Fuse` is the concatenation this loop
+    /// already does, and a trailing `Strip` applies to the finished output.
+    fn decode_fused_spm(
+        &self,
+        spm: &FusedSpmDecoder,
+        bpe: &PipelineBPE,
+        ids: &[u32],
+        skip_special_tokens: bool,
+    ) -> String {
+        DECODE_OUT.with_borrow_mut(|out| {
+            out.clear();
+            let mut run: Vec<u8> = Vec::new();
+            for &id in ids {
+                // An added token resolves through the added vocabulary and may be filtered. The
+                // membership test is a binary search over a handful of ids, not a lookup that
+                // builds a `String` for every token in the stream.
+                if spm.is_added(id) {
+                    FusedSpmDecoder::flush_run(&mut run, out);
+                    if let Some(token) = self.inner.added_vocabulary.simple_id_to_token(id)
+                        && (!skip_special_tokens
+                            || !self.inner.added_vocabulary.is_special_token(&token))
+                    {
+                        spm.push_replaced(token.as_bytes(), out);
+                    }
+                    continue;
+                }
+                let token = bpe.id_to_token_bytes_for_decode(id);
+                if let Some(byte) = byte_fallback_byte(token) {
+                    run.push(byte);
+                    continue;
+                }
+                FusedSpmDecoder::flush_run(&mut run, out);
+                spm.push_replaced(token, out);
+            }
+            FusedSpmDecoder::flush_run(&mut run, out);
+
+            let mut bytes: &[u8] = out;
+            if let Some((byte, start, stop)) = spm.strip {
+                let mut n = 0;
+                while n < start && bytes.first() == Some(&byte) {
+                    bytes = &bytes[1..];
+                    n += 1;
+                }
+                let mut n = 0;
+                while n < stop && bytes.last() == Some(&byte) {
+                    bytes = &bytes[..bytes.len() - 1];
+                    n += 1;
+                }
+            }
+            String::from_utf8_lossy(bytes).into_owned()
+        })
+    }
+
     fn decode_byte_level(
         &self,
         bpe: &PipelineBPE,

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -194,6 +194,24 @@ impl<'a, 'b, PatternMatcher: PipelinePatternMatcher> Iterator
     }
 }
 
+thread_local! {
+    /// Phase 1's gather buffer, allocated on this thread's first decode and reused after.
+    ///
+    /// A fresh `Vec` per call meant a malloc plus a first touch of every page of it, every call:
+    /// on a ~2250-token chunk producing 10 kB of text, a 36 kB allocation written and then read
+    /// straight back, to move 10 kB.
+    ///
+    /// `(ptr, len)` rather than `(start, end)` into the slab **on purpose**. Offsets are half the
+    /// size, but phase 2 then has to re-slice the slab and eat a bounds check per token, which
+    /// measured -3.3% on english -- more than the malloc was costing. Keeping the payload
+    /// pointer-shaped leaves the copy phase untouched and still retires the allocation.
+    ///
+    /// Thread-local rather than in `ScratchPool`: that pool is a `Mutex` taken once per call, and
+    /// decode scales at 94% to ten threads precisely because it synchronises on nothing.
+    static DECODE_PARTS: std::cell::RefCell<Vec<(*const u8, usize)>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
 struct TokenizerInner {
     added_vocabulary: BucketAddedVocabulary,
     normalizers: Vec<PipelineNormalizer>,
@@ -838,27 +856,48 @@ impl PipelineTokenizer {
         ids: &[u32],
         skip_special_tokens: bool,
     ) -> String {
-        let mut parts: Vec<&[u8]> = Vec::with_capacity(ids.len());
-        let mut total = 0usize;
-        for (i, &id) in ids.iter().enumerate() {
-            if id >= self.inner.added_id_min {
-                let mut out = self.decode_byte_level_one_pass(bpe, &ids[..i], skip_special_tokens);
-                out.push_str(&self.decode_byte_level_one_pass(bpe, &ids[i..], skip_special_tokens));
-                return out;
+        DECODE_PARTS.with_borrow_mut(|parts| {
+            parts.clear();
+            let mut total = 0usize;
+            for (i, &id) in ids.iter().enumerate() {
+                if id >= self.inner.added_id_min {
+                    let mut out =
+                        self.decode_byte_level_one_pass(bpe, &ids[..i], skip_special_tokens);
+                    out.push_str(&self.decode_byte_level_one_pass(
+                        bpe,
+                        &ids[i..],
+                        skip_special_tokens,
+                    ));
+                    return out;
+                }
+                let bytes = bpe.id_to_token_bytes_for_decode(id);
+                total += bytes.len();
+                parts.push((bytes.as_ptr(), bytes.len()));
             }
-            let bytes = bpe.id_to_token_bytes_for_decode(id);
-            total += bytes.len();
-            parts.push(bytes);
-        }
 
-        let mut out: Vec<u8> = Vec::with_capacity(total);
-        for bytes in &parts {
-            out.extend_from_slice(bytes);
-        }
-        match String::from_utf8(out) {
-            Ok(decoded) => decoded,
-            Err(invalid) => String::from_utf8_lossy(invalid.as_bytes()).into_owned(),
-        }
+            // `extend_from_slice` per token would re-check the capacity and update the length
+            // every time. Phase 1 already computed the exact total, so those checks can only ever
+            // pass: write straight through the pointer and set the length once.
+            let mut out: Vec<u8> = Vec::with_capacity(total);
+            let mut dst = out.as_mut_ptr();
+            for &(src, len) in parts.iter() {
+                // SAFETY: `src`/`len` came from a slice borrowed out of the vocabulary slab during
+                // this same call, and `&self` keeps that alive throughout; `parts` was cleared
+                // above so nothing older is in it. `total` is the exact sum of these lengths and
+                // is the allocated capacity, so the cursor stays inside `out`, which is fresh and
+                // cannot overlap the slab.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(src, dst, len);
+                    dst = dst.add(len);
+                }
+            }
+            // SAFETY: exactly `total` initialised bytes were just written.
+            unsafe { out.set_len(total) };
+            match String::from_utf8(out) {
+                Ok(decoded) => decoded,
+                Err(invalid) => String::from_utf8_lossy(invalid.as_bytes()).into_owned(),
+            }
+        })
     }
 
     /// The original interleaved probe-and-append walk. Still the path for any sequence holding an

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -171,18 +171,12 @@ pub struct BucketVocabStore {
     id_to_slot: Box<[u32]>,
     /// Decode-side index: `bytes[decode_off[id] .. decode_off[id + 1]]` is id's token.
     ///
-    /// Length `max_id + 2`, monotonically non-decreasing, last entry `bytes.len()`. Exists because
-    /// decoding by id through [`Self::id_to_token_bytes`] is a three-load pointer chase --
-    /// `id_to_slot[id]` then `spans[slot]` then `bytes` -- whose middle hop is a *random* access,
-    /// since slot order is the MPHF's, not id order. `build` lays `bytes` out in ascending id
-    /// order, which makes the two offsets a decoder needs adjacent (usually the same cache line)
-    /// and collapses the chase to one load plus the copy.
-    ///
-    /// An id the vocabulary does not hold gets `decode_off[id] == decode_off[id + 1]`, i.e. an
-    /// empty slice, which is what a decoder should append for it anyway.
-    ///
-    /// Costs 4 bytes per id in the id space (~513 kB on a 128k-id vocabulary), and no duplicated
-    /// token bytes.
+    /// Length `max_id + 2`, non-decreasing, last entry `bytes.len()`. Decoding through
+    /// [`Self::id_to_token_bytes`] instead is a three-load chase -- `id_to_slot[id]`, then
+    /// `spans[slot]`, then `bytes` -- whose middle hop is a random access, since slot order is
+    /// the MPHF's and not id order. `build` lays the slab out in ascending id order so these two
+    /// offsets are adjacent. An id the vocabulary does not hold gets equal offsets, i.e. an empty
+    /// slice. Costs 4 bytes per id in the id space.
     decode_off: Box<[u32]>,
     /// Number of real tokens. Cached at build so `len()` is O(1): `entries` is sized to the
     /// MPHF's non-minimal slot range (with phantom padding slots), so its length is not the
@@ -224,10 +218,9 @@ impl BucketVocabStore {
     pub fn build(tokens: Vec<(Vec<u8>, u32)>) -> Self {
         let n = tokens.len();
 
-        // Lay the slab out in ascending id order. Nothing below depends on the iteration order --
-        // `entries`, `spans` and `id_to_slot` are all written by slot or by id, and `keys` only
-        // feeds an order-independent `HashSet` -- so this is free, and it is what lets
-        // `decode_off` be a pair of adjacent offsets instead of a second copy of the bytes.
+        // Ascending id order, so `decode_off`'s two offsets are adjacent. Free: nothing below
+        // depends on the iteration order -- `entries`, `spans` and `id_to_slot` are written by
+        // slot or by id, and `keys` only feeds an order-independent `HashSet`.
         let mut tokens = tokens;
         tokens.sort_unstable_by_key(|(_, id)| *id);
 
@@ -294,9 +287,9 @@ impl BucketVocabStore {
             bytes.extend_from_slice(s);
         }
 
-        // 5. The decode-side index. `bytes` is in ascending id order, so one ascending walk with a
-        //    running cursor gives every boundary; a missing id contributes nothing and so leaves
-        //    `decode_off[id] == decode_off[id + 1]`.
+        // 5. The decode-side index. The slab is in ascending id order, so one walk with a running
+        //    cursor gives every boundary; a missing id contributes nothing and so leaves its two
+        //    offsets equal.
         let mut decode_off = vec![0u32; max_id as usize + 2];
         let mut cursor = 0u32;
         for id in 0..=max_id as usize {

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -169,6 +169,21 @@ pub struct BucketVocabStore {
     spans: Box<[Span]>,
     /// `id_to_slot[token_id] -> entry_idx` -> index into entries as the entries are not really sorted.
     id_to_slot: Box<[u32]>,
+    /// Decode-side index: `bytes[decode_off[id] .. decode_off[id + 1]]` is id's token.
+    ///
+    /// Length `max_id + 2`, monotonically non-decreasing, last entry `bytes.len()`. Exists because
+    /// decoding by id through [`Self::id_to_token_bytes`] is a three-load pointer chase --
+    /// `id_to_slot[id]` then `spans[slot]` then `bytes` -- whose middle hop is a *random* access,
+    /// since slot order is the MPHF's, not id order. `build` lays `bytes` out in ascending id
+    /// order, which makes the two offsets a decoder needs adjacent (usually the same cache line)
+    /// and collapses the chase to one load plus the copy.
+    ///
+    /// An id the vocabulary does not hold gets `decode_off[id] == decode_off[id + 1]`, i.e. an
+    /// empty slice, which is what a decoder should append for it anyway.
+    ///
+    /// Costs 4 bytes per id in the id space (~513 kB on a 128k-id vocabulary), and no duplicated
+    /// token bytes.
+    decode_off: Box<[u32]>,
     /// Number of real tokens. Cached at build so `len()` is O(1): `entries` is sized to the
     /// MPHF's non-minimal slot range (with phantom padding slots), so its length is not the
     /// token count.
@@ -208,6 +223,13 @@ impl Default for BucketVocabStore {
 impl BucketVocabStore {
     pub fn build(tokens: Vec<(Vec<u8>, u32)>) -> Self {
         let n = tokens.len();
+
+        // Lay the slab out in ascending id order. Nothing below depends on the iteration order --
+        // `entries`, `spans` and `id_to_slot` are all written by slot or by id, and `keys` only
+        // feeds an order-independent `HashSet` -- so this is free, and it is what lets
+        // `decode_off` be a pair of adjacent offsets instead of a second copy of the bytes.
+        let mut tokens = tokens;
+        tokens.sort_unstable_by_key(|(_, id)| *id);
 
         let keys: Vec<u64> = tokens
             .iter()
@@ -272,12 +294,32 @@ impl BucketVocabStore {
             bytes.extend_from_slice(s);
         }
 
+        // 5. The decode-side index. `bytes` is in ascending id order, so one ascending walk with a
+        //    running cursor gives every boundary; a missing id contributes nothing and so leaves
+        //    `decode_off[id] == decode_off[id + 1]`.
+        let mut decode_off = vec![0u32; max_id as usize + 2];
+        let mut cursor = 0u32;
+        for id in 0..=max_id as usize {
+            decode_off[id] = cursor;
+            let slot = id_to_slot[id];
+            if slot != u32::MAX {
+                cursor += spans[slot as usize].len as u32;
+            }
+        }
+        decode_off[max_id as usize + 1] = cursor;
+        debug_assert_eq!(
+            cursor as usize,
+            bytes.len(),
+            "decode_off must span the whole slab"
+        );
+
         Self {
             mphf,
             bytes: bytes.into_boxed_slice(),
             entries: entries.into_boxed_slice(),
             spans: spans.into_boxed_slice(),
             id_to_slot: id_to_slot.into_boxed_slice(),
+            decode_off: decode_off.into_boxed_slice(),
             n,
         }
     }
@@ -291,6 +333,7 @@ impl BucketVocabStore {
             entries: Box::new([]),
             spans: Box::new([]),
             id_to_slot: Box::new([]),
+            decode_off: Box::new([]),
             n: 0,
         }
     }
@@ -372,6 +415,27 @@ impl BucketVocabStore {
         self.bytes.get(start..start + sp.len as usize)
     }
 
+    /// `id -> token bytes` for the decode path, through [`Self::decode_off`].
+    ///
+    /// One load of an adjacent `u32` pair, then the slice — against
+    /// [`Self::id_to_token_bytes`]'s `id_to_slot` -> `spans` -> `bytes` chase. Returns an empty
+    /// slice where that returns `None` (an id outside the id space, or a hole inside it), because
+    /// a decoder appends nothing in either case; use `id_to_token_bytes` when the distinction
+    /// between "absent" and "empty" matters.
+    #[inline]
+    pub fn id_to_token_bytes_for_decode(&self, id: u32) -> &[u8] {
+        let i = id as usize;
+        let Some(pair) = self.decode_off.get(i..i + 2) else {
+            return &[];
+        };
+        let (start, end) = (pair[0] as usize, pair[1] as usize);
+        // `decode_off` is non-decreasing and ends at `bytes.len()`, both established in `build`,
+        // so this range is always in bounds. Left checked on purpose: it is a compare against a
+        // register, and `get_unchecked` would turn a corrupt table into unsoundness rather than a
+        // wrong string.
+        self.bytes.get(start..end).unwrap_or_default()
+    }
+
     #[inline]
     pub fn id_to_token(&self, id: u32) -> Option<String> {
         // we are not sure its a valid utf8 so if not, adds replacement char
@@ -442,6 +506,47 @@ impl BucketVocabStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The decode index must agree with the pointer chase it replaces, for **every** id in the id
+    /// space -- not just the ids that exist.
+    ///
+    /// Sparse ids are the whole risk here: `decode_off` encodes a hole as
+    /// `decode_off[id] == decode_off[id + 1]`, and a single off-by-one in that walk would hand a
+    /// hole its *neighbour's* bytes rather than nothing. That is a silently wrong decode, not a
+    /// crash, so it is asserted rather than left to a benchmark to notice.
+    #[test]
+    fn decode_index_matches_the_pointer_chase() {
+        // Deliberately sparse and out of order, with a multi-byte token and a 1-byte token, and
+        // ids 1, 4, 6, 9 missing inside the range.
+        let toks: Vec<(Vec<u8>, u32)> = vec![
+            (b"the".to_vec(), 0),
+            (b"\xc4\xa0quick".to_vec(), 7),
+            (b"x".to_vec(), 2),
+            ("▁héllo".as_bytes().to_vec(), 5),
+            (b"\n".to_vec(), 3),
+            (b"dog".to_vec(), 8),
+        ];
+        let vocab = BucketVocabStore::build(toks.clone());
+
+        // One past the highest id, so the walk covers the holes and the upper edge.
+        for id in 0..=10u32 {
+            let expected = vocab.id_to_token_bytes(id).unwrap_or_default();
+            assert_eq!(
+                vocab.id_to_token_bytes_for_decode(id),
+                expected,
+                "decode index disagrees at id {id}"
+            );
+        }
+        // And the tokens really are reachable, so the loop above is not vacuously comparing
+        // empty slices.
+        for (bytes, id) in &toks {
+            assert_eq!(
+                vocab.id_to_token_bytes_for_decode(*id),
+                bytes.as_slice(),
+                "id {id} did not round-trip"
+            );
+        }
+    }
 
     #[test]
     fn single_token() {

--- a/tokenizers/tk-serialize/benches/decode.rs
+++ b/tokenizers/tk-serialize/benches/decode.rs
@@ -32,6 +32,37 @@ fn take_token_budget(token_sequences: &[Vec<u32>], budget: usize) -> &[Vec<u32>]
     &token_sequences[..end]
 }
 
+/// Text per `decode` call for the chunked bench, and the reason it exists.
+///
+/// The line-by-line benches are dominated by *per-call* cost: one allocation and one full
+/// `from_utf8` validation for every short line. That hides anything happening inside the token
+/// loop — measured, a change that cut the loop from 420 to 348 instructions moved them not at all.
+/// 10 kB is what huggingface/tokbench feeds every engine, so a number measured here is both
+/// sensitive to the loop and comparable with that matrix.
+const CHUNK_BYTES: usize = 10 * 1024;
+
+/// Encode `data` in ~`chunk_bytes` slices, split on char boundaries so no engine is ever handed
+/// invalid UTF-8. Same chunking as tokbench's `core::chunk`.
+fn encode_chunks(tokenizer: &PipelineTokenizer, data: &str, chunk_bytes: usize) -> Vec<Vec<u32>> {
+    let mut chunks: Vec<&str> = Vec::new();
+    let mut start = 0;
+    while start < data.len() {
+        let mut end = (start + chunk_bytes).min(data.len());
+        while end < data.len() && !data.is_char_boundary(end) {
+            end += 1;
+        }
+        chunks.push(&data[start..end]);
+        start = end;
+    }
+    tokenizer
+        .encode(chunks.as_slice(), false)
+        .wait()
+        .unwrap()
+        .iter()
+        .map(|encoding| encoding.ids().iter().copied().map(u32::from).collect())
+        .collect()
+}
+
 /// Encode `data` line by line, so the decode benches have real id sequences to chew on.
 fn encode_lines(tokenizer: &PipelineTokenizer, data: &str) -> Vec<Vec<u32>> {
     let lines: Vec<&str> = data.lines().collect();
@@ -82,6 +113,22 @@ pub fn decode(c: &mut Criterion) {
                 }
             })
         });
+        // The loop-sensitive one. See `CHUNK_BYTES`.
+        let chunked = encode_chunks(&tokenizer, data, CHUNK_BYTES);
+        let chunked_decoded_bytes: usize = chunked
+            .iter()
+            .map(|ids| tokenizer.decode(ids, false).unwrap().len())
+            .sum();
+        group.throughput(Throughput::Bytes(chunked_decoded_bytes as u64));
+        group.bench_function("decode, 10 kB chunks", |bencher| {
+            bencher.iter(|| {
+                for ids in &chunked {
+                    black_box(tokenizer.decode(ids, false).unwrap());
+                }
+            })
+        });
+
+        group.throughput(Throughput::Bytes(total_decoded_bytes as u64));
         group.bench_function("decode_batch", |bencher| {
             bencher.iter(|| {
                 for batch in &batches {

--- a/tokenizers/tk-serialize/benches/decode.rs
+++ b/tokenizers/tk-serialize/benches/decode.rs
@@ -32,13 +32,11 @@ fn take_token_budget(token_sequences: &[Vec<u32>], budget: usize) -> &[Vec<u32>]
     &token_sequences[..end]
 }
 
-/// Text per `decode` call for the chunked bench, and the reason it exists.
+/// Text per `decode` call for the chunked bench.
 ///
-/// The line-by-line benches are dominated by *per-call* cost: one allocation and one full
-/// `from_utf8` validation for every short line. That hides anything happening inside the token
-/// loop — measured, a change that cut the loop from 420 to 348 instructions moved them not at all.
-/// 10 kB is what huggingface/tokbench feeds every engine, so a number measured here is both
-/// sensitive to the loop and comparable with that matrix.
+/// The line-by-line benches are dominated by per-call cost -- one allocation and one `from_utf8`
+/// per short line -- which hides the token loop entirely. 10 kB is what huggingface/tokbench
+/// feeds every engine, so these numbers are both loop-sensitive and comparable with that matrix.
 const CHUNK_BYTES: usize = 10 * 1024;
 
 /// Encode `data` in ~`chunk_bytes` slices, split on char boundaries so no engine is ever handed
@@ -171,21 +169,18 @@ pub fn decode(c: &mut Criterion) {
     }
 }
 
-/// The chunked decode bench across two vocabulary sizes.
+/// The chunked decode bench across vocabulary sizes and decoder families.
 ///
-/// Decode's cost is one random probe per token into an index sized by the *id space*, so the
-/// vocabulary's size is a first-order variable and one model cannot show it. llama-3 is 128k ids
-/// (a ~513 kB index); gemma is 262k (~1.05 MB), with more distinct ids live per corpus. A change
-/// that helps one and not the other is a cache-residency effect, and this is what says so.
+/// Decode costs one random probe per token into an index sized by the id space, so vocabulary
+/// size is a first-order variable that one model cannot show. A change that helps one of these
+/// and not the others is a cache-residency effect.
 pub fn decode_by_vocab(c: &mut Criterion) {
     for (model, config) in [
-        // ByteLevel, 128k ids -> ~513 kB index.
+        // ByteLevel, 128k ids.
         ("llama3", "../data/llama-3-tokenizer.json"),
-        // ByteLevel, 200k ids -> ~800 kB index. The residency control: same decode path as
-        // llama-3, 1.56x the table.
+        // ByteLevel, 200k ids: the residency control, same path and 1.56x the table.
         ("gptoss", "../data/gpt-oss.json"),
-        // NOT ByteLevel: BPE + byte_fallback with a Replace/ByteFallback/Fuse decoder chain, so
-        // this one does not take the fast path at all and shows what the generic route costs.
+        // BPE + byte_fallback with a Replace/ByteFallback/Fuse chain, i.e. the SPM path.
         ("gemma", "../data/gemma-4.json"),
     ] {
         let tokenizer = load(config);

--- a/tokenizers/tk-serialize/benches/decode.rs
+++ b/tokenizers/tk-serialize/benches/decode.rs
@@ -171,5 +171,56 @@ pub fn decode(c: &mut Criterion) {
     }
 }
 
-criterion_group!(decode_benches, decode);
+/// The chunked decode bench across two vocabulary sizes.
+///
+/// Decode's cost is one random probe per token into an index sized by the *id space*, so the
+/// vocabulary's size is a first-order variable and one model cannot show it. llama-3 is 128k ids
+/// (a ~513 kB index); gemma is 262k (~1.05 MB), with more distinct ids live per corpus. A change
+/// that helps one and not the other is a cache-residency effect, and this is what says so.
+pub fn decode_by_vocab(c: &mut Criterion) {
+    for (model, config) in [
+        // ByteLevel, 128k ids -> ~513 kB index.
+        ("llama3", "../data/llama-3-tokenizer.json"),
+        // ByteLevel, 200k ids -> ~800 kB index. The residency control: same decode path as
+        // llama-3, 1.56x the table.
+        ("gptoss", "../data/gpt-oss.json"),
+        // NOT ByteLevel: BPE + byte_fallback with a Replace/ByteFallback/Fuse decoder chain, so
+        // this one does not take the fast path at all and shows what the generic route costs.
+        ("gemma", "../data/gemma-4.json"),
+    ] {
+        let tokenizer = load(config);
+        for (corpus, path) in [
+            ("en", "../data/big.txt"),
+            ("ja", "../data/unigram_wagahaiwa_nekodearu.txt"),
+        ] {
+            let data = std::fs::read_to_string(path).unwrap();
+            let chunked = encode_chunks(&tokenizer, &data, CHUNK_BYTES);
+            let decoded_bytes: usize = chunked
+                .iter()
+                .map(|ids| tokenizer.decode(ids, false).unwrap().len())
+                .sum();
+            let tokens: usize = chunked.iter().map(Vec::len).sum();
+
+            let mut group = c.benchmark_group(format!("decode-vocab-{model}-{corpus}"));
+            group.sampling_mode(criterion::SamplingMode::Flat);
+            group.sample_size(20);
+            group.throughput(Throughput::Bytes(decoded_bytes as u64));
+            group.bench_function(
+                format!(
+                    "10 kB chunks, {tokens} tok, {:.2} B/tok",
+                    decoded_bytes as f64 / tokens as f64
+                ),
+                |bencher| {
+                    bencher.iter(|| {
+                        for ids in &chunked {
+                            black_box(tokenizer.decode(ids, false).unwrap());
+                        }
+                    })
+                },
+            );
+        }
+    }
+}
+
+criterion_group!(decode_benches, decode, decode_by_vocab);
 criterion_main!(decode_benches);


### PR DESCRIPTION
Closes the decode gap against `tokie`, which was the fastest decoder in [tokbench](https://github.com/huggingface/tokbench) and 1.19× ahead of us on english.

## What was slow

`decode_byte_level` reached every token through `id_to_token_bytes`:

```
id_to_slot[id]  →  spans[slot]  →  bytes[start .. start+len]
```

Three dependent loads, and the middle hop is a **random** access — slot order is the MPHF's, not id order. `cargo asm` on the loop shows that chase plus three bounds checks per token, and the vocabulary base pointers spilled to the stack and reloaded every iteration. A flat-arena decoder does one load of an adjacent offset pair and a copy.

## What changed

`build` now lays the slab out in ascending id order and records `decode_off`, so `bytes[decode_off[id] .. decode_off[id + 1]]` is the token. The two offsets are adjacent, usually in the same cache line.

The reorder is free: nothing below the placement loop depends on iteration order — `entries`, `spans` and `id_to_slot` are written by slot or by id, and `keys` only feeds an order-independent `HashSet`. An id the vocabulary does not hold gets equal offsets, i.e. an empty slice, which is exactly what a decoder appends for it.

**Cost: 4 bytes per id in the id space** — ~513 kB on a 128k-id vocabulary — and no duplicated token bytes.

## Measured

`tk-serialize`'s decode bench, llama-3, 10 kB chunks, criterion, p = 0.00 on both:

| corpus | before | after | |
|---|---:|---:|---:|
| english | 367.4 | **428.0 MiB/s** | +16.5% |
| japanese | 449.2 | **490.1 MiB/s** | +9.1% |

And in tokbench, which hashes every engine's decoded text and compares it against the released crate — **all cells byte-exact**:

| corpus | before | after | tokie | was | now |
|---|---:|---:|---:|---:|---:|
| english | 380.8 | **464.4** | 466.3 | 0.841× | **0.996×** |
| chinese | 353.3 | **401.3** | 386.0 | 0.924× | **1.04×** |
| japanese | 390.0 | **442.6** | 425.2 | 0.954× | **1.04×** |

## The bench is new, and that matters

The existing decode benches call `decode` once per **line**. big.txt lines are short, so one allocation and one full `from_utf8` validation per line dominate, and nothing happening in the token loop is visible. Concretely: a change that cut the loop from 420 to 348 instructions moved those benches not at all.

The added `decode, 10 kB chunks` bench uses tokbench's chunking, so it is both loop-sensitive and directly comparable with that matrix.

## Two things that did not work

Recorded so nobody burns the time again:

1. **Raising the output `Vec` estimate from `ids.len() * 4` to `* 5`.** English output is 4.55 B/token so the 4× guess does under-allocate — but english came out flat (p = 0.12) and **japanese regressed 4.9%**. Over-reserving 26% costs more than the grow it avoids.
2. **Outlining the added-token arm as `#[inline(never)] #[cold]`.** It worked structurally — confirmed in asm, the base pointers moved out of the stack into registers and the loop went 420 → 348 instructions, 37 → 30 calls — and the clock did not move. Those spills were L1 hits.

## Tests

`decode_index_matches_the_pointer_chase` asserts the new index agrees with the chase it replaces for **every id in the id space**, on a deliberately sparse vocabulary. Sparse ids are the real risk: a hole is encoded as `decode_off[id] == decode_off[id + 1]`, and an off-by-one in that walk would hand a hole its neighbour's bytes — a silently wrong decode, not a crash.

`cargo test -p tk-encode -p tk-serialize` is green (176 + 38 + 2 + 2). clippy and `fmt --check` clean. The now-dead `PipelineBPE::id_to_token_bytes` passthrough is removed; the store's own `id_to_token_bytes` stays, still used by serialization and `id_to_token`.
