### PR TITLE
perf(decode): prefetch the decode index eight tokens ahead

### DIFF
--- a/tokenizers/tk-encode/src/models/bpe/model.rs
+++ b/tokenizers/tk-encode/src/models/bpe/model.rs
@@ -90,6 +90,13 @@ impl PipelineBPE {
         self.vocab.id_to_token_bytes_for_decode(id)
     }
 
+    /// Warm the decode index for an id a few tokens ahead of where it is needed.
+    /// See `BucketVocabStore::prefetch_for_decode`.
+    #[inline]
+    pub(crate) fn prefetch_for_decode(&self, id: u32) {
+        self.vocab.prefetch_for_decode(id);
+    }
+
     /// A token as a `String`, for the decoder-chain route. Only meaningful when the entries are
     /// the token strings as written, i.e. when [`Self::is_byte_level`] is false; a byte-level
     /// model decodes through [`Self::id_to_token_bytes_for_decode`] instead.

--- a/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
+++ b/tokenizers/tk-encode/src/tokenizer/pipeline/mod.rs
@@ -813,7 +813,15 @@ impl PipelineTokenizer {
     ) -> String {
         // Byte-level tokens average ~4 bytes
         let mut out: Vec<u8> = Vec::with_capacity(ids.len() * 4);
-        for &id in ids {
+        // How far ahead to warm the decode index. The loop's cost is one random access per token
+        // into a table indexed by id, so the ids that are already in hand are free latency to
+        // hide. 8 is enough to cover an L2 hit at this loop's ~9 ns/token without running so far
+        // ahead that the line is evicted before use.
+        const PREFETCH_AHEAD: usize = 8;
+        for (i, &id) in ids.iter().enumerate() {
+            if let Some(&ahead) = ids.get(i + PREFETCH_AHEAD) {
+                bpe.prefetch_for_decode(ahead);
+            }
             if id >= self.inner.added_id_min
                 && let Some(token) = self.inner.added_vocabulary.simple_id_to_token(id)
             {

--- a/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
+++ b/tokenizers/tk-encode/src/vocab/bucket_vocab_store.rs
@@ -415,6 +415,42 @@ impl BucketVocabStore {
         self.bytes.get(start..start + sp.len as usize)
     }
 
+    /// Start the load of `id`'s offsets without waiting for it.
+    ///
+    /// Decode's remaining cost is one random access into [`Self::decode_off`], which is indexed by
+    /// a token id and so has no spatial locality to exploit -- measured at ~9 ns per token on
+    /// llama-3/english against 4.08 ns with the table hot in L1. A decoder knows every id it is
+    /// about to need, so it can issue that load some tokens ahead of using it.
+    ///
+    /// A hint, never a correctness requirement: `prfm`/`prefetchnta` cannot fault, an out-of-range
+    /// id is filtered here anyway, and the whole thing compiles to nothing on an architecture
+    /// without a prefetch instruction.
+    #[inline]
+    pub fn prefetch_for_decode(&self, id: u32) {
+        let i = id as usize;
+        if i + 1 >= self.decode_off.len() {
+            return;
+        }
+        // SAFETY: `i + 1 < len`, so `add(i)` is in bounds and does not wrap.
+        let p = unsafe { self.decode_off.as_ptr().add(i) }.cast::<u8>();
+        #[cfg(target_arch = "aarch64")]
+        // SAFETY: `prfm` has no memory effects and cannot fault; it only warms a cache line.
+        unsafe {
+            core::arch::asm!(
+                "prfm pldl1keep, [{p}]",
+                p = in(reg) p,
+                options(nostack, readonly, preserves_flags)
+            );
+        }
+        #[cfg(target_arch = "x86_64")]
+        // SAFETY: `_mm_prefetch` has no memory effects and cannot fault.
+        unsafe {
+            core::arch::x86_64::_mm_prefetch(p.cast::<i8>(), core::arch::x86_64::_MM_HINT_T0);
+        }
+        #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+        let _ = p;
+    }
+
     /// `id -> token bytes` for the decode path, through [`Self::decode_off`].
     ///
     /// One load of an adjacent `u32` pair, then the slice — against


### PR DESCRIPTION
Stacked on #2387. **Marginal — english +3.1%, japanese flat.** Opened so the measurement exists as an artifact; close it if 3% is not worth ~35 lines of arch-gated inline asm in a hot path.

## What it does

After #2387's id-ordered index, decode's entire remaining cost is one random access per token into `decode_off`, indexed by a token id and therefore with no spatial locality to exploit. A decoder already holds every id it is about to need, so the load can be issued ahead of use: `prfm pldl1keep` on aarch64, `_mm_prefetch` on x86_64, nothing elsewhere. A hint only — it cannot fault, an out-of-range id is filtered before it, and the portable build emits nothing.

Eight ahead covers an L2 hit at ~9 ns/token without running so far ahead that the line is evicted before use.

## Why only 3%

The iterations were already independent, so the out-of-order engine was overlapping these loads without help. Decoding one chunk repeatedly, so the tables collapse into L1, runs the identical loop at **4.08 ns/token against 9.08** — but that 2.2× is a cache **capacity** effect across the whole working set, not per-access latency sitting idle waiting to be hidden. Prefetching cannot shrink a working set.

That is also the honest ceiling statement for this loop: the remaining headroom is the size of a table indexed by the id space, and ids cannot be renumbered — they are the model contract.

## Rejected on the way, with numbers

**Inlining short tokens into the index** (8-byte entry: tag byte + 7 payload bytes, longer tokens spilling to the slab). Flat on both corpora — and not because the path was cold:

| | ≤ 7 bytes (inline-eligible) | ≥ 8 (spilled) |
|---|---:|---:|
| english | **88.5%** | 11.5% |
| japanese | **95.0%** | 5.0% |

It does remove the second dependent load, but that load was already cheap — the slab is id-ordered, so it tracks text locality — while the entry grew 4 → 8 bytes and doubled the footprint of the one table that *does* miss. English touches 31,395 distinct ids, so the live index went ~126 kB → ~251 kB. **The index wants to be small, not informative.**

**SIMD UTF-8 validation.** Measured share of decode time:

| | `from_utf8` | alloc | gather + copy |
|---|---:|---:|---:|
| english | 1.1% (0.02 ns/B) | 0.8% | 98.2% |
| japanese | 27.0% (0.54 ns/B) | 0.8% | 72.3% |

std's ASCII fast path already runs at 0.02 ns/byte, so a SIMD validator is worth nothing on Latin text. It is worth revisiting for non-Latin, where a 4× validator would buy roughly +25% on japanese.

## Tests

`cargo test -p tk-encode` green (176 + 2). clippy and `fmt --check` clean. No behaviour change: the prefetch is a hint, and the sparse-id equivalence test from #2387 still gates the lookup itself.
