### PR TITLE
fix(bpe): drop heap entries with non-positive pair_counts before u64 cast

### DIFF
--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -516,8 +516,22 @@ impl BpeTrainer {
                 break;
             };
 
-            if top.count != pair_counts[&top.pair] as u64 {
-                top.count = pair_counts[&top.pair] as u64;
+            // Staleness check: the heap entry may be outdated because pair_counts
+            // was updated after the entry was pushed. Re-push with the current count
+            // so the max-heap can re-sort it.
+            //
+            // Guard: pair_counts is i32 and can go negative when max_token_length
+            // rejects the +1 side of a neighbour delta while the -1 side applies
+            // (issue #2320). A negative count sign-extends to u64::MAX when cast,
+            // winning the max-heap ahead of every legitimate pair. Drop spent entries
+            // before the cast to prevent phantom merges.
+            let live = pair_counts[&top.pair];
+            if live <= 0 {
+                // Pair has been exhausted or invalidated; discard and move on.
+                continue;
+            }
+            if top.count != live as u64 {
+                top.count = live as u64;
                 queue.push(top);
                 continue;
             }
@@ -678,6 +692,7 @@ impl Trainer for BpeTrainer {
 #[cfg(test)]
 mod tests {
     use super::{BpeTrainer, Pair, BPE};
+    use crate::tokenizer::AddedToken;
     use ahash::AHashMap;
     use compact_str::CompactString;
 
@@ -864,5 +879,79 @@ mod tests {
         .map(|(k, v)| (k.to_string(), v))
         .collect();
         assert_eq!(trained_vocab, expected_vocab)
+    }
+
+    /// Regression test for <https://github.com/huggingface/tokenizers/issues/2320>.
+    ///
+    /// When `continuing_subword_prefix` and `max_token_length` are both set, the
+    /// length guard can reject the `+1` neighbour delta for a pair while the `-1`
+    /// side still applies, driving `pair_counts[pair]` negative.  The staleness
+    /// re-check on the heap entry reads that negative `i32` value through `as u64`,
+    /// sign-extending it to `u64::MAX`, which then wins the max-heap and causes the
+    /// trainer to emit a merge for a pair that occurs zero times in the corpus
+    /// (a "phantom merge").
+    ///
+    /// The fix drops any heap entry whose live count is ≤ 0 before the cast.
+    #[test]
+    fn bpe_no_phantom_merge_with_prefix_and_max_token_length() {
+        // Minimal reproducer from issue #2320: 8-word corpus that reliably triggers
+        // the sign-extension on at least one run when prefix + max_token_length = 4.
+        let word_counts: AHashMap<CompactString, u64> = [
+            ("##c", 1),
+            ("##cac#", 1),
+            ("#ab", 1),
+            ("c#", 1),
+            ("####", 1),
+            ("accc#a#a#b", 1),
+            ("a", 1),
+            ("cb", 1),
+        ]
+        .iter()
+        .map(|(k, v)| (CompactString::from(*k), *v))
+        .collect();
+
+        let trainer = BpeTrainer::builder()
+            .show_progress(false)
+            .continuing_subword_prefix("##".to_string())
+            .max_token_length(Some(4))
+            .vocab_size(244)
+            .special_tokens(vec![
+                AddedToken::from("a".to_string(), true),
+                AddedToken::from("<unk>".to_string(), true),
+            ])
+            .build();
+
+        let mut model = BPE::default();
+        trainer.do_train(&word_counts, &mut model).unwrap();
+
+        // Verify: every merge in the trained model must correspond to a token pair
+        // that actually appears in the vocabulary produced so far.  A phantom merge
+        // (count == 0 at merge time) would produce a token unreachable from the
+        // corpus; its constituent parts would not form a valid entry in `merges`.
+        // We check the weaker invariant that the merge table is internally
+        // consistent: both parts of every merged pair must exist as vocab entries
+        // *before* (lower rank than) the merged token.
+        let vocab: AHashMap<u32, String> = model
+            .get_vocab()
+            .into_iter()
+            .map(|(k, v)| (v, k))
+            .collect();
+
+        for (pair, (rank, result_id)) in &model.merges {
+            let part_a_id = pair.0;
+            let part_b_id = pair.1;
+            assert!(
+                vocab.contains_key(&part_a_id),
+                "merge rank {rank}: left part id {part_a_id} not in vocab"
+            );
+            assert!(
+                vocab.contains_key(&part_b_id),
+                "merge rank {rank}: right part id {part_b_id} not in vocab"
+            );
+            assert!(
+                vocab.contains_key(result_id),
+                "merge rank {rank}: result id {result_id} not in vocab"
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #2320.

## Problem

When `continuing_subword_prefix` (or `end_of_word_suffix`) and `max_token_length` are both set, `BpeTrainer` can emit a merge for a pair that occurs **zero times** in the corpus — a phantom merge.

**Mechanism:**

`pair_counts` is `AHashMap<Pair, i32>` (signed). A neighbour-delta update subtracts 1 from the pair that is being displaced. When `max_token_length` rejects the matching `+1` side (because the would-be merged token would exceed the limit), the pair count can go negative.

The staleness re-check in the training loop reads this value through `as u64` with no sign guard:

```rust
// trainer.rs — before fix
if top.count != pair_counts[&top.pair] as u64 {  // -1 casts to u64::MAX
    top.count = pair_counts[&top.pair] as u64;    // u64::MAX stored
    queue.push(top);
    continue;
}
```

On the next pop, the staleness check passes (both sides are `u64::MAX`), `top.count < 1` is `false`, and the trainer merges a pair that nothing in the corpus could have produced — ahead of every legitimate pair, because this is a max-heap. The phantom merge silently consumes a vocabulary slot and shifts every subsequent merge rank, changing the trained tokenizer.

The two `queue.push` call sites correctly guard against non-positive counts:
```rust
let count = pair_counts[&pair];
if count > 0 { queue.push(Merge { ... count: count as u64, ... }); }
```
The staleness branch is the only path that skips the guard.

This affects `WordPieceTrainer` (which sets `continuing_subword_prefix("##")` by default) whenever `max_token_length` is also specified. Reproducible with 8 words / 38 bytes on `tokenizers==0.23.1`.

## Fix

Read the live count as `i32` first, drop the entry immediately if it is ≤ 0, then cast to `u64` for the comparison and re-push:

```rust
let live = pair_counts[&top.pair];
if live <= 0 {
    continue;  // spent or invalidated — do not cast to u64
}
if top.count != live as u64 {
    top.count = live as u64;
    queue.push(top);
    continue;
}
```

Widening `pair_counts` to `i64` (as proposed in the related #2058) does **not** fix this on its own — any negative value sign-extends through `as u64` identically.

## Test

Added `bpe_no_phantom_merge_with_prefix_and_max_token_length` using the 8-word corpus from the issue. It trains with `continuing_subword_prefix = "##"` and `max_token_length = 4`, then verifies that every entry in the trained merge table refers to vocabulary IDs that actually exist — a condition that would fail if a phantom merge were emitted, since the merged token would be unreachable from the corpus.